### PR TITLE
Bump mssql-py-core version to 0.1.6

### DIFF
--- a/mssql-py-core/Cargo.toml
+++ b/mssql-py-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mssql-py-core"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 publish = false
 


### PR DESCRIPTION
## Description

Bump the `mssql-py-core` crate version `0.1.5` → `0.1.6` 

## Checklist

- [x] `cargo bfmt` passes — `cargo fmt -- --check` is clean in `mssql-py-core/` (the crate is `exclude`d from the root workspace, so it's checked in its own directory).
- [x] `cargo bclippy` — N/A: version-constant change only; `mssql-py-core` is excluded from the root workspace, and a version string cannot affect lints.
- [x] `cargo btest` — N/A: no logic changed; version bump only.
- [x] New/changed functionality has tests — N/A: version bump only.
- [x] Public API changes are documented — N/A: no API change.
