### PR TITLE
Scope fuzz pipeline schedule to GitHub main

### DIFF
--- a/.pipeline/fuzz-pipeline.yml
+++ b/.pipeline/fuzz-pipeline.yml
@@ -1,3 +1,5 @@
+# Scheduled fuzz testing. Source repo is GitHub microsoft/mssql-rs, so the
+# schedule targets GitHub main.
 name: Rust TDS Lib Fuzz Testing
 trigger: none
 
@@ -7,7 +9,6 @@ schedules:
   branches:
     include:
     - main
-    - development
   always: true
 
 extends:


### PR DESCRIPTION
Repurposes `.pipeline/fuzz-pipeline.yml` to run on a schedule against **GitHub main**.

### Change
- Scheduled trigger now targets `main` only; removed `development` (which does not exist on GitHub).
- Keeps `trigger: none` and the existing `extends: validation-pipeline.yml` with `RunFuzz: true` (every 3 hours, `always: true`).

### Follow-up (manual, outside this PR)
This requires a **new ADO pipeline definition with GitHub as the source repo** (`microsoft/mssql-rs`), pointing at `.pipeline/fuzz-pipeline.yml`. ADO scheduled triggers only schedule branches of the pipeline's own source repo, so a GitHub-sourced definition is what makes the schedule resolve to GitHub main. The existing ADO-sourced fuzz pipeline is unaffected.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>