### PR TITLE
Repoint validation pipeline templates from ACR to public GHCR

### DIFF
--- a/.pipeline/templates/build-python-wheels-template.yml
+++ b/.pipeline/templates/build-python-wheels-template.yml
@@ -24,10 +24,6 @@ parameters:
   displayName: 'Publish wheel artifacts (disable for OneBranch pipeline)'
 
 steps:
-# Login to Azure Container Registry for container-based builds
-- ${{ if or(eq(parameters.osType, 'Linux'), eq(parameters.osType, 'Alpine')) }}:
-  - template: azure-cli-login-template.yml
-
 # Container-based builds for Linux (glibc - manylinux)
 - ${{ if eq(parameters.osType, 'Linux') }}:
   - script: |
@@ -36,9 +32,9 @@ steps:
       # Determine container image based on architecture
       # Using pre-built images with Rust and maturin pre-installed for faster builds
       if [ "${{ parameters.architecture }}" = "x64" ]; then
-        CONTAINER_IMAGE="tdslibrs.azurecr.io/python-build/manylinux_2_34_x86_64_rust:latest"
+        CONTAINER_IMAGE="ghcr.io/microsoft/mssql-rs/python-build/manylinux_2_34_x86_64_rust:latest"
       elif [ "${{ parameters.architecture }}" = "ARM64" ] || [ "${{ parameters.architecture }}" = "arm64" ]; then
-        CONTAINER_IMAGE="tdslibrs.azurecr.io/python-build/manylinux_2_34_aarch64_rust:latest"
+        CONTAINER_IMAGE="ghcr.io/microsoft/mssql-rs/python-build/manylinux_2_34_aarch64_rust:latest"
       else
         echo "ERROR: Unsupported architecture: ${{ parameters.architecture }}"
         exit 1
@@ -124,9 +120,9 @@ steps:
       # Determine container image based on architecture
       # Using pre-built images with Rust and maturin pre-installed for faster builds
       if [ "${{ parameters.architecture }}" = "x64" ]; then
-        CONTAINER_IMAGE="tdslibrs.azurecr.io/python-build/musllinux_1_2_x86_64_rust:latest"
+        CONTAINER_IMAGE="ghcr.io/microsoft/mssql-rs/python-build/musllinux_1_2_x86_64_rust:latest"
       elif [ "${{ parameters.architecture }}" = "ARM64" ] || [ "${{ parameters.architecture }}" = "arm64" ]; then
-        CONTAINER_IMAGE="tdslibrs.azurecr.io/python-build/musllinux_1_2_aarch64_rust:latest"
+        CONTAINER_IMAGE="ghcr.io/microsoft/mssql-rs/python-build/musllinux_1_2_aarch64_rust:latest"
       else
         echo "ERROR: Unsupported architecture: ${{ parameters.architecture }}"
         exit 1

--- a/.pipeline/templates/build-template-alpine.yml
+++ b/.pipeline/templates/build-template-alpine.yml
@@ -24,7 +24,7 @@ parameters:
 - name: alpineimagetag
   displayName: Alpine Image Tag
   type: string
-  default: 'tdslibrs.azurecr.io/build/alpine:3.18'
+  default: 'ghcr.io/microsoft/mssql-rs/build/alpine:3.18'
 
 steps:
 - script: |
@@ -32,10 +32,7 @@ steps:
   displayName: Set Archive file name 
   condition: succeeded()
   
-- template: azure-cli-login-template.yml
-
 - script: |
-    az acr login -n tdslibrs
     bash .pipeline/scripts/docker-cargo-run.sh \
       -v "$PWD:/workspace" \
       -e "ARCHIVE_NAME=tdslib-nextest-musl.tar.zst" \

--- a/.pipeline/templates/build-template-container.yml
+++ b/.pipeline/templates/build-template-container.yml
@@ -79,17 +79,10 @@ steps:
     df -h "$WORK_DISK"
   displayName: Relocate Docker storage to work folder disk
 
-- template: azure-cli-login-template.yml
-
-- task: AzureCLI@2
-  displayName: Login to ACR and pull build image
-  inputs:
-    azureSubscription: 'ACR-Tdslibrs'
-    scriptType: 'bash'
-    scriptLocation: 'inlineScript'
-    inlineScript: |
-      az acr login --name tdslibrs
-      docker pull tdslibrs.azurecr.io/build/ubuntu:22.04
+- script: |
+    set -euo pipefail
+    docker pull ghcr.io/microsoft/mssql-rs/build/ubuntu:22.04
+  displayName: Pull build image
 
 - script: |
     set -euo pipefail
@@ -120,7 +113,7 @@ steps:
     SQL_PASSWORD: $(SQL_PASSWORD)
 
 - script: |
-    BUILD_IMAGE="tdslibrs.azurecr.io/build/ubuntu:22.04"
+    BUILD_IMAGE="ghcr.io/microsoft/mssql-rs/build/ubuntu:22.04"
     
     # Set IS_PR_BUILD flag
     if [ "$(Build.Reason)" = "PullRequest" ]; then
@@ -157,7 +150,7 @@ steps:
     CARGO_REGISTRIES_MSSQL_RS_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_TOKEN)
 
 - script: |
-    BUILD_IMAGE="tdslibrs.azurecr.io/build/ubuntu:22.04"
+    BUILD_IMAGE="ghcr.io/microsoft/mssql-rs/build/ubuntu:22.04"
     
     bash .pipeline/scripts/docker-cargo-run.sh --rm \
       -v $PWD:/workspace \
@@ -173,7 +166,7 @@ steps:
     CARGO_REGISTRIES_MSSQL_RS_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_TOKEN)
 
 - script: |
-    BUILD_IMAGE="tdslibrs.azurecr.io/build/ubuntu:22.04"
+    BUILD_IMAGE="ghcr.io/microsoft/mssql-rs/build/ubuntu:22.04"
     
     bash .pipeline/scripts/docker-cargo-run.sh --rm \
       -v $PWD:/workspace \
@@ -189,7 +182,7 @@ steps:
     CARGO_REGISTRIES_MSSQL_RS_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_TOKEN)
 
 - script: |
-    BUILD_IMAGE="tdslibrs.azurecr.io/build/ubuntu:22.04"
+    BUILD_IMAGE="ghcr.io/microsoft/mssql-rs/build/ubuntu:22.04"
     
     bash .pipeline/scripts/docker-cargo-run.sh --rm \
       --network testnet \
@@ -258,7 +251,7 @@ steps:
 
 - ${{ if eq(parameters.enableJsBuild, true) }}:
   - script: |
-      BUILD_IMAGE="tdslibrs.azurecr.io/build/ubuntu:22.04"
+      BUILD_IMAGE="ghcr.io/microsoft/mssql-rs/build/ubuntu:22.04"
       
       bash .pipeline/scripts/docker-cargo-run.sh --rm \
         -v $PWD:/workspace \
@@ -275,7 +268,7 @@ steps:
 
 - ${{ if eq(parameters.enableJsTest, true) }}:
   - script: |
-      BUILD_IMAGE="tdslibrs.azurecr.io/build/ubuntu:22.04"
+      BUILD_IMAGE="ghcr.io/microsoft/mssql-rs/build/ubuntu:22.04"
       
       bash .pipeline/scripts/docker-cargo-run.sh --rm \
         --network testnet \
@@ -303,7 +296,7 @@ steps:
       testRunTitle: $(System.PhaseName)-Js
 
 - script: |
-    BUILD_IMAGE="tdslibrs.azurecr.io/build/ubuntu:22.04"
+    BUILD_IMAGE="ghcr.io/microsoft/mssql-rs/build/ubuntu:22.04"
     
     bash .pipeline/scripts/docker-cargo-run.sh --rm \
       --network testnet \

--- a/.pipeline/templates/kerberos-test-template.yml
+++ b/.pipeline/templates/kerberos-test-template.yml
@@ -72,7 +72,7 @@ jobs:
       
       - template: install-ubuntu-dependency.yaml
         parameters:
-          installAzCli: true
+          installAzCli: false
           installDocker: true
       
       - script: |

--- a/.pipeline/templates/kerberos-test-template.yml
+++ b/.pipeline/templates/kerberos-test-template.yml
@@ -75,18 +75,11 @@ jobs:
           installAzCli: true
           installDocker: true
       
-      - template: azure-cli-login-template.yml
-
-      - task: AzureCLI@2
-        displayName: 'Login to ACR and pull images'
-        inputs:
-          azureSubscription: 'ACR-Tdslibrs'
-          scriptType: 'bash'
-          scriptLocation: 'inlineScript'
-          inlineScript: |
-            az acr login -n tdslibrs
-            # Pull base images needed for Kerberos tests
-            docker pull tdslibrs.azurecr.io/import/debian:bookworm
+      - script: |
+          set -euo pipefail
+          # Pull base images needed for Kerberos tests
+          docker pull ghcr.io/microsoft/mssql-rs/import/debian:bookworm
+        displayName: 'Pull base images'
 
       # Download nextest archives (for --archive mode)
       # Both glibc and musl archives are in Build_Linux artifact

--- a/.pipeline/templates/test-longhaul-template.yml
+++ b/.pipeline/templates/test-longhaul-template.yml
@@ -27,17 +27,10 @@ steps:
     installAzCli: false
     installDocker: true
 
-- template: azure-cli-login-template.yml
-
-- task: AzureCLI@2
-  displayName: Login to ACR and pull build image
-  inputs:
-    azureSubscription: 'Magnitude Test'
-    scriptType: 'bash'
-    scriptLocation: 'inlineScript'
-    inlineScript: |
-      az acr login --name tdslibrs
-      docker pull tdslibrs.azurecr.io/build/ubuntu:22.04
+- script: |
+    set -euo pipefail
+    docker pull ghcr.io/microsoft/mssql-rs/build/ubuntu:22.04
+  displayName: Pull build image
 
 - script: |
     set -euo pipefail
@@ -69,7 +62,7 @@ steps:
     SQL_PASSWORD: $(SQL_PASSWORD)
 
 - script: |
-    BUILD_IMAGE="tdslibrs.azurecr.io/build/ubuntu:22.04"
+    BUILD_IMAGE="ghcr.io/microsoft/mssql-rs/build/ubuntu:22.04"
     
     docker run --rm \
       --network testnet \

--- a/.pipeline/templates/test-matrix-template-alpine.yml
+++ b/.pipeline/templates/test-matrix-template-alpine.yml
@@ -28,7 +28,7 @@ jobs:
         displayName: 'Download Pipeline Artifacts'
       - template: install-ubuntu-dependency.yaml
         parameters:
-          installAzCli: true
+          installAzCli: false
           installDocker: true  
 
       - script: |

--- a/.pipeline/templates/test-matrix-template-alpine.yml
+++ b/.pipeline/templates/test-matrix-template-alpine.yml
@@ -30,7 +30,6 @@ jobs:
         parameters:
           installAzCli: true
           installDocker: true  
-      - template: azure-cli-login-template.yml
 
       - script: |
           echo $(container)

--- a/.pipeline/templates/test-matrix-template-alpine_arm64.yml
+++ b/.pipeline/templates/test-matrix-template-alpine_arm64.yml
@@ -29,7 +29,6 @@ jobs:
         parameters:
           installAzCli: true
           installDocker: true  
-      - template: azure-cli-login-template.yml
 
       - script: |
           echo $(container)

--- a/.pipeline/templates/test-matrix-template-alpine_arm64.yml
+++ b/.pipeline/templates/test-matrix-template-alpine_arm64.yml
@@ -27,7 +27,7 @@ jobs:
         displayName: 'Download Pipeline Artifacts'
       - template: install-ubuntu-dependency.yaml
         parameters:
-          installAzCli: true
+          installAzCli: false
           installDocker: true  
 
       - script: |

--- a/.pipeline/templates/test-matrix-template-arm64.yml
+++ b/.pipeline/templates/test-matrix-template-arm64.yml
@@ -20,7 +20,7 @@ jobs:
           dockerVersion: '29.0.0'
       - template: install-ubuntu-dependency.yaml
         parameters:
-          installAzCli: true
+          installAzCli: false
           installDocker: true
 
       - task: DownloadPipelineArtifact@2

--- a/.pipeline/templates/test-matrix-template-arm64.yml
+++ b/.pipeline/templates/test-matrix-template-arm64.yml
@@ -22,7 +22,6 @@ jobs:
         parameters:
           installAzCli: true
           installDocker: true
-      - template: azure-cli-login-template.yml
 
       - task: DownloadPipelineArtifact@2
         inputs:
@@ -30,7 +29,6 @@ jobs:
           artifactName: 'Build_Linux_ARM'
         displayName: 'Download Pipeline Artifacts'
       - script: |
-          az acr login -n tdslibrs
           echo $(container)
           echo $(entry)
           echo $container

--- a/.pipeline/templates/test-matrix-template.yml
+++ b/.pipeline/templates/test-matrix-template.yml
@@ -21,15 +21,12 @@ jobs:
       - template: install-ubuntu-dependency.yaml
         parameters:
           installAzCli: true
-      - template: azure-cli-login-template.yml
-
       - task: DownloadPipelineArtifact@2
         inputs:
           buildType: 'current'
           artifactName: 'Build_Linux'
         displayName: 'Download Pipeline Artifacts'
       - script: |
-          az acr login -n tdslibrs
           echo $(container)
           echo $(entry)
           echo $container

--- a/.pipeline/templates/test-matrix-template.yml
+++ b/.pipeline/templates/test-matrix-template.yml
@@ -20,7 +20,7 @@ jobs:
           dockerVersion: '29.0.0'
       - template: install-ubuntu-dependency.yaml
         parameters:
-          installAzCli: true
+          installAzCli: false
       - task: DownloadPipelineArtifact@2
         inputs:
           buildType: 'current'

--- a/.pipeline/templates/test-mssql-python-template.yml
+++ b/.pipeline/templates/test-mssql-python-template.yml
@@ -17,17 +17,10 @@ steps:
     installAzCli: false
     installDocker: true
 
-- template: azure-cli-login-template.yml
-
-- task: AzureCLI@2
-  displayName: Login to ACR and pull build image
-  inputs:
-    azureSubscription: 'ACR-Tdslibrs'
-    scriptType: 'bash'
-    scriptLocation: 'inlineScript'
-    inlineScript: |
-      az acr login --name tdslibrs
-      docker pull tdslibrs.azurecr.io/build/ubuntu:22.04
+- script: |
+    set -euo pipefail
+    docker pull ghcr.io/microsoft/mssql-rs/build/ubuntu:22.04
+  displayName: Pull build image
 
 - script: |
     set -euo pipefail
@@ -106,7 +99,7 @@ steps:
 
 # Run test-python.sh --mssql-python (builds ddbc + py-core, runs tests)
 - script: |
-    BUILD_IMAGE="tdslibrs.azurecr.io/build/ubuntu:22.04"
+    BUILD_IMAGE="ghcr.io/microsoft/mssql-rs/build/ubuntu:22.04"
     
     # Build connection string for mssql-python tests (expects DB_CONNECTION_STRING env var)
     # Format matches mssql-python's pr-validation-pipeline.yml: Uid/Pwd (not User Id/Password)
@@ -152,7 +145,7 @@ steps:
 
 # Build wheel artifact (reuse already-built .so files from test step)
 - script: |
-    BUILD_IMAGE="tdslibrs.azurecr.io/build/ubuntu:22.04"
+    BUILD_IMAGE="ghcr.io/microsoft/mssql-rs/build/ubuntu:22.04"
     
     docker run --rm \
       -v $PWD:/workspace \

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -391,16 +391,16 @@ stages:
         artifactName: 'Build_Linux'
         matrix:
           Alpine3_18:
-            container: tdslibrs.azurecr.io/import/alpine:3.18
+            container: ghcr.io/microsoft/mssql-rs/import/alpine:3.18
             entry: alpine.sh
           Alpine3_19:
-            container: tdslibrs.azurecr.io/import/alpine:3.19
+            container: ghcr.io/microsoft/mssql-rs/import/alpine:3.19
             entry: alpine.sh
           Alpine3_20:
-            container: tdslibrs.azurecr.io/import/alpine:3.20
+            container: ghcr.io/microsoft/mssql-rs/import/alpine:3.20
             entry: alpine.sh
           Alpine3_21:
-            container: tdslibrs.azurecr.io/import/alpine:3.21
+            container: ghcr.io/microsoft/mssql-rs/import/alpine:3.21
             entry: alpine.sh
 
 - stage: Test_alpine_arm64
@@ -416,16 +416,16 @@ stages:
         poolImageOverride: imageOverride -equals RUST-UBUNTU-ARM64
         matrix:
           Alpine3_18:
-            container: tdslibrs.azurecr.io/import/alpine:3.18
+            container: ghcr.io/microsoft/mssql-rs/import/alpine:3.18
             entry: alpine.sh
           Alpine3_19:
-            container: tdslibrs.azurecr.io/import/alpine:3.19
+            container: ghcr.io/microsoft/mssql-rs/import/alpine:3.19
             entry: alpine.sh
           Alpine3_20:
-            container: tdslibrs.azurecr.io/import/alpine:3.20
+            container: ghcr.io/microsoft/mssql-rs/import/alpine:3.20
             entry: alpine.sh
           Alpine3_21:
-            container: tdslibrs.azurecr.io/import/alpine:3.21
+            container: ghcr.io/microsoft/mssql-rs/import/alpine:3.21
             entry: alpine.sh
 
 - stage: Test_amd64
@@ -438,25 +438,25 @@ stages:
       parameters:
         matrix:
           DebianBookworm:
-            container: tdslibrs.azurecr.io/import/debian:bookworm
+            container: ghcr.io/microsoft/mssql-rs/import/debian:bookworm
             entry: deb-bookworm.sh
           AzLinux3:
             container: mcr.microsoft.com/azurelinux/base/core:3.0
             entry: azlinux3.sh
           RHEL9:
-            container: tdslibrs.azurecr.io/import/redhat/ubi9:latest
+            container: ghcr.io/microsoft/mssql-rs/import/redhat/ubi9:latest
             entry: rhel.sh
           OracleLinux9:
-            container: tdslibrs.azurecr.io/import/oraclelinux:9
+            container: ghcr.io/microsoft/mssql-rs/import/oraclelinux:9
             entry: rhel.sh
           SLES15:
             container: registry.suse.com/suse/sle15
             entry: sles.sh
           Ubuntu22:
-            container: tdslibrs.azurecr.io/import/ubuntu:22.04
+            container: ghcr.io/microsoft/mssql-rs/import/ubuntu:22.04
             entry: deb-bookworm.sh
           Ubuntu24:
-            container: tdslibrs.azurecr.io/import/ubuntu:24.04
+            container: ghcr.io/microsoft/mssql-rs/import/ubuntu:24.04
             entry: deb-bookworm.sh
 
 
@@ -470,25 +470,25 @@ stages:
       parameters:
         matrix:
           DebianBookworm:
-            container: tdslibrs.azurecr.io/import/debian:bookworm
+            container: ghcr.io/microsoft/mssql-rs/import/debian:bookworm
             entry: deb-bookworm.sh
           AzLinux3:
             container: mcr.microsoft.com/azurelinux/base/core:3.0
             entry: azlinux3.sh
           RHEL9:
-            container: tdslibrs.azurecr.io/import/redhat/ubi9:latest
+            container: ghcr.io/microsoft/mssql-rs/import/redhat/ubi9:latest
             entry: rhel.sh
           OracleLinux9:
-            container: tdslibrs.azurecr.io/import/oraclelinux:9
+            container: ghcr.io/microsoft/mssql-rs/import/oraclelinux:9
             entry: rhel.sh
           SLES15:
             container: registry.suse.com/suse/sle15
             entry: sles.sh
           Ubuntu22:
-            container: tdslibrs.azurecr.io/import/ubuntu:22.04
+            container: ghcr.io/microsoft/mssql-rs/import/ubuntu:22.04
             entry: deb-bookworm.sh
           Ubuntu24:
-            container: tdslibrs.azurecr.io/import/ubuntu:24.04
+            container: ghcr.io/microsoft/mssql-rs/import/ubuntu:24.04
             entry: deb-bookworm.sh
 
 - ${{ if eq(parameters.includeInfraStages, true) }}:


### PR DESCRIPTION
## Summary

Full cutover of the Azure DevOps validation pipeline templates from the private ACR (`tdslibrs.azurecr.io`) to the public GHCR mirror (`ghcr.io/microsoft/mssql-rs`), for both PR-triggered jobs and the dev-branch CI test matrix.

### What changed
- **Host swap (path preserved):** every `tdslibrs.azurecr.io/<path>:<tag>` → `ghcr.io/microsoft/mssql-rs/<path>:<tag>` in `container:` resources, `BUILD_IMAGE=`/`CONTAINER_IMAGE=` vars, and `docker pull` commands.
- **Removed ACR login:** dropped the `- template: azure-cli-login-template.yml` includes and `az acr login -n tdslibrs` steps from the build/test templates. GHCR packages are **public**, so anonymous `docker pull` works (verified: anonymous manifest GET / pull of every tag returns HTTP 200) — no `docker login` / `az acr login` needed.
- **Inline tasks simplified:** `AzureCLI@2` tasks that did only ACR login + pull were replaced with plain `docker pull` `- script:` steps.

### Files changed
- `validation-stages.yml` — alpine + Test_amd64/Test_arm64 `container:` matrices (mcr.microsoft.com / registry.suse.com refs left untouched)
- `build-template-container.yml`
- `build-template-alpine.yml`
- `build-python-wheels-template.yml`
- `kerberos-test-template.yml`
- `test-mssql-python-template.yml`
- `test-longhaul-template.yml` (only the ACR image pull stripped; `Magnitude Test` was used solely for that here)
- `test-matrix-template.yml`, `test-matrix-template-arm64.yml`, `test-matrix-template-alpine.yml`, `test-matrix-template-alpine_arm64.yml`

### Left intentionally unchanged
- `private-link-smoke-template.yml` — genuine ACR private-link smoke test (`az acr login` / `az acr repository delete`).
- `azure-cli-login-template.yml` — still referenced by the private-link smoke test.
- `sync-container-images.yml` — the producer pipeline.

### Verification
- `grep -rn "tdslibrs.azurecr.io" .pipeline/templates/` → zero matches outside the private-link smoke path.
- No orphaned `azure-cli-login-template.yml` includes remain in build/test templates.
- YAML validity checked for every edited file.

Depends conceptually on the GHCR mirror established in #65 (15 images mirrored, 11 packages made public).

> Draft — do not merge.