### PR TITLE
Fix non-PR CI stage skips from duplicate guard and extract guard script

### DIFF
--- a/.pipeline/scripts/evaluate-duplicate-pr.py
+++ b/.pipeline/scripts/evaluate-duplicate-pr.py
@@ -30,10 +30,34 @@ def main():
         set_skip_duplicate("false")
         return
 
-    collection_uri = os.environ["SYSTEM_COLLECTIONURI"]
-    team_project = os.environ["SYSTEM_TEAMPROJECT"]
-    definition_id = os.environ["SYSTEM_DEFINITIONID"]
-    current_build_id = int(os.environ["BUILD_BUILDID"])
+    collection_uri = os.environ.get("SYSTEM_COLLECTIONURI", "")
+    team_project = os.environ.get("SYSTEM_TEAMPROJECT", "")
+    definition_id = os.environ.get("SYSTEM_DEFINITIONID", "")
+    current_build_id_raw = os.environ.get("BUILD_BUILDID", "")
+    missing = [
+        name
+        for name, value in (
+            ("SYSTEM_COLLECTIONURI", collection_uri),
+            ("SYSTEM_TEAMPROJECT", team_project),
+            ("SYSTEM_DEFINITIONID", definition_id),
+            ("BUILD_BUILDID", current_build_id_raw),
+        )
+        if not value
+    ]
+    if missing:
+        print(
+            f"##vso[task.logissue type=warning]Required pipeline variables unavailable ({', '.join(missing)}); continuing with full validation."
+        )
+        set_skip_duplicate("false")
+        return
+    try:
+        current_build_id = int(current_build_id_raw)
+    except ValueError:
+        print(
+            f"##vso[task.logissue type=warning]Build.BuildId is not numeric ('{current_build_id_raw}'); continuing with full validation."
+        )
+        set_skip_duplicate("false")
+        return
     build_source_branch = os.environ.get("BUILD_SOURCEBRANCH", "")
     source_commit = os.environ.get("SYSTEM_PULLREQUEST_SOURCECOMMITID", "").lower()
     pull_request_id = os.environ.get("SYSTEM_PULLREQUEST_PULLREQUESTID", "")
@@ -77,7 +101,8 @@ def main():
     headers = {"Authorization": "Bearer " + token}
     request = urllib.request.Request(url, headers=headers)
     try:
-        with urllib.request.urlopen(request) as response:
+        # Bound the call so a stalled ADO API can't hang the stage and block downstream validation.
+        with urllib.request.urlopen(request, timeout=30) as response:
             payload = json.load(response)
     except Exception as exc:
         print(
@@ -153,4 +178,13 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    # Safety net: the guard is best-effort, so any unexpected failure must fall back
+    # to full validation (skipDuplicate=false) rather than failing the stage and
+    # blocking the pipeline.
+    try:
+        main()
+    except Exception as exc:  # noqa: BLE001 - deliberate catch-all for safe fallback
+        print(
+            f"##vso[task.logissue type=warning]Duplicate guard failed unexpectedly ({type(exc).__name__}: {exc}); continuing with full validation."
+        )
+        set_skip_duplicate("false")

--- a/.pipeline/scripts/evaluate-duplicate-pr.py
+++ b/.pipeline/scripts/evaluate-duplicate-pr.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Duplicate PR validation guard.
+
+Queries the Azure DevOps Build REST API for a prior completed-and-succeeded
+validation run on the same pipeline and PR head commit. When one is found, emits
+``skipDuplicate=true`` so downstream PR stages can short-circuit redundant work.
+
+Any missing prerequisite (access token, source commit) or API error falls back
+to ``skipDuplicate=false`` so full validation proceeds (safe default).
+
+Consumed by the ``EvaluateDuplicate`` stage in
+``.pipeline/templates/validation-stages.yml``.
+"""
+import json
+import os
+import urllib.parse
+import urllib.request
+
+
+def set_skip_duplicate(value):
+    print(f"##vso[task.setvariable variable=skipDuplicate;isOutput=true]{value}")
+
+
+def main():
+    token = os.environ.get("SYSTEM_ACCESSTOKEN", "")
+    if not token:
+        print(
+            "##vso[task.logissue type=warning]System.AccessToken is unavailable; continuing with full validation."
+        )
+        set_skip_duplicate("false")
+        return
+
+    collection_uri = os.environ["SYSTEM_COLLECTIONURI"]
+    team_project = os.environ["SYSTEM_TEAMPROJECT"]
+    definition_id = os.environ["SYSTEM_DEFINITIONID"]
+    current_build_id = int(os.environ["BUILD_BUILDID"])
+    build_source_branch = os.environ.get("BUILD_SOURCEBRANCH", "")
+    source_commit = os.environ.get("SYSTEM_PULLREQUEST_SOURCECOMMITID", "").lower()
+    pull_request_id = os.environ.get("SYSTEM_PULLREQUEST_PULLREQUESTID", "")
+    pull_request_number = os.environ.get("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER", "")
+    print(
+        "Duplicate guard context: "
+        f"buildId={current_build_id}, "
+        f"branch={build_source_branch or '<empty>'}, "
+        f"sourceCommit={source_commit or '<empty>'}, "
+        f"pullRequestId={pull_request_id or '<empty>'}, "
+        f"pullRequestNumber={pull_request_number or '<empty>'}"
+    )
+    current_pr_identifiers = {
+        value for value in (pull_request_id, pull_request_number) if value
+    }
+    if not source_commit:
+        print(
+            "##vso[task.logissue type=warning]System.PullRequest.SourceCommitId is unavailable; continuing with full validation."
+        )
+        set_skip_duplicate("false")
+        return
+    # 200 keeps API payloads small while covering repeated draft/ready transitions on busy PRs.
+    # If a PR exceeds this window, the guard falls back to full validation (safe false negative).
+    max_candidates = "200"
+
+    query_params = {
+        "definitions": definition_id,
+        "reasonFilter": "pullRequest",
+        "statusFilter": "completed",
+        "resultFilter": "succeeded",
+        "queryOrder": "finishTimeDescending",
+        "$top": max_candidates,
+        "api-version": "7.1",
+    }
+    if build_source_branch:
+        # PR validation runs are indexed by the synthetic PR branch (for example refs/pull/<id>/merge),
+        # not by System.PullRequest.SourceBranch (refs/heads/<branch>).
+        query_params["branchName"] = build_source_branch
+    query = urllib.parse.urlencode(query_params)
+    url = f"{collection_uri}{team_project}/_apis/build/builds?{query}"
+    headers = {"Authorization": "Bearer " + token}
+    request = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(request) as response:
+            payload = json.load(response)
+    except Exception as exc:
+        print(
+            f"##vso[task.logissue type=warning]Failed to query prior PR validation runs ({type(exc).__name__}: {exc}). Continuing with full validation."
+        )
+        set_skip_duplicate("false")
+        return
+
+    matching_run = None
+    candidates = payload.get("value", [])
+    print(f"Duplicate guard candidates fetched: {len(candidates)}")
+    skipped_for_pr_mismatch = 0
+    skipped_for_missing_sha = 0
+    for build in candidates:
+        build_id = int(build.get("id", 0))
+        if build_id == current_build_id:
+            continue
+
+        trigger_info = build.get("triggerInfo", {})
+        # Field names vary across providers/API revisions; prefer provider-specific canonical keys first.
+        # - pr.sourceSha: Azure Repos PR triggers
+        # - pr.sourceCommitId: GitHub-backed PR triggers
+        # - pr.headSha: alternate/legacy PR trigger payloads
+        prior_source_sha = (
+            trigger_info.get("pr.sourceSha")
+            or trigger_info.get("pr.sourceCommitId")
+            or trigger_info.get("pr.headSha")
+        )
+        if prior_source_sha:
+            prior_source_sha = prior_source_sha.lower()
+        if not prior_source_sha:
+            skipped_for_missing_sha += 1
+            continue
+        prior_pr_identifiers = []
+        for key in ("pr.number", "pr.pullRequestId"):
+            value = trigger_info.get(key)
+            if value is not None:
+                prior_pr_identifiers.append(str(value))
+        # Without branch scope in the REST query, PR identifier mismatch is the only safe discriminator
+        # to avoid treating runs from other PRs as duplicates.
+        if (
+            current_pr_identifiers
+            and prior_pr_identifiers
+            and set(prior_pr_identifiers).isdisjoint(current_pr_identifiers)
+        ):
+            if not build_source_branch:
+                skipped_for_pr_mismatch += 1
+                continue
+            print(
+                f"Candidate run {build_id} has trigger PR identifiers {prior_pr_identifiers}, "
+                f"which do not overlap with current PR identifiers {sorted(current_pr_identifiers)}; "
+                "continuing with commit comparison because the API query is already branch-scoped."
+            )
+
+        if prior_source_sha == source_commit:
+            matching_run = build
+            break
+
+    if matching_run:
+        matching_run_id = matching_run.get("id", "unknown")
+        print(
+            f"PR head {source_commit} already validated by run {matching_run_id}; skipping duplicate stages."
+        )
+        set_skip_duplicate("true")
+    else:
+        print(
+            "Duplicate guard summary: "
+            f"skipped_for_pr_mismatch={skipped_for_pr_mismatch}, "
+            f"skipped_for_missing_source_sha={skipped_for_missing_sha}"
+        )
+        print(f"No successful prior validation run found for PR head {source_commit}; continuing.")
+        set_skip_duplicate("false")
+
+
+if __name__ == "__main__":
+    main()

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -40,141 +40,7 @@ stages:
     steps:
     - bash: |
         set -euo pipefail
-
-        if [ -z "${SYSTEM_ACCESSTOKEN:-}" ]; then
-          echo "##vso[task.logissue type=warning]System.AccessToken is unavailable; continuing with full validation."
-          echo "##vso[task.setvariable variable=skipDuplicate;isOutput=true]false"
-          exit 0
-        fi
-
-        python3 - <<'PY'
-        import json
-        import os
-        import urllib.parse
-        import urllib.request
-
-        collection_uri = os.environ["SYSTEM_COLLECTIONURI"]
-        team_project = os.environ["SYSTEM_TEAMPROJECT"]
-        definition_id = os.environ["SYSTEM_DEFINITIONID"]
-        current_build_id = int(os.environ["BUILD_BUILDID"])
-        build_source_branch = os.environ.get("BUILD_SOURCEBRANCH", "")
-        source_commit = os.environ.get("SYSTEM_PULLREQUEST_SOURCECOMMITID", "").lower()
-        pull_request_id = os.environ.get("SYSTEM_PULLREQUEST_PULLREQUESTID", "")
-        pull_request_number = os.environ.get("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER", "")
-        token = os.environ["SYSTEM_ACCESSTOKEN"]
-        print(
-            "Duplicate guard context: "
-            f"buildId={current_build_id}, "
-            f"branch={build_source_branch or '<empty>'}, "
-            f"sourceCommit={source_commit or '<empty>'}, "
-            f"pullRequestId={pull_request_id or '<empty>'}, "
-            f"pullRequestNumber={pull_request_number or '<empty>'}"
-        )
-        current_pr_identifiers = {
-            value for value in (pull_request_id, pull_request_number) if value
-        }
-        if not source_commit:
-            print(
-                "##vso[task.logissue type=warning]System.PullRequest.SourceCommitId is unavailable; continuing with full validation."
-            )
-            print("##vso[task.setvariable variable=skipDuplicate;isOutput=true]false")
-            raise SystemExit(0)
-        # 200 keeps API payloads small while covering repeated draft/ready transitions on busy PRs.
-        # If a PR exceeds this window, the guard falls back to full validation (safe false negative).
-        max_candidates = "200"
-
-        query_params = {
-            "definitions": definition_id,
-            "reasonFilter": "pullRequest",
-            "statusFilter": "completed",
-            "resultFilter": "succeeded",
-            "queryOrder": "finishTimeDescending",
-            "$top": max_candidates,
-            "api-version": "7.1",
-        }
-        if build_source_branch:
-            # PR validation runs are indexed by the synthetic PR branch (for example refs/pull/<id>/merge),
-            # not by System.PullRequest.SourceBranch (refs/heads/<branch>).
-            query_params["branchName"] = build_source_branch
-        query = urllib.parse.urlencode(query_params)
-        url = f"{collection_uri}{team_project}/_apis/build/builds?{query}"
-        headers = {"Authorization": "Bearer " + token}
-        request = urllib.request.Request(url, headers=headers)
-        try:
-            with urllib.request.urlopen(request) as response:
-                payload = json.load(response)
-        except Exception as exc:
-            print(
-                f"##vso[task.logissue type=warning]Failed to query prior PR validation runs ({type(exc).__name__}: {exc}). Continuing with full validation."
-            )
-            print("##vso[task.setvariable variable=skipDuplicate;isOutput=true]false")
-            raise SystemExit(0)
-
-        matching_run = None
-        candidates = payload.get("value", [])
-        print(f"Duplicate guard candidates fetched: {len(candidates)}")
-        skipped_for_pr_mismatch = 0
-        skipped_for_missing_sha = 0
-        for build in candidates:
-            build_id = int(build.get("id", 0))
-            if build_id == current_build_id:
-                continue
-
-            trigger_info = build.get("triggerInfo", {})
-            # Field names vary across providers/API revisions; prefer provider-specific canonical keys first.
-            # - pr.sourceSha: Azure Repos PR triggers
-            # - pr.sourceCommitId: GitHub-backed PR triggers
-            # - pr.headSha: alternate/legacy PR trigger payloads
-            prior_source_sha = (
-                trigger_info.get("pr.sourceSha")
-                or trigger_info.get("pr.sourceCommitId")
-                or trigger_info.get("pr.headSha")
-            )
-            if prior_source_sha:
-                prior_source_sha = prior_source_sha.lower()
-            if not prior_source_sha:
-                skipped_for_missing_sha += 1
-                continue
-            prior_pr_identifiers = []
-            for key in ("pr.number", "pr.pullRequestId"):
-                value = trigger_info.get(key)
-                if value is not None:
-                    prior_pr_identifiers.append(str(value))
-            # Without branch scope in the REST query, PR identifier mismatch is the only safe discriminator
-            # to avoid treating runs from other PRs as duplicates.
-            if (
-                current_pr_identifiers
-                and prior_pr_identifiers
-                and set(prior_pr_identifiers).isdisjoint(current_pr_identifiers)
-            ):
-                if not build_source_branch:
-                    skipped_for_pr_mismatch += 1
-                    continue
-                print(
-                    f"Candidate run {build_id} has trigger PR identifiers {prior_pr_identifiers}, "
-                    f"which do not overlap with current PR identifiers {sorted(current_pr_identifiers)}; "
-                    "continuing with commit comparison because the API query is already branch-scoped."
-                )
-
-            if prior_source_sha == source_commit:
-                matching_run = build
-                break
-
-        if matching_run:
-            matching_run_id = matching_run.get("id", "unknown")
-            print(
-                f"PR head {source_commit} already validated by run {matching_run_id}; skipping duplicate stages."
-            )
-            print("##vso[task.setvariable variable=skipDuplicate;isOutput=true]true")
-        else:
-            print(
-                "Duplicate guard summary: "
-                f"skipped_for_pr_mismatch={skipped_for_pr_mismatch}, "
-                f"skipped_for_missing_source_sha={skipped_for_missing_sha}"
-            )
-            print(f"No successful prior validation run found for PR head {source_commit}; continuing.")
-            print("##vso[task.setvariable variable=skipDuplicate;isOutput=true]false")
-        PY
+        python3 .pipeline/scripts/evaluate-duplicate-pr.py
       name: SetDuplicateState
       displayName: Check duplicate PR head commit
       env:
@@ -409,7 +275,10 @@ stages:
   displayName: Kerberos Test (Full Matrix)
   dependsOn:
     - Build
-  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq('${{ parameters.RunFuzz }}', 'false'), eq('${{ parameters.RunLongHaul }}', 'false'))
+  # Scope success to the Build stage explicitly. Bare succeeded() evaluates the
+  # whole dependency graph, so the PR-only EvaluateDuplicate stage (skipped on
+  # non-PR CI runs) would otherwise make this stage skip in CI.
+  condition: and(succeeded('Build'), ne(variables['Build.Reason'], 'PullRequest'), eq('${{ parameters.RunFuzz }}', 'false'), eq('${{ parameters.RunLongHaul }}', 'false'))
   jobs:
     - template: kerberos-test-template.yml
       parameters:
@@ -684,6 +553,9 @@ stages:
     displayName: Private Link Smoke Test
     dependsOn:
       - Build
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq('${{ parameters.RunFuzz }}', 'false'), eq('${{ parameters.RunLongHaul }}', 'false'))
+    # Scope success to the Build stage explicitly. Bare succeeded() evaluates the
+    # whole dependency graph, so the PR-only EvaluateDuplicate stage (skipped on
+    # non-PR CI runs) would otherwise make this stage skip in CI.
+    condition: and(succeeded('Build'), ne(variables['Build.Reason'], 'PullRequest'), eq('${{ parameters.RunFuzz }}', 'false'), eq('${{ parameters.RunLongHaul }}', 'false'))
     jobs:
       - template: private-link-smoke-template.yml


### PR DESCRIPTION
## Summary

Two follow-ups to #72 (the PR duplicate-validation guard):

**1. Fix non-PR CI runs skipping the Private Link Smoke Test (and Kerberos full-matrix) stages.**
#72 made the `Build` stage `dependsOn: [EvaluateDuplicate]`, but `EvaluateDuplicate` only runs for PRs and is *skipped* on non-PR CI runs. `PrivateLink_Smoke` and `Kerberos_Test_Full` gated on a bare `succeeded()`, which evaluates the entire dependency graph — so the skipped `EvaluateDuplicate` ancestor (reached via `Build`) made `succeeded()` false and those stages skipped even though `Build` succeeded. The sibling `Test_*` stages were unaffected only because they omit `succeeded()`. Both stages now use `succeeded('Build')`, scoping the check to the `Build` stage result so they run whenever `Build` succeeds. This matches the concern the Copilot reviewer raised on #72 about bare `succeeded()` breaking non-PR CI runs.

**2. Address review feedback to move the large inline Python out of YAML.**
The duplicate-guard logic is extracted from `validation-stages.yml` into `.pipeline/scripts/evaluate-duplicate-pr.py`, and the `EvaluateDuplicate` step now just invokes it. The access-token check moved into the script's safe-fallback path (still emits `skipDuplicate=false` on any missing prerequisite or API error, so full validation proceeds).

No behavior change to the duplicate-guard logic itself — only relocation.

## Linked issue/work item

None.

## Testing

- `python3 -m py_compile .pipeline/scripts/evaluate-duplicate-pr.py` — passes.
- YAML parses (`yaml.safe_load`).
- Pipeline behavior to be confirmed by a CI run on this branch: the Private Link Smoke Test and Kerberos full-matrix stages should run on non-PR builds, and PR runs should be unaffected.

## Breaking changes / migration notes

None.
