### PR TITLE
Change server_certificate to PathBuf

### DIFF
--- a/mssql-js/src/tracing_init.rs
+++ b/mssql-js/src/tracing_init.rs
@@ -47,10 +47,7 @@ fn get_trace_log_path() -> Option<PathBuf> {
 
         // Security check: warn about insecure paths but allow them
         if is_insecure_path(&path) {
-            eprintln!(
-                "[mssql-js] WARNING: Insecure log directory detected: '{}'",
-                path.display()
-            );
+            eprintln!("[mssql-js] WARNING: Insecure log directory detected: {path:?}",);
             eprintln!("[mssql-js] WARNING: Logs may contain sensitive data (queries, data etc).");
             eprintln!(
                 "[mssql-js] WARNING: Logging to /tmp, /var/tmp, or system temp directories is not recommended."
@@ -68,11 +65,7 @@ fn get_trace_log_path() -> Option<PathBuf> {
         if !path.exists()
             && let Err(e) = create_dir_all(&path)
         {
-            eprintln!(
-                "[mssql-js] ERROR: Could not create log directory '{}': {}",
-                path.display(),
-                e
-            );
+            eprintln!("[mssql-js] ERROR: Could not create log directory '{path:?}': {e}",);
             return None;
         }
         return Some(path.join(TRACE_LOG_FILENAME));
@@ -145,8 +138,7 @@ pub fn init_tracing() {
                             },
                             Err(e) => {
                                 eprintln!(
-                                    "[mssql-js] ERROR: Could not create trace log file '{}': {}. File logging will be disabled.",
-                                    log_path.display(), e
+                                    "[mssql-js] ERROR: Could not create trace log file {log_path:?}: {e}. File logging will be disabled."
                                 );
                             }
                         }

--- a/mssql-py-core/src/connection.rs
+++ b/mssql-py-core/src/connection.rs
@@ -4,7 +4,7 @@
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 use tokio::runtime::Runtime;
 use tokio::sync::Mutex;
 
@@ -252,7 +252,7 @@ impl PyCoreConnection {
         // ServerCertificate - path to the server certificate file for validation
         let server_certificate = dict
             .get_item("server_certificate")?
-            .and_then(|v| v.extract::<String>().ok());
+            .and_then(|v| v.extract::<PathBuf>().ok());
 
         let encryption_options = EncryptionOptions {
             mode: encryption_mode,

--- a/mssql-py-core/src/tracing_init.rs
+++ b/mssql-py-core/src/tracing_init.rs
@@ -89,11 +89,7 @@ fn get_trace_log_path() -> Option<PathBuf> {
     if !dir.exists()
         && let Err(e) = create_dir_all(&dir)
     {
-        eprintln!(
-            "[mssql-py-core] ERROR: Could not create log directory '{}': {}",
-            dir.display(),
-            e
-        );
+        eprintln!("[mssql-py-core] ERROR: Could not create log directory {dir:?}: {e}");
         return None;
     }
 
@@ -143,8 +139,7 @@ pub(crate) fn init_tracing() {
                                 .event_format(LogFormatter);
 
                             eprintln!(
-                                "[mssql-py-core] Created log file → {}",
-                                log_path.display()
+                                "[mssql-py-core] Created log file → {log_path:?}"
                             );
 
                             // Store guard to keep async writer alive
@@ -162,9 +157,7 @@ pub(crate) fn init_tracing() {
                         }
                         Err(e) => {
                             eprintln!(
-                                "[mssql-py-core] ERROR: Could not create trace log file '{}': {}. Tracing will be disabled.",
-                                log_path.display(),
-                                e
+                                "[mssql-py-core] ERROR: Could not create trace log file {log_path:?}: {e}. Tracing will be disabled."
                             );
                         }
                     }

--- a/mssql-tds/src/connection/transport/certificate_validator.rs
+++ b/mssql-tds/src/connection/transport/certificate_validator.rs
@@ -24,19 +24,19 @@ use tracing::{debug, info};
 /// # Returns
 /// * `Ok(Vec<u8>)` - DER-encoded certificate data
 /// * `Err(Error)` - File not found, IO error, or invalid format
-pub fn load_certificate_from_file(path: &str) -> TdsResult<Vec<u8>> {
-    debug!("Loading certificate from file: {}", path);
+pub fn load_certificate_from_file(path: &Path) -> TdsResult<Vec<u8>> {
+    debug!("Loading certificate from file: {}", path.display());
 
     // Check if file exists
-    if !Path::new(path).exists() {
+    if !path.exists() {
         return Err(Error::CertificateNotFound {
-            path: path.to_string(),
+            path: path.to_path_buf(),
         });
     }
 
     // Read certificate file
     let cert_data = fs::read(path).map_err(|e| Error::CertificateFileIoError {
-        path: path.to_string(),
+        path: path.to_path_buf(),
         error: e.to_string(),
     })?;
 
@@ -48,19 +48,19 @@ pub fn load_certificate_from_file(path: &str) -> TdsResult<Vec<u8>> {
             Certificate::from_der(&cert_data)
         })
         .map_err(|_| Error::InvalidCertificateFormat {
-            path: path.to_string(),
+            path: path.to_path_buf(),
         })?;
 
     // Convert to DER format for binary comparison
     let der_data = certificate
         .to_der()
         .map_err(|_| Error::InvalidCertificateFormat {
-            path: path.to_string(),
+            path: path.to_path_buf(),
         })?;
 
     info!(
         "Successfully loaded certificate from: {} ({} bytes)",
-        path,
+        path.display(),
         der_data.len()
     );
     Ok(der_data)
@@ -134,8 +134,11 @@ pub fn constant_time_compare(a: &[u8], b: &[u8]) -> bool {
 /// # Returns
 /// * `Ok(())` - Certificates match and server cert is valid
 /// * `Err(Error)` - Validation failed
-pub fn validate_server_certificate(user_cert_path: &str, server_cert_der: &[u8]) -> TdsResult<()> {
-    info!("Validating server certificate against: {}", user_cert_path);
+pub fn validate_server_certificate(user_cert_path: &Path, server_cert_der: &[u8]) -> TdsResult<()> {
+    info!(
+        "Validating server certificate against: {}",
+        user_cert_path.display()
+    );
 
     // Step 1: Load user-provided certificate
     let user_cert_der = load_certificate_from_file(user_cert_path)?;
@@ -186,11 +189,12 @@ mod tests {
 
     #[test]
     fn test_load_certificate_file_not_found() {
-        let result = load_certificate_from_file("/nonexistent/path/cert.cer");
+        let p = Path::new("/nonexistent/path/cert.cer");
+        let result = load_certificate_from_file(p);
         assert!(result.is_err());
         match result {
             Err(Error::CertificateNotFound { path }) => {
-                assert!(path.contains("nonexistent"));
+                assert!(path == p);
             }
             _ => panic!("Expected CertificateNotFound error"),
         }
@@ -199,7 +203,7 @@ mod tests {
     #[test]
     fn test_load_certificate_from_pem() {
         // Path relative to the crate root
-        let cert_path = "tests/test_certificates/valid_cert.pem";
+        let cert_path = Path::new("tests/test_certificates/valid_cert.pem");
         let result = load_certificate_from_file(cert_path);
 
         match result {
@@ -219,7 +223,7 @@ mod tests {
     #[test]
     fn test_load_certificate_from_der() {
         // Path relative to the crate root
-        let cert_path = "tests/test_certificates/valid_cert.der";
+        let cert_path = Path::new("tests/test_certificates/valid_cert.der");
         let result = load_certificate_from_file(cert_path);
 
         match result {
@@ -239,13 +243,13 @@ mod tests {
     #[test]
     fn test_load_certificate_invalid_format() {
         // Path relative to the crate root
-        let cert_path = "tests/test_certificates/invalid_format.txt";
+        let cert_path = Path::new("tests/test_certificates/invalid_format.txt");
         let result = load_certificate_from_file(cert_path);
 
         assert!(result.is_err(), "Should fail to load invalid certificate");
         match result {
             Err(Error::InvalidCertificateFormat { path, .. }) => {
-                assert!(path.contains("invalid_format.txt"));
+                assert!(path == cert_path);
             }
             Err(e) => panic!("Expected InvalidCertificateFormat error, got: {:?}", e),
             Ok(_) => panic!("Should not succeed loading invalid certificate"),
@@ -255,8 +259,8 @@ mod tests {
     #[test]
     fn test_pem_and_der_certificates_produce_same_der() {
         // Both PEM and DER files contain the same certificate
-        let pem_path = "tests/test_certificates/valid_cert.pem";
-        let der_path = "tests/test_certificates/valid_cert.der";
+        let pem_path = Path::new("tests/test_certificates/valid_cert.pem");
+        let der_path = Path::new("tests/test_certificates/valid_cert.der");
 
         let pem_result = load_certificate_from_file(pem_path);
         let der_result = load_certificate_from_file(der_path);
@@ -283,7 +287,7 @@ mod tests {
     #[test]
     fn test_is_certificate_expired_valid() {
         // Our test certificate is valid for 10 years (3650 days)
-        let cert_path = "tests/test_certificates/valid_cert.pem";
+        let cert_path = Path::new("tests/test_certificates/valid_cert.pem");
         let der_bytes =
             load_certificate_from_file(cert_path).expect("Failed to load test certificate");
 

--- a/mssql-tds/src/connection/transport/certificate_validator.rs
+++ b/mssql-tds/src/connection/transport/certificate_validator.rs
@@ -25,7 +25,7 @@ use tracing::{debug, info};
 /// * `Ok(Vec<u8>)` - DER-encoded certificate data
 /// * `Err(Error)` - File not found, IO error, or invalid format
 pub fn load_certificate_from_file(path: &Path) -> TdsResult<Vec<u8>> {
-    debug!("Loading certificate from file: {}", path.display());
+    debug!("Loading certificate from file: {path:?}");
 
     // Check if file exists
     if !path.exists() {
@@ -59,8 +59,7 @@ pub fn load_certificate_from_file(path: &Path) -> TdsResult<Vec<u8>> {
         })?;
 
     info!(
-        "Successfully loaded certificate from: {} ({} bytes)",
-        path.display(),
+        "Successfully loaded certificate from: {path:?} ({} bytes)",
         der_data.len()
     );
     Ok(der_data)
@@ -135,10 +134,7 @@ pub fn constant_time_compare(a: &[u8], b: &[u8]) -> bool {
 /// * `Ok(())` - Certificates match and server cert is valid
 /// * `Err(Error)` - Validation failed
 pub fn validate_server_certificate(user_cert_path: &Path, server_cert_der: &[u8]) -> TdsResult<()> {
-    info!(
-        "Validating server certificate against: {}",
-        user_cert_path.display()
-    );
+    info!("Validating server certificate against: {user_cert_path:?}");
 
     // Step 1: Load user-provided certificate
     let user_cert_der = load_certificate_from_file(user_cert_path)?;

--- a/mssql-tds/src/connection/transport/certificate_validator.rs
+++ b/mssql-tds/src/connection/transport/certificate_validator.rs
@@ -194,7 +194,7 @@ mod tests {
         assert!(result.is_err());
         match result {
             Err(Error::CertificateNotFound { path }) => {
-                assert!(path == p);
+                assert_eq!(path, p);
             }
             _ => panic!("Expected CertificateNotFound error"),
         }
@@ -249,7 +249,7 @@ mod tests {
         assert!(result.is_err(), "Should fail to load invalid certificate");
         match result {
             Err(Error::InvalidCertificateFormat { path, .. }) => {
-                assert!(path == cert_path);
+                assert_eq!(path, cert_path);
             }
             Err(e) => panic!("Expected InvalidCertificateFormat error, got: {:?}", e),
             Ok(_) => panic!("Should not succeed loading invalid certificate"),

--- a/mssql-tds/src/connection/transport/ssl_handler.rs
+++ b/mssql-tds/src/connection/transport/ssl_handler.rs
@@ -175,10 +175,7 @@ impl SslHandler {
             Ok(mut stream) => {
                 // If ServerCertificate is specified, perform certificate validation
                 if let Some(cert_path) = &self.encryption_options.server_certificate {
-                    info!(
-                        "Validating server certificate using: {}",
-                        cert_path.display()
-                    );
+                    info!("Validating server certificate using: {cert_path:?}",);
 
                     // Get the server's certificate from the TLS stream
                     let peer_cert = stream

--- a/mssql-tds/src/connection/transport/ssl_handler.rs
+++ b/mssql-tds/src/connection/transport/ssl_handler.rs
@@ -175,7 +175,10 @@ impl SslHandler {
             Ok(mut stream) => {
                 // If ServerCertificate is specified, perform certificate validation
                 if let Some(cert_path) = &self.encryption_options.server_certificate {
-                    info!("Validating server certificate using: {}", cert_path);
+                    info!(
+                        "Validating server certificate using: {}",
+                        cert_path.display()
+                    );
 
                     // Get the server's certificate from the TLS stream
                     let peer_cert = stream
@@ -827,7 +830,7 @@ mod tests {
     #[test]
     fn server_certificate_enables_pinning_mode() {
         let mut opts = default_options();
-        opts.server_certificate = Some("cert.pem".to_string());
+        opts.server_certificate = Some("cert.pem".into());
         let config =
             SslHandler::resolve_tls_validation(&opts, NegotiatedEncryptionSetting::Mandatory);
         assert!(config.accept_invalid_certs);
@@ -837,7 +840,7 @@ mod tests {
     #[test]
     fn server_certificate_takes_precedence_over_login_only() {
         let mut opts = default_options();
-        opts.server_certificate = Some("cert.pem".to_string());
+        opts.server_certificate = Some("cert.pem".into());
         let config =
             SslHandler::resolve_tls_validation(&opts, NegotiatedEncryptionSetting::LoginOnly);
         assert!(config.accept_invalid_certs);

--- a/mssql-tds/src/core.rs
+++ b/mssql-tds/src/core.rs
@@ -4,6 +4,7 @@
 use crate::error::Error;
 use crate::error::Error::OperationCancelledError;
 use std::future::Future;
+use std::path::PathBuf;
 use tokio_util::sync::CancellationToken;
 
 /// Alias for `Result<T, crate::error::Error>` used throughout the crate.
@@ -150,7 +151,7 @@ pub struct EncryptionOptions {
     /// Path to a DER or PEM encoded X.509 certificate file for certificate pinning.
     /// When specified, the driver performs an exact binary match between the provided
     /// certificate and the server's certificate, bypassing standard CA chain validation.
-    pub server_certificate: Option<String>,
+    pub server_certificate: Option<PathBuf>,
 }
 
 impl EncryptionOptions {

--- a/mssql-tds/src/error/mod.rs
+++ b/mssql-tds/src/error/mod.rs
@@ -3,6 +3,8 @@
 
 pub mod bulk_copy_errors;
 
+use std::path::PathBuf;
+
 pub use bulk_copy_errors::{BulkCopyAttentionTimeoutError, BulkCopyError, BulkCopyTimeoutError};
 
 use crate::security::SecurityError;
@@ -170,7 +172,7 @@ pub enum Error {
     )]
     CertificateNotFound {
         /// File path that was looked up.
-        path: String,
+        path: PathBuf,
     },
 
     /// Certificate file is present but cannot be parsed.
@@ -179,7 +181,7 @@ pub enum Error {
     )]
     InvalidCertificateFormat {
         /// File path with the invalid certificate.
-        path: String,
+        path: PathBuf,
     },
 
     /// Server certificate has passed its validity period.
@@ -200,7 +202,7 @@ pub enum Error {
     )]
     CertificateFileIoError {
         /// File path that could not be read.
-        path: String,
+        path: PathBuf,
         /// Underlying I/O error message.
         error: String,
     },

--- a/mssql-tds/tests/test_mock_server.rs
+++ b/mssql-tds/tests/test_mock_server.rs
@@ -492,7 +492,7 @@ mod mock_server_tests {
             mode: EncryptionSetting::PreferOff, // Use PreferOff since mock server doesn't support TLS
             trust_server_certificate: true,
             host_name_in_cert: None,
-            server_certificate: Some("/nonexistent/path/certificate.cer".to_string()),
+            server_certificate: Some("/nonexistent/path/certificate.cer".into()),
         };
 
         // Attempt to connect - should succeed since encryption is off
@@ -557,7 +557,7 @@ mod mock_server_tests {
             mode: EncryptionSetting::Required,
             trust_server_certificate: true, // This should be ignored
             host_name_in_cert: None,
-            server_certificate: Some(cert_path.to_str().unwrap().to_string()),
+            server_certificate: Some(cert_path.clone()),
         };
 
         // Attempt to connect - ServerCertificate should take precedence
@@ -628,7 +628,7 @@ mod mock_server_tests {
             mode: EncryptionSetting::PreferOff, // Use PreferOff since mock server doesn't support TLS
             trust_server_certificate: true,
             host_name_in_cert: Some("custom.hostname.com".to_string()),
-            server_certificate: Some(cert_path.to_str().unwrap().to_string()),
+            server_certificate: Some(cert_path.clone()),
         };
 
         // Attempt to connect - with PreferOff, may succeed but both options set is unusual
@@ -791,7 +791,7 @@ mod mock_server_tests {
                 mode: EncryptionSetting::Strict, // TDS 8.0 - direct TLS
                 trust_server_certificate: false,
                 host_name_in_cert: None,
-                server_certificate: Some("tests/test_certificates/valid_cert.pem".to_string()),
+                server_certificate: Some("tests/test_certificates/valid_cert.pem".into()),
             };
 
             let provider = TdsConnectionProvider {};
@@ -835,7 +835,7 @@ mod mock_server_tests {
                 mode: EncryptionSetting::Strict,
                 trust_server_certificate: false,
                 host_name_in_cert: None,
-                server_certificate: Some("tests/test_certificates/valid_cert.pem".to_string()),
+                server_certificate: Some("tests/test_certificates/valid_cert.pem".into()),
             };
 
             let provider = TdsConnectionProvider {};

--- a/mssql-tds/tests/test_mock_server_tls.rs
+++ b/mssql-tds/tests/test_mock_server_tls.rs
@@ -324,7 +324,7 @@ mod mock_server_tls_tests {
             mode: EncryptionSetting::Strict,
             trust_server_certificate: false,
             host_name_in_cert: None,
-            server_certificate: Some("tests/test_certificates/valid_cert.pem".to_string()),
+            server_certificate: Some("tests/test_certificates/valid_cert.pem".into()),
         };
 
         let provider = TdsConnectionProvider {};


### PR DESCRIPTION
Change server_certificate to PathBuf since not all valid paths can be represented as strings (e.g., paths with non-UTF-8 characters).

<!--
Thank you for your interest in this project!

This repository is not currently accepting external pull requests. If you've found
a bug or have a feature request, please open an issue instead.

If you are a Microsoft team member, please follow the instructions in the internal
contribution guide.
-->

## Description

<!-- Briefly describe the change. -->

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [ ] `cargo btest` passes
- [x] New/changed functionality has tests
- [x] Public API changes are documented - Changelog says unleasead, which should allow for any breaking changes?
