### PR TITLE
Bump mssql-py-core version to 0.1.5

### DIFF
--- a/mssql-py-core/Cargo.toml
+++ b/mssql-py-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mssql-py-core"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 publish = false
 


### PR DESCRIPTION
Bumps the `mssql-py-core` crate version from `0.1.4` to `0.1.5` in `mssql-py-core/Cargo.toml`.

