### PR TITLE
Add FedAuth challenge support to mock TDS server

### DIFF
--- a/mssql-mock-tds/src/protocol.rs
+++ b/mssql-mock-tds/src/protocol.rs
@@ -33,6 +33,7 @@ pub enum ProtocolError {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PacketType {
     SqlBatch = 0x01,
+    FedAuthToken = 0x08,
     PreLogin = 0x12,
     TabularResult = 0x04,
     Attention = 0x06,
@@ -46,6 +47,7 @@ impl TryFrom<u8> for PacketType {
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0x01 => Ok(PacketType::SqlBatch),
+            0x08 => Ok(PacketType::FedAuthToken),
             0x12 => Ok(PacketType::PreLogin),
             0x04 => Ok(PacketType::TabularResult),
             0x06 => Ok(PacketType::Attention),
@@ -149,6 +151,7 @@ pub enum TokenType {
     Done = 0xFD,
     DoneProc = 0xFE,
     DoneInProc = 0xFF,
+    FedAuthInfo = 0xEE,
     EnvChange = 0xE3,
     LoginAck = 0xAD,
     Error = 0xAA,
@@ -475,6 +478,78 @@ pub fn build_feature_ext_ack_fedauth() -> BytesMut {
 
     // Terminator
     token_data.put_u8(FEATURE_EXT_TERMINATOR);
+
+    token_data
+}
+
+/// Parse a FedAuthToken packet payload and extract the raw token bytes.
+pub fn parse_fedauth_token(packet_data: &[u8]) -> Result<Vec<u8>, ProtocolError> {
+    if packet_data.len() < 8 {
+        return Err(ProtocolError::Protocol(
+            "FedAuthToken packet too short".to_string(),
+        ));
+    }
+
+    let total_length =
+        u32::from_le_bytes(packet_data[0..4].try_into().expect("slice with known size")) as usize;
+    let token_length =
+        u32::from_le_bytes(packet_data[4..8].try_into().expect("slice with known size")) as usize;
+
+    if total_length + size_of::<u32>() != packet_data.len() {
+        return Err(ProtocolError::Protocol(format!(
+            "FedAuthToken payload length mismatch: declared {total_length}, actual {}",
+            packet_data.len()
+        )));
+    }
+
+    if total_length != token_length + size_of::<u32>() {
+        return Err(ProtocolError::Protocol(format!(
+            "FedAuthToken inner length mismatch: declared {token_length} token bytes inside {total_length} byte payload"
+        )));
+    }
+
+    Ok(packet_data[8..].to_vec())
+}
+
+/// Build a TabularResult packet containing a FedAuth challenge.
+pub fn build_fedauth_challenge_response(sts_url: &str, spn: &str) -> BytesMut {
+    let mut response = build_feature_ext_ack_fedauth();
+    response.extend_from_slice(&build_fedauth_info_token(sts_url, spn));
+    wrap_in_packet(PacketType::TabularResult, response)
+}
+
+fn build_fedauth_info_token(sts_url: &str, spn: &str) -> BytesMut {
+    let options = [(0x01_u8, sts_url), (0x02_u8, spn)];
+    let mut token_data = BytesMut::new();
+    token_data.put_u8(TokenType::FedAuthInfo as u8);
+
+    let option_headers_len = options.len() * 9;
+    let encoded_values: Vec<Vec<u8>> = options
+        .iter()
+        .map(|(_, value)| {
+            value
+                .encode_utf16()
+                .flat_map(|unit| unit.to_le_bytes())
+                .collect::<Vec<u8>>()
+        })
+        .collect();
+    let string_bytes_len: usize = encoded_values.iter().map(Vec::len).sum();
+    let payload_len = size_of::<u32>() + option_headers_len + string_bytes_len;
+
+    token_data.put_i32_le(payload_len as i32);
+    token_data.put_u32_le(options.len() as u32);
+
+    let mut current_offset = (size_of::<u32>() + option_headers_len) as u32;
+    for ((option_id, _), encoded) in options.iter().zip(encoded_values.iter()) {
+        token_data.put_u8(*option_id);
+        token_data.put_u32_le(encoded.len() as u32);
+        token_data.put_u32_le(current_offset);
+        current_offset += encoded.len() as u32;
+    }
+
+    for encoded in encoded_values {
+        token_data.extend_from_slice(&encoded);
+    }
 
     token_data
 }

--- a/mssql-mock-tds/src/server.rs
+++ b/mssql-mock-tds/src/server.rs
@@ -5,9 +5,10 @@
 
 use crate::protocol::{
     PACKET_HEADER_SIZE, PacketHeader, PacketType, ProtocolError, build_done_token,
-    build_error_response, build_feature_ext_ack_fedauth, build_login_ack, build_prelogin_response,
-    build_prelogin_response_with_fedauth, build_query_result, build_routing_response,
-    parse_login7_auth, parse_sql_batch,
+    build_error_response, build_feature_ext_ack_fedauth, build_fedauth_challenge_response,
+    build_login_ack, build_prelogin_response, build_prelogin_response_with_fedauth,
+    build_query_result, build_routing_response, parse_fedauth_token, parse_login7_auth,
+    parse_sql_batch,
 };
 use crate::query_response::QueryRegistry;
 use bytes::BytesMut;
@@ -20,6 +21,9 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::Mutex;
 use tokio_native_tls::{TlsAcceptor, TlsStream};
 use tracing::{debug, error, info, warn};
+
+const FEDAUTH_CHALLENGE_STS_URL: &str = "https://login.microsoftonline.com/test-tenant/";
+const FEDAUTH_CHALLENGE_SPN: &str = "https://database.windows.net/";
 
 /// Configuration for connection redirection
 ///
@@ -57,6 +61,8 @@ pub struct ConnectionProcessor {
     pub user_agent: Option<String>,
     /// ServerName received in the Login7 packet
     received_server_name: Option<String>,
+    /// Whether the server is waiting for a follow-up FedAuthToken packet
+    awaiting_fedauth_token: bool,
     /// Reference to the shared query registry
     query_registry: Arc<Mutex<QueryRegistry>>,
     /// Packet buffer for this connection
@@ -74,6 +80,7 @@ impl ConnectionProcessor {
             received_token: None,
             user_agent: None,
             received_server_name: None,
+            awaiting_fedauth_token: false,
             query_registry,
             buffer: BytesMut::with_capacity(4096),
             redirection: None,
@@ -92,6 +99,7 @@ impl ConnectionProcessor {
             received_token: None,
             user_agent: None,
             received_server_name: None,
+            awaiting_fedauth_token: false,
             query_registry,
             buffer: BytesMut::with_capacity(4096),
             redirection,
@@ -194,34 +202,10 @@ impl ConnectionProcessor {
                 // Store the server name for test verification
                 self.received_server_name = auth_info.server_name.clone();
 
-                // FedAuth is always supported - check if client used it
-                if auth_info.has_fedauth {
-                    let token_len = auth_info
-                        .access_token_bytes
-                        .as_ref()
-                        .map(|v| v.len())
-                        .unwrap_or(0);
-                    debug!(
-                        "FedAuth detected with {} byte token from {}",
-                        token_len, self.addr
-                    );
-
-                    // Store the received token for verification
-                    if let Some(token_bytes) = auth_info.access_token_bytes {
-                        debug!(
-                            "Stored access token ({} bytes) from {} for verification",
-                            token_bytes.len(),
-                            self.addr
-                        );
-                        self.received_token = Some(token_bytes);
-                    }
-                }
-
-                // Always authenticate (both FedAuth and username/password are supported)
-                self.is_authenticated = true;
-
                 // Check if redirection is configured
                 if let Some(ref redir) = self.redirection {
+                    self.awaiting_fedauth_token = false;
+                    self.is_authenticated = true;
                     // Redirect the client to a different server
                     info!(
                         "Redirecting client {} to {}:{}",
@@ -231,7 +215,42 @@ impl ConnectionProcessor {
                         &redir.redirect_host,
                         redir.redirect_port,
                     ))
+                } else if auth_info.has_fedauth && auth_info.access_token_bytes.is_none() {
+                    self.awaiting_fedauth_token = true;
+                    self.is_authenticated = false;
+                    debug!(
+                        "FedAuth login without inline token from {}; sending challenge",
+                        self.addr
+                    );
+                    Some(build_fedauth_challenge_response(
+                        FEDAUTH_CHALLENGE_STS_URL,
+                        FEDAUTH_CHALLENGE_SPN,
+                    ))
                 } else {
+                    self.awaiting_fedauth_token = false;
+                    self.is_authenticated = true;
+
+                    if auth_info.has_fedauth {
+                        let token_len = auth_info
+                            .access_token_bytes
+                            .as_ref()
+                            .map(|v| v.len())
+                            .unwrap_or(0);
+                        debug!(
+                            "FedAuth detected with {} byte token from {}",
+                            token_len, self.addr
+                        );
+
+                        if let Some(token_bytes) = auth_info.access_token_bytes {
+                            debug!(
+                                "Stored access token ({} bytes) from {} for verification",
+                                token_bytes.len(),
+                                self.addr
+                            );
+                            self.received_token = Some(token_bytes);
+                        }
+                    }
+
                     // Build response with LoginAck + optional FeatureExtAck + Done
                     let mut response = build_login_ack();
 
@@ -251,6 +270,49 @@ impl ConnectionProcessor {
                     packet.extend_from_slice(&response);
 
                     Some(packet)
+                }
+            }
+
+            PacketType::FedAuthToken => {
+                if !self.awaiting_fedauth_token {
+                    warn!(
+                        "Received unexpected FedAuthToken packet from {} without challenge",
+                        self.addr
+                    );
+                    Some(build_error_response("Unexpected FedAuth token"))
+                } else {
+                    debug!("Handling FedAuthToken from {}", self.addr);
+                    let packet_body = &packet_data[PACKET_HEADER_SIZE..];
+
+                    match parse_fedauth_token(packet_body) {
+                        Ok(token_bytes) => {
+                            debug!(
+                                "Stored challenged access token ({} bytes) from {}",
+                                token_bytes.len(),
+                                self.addr
+                            );
+                            self.received_token = Some(token_bytes);
+                            self.awaiting_fedauth_token = false;
+                            self.is_authenticated = true;
+
+                            let mut response = build_login_ack();
+                            response.extend_from_slice(&build_done_token(0));
+
+                            let total_length = (PACKET_HEADER_SIZE + response.len()) as u16;
+                            let mut packet = BytesMut::with_capacity(total_length as usize);
+                            let resp_header =
+                                PacketHeader::new(PacketType::TabularResult, total_length, 1);
+                            resp_header.write(&mut packet);
+                            packet.extend_from_slice(&response);
+
+                            Some(packet)
+                        }
+                        Err(e) => {
+                            warn!("Failed to parse FedAuthToken from {}: {}", self.addr, e);
+                            self.awaiting_fedauth_token = false;
+                            Some(build_error_response(&format!("FedAuth parse error: {}", e)))
+                        }
+                    }
                 }
             }
 

--- a/mssql-tds/tests/test_mock_server_fedauth.rs
+++ b/mssql-tds/tests/test_mock_server_fedauth.rs
@@ -6,9 +6,12 @@
 #[cfg(test)]
 mod mock_server_fedauth_tests {
     use mssql_mock_tds::MockTdsServer;
-    use mssql_tds::connection::client_context::{ClientContext, TdsAuthenticationMethod};
+    use mssql_tds::connection::client_context::{
+        ClientContext, EntraIdTokenFactory, TdsAuthenticationMethod,
+    };
     use mssql_tds::connection_provider::tds_connection_provider::TdsConnectionProvider;
-    use mssql_tds::core::{EncryptionOptions, EncryptionSetting};
+    use mssql_tds::core::{EncryptionOptions, EncryptionSetting, TdsResult};
+    use std::sync::{Arc, Mutex};
     use tokio::sync::oneshot;
     use tracing_subscriber::FmtSubscriber;
 
@@ -26,6 +29,32 @@ mod mock_server_fedauth_tests {
         // The access token should be a valid JWT-like structure, but for mock testing
         // we just need a non-empty string that the mock server will accept
         "mock_access_token_for_testing_12345".to_string()
+    }
+
+    #[derive(Clone)]
+    struct MockEntraFactory {
+        token: String,
+        calls: Arc<Mutex<Vec<(String, String, TdsAuthenticationMethod)>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl EntraIdTokenFactory for MockEntraFactory {
+        async fn create_token(
+            &self,
+            spn: String,
+            sts_url: String,
+            auth_method: TdsAuthenticationMethod,
+        ) -> TdsResult<Vec<u8>> {
+            self.calls
+                .lock()
+                .expect("factory call capture mutex poisoned")
+                .push((spn, sts_url, auth_method));
+            Ok(self
+                .token
+                .encode_utf16()
+                .flat_map(|unit| unit.to_le_bytes())
+                .collect())
+        }
     }
 
     /// Test basic connectivity to mock server using access token authentication
@@ -348,6 +377,91 @@ mod mock_server_fedauth_tests {
                 "✓ Unique token '{}' verified successfully",
                 &unique_token[..50.min(unique_token.len())]
             );
+        }
+
+        let _ = shutdown_tx.send(());
+        let _ = tokio::time::timeout(tokio::time::Duration::from_secs(2), server_handle).await;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_connect_with_fedauth_challenge_and_token_factory()
+    -> Result<(), Box<dyn std::error::Error>> {
+        init_tracing();
+
+        let server = MockTdsServer::new("127.0.0.1:0").await?;
+        let server_addr = server.local_addr();
+        let connection_store = server.connection_store();
+
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let server_handle =
+            tokio::spawn(async move { server.run_with_shutdown(shutdown_rx).await });
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        let token = "mock_service_principal_token".to_string();
+        let factory_calls = Arc::new(Mutex::new(Vec::new()));
+
+        let datasource = format!("tcp:{},{}", server_addr.ip(), server_addr.port());
+        let mut context = ClientContext::default();
+        context.tds_authentication_method =
+            TdsAuthenticationMethod::ActiveDirectoryServicePrincipal;
+        context.database = "master".to_string();
+        context.encryption_options = EncryptionOptions {
+            mode: EncryptionSetting::PreferOff,
+            trust_server_certificate: true,
+            host_name_in_cert: None,
+            server_certificate: None,
+        };
+        context.auth_method_map.insert(
+            TdsAuthenticationMethod::ActiveDirectoryServicePrincipal,
+            Box::new(MockEntraFactory {
+                token: token.clone(),
+                calls: Arc::clone(&factory_calls),
+            }),
+        );
+
+        let provider = TdsConnectionProvider {};
+        let mut client = provider.create_client(context, &datasource, None).await?;
+        client.execute("SELECT 1".to_string(), None, None).await?;
+        drop(client);
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        {
+            let calls = factory_calls
+                .lock()
+                .expect("factory call capture mutex poisoned");
+            assert_eq!(calls.len(), 1, "token factory should be called once");
+            assert_eq!(
+                calls[0],
+                (
+                    "https://database.windows.net/".to_string(),
+                    "https://login.microsoftonline.com/test-tenant/".to_string(),
+                    TdsAuthenticationMethod::ActiveDirectoryServicePrincipal
+                )
+            );
+        }
+
+        {
+            let store = connection_store.lock().await;
+            assert_eq!(
+                store.count(),
+                1,
+                "Server should have stored exactly one connection"
+            );
+
+            let conn_info = store
+                .all()
+                .values()
+                .next()
+                .expect("Should have at least one connection");
+            let received_token = conn_info
+                .received_token_as_string()
+                .expect("Should have received challenged token as string");
+
+            assert_eq!(received_token, token);
         }
 
         let _ = shutdown_tx.send(());


### PR DESCRIPTION
## Summary

Adds FedAuth challenge support to the mock TDS server plus a Rust integration test that drives the full FedAuth challenge → `EntraIdTokenFactory` → `FedAuthToken` handshake on the wire.

This is the test-infrastructure half of #78, split out so it can land independently. #78 keeps the actual product fix (the connection-time GIL release in `mssql-py-core`) plus its Python regression test, which depends on this mock-server support.

## Changes

- **`mssql-mock-tds/src/protocol.rs`** — build a `FedAuthInfo` challenge token (STS URL + SPN) and parse the follow-up `FedAuthToken` packet payload.
- **`mssql-mock-tds/src/server.rs`** — when a login indicates FedAuth with no inline token, respond with the challenge, then accept and store the returned `FedAuthToken`. Existing inline-access-token and query behavior is unchanged.
- **`mssql-tds/tests/test_mock_server_fedauth.rs`** — integration test asserting the factory receives `(spn, sts_url, auth_method)` and the server receives the returned token.

## Validation

`cargo test -p mssql-tds --test test_mock_server_fedauth` → 5/5 pass. Clippy clean on both crates.

## Sequencing

Once this merges, `main` will be merged into #78 so its Python regression test can run against this mock-server support.