### PR TITLE
Add positioned cursor operations, options, and cursor/fetch status surfacing

### DIFF
--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -9,13 +9,14 @@ use crate::connection::client_context::ClientContext;
 use crate::connection::session_recovery::RecoveryContext;
 use crate::cursor::{
     CursorConcurrency, CursorOpenResponse, CursorOperation, CursorOptionCode, CursorOptionValue,
-    CursorPrepExecResponse, CursorPrepareResponse, CursorScrollOption, FetchDirection,
+    CursorPrepExecResponse, CursorPrepareResponse, CursorScrollOption, CursorStatus,
+    FetchDirection,
 };
 use crate::datatypes::bulk_copy_metadata::BulkCopyColumnMetadata;
 use crate::datatypes::row_writer::{DefaultRowWriter, RowWriter};
 use crate::datatypes::sql_string::SqlString;
 use crate::datatypes::sqltypes::SqlType;
-use crate::error::Error::UsageError;
+use crate::error::Error::{ProtocolError, UsageError};
 use crate::error::SqlErrorInfo;
 use crate::io::packet_writer::PacketWriter;
 use crate::message::bulk_load::{StreamingBulkLoadWriter, build_insert_bulk_command};
@@ -51,6 +52,17 @@ use crate::{
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+/// State of the `ReturnStatus` token observed while draining the most recent
+/// cursor RPC response. Distinguishes "no token was sent" from an actual raw
+/// status value, so neither case is silently collapsed at interpretation time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReturnStatus {
+    /// No `ReturnStatus` token was sent for the most recent RPC.
+    NotReceived,
+    /// The server sent a `ReturnStatus` token carrying this raw value.
+    Received(i32),
+}
+
 /// Active TDS connection to a SQL Server instance.
 ///
 /// Created by [`TdsConnectionProvider::create_client()`](crate::connection_provider::tds_connection_provider::TdsConnectionProvider::create_client).
@@ -67,6 +79,9 @@ pub struct TdsClient {
     count_map: HashMap<CurrentCommand, u64>,
 
     return_values: Vec<ReturnValue>,
+    /// State of the most recent `ReturnStatus` token, captured while draining a
+    /// cursor RPC response and interpreted as a [`CursorStatus`].
+    last_return_status: ReturnStatus,
     current_result_set_has_been_read_till_end: bool,
 
     /// The remaining request timeout for operations. This is updated after each token read.
@@ -105,6 +120,7 @@ impl TdsClient {
             current_metadata: None,
             count_map: HashMap::new(),
             return_values: Vec::new(),
+            last_return_status: ReturnStatus::NotReceived,
             current_result_set_has_been_read_till_end: false,
             remaining_request_timeout: None,
             cancel_handle: None,
@@ -1441,6 +1457,7 @@ impl TdsClient {
     /// rest and collects the OUTPUT parameters.
     async fn consume_cursor_open_response(&mut self) -> TdsResult<CursorOpenResponse> {
         self.drain_cursor_response().await?;
+        let status = self.captured_cursor_status()?;
 
         Ok(CursorOpenResponse {
             cursor_id: self.extract_return_value_int(0)?,
@@ -1451,7 +1468,25 @@ impl TdsClient {
                 self.extract_return_value_int(2)? as u32,
             ),
             row_count: self.extract_return_value_int(3)?,
+            status,
         })
+    }
+
+    /// Interprets the most recently captured `ReturnStatus` token as a
+    /// [`CursorStatus`] for the open-family RPCs.
+    ///
+    /// A missing token (`NotReceived`) maps to [`CursorStatus::Succeeded`]; an
+    /// unrecognized raw value is surfaced as a protocol error rather than being
+    /// silently treated as success.
+    fn captured_cursor_status(&self) -> TdsResult<CursorStatus> {
+        match self.last_return_status {
+            ReturnStatus::NotReceived => Ok(CursorStatus::Succeeded),
+            ReturnStatus::Received(raw) => CursorStatus::from_raw(raw).ok_or_else(|| {
+                ProtocolError(format!(
+                    "server returned an unrecognized cursor status: {raw}"
+                ))
+            }),
+        }
     }
 
     /// Shared response tail for the cursor open-family RPCs (`sp_cursoropen`,
@@ -1465,6 +1500,9 @@ impl TdsClient {
         // Clear any stale metadata up-front so an error here cannot leak columns
         // from a previous result set through get_metadata().
         self.current_metadata = None;
+        // Clear any stale return status so a missing ReturnStatus token surfaces
+        // as Succeeded rather than the previous RPC's status.
+        self.last_return_status = ReturnStatus::NotReceived;
         let metadata = self.move_to_column_metadata().await?;
         self.current_metadata = metadata;
         let server_errors = self.drain_stream().await?;
@@ -1871,6 +1909,7 @@ impl TdsClient {
         rpc.serialize(&mut pw).await?;
 
         self.drain_cursor_response().await?;
+        let status = self.captured_cursor_status()?;
 
         // OUTPUT ordinals: 0=prepared_handle, 1=cursor, 2=scrollopt, 3=ccopt, 4=rowcount
         Ok(CursorPrepExecResponse {
@@ -1884,6 +1923,7 @@ impl TdsClient {
                     self.extract_return_value_int(3)? as u32,
                 ),
                 row_count: self.extract_return_value_int(4)?,
+                status,
             },
         })
     }
@@ -2062,6 +2102,7 @@ impl TdsClient {
         rpc.serialize(&mut pw).await?;
 
         self.drain_cursor_response().await?;
+        let status = self.captured_cursor_status()?;
 
         // OUTPUT ordinals: 0=prepared_handle, 1=scrollopt, 2=ccopt (no rowcount).
         Ok(CursorPrepareResponse {
@@ -2072,6 +2113,7 @@ impl TdsClient {
             negotiated_concurrency: CursorConcurrency::from_bits_truncate(
                 self.extract_return_value_int(2)? as u32,
             ),
+            status,
         })
     }
 
@@ -2180,8 +2222,9 @@ impl TdsClient {
                     let return_value = return_value_token.into();
                     self.return_values.push(return_value);
                 }
-                Tokens::ReturnStatus(_return_status) => {
-                    info!(?_return_status);
+                Tokens::ReturnStatus(return_status) => {
+                    self.last_return_status = ReturnStatus::Received(return_status.value);
+                    info!(?return_status);
                 }
                 _ => {
                     info!(?token);
@@ -2291,6 +2334,7 @@ impl TdsClient {
                     self.return_values.push(return_value);
                 }
                 Tokens::ReturnStatus(return_status) => {
+                    self.last_return_status = ReturnStatus::Received(return_status.value);
                     info!("Received return_status token: {:?}", return_status);
                     continue;
                 }

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -1712,6 +1712,16 @@ impl TdsClient {
             return Err(UsageError(ALREADY_EXECUTING_ERROR.to_string()));
         }
 
+        // The column values are sent as named (@column) RPC parameters, so each
+        // must carry a name; an unnamed parameter would panic during
+        // serialization. Reject it as a usage error before any I/O.
+        if values.iter().any(|p| p.name.is_none()) {
+            return Err(UsageError(
+                "perform_cursor_operation values must be named parameters (column names prefixed with `@`)"
+                    .to_string(),
+            ));
+        }
+
         let reconnect_elapsed = self.check_and_reconnect(timeout_sec, cancel_handle).await?;
         let timeout_sec = Self::deduct_timeout(timeout_sec, reconnect_elapsed);
 

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -1598,7 +1598,9 @@ impl TdsClient {
     #[instrument(skip(self), level = "info")]
     pub async fn next_cursor_row(&mut self) -> TdsResult<Option<(Vec<ColumnValues>, FetchStatus)>> {
         // Guard: only valid on an sp_cursorfetch result, whose last column is the
-        // hidden `rowstat`. Refuse to strip a real column from a normal result.
+        // trailing `rowstat`. The server names it `rowstat` but does NOT set the
+        // hidden flag on it, so it is identified by name. Refuse to strip a real
+        // column from a normal result.
         let has_rowstat = self
             .get_metadata()
             .last()

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -10,7 +10,7 @@ use crate::connection::session_recovery::RecoveryContext;
 use crate::cursor::{
     CursorConcurrency, CursorOpenResponse, CursorOperation, CursorOptionCode, CursorOptionValue,
     CursorPrepExecResponse, CursorPrepareResponse, CursorScrollOption, CursorStatus,
-    FetchDirection,
+    FetchDirection, FetchStatus,
 };
 use crate::datatypes::bulk_copy_metadata::BulkCopyColumnMetadata;
 use crate::datatypes::row_writer::{DefaultRowWriter, RowWriter};
@@ -1578,6 +1578,56 @@ impl TdsClient {
             self.execution_context.set_has_open_batch(true);
         }
         Ok(())
+    }
+
+    /// Reads the next row from an open cursor's fetch buffer, splitting off the
+    /// hidden trailing `rowstat` column and decoding it as a [`FetchStatus`].
+    ///
+    /// `sp_cursorfetch` appends a hidden `int` `rowstat` column to every row
+    /// (see [`cursor_fetch`](Self::cursor_fetch)). This method strips that
+    /// column from the returned data and decodes it, so a driver can report
+    /// per-row state (`SQL_ROW_DELETED` / `UPDATED` / `ADDED`) for keyset and
+    /// dynamic cursors. Use it instead of [`next_row`](ResultSet::next_row) when
+    /// consuming a cursor fetch.
+    ///
+    /// Returns `Ok(None)` at the end of the fetch buffer. The data columns are
+    /// returned without the `rowstat`, though
+    /// [`get_metadata`](ResultSet::get_metadata) still includes its descriptor.
+    /// Returns a usage error if the current result set is not a cursor fetch
+    /// (no trailing `rowstat` column).
+    #[instrument(skip(self), level = "info")]
+    pub async fn next_cursor_row(&mut self) -> TdsResult<Option<(Vec<ColumnValues>, FetchStatus)>> {
+        // Guard: only valid on an sp_cursorfetch result, whose last column is the
+        // hidden `rowstat`. Refuse to strip a real column from a normal result.
+        let has_rowstat = self
+            .get_metadata()
+            .last()
+            .map(|c| c.column_name.eq_ignore_ascii_case("rowstat"))
+            .unwrap_or(false);
+        if !has_rowstat {
+            return Err(UsageError(
+                "next_cursor_row requires a cursor fetch result with a trailing rowstat column"
+                    .to_string(),
+            ));
+        }
+
+        let Some(mut row) = self.next_row().await? else {
+            return Ok(None);
+        };
+        let rowstat = row.pop().ok_or_else(|| {
+            crate::error::Error::ProtocolError(
+                "cursor fetch row is missing its trailing rowstat column".to_string(),
+            )
+        })?;
+        let bits = match rowstat {
+            ColumnValues::Int(v) => v as u32,
+            other => {
+                return Err(crate::error::Error::ProtocolError(format!(
+                    "expected an INT rowstat column at the end of a cursor fetch row, got {other:?}"
+                )));
+            }
+        };
+        Ok(Some((row, FetchStatus::from_bits_truncate(bits))))
     }
 
     /// Closes a server cursor and releases server resources (`sp_cursorclose`, RPC ID 9).

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -8,8 +8,8 @@ use crate::connection::bulk_copy_state::ATTENTION_TIMEOUT_SECONDS;
 use crate::connection::client_context::ClientContext;
 use crate::connection::session_recovery::RecoveryContext;
 use crate::cursor::{
-    CursorConcurrency, CursorOpenResponse, CursorPrepExecResponse, CursorPrepareResponse,
-    CursorScrollOption, FetchDirection,
+    CursorConcurrency, CursorOpenResponse, CursorOperation, CursorOptionCode, CursorOptionValue,
+    CursorPrepExecResponse, CursorPrepareResponse, CursorScrollOption, FetchDirection,
 };
 use crate::datatypes::bulk_copy_metadata::BulkCopyColumnMetadata;
 use crate::datatypes::row_writer::{DefaultRowWriter, RowWriter};
@@ -1575,6 +1575,173 @@ impl TdsClient {
 
         let rpc = SqlRpc::new(
             RpcType::ProcId(RpcProcs::CursorClose),
+            Some(params),
+            None,
+            &db_collation,
+            &self.execution_context,
+        );
+
+        let mut pw =
+            rpc.create_packet_writer(self.transport.as_writer(), timeout_sec, cancel_handle);
+        rpc.serialize(&mut pw).await?;
+
+        let server_errors = self.drain_stream().await?;
+        self.execution_context.set_has_open_batch(false);
+        if !server_errors.is_empty() {
+            return Err(crate::error::Error::from_sql_errors(server_errors));
+        }
+        Ok(())
+    }
+
+    /// Performs a positioned operation on the current fetch buffer of an open
+    /// cursor (`sp_cursor`, RPC ID 1).
+    ///
+    /// Supports positioned `UPDATE` / `DELETE` / `INSERT` (and `LOCK`,
+    /// `REFRESH`, `SETPOSITION`) via [`CursorOperation`]. The `values` are the
+    /// column values for `UPDATE` / `INSERT`, supplied as **named** parameters
+    /// whose names are the target columns prefixed with `@` (e.g. `@Name`);
+    /// pass an empty vector for `DELETE` / `LOCK`. `rownum` selects the 1-based
+    /// row within the fetch buffer (`0` targets all rows). `table` names the
+    /// target table when the cursor's SELECT joins multiple tables; pass `""`
+    /// to default to the first table in the FROM clause.
+    ///
+    /// Requires an updatable cursor (non-`READONLY` concurrency). A concurrency
+    /// conflict or constraint violation is surfaced as an
+    /// [`Error`](crate::error::Error) carrying the server message.
+    #[allow(clippy::too_many_arguments)] // Matches sp_cursor's positional parameters
+    #[instrument(skip(self, values), level = "info")]
+    pub async fn perform_cursor_operation(
+        &mut self,
+        cursor_id: i32,
+        optype: CursorOperation,
+        rownum: i32,
+        table: &str,
+        values: Vec<RpcParameter>,
+        timeout_sec: Option<u32>,
+        cancel_handle: Option<&CancelHandle>,
+    ) -> TdsResult<()> {
+        if self.execution_context.has_open_batch() {
+            return Err(UsageError(ALREADY_EXECUTING_ERROR.to_string()));
+        }
+
+        let reconnect_elapsed = self.check_and_reconnect(timeout_sec, cancel_handle).await?;
+        let timeout_sec = Self::deduct_timeout(timeout_sec, reconnect_elapsed);
+
+        self.remaining_request_timeout = Self::timeout_to_duration(timeout_sec);
+        self.cancel_handle = cancel_handle.map(|handle| handle.child_handle());
+        self.return_values.clear();
+        self.transport.reset_reader();
+
+        let db_collation = self.negotiated_settings.database_collation;
+
+        // sp_cursor positional params: cursor, optype, rownum, table. The column
+        // values follow as named (@column) RPC parameters, so no parameter
+        // declaration string is sent (unlike sp_cursoropen).
+        let positional_params = vec![
+            RpcParameter::new(None, StatusFlags::NONE, SqlType::Int(Some(cursor_id))),
+            RpcParameter::new(
+                None,
+                StatusFlags::NONE,
+                SqlType::Int(Some(optype.bits() as i32)),
+            ),
+            RpcParameter::new(None, StatusFlags::NONE, SqlType::Int(Some(rownum))),
+            RpcParameter::new(
+                None,
+                StatusFlags::NONE,
+                SqlType::NVarcharMax(Some(SqlString::from_utf8_string(table.to_string()))),
+            ),
+        ];
+
+        let user_params = if values.is_empty() {
+            None
+        } else {
+            Some(values)
+        };
+
+        let rpc = SqlRpc::new(
+            RpcType::ProcId(RpcProcs::Cursor),
+            Some(positional_params),
+            user_params,
+            &db_collation,
+            &self.execution_context,
+        );
+
+        let mut pw =
+            rpc.create_packet_writer(self.transport.as_writer(), timeout_sec, cancel_handle);
+        rpc.serialize(&mut pw).await?;
+
+        let server_errors = self.drain_stream().await?;
+        self.execution_context.set_has_open_batch(false);
+        if !server_errors.is_empty() {
+            return Err(crate::error::Error::from_sql_errors(server_errors));
+        }
+        Ok(())
+    }
+
+    /// Sets an option on an open cursor (`sp_cursoroption`, RPC ID 8).
+    ///
+    /// Most commonly used to assign a **name** to the cursor
+    /// ([`CursorOptionCode::CursorName`]) so Transact-SQL `WHERE CURRENT OF`
+    /// positioned statements can target it, or to toggle text-pointer handling.
+    /// The `value` variant must match what `code` expects: only
+    /// [`CursorOptionCode::CursorName`] takes a [`CursorOptionValue::String`];
+    /// every other code takes a [`CursorOptionValue::Int`]. A mismatch returns
+    /// a usage error without contacting the server.
+    #[instrument(skip(self), level = "info")]
+    pub async fn set_cursor_option(
+        &mut self,
+        cursor_id: i32,
+        code: CursorOptionCode,
+        value: CursorOptionValue,
+        timeout_sec: Option<u32>,
+        cancel_handle: Option<&CancelHandle>,
+    ) -> TdsResult<()> {
+        if self.execution_context.has_open_batch() {
+            return Err(UsageError(ALREADY_EXECUTING_ERROR.to_string()));
+        }
+
+        // Validate the value type matches the option code before any server
+        // round-trip, so bad input fails fast.
+        let value_param = match (&value, code.expects_string()) {
+            (CursorOptionValue::String(s), true) => RpcParameter::new(
+                None,
+                StatusFlags::NONE,
+                SqlType::NVarcharMax(Some(SqlString::from_utf8_string(s.clone()))),
+            ),
+            (CursorOptionValue::Int(i), false) => {
+                RpcParameter::new(None, StatusFlags::NONE, SqlType::Int(Some(*i)))
+            }
+            _ => {
+                return Err(UsageError(format!(
+                    "sp_cursoroption code {code:?} expects a {} value",
+                    if code.expects_string() {
+                        "string"
+                    } else {
+                        "integer"
+                    }
+                )));
+            }
+        };
+
+        let reconnect_elapsed = self.check_and_reconnect(timeout_sec, cancel_handle).await?;
+        let timeout_sec = Self::deduct_timeout(timeout_sec, reconnect_elapsed);
+
+        self.remaining_request_timeout = Self::timeout_to_duration(timeout_sec);
+        self.cancel_handle = cancel_handle.map(|handle| handle.child_handle());
+        self.return_values.clear();
+        self.transport.reset_reader();
+
+        let db_collation = self.negotiated_settings.database_collation;
+
+        // sp_cursoroption positional params: cursor, code, value.
+        let params = vec![
+            RpcParameter::new(None, StatusFlags::NONE, SqlType::Int(Some(cursor_id))),
+            RpcParameter::new(None, StatusFlags::NONE, SqlType::Int(Some(code as i32))),
+            value_param,
+        ];
+
+        let rpc = SqlRpc::new(
+            RpcType::ProcId(RpcProcs::CursorOption),
             Some(params),
             None,
             &db_collation,

--- a/mssql-tds/src/cursor/cursor_response.rs
+++ b/mssql-tds/src/cursor/cursor_response.rs
@@ -157,12 +157,14 @@ mod tests {
             status: CursorStatus::Succeeded,
         };
         assert_eq!(resp.prepared_handle, 77);
-        assert!(resp
-            .negotiated_scroll
-            .contains(CursorScrollOption::FORWARD_ONLY));
-        assert!(resp
-            .negotiated_scroll
-            .contains(CursorScrollOption::AUTO_CLOSE));
+        assert!(
+            resp.negotiated_scroll
+                .contains(CursorScrollOption::FORWARD_ONLY)
+        );
+        assert!(
+            resp.negotiated_scroll
+                .contains(CursorScrollOption::AUTO_CLOSE)
+        );
         assert_eq!(resp.negotiated_concurrency, CursorConcurrency::READONLY);
     }
 

--- a/mssql-tds/src/cursor/cursor_response.rs
+++ b/mssql-tds/src/cursor/cursor_response.rs
@@ -18,8 +18,8 @@ use super::cursor_types::{CursorConcurrency, CursorScrollOption};
 /// type/concurrency values (which may differ from what the caller requested).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CursorOpenResponse {
-    /// Server-assigned cursor handle. Pass to `cursor_fetch`, `cursor_op`,
-    /// `cursor_option`, and `cursor_close`.
+    /// Server-assigned cursor handle. Pass to `cursor_fetch`,
+    /// `perform_cursor_operation`, `set_cursor_option`, and `cursor_close`.
     pub cursor_id: i32,
     /// Cursor type the server actually granted. May differ from the
     /// requested `scrollopt` if the server downgraded.

--- a/mssql-tds/src/cursor/cursor_response.rs
+++ b/mssql-tds/src/cursor/cursor_response.rs
@@ -8,7 +8,7 @@
 //! set `AUTO_FETCH` or `RETURN_METADATA`, rows/metadata are available in the
 //! token stream via `get_next_row_into()`.
 
-use super::cursor_types::{CursorConcurrency, CursorScrollOption};
+use super::cursor_types::{CursorConcurrency, CursorScrollOption, CursorStatus};
 
 /// Response from `sp_cursoropen` (`RpcProcs::CursorOpen`),
 /// `sp_cursorexecute` (`RpcProcs::CursorExecute`), or the cursor portion
@@ -30,6 +30,10 @@ pub struct CursorOpenResponse {
     /// Row count returned by the server. When `AUTO_FETCH` is set, this
     /// is the number of rows in the first fetch batch.
     pub row_count: i32,
+    /// Cursor status from the RPC `ReturnStatus` token. Reports whether the
+    /// cursor was auto-closed ([`CursorStatus::Closed`]) at end-of-results or is
+    /// still being populated asynchronously ([`CursorStatus::Async`], keyset).
+    pub status: CursorStatus,
 }
 
 /// Response from `sp_cursorprepexec` (`RpcProcs::CursorPrepExec`).
@@ -56,6 +60,9 @@ pub struct CursorPrepareResponse {
     pub negotiated_scroll: CursorScrollOption,
     /// Concurrency the server will grant (negotiated at prepare time).
     pub negotiated_concurrency: CursorConcurrency,
+    /// Status from the RPC `ReturnStatus` token (normally
+    /// [`CursorStatus::Succeeded`] for a prepare, which opens no cursor).
+    pub status: CursorStatus,
 }
 
 #[cfg(test)]
@@ -69,6 +76,7 @@ mod tests {
             negotiated_scroll: CursorScrollOption::FORWARD_ONLY,
             negotiated_concurrency: CursorConcurrency::READONLY,
             row_count: 100,
+            status: CursorStatus::Succeeded,
         };
         assert_eq!(resp.cursor_id, 42);
         assert_eq!(resp.negotiated_scroll, CursorScrollOption::FORWARD_ONLY);
@@ -84,6 +92,7 @@ mod tests {
             negotiated_scroll: CursorScrollOption::KEYSET_DRIVEN,
             negotiated_concurrency: CursorConcurrency::READONLY,
             row_count: 0,
+            status: CursorStatus::Succeeded,
         };
         assert_ne!(resp.negotiated_scroll, CursorScrollOption::DYNAMIC);
         assert_eq!(resp.negotiated_scroll, CursorScrollOption::KEYSET_DRIVEN);
@@ -96,6 +105,7 @@ mod tests {
             negotiated_scroll: CursorScrollOption::STATIC,
             negotiated_concurrency: CursorConcurrency::OPTCC,
             row_count: 50,
+            status: CursorStatus::Succeeded,
         };
         let cloned = resp.clone();
         assert_eq!(resp, cloned);
@@ -110,6 +120,7 @@ mod tests {
                 negotiated_scroll: CursorScrollOption::KEYSET_DRIVEN,
                 negotiated_concurrency: CursorConcurrency::OPTCC,
                 row_count: 200,
+                status: CursorStatus::Succeeded,
             },
         };
         assert_eq!(resp.prepared_handle, 99);
@@ -130,6 +141,7 @@ mod tests {
                 negotiated_scroll: CursorScrollOption::DYNAMIC,
                 negotiated_concurrency: CursorConcurrency::LOCKCC,
                 row_count: 0,
+                status: CursorStatus::Succeeded,
             },
         };
         let cloned = resp.clone();
@@ -142,16 +154,15 @@ mod tests {
             prepared_handle: 77,
             negotiated_scroll: CursorScrollOption::FORWARD_ONLY | CursorScrollOption::AUTO_CLOSE,
             negotiated_concurrency: CursorConcurrency::READONLY,
+            status: CursorStatus::Succeeded,
         };
         assert_eq!(resp.prepared_handle, 77);
-        assert!(
-            resp.negotiated_scroll
-                .contains(CursorScrollOption::FORWARD_ONLY)
-        );
-        assert!(
-            resp.negotiated_scroll
-                .contains(CursorScrollOption::AUTO_CLOSE)
-        );
+        assert!(resp
+            .negotiated_scroll
+            .contains(CursorScrollOption::FORWARD_ONLY));
+        assert!(resp
+            .negotiated_scroll
+            .contains(CursorScrollOption::AUTO_CLOSE));
         assert_eq!(resp.negotiated_concurrency, CursorConcurrency::READONLY);
     }
 
@@ -161,6 +172,7 @@ mod tests {
             prepared_handle: 12,
             negotiated_scroll: CursorScrollOption::STATIC,
             negotiated_concurrency: CursorConcurrency::OPTCCVAL,
+            status: CursorStatus::Succeeded,
         };
         let cloned = resp.clone();
         assert_eq!(resp, cloned);

--- a/mssql-tds/src/query/metadata.rs
+++ b/mssql-tds/src/query/metadata.rs
@@ -53,6 +53,12 @@ impl ColumnMetadata {
     pub fn is_encrypted(&self) -> bool {
         (self.flags & 0x2000) != 0x00
     }
+    /// Column is a key column used in cursor operations (`fKey`, bit 14 of the
+    /// COLMETADATA Flags word). A driver uses this to build positioned-update
+    /// predicates (`WHERE` clauses) for updatable server cursors.
+    pub fn is_key_column(&self) -> bool {
+        (self.flags & 0x4000) != 0x00
+    }
     /// Column uses Partially Length-prefixed (PLP) encoding (e.g., `varchar(max)`).
     pub fn is_plp(&self) -> bool {
         matches!(
@@ -258,6 +264,17 @@ mod tests {
         let metadata =
             create_test_column_metadata(0x00, TypeInfoVariant::FixedLen(FixedLengthTypes::Int4));
         assert!(!metadata.is_encrypted());
+    }
+
+    #[test]
+    fn test_is_key_column() {
+        let metadata =
+            create_test_column_metadata(0x4000, TypeInfoVariant::FixedLen(FixedLengthTypes::Int4));
+        assert!(metadata.is_key_column());
+
+        let metadata =
+            create_test_column_metadata(0x00, TypeInfoVariant::FixedLen(FixedLengthTypes::Int4));
+        assert!(!metadata.is_key_column());
     }
 
     #[test]

--- a/mssql-tds/src/query/metadata.rs
+++ b/mssql-tds/src/query/metadata.rs
@@ -45,13 +45,15 @@ impl ColumnMetadata {
     pub fn is_computed(&self) -> bool {
         (self.flags & 0x20) != 0x00
     }
-    /// Column is a sparse column set (`xml COLUMN_SET FOR ALL_SPARSE_COLUMNS`).
+    /// Column is a sparse column set (`xml COLUMN_SET FOR ALL_SPARSE_COLUMNS`),
+    /// `fSparseColumnSet`, bit 10 of the COLMETADATA Flags word.
     pub fn is_sparse_column_set(&self) -> bool {
-        (self.flags & 0x1000) != 0x00
+        (self.flags & 0x0400) != 0x00
     }
-    /// Column is protected by Always Encrypted.
+    /// Column is protected by Always Encrypted (`fEncrypted`, bit 11 of the
+    /// COLMETADATA Flags word).
     pub fn is_encrypted(&self) -> bool {
-        (self.flags & 0x2000) != 0x00
+        (self.flags & 0x0800) != 0x00
     }
     /// Column is a key column used in cursor operations (`fKey`, bit 14 of the
     /// COLMETADATA Flags word). A driver uses this to build positioned-update
@@ -247,8 +249,13 @@ mod tests {
     #[test]
     fn test_is_sparse_column_set() {
         let metadata =
-            create_test_column_metadata(0x1000, TypeInfoVariant::FixedLen(FixedLengthTypes::Int4));
+            create_test_column_metadata(0x0400, TypeInfoVariant::FixedLen(FixedLengthTypes::Int4));
         assert!(metadata.is_sparse_column_set());
+
+        // 0x1000 is fUnused1, not fSparseColumnSet.
+        let metadata =
+            create_test_column_metadata(0x1000, TypeInfoVariant::FixedLen(FixedLengthTypes::Int4));
+        assert!(!metadata.is_sparse_column_set());
 
         let metadata =
             create_test_column_metadata(0x00, TypeInfoVariant::FixedLen(FixedLengthTypes::Int4));
@@ -258,8 +265,13 @@ mod tests {
     #[test]
     fn test_is_encrypted() {
         let metadata =
-            create_test_column_metadata(0x2000, TypeInfoVariant::FixedLen(FixedLengthTypes::Int4));
+            create_test_column_metadata(0x0800, TypeInfoVariant::FixedLen(FixedLengthTypes::Int4));
         assert!(metadata.is_encrypted());
+
+        // 0x2000 is fHidden (FOR BROWSE), not fEncrypted.
+        let metadata =
+            create_test_column_metadata(0x2000, TypeInfoVariant::FixedLen(FixedLengthTypes::Int4));
+        assert!(!metadata.is_encrypted());
 
         let metadata =
             create_test_column_metadata(0x00, TypeInfoVariant::FixedLen(FixedLengthTypes::Int4));

--- a/mssql-tds/src/query/metadata.rs
+++ b/mssql-tds/src/query/metadata.rs
@@ -55,6 +55,11 @@ impl ColumnMetadata {
     pub fn is_encrypted(&self) -> bool {
         (self.flags & 0x0800) != 0x00
     }
+    /// Column is hidden (`fHidden`, bit 13 of the COLMETADATA Flags word), for
+    /// example a `FOR BROWSE` key column.
+    pub fn is_hidden(&self) -> bool {
+        (self.flags & 0x2000) != 0x00
+    }
     /// Column is a key column used in cursor operations (`fKey`, bit 14 of the
     /// COLMETADATA Flags word). A driver uses this to build positioned-update
     /// predicates (`WHERE` clauses) for updatable server cursors.
@@ -276,6 +281,17 @@ mod tests {
         let metadata =
             create_test_column_metadata(0x00, TypeInfoVariant::FixedLen(FixedLengthTypes::Int4));
         assert!(!metadata.is_encrypted());
+    }
+
+    #[test]
+    fn test_is_hidden() {
+        let metadata =
+            create_test_column_metadata(0x2000, TypeInfoVariant::FixedLen(FixedLengthTypes::Int4));
+        assert!(metadata.is_hidden());
+
+        let metadata =
+            create_test_column_metadata(0x00, TypeInfoVariant::FixedLen(FixedLengthTypes::Int4));
+        assert!(!metadata.is_hidden());
     }
 
     #[test]

--- a/mssql-tds/src/token/parsers/colmetadata_parser.rs
+++ b/mssql-tds/src/token/parsers/colmetadata_parser.rs
@@ -30,15 +30,20 @@
 //! └───────────┴───────┴──────────┴─────────────┴──────────────┴────────────┘
 //!     0-3       4-5       6         7 ... M      M+1 ... P     P+1 ... Q
 //!
-//! Flags (bitmask):
-//!   0x01 = Nullable
-//!   0x08 = Identity column
-//!   0x10 = Computed column
-//!   0x20 = Fixed length CLR type
-//!   0x40 = Hidden (e.g., FOR BROWSE)
-//!   0x80 = Key column (used in cursor operations)
-//!   0x100= Nullable unknown
-//!   0x200= Column is encrypted (Always Encrypted feature)
+//! Flags (bitmask, per MS-TDS COLMETADATA, least-significant-bit order):
+//!   0x0001 = Nullable (fNullable)
+//!   0x0002 = Case-sensitive collation (fCaseSen)
+//!   0x000C = Updateable (2-bit: 0=read-only, 1=read/write, 2=unknown)
+//!   0x0010 = Identity column (fIdentity)
+//!   0x0020 = Computed column (fComputed)
+//!   0x00C0 = usReservedODBC (2-bit, reserved)
+//!   0x0100 = Fixed-length CLR type (fFixedLenCLRType)
+//!   0x0200 = Default value, used for table-valued parameters (fIsDefault)
+//!   0x0400 = Sparse column set (fSparseColumnSet)
+//!   0x0800 = Encrypted, Always Encrypted (fEncrypted)
+//!   0x2000 = Hidden, e.g. FOR BROWSE (fHidden)
+//!   0x4000 = Key column, used in cursor operations (fKey)
+//!   0x8000 = Nullable unknown (fNullableUnknown)
 //!
 //! TypeInfo varies by DataType:
 //!   - INT/BIGINT:    No additional info

--- a/mssql-tds/src/token/parsers/returnstatus_parser.rs
+++ b/mssql-tds/src/token/parsers/returnstatus_parser.rs
@@ -88,7 +88,7 @@ where
         // This is the value from a stored procedure's RETURN statement
         let value = reader.read_int32().await?;
 
-        Ok(Tokens::from(ReturnStatusToken { _value: value }))
+        Ok(Tokens::from(ReturnStatusToken { value }))
     }
 }
 
@@ -106,7 +106,7 @@ mod tests {
 
         match result {
             Tokens::ReturnStatus(token) => {
-                assert_eq!(token._value, 0);
+                assert_eq!(token.value, 0);
             }
             _ => panic!("Expected ReturnStatus token"),
         }
@@ -121,7 +121,7 @@ mod tests {
 
         match result {
             Tokens::ReturnStatus(token) => {
-                assert_eq!(token._value, -1);
+                assert_eq!(token.value, -1);
             }
             _ => panic!("Expected ReturnStatus token"),
         }
@@ -136,7 +136,7 @@ mod tests {
 
         match result {
             Tokens::ReturnStatus(token) => {
-                assert_eq!(token._value, 42);
+                assert_eq!(token.value, 42);
             }
             _ => panic!("Expected ReturnStatus token"),
         }
@@ -151,7 +151,7 @@ mod tests {
 
         match result {
             Tokens::ReturnStatus(token) => {
-                assert_eq!(token._value, i32::MAX);
+                assert_eq!(token.value, i32::MAX);
             }
             _ => panic!("Expected ReturnStatus token"),
         }
@@ -166,7 +166,7 @@ mod tests {
 
         match result {
             Tokens::ReturnStatus(token) => {
-                assert_eq!(token._value, i32::MIN);
+                assert_eq!(token.value, i32::MIN);
             }
             _ => panic!("Expected ReturnStatus token"),
         }

--- a/mssql-tds/src/token/tokens.rs
+++ b/mssql-tds/src/token/tokens.rs
@@ -962,7 +962,7 @@ pub(crate) struct ReturnStatusToken {
 
 impl Token for ReturnStatusToken {
     fn token_type(&self) -> TokenType {
-        TokenType::ReturnValue
+        TokenType::ReturnStatus
     }
 }
 

--- a/mssql-tds/src/token/tokens.rs
+++ b/mssql-tds/src/token/tokens.rs
@@ -957,7 +957,7 @@ impl DoneToken {
 pub(crate) struct ReturnStatusToken {
     /// Return value from the stored procedure's RETURN statement
     /// Convention: 0 = success, negative = error, positive = application-specific
-    pub _value: i32,
+    pub value: i32,
 }
 
 impl Token for ReturnStatusToken {

--- a/mssql-tds/tests/test_cursor_ops.rs
+++ b/mssql-tds/tests/test_cursor_ops.rs
@@ -10,8 +10,13 @@ mod common;
 
 use common::{begin_connection, build_tcp_datasource};
 use mssql_tds::connection::tds_client::{ResultSet, ResultSetClient};
-use mssql_tds::cursor::{CursorConcurrency, CursorScrollOption, FetchDirection};
+use mssql_tds::cursor::{
+    CursorConcurrency, CursorOperation, CursorOptionCode, CursorOptionValue, CursorScrollOption,
+    FetchDirection,
+};
 use mssql_tds::datatypes::column_values::ColumnValues;
+use mssql_tds::datatypes::sqltypes::SqlType;
+use mssql_tds::message::parameters::rpc_parameters::{RpcParameter, StatusFlags};
 
 /// Set up a temp table with the given number of rows.
 async fn setup_temp_table(
@@ -1343,5 +1348,198 @@ async fn cursor_unprepare_invalid_handle() {
         .await
         .unwrap();
     client.close_query().await.unwrap();
+    client.close_connection().await.unwrap();
+}
+
+// --- Positioned operations (sp_cursor) and cursor options (sp_cursoroption) ---
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cursor_positioned_update() {
+    let mut client = begin_connection(&build_tcp_datasource()).await;
+    setup_temp_table(&mut client, 5).await;
+
+    // Updatable cursor: keyset-driven with optimistic concurrency.
+    let resp = client
+        .cursor_open(
+            "SELECT id, name, value FROM #ct ORDER BY id",
+            CursorScrollOption::KEYSET_DRIVEN,
+            CursorConcurrency::OPTCC,
+            0,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    let cursor_id = resp.cursor_id;
+    assert_ne!(cursor_id, 0);
+
+    // Fetch the first row into the fetch buffer, then drain the rowset so the
+    // connection is free for the positioned operation.
+    client
+        .cursor_fetch(cursor_id, FetchDirection::NEXT, 0, 1, None, None)
+        .await
+        .unwrap();
+    let rows = read_all_rows(&mut client).await;
+    assert_eq!(rows.len(), 1);
+    let first_id = match rows[0][0] {
+        ColumnValues::Int(v) => v,
+        ref other => panic!("expected INT id, got {other:?}"),
+    };
+
+    // Positioned UPDATE of row 1 in the fetch buffer: value = 999. The column
+    // value is supplied as a named @value parameter.
+    client
+        .perform_cursor_operation(
+            cursor_id,
+            CursorOperation::UPDATE,
+            1,
+            "",
+            vec![RpcParameter::new(
+                Some("@value".to_string()),
+                StatusFlags::NONE,
+                SqlType::Int(Some(999)),
+            )],
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    client.cursor_close(cursor_id, None, None).await.unwrap();
+
+    // Verify the row was modified.
+    client
+        .execute(
+            format!("SELECT value FROM #ct WHERE id = {first_id}"),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    let verify = read_all_rows(&mut client).await;
+    assert_eq!(verify.len(), 1);
+    assert_eq!(verify[0][0], ColumnValues::Int(999));
+
+    client.close_connection().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cursor_positioned_delete() {
+    let mut client = begin_connection(&build_tcp_datasource()).await;
+    setup_temp_table(&mut client, 5).await;
+
+    let resp = client
+        .cursor_open(
+            "SELECT id, name, value FROM #ct ORDER BY id",
+            CursorScrollOption::KEYSET_DRIVEN,
+            CursorConcurrency::OPTCC,
+            0,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    let cursor_id = resp.cursor_id;
+
+    client
+        .cursor_fetch(cursor_id, FetchDirection::NEXT, 0, 1, None, None)
+        .await
+        .unwrap();
+    let rows = read_all_rows(&mut client).await;
+    assert_eq!(rows.len(), 1);
+    let first_id = match rows[0][0] {
+        ColumnValues::Int(v) => v,
+        ref other => panic!("expected INT id, got {other:?}"),
+    };
+
+    // Positioned DELETE of row 1 in the fetch buffer (no value params).
+    client
+        .perform_cursor_operation(
+            cursor_id,
+            CursorOperation::DELETE,
+            1,
+            "",
+            vec![],
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    client.cursor_close(cursor_id, None, None).await.unwrap();
+
+    // Verify the row is gone.
+    client
+        .execute(
+            format!("SELECT COUNT(*) FROM #ct WHERE id = {first_id}"),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    let verify = read_all_rows(&mut client).await;
+    assert_eq!(verify.len(), 1);
+    assert_eq!(verify[0][0], ColumnValues::Int(0));
+
+    client.close_connection().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cursor_option_set_name() {
+    let mut client = begin_connection(&build_tcp_datasource()).await;
+    setup_temp_table(&mut client, 3).await;
+
+    let resp = client
+        .cursor_open(
+            "SELECT id, name, value FROM #ct ORDER BY id",
+            CursorScrollOption::KEYSET_DRIVEN,
+            CursorConcurrency::OPTCC,
+            0,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    let cursor_id = resp.cursor_id;
+
+    // Assign a Transact-SQL cursor name (used by WHERE CURRENT OF). The string
+    // value matches CursorOptionCode::CursorName's expectation.
+    client
+        .set_cursor_option(
+            cursor_id,
+            CursorOptionCode::CursorName,
+            CursorOptionValue::String("my_named_cursor".to_string()),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    client.cursor_close(cursor_id, None, None).await.unwrap();
+    client.close_connection().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cursor_option_rejects_type_mismatch() {
+    let mut client = begin_connection(&build_tcp_datasource()).await;
+
+    // CursorName expects a string; passing an Int must fail fast with a usage
+    // error before any server round-trip.
+    let result = client
+        .set_cursor_option(
+            1,
+            CursorOptionCode::CursorName,
+            CursorOptionValue::Int(7),
+            None,
+            None,
+        )
+        .await;
+    assert!(result.is_err(), "type mismatch should be rejected");
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        err_msg.contains("expects a string value"),
+        "error should mention expected type: {err_msg}"
+    );
+
     client.close_connection().await.unwrap();
 }

--- a/mssql-tds/tests/test_cursor_ops.rs
+++ b/mssql-tds/tests/test_cursor_ops.rs
@@ -12,7 +12,7 @@ use common::{begin_connection, build_tcp_datasource};
 use mssql_tds::connection::tds_client::{ResultSet, ResultSetClient};
 use mssql_tds::cursor::{
     CursorConcurrency, CursorOperation, CursorOptionCode, CursorOptionValue, CursorScrollOption,
-    FetchDirection,
+    CursorStatus, FetchDirection,
 };
 use mssql_tds::datatypes::column_values::ColumnValues;
 use mssql_tds::datatypes::sqltypes::SqlType;
@@ -1541,5 +1541,89 @@ async fn cursor_option_rejects_type_mismatch() {
         "error should mention expected type: {err_msg}"
     );
 
+    client.close_connection().await.unwrap();
+}
+
+// --- Status surfacing (Gap 2): CursorStatus on open-family responses ---
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cursor_open_reports_succeeded_status() {
+    let mut client = begin_connection(&build_tcp_datasource()).await;
+    setup_temp_table(&mut client, 5).await;
+
+    let resp = client
+        .cursor_open(
+            "SELECT id FROM #ct ORDER BY id",
+            CursorScrollOption::KEYSET_DRIVEN,
+            CursorConcurrency::READONLY,
+            0,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    // A normal open is neither auto-closed nor asynchronously populated.
+    assert_eq!(resp.status, CursorStatus::Succeeded);
+
+    client
+        .cursor_close(resp.cursor_id, None, None)
+        .await
+        .unwrap();
+    client.close_connection().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cursor_prepexec_reports_succeeded_status() {
+    let mut client = begin_connection(&build_tcp_datasource()).await;
+    setup_temp_table(&mut client, 3).await;
+
+    let resp = client
+        .cursor_prepexec(
+            "SELECT id FROM #ct ORDER BY id",
+            vec![],
+            CursorScrollOption::FORWARD_ONLY,
+            CursorConcurrency::READONLY,
+            0,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.cursor.status, CursorStatus::Succeeded);
+
+    client
+        .cursor_close(resp.cursor.cursor_id, None, None)
+        .await
+        .unwrap();
+    client
+        .cursor_unprepare(resp.prepared_handle, None, None)
+        .await
+        .unwrap();
+    client.close_connection().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cursor_prepare_reports_succeeded_status() {
+    let mut client = begin_connection(&build_tcp_datasource()).await;
+    setup_temp_table(&mut client, 3).await;
+
+    let resp = client
+        .cursor_prepare(
+            "SELECT id FROM #ct ORDER BY id",
+            "",
+            CursorScrollOption::FORWARD_ONLY,
+            CursorConcurrency::READONLY,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    // Prepare opens no cursor, so the status is always success.
+    assert_eq!(resp.status, CursorStatus::Succeeded);
+
+    client
+        .cursor_unprepare(resp.prepared_handle, None, None)
+        .await
+        .unwrap();
     client.close_connection().await.unwrap();
 }

--- a/mssql-tds/tests/test_cursor_ops.rs
+++ b/mssql-tds/tests/test_cursor_ops.rs
@@ -12,7 +12,7 @@ use common::{begin_connection, build_tcp_datasource};
 use mssql_tds::connection::tds_client::{ResultSet, ResultSetClient};
 use mssql_tds::cursor::{
     CursorConcurrency, CursorOperation, CursorOptionCode, CursorOptionValue, CursorScrollOption,
-    CursorStatus, FetchDirection,
+    CursorStatus, FetchDirection, FetchStatus,
 };
 use mssql_tds::datatypes::column_values::ColumnValues;
 use mssql_tds::datatypes::sqltypes::SqlType;
@@ -1625,5 +1625,80 @@ async fn cursor_prepare_reports_succeeded_status() {
         .cursor_unprepare(resp.prepared_handle, None, None)
         .await
         .unwrap();
+    client.close_connection().await.unwrap();
+}
+
+// --- Per-row rowstat / FetchStatus (Gap 3) ---
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cursor_rowstat_succeeded() {
+    let mut client = begin_connection(&build_tcp_datasource()).await;
+    setup_temp_table(&mut client, 5).await;
+
+    let resp = client
+        .cursor_open(
+            "SELECT id, name, value FROM #ct ORDER BY id",
+            CursorScrollOption::KEYSET_DRIVEN,
+            CursorConcurrency::READONLY,
+            0,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    let cursor_id = resp.cursor_id;
+
+    client
+        .cursor_fetch(cursor_id, FetchDirection::NEXT, 0, 5, None, None)
+        .await
+        .unwrap();
+
+    // next_cursor_row splits the hidden trailing rowstat column off each row.
+    let mut ids = Vec::new();
+    while let Some((row, status)) = client.next_cursor_row().await.unwrap() {
+        // Unchanged keyset rows fetch successfully.
+        assert!(
+            status.contains(FetchStatus::SUCCEEDED),
+            "expected SUCCEEDED rowstat, got {status:?}"
+        );
+        // Only id, name, value remain after the rowstat is stripped.
+        assert_eq!(
+            row.len(),
+            3,
+            "rowstat column should be stripped from the row"
+        );
+        if let ColumnValues::Int(id) = row[0] {
+            ids.push(id);
+        }
+    }
+    client.close_query().await.unwrap();
+    assert_eq!(ids, vec![1, 2, 3, 4, 5]);
+
+    client.cursor_close(cursor_id, None, None).await.unwrap();
+    client.close_connection().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn next_cursor_row_rejects_non_cursor_result() {
+    let mut client = begin_connection(&build_tcp_datasource()).await;
+    setup_temp_table(&mut client, 2).await;
+
+    // An ordinary query result has no trailing rowstat column, so next_cursor_row
+    // must refuse to strip a real data column.
+    client
+        .execute("SELECT id FROM #ct ORDER BY id".to_string(), None, None)
+        .await
+        .unwrap();
+    let result = client.next_cursor_row().await;
+    assert!(
+        result.is_err(),
+        "next_cursor_row on a normal result set must error"
+    );
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        err_msg.contains("rowstat"),
+        "error should mention rowstat: {err_msg}"
+    );
+    client.close_query().await.unwrap();
     client.close_connection().await.unwrap();
 }


### PR DESCRIPTION
## Summary

Continuation of the cursor RPC work (PR4), migrated from ADO PR #7767. Adds the
remaining cursor surface needed for an updatable, status-aware cursor client:

- **`perform_cursor_operation`** (`sp_cursor`) — positioned UPDATE/DELETE/INSERT/LOCK on the current fetch buffer.
- **`set_cursor_option`** (`sp_cursoroption`) — assign a T-SQL cursor name (for `WHERE CURRENT OF`) and other option codes.
- **`ColumnMetadata::is_key_column()`** — `fKey` (0x4000) COLMETADATA flag.
- **`CursorStatus` surfacing** — open-family responses now report the RPC `ReturnStatus` (auto-closed / async keyset).
- **Per-row `FetchStatus`** — `next_cursor_row()` exposes the hidden `rowstat` column for keyset/dynamic cursors.

## Review feedback (from ADO PR #7767)

Incorporated and folded into the relevant commits:

- Replaced `last_return_status: Option<i32>` with a named `ReturnStatus { NotReceived, Received(i32) }` enum.
- `captured_cursor_status` now returns `TdsResult<CursorStatus>`: a missing token maps to `Succeeded`, while an unrecognized raw value surfaces as `Error::ProtocolError` instead of being silently treated as success.
- Renamed `cursor_op` -> `perform_cursor_operation` and `cursor_option` -> `set_cursor_option`.
- Moved the `has_open_batch` guard ahead of value validation in `set_cursor_option` (validation still precedes any I/O).

## Deferred

Consolidating the cursor APIs into a `CursorClient` trait (PR #7767 thread 96840) is tracked separately in **User Story #45976** under Feature 42848.

## Testing

`cargo bfmt`, `cargo bclippy` (`-D warnings`), and `cargo btest` all green — 1799 tests pass (connectivity excluded; environmental).