### PR TITLE
Sync ADO main to GitHub main

### DIFF
--- a/.pipeline/OneBranch/NonOfficialPythonWheelsPublish.yml
+++ b/.pipeline/OneBranch/NonOfficialPythonWheelsPublish.yml
@@ -8,8 +8,10 @@
 # Support:        https://aka.ms/onebranchsup                                   #
 #################################################################################
 
+# CI trigger only on development. Main-branch coverage comes from the
+# Official pipeline (on merge) and the nightly schedule below; no need to
+# also fire NonOfficial on every merge to main.
 trigger:
-- main
 - development
 
 pr:

--- a/.pipeline/OneBranch/OfficialPythonWheelsBuild.yml
+++ b/.pipeline/OneBranch/OfficialPythonWheelsBuild.yml
@@ -10,8 +10,13 @@
 # Support:        https://aka.ms/onebranchsup                                   #
 #################################################################################
 
-# No CI or PR triggers — official builds are manual only
-trigger: none
+# Official build runs on every merge to main; no PR validation (PRs are
+# validated by the separate validation pipeline). Can also be queued manually.
+trigger:
+  batch: true
+  branches:
+    include:
+      - main
 pr: none
 
 variables:

--- a/.pipeline/validation-pipeline.yml
+++ b/.pipeline/validation-pipeline.yml
@@ -1,5 +1,6 @@
-trigger: 
-- main
+# CI trigger only on development. Main-branch builds are produced by the
+# Official pipeline (OneBranch/OfficialPythonWheelsBuild.yml) on merge.
+trigger:
 - development
 
 parameters:

--- a/docs/github-migration-plan.md
+++ b/docs/github-migration-plan.md
@@ -1,0 +1,415 @@
+# Plan: Move Development to GitHub, Rename ADO `main` → `stable`
+
+## Problem
+
+Today the source-of-truth for development is Azure DevOps (`mssql-rs/mssql-rs`):
+
+- Contributors PR to ADO `development`.
+- ADO `validation-pipeline.yml` runs on PR + on push to `development`.
+- A helper pipeline (`sync-development-to-main.yml`) auto-opens an ADO PR `development → main` once `development` is green.
+- OneBranch official build runs on push to ADO `main`. Releases come from there.
+- ADO `main` is one-way mirrored to `github.com/microsoft/mssql-rs` `main` for transparency.
+
+We want to flip this so GitHub is the development surface, ADO is the release surface:
+
+- Contributors PR to GitHub `main` (which becomes the new "development" branch).
+- ADO `main` is renamed to `stable`. `stable` is the release branch.
+- `validation-pipeline.yml` is **split into two separate pipeline YAMLs** so each can be authorized on a different set of service connections:
+  - **`validation-pipeline-pr.yml`** — runs on PR open/update against GitHub `main`. Stages: `Build`, `Kerberos_Test_PR` (2 distros), `Build_mssql_python` cross-repo. Acts as the required GitHub PR check. **Authorized on a single read-only SC** (`mssqlrs-acr-pull`, AcrPull on `tdslibrs`) — no ACI, no ACR push, no Azure SQL, no broad subscription scope. Safe to run from contributor (eventually fork) source.
+  - **`validation-pipeline-ci.yml`** — runs on push to GitHub `main` (post-merge only). Stages: full distro matrix (`Test_alpine`, `Test_alpine_arm64`, `Test_amd64`, `Test_arm64`), `Kerberos_Test_Full` (9 distros), `PrivateLink_Smoke`. **Authorized on the elevated SCs** (ACI deploy, ACR push, MI handling) because it only ever runs from already-merged trusted code on `main`.
+  - The split replaces the `Build.Reason == 'PullRequest'` stage gating that exists today in a single `validation-pipeline.yml`. Common stage YAML lives in `templates/` and is referenced by both pipelines.
+- The GitHub→ADO sync is gated on **`validation-pipeline-ci.yml`** going green — never on the PR pipeline. Only after the CI pipeline passes on GitHub `main` does the sync pipeline open the ADO PR to `stable`.
+- All releases (OneBranch official build / release) continue to run from ADO `stable`.
+
+## Decisions (confirmed)
+
+| Topic | Decision |
+|---|---|
+| `stable` on GitHub | **No mirror** — `stable` lives only in ADO. |
+| PR validation CI for GitHub PRs | **ADO pipelines via Azure Pipelines GitHub App** (existing 1ES pools, ACR, internal feeds). Fork PRs require maintainer approval. |
+| GitHub → ADO sync | **Auto-create ADO PR** when GitHub `main` CI is green; human gates the merge. |
+| ADO `development` branch | **Keep** as transitional/internal branch (do not delete). |
+| External contributors | **Internal Microsoft contributors first**, open externally in a later phase. |
+| Cutover style | **Phased** — stand up GitHub flow in parallel, then deprecate ADO `development` PRs. |
+| Validation pipeline shape | **Split** `validation-pipeline.yml` into `validation-pipeline-pr.yml` and `validation-pipeline-ci.yml` so PR runs and post-merge CI runs can be authorized on different (least-privilege) service connections. |
+| ADO project hosting | **`validation-pipeline-pr.yml` lives in a public ADO project** so external GitHub PR viewers can click through to the check and read the run/logs anonymously. **All other pipelines — including `validation-pipeline-ci.yml`, the sync pipeline, `fuzz-pipeline.yml`, `benchmark-pipeline.yml`, and the OneBranch Official Build/Release — stay in the existing private `mssql-rs/mssql-rs` project**, even when their source repo is GitHub. The elevated service connections (`mssqlrs-aci-deploy`, `mssqlrs-acr-push`) live in the private project; only `mssqlrs-acr-pull` (read-only) is created in the public project. |
+
+## Target end-state
+
+```
+GitHub: microsoft/mssql-rs
+  main    ← contributors send PRs here
+            • PR opened/updated  → validation-pipeline-pr.yml (Build + Kerberos_Test_PR + Build_mssql_python)
+                                    AcrPull-only SC; posts required PR check back to GitHub
+            • PR merged to main → validation-pipeline-ci.yml
+                                    (full Test_alpine / amd64 / arm64 matrix, Kerberos_Test_Full, PrivateLink_Smoke)
+                                    holds the ACI / ACR / MI service connections
+            • CI green on main  → sync pipeline auto-opens ADO PR (GitHub main → ADO stable)
+
+Azure DevOps: mssql-rs/mssql-rs
+  stable  ← release branch (renamed from `main`)
+            • merge from sync PR → OneBranch Official Build (Wheels) triggers on push
+            • Manual release    → OneBranch Release pipeline (publish NuGet, tag, branch)
+  development ← retained as transitional/internal branch (no longer the dev surface)
+```
+
+## Visual overview
+
+> Mermaid blocks below use the Azure DevOps Wiki fence syntax (`::: mermaid` ... `:::`) instead of the standard fenced code block. They use only `flowchart` and `sequenceDiagram` types, plain ASCII labels (no `<br/>`, no emoji, no special unicode), no `stateDiagram-v2` composite states, and no thick (`==>`) or piped-label link variants.
+
+### Today (current state)
+
+::: mermaid
+flowchart LR
+    Dev([Developer])
+    subgraph ADO["Azure DevOps - mssql-rs/mssql-rs"]
+        ADOdev[(development)]
+        ADOmain[(main)]
+        ValPipe{{validation-pipeline.yml}}
+        SyncPipe{{sync-development-to-main.yml}}
+        OBBuild{{OneBranch Official Build}}
+        OBRelease{{OneBranch Release}}
+    end
+    subgraph GH["GitHub - microsoft/mssql-rs (mirror)"]
+        GHmain[("main (read-only mirror)")]
+    end
+
+    Dev -- "PR" --> ADOdev
+    ADOdev -- "PR / push triggers" --> ValPipe
+    ValPipe -- "green" --> SyncPipe
+    SyncPipe -- "auto-PR" --> ADOmain
+    ADOmain -- "push triggers" --> OBBuild
+    OBBuild -- "manual" --> OBRelease
+    ADOmain -- "one-way mirror" --> GHmain
+:::
+
+### Target (after cutover)
+
+::: mermaid
+flowchart LR
+    Dev([Microsoft contributor])
+    subgraph GH["GitHub - microsoft/mssql-rs (authoritative for dev)"]
+        GHmain[(main)]
+    end
+    subgraph ADOPub["Azure DevOps - public project (anon read)"]
+        ValPipePR{{"validation-pipeline-pr.yml (AcrPull only)"}}
+    end
+    subgraph ADO["Azure DevOps - mssql-rs/mssql-rs (private)"]
+        ADOstable[("stable (release branch)")]
+        ADOdev2[("development (internal-only)")]
+        ValPipeCI{{"validation-pipeline-ci.yml (elevated SCs)"}}
+        SyncNew{{sync-github-main-to-stable.yml}}
+        OBBuild2{{OneBranch Official Build}}
+        OBRelease2{{OneBranch Release}}
+    end
+
+    Dev -- "PR to main" --> GHmain
+    GHmain -- "PR trigger" --> ValPipePR
+    ValPipePR -. "required check" .-> GHmain
+    GHmain -- "push trigger (post-merge)" --> ValPipeCI
+    ValPipeCI -- "pipeline-completion" --> SyncNew
+    SyncNew -- "auto-PR (human approves)" --> ADOstable
+    ADOstable -- "push triggers" --> OBBuild2
+    OBBuild2 -- "manual" --> OBRelease2
+:::
+
+### PR to release sequence
+
+::: mermaid
+sequenceDiagram
+    autonumber
+    actor Dev as Microsoft contributor
+    participant GH as GitHub main
+    participant ADOPR as validation-pipeline-pr.yml
+    participant ADOCI as validation-pipeline-ci.yml
+    participant Sync as sync-github-main-to-stable
+    participant Stable as ADO stable
+    participant OB as OneBranch (Build then Release)
+
+    Dev->>GH: Open PR to main
+    GH->>ADOPR: PR trigger (AcrPull-only SC)
+    ADOPR-->>GH: Required check (Build + Kerberos_PR + mssql-python build)
+    Dev->>GH: Merge PR
+    GH->>ADOCI: Push trigger (elevated SCs)
+    ADOCI->>ADOCI: Full distro matrix + Kerberos_Full + PrivateLink_Smoke
+    ADOCI-->>Sync: pipeline-completion (Succeeded only)
+    Sync->>Stable: Fast-forward sync/github-main and open or update the rolling PR into stable
+    Note over Stable: Human reviewer approves & merges
+    Stable->>OB: Push triggers Official Build (wheels)
+    OB->>OB: Manual release (publish NuGet, tag, branch)
+:::
+
+### Cutover phase progression
+
+::: mermaid
+flowchart TB
+    Today["Today: ADO development = dev surface, ADO main = release, GitHub main = mirror"]
+    Phase0["Phase 0: Audit pipelines and secrets"]
+    Phase1a["Phase 1a: Harden secrets and service connections"]
+    Phase1b["Phase 1b: Stand up GitHub-source pipeline (parallel run)"]
+    Phase2["Phase 2: Build sync GitHub main to stable"]
+
+    subgraph Cutover["Phase 3: Cutover window"]
+        direction TB
+        C1["Freeze ADO development"]
+        C2["Rename ADO main to stable"]
+        C3["Stop ADO to GitHub mirror"]
+        C4["Land branch-ref YAML edits"]
+        C5["Promote GitHub PR check to required"]
+        C6["Internalize ADO development"]
+        C7["Announce"]
+        C1 --> C2 --> C3 --> C4 --> C5 --> C6 --> C7
+    end
+
+    Phase4["Phase 4: Hardening and cleanup"]
+    Steady["Steady state: GitHub main = dev surface, ADO stable = release, ADO development = internal-only"]
+    Phase5["Phase 5 (deferred): Open to external contributors (CLA, GH Actions)"]
+
+    Today --> Phase0 --> Phase1a --> Phase1b --> Phase2 --> Cutover --> Phase4 --> Steady --> Phase5
+:::
+
+### Trust boundary and service connections (Phase 1a)
+
+::: mermaid
+flowchart TB
+    subgraph GHrun["GitHub-sourced pipeline run (wider trust boundary)"]
+        Job["Pipeline job"]
+    end
+
+    subgraph SC["Purpose-scoped OIDC service connections"]
+        SCAci["mssqlrs-aci-deploy: scope rg=rust-lib-rg, role ACI ops only"]
+        SCAcr["mssqlrs-acr-push: scope ACR=tdslibrs, role AcrPush"]
+    end
+
+    subgraph Azure["Azure resources"]
+        ACI["ACI in trusted VNet, MI auth only"]
+        ACR["ACR tdslibrs"]
+        SQL["Azure SQL mssqlrustlibtest, MI auth (no password)"]
+    end
+
+    Job -- "least-privilege OIDC token" --> SCAci
+    Job -- "least-privilege OIDC token" --> SCAcr
+    SCAci -- "deploy / delete only" --> ACI
+    SCAcr -- "push image" --> ACR
+    ACI -- "MI auth" --> SQL
+    ACI -. "pull image" .-> ACR
+
+    Banned["Removed: stored ACI SQL password; subscription-wide Magnitude Test on GitHub-source pipeline; variable groups with secrets"]
+    GHrun -. "no longer references" .-> Banned
+:::
+
+## Phased rollout
+
+### Phase 0 — Pre-work (no user-visible change)
+
+- Audit every `.pipeline/**/*.yml` reference to `development` and `main` and decide the new branch each one points at.
+  - `OneBranch/OfficialPythonWheelsBuild.yml`: `main` → `stable`.
+  - `OneBranch/OfficialPythonWheelsRelease.yml`: resource ref `refs/heads/main` → `refs/heads/stable`.
+  - `OneBranch/NonOfficialPythonWheelsPublish.yml`: trigger `development` → GitHub `main`; PR `main`/`development` → GitHub `main`; nightly schedule `main` → `stable`; resource ref `refs/heads/main` → `refs/heads/stable`.
+  - `validation-pipeline.yml`: **split** into `validation-pipeline-pr.yml` (PR trigger on GitHub `main`) and `validation-pipeline-ci.yml` (CI trigger on push to GitHub `main`). Move all reusable stages into `templates/` so both files are thin wrappers.
+  - `fuzz-pipeline.yml`: schedule branches `main`, `development` → `stable`, GitHub `main`.
+  - `benchmark-pipeline.yml`: PR branches `main`, `development` → GitHub `main`; `baselineBranch` default → GitHub `main`.
+  - `sync-container-images.yml`: branches `development`, `main` → `stable` (and GitHub `main` if needed).
+  - `sync-development-to-main.yml`: **delete** (replaced by new sync below).
+  - `templates/test-mssql-python-template.yml` + `-macos`: confirm `MSSQL_PYTHON_BRANCH=main` fallback still correct (it points at `microsoft/mssql-python`, unrelated to this rename).
+- Decide on `mssql-python` cross-repo branch references (`docs/release-management.md` mentions "main/development" — needs rewording for `stable` vs GitHub `main`).
+- Inventory secret/service-connection access from GitHub-triggered runs (1ES pool authorization, ACR pull token, NuGet feed PAT, OneBranch service connections).
+
+### Phase 1 — Stand up GitHub PR + CI validation in parallel
+
+Goal: GitHub PRs to `main` produce the same PR check signal that ADO `development` PRs do today, **and** post-merge pushes to GitHub `main` produce the same full CI matrix run that pushes to ADO `development` do today — **without** disrupting the existing ADO `development` flow, and with PR runs and CI runs cleanly separated so they can hold different service-connection grants.
+
+`validation-pipeline.yml` today encodes both modes in one file via `eq(variables['Build.Reason'], 'PullRequest')` conditions. We split it into two YAMLs (`validation-pipeline-pr.yml` and `validation-pipeline-ci.yml`) sharing the same stage templates from `templates/`. Each ADO pipeline definition points at one YAML and is authorized on its own service connections.
+
+#### Phase 1a — Secret & service-connection hardening (prerequisite)
+
+GitHub-sourced runs broaden the trust boundary (compromised contributor account, future fork PRs, leak via build logs). Before any GitHub trigger goes live, the pipeline must be safe to run under that wider trust model. Concretely:
+
+1. **Verify (and keep) the no-stored-SQL-password posture.**
+   - Audited as of this plan: every pipeline that needs a SQL Server password generates it per-job via `templates/generate-sql-password-template.yml` (job-scoped, secret-masked, ephemeral). Confirmed callers: `sql-setup-template.yml`, `build-template.yml`, `build-template-container.yml`, `test-longhaul-template.yml`, `test-matrix-template-alpine.yml`. `benchmark-pipeline.yml` inherits via `sql-setup-template.yml`.
+   - Audited: `private-link-smoke-template.yml` connects to Azure SQL via **managed identity only** (`SMOKE_AUTH_MODE=managed_identity`, `MI_CLIENT_ID=…`, no password env var passed to the smoke container).
+   - No stored SQL credential exists in a pipeline variable group today.
+   - **Action**: add a CI guardrail (a small linter step in `validation-pipeline.yml`, or a docs-and-PR-template note) that flags any new template that introduces a `SQL_PASSWORD`, `MSSQL_SA_PASSWORD`, or similar pipeline variable / variable-group reference instead of including `generate-sql-password-template.yml` or using MI. The goal is to prevent regression once GitHub-sourced runs are live.
+
+2. **Remove the ACI SQL host from pipeline-protected configuration.**
+   - The Azure SQL server FQDN (`mssqlrustlibtest.database.windows.net`) and database name are currently template parameters with defaults — that's already non-secret. Confirm there is no variable group / secret variable holding host info that GitHub-sourced runs would inherit. Keep host/DB as plain template parameters, or move to a non-secret pipeline variable.
+   - Document explicitly in the smoke template that host/DB are non-sensitive (the security boundary is at the network + MI level, not at hostname obscurity).
+
+3. **Split the `Magnitude Test` service connection by trust boundary.**
+   - Today this service connection is used by `azure-cli-login-template.yml`, `sync-container-images.yml`, `private-link-smoke-template.yml`, `test-longhaul-template.yml`, and `build-template-container.yml` — i.e. broad subscription-level Azure access.
+   - Trust-boundary rule for the split:
+     - **`validation-pipeline-pr.yml`** (runs from contributor source, eventually from forks): authorized on **exactly one** Azure service connection — `mssqlrs-acr-pull` — with **AcrPull only** on ACR `tdslibrs`. This is the minimum needed to pull build images for the PR build/test stages. Read-only, single resource, no mutating action, no SQL access, no MI handout, no VNet rights. Any stage that needs more than image pull does **not** belong in the PR pipeline.
+     - **`validation-pipeline-ci.yml`** (runs only from already-merged code on `main`): authorized on the new least-privilege OIDC-federated service connections below.
+   - The new connections:
+     - `mssqlrs-acr-pull` — **AcrPull only** on ACR `tdslibrs`. **PR pipeline only.**
+     - `mssqlrs-aci-deploy` — can only manage ACI in `rust-lib-rg`. CI pipeline only. Used by `private-link-smoke-template.yml`.
+     - `mssqlrs-acr-push` — **AcrPush** on ACR `tdslibrs`. CI pipeline only. Used by `sync-container-images.yml` and the smoke build step.
+     - `mssqlrs-storage-readonly` — only if any pipeline needs blob/Key Vault read; otherwise omit.
+   - Because the CI pipeline only runs from `main` after a human-reviewed merge, the elevated SCs (`mssqlrs-aci-deploy`, `mssqlrs-acr-push`) are never exposed to PR-time code execution. A forked PR (Phase 5) physically cannot trigger `validation-pipeline-ci.yml` — it has no PR trigger. The worst a malicious PR can do via `mssqlrs-acr-pull` is read public-to-the-pipeline image bytes from one ACR.
+
+   **Outline of the work (suggestive — needs further research before execution):**
+
+   - Pick an identity type for each new service connection. The Microsoft corp tenant restricts `az ad app create`, so a classic Entra app registration likely needs an Identity Service request; a User-Assigned Managed Identity in our subscription may be a friendlier option. Confirm which one OneBranch / 1ES guidance currently recommends for ADO workload-identity federation in our org.
+   - Decide the RBAC scope and role for each connection. Aim for the smallest scope that works (resource group for ACI, the ACR resource itself for image push, AcrPull on the same ACR for the PR connection). Built-in roles `AcrPull` / `AcrPush` cover the ACR cases; for ACI a custom role limited to `Microsoft.ContainerInstance/*` plus the VNet `join/action` is likely better than `Contributor`, but the exact action list needs to be verified against `private-link-smoke-template.yml` behavior.
+   - Create each ADO service connection using the **Workload Identity federation (manual)** option and bind it to the identity from above. The exact UI flow and the federation subject claim format are evolving — check current ADO docs at the time of execution.
+   - Lock each connection down: disable "Grant access permission to all pipelines" and grant access explicitly to the one pipeline definition that needs it (`mssqlrs-acr-pull` → PR definition only; `mssqlrs-aci-deploy` / `mssqlrs-acr-push` → CI definition only). Add an approval check for runs originating from forked PRs (dormant while internal-only, useful for Phase 5).
+   - Parameterize `azure-cli-login-template.yml` and the ACI / ACR templates so the service-connection name comes from a parameter instead of being hardcoded to `Magnitude Test`. Keep the legacy default during the parallel period so the ADO-source pipeline is untouched; the GitHub-source pipelines pass the new least-privilege connection names.
+   - Verify after wiring: queue a restricted run of each GitHub-source pipeline and confirm subscription-wide Azure operations fail with `AuthorizationFailed`; confirm the PR pipeline can only pull from ACR; confirm the CI pipeline can do ACI deploy + ACR push but nothing else.
+
+   **Open research items before this can be executed:**
+   - Which identity type (UAMI vs Entra app via Identity Service request) is the supported path in the corp tenant today; what the lead time is for either.
+   - Exact list of `Action` / `DataAction` permissions needed for the ACI deploy + VNet-injection flow used by `private-link-smoke-template.yml` (drives the custom role definition).
+   - Whether OneBranch official build pipelines have any opinion on / requirement for which service connection performs the smoke deploy.
+   - Whether `test-longhaul-template.yml` and `build-template-container.yml` truly need their current `Magnitude Test` scope, or can move to one of the narrower connections (avoids leaving `Magnitude Test` in use as a back door).
+   - Whether the PR pipeline's image pulls can be served by an anonymous-pull ACR repository or by a build-pool-side credential, removing the need for `mssqlrs-acr-pull` entirely.
+
+   **Why split + federate** (rather than just narrow `Magnitude Test`):
+   - One identity per blast radius — compromising the ACR-push connection cannot delete ACI; compromising the ACI connection cannot push malicious images; the PR connection can only read from one ACR.
+   - OIDC federation eliminates stored client secrets, so a leaked pipeline log or a compromised ADO project secret store can't be replayed.
+   - Per-pipeline authorization stops a future ADO pipeline (or a forked-PR run) from silently inheriting these credentials.
+
+4. **Lock down `System.AccessToken` scope.**
+   - On the new GitHub-source pipeline definition, set "Limit job authorization scope to current project" (already default) and "Protect access to repositories in YAML pipelines" → require the pipeline to declare every repo it touches under `resources.repositories`.
+
+5. **Pipeline-side approval gate for protected resources.**
+   - For each new least-privilege service connection, enable "Approvals and checks" → require a maintainer approval for any run from a forked PR. This is dormant while we're internal-only but pre-wires Phase 5.
+
+6. **Audit existing variable groups.**
+   - Enumerate every variable group (`Library` in ADO) referenced by the pipelines we're enabling on GitHub. Remove any secret that is no longer needed; for those that remain, mark them as pipeline-permission-restricted to the ADO-source pipeline definition only. The GitHub-source definition starts with **zero** variable group access and only adds what's strictly required after audit.
+
+7. **Log scrubbing check.**
+   - Run a probe job that echoes every variable used to confirm no surprise secret bleeds into logs visible to GitHub PR authors. The Azure Pipelines App posts log links into PRs.
+
+Exit criteria for Phase 1a: a dry-run of both `validation-pipeline-pr.yml` (authorized on `mssqlrs-acr-pull` only) and `validation-pipeline-ci.yml` (authorized on the new least-privilege OIDC SCs) on a throwaway GitHub branch passes, with no stored SQL credential and no broad-subscription token in either run. Confirm by inspecting each run's "Authorized resources" panel that the PR pipeline lists exactly one Azure SC (`mssqlrs-acr-pull`) and the CI pipeline lists only `mssqlrs-aci-deploy` + `mssqlrs-acr-push`.
+
+#### Phase 1b — GitHub pipeline wiring
+
+1. **(Already done)** Azure Pipelines GitHub App is installed on `microsoft/mssql-rs`. No action — proceed to defining pipelines against the GitHub source.
+2. Create the split YAMLs:
+   - `validation-pipeline-pr.yml` — only `pr:` trigger on GitHub `main`. Stages: `Build`, `Kerberos_Test_PR`, `Build_mssql_python`. Reuses templates from `templates/`. No `azure-cli-login-template.yml`, no ACI/ACR/MI references.
+   - `validation-pipeline-ci.yml` — only `trigger:` (CI) on push to GitHub `main`. Stages: `Test_alpine`, `Test_alpine_arm64`, `Test_amd64`, `Test_arm64`, `Kerberos_Test_Full`, `PrivateLink_Smoke`. May reference the elevated SCs from Phase 1a.
+   - The legacy `validation-pipeline.yml` stays in place during the parallel period (still triggered by ADO `development`) and is removed in Phase 4.
+3. Add **two new** ADO pipeline definitions (UI-created), both whose source repo is the GitHub repo, in the projects called out in the Decisions table:
+   - **Public ADO project** → pipeline pointing at `validation-pipeline-pr.yml`. **Authorize it on `mssqlrs-acr-pull` only** (AcrPull on `tdslibrs`, created in this same public project). Plus the 1ES pool and the NuGet feed PAT. Nothing else. This pipeline's runs/logs are anonymously readable, which is the whole reason it lives here.
+   - **Private `mssql-rs/mssql-rs` project** → pipeline pointing at `validation-pipeline-ci.yml`. **Authorize it on the new least-privilege OIDC SCs from Phase 1a** (`mssqlrs-aci-deploy`, `mssqlrs-acr-push`, etc., all created in the private project). Restrict to push events from `main` (no PR trigger). All other GitHub-sourced pipelines (`fuzz-pipeline.yml`, `benchmark-pipeline.yml`, etc.) also live here.
+   - Initially restrict the PR-pipeline trigger to PRs from internal Microsoft contributors (use the GitHub team allowlist on the pipeline definition).
+4. Confirm 1ES pool, ACR, NuGet feed, Kerberos test infra, and `mssql-python` cross-repo template all work when the source is GitHub, for both pipelines. Pay particular attention to:
+   - `persistCredentials`/`System.AccessToken` semantics differ for GitHub-sourced runs.
+   - Fork PRs cannot access protected resources — keep "approval for outside contributors" enabled on the PR pipeline (dormant while internal-only).
+   - The CI pipeline must succeed with only the elevated SCs (no fallback to `Magnitude Test`).
+5. Wire status checks back to GitHub (Azure Pipelines App does this automatically once installed). The PR pipeline posts the required check on the PR; the CI pipeline posts a status on the merge commit on `main`.
+6. Validate with a couple of test PRs on a throwaway branch — confirm both pipelines run on the right events and complete successfully.
+
+### Phase 2 — Build the GitHub-main → ADO-stable sync
+
+Replace `sync-development-to-main.yml` with a new pipeline:
+
+- **Trigger**: pipeline-completion trigger on **`validation-pipeline-ci.yml`** against GitHub `main` (the post-merge pipeline, not the PR pipeline). Optionally also a scheduled fallback (e.g. every 30 min) in case the completion trigger misfires.
+- **Source repo**: ADO `mssql-rs/mssql-rs` (so `az repos pr create` has the right context).
+- **Gating**: only proceeds if the upstream `validation-pipeline-ci.yml` run completed with `result == 'Succeeded'`. A failed CI run on GitHub `main` must NOT auto-promote to `stable`.
+- **Behavior** (single rolling sync PR, not one-PR-per-commit):
+  1. Fetch the GitHub `main` SHA the upstream CI run was built from (via `resources.pipelines.*.sourceCommit`).
+  2. **Use a single, stable working branch name — `sync/github-main`** (no SHA suffix) — and **fast-forward** it to that SHA in the ADO repo. If the working branch doesn't exist yet, create it. If a non-fast-forward update would be needed (someone hand-edited the working branch), fail loudly — never force-push.
+  3. Look up an existing **active** PR with source `sync/github-main` and target `stable`:
+     - **No active PR**: open one. Title: `Sync GitHub main → stable (<short-sha>)`. Description lists the commit range `<previous-stable-tip>..<github-main-sha>` with one bullet per GitHub commit (subject + author + GitHub URL) and a link to the green CI run.
+     - **Active PR exists**: do NOT open a second one. The branch fast-forward in step 2 has already updated the PR's source ref, so ADO automatically refreshes its diff and the file list. Update the PR title to the new HEAD short SHA and **append** the new commits to the description (mark previously-listed commits as already covered). Post a single PR comment summarizing what was added in this run and which CI run produced it. Reviewer votes are reset by the branch update; that is acceptable and intentional — the diff is now larger and needs re-review.
+  4. Skip the entire step if `git diff stable..sync/github-main` is empty (already merged, or upstream commit was a no-op against `stable`).
+  5. **Concurrency guard**: take a lease (e.g. an ADO build-tag-based mutex, or a short pipeline lock variable) so two CI runs completing back-to-back can't race on the branch update / PR open. The second run waits, then sees the first run's PR and falls through to the "active PR exists" path.
+  6. **Race with human merge**: if between step 2 (fast-forward) and step 3 (PR lookup) the human merges the PR, the next run will find no active PR and a non-empty diff, and will correctly open a fresh PR for the new commits since `stable`. Idempotent.
+- This produces **one open sync PR at all times** that always reflects the latest CI-green GitHub `main` HEAD; the human merges when ready, batches as many or as few commits as they like, and the next CI run after the merge starts the next batch.
+- Human reviewer merges the ADO PR → triggers OneBranch Official Build on `stable` → release flow unchanged.
+
+Add a one-time job (or document a manual step) to perform the **first** `stable ←→ GitHub main` reconciliation: at cutover, ADO `main` and GitHub `main` will diverge in history (rename + any in-flight merges), so the first sync may need a forced fast-forward or a merge commit.
+
+### Phase 3 — Cutover
+
+Schedule a cutover window (~1–2 hours):
+
+1. **Freeze** ADO `development` (branch policy: block all pushes/PRs).
+2. Drain in-flight ADO `development → main` PRs (merge or close).
+3. **Rename** in ADO: `main` → `stable`. (Update default branch in repo settings.)
+   - Update branch policies attached to the old `main` to attach to `stable`.
+   - Update any pipeline definitions whose "Default branch for manual and scheduled builds" was `main`.
+4. **Stop** the existing ADO `main` → GitHub `main` mirror job. From now on, GitHub `main` is authoritative; nothing else writes to it.
+5. Verify GitHub `main` HEAD matches ADO `stable` HEAD at this instant (they should — the mirror was the source).
+6. Merge the Phase-0 YAML edits (pipeline branch references) into ADO `stable` directly via a one-off `stable` PR (since `development` is frozen and GitHub-main validation is not yet promoted to required).
+7. Mirror that change forward to GitHub `main` (one-time push) so the two are in sync.
+8. **Promote** the GitHub-main validation pipeline (PR-mode) check to a **required** PR check on GitHub `main`. The CI-mode run is not a PR check (it runs on the merge commit) but its success is the gate for the GitHub→stable sync (Phase 2).
+9. Add GitHub branch protection on `main`: require PR, require Azure Pipelines check, require CODEOWNERS review, dismiss stale reviews, no force pushes, no deletion.
+10. Update `CONTRIBUTING.md`: document that PRs go to GitHub `main`; note that contributions are currently limited to Microsoft employees.
+11. Update `.github/copilot-instructions.md` ("Integration branch" wording) and the prompt files in `.github/prompts/` (`createPr.prompt.md`, `createDraftPr.prompt.md`) to target GitHub `main` instead of ADO `development`.
+12. Re-enable ADO `development` as a **read-only / internal-use** branch — keep it in case internal automation still references it, but block PRs to it via branch policy.
+13. Announce cutover (team channels, README banner if desired).
+
+### Phase 4 — Hardening & cleanup
+
+- Delete `sync-development-to-main.yml` from the ADO repo (after the new GitHub→stable sync has been observed working for ≥ 1 week).
+- Remove the legacy `validation-pipeline.yml` (and its ADO pipeline definition) once no PRs target ADO `development` and the GitHub-sourced PR + CI pipelines have been the source of truth for at least one full release cycle.
+- Remove the parallel ADO-source pipeline definition; leave only the GitHub-source one.
+- Update `docs/release-management.md` flow diagrams (replace "Push to main/development" with "Push to GitHub main" and "Push to ADO stable").
+- Verify `mssql-python` cross-repo flow still works (it pulls `mssql-py-core` artifacts by NuGet version; nothing in those artifacts depends on the old branch names, but confirm).
+- Decide on telemetry: ensure release notes/tags created by `OfficialPythonWheelsRelease.yml` reflect the `stable` branch correctly.
+
+### Phase 5 (deferred) — Open to external contributors
+
+Out of scope for this plan, but anticipated next:
+
+- Add Microsoft CLA bot.
+- Update `CONTRIBUTING.md` for external contributions.
+- **(Already done)** "Require approval for builds from forks" and "Limit job authorization scope" are already configured on the GitHub-source pipeline definition. Verify the settings still apply once the PR/CI pipeline split lands.
+- Consider a lightweight GitHub Actions workflow (fmt + clippy + unit tests on `ubuntu-latest`) so fork PRs get *some* signal without needing maintainer approval to run the heavyweight ADO matrix.
+
+## Files that will change
+
+Pipelines (all in `.pipeline/`):
+
+- `validation-pipeline.yml` — **split** into:
+  - New: `validation-pipeline-pr.yml` (PR pipeline; `mssqlrs-acr-pull` only)
+  - New: `validation-pipeline-ci.yml` (CI pipeline; holds elevated SCs)
+  - Legacy `validation-pipeline.yml` retained during parallel period, deleted in Phase 4.
+- `fuzz-pipeline.yml` — schedule branches
+- `benchmark-pipeline.yml` — PR branches + default param
+- `sync-container-images.yml` — branches
+- `sync-development-to-main.yml` — **delete** (Phase 4)
+- `OneBranch/OfficialPythonWheelsBuild.yml` — trigger branch + resource ref
+- `OneBranch/OfficialPythonWheelsRelease.yml` — resource ref
+- `OneBranch/NonOfficialPythonWheelsPublish.yml` — trigger + PR + schedule + resource ref
+- New: `.pipeline/sync-github-main-to-stable.yml`
+
+Docs / repo metadata:
+
+- `CONTRIBUTING.md`
+- `README.md` (banner, if desired)
+- `docs/release-management.md`
+- `.github/copilot-instructions.md`
+- `.github/prompts/createPr.prompt.md`
+- `.github/prompts/createDraftPr.prompt.md`
+- `.github/CODEOWNERS` (verify ownership rules still apply on GitHub PRs)
+- `.github/PULL_REQUEST_TEMPLATE.md` (verify wording is GitHub-appropriate)
+
+ADO / GitHub admin (no file changes — manual config):
+
+- ADO branch rename `main` → `stable`, default branch update, branch policy migration.
+- ADO branch policy on `development` → block PRs.
+- ADO pipeline definitions: update default branch for scheduled/manual runs.
+- Stop existing ADO→GitHub mirror job.
+- GitHub: install Azure Pipelines App, branch protection rules on `main`, add Microsoft team as code reviewers, update CODEOWNERS if needed.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| ADO pipelines triggered from GitHub can't access internal resources | Phase 1 validates this end-to-end before cutover; restrict to internal contributors so PR-secret-scope is acceptable. |
+| Divergent history at cutover | Phase 3 step 5 verifies HEAD parity; if mismatched, do a one-shot reset of GitHub `main` to ADO `stable` (or vice-versa) inside the freeze window. |
+| Existing scheduled triggers (nightly, fuzz, benchmark) silently stop firing because branch references go stale | Phase 0 inventory + Phase 4 verification with a calendar reminder one week post-cutover. |
+| Auto-sync pipeline opens duplicate PRs or loops | Reuse the dedup logic from `sync-development-to-main.yml` (check for active PR + diff); fast-forward-only push to working branch. |
+| Force-push or rewrite on GitHub `main` corrupts ADO `stable` | GitHub branch protection forbids force-push/delete; sync pipeline only fast-forwards. |
+| Release pipeline (OneBranch) misconfigured for `stable` | Run a dry-run release with `publishNuGet=false`, `tagRelease=false` (defaults) on `stable` immediately post-cutover before the next real release. |
+| Internal automation still pushes to ADO `development` | Phase 3 keeps `development` alive; Phase 4 monitors and removes once quiet. |
+
+## Open items (not blockers, decide during execution)
+
+- Pipeline-completion trigger vs scheduled fallback (or both) for the GitHub→stable sync.
+- What happens if CI-mode on GitHub `main` fails: alert channel, who triages, whether to auto-revert the GitHub merge or just block the next sync until a forward-fix lands.
+- Whether the GitHub-main validation pipeline should also publish coverage to GitHub PR comments (today `azurepipelines-coverage.yml` posts to ADO PRs).
+- Whether to keep `azurepipelines-coverage.yml` as-is or add a Codecov/GH-native alternative.

--- a/docs/issue_38_sp_prepare_named_params.md
+++ b/docs/issue_38_sp_prepare_named_params.md
@@ -1,0 +1,127 @@
+# GitHub issue [microsoft/mssql-rs#38](https://github.com/microsoft/mssql-rs/issues/38): sp_prepare fails when statement uses a non-int named parameter
+
+## Summary
+
+`TdsClient::execute_sp_prepare` was forwarding the user's named parameter
+values as RPC parameters on the `sp_prepare` call. `sp_prepare`'s signature
+is fixed (`@handle int OUTPUT, @params ntext, @stmt ntext, @options int`)
+and accepts no caller-supplied values; those belong on `sp_execute`,
+`sp_prepexec`, or `sp_executesql`. When the extra named arguments did not
+coincidentally fit the types `sp_prepare` expects, the server returned
+
+  Msg 214: Procedure expects parameter '@options' of type 'int'.
+
+`drain_stream()` collected the ERROR token but the call site dropped the
+returned `Vec<SqlErrorInfo>`. The post-drain shape check then saw
+`ColumnValues::Null` for the `@handle` output and raised the generic
+`ProtocolError("Expected an integer value")` reported in the issue.
+
+## Root cause
+
+In `mssql-tds/src/connection/tds_client.rs`, `execute_sp_prepare` built the
+RPC as:
+
+```rust
+let rpc = SqlRpc::new(
+    RpcType::ProcId(RpcProcs::Prepare),
+    positional_parameters,
+    Some(named_params),    // <-- bug: user values smuggled onto sp_prepare
+    &database_collation,
+    &self.execution_context,
+);
+```
+
+`SqlRpc::write_named_parameters` (`mssql-tds/src/message/rpc.rs`) iterates
+the named slice and serializes every entry on the wire. Because the wire
+contract for `sp_prepare` does not include user values, the server tried to
+bind those as `@options` and rejected anything that wasn't an int.
+
+The same call site also discarded `drain_stream`'s returned errors:
+
+```rust
+self.drain_stream().await?;     // returned Vec<SqlErrorInfo> dropped
+// ... shape check then raised a generic ProtocolError
+```
+
+This collapsed the real diagnostic into an unrelated message and is the
+reason the issue was originally misread as a parameter-declaration bug.
+
+## Fix
+
+`mssql-tds/src/connection/tds_client.rs::execute_sp_prepare`:
+
+- Pass `None` (not `Some(named_params)`) as the RPC named-parameter list.
+  `named_params` is still consumed locally to build the `@params` text
+  string serialized as the second positional argument; only the wire-level
+  RPC named arguments are dropped.
+- Capture the `Vec<SqlErrorInfo>` returned by `drain_stream()` and, when
+  non-empty, return `Error::SqlServerError { errors }` so callers see the
+  actual server diagnostic.
+
+The other RPC paths (`execute_sp_executesql`, `execute_sp_prepexec`) are
+correct as-is: those stored procedures' contracts include the user's
+parameter values after the fixed positional arguments, and the server
+expects them on the wire.
+
+## Tests
+
+Added in `mssql-tds/tests/test_rpc_results.rs` (the file already contains
+the other `sp_prepare` / `sp_prepexec` integration tests):
+
+- `test_sp_prepare_with_named_nvarchar_param_succeeds`: regression test
+  for [microsoft/mssql-rs#38](https://github.com/microsoft/mssql-rs/issues/38);
+  prepares a statement that references
+  `@db_name nvarchar(6)` and asserts a positive handle is returned, then
+  unprepares it.
+- `test_sp_prepare_surfaces_server_error_on_invalid_sql`: verifies the
+  diagnostics fix; preparing an undeclared-variable statement returns
+  `Error::SqlServerError` carrying the populated server message instead
+  of a generic `ProtocolError`.
+
+Both are integration tests; like the rest of the file they require the
+DB environment variables (`DB_HOST`, `DB_USERNAME`, `SQL_PASSWORD`).
+
+## Why the existing tests didn't catch this
+
+- The integration tests in `mssql-tds/tests/test_rpc_results.rs` for
+  `sp_prepare` (`test_sp_prepare_and_unprepare_multi_param`) only use
+  `Int` user parameters. SQL Server tolerates extra named values on
+  `sp_prepare` when their types happen to match what the optional
+  `@options` parameter accepts (int), so all-int tests pass against a
+  live server even though the code is wrong.
+- No existing test exercises `sp_prepare` with `NVarchar`, `NChar`,
+  `Decimal`, `DateTime2`, `Uuid`, `Vector`, or any other non-int user
+  parameter type.
+- No negative test asserts what happens when `sp_prepare` fails. With
+  the drained errors discarded, even a CI run that happened to surface
+  the bug would have reported the misleading
+  `ProtocolError("Expected an integer value")`.
+- No mock-server test exercises the wire-level RPC structure.
+  `mssql-mock-tds` exists but is not used to assert that `sp_prepare` is
+  sent without user named parameters or that ERROR tokens propagate as
+  `SqlServerError`.
+- The integration tests panic when `DB_HOST`/`DB_USERNAME`/`SQL_PASSWORD`
+  are not set (`mssql-tds/tests/common/mod.rs`). They cannot run as
+  unit-only checks, so the suite often runs in environments where the
+  prepare paths simply do not execute.
+
+## Test-coverage follow-ups
+
+These are scoped to the `sp_prepare` regression and would have caught
+this specific class of bug. They are not part of this fix.
+
+- Add per-type integration tests for `sp_prepare`, `sp_prepexec`, and
+  `sp_executesql` that cover at least: `Char`, `NChar`, `Varchar`,
+  `NVarchar`, `VarcharMax`, `NVarcharMax`, `Decimal` with explicit
+  precision and scale, `DateTime2`, `DateTimeOffset`, `Time`, `Uuid`,
+  `VarBinary`, `Vector`. This would have caught the
+  [microsoft/mssql-rs#38](https://github.com/microsoft/mssql-rs/issues/38)
+  regression on the first non-int type added.
+- Add a mock-TDS test that injects an ERROR token into the response
+  stream for an `sp_prepare` RPC and asserts the call surfaces it as
+  `SqlServerError`. This covers the diagnostics path without a live
+  server.
+- Make the integration helpers in `mssql-tds/tests/common/mod.rs` skip
+  cleanly (instead of panicking) when the database environment variables
+  are absent, so CI without a SQL Server can still run the unit-style
+  tests.

--- a/mssql-js/src/tracing_init.rs
+++ b/mssql-js/src/tracing_init.rs
@@ -47,10 +47,7 @@ fn get_trace_log_path() -> Option<PathBuf> {
 
         // Security check: warn about insecure paths but allow them
         if is_insecure_path(&path) {
-            eprintln!(
-                "[mssql-js] WARNING: Insecure log directory detected: '{}'",
-                path.display()
-            );
+            eprintln!("[mssql-js] WARNING: Insecure log directory detected: {path:?}",);
             eprintln!("[mssql-js] WARNING: Logs may contain sensitive data (queries, data etc).");
             eprintln!(
                 "[mssql-js] WARNING: Logging to /tmp, /var/tmp, or system temp directories is not recommended."
@@ -68,11 +65,7 @@ fn get_trace_log_path() -> Option<PathBuf> {
         if !path.exists()
             && let Err(e) = create_dir_all(&path)
         {
-            eprintln!(
-                "[mssql-js] ERROR: Could not create log directory '{}': {}",
-                path.display(),
-                e
-            );
+            eprintln!("[mssql-js] ERROR: Could not create log directory '{path:?}': {e}",);
             return None;
         }
         return Some(path.join(TRACE_LOG_FILENAME));
@@ -145,8 +138,7 @@ pub fn init_tracing() {
                             },
                             Err(e) => {
                                 eprintln!(
-                                    "[mssql-js] ERROR: Could not create trace log file '{}': {}. File logging will be disabled.",
-                                    log_path.display(), e
+                                    "[mssql-js] ERROR: Could not create trace log file {log_path:?}: {e}. File logging will be disabled."
                                 );
                             }
                         }

--- a/mssql-py-core/src/bulkcopy.rs
+++ b/mssql-py-core/src/bulkcopy.rs
@@ -1707,6 +1707,10 @@ impl PythonRowAdapter {
                 let vector = SqlVector::try_from_f32(values)?;
                 Ok(ColumnValues::Vector(vector))
             }
+            VectorBaseType::Float16 => Err(Error::UsageError(format!(
+                "Float16 VECTOR column '{}' is not supported in Python bulk copy yet",
+                target_meta.column_name
+            ))),
         }
     }
 
@@ -1791,6 +1795,10 @@ impl PythonRowAdapter {
                 let vector = SqlVector::try_from_f32(floats)?;
                 Ok(ColumnValues::Vector(vector))
             }
+            VectorBaseType::Float16 => Err(Error::UsageError(format!(
+                "Float16 VECTOR column '{}' is not supported in Python bulk copy JSON coercion",
+                target_meta.column_name
+            ))),
         }
     }
 

--- a/mssql-py-core/src/connection.rs
+++ b/mssql-py-core/src/connection.rs
@@ -4,7 +4,7 @@
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 use tokio::runtime::Runtime;
 use tokio::sync::Mutex;
 
@@ -254,7 +254,7 @@ impl PyCoreConnection {
         // ServerCertificate - path to the server certificate file for validation
         let server_certificate = dict
             .get_item("server_certificate")?
-            .and_then(|v| v.extract::<String>().ok());
+            .and_then(|v| v.extract::<PathBuf>().ok());
 
         let encryption_options = EncryptionOptions {
             mode: encryption_mode,

--- a/mssql-py-core/src/cursor.rs
+++ b/mssql-py-core/src/cursor.rs
@@ -550,6 +550,9 @@ impl PyCoreCursor {
                             return list.into_any();
                         }
                     }
+                    VectorBaseType::Float16 => {
+                        // Let it fall through to the string conversion below
+                    }
                 }
                 // Fallback to string if conversion fails
                 format!("{:?}", v)

--- a/mssql-py-core/src/tracing_init.rs
+++ b/mssql-py-core/src/tracing_init.rs
@@ -89,11 +89,7 @@ fn get_trace_log_path() -> Option<PathBuf> {
     if !dir.exists()
         && let Err(e) = create_dir_all(&dir)
     {
-        eprintln!(
-            "[mssql-py-core] ERROR: Could not create log directory '{}': {}",
-            dir.display(),
-            e
-        );
+        eprintln!("[mssql-py-core] ERROR: Could not create log directory {dir:?}: {e}");
         return None;
     }
 
@@ -143,8 +139,7 @@ pub(crate) fn init_tracing() {
                                 .event_format(LogFormatter);
 
                             eprintln!(
-                                "[mssql-py-core] Created log file → {}",
-                                log_path.display()
+                                "[mssql-py-core] Created log file → {log_path:?}"
                             );
 
                             // Store guard to keep async writer alive
@@ -162,9 +157,7 @@ pub(crate) fn init_tracing() {
                         }
                         Err(e) => {
                             eprintln!(
-                                "[mssql-py-core] ERROR: Could not create trace log file '{}': {}. Tracing will be disabled.",
-                                log_path.display(),
-                                e
+                                "[mssql-py-core] ERROR: Could not create trace log file {log_path:?}: {e}. Tracing will be disabled."
                             );
                         }
                     }

--- a/mssql-tds-cli/src/main.rs
+++ b/mssql-tds-cli/src/main.rs
@@ -20,7 +20,7 @@ use mssql_tds::core::TdsResult;
 
 #[tokio::main]
 async fn main() {
-    if let Err(e) = main_cli().await {
+    if let Err(e) = Box::pin(main_cli()).await {
         eprintln!("Application error: {e}");
     }
 }

--- a/mssql-tds/Cargo.toml
+++ b/mssql-tds/Cargo.toml
@@ -46,6 +46,8 @@ encoding_rs = "0.8"
 x509-parser = "0.18.0"
 # For DNS resolution (reverse DNS lookup for SPN canonicalization)
 dns-lookup = "2.0"
+# Required to deserialize Vector(Float16) values from the TDS stream (Vector feature v2)
+half = "2.7.1"
 
 
 

--- a/mssql-tds/src/connection/client_context.rs
+++ b/mssql-tds/src/connection/client_context.rs
@@ -76,6 +76,8 @@ pub enum VectorVersion {
     Off,
     /// Support Vector feature version 1 (float32 dimension type)
     V1,
+    /// Support Vector feature version 2 (float16 and float32 dimension types)
+    V2,
 }
 
 /// Provides a trait for creating Entra ID tokens.
@@ -348,6 +350,7 @@ impl ClientContext {
                 port: 1433,
                 instance_name: None,
             },
+            // TODO: make V2 as default when full V2 support is added
             vector_version: VectorVersion::V1,
             user_agent: UserAgent::default(),
         }
@@ -403,6 +406,7 @@ impl ClientContext {
                 port: 1433,
                 instance_name: None,
             },
+            // TODO: make V2 as default when full V2 support is added
             vector_version: VectorVersion::V1,
             user_agent: UserAgent::default(),
         }

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -832,6 +832,22 @@ impl TdsClient {
     /// is no longer needed.
     ///
     /// Drains the token stream internally — no rows are returned.
+    ///
+    /// # Arguments
+    ///
+    /// * `sql` — the parameterized T-SQL statement to prepare. Parameter
+    ///   placeholders (e.g. `@p1`, `@db_name`) referenced here must be
+    ///   declared in `named_params`.
+    /// * `named_params` — declarations of the statement's parameters. Only
+    ///   the `name` and SQL `type` of each entry are used to build the
+    ///   `@params` declaration string passed to `sp_prepare`; any values
+    ///   carried by the entries are ignored. Supply the actual parameter
+    ///   values later on the matching
+    ///   [`execute_sp_execute()`](Self::execute_sp_execute) call.
+    /// * `timeout_sec` — optional per-request timeout in seconds. `None`
+    ///   means no timeout beyond the connection default.
+    /// * `cancel_handle` — optional handle to cooperatively cancel the
+    ///   request.
     #[instrument(skip(self, named_params), level = "info")]
     pub async fn execute_sp_prepare(
         &mut self,
@@ -889,10 +905,16 @@ impl TdsClient {
         let positional_parameters = Some(positional_parameters_vec);
 
         // Build the RPC request.
+        // sp_prepare's RPC contract is fixed: @handle (output int), @params (ntext),
+        // @stmt (ntext), @options (int, optional). It does not accept any user
+        // parameter values; those are sent later on sp_execute (or together on
+        // sp_prepexec / sp_executesql). Forwarding `named_params` here causes the
+        // server to surface "Procedure expects parameter '@options' of type 'int'."
+        // for any non-int user parameter type.
         let rpc = SqlRpc::new(
             RpcType::ProcId(RpcProcs::Prepare),
             positional_parameters,
-            Some(named_params),
+            None,
             &database_collation,
             &self.execution_context,
         );
@@ -901,10 +923,16 @@ impl TdsClient {
             rpc.create_packet_writer(self.transport.as_writer(), timeout_sec, cancel_handle);
         rpc.serialize(&mut packet_writer).await?;
 
-        // Drain to completion to get output parameters
-        self.drain_stream().await?;
+        // Drain to completion to get output parameters and any server errors.
+        let server_errors = self.drain_stream().await?;
 
         // We need to get the return value, and then extract the handle from it.
+        // If the server reported errors during prepare, surface them instead of a
+        // generic ProtocolError so callers can see the underlying SQL Server
+        // diagnostic.
+        if !server_errors.is_empty() {
+            return Err(crate::error::Error::from_sql_errors(server_errors));
+        }
         if self.return_values.len() == 1 {
             let returned_parameter = self.return_values.first().unwrap();
             if let ColumnValues::Int(handle) = &returned_parameter.value {
@@ -967,8 +995,13 @@ impl TdsClient {
             rpc.create_packet_writer(self.transport.as_writer(), timeout_sec, cancel_handle);
         rpc.serialize(&mut packet_writer).await?;
 
-        // Drain the result set. A successful unprepare will not return any results.
-        self.drain_stream().await?;
+        // Drain the result set. A successful unprepare returns no results,
+        // but surface any server errors collected during the drain instead of
+        // silently discarding them.
+        let server_errors = self.drain_stream().await?;
+        if !server_errors.is_empty() {
+            return Err(crate::error::Error::from_sql_errors(server_errors));
+        }
         Ok(())
     }
 

--- a/mssql-tds/src/connection/transport/certificate_validator.rs
+++ b/mssql-tds/src/connection/transport/certificate_validator.rs
@@ -24,19 +24,19 @@ use tracing::{debug, info};
 /// # Returns
 /// * `Ok(Vec<u8>)` - DER-encoded certificate data
 /// * `Err(Error)` - File not found, IO error, or invalid format
-pub fn load_certificate_from_file(path: &str) -> TdsResult<Vec<u8>> {
-    debug!("Loading certificate from file: {}", path);
+pub fn load_certificate_from_file(path: &Path) -> TdsResult<Vec<u8>> {
+    debug!("Loading certificate from file: {path:?}");
 
     // Check if file exists
-    if !Path::new(path).exists() {
+    if !path.exists() {
         return Err(Error::CertificateNotFound {
-            path: path.to_string(),
+            path: path.to_path_buf(),
         });
     }
 
     // Read certificate file
     let cert_data = fs::read(path).map_err(|e| Error::CertificateFileIoError {
-        path: path.to_string(),
+        path: path.to_path_buf(),
         error: e.to_string(),
     })?;
 
@@ -48,19 +48,18 @@ pub fn load_certificate_from_file(path: &str) -> TdsResult<Vec<u8>> {
             Certificate::from_der(&cert_data)
         })
         .map_err(|_| Error::InvalidCertificateFormat {
-            path: path.to_string(),
+            path: path.to_path_buf(),
         })?;
 
     // Convert to DER format for binary comparison
     let der_data = certificate
         .to_der()
         .map_err(|_| Error::InvalidCertificateFormat {
-            path: path.to_string(),
+            path: path.to_path_buf(),
         })?;
 
     info!(
-        "Successfully loaded certificate from: {} ({} bytes)",
-        path,
+        "Successfully loaded certificate from: {path:?} ({} bytes)",
         der_data.len()
     );
     Ok(der_data)
@@ -134,8 +133,8 @@ pub fn constant_time_compare(a: &[u8], b: &[u8]) -> bool {
 /// # Returns
 /// * `Ok(())` - Certificates match and server cert is valid
 /// * `Err(Error)` - Validation failed
-pub fn validate_server_certificate(user_cert_path: &str, server_cert_der: &[u8]) -> TdsResult<()> {
-    info!("Validating server certificate against: {}", user_cert_path);
+pub fn validate_server_certificate(user_cert_path: &Path, server_cert_der: &[u8]) -> TdsResult<()> {
+    info!("Validating server certificate against: {user_cert_path:?}");
 
     // Step 1: Load user-provided certificate
     let user_cert_der = load_certificate_from_file(user_cert_path)?;
@@ -186,11 +185,12 @@ mod tests {
 
     #[test]
     fn test_load_certificate_file_not_found() {
-        let result = load_certificate_from_file("/nonexistent/path/cert.cer");
+        let p = Path::new("/nonexistent/path/cert.cer");
+        let result = load_certificate_from_file(p);
         assert!(result.is_err());
         match result {
             Err(Error::CertificateNotFound { path }) => {
-                assert!(path.contains("nonexistent"));
+                assert_eq!(path, p);
             }
             _ => panic!("Expected CertificateNotFound error"),
         }
@@ -199,7 +199,7 @@ mod tests {
     #[test]
     fn test_load_certificate_from_pem() {
         // Path relative to the crate root
-        let cert_path = "tests/test_certificates/valid_cert.pem";
+        let cert_path = Path::new("tests/test_certificates/valid_cert.pem");
         let result = load_certificate_from_file(cert_path);
 
         match result {
@@ -219,7 +219,7 @@ mod tests {
     #[test]
     fn test_load_certificate_from_der() {
         // Path relative to the crate root
-        let cert_path = "tests/test_certificates/valid_cert.der";
+        let cert_path = Path::new("tests/test_certificates/valid_cert.der");
         let result = load_certificate_from_file(cert_path);
 
         match result {
@@ -239,13 +239,13 @@ mod tests {
     #[test]
     fn test_load_certificate_invalid_format() {
         // Path relative to the crate root
-        let cert_path = "tests/test_certificates/invalid_format.txt";
+        let cert_path = Path::new("tests/test_certificates/invalid_format.txt");
         let result = load_certificate_from_file(cert_path);
 
         assert!(result.is_err(), "Should fail to load invalid certificate");
         match result {
             Err(Error::InvalidCertificateFormat { path, .. }) => {
-                assert!(path.contains("invalid_format.txt"));
+                assert_eq!(path, cert_path);
             }
             Err(e) => panic!("Expected InvalidCertificateFormat error, got: {:?}", e),
             Ok(_) => panic!("Should not succeed loading invalid certificate"),
@@ -255,8 +255,8 @@ mod tests {
     #[test]
     fn test_pem_and_der_certificates_produce_same_der() {
         // Both PEM and DER files contain the same certificate
-        let pem_path = "tests/test_certificates/valid_cert.pem";
-        let der_path = "tests/test_certificates/valid_cert.der";
+        let pem_path = Path::new("tests/test_certificates/valid_cert.pem");
+        let der_path = Path::new("tests/test_certificates/valid_cert.der");
 
         let pem_result = load_certificate_from_file(pem_path);
         let der_result = load_certificate_from_file(der_path);
@@ -283,7 +283,7 @@ mod tests {
     #[test]
     fn test_is_certificate_expired_valid() {
         // Our test certificate is valid for 10 years (3650 days)
-        let cert_path = "tests/test_certificates/valid_cert.pem";
+        let cert_path = Path::new("tests/test_certificates/valid_cert.pem");
         let der_bytes =
             load_certificate_from_file(cert_path).expect("Failed to load test certificate");
 

--- a/mssql-tds/src/connection/transport/ssl_handler.rs
+++ b/mssql-tds/src/connection/transport/ssl_handler.rs
@@ -212,7 +212,7 @@ impl SslHandler {
 
                 // If ServerCertificate is specified, perform certificate validation
                 if let Some(cert_path) = &self.encryption_options.server_certificate {
-                    info!("Validating server certificate using: {}", cert_path);
+                    info!("Validating server certificate using: {cert_path:?}",);
 
                     // Get the server's certificate from the TLS stream
                     let peer_cert = stream
@@ -902,7 +902,7 @@ mod tests {
     #[test]
     fn server_certificate_enables_pinning_mode() {
         let mut opts = default_options();
-        opts.server_certificate = Some("cert.pem".to_string());
+        opts.server_certificate = Some("cert.pem".into());
         let config =
             SslHandler::resolve_tls_validation(&opts, NegotiatedEncryptionSetting::Mandatory);
         assert!(config.accept_invalid_certs);
@@ -913,7 +913,7 @@ mod tests {
     #[test]
     fn server_certificate_takes_precedence_over_login_only() {
         let mut opts = default_options();
-        opts.server_certificate = Some("cert.pem".to_string());
+        opts.server_certificate = Some("cert.pem".into());
         let config =
             SslHandler::resolve_tls_validation(&opts, NegotiatedEncryptionSetting::LoginOnly);
         assert!(config.accept_invalid_certs);
@@ -954,7 +954,7 @@ mod tests {
     #[test]
     fn strict_with_server_certificate_enables_alpn() {
         let mut opts = default_options();
-        opts.server_certificate = Some("cert.pem".to_string());
+        opts.server_certificate = Some("cert.pem".into());
         let config = SslHandler::resolve_tls_validation(&opts, NegotiatedEncryptionSetting::Strict);
         assert!(config.use_alpn);
         assert!(config.accept_invalid_certs);

--- a/mssql-tds/src/core.rs
+++ b/mssql-tds/src/core.rs
@@ -4,6 +4,7 @@
 use crate::error::Error;
 use crate::error::Error::OperationCancelledError;
 use std::future::Future;
+use std::path::PathBuf;
 use tokio_util::sync::CancellationToken;
 
 /// Alias for `Result<T, crate::error::Error>` used throughout the crate.
@@ -220,7 +221,7 @@ pub struct EncryptionOptions {
     /// Path to a DER or PEM encoded X.509 certificate file for certificate pinning.
     /// When specified, the driver performs an exact binary match between the provided
     /// certificate and the server's certificate, bypassing standard CA chain validation.
-    pub server_certificate: Option<String>,
+    pub server_certificate: Option<PathBuf>,
 }
 
 impl EncryptionOptions {

--- a/mssql-tds/src/datatypes/decoder.rs
+++ b/mssql-tds/src/datatypes/decoder.rs
@@ -2578,9 +2578,7 @@ mod test {
         use super::*;
         use crate::datatypes::{
             sql_vector::SqlVector,
-            sqldatatypes::{
-                VECTOR_MAX_DIMENSIONS, VectorBaseType, VectorLayoutFormat, VectorLayoutVersion,
-            },
+            sqldatatypes::{VectorBaseType, VectorLayoutFormat, VectorLayoutVersion},
         };
 
         #[test]
@@ -2603,9 +2601,10 @@ mod test {
 
         #[test]
         fn test_vector_max_dimensions() {
-            let dimensions: Vec<f32> = (0..VECTOR_MAX_DIMENSIONS).map(|i| i as f32).collect();
+            let max_dim = VectorBaseType::Float32.max_dimensions();
+            let dimensions: Vec<f32> = (0..max_dim).map(|i| i as f32).collect();
             let vector = SqlVector::try_from_f32(dimensions).unwrap();
-            assert_eq!(vector.dimension_count(), VECTOR_MAX_DIMENSIONS);
+            assert_eq!(vector.dimension_count(), max_dim);
         }
 
         #[test]
@@ -2701,7 +2700,8 @@ mod test {
 
         #[test]
         fn test_vector_too_many_dimensions() {
-            let dimensions: Vec<f32> = (0..(VECTOR_MAX_DIMENSIONS + 1)).map(|i| i as f32).collect();
+            let max_dim = VectorBaseType::Float32.max_dimensions();
+            let dimensions: Vec<f32> = (0..(max_dim + 1)).map(|i| i as f32).collect();
             let result = SqlVector::try_from_f32(dimensions);
             assert!(result.is_err());
             assert!(result.unwrap_err().to_string().contains("exceeds maximum"));

--- a/mssql-tds/src/datatypes/sql_vector.rs
+++ b/mssql-tds/src/datatypes/sql_vector.rs
@@ -3,8 +3,7 @@
 
 use crate::core::TdsResult;
 use crate::datatypes::sqldatatypes::{
-    VECTOR_HEADER_SIZE, VECTOR_MAX_DIMENSIONS, VECTOR_MAX_SIZE, VectorBaseType, VectorLayoutFormat,
-    VectorLayoutVersion,
+    VECTOR_HEADER_SIZE, VECTOR_MAX_SIZE, VectorBaseType, VectorLayoutFormat, VectorLayoutVersion,
 };
 use crate::error::Error;
 
@@ -15,6 +14,8 @@ use crate::error::Error;
 pub enum VectorData {
     /// Single-precision float vector.
     Float32(Vec<f32>),
+    /// Half-precision float vector (stored in memory as f32).
+    Float16(Vec<f32>),
 }
 
 /// Represents a SQL Server Vector data type value.
@@ -48,6 +49,19 @@ impl SqlVector {
         Ok(vector)
     }
 
+    /// Creates a new SqlVector with the specified values, tagged for Float16 storage.
+    ///
+    /// # Arguments
+    /// * `values` - The vector dimension values (passed as f32, but treated as Float16)
+    pub fn try_from_f16(values: Vec<f32>) -> TdsResult<Self> {
+        let vector = Self {
+            base_type: VectorBaseType::Float16,
+            data: VectorData::Float16(values),
+        };
+        vector.validate_dimensions()?;
+        Ok(vector)
+    }
+
     /// Creates a SqlVector from raw header fields and raw bytes (used during deserialization).
     /// Validates the TDS header fields then parses and stores the typed data.
     pub(crate) fn try_from_raw(
@@ -61,6 +75,18 @@ impl SqlVector {
         VectorLayoutVersion::try_from(layout_version)?;
         let base_type_enum = VectorBaseType::try_from(base_type)?;
 
+        // Validate that the payload size matches the element size precisely
+        if !raw_bytes
+            .len()
+            .is_multiple_of(base_type_enum.element_size_bytes())
+        {
+            return Err(Error::ProtocolError(format!(
+                "Malformed vector payload: byte length ({}) is not a multiple of the element size ({})",
+                raw_bytes.len(),
+                base_type_enum.element_size_bytes()
+            )));
+        }
+
         // Parse raw bytes into typed data based on base type
         let data = match base_type_enum {
             VectorBaseType::Float32 => {
@@ -69,6 +95,16 @@ impl SqlVector {
                     .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
                     .collect();
                 VectorData::Float32(f32_values)
+            }
+            VectorBaseType::Float16 => {
+                // For Vector V2, SQL Server sends 16-bit Float16 types.
+                // Since JavaScript and Python standard APIs do not commonly support native Float16 memory views,
+                // we decode these half-precision bits (via the `half` crate) into standard f32 memory representations.
+                let f32_values: Vec<f32> = raw_bytes
+                    .chunks_exact(2)
+                    .map(|chunk| half::f16::from_le_bytes([chunk[0], chunk[1]]).to_f32())
+                    .collect();
+                VectorData::Float16(f32_values)
             }
         };
 
@@ -81,10 +117,12 @@ impl SqlVector {
     }
 
     /// Returns a reference to the dimension values as a float slice.
-    /// Returns None if the vector is not Float32 type.
+    /// Since both Float32 and Float16 are stored natively as f32, this returns `Some` for both.
+    /// Returns `None` if the vector data cannot be represented as an f32 slice.
     pub fn as_f32(&self) -> Option<&[f32]> {
         match &self.data {
             VectorData::Float32(v) => Some(v),
+            VectorData::Float16(v) => Some(v),
         }
     }
 
@@ -92,6 +130,7 @@ impl SqlVector {
     pub fn dimension_count(&self) -> u16 {
         match &self.data {
             VectorData::Float32(v) => v.len() as u16,
+            VectorData::Float16(v) => v.len() as u16,
         }
     }
 
@@ -102,11 +141,12 @@ impl SqlVector {
         self.base_type
     }
 
-    /// Returns the total size in bytes (header + dimension values).
+    /// Returns the total size in bytes (header + dimension values) on the wire.
     /// Used during serialization (Phase 3).
     pub(crate) fn total_size(&self) -> usize {
         let element_bytes = match &self.data {
-            VectorData::Float32(v) => v.len() * size_of::<f32>(),
+            VectorData::Float32(v) => v.len() * self.base_type.element_size_bytes(),
+            VectorData::Float16(v) => v.len() * self.base_type.element_size_bytes(),
         };
         VECTOR_HEADER_SIZE + element_bytes
     }
@@ -115,6 +155,7 @@ impl SqlVector {
     fn validate_dimensions(&self) -> TdsResult<()> {
         let dimension_count = match &self.data {
             VectorData::Float32(v) => v.len(),
+            VectorData::Float16(v) => v.len(),
         };
 
         if dimension_count == 0 {
@@ -123,10 +164,11 @@ impl SqlVector {
             ));
         }
 
-        if dimension_count > VECTOR_MAX_DIMENSIONS as usize {
+        let max_dimensions = self.base_type.max_dimensions();
+        if dimension_count > max_dimensions as usize {
             return Err(Error::ProtocolError(format!(
-                "Vector dimension count {} exceeds maximum of {}",
-                dimension_count, VECTOR_MAX_DIMENSIONS
+                "Vector dimension count {} exceeds maximum of {} for base type {:?}",
+                dimension_count, max_dimensions, self.base_type
             )));
         }
 
@@ -158,8 +200,16 @@ mod tests {
 
     #[test]
     fn test_validate_too_many_dimensions() {
-        let values = vec![0.0f32; (VECTOR_MAX_DIMENSIONS + 1) as usize];
+        let values = vec![0.0f32; (VectorBaseType::Float32.max_dimensions() + 1) as usize];
         let result = SqlVector::try_from_f32(values);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("exceeds maximum"));
+    }
+
+    #[test]
+    fn test_validate_too_many_dimensions_f16() {
+        let values = vec![0.0f32; (VectorBaseType::Float16.max_dimensions() + 1) as usize];
+        let result = SqlVector::try_from_f16(values);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("exceeds maximum"));
     }
@@ -201,6 +251,21 @@ mod tests {
     }
 
     #[test]
+    fn test_from_raw_float16() {
+        let raw_bytes = vec![0, 60]; // 1.0f16 in little-endian (0x3C00)
+        let vector = SqlVector::try_from_raw(
+            VectorLayoutFormat::V1 as u8,
+            VectorLayoutVersion::V1 as u8,
+            VectorBaseType::Float16 as u8,
+            raw_bytes,
+        )
+        .unwrap();
+        assert_eq!(vector.base_type(), VectorBaseType::Float16);
+        assert_eq!(vector.dimension_count(), 1);
+        assert_eq!(vector.as_f32().unwrap(), &[1.0]);
+    }
+
+    #[test]
     fn test_validate_unsupported_base_type() {
         let raw_bytes = 1.0_f32.to_le_bytes().to_vec();
         let result = SqlVector::try_from_raw(
@@ -218,6 +283,21 @@ mod tests {
         let values = vec![1.0, 2.0, 3.0];
         let vector = SqlVector::try_from_f32(values).unwrap();
         assert_eq!(vector.total_size(), VECTOR_HEADER_SIZE + 3 * 4); // 8 + 12 = 20
+    }
+
+    #[test]
+    fn test_total_size_float16_uses_wire_size() {
+        let raw_bytes = vec![0, 60, 0, 60, 0, 60]; // 3 float16 elements
+        let vector = SqlVector::try_from_raw(
+            VectorLayoutFormat::V1 as u8,
+            VectorLayoutVersion::V1 as u8,
+            VectorBaseType::Float16 as u8,
+            raw_bytes,
+        )
+        .unwrap();
+        // Native V1 wrapper (f32) has 3 elements. Float16 size is 2 bytes per element.
+        // Should calculate 8 (header) + 3*2 = 14 bytes
+        assert_eq!(vector.total_size(), VECTOR_HEADER_SIZE + 3 * 2);
     }
 
     #[test]

--- a/mssql-tds/src/datatypes/sqldatatypes.rs
+++ b/mssql-tds/src/datatypes/sqldatatypes.rs
@@ -299,6 +299,8 @@ impl TryFrom<u8> for VectorLayoutVersion {
 pub enum VectorBaseType {
     /// 32-bit floating point (0x00)
     Float32 = 0x00,
+    /// 16-bit (half-precision) floating point (0x01).
+    Float16 = 0x01,
 }
 
 impl VectorBaseType {
@@ -306,6 +308,19 @@ impl VectorBaseType {
     pub const fn element_size_bytes(self) -> usize {
         match self {
             VectorBaseType::Float32 => 4,
+            VectorBaseType::Float16 => 2,
+        }
+    }
+
+    /// Returns the maximum number of dimensions a single vector value of this
+    /// base type can hold. Based on the TDS protocol, the maximum payload size
+    /// is constrained by [`VECTOR_MAX_SIZE`] (8000 bytes) which allows up to
+    /// 1998 elements for Float32 and 3996 elements for Float16 vectors.
+    pub const fn max_dimensions(self) -> u16 {
+        // (VECTOR_MAX_SIZE - VECTOR_HEADER_SIZE) / element_size_bytes
+        match self {
+            VectorBaseType::Float32 => 1998,
+            VectorBaseType::Float16 => 3996,
         }
     }
 }
@@ -316,6 +331,7 @@ impl TryFrom<u8> for VectorBaseType {
     fn try_from(value: u8) -> TdsResult<Self> {
         match value {
             0x00 => Ok(VectorBaseType::Float32),
+            0x01 => Ok(VectorBaseType::Float16),
             _ => Err(Error::ProtocolError(format!(
                 "Unsupported Vector base type: 0x{:02X}",
                 value
@@ -324,8 +340,6 @@ impl TryFrom<u8> for VectorBaseType {
     }
 }
 
-/// Maximum number of dimensions in a TDS vector.
-pub(crate) const VECTOR_MAX_DIMENSIONS: u16 = 1998;
 /// Size of the vector header in bytes.
 pub const VECTOR_HEADER_SIZE: usize = 8;
 /// Maximum total vector payload size in bytes.
@@ -1189,11 +1203,15 @@ mod tests {
         let bt = VectorBaseType::try_from(0x00).unwrap();
         assert_eq!(bt, VectorBaseType::Float32);
         assert_eq!(bt.element_size_bytes(), 4);
+
+        let bt16 = VectorBaseType::try_from(0x01).unwrap();
+        assert_eq!(bt16, VectorBaseType::Float16);
+        assert_eq!(bt16.element_size_bytes(), 2);
     }
 
     #[test]
     fn vector_base_type_try_from_invalid() {
-        assert!(VectorBaseType::try_from(0x01).is_err());
+        assert!(VectorBaseType::try_from(0x02).is_err());
         assert!(VectorBaseType::try_from(0xFF).is_err());
     }
 

--- a/mssql-tds/src/datatypes/sqltypes.rs
+++ b/mssql-tds/src/datatypes/sqltypes.rs
@@ -16,8 +16,8 @@ use crate::{
         decoder::DecimalParts,
         sql_string::SqlString,
         sqldatatypes::{
-            FixedLengthTypes, TdsDataType, VECTOR_HEADER_SIZE, VECTOR_MAX_DIMENSIONS,
-            VectorBaseType, VectorLayoutFormat, VectorLayoutVersion,
+            FixedLengthTypes, TdsDataType, VECTOR_HEADER_SIZE, VectorBaseType, VectorLayoutFormat,
+            VectorLayoutVersion,
         },
     },
     error::Error,
@@ -875,10 +875,11 @@ impl SqlType {
             SqlType::Vector(sql_vector, dimensions, base_type) => {
                 packet_writer.write_byte_async(nullable_type as u8).await?;
 
-                if *dimensions > VECTOR_MAX_DIMENSIONS {
+                let max_dim = base_type.max_dimensions();
+                if *dimensions > max_dim {
                     return Err(Error::UsageError(format!(
-                        "Vector dimensions {} exceeds maximum supported dimensions {}",
-                        dimensions, VECTOR_MAX_DIMENSIONS
+                        "Vector dimensions {} exceeds maximum supported dimensions {} for base type {:?}",
+                        dimensions, max_dim, base_type
                     )));
                 }
 

--- a/mssql-tds/src/datatypes/tds_value_serializer.rs
+++ b/mssql-tds/src/datatypes/tds_value_serializer.rs
@@ -1718,6 +1718,9 @@ impl TdsValueSerializer {
                     writer.write_i32_async((*f).to_bits() as i32).await?;
                 }
             }
+            VectorData::Float16(_) => {
+                todo!("Phase 2: Float16 serialization");
+            }
         }
 
         Ok(())

--- a/mssql-tds/src/error/mod.rs
+++ b/mssql-tds/src/error/mod.rs
@@ -3,6 +3,8 @@
 
 pub mod bulk_copy_errors;
 
+use std::path::PathBuf;
+
 pub use bulk_copy_errors::{BulkCopyAttentionTimeoutError, BulkCopyError, BulkCopyTimeoutError};
 
 use crate::security::SecurityError;
@@ -170,7 +172,7 @@ pub enum Error {
     )]
     CertificateNotFound {
         /// File path that was looked up.
-        path: String,
+        path: PathBuf,
     },
 
     /// Certificate file is present but cannot be parsed.
@@ -179,7 +181,7 @@ pub enum Error {
     )]
     InvalidCertificateFormat {
         /// File path with the invalid certificate.
-        path: String,
+        path: PathBuf,
     },
 
     /// Server certificate has passed its validity period.
@@ -200,7 +202,7 @@ pub enum Error {
     )]
     CertificateFileIoError {
         /// File path that could not be read.
-        path: String,
+        path: PathBuf,
         /// Underlying I/O error message.
         error: String,
     },

--- a/mssql-tds/src/message/features/vectorfeature.rs
+++ b/mssql-tds/src/message/features/vectorfeature.rs
@@ -18,8 +18,8 @@ pub(crate) struct VectorFeature {
 impl VectorFeature {
     /// The maximum Vector feature version supported by this library.
     /// This represents the highest version this TDS client can negotiate with the server.
-    /// Version 1 supports single-precision float (float32) dimension type.
-    pub const VERSION: u8 = 1;
+    /// Version 2 supports float16 and float32 dimension types.
+    pub const VERSION: u8 = 2;
 
     /// Creates a new VectorFeature instance with the specified client version.
     pub fn new(client_version: u8) -> Self {
@@ -51,6 +51,7 @@ impl From<VectorVersion> for Option<VectorFeature> {
         match version {
             VectorVersion::Off => None,
             VectorVersion::V1 => Some(VectorFeature::new(1)),
+            VectorVersion::V2 => Some(VectorFeature::new(2)),
         }
     }
 }
@@ -148,7 +149,7 @@ mod tests {
     #[test]
     fn test_deserialize_invalid_version() {
         let mut feature = VectorFeature::default();
-        let data = vec![2u8]; // Server supports version 2
+        let data = vec![3u8]; // Server supports version 3
         let result = feature.deserialize(&data);
         assert!(result.is_err());
         assert!(
@@ -174,8 +175,8 @@ mod tests {
     }
 
     #[test]
-    fn test_acknowledged_and_negotiated_version() {
-        let mut feature = VectorFeature::default();
+    fn test_negotiate_v1_client_v1_server() {
+        let mut feature = VectorFeature::new(1);
         assert!(!feature.is_acknowledged());
         assert_eq!(feature.negotiated_version(), 0);
 
@@ -185,5 +186,33 @@ mod tests {
 
         assert!(feature.is_acknowledged());
         assert_eq!(feature.negotiated_version(), 1);
+    }
+
+    #[test]
+    fn test_negotiate_v2_client_v1_server() {
+        let mut feature = VectorFeature::default(); // Client supports up to version 2;
+        assert!(!feature.is_acknowledged());
+        assert_eq!(feature.negotiated_version(), 0);
+
+        // Simulate server acknowledgment with version 1 (downgrade fallback)
+        feature.set_acknowledged(true);
+        feature.deserialize(&[1u8]).unwrap();
+
+        assert!(feature.is_acknowledged());
+        assert_eq!(feature.negotiated_version(), 1);
+    }
+
+    #[test]
+    fn test_negotiate_v2_client_v2_server() {
+        let mut feature = VectorFeature::new(2);
+        assert!(!feature.is_acknowledged());
+        assert_eq!(feature.negotiated_version(), 0);
+
+        // Simulate server acknowledgment with version 2
+        feature.set_acknowledged(true);
+        feature.deserialize(&[2u8]).unwrap();
+
+        assert!(feature.is_acknowledged());
+        assert_eq!(feature.negotiated_version(), 2);
     }
 }

--- a/mssql-tds/tests/test_mock_server.rs
+++ b/mssql-tds/tests/test_mock_server.rs
@@ -492,7 +492,7 @@ mod mock_server_tests {
             mode: EncryptionSetting::PreferOff, // Use PreferOff since mock server doesn't support TLS
             trust_server_certificate: true,
             host_name_in_cert: None,
-            server_certificate: Some("/nonexistent/path/certificate.cer".to_string()),
+            server_certificate: Some("/nonexistent/path/certificate.cer".into()),
         };
 
         // Attempt to connect - should succeed since encryption is off
@@ -557,7 +557,7 @@ mod mock_server_tests {
             mode: EncryptionSetting::Required,
             trust_server_certificate: true, // This should be ignored
             host_name_in_cert: None,
-            server_certificate: Some(cert_path.to_str().unwrap().to_string()),
+            server_certificate: Some(cert_path.clone()),
         };
 
         // Attempt to connect - ServerCertificate should take precedence
@@ -628,7 +628,7 @@ mod mock_server_tests {
             mode: EncryptionSetting::PreferOff, // Use PreferOff since mock server doesn't support TLS
             trust_server_certificate: true,
             host_name_in_cert: Some("custom.hostname.com".to_string()),
-            server_certificate: Some(cert_path.to_str().unwrap().to_string()),
+            server_certificate: Some(cert_path.clone()),
         };
 
         // Attempt to connect - with PreferOff, may succeed but both options set is unusual
@@ -688,7 +688,7 @@ mod mock_server_tests {
                 mode: EncryptionSetting::Required,
                 trust_server_certificate: false,
                 host_name_in_cert: None,
-                server_certificate: Some("tests/test_certificates/valid_cert.pem".to_string()),
+                server_certificate: Some("tests/test_certificates/valid_cert.pem".into()),
             };
 
             let provider = TdsConnectionProvider {};
@@ -726,7 +726,7 @@ mod mock_server_tests {
                 mode: EncryptionSetting::Required,
                 trust_server_certificate: false,
                 host_name_in_cert: None,
-                server_certificate: Some("tests/test_certificates/valid_cert.pem".to_string()),
+                server_certificate: Some("tests/test_certificates/valid_cert.pem".into()),
             };
 
             let provider = TdsConnectionProvider {};
@@ -791,7 +791,7 @@ mod mock_server_tests {
                 mode: EncryptionSetting::Strict, // TDS 8.0 - direct TLS
                 trust_server_certificate: false,
                 host_name_in_cert: None,
-                server_certificate: Some("tests/test_certificates/valid_cert.pem".to_string()),
+                server_certificate: Some("tests/test_certificates/valid_cert.pem".into()),
             };
 
             let provider = TdsConnectionProvider {};
@@ -835,7 +835,7 @@ mod mock_server_tests {
                 mode: EncryptionSetting::Strict,
                 trust_server_certificate: false,
                 host_name_in_cert: None,
-                server_certificate: Some("tests/test_certificates/valid_cert.pem".to_string()),
+                server_certificate: Some("tests/test_certificates/valid_cert.pem".into()),
             };
 
             let provider = TdsConnectionProvider {};

--- a/mssql-tds/tests/test_mock_server_tls.rs
+++ b/mssql-tds/tests/test_mock_server_tls.rs
@@ -324,7 +324,7 @@ mod mock_server_tls_tests {
             mode: EncryptionSetting::Strict,
             trust_server_certificate: false,
             host_name_in_cert: None,
-            server_certificate: Some("tests/test_certificates/valid_cert.pem".to_string()),
+            server_certificate: Some("tests/test_certificates/valid_cert.pem".into()),
         };
 
         let provider = TdsConnectionProvider {};

--- a/mssql-tds/tests/test_rpc_results.rs
+++ b/mssql-tds/tests/test_rpc_results.rs
@@ -6,14 +6,18 @@ mod common;
 
 mod rpc_results {
     use crate::common::{begin_connection, build_tcp_datasource, get_scalar_value, init_tracing};
-    use mssql_tds::connection::tds_client::{ResultSet, ResultSetClient};
-    use mssql_tds::datatypes::column_values::ColumnValues;
+    use mssql_tds::connection::tds_client::{ResultSet, ResultSetClient, TdsClient};
+    use mssql_tds::datatypes::column_values::{ColumnValues, SqlDateTime2, SqlTime};
+    use mssql_tds::datatypes::decoder::DecimalParts;
+    use mssql_tds::datatypes::sql_string::SqlString;
     use mssql_tds::datatypes::sqltypes::SqlType;
+    use mssql_tds::error::Error;
     use mssql_tds::{
         core::TdsResult,
         message::parameters::rpc_parameters::{RpcParameter, StatusFlags},
         token::tokenitems::ReturnValueStatus,
     };
+    use uuid::Uuid;
 
     #[ctor::ctor]
     fn init() {
@@ -229,6 +233,278 @@ mod rpc_results {
         // This should simply complete and be successful.
         let result = connection.execute_sp_unprepare(handle, None, None).await;
         assert!(result.is_ok());
+    }
+
+    /// Issue #38 regression: preparing a statement that references a non-int
+    /// named parameter (here `@db_name nvarchar(6)`) used to fail with
+    /// `ProtocolError("Expected an integer value")` because
+    /// `execute_sp_prepare` was forwarding user values onto an RPC whose
+    /// signature does not accept them. After the fix the prepare succeeds
+    /// and a positive handle is returned.
+    #[tokio::test]
+    async fn test_sp_prepare_with_named_nvarchar_param_succeeds() {
+        let query = "select name from sys.databases where name = @db_name";
+        let db_name_param = RpcParameter::new(
+            Some("@db_name".to_string()),
+            StatusFlags::NONE,
+            SqlType::NVarchar(
+                Some(SqlString::from_utf8_string("master".to_string())),
+                6_u16,
+            ),
+        );
+
+        let mut connection = begin_connection(&build_tcp_datasource()).await;
+
+        let handle = connection
+            .execute_sp_prepare(query.to_string(), vec![db_name_param], None, None)
+            .await
+            .expect("sp_prepare should succeed for an NVARCHAR-parameterized statement");
+
+        assert!(handle > 0, "expected a positive prepared statement handle");
+
+        connection
+            .execute_sp_unprepare(handle, None, None)
+            .await
+            .expect("sp_unprepare should succeed");
+    }
+
+    /// Mirrors `test_sp_prepare_surfaces_server_error_on_invalid_sql` for the
+    /// `sp_unprepare` path: passing a handle that was never produced by
+    /// `sp_prepare` makes the server return msg 8179 ("Could not find prepared
+    /// statement with handle ..."). After the Issue #38 fix sweep, those
+    /// drained errors are surfaced as `Error::SqlServerError` instead of being
+    /// silently discarded.
+    #[tokio::test]
+    async fn test_sp_unprepare_surfaces_server_error_on_invalid_handle() {
+        let mut connection = begin_connection(&build_tcp_datasource()).await;
+
+        let res = connection.execute_sp_unprepare(0, None, None).await;
+
+        match res {
+            Ok(()) => panic!("Expected sp_unprepare to fail for handle 0"),
+            Err(Error::SqlServerError { errors }) => {
+                assert!(
+                    errors
+                        .iter()
+                        .any(|e| e.number != 0 && !e.message.is_empty()),
+                    "expected at least one populated server error, got: {:?}",
+                    errors,
+                );
+            }
+            Err(other) => panic!(
+                "Expected SqlServerError carrying the server diagnostic, got: {}",
+                other
+            ),
+        }
+    }
+
+    /// Verifies the diagnostics improvement that landed with the Issue #38
+    /// fix: when the server returns an ERROR token during `sp_prepare`, the
+    /// call surfaces it as `Error::SqlServerError` carrying the actual server
+    /// message instead of a generic `ProtocolError`.
+    #[tokio::test]
+    async fn test_sp_prepare_surfaces_server_error_on_invalid_sql() {
+        // References an undeclared parameter; the server rejects this during
+        // prepare with msg 137 ("Must declare the scalar variable...").
+        let invalid_sql = "select * from sys.databases where database_id = @missing";
+
+        let mut connection = begin_connection(&build_tcp_datasource()).await;
+
+        let res = connection
+            .execute_sp_prepare(invalid_sql.to_string(), vec![], None, None)
+            .await;
+
+        match res {
+            Ok(handle) => panic!("Expected sp_prepare to fail; got handle {}", handle),
+            Err(Error::SqlServerError { errors }) => {
+                assert!(
+                    errors
+                        .iter()
+                        .any(|e| e.number != 0 && !e.message.is_empty()),
+                    "expected at least one populated server error, got: {:?}",
+                    errors,
+                );
+            }
+            Err(other) => panic!(
+                "Expected SqlServerError carrying the server diagnostic, got: {}",
+                other
+            ),
+        }
+    }
+
+    /// End-to-end coverage for `sp_prepare` + `sp_execute` across a mix of
+    /// parameter types. Creates a session-scoped temp table, populates a
+    /// single row whose values are sent through `sp_executesql` (so the wire
+    /// encoding round-trips), then for each column runs a
+    /// `sp_prepare` -> `sp_execute` -> `sp_unprepare` cycle that filters by
+    /// that column with a parameter of the matching `SqlType`. Each cycle
+    /// asserts the row's id is returned, proving both the prepare-side
+    /// `@params` declaration and the execute-side parameter encoding work
+    /// for that type.
+    ///
+    /// Types deliberately not covered here:
+    /// - `Char(_, N)` and `NChar(_, N)`: the parameter-declaration string
+    ///   currently drops the length suffix; tracked separately as the
+    ///   parameter-declaration alignment work.
+    #[tokio::test]
+    async fn test_sp_prepare_then_execute_against_temp_table() {
+        let mut connection = begin_connection(&build_tcp_datasource()).await;
+
+        let create_sql = "create table #prepare_param_tests (
+            id        int             not null,
+            nvc       nvarchar(50)    null,
+            nvm       nvarchar(max)   null,
+            amt       decimal(18, 4)  null,
+            dt2       datetime2(7)    null,
+            t         time(7)         null,
+            uid       uniqueidentifier null,
+            raw       varbinary(16)   null,
+            rawmax    varbinary(max)  null,
+            big       bigint          null,
+            sml       smallint        null,
+            tny       tinyint         null,
+            flag      bit             null,
+            flt       float           null
+        )";
+        execute_non_query(&mut connection, create_sql.to_string())
+            .await
+            .unwrap();
+
+        let nvc_val = SqlString::from_utf8_string("alpha".to_string());
+        let nvm_val = SqlString::from_utf8_string(
+            "long unicode value that exceeds typical inline length thresholds".to_string(),
+        );
+        let amt_val = DecimalParts::from_string("12345.6789", 18, 4).unwrap();
+        let dt2_val = SqlDateTime2 {
+            days: 737_438,
+            time: SqlTime {
+                time_nanoseconds: 372_300_000_000,
+                scale: 7,
+            },
+        };
+        let t_val = SqlTime {
+            time_nanoseconds: 432_000_000_000,
+            scale: 7,
+        };
+        let uid_val = Uuid::parse_str("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee").unwrap();
+        let raw_val: Vec<u8> = vec![0x00, 0x01, 0xFE, 0xFF];
+        let rawmax_val: Vec<u8> = vec![0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80];
+        let big_val: i64 = 9_876_543_210;
+        let sml_val: i16 = -1234;
+        let tny_val: u8 = 200;
+        let flag_val: bool = true;
+        let flt_val: f64 = 12_345.678_901_234_567;
+
+        let make_param = |name: &str, value: SqlType| -> RpcParameter {
+            RpcParameter::new(Some(name.to_string()), StatusFlags::NONE, value)
+        };
+
+        let insert_sql = "insert into #prepare_param_tests
+            (id, nvc, nvm, amt, dt2, t, uid, raw, rawmax, big, sml, tny, flag, flt)
+            values
+            (1, @nvc, @nvm, @amt, @dt2, @t, @uid, @raw, @rawmax, @big, @sml, @tny, @flag, @flt)";
+
+        let insert_params = vec![
+            make_param("@nvc", SqlType::NVarchar(Some(nvc_val.clone()), 50)),
+            make_param("@nvm", SqlType::NVarcharMax(Some(nvm_val.clone()))),
+            make_param("@amt", SqlType::Decimal(Some(amt_val.clone()))),
+            make_param("@dt2", SqlType::DateTime2(Some(dt2_val.clone()))),
+            make_param("@t", SqlType::Time(Some(t_val.clone()))),
+            make_param("@uid", SqlType::Uuid(Some(uid_val))),
+            make_param("@raw", SqlType::VarBinary(Some(raw_val.clone()), 16)),
+            make_param("@rawmax", SqlType::VarBinaryMax(Some(rawmax_val.clone()))),
+            make_param("@big", SqlType::BigInt(Some(big_val))),
+            make_param("@sml", SqlType::SmallInt(Some(sml_val))),
+            make_param("@tny", SqlType::TinyInt(Some(tny_val))),
+            make_param("@flag", SqlType::Bit(Some(flag_val))),
+            make_param("@flt", SqlType::Float(Some(flt_val))),
+        ];
+
+        connection
+            .execute_sp_executesql(insert_sql.to_string(), insert_params, None, None)
+            .await
+            .expect("seed row insert via sp_executesql");
+
+        let cases: Vec<(&str, &str, SqlType)> = vec![
+            ("nvc", "@nvc", SqlType::NVarchar(Some(nvc_val.clone()), 50)),
+            ("nvm", "@nvm", SqlType::NVarcharMax(Some(nvm_val.clone()))),
+            ("amt", "@amt", SqlType::Decimal(Some(amt_val.clone()))),
+            ("dt2", "@dt2", SqlType::DateTime2(Some(dt2_val.clone()))),
+            ("t", "@t", SqlType::Time(Some(t_val.clone()))),
+            ("uid", "@uid", SqlType::Uuid(Some(uid_val))),
+            ("raw", "@raw", SqlType::VarBinary(Some(raw_val.clone()), 16)),
+            (
+                "rawmax",
+                "@rawmax",
+                SqlType::VarBinaryMax(Some(rawmax_val.clone())),
+            ),
+            ("big", "@big", SqlType::BigInt(Some(big_val))),
+            ("sml", "@sml", SqlType::SmallInt(Some(sml_val))),
+            ("tny", "@tny", SqlType::TinyInt(Some(tny_val))),
+            ("flag", "@flag", SqlType::Bit(Some(flag_val))),
+            ("flt", "@flt", SqlType::Float(Some(flt_val))),
+        ];
+
+        for (column, param_name, value) in cases {
+            let id = prepare_select_and_fetch_id(&mut connection, column, param_name, value).await;
+            assert_eq!(
+                id, 1,
+                "filter on column `{column}` via sp_prepare/sp_execute should have returned id=1"
+            );
+        }
+    }
+
+    /// Runs the full prepare/execute/unprepare cycle for a single
+    /// `WHERE <column> = <param>` filter against `#prepare_param_tests`
+    /// and returns the scalar id from the matched row.
+    async fn prepare_select_and_fetch_id(
+        connection: &mut TdsClient,
+        column: &str,
+        param_name: &str,
+        value: SqlType,
+    ) -> i32 {
+        let sql = format!(
+            "select id from #prepare_param_tests where {column} = {param_name}",
+            column = column,
+            param_name = param_name,
+        );
+        let param = RpcParameter::new(Some(param_name.to_string()), StatusFlags::NONE, value);
+
+        let handle = connection
+            .execute_sp_prepare(sql.clone(), vec![param.clone()], None, None)
+            .await
+            .unwrap_or_else(|err| {
+                panic!("sp_prepare failed for column `{column}`: {err}");
+            });
+        assert!(
+            handle > 0,
+            "expected positive prepared handle for column `{column}`"
+        );
+
+        connection
+            .execute_sp_execute(handle, None, Some(vec![param]), None, None)
+            .await
+            .unwrap_or_else(|err| {
+                panic!("sp_execute failed for column `{column}`: {err}");
+            });
+
+        let scalar = get_scalar_value(connection)
+            .await
+            .unwrap_or_else(|err| panic!("reading scalar for column `{column}` failed: {err}"));
+
+        let id = match scalar {
+            Some(ColumnValues::Int(value)) => value,
+            other => panic!("expected Int scalar for column `{column}`, got {:?}", other),
+        };
+
+        connection
+            .execute_sp_unprepare(handle, None, None)
+            .await
+            .unwrap_or_else(|err| {
+                panic!("sp_unprepare failed for column `{column}`: {err}");
+            });
+
+        id
     }
 
     #[tokio::test]

--- a/mssql-tds/tests/test_vector_type.rs
+++ b/mssql-tds/tests/test_vector_type.rs
@@ -66,6 +66,63 @@ mod vector_integration_tests {
         }
     }
 
+    /// Test basic vector16 deserialization with a simple 3-dimensional vector
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[ignore = "Not supported in pipeline currently so skipping"]
+    async fn test_vector16_basic_deserialization() {
+        let mut client = begin_connection(&build_tcp_datasource()).await;
+
+        // Enable preview features before testing
+        // TODO: disable once v16 is available in sql server
+        client
+            .execute("USE UserDatabase;".to_string(), None, None)
+            .await
+            .unwrap();
+        client
+            .execute(
+                "ALTER DATABASE SCOPED CONFIGURATION SET PREVIEW_FEATURES = ON;".to_string(),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        // Query a simple 3-dimensional float16 vector
+        let query = "SELECT CAST('[1.0, 2.0, 3.0]' AS VECTOR(3, float16)) AS VectorColumn";
+        client.execute(query.to_string(), None, None).await.unwrap();
+
+        if let Some(resultset) = client.get_current_resultset() {
+            // Verify metadata
+            let columns = resultset.get_metadata();
+            assert_eq!(columns.len(), 1);
+            assert_eq!(columns[0].column_name, "VectorColumn");
+
+            // Read the row
+            let mut row_count = 0;
+            while let Some(row) = resultset.next_row().await.unwrap() {
+                row_count += 1;
+                assert_eq!(row.len(), 1);
+
+                // Verify the vector data
+                match &row[0] {
+                    ColumnValues::Vector(vector) => {
+                        assert_eq!(vector.dimension_count(), 3);
+                        assert_eq!(vector.base_type(), VectorBaseType::Float16);
+                        let values = vector.as_f32().expect("Should unpack to f32 vector slice");
+                        assert_eq!(values.len(), 3);
+                        assert!((values[0] - 1.0).abs() < 0.001);
+                        assert!((values[1] - 2.0).abs() < 0.001);
+                        assert!((values[2] - 3.0).abs() < 0.001);
+                    }
+                    _ => panic!("Expected Vector column value, got: {:?}", row[0]),
+                }
+            }
+            assert_eq!(row_count, 1, "Expected 1 row");
+        } else {
+            panic!("Expected a result set");
+        }
+    }
+
     /// Test vector column metadata via get_metadata(): type, length, scale, flags
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_vector_metadata_fields() {
@@ -89,6 +146,65 @@ mod vector_integration_tests {
         // Expected metadata values for VECTOR(3), Float32 base type
         let expected_length = VECTOR_HEADER_SIZE + 3 * VectorBaseType::Float32.element_size_bytes();
         let expected_scale = VectorBaseType::Float32 as u8; // SCALE carries base type byte
+
+        // Column 0: NonNullVec
+        let col0 = &metadata[0];
+        assert_eq!(col0.column_name, "NonNullVec");
+        assert_eq!(col0.data_type, TdsDataType::Vector);
+        assert_eq!(col0.type_info.length, expected_length);
+        assert_eq!(col0.get_scale(), Some(expected_scale));
+        assert!(!col0.is_plp());
+        // Expression columns are generally nullable in SQL Server metadata
+        assert!(col0.is_nullable());
+
+        // Column 1: NullVec
+        let col1 = &metadata[1];
+        assert_eq!(col1.column_name, "NullVec");
+        assert_eq!(col1.data_type, TdsDataType::Vector);
+        assert_eq!(col1.type_info.length, expected_length);
+        assert_eq!(col1.get_scale(), Some(expected_scale));
+        assert!(!col1.is_plp());
+        assert!(col1.is_nullable());
+    }
+
+    /// Test vector16 column metadata via get_metadata(): type, length, scale, flags
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[ignore = "Not supported in pipeline currently so skipping"]
+    async fn test_vector16_metadata_fields() {
+        use mssql_tds::datatypes::sqldatatypes::{TdsDataType, VECTOR_HEADER_SIZE, VectorBaseType};
+
+        let mut client = begin_connection(&build_tcp_datasource()).await;
+
+        // TODO: disable once v16 is available in sql server
+        client
+            .execute("USE UserDatabase;".to_string(), None, None)
+            .await
+            .unwrap();
+        client
+            .execute(
+                "ALTER DATABASE SCOPED CONFIGURATION SET PREVIEW_FEATURES = ON;".to_string(),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let query = "SELECT
+            CAST('[1.0, 2.0, 3.0]' AS VECTOR(3, float16)) AS NonNullVec,
+            CAST(NULL AS VECTOR(3, float16)) AS NullVec";
+
+        client.execute(query.to_string(), None, None).await.unwrap();
+
+        let resultset = client
+            .get_current_resultset()
+            .expect("Expected a result set");
+
+        let metadata = resultset.get_metadata();
+        assert_eq!(metadata.len(), 2);
+
+        // Expected metadata values for VECTOR(3, float16), Float16 base type
+        let expected_length = VECTOR_HEADER_SIZE + 3 * VectorBaseType::Float16.element_size_bytes();
+        let expected_scale = VectorBaseType::Float16 as u8; // SCALE carries base type byte
 
         // Column 0: NonNullVec
         let col0 = &metadata[0];
@@ -167,6 +283,60 @@ mod vector_integration_tests {
                         assert!((values[0] - 0.0).abs() < 0.001);
                         assert!((values[100] - 100.0).abs() < 0.001);
                         assert!((values[1997] - 1997.0).abs() < 0.001);
+                    }
+                    _ => panic!("Expected Vector column value"),
+                }
+            }
+            assert_eq!(row_count, 1, "Expected exactly 1 row");
+        }
+    }
+
+    /// Test vector16 with maximum dimensions (3996)
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[ignore = "Not supported in pipeline currently so skipping"]
+    async fn test_vector16_max_dimensions() {
+        let mut client = begin_connection(&build_tcp_datasource()).await;
+
+        // TODO: disable once v16 is available in sql server
+        client
+            .execute("USE UserDatabase;".to_string(), None, None)
+            .await
+            .unwrap();
+        client
+            .execute(
+                "ALTER DATABASE SCOPED CONFIGURATION SET PREVIEW_FEATURES = ON;".to_string(),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        // Create a vector with 3996 dimensions (max supported for float16)
+        let vector_values: Vec<String> = (0..3996).map(|i| format!("{}.0", i)).collect();
+        let vector_literal = format!("[{}]", vector_values.join(", "));
+        let query = format!(
+            "SELECT CAST('{}' AS VECTOR(3996, float16)) AS MaxVector",
+            vector_literal
+        );
+
+        client.execute(query, None, None).await.unwrap();
+
+        if let Some(resultset) = client.get_current_resultset() {
+            let mut row_count = 0;
+            while let Some(row) = resultset.next_row().await.unwrap() {
+                row_count += 1;
+                match &row[0] {
+                    ColumnValues::Vector(vector) => {
+                        assert_eq!(vector.dimension_count(), 3996);
+                        assert_eq!(vector.base_type(), VectorBaseType::Float16);
+                        let values = vector.as_f32().unwrap();
+                        assert_eq!(values.len(), 3996);
+
+                        // Spot check a few values
+                        assert!((values[0] - 0.0).abs() < 0.001);
+                        assert!((values[100] - 100.0).abs() < 0.001);
+                        // Float16 rounds 3995.0 to 3996.0 due to 11-bit precision limit above 2048.
+                        assert!((values[3995] - 3995.0).abs() <= 2.0);
                     }
                     _ => panic!("Expected Vector column value"),
                 }
@@ -353,6 +523,148 @@ mod vector_integration_tests {
                             row_index, expected, actual
                         );
                     }
+                }
+
+                row_index += 1;
+            }
+        }
+        assert_eq!(row_index, 3, "Expected 3 rows");
+    }
+
+    /// Test vector16 NULL value
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[ignore = "Not supported in pipeline currently so skipping"]
+    async fn test_vector16_null_value() {
+        let mut client = begin_connection(&build_tcp_datasource()).await;
+
+        // TODO: disable once v16 is available in sql server
+        client
+            .execute("USE UserDatabase;".to_string(), None, None)
+            .await
+            .unwrap();
+        client
+            .execute(
+                "ALTER DATABASE SCOPED CONFIGURATION SET PREVIEW_FEATURES = ON;".to_string(),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let query = "SELECT CAST(NULL AS VECTOR(3, float16)) AS NullVector";
+
+        client.execute(query.to_string(), None, None).await.unwrap();
+
+        if let Some(resultset) = client.get_current_resultset() {
+            let mut row_count = 0;
+            while let Some(row) = resultset.next_row().await.unwrap() {
+                row_count += 1;
+                match &row[0] {
+                    ColumnValues::Null => {
+                        // Expected - NULL vector should be ColumnValues::Null
+                    }
+                    _ => panic!("Expected Null column value, got: {:?}", row[0]),
+                }
+            }
+            assert_eq!(row_count, 1, "Expected exactly 1 row");
+        }
+    }
+
+    /// Test both float32 and float16 vectors in a table with multiple rows
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[ignore = "Not supported in pipeline currently so skipping"]
+    async fn test_vector_mixed_types_multiple_rows() {
+        let mut client = begin_connection(&build_tcp_datasource()).await;
+
+        // TODO: disable once v16 is available in sql server
+        client
+            .execute("USE UserDatabase;".to_string(), None, None)
+            .await
+            .unwrap();
+        client
+            .execute(
+                "ALTER DATABASE SCOPED CONFIGURATION SET PREVIEW_FEATURES = ON;".to_string(),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        // Create temp table with both vector column types
+        let setup = "
+            CREATE TABLE #MixedVectorTest (
+                Id INT,
+                Vec32 VECTOR(2),
+                Vec16 VECTOR(2, float16)
+            );
+            INSERT INTO #MixedVectorTest VALUES (1, CAST('[1.0, 2.0]' AS VECTOR(2)), CAST('[1.0, 2.0]' AS VECTOR(2, float16)));
+            INSERT INTO #MixedVectorTest VALUES (2, CAST('[4.0, 5.0]' AS VECTOR(2)), NULL);
+            INSERT INTO #MixedVectorTest VALUES (3, NULL, CAST('[3.0, 4.0]' AS VECTOR(2, float16)));
+        ";
+
+        client.execute(setup.to_string(), None, None).await.unwrap();
+
+        // Consume setup results
+        while client.move_to_next().await.unwrap() {}
+
+        // Query the data
+        client
+            .execute(
+                "SELECT Id, Vec32, Vec16 FROM #MixedVectorTest ORDER BY Id".to_string(),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let expected_v32 = [Some(vec![1.0, 2.0]), Some(vec![4.0, 5.0]), None];
+        let expected_v16 = [Some(vec![1.0, 2.0]), None, Some(vec![3.0, 4.0])];
+
+        let mut row_index = 0;
+        if let Some(resultset) = client.get_current_resultset() {
+            while let Some(row) = resultset.next_row().await.unwrap() {
+                assert_eq!(row.len(), 3);
+
+                // Check Id
+                match &row[0] {
+                    ColumnValues::Int(id) => {
+                        assert_eq!(*id, (row_index + 1) as i32);
+                    }
+                    _ => panic!("Expected Int for Id"),
+                }
+
+                // Check Vec32
+                match (&row[1], &expected_v32[row_index]) {
+                    (ColumnValues::Vector(vector), Some(expected)) => {
+                        assert_eq!(vector.dimension_count(), expected.len() as u16);
+                        assert_eq!(vector.base_type(), VectorBaseType::Float32);
+                        let values = vector.as_f32().unwrap();
+                        for (i, &expected_val) in expected.iter().enumerate() {
+                            assert!((values[i] - expected_val).abs() < 0.001);
+                        }
+                    }
+                    (ColumnValues::Null, None) => {}
+                    (actual, expected) => panic!(
+                        "Mismatch Vec32 at row {}: expected {:?}, got {:?}",
+                        row_index, expected, actual
+                    ),
+                }
+
+                // Check Vec16
+                match (&row[2], &expected_v16[row_index]) {
+                    (ColumnValues::Vector(vector), Some(expected)) => {
+                        assert_eq!(vector.dimension_count(), expected.len() as u16);
+                        assert_eq!(vector.base_type(), VectorBaseType::Float16);
+                        let values = vector.as_f32().unwrap();
+                        for (i, &expected_val) in expected.iter().enumerate() {
+                            assert!((values[i] - expected_val).abs() < 0.001);
+                        }
+                    }
+                    (ColumnValues::Null, None) => {}
+                    (actual, expected) => panic!(
+                        "Mismatch Vec16 at row {}: expected {:?}, got {:?}",
+                        row_index, expected, actual
+                    ),
                 }
 
                 row_index += 1;


### PR DESCRIPTION
Sync ADO with GitHub.

Brings the following commits from the ADO `main` branch into GitHub `main`:

- Merged PR 7508: Sync development to main
- Merged PR 7543: Issue #38: fix sp_prepare with non-int named parameters
- Merged PR 7515: Add plan: move development to GitHub, rename main to stable
- Merged PR 7507: Port PR #22 (server_certificate to PathBuf) from @olback
- Merged PR 7493: Add support for vector float16 Feature Extension and deserialization
- Merged PR 7418: Consolidate main-branch build triggers: Official-on-merge only