### PR TITLE
Upgrade pyo3 to 0.29.0 in mssql-py-core

### DIFF
--- a/mssql-py-core/Cargo.toml
+++ b/mssql-py-core/Cargo.toml
@@ -9,7 +9,7 @@ name = "mssql_py_core"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.27.2", features = ["extension-module"] }
+pyo3 = { version = "0.29.0", features = ["extension-module"] }
 mssql-tds = { path = "../mssql-tds" }
 tokio = { version = "1", features = ["full", "rt-multi-thread"] }
 async-trait = "0.1"
@@ -25,4 +25,4 @@ serde_json = "1.0"
 uuid = "1.19"
 
 [build-dependencies]
-pyo3-build-config = "0.27.2"
+pyo3-build-config = "0.29.0"

--- a/mssql-py-core/src/lib.rs
+++ b/mssql-py-core/src/lib.rs
@@ -48,7 +48,7 @@ fn mssql_py_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     tracing_init::init_tracing();
 
     // Statically capture the Python version once during module initialization
-    let py_version = m.py().version();
+    let py_version = pyo3::Python::version_str();
     let _ = RUNTIME_DETAILS.set(format!("Python {}", py_version));
 
     // Statically capture the mssql_python driver version during module initialization


### PR DESCRIPTION
Upgrades `pyo3` and `pyo3-build-config` from `0.27.2` to `0.29.0` in `mssql-py-core`.

### Changes
- `mssql-py-core/Cargo.toml`: `pyo3` and `pyo3-build-config` `0.27.2` -> `0.29.0`.
- `mssql-py-core/src/lib.rs`: replace deprecated `Python::version()` with `Python::version_str()` (the old method is deprecated as of 0.29).

### Verification
- `cargo build` succeeds against Python 3.12.
- `cargo clippy --all-targets -- -D warnings` is clean.

No deprecated `IntoPy`/`ToPyObject`/`PyCell` APIs were in use, so no further migration was required.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>