### PR TITLE
Add built-in Entra ID token factories behind entra-auth feature

### DIFF
--- a/mssql-tds/Cargo.toml
+++ b/mssql-tds/Cargo.toml
@@ -26,6 +26,11 @@ tls-schannel-direct = []
 # unconditionally — useful as an escape hatch if the rewrite needs to
 # be temporarily disabled in production.
 tls-schannel-direct-on-windows = ["tls-schannel-direct"]
+# Built-in Entra ID (Azure AD) token factories backed by the Azure SDK for Rust
+# (`azure_identity`). Off by default; the mssql-odbc driver enables it so the
+# ODBC layer can "just specify an auth method" and let mssql-tds acquire the
+# token. Pulls in the optional `azure_identity` / `azure_core` dependencies.
+entra-auth = ["dep:azure_identity", "dep:azure_core"]
 
 
 [lints]
@@ -58,6 +63,12 @@ x509-parser = "0.18.0"
 dns-lookup = "2.0"
 # Required to deserialize Vector(Float16) values from the TDS stream (Vector feature v2)
 half = "2.7.1"
+
+# Optional Azure SDK dependencies for the built-in Entra ID token factories
+# (feature = "entra-auth"). Same versions as the dev-dependencies below so the
+# resolved lockfile stays unified.
+azure_identity = { version = "0.25.0", optional = true }
+azure_core = { version = "0.25.0", optional = true }
 
 
 

--- a/mssql-tds/src/connection.rs
+++ b/mssql-tds/src/connection.rs
@@ -17,6 +17,14 @@ pub(crate) mod connection_actions;
 /// [`CursorClient`](crate::connection::cursor_ops::CursorClient) trait.
 pub mod cursor_ops;
 pub(crate) mod datasource_parser;
+/// Built-in Entra ID (Azure AD) token factories backed by `azure_identity`.
+///
+/// Compiled for the `entra-auth` feature, and also under `cfg(test)` so the
+/// no-network unit tests run in the default test profile (CI does not pass
+/// `--all-features`). `azure_identity` is already a dev-dependency, so the
+/// `test` arm adds no extra build cost.
+#[cfg(any(feature = "entra-auth", test))]
+pub mod entra_auth;
 pub(crate) mod execution_context;
 pub(crate) mod instance_cache;
 pub(crate) mod metadata_retriever;

--- a/mssql-tds/src/connection/entra_auth.rs
+++ b/mssql-tds/src/connection/entra_auth.rs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Built-in Entra ID (Azure AD) token factories backed by the Azure SDK for
+//! Rust (`azure_identity`).
+//!
+//! The ODBC layer selects an authentication method (e.g.
+//! `Authentication=ActiveDirectoryManagedIdentity`); mssql-tds owns token
+//! acquisition. [`register_builtin_entra_factories`](ClientContext::register_builtin_entra_factories)
+//! maps the method plus credential inputs onto an [`AzureIdentityTokenFactory`]
+//! and installs it in the context's `auth_method_map` — unless the caller has
+//! already injected their own factory for that method, which always wins.
+//!
+//! Only the token-credential flows that `azure_identity` actually ships are
+//! handled here: service principal (client secret), managed identity, the
+//! default credential chain, and workload identity. Username/password
+//! (`ActiveDirectoryPassword`), interactive, and device-code flows have no
+//! `azure_identity` credential and are handled elsewhere.
+
+pub mod builder;
+pub mod encoding;
+pub mod factory;
+
+pub use factory::AzureIdentityTokenFactory;

--- a/mssql-tds/src/connection/entra_auth/builder.rs
+++ b/mssql-tds/src/connection/entra_auth/builder.rs
@@ -1,0 +1,210 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Maps a [`ClientContext`]'s authentication method and credential inputs onto a
+//! built-in [`AzureIdentityTokenFactory`] and registers it.
+
+use crate::connection::client_context::{
+    ClientContext, CloneableEntraIdTokenFactory, TdsAuthenticationMethod,
+};
+use crate::connection::entra_auth::factory::{AzureIdentityTokenFactory, CredentialConfig};
+
+/// Derives the [`CredentialConfig`] for the context's authentication method, or
+/// `None` for methods without a built-in `azure_identity` credential.
+pub(crate) fn config_for_method(context: &ClientContext) -> Option<CredentialConfig> {
+    match context.tds_authentication_method {
+        TdsAuthenticationMethod::ActiveDirectoryServicePrincipal => {
+            Some(CredentialConfig::ServicePrincipalSecret {
+                client_id: context.user_name.clone(),
+                secret: context.password.clone(),
+            })
+        }
+        TdsAuthenticationMethod::ActiveDirectoryManagedIdentity
+        | TdsAuthenticationMethod::ActiveDirectoryMSI => Some(CredentialConfig::ManagedIdentity {
+            user_assigned_client_id: non_empty(&context.user_name),
+        }),
+        TdsAuthenticationMethod::ActiveDirectoryDefault => Some(CredentialConfig::Default),
+        TdsAuthenticationMethod::ActiveDirectoryWorkloadIdentity => {
+            Some(CredentialConfig::WorkloadIdentity {
+                client_id: non_empty(&context.user_name),
+                tenant_id: None,
+            })
+        }
+        _ => None,
+    }
+}
+
+fn non_empty(value: &str) -> Option<String> {
+    (!value.is_empty()).then(|| value.to_string())
+}
+
+impl ClientContext {
+    /// Installs a built-in [`AzureIdentityTokenFactory`] for the context's
+    /// authentication method.
+    ///
+    /// A factory already present in `auth_method_map` for that method is left
+    /// untouched, so a caller-injected factory always wins. Methods without a
+    /// built-in `azure_identity` credential (e.g. `ActiveDirectoryPassword`,
+    /// `SSPI`, `AccessToken`) are a no-op here.
+    ///
+    /// Invoked automatically from the connect path when the `entra-auth`
+    /// feature is enabled; also available for explicit use.
+    pub fn register_builtin_entra_factories(&mut self) {
+        if self
+            .auth_method_map
+            .contains_key(&self.tds_authentication_method)
+        {
+            return;
+        }
+        if let Some(config) = config_for_method(self) {
+            let factory: Box<dyn CloneableEntraIdTokenFactory> =
+                Box::new(AzureIdentityTokenFactory::new(config));
+            self.auth_method_map
+                .insert(self.tds_authentication_method.clone(), factory);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connection::client_context::EntraIdTokenFactory;
+    use crate::core::TdsResult;
+    use async_trait::async_trait;
+
+    fn context_for(method: TdsAuthenticationMethod) -> ClientContext {
+        ClientContext {
+            tds_authentication_method: method,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn service_principal_maps_user_and_password() {
+        let mut context = context_for(TdsAuthenticationMethod::ActiveDirectoryServicePrincipal);
+        context.user_name = "client-123".to_string();
+        context.password = "secret-xyz".to_string();
+        match config_for_method(&context) {
+            Some(CredentialConfig::ServicePrincipalSecret { client_id, secret }) => {
+                assert_eq!(client_id, "client-123");
+                assert_eq!(secret, "secret-xyz");
+            }
+            other => panic!("expected service principal config, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn managed_identity_user_assigned_id_is_optional() {
+        assert!(matches!(
+            config_for_method(&context_for(
+                TdsAuthenticationMethod::ActiveDirectoryManagedIdentity
+            )),
+            Some(CredentialConfig::ManagedIdentity {
+                user_assigned_client_id: None
+            })
+        ));
+
+        let mut context = context_for(TdsAuthenticationMethod::ActiveDirectoryMSI);
+        context.user_name = "uami-client-id".to_string();
+        match config_for_method(&context) {
+            Some(CredentialConfig::ManagedIdentity {
+                user_assigned_client_id: Some(id),
+            }) => assert_eq!(id, "uami-client-id"),
+            other => panic!("expected user-assigned managed identity, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn default_and_workload_identity_map() {
+        assert!(matches!(
+            config_for_method(&context_for(
+                TdsAuthenticationMethod::ActiveDirectoryDefault
+            )),
+            Some(CredentialConfig::Default)
+        ));
+        assert!(matches!(
+            config_for_method(&context_for(
+                TdsAuthenticationMethod::ActiveDirectoryWorkloadIdentity
+            )),
+            Some(CredentialConfig::WorkloadIdentity { .. })
+        ));
+    }
+
+    #[test]
+    fn unsupported_methods_have_no_builtin() {
+        for method in [
+            TdsAuthenticationMethod::Password,
+            TdsAuthenticationMethod::SSPI,
+            TdsAuthenticationMethod::ActiveDirectoryPassword,
+            TdsAuthenticationMethod::ActiveDirectoryInteractive,
+            TdsAuthenticationMethod::ActiveDirectoryDeviceCodeFlow,
+            TdsAuthenticationMethod::ActiveDirectoryIntegrated,
+            TdsAuthenticationMethod::AccessToken,
+        ] {
+            assert!(config_for_method(&context_for(method)).is_none());
+        }
+    }
+
+    #[test]
+    fn register_inserts_builtin_when_absent() {
+        let mut context = context_for(TdsAuthenticationMethod::ActiveDirectoryDefault);
+        assert!(context.auth_method_map.is_empty());
+        context.register_builtin_entra_factories();
+        assert!(
+            context
+                .auth_method_map
+                .contains_key(&TdsAuthenticationMethod::ActiveDirectoryDefault)
+        );
+    }
+
+    #[test]
+    fn register_is_noop_for_unsupported_method() {
+        let mut context = context_for(TdsAuthenticationMethod::AccessToken);
+        context.register_builtin_entra_factories();
+        assert!(context.auth_method_map.is_empty());
+    }
+
+    #[derive(Clone)]
+    struct StubFactory;
+
+    #[async_trait]
+    impl EntraIdTokenFactory for StubFactory {
+        async fn create_token(
+            &self,
+            _spn: String,
+            _sts_url: String,
+            _auth_method: TdsAuthenticationMethod,
+        ) -> TdsResult<Vec<u8>> {
+            Ok(vec![0xAB])
+        }
+    }
+
+    #[tokio::test]
+    async fn caller_injected_factory_wins() {
+        let mut context = context_for(TdsAuthenticationMethod::ActiveDirectoryDefault);
+        let stub: Box<dyn CloneableEntraIdTokenFactory> = Box::new(StubFactory);
+        context
+            .auth_method_map
+            .insert(TdsAuthenticationMethod::ActiveDirectoryDefault, stub);
+
+        context.register_builtin_entra_factories();
+
+        let factory = context
+            .auth_method_map
+            .get(&TdsAuthenticationMethod::ActiveDirectoryDefault)
+            .expect("factory present");
+        let token = factory
+            .create_token(
+                String::new(),
+                String::new(),
+                TdsAuthenticationMethod::ActiveDirectoryDefault,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            token,
+            vec![0xAB],
+            "built-in must not replace caller factory"
+        );
+    }
+}

--- a/mssql-tds/src/connection/entra_auth/encoding.rs
+++ b/mssql-tds/src/connection/entra_auth/encoding.rs
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Small, network-free helpers shared by the built-in Entra ID factories:
+//! scope normalization, STS URL parsing, and FEDAUTHTOKEN wire encoding.
+
+/// An STS (Security Token Service) authority parsed from the server-provided
+/// `sts_url` in the `FEDAUTHINFO` token.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct StsUrl {
+    /// The authority host, passed through verbatim to
+    /// `TokenCredentialOptions::set_authority_host`. May include a tenant path
+    /// segment; `azure_identity` rebuilds the token endpoint from the authority
+    /// origin plus the explicit tenant, so a trailing path is harmless.
+    pub authority_host: String,
+    /// The tenant identifier (GUID or domain) taken from the first path segment,
+    /// when present. Required by the service-principal flow.
+    pub tenant_id: Option<String>,
+}
+
+/// Normalizes an SPN/resource into an OAuth2 scope ending in `/.default`.
+///
+/// Azure SQL hands back a resource such as `https://database.windows.net/`; the
+/// credential APIs expect a scope like `https://database.windows.net/.default`.
+pub(crate) fn normalize_scope(spn: &str) -> String {
+    if spn.ends_with("/.default") {
+        spn.to_string()
+    } else if spn.ends_with('/') {
+        format!("{spn}.default")
+    } else {
+        format!("{spn}/.default")
+    }
+}
+
+/// Parses the server-provided `sts_url` into an [`StsUrl`].
+///
+/// `https://login.microsoftonline.com/<tenant>` yields `tenant_id = <tenant>`;
+/// a bare `https://login.microsoftonline.com/` yields `tenant_id = None`.
+pub(crate) fn parse_sts_url(sts_url: &str) -> StsUrl {
+    let trimmed = sts_url.trim();
+    let after_scheme = trimmed
+        .split_once("://")
+        .map(|(_, rest)| rest)
+        .unwrap_or(trimmed);
+    let tenant_id = after_scheme
+        .split('/')
+        .nth(1)
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty())
+        .map(str::to_string);
+    StsUrl {
+        authority_host: trimmed.to_string(),
+        tenant_id,
+    }
+}
+
+/// Encodes a JWT into the little-endian UTF-16 byte sequence expected in the
+/// `FEDAUTHTOKEN` payload.
+pub(crate) fn encode_jwt_utf16le(jwt: &str) -> Vec<u8> {
+    jwt.encode_utf16().flat_map(u16::to_le_bytes).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_scope_appends_default() {
+        assert_eq!(
+            normalize_scope("https://database.windows.net"),
+            "https://database.windows.net/.default"
+        );
+        assert_eq!(
+            normalize_scope("https://database.windows.net/"),
+            "https://database.windows.net/.default"
+        );
+        assert_eq!(
+            normalize_scope("https://database.windows.net/.default"),
+            "https://database.windows.net/.default"
+        );
+    }
+
+    #[test]
+    fn parse_sts_url_extracts_tenant() {
+        let parsed = parse_sts_url("https://login.microsoftonline.com/contoso-tenant-id");
+        assert_eq!(
+            parsed.authority_host,
+            "https://login.microsoftonline.com/contoso-tenant-id"
+        );
+        assert_eq!(parsed.tenant_id.as_deref(), Some("contoso-tenant-id"));
+    }
+
+    #[test]
+    fn parse_sts_url_handles_trailing_slash_and_missing_tenant() {
+        assert_eq!(parse_sts_url("https://login.windows.net/").tenant_id, None);
+        assert_eq!(parse_sts_url("https://login.windows.net").tenant_id, None);
+        let parsed = parse_sts_url("https://login.windows.net/my-tenant/");
+        assert_eq!(parsed.tenant_id.as_deref(), Some("my-tenant"));
+    }
+
+    #[test]
+    fn encode_jwt_utf16le_is_little_endian() {
+        assert_eq!(encode_jwt_utf16le("AB"), vec![0x41, 0x00, 0x42, 0x00]);
+        assert!(encode_jwt_utf16le("").is_empty());
+    }
+}

--- a/mssql-tds/src/connection/entra_auth/factory.rs
+++ b/mssql-tds/src/connection/entra_auth/factory.rs
@@ -1,0 +1,163 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! [`AzureIdentityTokenFactory`] — an [`EntraIdTokenFactory`] that acquires
+//! tokens through `azure_identity` credentials.
+
+use async_trait::async_trait;
+use azure_core::credentials::{Secret, TokenCredential};
+use azure_identity::{
+    ClientAssertionCredentialOptions, ClientSecretCredential, ClientSecretCredentialOptions,
+    DefaultAzureCredential, ManagedIdentityCredential, ManagedIdentityCredentialOptions,
+    TokenCredentialOptions, UserAssignedId, WorkloadIdentityCredential,
+    WorkloadIdentityCredentialOptions,
+};
+
+use crate::connection::client_context::{EntraIdTokenFactory, TdsAuthenticationMethod};
+use crate::connection::entra_auth::encoding::{
+    StsUrl, encode_jwt_utf16le, normalize_scope, parse_sts_url,
+};
+use crate::core::TdsResult;
+use crate::error::Error;
+
+/// Which `azure_identity` credential to build, plus the inputs it needs.
+#[derive(Clone, Debug)]
+pub(crate) enum CredentialConfig {
+    /// `ClientSecretCredential` — service principal with a client secret.
+    ServicePrincipalSecret { client_id: String, secret: String },
+    /// `ManagedIdentityCredential` — system- or user-assigned managed identity.
+    ManagedIdentity {
+        user_assigned_client_id: Option<String>,
+    },
+    /// `DefaultAzureCredential` — the default credential chain.
+    Default,
+    /// `WorkloadIdentityCredential` — federated Kubernetes/AKS workload identity.
+    WorkloadIdentity {
+        client_id: Option<String>,
+        tenant_id: Option<String>,
+    },
+}
+
+/// A built-in [`EntraIdTokenFactory`] backed by `azure_identity`.
+///
+/// One factory wraps one [`CredentialConfig`]; the FedAuth handshake supplies
+/// the SPN (resource) and STS authority at token-acquisition time.
+#[derive(Clone, Debug)]
+pub struct AzureIdentityTokenFactory {
+    config: CredentialConfig,
+}
+
+impl AzureIdentityTokenFactory {
+    pub(crate) fn new(config: CredentialConfig) -> Self {
+        Self { config }
+    }
+
+    async fn acquire_jwt(&self, scope: &str, sts: &StsUrl) -> TdsResult<String> {
+        let response = match &self.config {
+            CredentialConfig::ServicePrincipalSecret { client_id, secret } => {
+                let tenant_id = sts.tenant_id.as_deref().ok_or_else(|| {
+                    Error::ConnectionError(
+                        "Service principal authentication requires a tenant, but none could be \
+                         determined from the server's STS URL."
+                            .to_string(),
+                    )
+                })?;
+                let credential = ClientSecretCredential::new(
+                    tenant_id,
+                    client_id.clone(),
+                    Secret::from(secret.clone()),
+                    Some(ClientSecretCredentialOptions {
+                        credential_options: authority_options(sts),
+                    }),
+                )
+                .map_err(token_error)?;
+                credential.get_token(&[scope], None).await
+            }
+            CredentialConfig::ManagedIdentity {
+                user_assigned_client_id,
+            } => {
+                let options = ManagedIdentityCredentialOptions {
+                    credential_options: authority_options(sts),
+                    user_assigned_id: user_assigned_client_id
+                        .clone()
+                        .map(UserAssignedId::ClientId),
+                };
+                let credential =
+                    ManagedIdentityCredential::new(Some(options)).map_err(token_error)?;
+                credential.get_token(&[scope], None).await
+            }
+            CredentialConfig::Default => {
+                let credential = DefaultAzureCredential::with_options(authority_options(sts))
+                    .map_err(token_error)?;
+                credential.get_token(&[scope], None).await
+            }
+            CredentialConfig::WorkloadIdentity {
+                client_id,
+                tenant_id,
+            } => {
+                let options = WorkloadIdentityCredentialOptions {
+                    credential_options: ClientAssertionCredentialOptions {
+                        credential_options: authority_options(sts),
+                        ..Default::default()
+                    },
+                    client_id: client_id.clone(),
+                    tenant_id: tenant_id.clone().or_else(|| sts.tenant_id.clone()),
+                    token_file_path: None,
+                };
+                let credential =
+                    WorkloadIdentityCredential::new(Some(options)).map_err(token_error)?;
+                credential.get_token(&[scope], None).await
+            }
+        };
+
+        Ok(response.map_err(token_error)?.token.secret().to_string())
+    }
+}
+
+#[async_trait]
+impl EntraIdTokenFactory for AzureIdentityTokenFactory {
+    async fn create_token(
+        &self,
+        spn: String,
+        sts_url: String,
+        _auth_method: TdsAuthenticationMethod,
+    ) -> TdsResult<Vec<u8>> {
+        let scope = normalize_scope(&spn);
+        let sts = parse_sts_url(&sts_url);
+        let jwt = self.acquire_jwt(&scope, &sts).await?;
+        Ok(encode_jwt_utf16le(&jwt))
+    }
+}
+
+fn authority_options(sts: &StsUrl) -> TokenCredentialOptions {
+    let mut options = TokenCredentialOptions::default();
+    options.set_authority_host(sts.authority_host.clone());
+    options
+}
+
+fn token_error(error: azure_core::Error) -> Error {
+    Error::ConnectionError(format!("Entra ID token acquisition failed: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn service_principal_without_tenant_errors() {
+        let factory = AzureIdentityTokenFactory::new(CredentialConfig::ServicePrincipalSecret {
+            client_id: "client-id".to_string(),
+            secret: "client-secret".to_string(),
+        });
+        // STS URL carries no tenant segment, so the service-principal flow has
+        // no tenant to authenticate against and must fail fast (no network).
+        let result = factory
+            .create_token(
+                "https://database.windows.net/".to_string(),
+                "https://login.microsoftonline.com/".to_string(),
+                TdsAuthenticationMethod::ActiveDirectoryServicePrincipal,
+            )
+            .await;
+        assert!(matches!(result, Err(Error::ConnectionError(_))));
+    }
+}

--- a/mssql-tds/src/connection_provider/tds_connection_provider.rs
+++ b/mssql-tds/src/connection_provider/tds_connection_provider.rs
@@ -99,6 +99,12 @@ impl TdsConnectionProvider {
         // Validate the ClientContext before attempting connection
         context.validate()?;
 
+        // Install built-in Entra ID token factories for the selected auth method
+        // (unless the caller already injected one). Realizes the "just specify a
+        // method" UX without changing the FedAuth handshake.
+        #[cfg(feature = "entra-auth")]
+        context.register_builtin_entra_factories();
+
         validate_multi_subnet_failover(
             context.multi_subnet_failover,
             &context.failover_partner,


### PR DESCRIPTION
## Summary

Adds authentication support for the under-development **mssql-odbc** (Rust ODBC) driver by letting the ODBC layer *just specify an auth method* while **mssql-tds** owns token acquisition via the Azure SDK for Rust (`azure_identity`).

Implements ADO story [45484](https://dev.azure.com/SqlClientDrivers/mssql-rs/_workitems/edit/45484) ("mssql-odbc | Connection & Authentication") under feature [42845](https://dev.azure.com/SqlClientDrivers/mssql-rs/_workitems/edit/42845).

> **Design doc:** published to the wiki — **mssql-odbc Authentication** (`Design/mssql-odbc-Authentication`).

## What's here

- **`entra-auth` cargo feature** + optional `azure_identity` / `azure_core` deps — **off by default**, enabled by mssql-odbc. Non-feature builds don't pull in the Azure stack.
- **New `connection/entra_auth/` module:**
  - `encoding.rs` — scope normalization, STS-URL → authority/tenant parsing, UTF-16-LE `FEDAUTHTOKEN` encoding.
  - `factory.rs` — `AzureIdentityTokenFactory`, an `EntraIdTokenFactory` that builds the right `azure_identity` credential from the server-provided SPN/STS during the FedAuth handshake.
  - `builder.rs` — `register_builtin_entra_factories`, mapping the selected method + credential inputs onto a factory. **A caller-injected factory always wins.**
- **Auto-registration** wired into `TdsConnectionProvider::create_client` (feature-gated), so no caller wiring is required.

## Methods covered

| Method | Credential |
|---|---|
| `ActiveDirectoryServicePrincipal` | `ClientSecretCredential` (client id = user, secret = password) |
| `ActiveDirectoryManagedIdentity` / `ActiveDirectoryMSI` | `ManagedIdentityCredential` (optional user-assigned client id) |
| `ActiveDirectoryDefault` | `DefaultAzureCredential` |
| `ActiveDirectoryWorkloadIdentity` | `WorkloadIdentityCredential` |

## Testing

- 12 no-network unit tests (scope/STS parsing, UTF-16-LE encoding, method→config mapping, caller-precedence, service-principal-without-tenant error path).
- The module is gated `cfg(any(feature = "entra-auth", test))` so these tests run in the **default** CI test profile (CI nextest doesn't pass `--all-features`) at zero extra dependency cost — `azure_identity` is already a dev-dependency.
- `cargo fmt --check`, `cargo bclippy` (`--all-features -D warnings`), and default-feature `clippy --all-targets` all clean.

## Out of scope / follow-ups

- Live env-gated e2e tests against Azure SQL (need provisioned identities).
- `ActiveDirectoryPassword` / Interactive / DeviceCode / Integrated — no `azure_identity` credential exists for these (username/password & interactive flows); tracked separately.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>