### PR TITLE
Chore: Upgrade Rust toolchain to 1.95

### DIFF
--- a/mssql-tds/src/sql_identifier.rs
+++ b/mssql-tds/src/sql_identifier.rs
@@ -179,12 +179,10 @@ pub fn parse_multipart_identifier(
                 "Unclosed quoted identifier".to_string(),
             ));
         }
-        State::Init => {
-            if !allow_empty {
-                return Err(crate::error::Error::UsageError(
-                    "Empty identifier is not allowed".to_string(),
-                ));
-            }
+        State::Init if !allow_empty => {
+            return Err(crate::error::Error::UsageError(
+                "Empty identifier is not allowed".to_string(),
+            ));
         }
         _ => {}
     }

--- a/mssql-tds/src/ssrp.rs
+++ b/mssql-tds/src/ssrp.rs
@@ -254,15 +254,13 @@ fn push_protocol(
                 });
             }
         }
-        "np" => {
-            if !value.is_empty() {
-                protocols.push(SsrpInstanceInfo {
-                    instance_name: instance_name.to_string(),
-                    protocol: "np".to_string(),
-                    tcp_port: None,
-                    pipe_path: Some(value.to_string()),
-                });
-            }
+        "np" if !value.is_empty() => {
+            protocols.push(SsrpInstanceInfo {
+                instance_name: instance_name.to_string(),
+                protocol: "np".to_string(),
+                tcp_port: None,
+                pipe_path: Some(value.to_string()),
+            });
         }
         _ => {} // via, rpc, spx, adsp, sm — skip
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,5 +3,5 @@
 # always come with support for the host platform.
 targets = ["i686-pc-windows-msvc", "aarch64-pc-windows-msvc", "aarch64-unknown-linux-musl", "x86_64-unknown-linux-musl"]
 # Public channel for OSS development. OneBranch pipelines override this
-# with ms-prod-1.90 via the rustToolchain.version templateContext setting.
-channel = "1.90"
+# with ms-prod-1.95 via the rustToolchain.version templateContext setting.
+channel = "1.95"


### PR DESCRIPTION
## Summary

Bumps the pinned Rust toolchain from **1.90** to **1.95**.

[AB#46029](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46029)

- Update `channel` in `rust-toolchain.toml` (`1.90` → `1.95`) and the accompanying `ms-prod` comment.
- Fix the two new `clippy::collapsible_match` lints surfaced by 1.95's clippy (`-D warnings`):
  - `mssql-tds/src/sql_identifier.rs` — collapse the inner `if !allow_empty` into a `State::Init` match guard.
  - `mssql-tds/src/ssrp.rs` — collapse the inner `if !value.is_empty()` into the `"np"` match guard.

## Validation

**Windows (1.95.0):**
- `cargo build --workspace` ✅
- `cargo bclippy` ✅ (clean after fixes)
- `rustfmt --check` ✅
- `cargo nextest run --workspace` — 1607 unit tests pass; the 315 failures are integration tests requiring a live SQL Server (`SEC_E_WRONG_PRINCIPAL` TLS handshake), unrelated to the toolchain.

**WSL (Ubuntu 22.04, 1.95.0):**
- `cargo build --workspace` ✅

> Note: `cargo bfmt` fails locally due to an MS-internal `rustfmt` shim in `.cargo\bin` that only recognizes `ms-` toolchains; formatting was verified with the toolchain's own `cargo-fmt`. CI uses `ms-prod-1.95` and is unaffected.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>