### PR TITLE
Update instructions and prompts for GitHub-based development

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-# Copilot Instructions — mssql-tds
+# Copilot Instructions — mssql-rs
 
 ## Project Overview
 
@@ -100,7 +100,6 @@ Every `.rs` file must start with:
 ### Branches
 
 - Feature branches: `dev/<developer>/<feature-name>`
-- Integration branch: `development`
 - Default branch: `main`
 
 ### Pre-Commit Hook

--- a/.github/prompts/createDraftPr.prompt.md
+++ b/.github/prompts/createDraftPr.prompt.md
@@ -2,8 +2,7 @@
 name: createDraftPr
 description: Describe when to use this prompt
 ---
-Using #microsoft/azure-devops-mcp create a DRAFT PR for this branch. The organization is sqlclient drivers, project is mssql-rs, the repository is mssql-rs and target branch is the `development` branch. 
-If the MCP server is not available, then try to use Az CLI. 
+Create a DRAFT GitHub PR for this branch in the `microsoft/mssql-rs` repository, targeting the `main` branch.
 
 Do not use unicode characters or superlatives in the PR description.
 

--- a/.github/prompts/createPr.prompt.md
+++ b/.github/prompts/createPr.prompt.md
@@ -2,8 +2,7 @@
 name: createPr
 description: Describe when to use this prompt
 ---
-#microsoft/azure-devops-mcp create a PR for this branch. The project is mssql-rs, the repository is mssql-rs and target branch is the `development` branch. 
-If the MCP server is not available, then try to use Az CLI. 
+Create a GitHub PR for this branch in the `microsoft/mssql-rs` repository, targeting the `main` branch.
 
 Do not use unicode characters or superlatives in the PR description.
 

--- a/.github/prompts/createTask.prompt.md
+++ b/.github/prompts/createTask.prompt.md
@@ -2,7 +2,7 @@
 name: createTask
 description: Describe when to use this prompt
 ---
-Using #microsoft/azure-devops-mcp create a Task for this branch. The organization is sqlclient drivers, project is mssql-rs, the repository is mssql-rs.
+Using #microsoft/azure-devops-mcp create a Task for this branch. The organization is sqlclientdrivers, project is mssql-rs, the repository is mssql-rs.
 
 The task should describe the work that has been done in this branch. It should be created using the changes from the current branch and the target branch. The task should explain the what and why of the changes, not the how. The task should be concise and clear, and should not include any implementation details or code snippets.
 


### PR DESCRIPTION
## Description

Updates the Copilot instructions and prompt files to reflect the move of source development from Azure DevOps to GitHub.

## Changes

- Switch `createPr` and `createDraftPr` prompts from the Azure DevOps MCP / Az CLI workflow to GitHub PR creation targeting the `main` branch.
- Remove the obsolete `development` integration branch reference from the branch conventions in the Copilot instructions.
- Correct the project title in the Copilot instructions from `mssql-tds` to `mssql-rs`.
- Fix the Azure DevOps organization name (`sqlclientdrivers`) used by the `createTask` prompt, which remains on ADO for work item tracking.

## Related Issues

<!-- Link to related issues if applicable -->

## Checklist

- [ ] `cargo bfmt` passes
- [ ] `cargo bclippy` passes
- [ ] `cargo btest` passes
- [x] New/changed functionality has tests (N/A — documentation/prompt changes only)
- [x] Public API changes are documented (N/A)
