### PR TITLE
Make GitHub-main->stable sync pipeline GitHub-sourced

### DIFF
--- a/.pipeline/sync-github-main-to-stable.yml
+++ b/.pipeline/sync-github-main-to-stable.yml
@@ -1,6 +1,6 @@
 # Pipeline to create a PR from GitHub main into the Azure DevOps stable branch.
 # The pipeline source is GitHub microsoft/mssql-rs, so it triggers natively on
-# every merge to main (via the Azure Pipelines GitHub App) and can also be run
+# every update to main (via the Azure Pipelines GitHub App) and can also be run
 # manually. The Azure Repos mssql-rs repository is a 'git' resource we push the
 # sync branch to and open the PR against, authenticated with System.AccessToken.
 # Skips PR creation if:
@@ -18,22 +18,17 @@ trigger:
 pr: none
 
 parameters:
-- name: targetBranch
-  displayName: ADO branch to sync GitHub main into
-  type: string
-  default: stable
 - name: syncBranch
   displayName: Intermediate ADO branch carrying GitHub main
   type: string
   default: sync/github-main-to-stable
-- name: adoRepository
-  displayName: Azure Repos repository to sync into
-  type: string
-  default: mssql-rs
 
 resources:
   repositories:
   # Azure Repos mssql-rs: we push the sync branch here and open the PR.
+  # NOTE: 'name' and 'ref' are resolved before parameters, so they cannot be
+  # parameterized. The target repo (mssql-rs) and branch (stable) are therefore
+  # hard-coded here and mirrored into the script env below to keep them in sync.
   - repository: ado
     type: git
     name: mssql-rs/mssql-rs
@@ -112,7 +107,7 @@ steps:
       --description $'Sync of GitHub microsoft/mssql-rs main into the '"$TARGET_BRANCH"$' branch.\n\nBefore merging, ensure CI has had a good run on GitHub main.'
   displayName: Sync GitHub main to target branch
   env:
-    TARGET_BRANCH: ${{ parameters.targetBranch }}
+    TARGET_BRANCH: stable
     SYNC_BRANCH: ${{ parameters.syncBranch }}
-    ADO_REPOSITORY: ${{ parameters.adoRepository }}
+    ADO_REPOSITORY: mssql-rs
     AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)

--- a/.pipeline/sync-github-main-to-stable.yml
+++ b/.pipeline/sync-github-main-to-stable.yml
@@ -1,15 +1,19 @@
 # Pipeline to create a PR from GitHub main into the Azure DevOps stable branch.
-# Runs automatically when microsoft/mssql-rs main is updated (resource-repository
-# trigger), and can be triggered manually. Skips PR creation if:
-# - An active PR into stable from the sync branch already exists
-# - There are no changes between GitHub main and stable
+# The pipeline source is GitHub microsoft/mssql-rs, so it triggers natively on
+# every merge to main (via the Azure Pipelines GitHub App) and can also be run
+# manually. The Azure Repos mssql-rs repository is a 'git' resource we push the
+# sync branch to and open the PR against, authenticated with System.AccessToken.
+# Skips PR creation if:
+# - An active PR into the target branch from the sync branch already exists
+# - There are no changes between GitHub main and the target branch
 #
 # Prerequisites:
-# - The github.com_microsoft service connection authorized in this project.
-# - The Build Service identity has Contribute + Create branch on this repo and
-#   permission to create pull requests.
+# - GitHub microsoft/mssql-rs configured as this pipeline's source repository.
+# - The Build Service identity has Contribute + Create branch on the Azure Repos
+#   mssql-rs repository and permission to create pull requests.
 
-trigger: none
+trigger:
+- main
 
 pr: none
 
@@ -22,18 +26,18 @@ parameters:
   displayName: Intermediate ADO branch carrying GitHub main
   type: string
   default: sync/github-main-to-stable
+- name: adoRepository
+  displayName: Azure Repos repository to sync into
+  type: string
+  default: mssql-rs
 
 resources:
   repositories:
-  - repository: ghmain
-    type: github
-    name: microsoft/mssql-rs
-    endpoint: github.com_microsoft
-    ref: refs/heads/main
-    trigger:
-      branches:
-        include:
-        - main
+  # Azure Repos mssql-rs: we push the sync branch here and open the PR.
+  - repository: ado
+    type: git
+    name: mssql-rs/mssql-rs
+    ref: refs/heads/stable
 
 pool:
   name: RUST-1ES-POOL-WUS3
@@ -41,17 +45,17 @@ pool:
     - imageOverride -equals RUST-1ES-UBUSLIM
 
 steps:
-# ADO repo: we push the sync branch here and open the PR. persistCredentials lets
-# us push back to origin using System.AccessToken.
+# GitHub main (self): the source we are syncing from.
 - checkout: self
+  fetchDepth: 0
+  path: s/gh
+
+# Azure Repos mssql-rs: persistCredentials lets us push back using
+# System.AccessToken.
+- checkout: ado
   fetchDepth: 0
   persistCredentials: true
   path: s/ado
-
-# GitHub repo: authenticated checkout of main via the service connection.
-- checkout: ghmain
-  fetchDepth: 0
-  path: s/gh
 
 - script: |
     set -euo pipefail
@@ -61,10 +65,10 @@ steps:
 
     cd "$ADO_DIR"
 
-    # The GitHub checkout is in detached HEAD, so fetch its commit explicitly by
-    # HEAD; this also brings the object closure into the ADO clone. ADO's
-    # checkout doesn't populate origin/<branch> tracking refs, so capture both
-    # sides from FETCH_HEAD rather than relying on origin/$TARGET_BRANCH.
+    # Bring GitHub main's commit (and object closure) into the Azure Repos clone.
+    # The GitHub checkout is in detached HEAD, so fetch by HEAD. ADO checkouts
+    # don't populate origin/<branch> tracking refs, so capture both sides from
+    # FETCH_HEAD rather than relying on origin/$TARGET_BRANCH.
     git fetch "$GH_DIR" HEAD
     GH_MAIN_SHA="$(git rev-parse FETCH_HEAD)"
     echo "GitHub main is at $GH_MAIN_SHA"
@@ -85,7 +89,7 @@ steps:
     PR_EXISTS=$(az repos pr list \
       --organization "$(System.TeamFoundationCollectionUri)" \
       --project "$(System.TeamProject)" \
-      --repository "$(Build.Repository.Name)" \
+      --repository "$ADO_REPOSITORY" \
       --source-branch "$SYNC_BRANCH" \
       --target-branch "$TARGET_BRANCH" \
       --status active \
@@ -101,7 +105,7 @@ steps:
     az repos pr create \
       --organization "$(System.TeamFoundationCollectionUri)" \
       --project "$(System.TeamProject)" \
-      --repository "$(Build.Repository.Name)" \
+      --repository "$ADO_REPOSITORY" \
       --source-branch "$SYNC_BRANCH" \
       --target-branch "$TARGET_BRANCH" \
       --title "Sync GitHub main to $TARGET_BRANCH" \
@@ -110,4 +114,5 @@ steps:
   env:
     TARGET_BRANCH: ${{ parameters.targetBranch }}
     SYNC_BRANCH: ${{ parameters.syncBranch }}
+    ADO_REPOSITORY: ${{ parameters.adoRepository }}
     AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)


### PR DESCRIPTION
[AB#45633](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/45633)

Reworks `.pipeline/sync-github-main-to-stable.yml` so it triggers reliably on merges to GitHub `main`.

### Why
The previous version was **ADO-sourced** and relied on a GitHub **resource-repository trigger** (`resources.repositories.ghmain.trigger`). That depends on a webhook ADO must register on the GitHub repo via the service connection, which wasn't wired up \u2014 so it never fired on merges to main.

### What changed
- **`self` is now GitHub** `microsoft/mssql-rs` with a native `trigger: [main]`. CI triggering goes through the Azure Pipelines GitHub App (same proven pattern as `validation-pipeline-ci.yml`).
- **Azure Repos `mssql-rs` is now a `type: git` resource** (`ado`), checked out with `persistCredentials` so we push the sync branch and open the PR using `System.AccessToken`.
- `az repos pr` now targets the ADO repo via a new `adoRepository` param (default `mssql-rs`) instead of `Build.Repository.Name` (which is now the GitHub repo).
- Dual checkout swapped: `self` -> `s/gh`, `ado` -> `s/ado`. The fetch-by-`HEAD` + `FETCH_HEAD` SHA logic is unchanged.

### Setup needed (outside this PR)
- Create a **new ADO pipeline definition with GitHub as source**, pointing at this file.
- Ensure the **Build Service identity** has Contribute + Create branch on the Azure Repos `mssql-rs` repo and permission to create PRs.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>