### PR TITLE
Repoint OneBranch wheels pipelines for GitHub migration

### DIFF
--- a/.pipeline/OneBranch/NonOfficialPythonWheelsPublish.yml
+++ b/.pipeline/OneBranch/NonOfficialPythonWheelsPublish.yml
@@ -8,15 +8,13 @@
 # Support:        https://aka.ms/onebranchsup                                   #
 #################################################################################
 
-# CI trigger only on development. Main-branch coverage comes from the
-# Official pipeline (on merge) and the nightly schedule below; no need to
-# also fire NonOfficial on every merge to main.
+# Source repo is GitHub microsoft/mssql-rs. CI runs on merge to main and on
+# PRs into main. Nightly schedule (below) also runs against main.
 trigger:
-- development
+- main
 
 pr:
 - main
-- development
 
 # Nightly builds
 schedules:

--- a/.pipeline/OneBranch/OfficialPythonWheelsBuild.yml
+++ b/.pipeline/OneBranch/OfficialPythonWheelsBuild.yml
@@ -10,13 +10,14 @@
 # Support:        https://aka.ms/onebranchsup                                   #
 #################################################################################
 
-# Official build runs on every merge to main; no PR validation (PRs are
-# validated by the separate validation pipeline). Can also be queued manually.
+# Official build runs on every merge to the ADO stable branch (stable mirrors
+# GitHub main); no PR validation (PRs are validated by the separate validation
+# pipeline). Can also be queued manually.
 trigger:
   batch: true
   branches:
     include:
-      - main
+      - stable
 pr: none
 
 variables:


### PR DESCRIPTION
Updates the OneBranch Python wheels pipeline triggers as part of the ADO -> GitHub migration.

### Changes
- **`NonOfficialPythonWheelsPublish.yml`** (GitHub-sourced): CI now runs on **merge to `main`** and on **PRs into `main`**. Removed `development` (does not exist on GitHub). Nightly schedule already targets `main`.
- **`OfficialPythonWheelsBuild.yml`** (ADO-sourced, OneBranch Official): build trigger moves from `main` to the ADO **`stable`** branch, which mirrors GitHub `main` via the sync pipeline. `pr: none` unchanged.

### Notes
- NonOfficial requires a **new ADO pipeline definition with GitHub as source**; the ADO `templates` (governed templates) resource is unchanged.
- Official stays ADO-sourced (OneBranch provenance) and builds from `stable`.
- Draft pending verification of the new pipeline definition wiring / OneBranch source policy.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>