### PR TITLE
Add manylinux_2_28 wheel build alongside manylinux_2_34

### DIFF
--- a/.pipeline/OneBranch/stages.yml
+++ b/.pipeline/OneBranch/stages.yml
@@ -161,6 +161,13 @@ stages:
         parameters:
           osType: Linux
           architecture: x64
+          manylinuxFlavor: '2_28'
+          publishArtifacts: false
+      - template: /.pipeline/templates/build-python-wheels-template.yml
+        parameters:
+          osType: Linux
+          architecture: x64
+          manylinuxFlavor: '2_34'
           publishArtifacts: false
       - template: /.pipeline/templates/build-python-wheels-template.yml
         parameters:
@@ -208,6 +215,13 @@ stages:
           parameters:
             osType: Linux
             architecture: arm64
+            manylinuxFlavor: '2_28'
+            publishArtifacts: false
+        - template: /.pipeline/templates/build-python-wheels-template.yml
+          parameters:
+            osType: Linux
+            architecture: arm64
+            manylinuxFlavor: '2_34'
             publishArtifacts: false
         - template: /.pipeline/templates/build-python-wheels-template.yml
           parameters:

--- a/.pipeline/templates/build-python-wheels-template.yml
+++ b/.pipeline/templates/build-python-wheels-template.yml
@@ -22,6 +22,17 @@ parameters:
   type: boolean
   default: true
   displayName: 'Publish wheel artifacts (disable for OneBranch pipeline)'
+- name: manylinuxFlavor
+  # Which manylinux glibc/OpenSSL ABI to target. Only consumed when osType=Linux.
+  # 2_28 -> AlmaLinux 8 base, libssl.so.1.1, glibc <= 2.28 (matches mssql-python's
+  # published Linux wheel tag and the RHEL 8 / Ubuntu 20.04 / Debian 11 family).
+  # 2_34 -> AlmaLinux 9 base, libssl.so.3,   glibc <= 2.34 (RHEL 9+, Ubuntu 22.04+,
+  # Debian 12+).
+  default: '2_28'
+  type: string
+  values:
+  - '2_28'
+  - '2_34'
 
 steps:
 # Container-based builds for Linux (glibc - manylinux)
@@ -29,18 +40,23 @@ steps:
   - script: |
       set -euo pipefail
       
-      # Determine container image based on architecture
-      # Using pre-built images with Rust and maturin pre-installed for faster builds
+      MANYLINUX_FLAVOR="${{ parameters.manylinuxFlavor }}"
+
+      # Determine container image based on architecture and manylinux flavor.
+      # Using pre-built images with Rust and maturin pre-installed for faster builds.
       if [ "${{ parameters.architecture }}" = "x64" ]; then
-        CONTAINER_IMAGE="ghcr.io/microsoft/mssql-rs/python-build/manylinux_2_34_x86_64_rust:latest"
+        CONTAINER_IMAGE="ghcr.io/microsoft/mssql-rs/python-build/manylinux_${MANYLINUX_FLAVOR}_x86_64_rust:latest"
+        MATURIN_COMPATIBILITY="manylinux_${MANYLINUX_FLAVOR}_x86_64"
       elif [ "${{ parameters.architecture }}" = "ARM64" ] || [ "${{ parameters.architecture }}" = "arm64" ]; then
-        CONTAINER_IMAGE="ghcr.io/microsoft/mssql-rs/python-build/manylinux_2_34_aarch64_rust:latest"
+        CONTAINER_IMAGE="ghcr.io/microsoft/mssql-rs/python-build/manylinux_${MANYLINUX_FLAVOR}_aarch64_rust:latest"
+        MATURIN_COMPATIBILITY="manylinux_${MANYLINUX_FLAVOR}_aarch64"
       else
         echo "ERROR: Unsupported architecture: ${{ parameters.architecture }}"
         exit 1
       fi
       
       echo "Building Python wheels in container: $CONTAINER_IMAGE"
+      echo "Maturin compatibility tag: $MATURIN_COMPATIBILITY"
       
       mkdir -p "$(ob_outputDirectory)/wheels"
       
@@ -49,6 +65,7 @@ steps:
         -v "$(ob_outputDirectory)/wheels:/workspace/target/wheels" \
         -e "WORKSPACE_DIR=/workspace" \
         -e "OUTPUT_DIR=/workspace/target/wheels" \
+        -e "MATURIN_COMPATIBILITY=$MATURIN_COMPATIBILITY" \
         "$CONTAINER_IMAGE" \
         bash /workspace/scripts/build-python-wheels-in-container.sh
       
@@ -63,7 +80,7 @@ steps:
       fi
       echo "✅ $WHEEL_COUNT wheels built successfully!"
       ls -lh "$(ob_outputDirectory)/wheels"
-    displayName: 'Build Python wheels in manylinux container (${{ parameters.architecture }})'
+    displayName: 'Build Python wheels in manylinux_${{ parameters.manylinuxFlavor }} container (${{ parameters.architecture }})'
     env:
       CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN)
       CARGO_REGISTRIES_MSSQL_RS_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_TOKEN)
@@ -121,14 +138,17 @@ steps:
       # Using pre-built images with Rust and maturin pre-installed for faster builds
       if [ "${{ parameters.architecture }}" = "x64" ]; then
         CONTAINER_IMAGE="ghcr.io/microsoft/mssql-rs/python-build/musllinux_1_2_x86_64_rust:latest"
+        MATURIN_COMPATIBILITY="musllinux_1_2_x86_64"
       elif [ "${{ parameters.architecture }}" = "ARM64" ] || [ "${{ parameters.architecture }}" = "arm64" ]; then
         CONTAINER_IMAGE="ghcr.io/microsoft/mssql-rs/python-build/musllinux_1_2_aarch64_rust:latest"
+        MATURIN_COMPATIBILITY="musllinux_1_2_aarch64"
       else
         echo "ERROR: Unsupported architecture: ${{ parameters.architecture }}"
         exit 1
       fi
       
       echo "Building Python wheels in container: $CONTAINER_IMAGE"
+      echo "Maturin compatibility tag: $MATURIN_COMPATIBILITY"
       
       mkdir -p "$(ob_outputDirectory)/wheels"
       
@@ -137,6 +157,7 @@ steps:
         -v "$(ob_outputDirectory)/wheels:/workspace/target/wheels" \
         -e "WORKSPACE_DIR=/workspace" \
         -e "OUTPUT_DIR=/workspace/target/wheels" \
+        -e "MATURIN_COMPATIBILITY=$MATURIN_COMPATIBILITY" \
         "$CONTAINER_IMAGE" \
         bash /workspace/scripts/build-python-wheels-in-container.sh
       
@@ -189,11 +210,21 @@ steps:
       Get-ChildItem "$(ob_outputDirectory)\wheels" | Format-Table Name, Length
     displayName: List all wheels
 
-# Publish artifacts for CI/PR pipelines (not needed for OneBranch which uses ob_outputDirectory)
+# Publish artifacts for CI/PR pipelines (not needed for OneBranch which uses ob_outputDirectory).
+# Include the manylinux flavor in the artifact name on Linux so calling this template twice
+# per arch (once per flavor) produces two distinct artifacts instead of colliding.
 - ${{ if eq(parameters.publishArtifacts, true) }}:
-  - task: PublishPipelineArtifact@1
-    displayName: 'Publish Python wheels'
-    inputs:
-      targetPath: '$(ob_outputDirectory)/wheels'
-      artifact: 'wheels_${{ parameters.osType }}_${{ parameters.architecture }}'
-      publishLocation: 'pipeline'
+  - ${{ if eq(parameters.osType, 'Linux') }}:
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish Python wheels'
+      inputs:
+        targetPath: '$(ob_outputDirectory)/wheels'
+        artifact: 'wheels_${{ parameters.osType }}_${{ parameters.architecture }}_manylinux_${{ parameters.manylinuxFlavor }}'
+        publishLocation: 'pipeline'
+  - ${{ if ne(parameters.osType, 'Linux') }}:
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish Python wheels'
+      inputs:
+        targetPath: '$(ob_outputDirectory)/wheels'
+        artifact: 'wheels_${{ parameters.osType }}_${{ parameters.architecture }}'
+        publishLocation: 'pipeline'

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -129,6 +129,12 @@ stages:
         parameters:
           osType: Linux
           architecture: x64
+          manylinuxFlavor: '2_28'
+      - template: build-python-wheels-template.yml
+        parameters:
+          osType: Linux
+          architecture: x64
+          manylinuxFlavor: '2_34'
       - template: build-python-wheels-template.yml
         parameters:
           osType: Alpine
@@ -166,6 +172,12 @@ stages:
         parameters:
           osType: Linux
           architecture: ARM64
+          manylinuxFlavor: '2_28'
+      - template: build-python-wheels-template.yml
+        parameters:
+          osType: Linux
+          architecture: ARM64
+          manylinuxFlavor: '2_34'
       - template: build-python-wheels-template.yml
         parameters:
           osType: Alpine

--- a/containers/Dockerfile.PythonBuild.manylinux_2_28.arm64
+++ b/containers/Dockerfile.PythonBuild.manylinux_2_28.arm64
@@ -1,0 +1,47 @@
+# Pre-built Python wheel build image for manylinux_2_28 (ARM64)
+# This image extends the official PyPA manylinux_2_28 image with pre-installed Rust
+# and maturin to speed up CI builds by avoiding runtime installation of these tools.
+# Base image is synced from quay.io/pypa to ACR via sync-container-images.yml pipeline
+#
+# manylinux_2_28 is based on AlmaLinux 8 (glibc 2.28, OpenSSL 1.1.1).
+# Wheels built here link against libssl.so.1.1 / libcrypto.so.1.1 and use only
+# glibc symbols up to GLIBC_2.28, matching RHEL 8, Ubuntu 20.04, Debian 11,
+# Amazon Linux 2, and other distros that expose OpenSSL 1.1 at runtime.
+
+FROM tdslibrs.azurecr.io/import/python-build/manylinux_2_28_aarch64:latest
+
+# Install system dependencies required for building Python wheels with Rust extensions
+RUN dnf install -y \
+    openssl-devel \
+    pkgconfig \
+    && dnf clean all
+
+# Install Rust toolchain (stable)
+# This is installed system-wide so all Python versions can use it
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+ENV PATH="/root/.cargo/bin:$PATH"
+
+# Verify Rust installation
+RUN rustc --version && cargo --version
+
+# Find a Python installation to use for installing maturin
+# manylinux images have multiple Python versions in /opt/python/
+RUN PYTHON_BIN=$(ls /opt/python/cp312-*/bin/python 2>/dev/null | head -n1) && \
+    if [ -z "$PYTHON_BIN" ]; then \
+        PYTHON_BIN=$(ls /opt/python/cp311-*/bin/python 2>/dev/null | head -n1); \
+    fi && \
+    if [ -z "$PYTHON_BIN" ]; then \
+        PYTHON_BIN=$(ls /opt/python/cp310-*/bin/python 2>/dev/null | head -n1); \
+    fi && \
+    echo "Installing maturin using: $PYTHON_BIN" && \
+    $PYTHON_BIN -m pip install --no-cache-dir maturin && \
+    $PYTHON_BIN -m pip show maturin
+
+# auditwheel is pre-installed in PyPA manylinux images (used for diagnostics;
+# auditwheel=skip in pyproject.toml disables library vendoring)
+RUN which auditwheel && auditwheel --version
+
+WORKDIR /workspace
+
+# Default command
+CMD ["bash"]

--- a/containers/Dockerfile.PythonBuild.manylinux_2_28.x64
+++ b/containers/Dockerfile.PythonBuild.manylinux_2_28.x64
@@ -1,0 +1,47 @@
+# Pre-built Python wheel build image for manylinux_2_28 (x64)
+# This image extends the official PyPA manylinux_2_28 image with pre-installed Rust
+# and maturin to speed up CI builds by avoiding runtime installation of these tools.
+# Base image is synced from quay.io/pypa to ACR via sync-container-images.yml pipeline
+#
+# manylinux_2_28 is based on AlmaLinux 8 (glibc 2.28, OpenSSL 1.1.1).
+# Wheels built here link against libssl.so.1.1 / libcrypto.so.1.1 and use only
+# glibc symbols up to GLIBC_2.28, matching RHEL 8, Ubuntu 20.04, Debian 11,
+# Amazon Linux 2, and other distros that expose OpenSSL 1.1 at runtime.
+
+FROM tdslibrs.azurecr.io/import/python-build/manylinux_2_28_x86_64:latest
+
+# Install system dependencies required for building Python wheels with Rust extensions
+RUN dnf install -y \
+    openssl-devel \
+    pkgconfig \
+    && dnf clean all
+
+# Install Rust toolchain (stable)
+# This is installed system-wide so all Python versions can use it
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+ENV PATH="/root/.cargo/bin:$PATH"
+
+# Verify Rust installation
+RUN rustc --version && cargo --version
+
+# Find a Python installation to use for installing maturin
+# manylinux images have multiple Python versions in /opt/python/
+RUN PYTHON_BIN=$(ls /opt/python/cp312-*/bin/python 2>/dev/null | head -n1) && \
+    if [ -z "$PYTHON_BIN" ]; then \
+        PYTHON_BIN=$(ls /opt/python/cp311-*/bin/python 2>/dev/null | head -n1); \
+    fi && \
+    if [ -z "$PYTHON_BIN" ]; then \
+        PYTHON_BIN=$(ls /opt/python/cp310-*/bin/python 2>/dev/null | head -n1); \
+    fi && \
+    echo "Installing maturin using: $PYTHON_BIN" && \
+    $PYTHON_BIN -m pip install --no-cache-dir maturin && \
+    $PYTHON_BIN -m pip show maturin
+
+# auditwheel is pre-installed in PyPA manylinux images (used for diagnostics;
+# auditwheel=skip in pyproject.toml disables library vendoring)
+RUN which auditwheel && auditwheel --version
+
+WORKDIR /workspace
+
+# Default command
+CMD ["bash"]

--- a/containers/PYTHON_WHEELS_README.md
+++ b/containers/PYTHON_WHEELS_README.md
@@ -18,11 +18,24 @@ All images are hosted in your Azure Container Registry (`tdslibrs.azurecr.io`) t
 ### 🚀 Pre-built Images with Rust (Recommended for CI/CD)
 These custom images extend official PyPA images with **Rust toolchain and maturin pre-installed** for faster builds.
 
-#### Linux (glibc-based - Ubuntu, RHEL, Debian, etc.)
+We maintain **two manylinux flavors** so we can ship a `.so` whose ABI honestly
+matches the wheel tag. mssql-py-core wheels are repackaged into mssql-python,
+which targets both OpenSSL 1.1 and OpenSSL 3 deployments, so we build for both:
+
+#### Linux glibc 2.28 / OpenSSL 1.1 (AlmaLinux 8 base)
+Wheel tag: `manylinux_2_28_<arch>`. Links to `libssl.so.1.1`, requires GLIBC ≤ 2.28.
+Targets RHEL 8, Ubuntu 20.04, Debian 11, Amazon Linux 2.
 - **x64**: `tdslibrs.azurecr.io/python-build/manylinux_2_28_x86_64_rust:latest`
 - **ARM64**: `tdslibrs.azurecr.io/python-build/manylinux_2_28_aarch64_rust:latest`
 
+#### Linux glibc 2.34 / OpenSSL 3 (AlmaLinux 9 base)
+Wheel tag: `manylinux_2_34_<arch>`. Links to `libssl.so.3`, requires GLIBC ≤ 2.34.
+Targets RHEL 9+, Ubuntu 22.04+, Debian 12+, Fedora 36+, Amazon Linux 2023.
+- **x64**: `tdslibrs.azurecr.io/python-build/manylinux_2_34_x86_64_rust:latest`
+- **ARM64**: `tdslibrs.azurecr.io/python-build/manylinux_2_34_aarch64_rust:latest`
+
 #### Alpine (musl-based)
+Wheel tag: `musllinux_1_2_<arch>`.
 - **x64**: `tdslibrs.azurecr.io/python-build/musllinux_1_2_x86_64_rust:latest`
 - **ARM64**: `tdslibrs.azurecr.io/python-build/musllinux_1_2_aarch64_rust:latest`
 
@@ -130,9 +143,15 @@ The Azure DevOps pipeline automatically builds wheels in containers:
 ```yaml
 - template: templates/build-python-wheels-template.yml
   parameters:
-    osType: Linux        # Linux, Alpine, or MacOS
-    architecture: x64    # x64 or ARM64
+    osType: Linux           # Linux, Alpine, MacOS, or Windows
+    architecture: x64       # x64 or ARM64
+    manylinuxFlavor: '2_28' # Only honored for osType=Linux: '2_28' or '2_34'
 ```
+
+For Linux, call the template **twice** per arch (once with `manylinuxFlavor: '2_28'`,
+once with `'2_34'`) to produce both flavors. The published artifacts include the
+flavor in their name (`wheels_Linux_<arch>_manylinux_2_28`,
+`wheels_Linux_<arch>_manylinux_2_34`) so they don't collide.
 
 **What it does**:
 1. Logs into ACR
@@ -148,7 +167,8 @@ The Azure DevOps pipeline automatically builds wheels in containers:
 
 - **Purpose**: Build portable binary wheels that work across many Linux distributions
 - **Standards**: 
-  - `manylinux_2_28`: Compatible with glibc 2.28+ (Ubuntu 20.04+, RHEL 8+, Debian 10+)
+  - `manylinux_2_28`: Compatible with glibc 2.28+ (RHEL 8, Ubuntu 20.04, Debian 11, Amazon Linux 2). Links against OpenSSL 1.1.
+  - `manylinux_2_34`: Compatible with glibc 2.34+ (RHEL 9+, Ubuntu 22.04+, Debian 12+). Links against OpenSSL 3.
   - `musllinux_1_2`: Compatible with musl 1.2+ (Alpine 3.13+)
 - **Pre-installed**: Multiple Python versions (3.8-3.14), compilers, build tools
 - **Official**: Maintained by PyPA at https://github.com/pypa/manylinux

--- a/containers/build-python-images.sh
+++ b/containers/build-python-images.sh
@@ -21,6 +21,24 @@ echo ""
 
 cd "$SCRIPT_DIR"
 
+# Build manylinux_2_28 x64 image (glibc 2.28, OpenSSL 1.1)
+echo "==> Building manylinux_2_28 x64 image..."
+docker build \
+    -f Dockerfile.PythonBuild.manylinux_2_28.x64 \
+    -t "${ACR_REGISTRY}/python-build/manylinux_2_28_x86_64_rust:latest" \
+    .
+echo "✅ manylinux_2_28 x64 image built successfully"
+echo ""
+
+# Build manylinux_2_28 ARM64 image (glibc 2.28, OpenSSL 1.1)
+echo "==> Building manylinux_2_28 ARM64 image..."
+docker build \
+    -f Dockerfile.PythonBuild.manylinux_2_28.arm64 \
+    -t "${ACR_REGISTRY}/python-build/manylinux_2_28_aarch64_rust:latest" \
+    .
+echo "✅ manylinux_2_28 ARM64 image built successfully"
+echo ""
+
 # Build manylinux x64 image
 echo "==> Building manylinux x64 image..."
 docker build \
@@ -62,6 +80,8 @@ echo "✅ All images built successfully!"
 echo "======================================================"
 echo ""
 echo "Built images:"
+echo "  - ${ACR_REGISTRY}/python-build/manylinux_2_28_x86_64_rust:latest"
+echo "  - ${ACR_REGISTRY}/python-build/manylinux_2_28_aarch64_rust:latest"
 echo "  - ${ACR_REGISTRY}/python-build/manylinux_2_34_x86_64_rust:latest"
 echo "  - ${ACR_REGISTRY}/python-build/manylinux_2_34_aarch64_rust:latest"
 echo "  - ${ACR_REGISTRY}/python-build/musllinux_1_2_x86_64_rust:latest"

--- a/containers/push-python-images.sh
+++ b/containers/push-python-images.sh
@@ -30,6 +30,18 @@ else
 fi
 
 
+# Push manylinux_2_28 x64 image
+echo "==> Pushing manylinux_2_28 x64 image..."
+docker push "${ACR_REGISTRY}/python-build/manylinux_2_28_x86_64_rust:latest"
+echo "✅ manylinux_2_28 x64 image pushed"
+echo ""
+
+# Push manylinux_2_28 ARM64 image
+echo "==> Pushing manylinux_2_28 ARM64 image..."
+docker push "${ACR_REGISTRY}/python-build/manylinux_2_28_aarch64_rust:latest"
+echo "✅ manylinux_2_28 ARM64 image pushed"
+echo ""
+
 # Push manylinux x64 image
 echo "==> Pushing manylinux x64 image..."
 docker push "${ACR_REGISTRY}/python-build/manylinux_2_34_x86_64_rust:latest"
@@ -59,6 +71,8 @@ echo "✅ All images pushed successfully!"
 echo "======================================================"
 echo ""
 echo "Images available in ACR:"
+echo "  - ${ACR_REGISTRY}/python-build/manylinux_2_28_x86_64_rust:latest"
+echo "  - ${ACR_REGISTRY}/python-build/manylinux_2_28_aarch64_rust:latest"
 echo "  - ${ACR_REGISTRY}/python-build/manylinux_2_34_x86_64_rust:latest"
 echo "  - ${ACR_REGISTRY}/python-build/manylinux_2_34_aarch64_rust:latest"
 echo "  - ${ACR_REGISTRY}/python-build/musllinux_1_2_x86_64_rust:latest"

--- a/mssql-py-core/pyproject.toml
+++ b/mssql-py-core/pyproject.toml
@@ -15,9 +15,21 @@ classifiers = [
 [tool.maturin]
 module-name = "mssql_py_core"
 # Don't vendor shared libraries (libssl, libcrypto) into the wheel.
-# Built on manylinux_2_34 (AlmaLinux 9) so the native extension links against
-# libssl.so.3 / libcrypto.so.3 and expects the OS to provide OpenSSL 3.x at runtime.
-# On macOS (Security.framework) and Windows (SChannel) there is no OpenSSL dep.
+#
+# Two manylinux flavors are built so the extension's ABI honestly matches the
+# wheel tag and so mssql-python can repackage either depending on the target
+# environment:
+#   - manylinux_2_28 (AlmaLinux 8): links libssl.so.1.1 / libcrypto.so.1.1,
+#     GLIBC <= 2.28. For RHEL 8, Ubuntu 20.04, Debian 11, Amazon Linux 2.
+#   - manylinux_2_34 (AlmaLinux 9): links libssl.so.3 / libcrypto.so.3,
+#     GLIBC <= 2.34. For RHEL 9+, Ubuntu 22.04+, Debian 12+.
+#
+# OpenSSL is intentionally a runtime OS dependency in both flavors; the host
+# is expected to provide it. The wheel filename tag is set explicitly via
+# `maturin build --compatibility manylinux_2_<N>_<arch>` from CI.
+#
+# macOS uses Security.framework and Windows uses SChannel, so neither has an
+# OpenSSL dependency.
 auditwheel = "skip"
 
 [project.optional-dependencies]

--- a/scripts/build-python-wheels-in-container.sh
+++ b/scripts/build-python-wheels-in-container.sh
@@ -7,6 +7,14 @@ set -e
 PYTHON_VERSIONS=("3.10" "3.11" "3.12" "3.13" "3.14")
 WORKSPACE_DIR="${WORKSPACE_DIR:-/workspace}"
 OUTPUT_DIR="${OUTPUT_DIR:-$WORKSPACE_DIR/target/wheels}"
+# Platform tag the produced wheels should advertise. Must match the build
+# container's actual ABI (e.g. manylinux_2_28 when building in a manylinux_2_28
+# image, manylinux_2_34 in a manylinux_2_34 image, musllinux_1_2 in a
+# musllinux_1_2 image). Passed to maturin as --compatibility so the wheel
+# filename and WHEEL metadata carry the correct tag; otherwise maturin defaults
+# to the un-publishable linux_* tag because auditwheel=skip is set in
+# pyproject.toml (we deliberately disable library bundling).
+MATURIN_COMPATIBILITY="${MATURIN_COMPATIBILITY:-}"
 
 echo "==> Building Python wheels in container"
 echo "Workspace: $WORKSPACE_DIR"
@@ -53,6 +61,15 @@ echo "Maturin is available"
 
 cd "$WORKSPACE_DIR/mssql-py-core"
 
+# Wipe any prior build artifacts so this invocation links against THIS
+# container's OpenSSL/glibc, not whatever a previous (different-flavor)
+# invocation cached into target/. Each pipeline job runs the template once
+# per manylinux flavor against the same workspace, so the cargo cache would
+# otherwise carry openssl-sys objects from the previous flavor across runs.
+echo ""
+echo "==> Cleaning cargo target to avoid cross-flavor cache contamination"
+cargo clean --manifest-path "$WORKSPACE_DIR/mssql-py-core/Cargo.toml" --quiet || true
+
 # Build wheels for each Python version
 for PY_VERSION in "${PYTHON_VERSIONS[@]}"; do
     # Find the Python binary (manylinux uses cpython naming)
@@ -74,11 +91,17 @@ for PY_VERSION in "${PYTHON_VERSIONS[@]}"; do
     echo ""
     echo "==> Building wheel for Python $PY_VERSION using $PYTHON_BIN"
     $PYTHON_BIN --version
-    
-    $FIRST_PYTHON -m maturin build --release \
-        --interpreter "$PYTHON_BIN" \
-        --out "$OUTPUT_DIR" \
-        --manifest-path "$WORKSPACE_DIR/mssql-py-core/Cargo.toml"
+
+    MATURIN_ARGS=(build --release
+        --interpreter "$PYTHON_BIN"
+        --out "$OUTPUT_DIR"
+        --manifest-path "$WORKSPACE_DIR/mssql-py-core/Cargo.toml")
+    if [ -n "$MATURIN_COMPATIBILITY" ]; then
+        echo "    Using --compatibility $MATURIN_COMPATIBILITY"
+        MATURIN_ARGS+=(--compatibility "$MATURIN_COMPATIBILITY")
+    fi
+
+    $FIRST_PYTHON -m maturin "${MATURIN_ARGS[@]}"
     
     echo "✅ Wheel built successfully for Python $PY_VERSION"
 done

--- a/scripts/build-wheels-docker-host.sh
+++ b/scripts/build-wheels-docker-host.sh
@@ -5,10 +5,14 @@ set -eu
 # This runs on the Azure DevOps agent, not inside the container
 
 # Parameters
-OS_TYPE="${1:-Linux}"  # Linux or Alpine
-ARCH="${2:-x64}"       # x64 or ARM64/arm64
+OS_TYPE="${1:-Linux}"           # Linux or Alpine
+ARCH="${2:-x64}"                # x64 or ARM64/arm64
 SOURCES_DIR="${3:-$(pwd)}"
 STAGING_DIR="${4:-$(pwd)/target/wheels}"
+# manylinux glibc floor: 2_28 (AlmaLinux 8, libssl.so.1.1) or 2_34 (AlmaLinux 9,
+# libssl.so.3). Ignored for Alpine. Default 2_28 — broadest reach and the tag
+# mssql-python's own Linux wheels carry.
+MANYLINUX_FLAVOR="${5:-2_28}"
 
 echo "Building Python wheels using container..."
 echo "OS Type: $OS_TYPE"
@@ -18,10 +22,17 @@ echo "Output Directory: $STAGING_DIR"
 
 # Determine container image based on OS type and architecture
 if [ "$OS_TYPE" = "Linux" ]; then
+  case "$MANYLINUX_FLAVOR" in
+    2_28|2_34) ;;
+    *) echo "ERROR: Unsupported MANYLINUX_FLAVOR: $MANYLINUX_FLAVOR (expected 2_28 or 2_34)"; exit 1 ;;
+  esac
+  echo "manylinux flavor: $MANYLINUX_FLAVOR"
   if [ "$ARCH" = "x64" ]; then
-    CONTAINER_IMAGE="tdslibrs.azurecr.io/python-build/manylinux_2_28_x86_64:latest"
+    CONTAINER_IMAGE="tdslibrs.azurecr.io/python-build/manylinux_${MANYLINUX_FLAVOR}_x86_64_rust:latest"
+    MATURIN_COMPATIBILITY="manylinux_${MANYLINUX_FLAVOR}_x86_64"
   elif [ "$ARCH" = "ARM64" ] || [ "$ARCH" = "arm64" ]; then
-    CONTAINER_IMAGE="tdslibrs.azurecr.io/python-build/manylinux_2_28_aarch64:latest"
+    CONTAINER_IMAGE="tdslibrs.azurecr.io/python-build/manylinux_${MANYLINUX_FLAVOR}_aarch64_rust:latest"
+    MATURIN_COMPATIBILITY="manylinux_${MANYLINUX_FLAVOR}_aarch64"
   else
     echo "ERROR: Unsupported architecture: $ARCH"
     exit 1
@@ -29,9 +40,11 @@ if [ "$OS_TYPE" = "Linux" ]; then
   SHELL_CMD="bash"
 elif [ "$OS_TYPE" = "Alpine" ]; then
   if [ "$ARCH" = "x64" ]; then
-    CONTAINER_IMAGE="tdslibrs.azurecr.io/python-build/musllinux_1_2_x86_64:latest"
+    CONTAINER_IMAGE="tdslibrs.azurecr.io/python-build/musllinux_1_2_x86_64_rust:latest"
+    MATURIN_COMPATIBILITY="musllinux_1_2_x86_64"
   elif [ "$ARCH" = "ARM64" ] || [ "$ARCH" = "arm64" ]; then
-    CONTAINER_IMAGE="tdslibrs.azurecr.io/python-build/musllinux_1_2_aarch64:latest"
+    CONTAINER_IMAGE="tdslibrs.azurecr.io/python-build/musllinux_1_2_aarch64_rust:latest"
+    MATURIN_COMPATIBILITY="musllinux_1_2_aarch64"
   else
     echo "ERROR: Unsupported architecture: $ARCH"
     exit 1
@@ -43,6 +56,7 @@ else
 fi
 
 echo "Using container: $CONTAINER_IMAGE"
+echo "Maturin compatibility tag: $MATURIN_COMPATIBILITY"
 echo "Shell command: $SHELL_CMD"
 
 # Login to ACR
@@ -59,6 +73,7 @@ docker run --rm \
   -v "$STAGING_DIR:/workspace/target/wheels" \
   -e "WORKSPACE_DIR=/workspace" \
   -e "OUTPUT_DIR=/workspace/target/wheels" \
+  -e "MATURIN_COMPATIBILITY=$MATURIN_COMPATIBILITY" \
   "$CONTAINER_IMAGE" \
   $SHELL_CMD /workspace/scripts/build-python-wheels-in-container.sh
 


### PR DESCRIPTION
## Why

mssql-py-core wheels are repackaged into `mssql-python`, which ships a single `manylinux_2_28` Linux wheel tag per arch. Today our build produces only glibc-2.34 / OpenSSL-3 binaries, so the `.so` embedded inside mssql-python's `manylinux_2_28` wheel actually requires `GLIBC_2.34` and `libssl.so.3` — the tag is a lie and the wheel will not load on real glibc-2.28 hosts (RHEL 8, Ubuntu 20.04, Debian 11, Amazon Linux 2).

This PR adds a true `manylinux_2_28` build path while keeping the existing `manylinux_2_34` path, so we can hand mssql-python an ABI-honest `.so` for each deployment target.

| Tag | Built in | Links to | Max GLIBC | For |
|---|---|---|---|---|
| `manylinux_2_28_<arch>` | AlmaLinux 8 | `libssl.so.1.1` | 2.28 | RHEL 8, Ubuntu 20.04, Debian 11, Amazon Linux 2 |
| `manylinux_2_34_<arch>` | AlmaLinux 9 | `libssl.so.3` | 2.34 | RHEL 9+, Ubuntu 22.04+, Debian 12+ |

OpenSSL stays a runtime OS dependency in both flavors (`auditwheel = "skip"` preserved); the wheel never bundles or statically links libssl.

## What changed

- **New Dockerfiles** `containers/Dockerfile.PythonBuild.manylinux_2_28.{x64,arm64}` mirroring the existing 2_34 ones, `FROM` the imported 2_28 ACR base.
- **`containers/build-python-images.sh` / `push-python-images.sh`** build and push both manylinux flavors (4 manylinux images + 2 musllinux = 6 total).
- **`scripts/build-python-wheels-in-container.sh`** reads `MATURIN_COMPATIBILITY` env and passes `--compatibility` to maturin so the wheel filename / WHEEL metadata carry the correct `manylinux_2_<N>_<arch>` tag. Previously fell back to the un-publishable `linux_*` tag because `auditwheel = "skip"` is set. Also runs `cargo clean` first so running both flavors against the same workspace in one job doesn't leak OpenSSL/glibc cache across flavors.
- **`scripts/build-wheels-docker-host.sh`** takes a `MANYLINUX_FLAVOR` arg (default `2_28`), picks the right `_rust` image, and sets `MATURIN_COMPATIBILITY`. Fixed stale references to the non-`_rust` base images.
- **`.pipeline/templates/build-python-wheels-template.yml`** adds a `manylinuxFlavor` parameter (default `2_28`); the published artifact name on Linux now includes the flavor (`wheels_Linux_<arch>_manylinux_2_28`, `..._manylinux_2_34`) so the two invocations per arch don't collide.
- **`.pipeline/OneBranch/stages.yml` and `.pipeline/templates/validation-stages.yml`** call the wheel template twice per Linux x64/arm64 job (once per flavor).
- **`mssql-py-core/pyproject.toml` comment + `containers/PYTHON_WHEELS_README.md`** describe the dual-flavor strategy.

## Verification

Built both Dockerfiles locally, ran the in-container wheel build through each, then inspected the produced wheels:

```
manylinux_2_28_x86_64.whl
  libssl.so.1.1  /  libcrypto.so.1.1   (OpenSSL 1.1)
  max GLIBC      2.28
  auditwheel show: 'constrains the platform tag to manylinux_2_28_x86_64'

manylinux_2_34_x86_64.whl
  libssl.so.3    /  libcrypto.so.3     (OpenSSL 3)
  max GLIBC      2.34
  auditwheel show: 'constrains the platform tag to manylinux_2_34_x86_64'
```

Cross-flavor cache contamination was reproduced and confirmed fixed by the new `cargo clean` step.

## Follow-ups (out of scope for this PR)

- Build and push the new `manylinux_2_28_*_rust` images to ACR (`./containers/build-python-images.sh && ./containers/push-python-images.sh`) and mirror to GHCR via the existing sync.
- Point mssql-python's repackaging at `wheels_Linux_<arch>_manylinux_2_28` for its 2_28 wheel (and `...manylinux_2_34` if/when they ship a 2_34 wheel as well).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>