### PR TITLE
Fix two fuzz-discovered panics in TDS token parsing

### DIFF
--- a/mssql-tds/src/datatypes/sqldatatypes.rs
+++ b/mssql-tds/src/datatypes/sqldatatypes.rs
@@ -1006,11 +1006,10 @@ where
         return Ok(type_info);
     }
 
-    unimplemented!(
-        "Couldnt find the Variable length equivalent of data_type.
-        Is this UDT: {:?}",
-        data_type
-    )
+    Err(Error::ProtocolError(format!(
+        "Unsupported TDS data type in TYPE_INFO stream: {data_type:?}. \
+         No variable-length encoding known for this type."
+    )))
 }
 
 /// Returns `true` if the TDS data type uses Unicode encoding (NVarChar, NChar, NText).
@@ -1154,6 +1153,24 @@ mod tests {
         assert!(TdsDataType::try_from(0xFF).is_err());
         assert!(TdsDataType::try_from(0x00).is_err());
         assert!(TdsDataType::try_from(0x99).is_err());
+    }
+
+    /// Regression: `read_type_info` previously called `unimplemented!()` for data
+    /// types that are neither fixed-length, variable-length, nor PLP (e.g. `SqlTable`
+    /// in a column metadata stream). Fuzzing reproduced this as a panic. The function
+    /// must now return a `ProtocolError` instead.
+    #[tokio::test]
+    async fn read_type_info_rejects_unsupported_type() {
+        use crate::token::parsers::common::test_utils::MockReader;
+
+        let mut reader = MockReader::new(Vec::new());
+        let err = read_type_info(&mut reader, TdsDataType::SqlTable)
+            .await
+            .expect_err("SqlTable has no variable-length encoding; expected ProtocolError");
+        assert!(
+            matches!(err, Error::ProtocolError(_)),
+            "expected ProtocolError, got {err:?}"
+        );
     }
 
     #[test]

--- a/mssql-tds/src/token/parsers/session_state_parser.rs
+++ b/mssql-tds/src/token/parsers/session_state_parser.rs
@@ -306,7 +306,7 @@ mod tests {
         // Regression: a 0xFF-encoded state_len near u32::MAX previously triggered
         // `bytes_read + state_len` overflow in the bounds check.
         let mut bytes = Vec::new();
-        let total_len: u32 = 11; // u32 total_length (4) + seq(4) + status(1) + state_id(1) + len_byte(1)
+        let total_len: u32 = 11; // bytes after total_length: seq(4) + status(1) + state_id(1) + len_byte(1) + extended_len(4)
         bytes.extend_from_slice(&total_len.to_le_bytes());
         bytes.extend_from_slice(&0u32.to_le_bytes()); // sequence_number
         bytes.push(0x00); // status

--- a/mssql-tds/src/token/parsers/session_state_parser.rs
+++ b/mssql-tds/src/token/parsers/session_state_parser.rs
@@ -108,16 +108,18 @@ where
                 len_byte as u32
             };
 
-            // Validate state_len against remaining token data.
-            if bytes_read + state_len > total_length {
+            // Validate state_len against remaining token data. Compare via subtraction
+            // because `bytes_read + state_len` overflows u32 when state_len is large
+            // (state_len is attacker-controlled, up to u32::MAX via the 0xFF extended
+            // encoding). `bytes_read < total_length` is guaranteed by the loop guard.
+            let remaining = total_length - bytes_read;
+            if state_len > remaining {
                 return Err(crate::error::Error::ProtocolError(format!(
                     "SESSIONSTATE: state data length {state_len} exceeds remaining \
-                     token bytes ({} remaining)",
-                    total_length - bytes_read
+                     token bytes ({remaining} remaining)"
                 )));
             }
 
-            // Read state data.
             let mut data = vec![0u8; state_len as usize];
             if state_len > 0 {
                 reader.read_bytes(&mut data).await?;
@@ -297,5 +299,27 @@ mod tests {
         assert!(result.is_err());
         let err_msg = format!("{}", result.unwrap_err());
         assert!(err_msg.contains("too short"));
+    }
+
+    #[tokio::test]
+    async fn reject_extended_length_overflow() {
+        // Regression: a 0xFF-encoded state_len near u32::MAX previously triggered
+        // `bytes_read + state_len` overflow in the bounds check.
+        let mut bytes = Vec::new();
+        let total_len: u32 = 11; // u32 total_length (4) + seq(4) + status(1) + state_id(1) + len_byte(1)
+        bytes.extend_from_slice(&total_len.to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // sequence_number
+        bytes.push(0x00); // status
+        bytes.push(0x00); // state_id
+        bytes.push(0xFF); // len_byte marker; followed by u32 length
+        bytes.extend_from_slice(&u32::MAX.to_le_bytes()); // extended length = u32::MAX
+        let mut reader = MockReader::new(bytes);
+        let parser = SessionStateTokenParser;
+        let context = ParserContext::default();
+
+        let result = parser.parse(&mut reader, &context).await;
+        assert!(result.is_err());
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(err_msg.contains("exceeds remaining"));
     }
 }


### PR DESCRIPTION
Addresses panics discovered by the scheduled fuzz pipeline. All 146 crash inputs from the pipeline artifacts reproduce locally and are cleared by this change.

Changes:
- session_state_parser: bounds check in SESSIONSTATE token parsing previously evaluated `bytes_read + state_len > total_length` in u32. `state_len` comes from the attacker-controlled 0xFF extended-length encoding and can be up to u32::MAX, overflowing the addition and panicking. Rewritten as a subtraction-based comparison (`state_len > total_length - bytes_read`), which is safe because the loop guard already guarantees `bytes_read < total_length`.
- sqldatatypes::read_type_info: the final fallback for an unrecognized TDS data type called `unimplemented!()`, which panics. Any server-side or fuzz-generated TYPE_INFO with an unsupported type (for example SqlTable in COLMETADATA) crashed the client. Replaced with `Error::ProtocolError` so the caller sees a recoverable protocol error instead.
- Added regression tests for both cases.

Validation:
- All 146 crash inputs from the pipeline artifacts now exit cleanly with errors rather than panicking.
- `cargo fmt --check` passes.
- Existing session_state_parser and sqldatatypes unit tests continue to pass.