### PR TITLE
Parse DatabaseMirroringPartner ENVCHANGE token during login

### DIFF
--- a/mssql-tds/src/message/login.rs
+++ b/mssql-tds/src/message/login.rs
@@ -453,6 +453,17 @@ impl LoginResponseModel {
                     self.change_properties.char_set = Some(string_change.new_value().clone());
                     Ok(())
                 }
+                EnvChangeTokenSubType::DatabaseMirroringPartner => {
+                    // The server advertises the mirroring/failover partner during
+                    // login for mirrored or AlwaysOn databases. We do not act on it
+                    // yet, but it must be consumed so login can proceed.
+                    event!(
+                        Level::DEBUG,
+                        "Ignoring database mirroring partner: {:?}",
+                        string_change.new_value()
+                    );
+                    Ok(())
+                }
                 _ => {
                     event!(
                         Level::ERROR,

--- a/mssql-tds/src/token/parsers/envchange_parser.rs
+++ b/mssql-tds/src/token/parsers/envchange_parser.rs
@@ -174,10 +174,11 @@ where
                 EnvChangeContainer::from((old_descriptor, new_descriptor))
             }
             EnvChangeTokenSubType::DatabaseMirroringPartner => {
-                return Err(crate::error::Error::UnimplementedFeature {
-                    feature: "DatabaseMirroringPartner".to_string(),
-                    context: "EnvChange token parsing not yet implemented".to_string(),
-                });
+                // MS-TDS 2.2.7.9: the new value carries the mirroring/failover
+                // partner server name as a B_VARCHAR; the old value is empty.
+                let new_value = reader.read_varchar_u8_length().await?;
+                let old_value = reader.read_varchar_u8_length().await?;
+                EnvChangeContainer::from((old_value, new_value))
             }
             EnvChangeTokenSubType::PromoteTransaction => {
                 return Err(crate::error::Error::UnimplementedFeature {
@@ -378,6 +379,41 @@ mod tests {
                     EnvChangeContainer::String(value_pair) => {
                         assert_eq!(value_pair.new_value(), "UTF8");
                         assert_eq!(value_pair.old_value(), "ASCII");
+                    }
+                    _ => panic!("Expected String container"),
+                }
+            }
+            _ => panic!("Expected EnvChange token"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_parse_database_mirroring_partner_change() {
+        // Sent during login for mirrored/AlwaysOn databases: new value carries the
+        // partner server name, old value is empty. See issue microsoft/mssql-python#600.
+        let mut body = Vec::new();
+        body.extend_from_slice(&encode_varchar_u8("partner.contoso.com"));
+        body.extend_from_slice(&encode_varchar_u8(""));
+        let data = build_envchange_token(
+            EnvChangeTokenSubType::DatabaseMirroringPartner.as_u8(),
+            body,
+        );
+
+        let mut reader = MockReader::new(data);
+        let parser = EnvChangeTokenParser::default();
+        let context = ParserContext::default();
+        let result = parser.parse(&mut reader, &context).await.unwrap();
+
+        match result {
+            Tokens::EnvChange(token) => {
+                assert_eq!(
+                    token.sub_type,
+                    EnvChangeTokenSubType::DatabaseMirroringPartner
+                );
+                match token.change_type {
+                    EnvChangeContainer::String(value_pair) => {
+                        assert_eq!(value_pair.new_value(), "partner.contoso.com");
+                        assert_eq!(value_pair.old_value(), "");
                     }
                     _ => panic!("Expected String container"),
                 }
@@ -898,28 +934,6 @@ mod tests {
         match result {
             Err(crate::error::Error::UnimplementedFeature { feature, .. }) => {
                 assert_eq!(feature, "UnicodeDataSortingComparisonFlags");
-            }
-            _ => panic!("Expected UnimplementedFeature error"),
-        }
-    }
-
-    #[tokio::test]
-    async fn test_parse_unimplemented_database_mirroring_partner() {
-        let body = Vec::new();
-        let data = build_envchange_token(
-            EnvChangeTokenSubType::DatabaseMirroringPartner.as_u8(),
-            body,
-        );
-
-        let mut reader = MockReader::new(data);
-        let parser = EnvChangeTokenParser::default();
-        let context = ParserContext::default();
-        let result = parser.parse(&mut reader, &context).await;
-
-        assert!(result.is_err());
-        match result {
-            Err(crate::error::Error::UnimplementedFeature { feature, .. }) => {
-                assert_eq!(feature, "DatabaseMirroringPartner");
             }
             _ => panic!("Expected UnimplementedFeature error"),
         }


### PR DESCRIPTION
## Summary

During login, SQL Server emits an `ENVCHANGE` token of subtype `DatabaseMirroringPartner` (0x05) whenever the target database participates in database mirroring or an AlwaysOn Availability Group (advertising the failover partner). The TDS parser previously returned `UnimplementedFeature` for this subtype, which aborted login response parsing and failed the connection.

This only surfaced on the native TDS connection path (e.g. mssql-python's `cursor.bulkcopy()`), since ODBC-based connections tolerate the token — which is why it appeared to be a bulkcopy-specific bug.

Changes:
- `envchange_parser.rs`: parse `DatabaseMirroringPartner` as a `B_VARCHAR` new   value + empty old value (MS-TDS 2.2.7.9), producing an `EnvChangeContainer::String`.
- `message/login.rs`: accept the subtype in `capture_change_property` (log at   debug, no-op) so login proceeds. The failover partner is not acted upon yet.
- Replaced the stale "unimplemented" parser test with a positive parse test.

## Linked issue

Relates to microsoft/mssql-python#600 (root cause; the user-facing fix ships once py-core picks up this crate).

## Testing

- `cargo test -p mssql-tds --lib` — envchange + login suites pass (4 pre-existing `certificate_validator` failures on `main` are unrelated/environment-based)
- `cargo fmt -p mssql-tds -- --check` clean
- `cargo clippy -p mssql-tds` clean

## Breaking changes

None.
