### PR TITLE
Boot on-demand SQL host for ARM test stages and run them on PRs

### DIFF
--- a/.pipeline/docs/arm-sql-host-design.md
+++ b/.pipeline/docs/arm-sql-host-design.md
@@ -80,12 +80,16 @@ ADO dependency between the jobs:
 
 | Direction | Artifact name              | Producer side                       | Consumer side                                |
 |-----------|----------------------------|-------------------------------------|----------------------------------------------|
-| host→test | `sql-ready-<instanceId>`   | `PublishPipelineArtifact@1` after `start.sh` | `poll-for-endpoint.sh` at start of test job  |
-| test→host | `<sentinelName>` (per matrix entry) | `PublishPipelineArtifact@1` always() at end of test job | `wait-for-teardown.sh` poll loop in SQL host |
+| host→test | `sql-ready-<instanceId>-<stageAttempt>`   | `PublishPipelineArtifact@1` after `start.sh` | `poll-for-endpoint.sh` at start of test job  |
+| test→host | `<sentinelName>-<stageAttempt>` (per matrix entry) | `PublishPipelineArtifact@1` always() at end of test job | `wait-for-teardown.sh` poll loop in SQL host |
 
 Both jobs are queued at the start of the stage and run concurrently. The
 test job's first SQL-touching step blocks on the `sql-ready` sentinel; the
-SQL host's wait step blocks on the `tests-done` sentinels.
+SQL host's wait step blocks on the teardown sentinels.
+
+Every rendezvous artifact name is suffixed with `$(System.StageAttempt)` (see
+the *Rerun safety* property below), so a stage rerun forms a fresh, isolated
+handshake instead of colliding with the previous attempt's artifacts.
 
 ### Shared SA password
 
@@ -297,7 +301,7 @@ coverage is the Rust integration suite.
 | `.pipeline/scripts/sql-host/derive-sql-password.sh`           | Derive shared SA password from build context.                  |
 | `.pipeline/scripts/sql-host/start.sh`                         | Boot SQL container, probe readiness, stage endpoint payload.   |
 | `.pipeline/scripts/sql-host/poll-for-endpoint.sh`             | Test-side: poll for sql-ready artifact, set DB_HOST/DB_PORT.   |
-| `.pipeline/scripts/sql-host/wait-for-teardown.sh`             | SQL-host-side: poll ADO REST for tests-done sentinels.         |
+| `.pipeline/scripts/sql-host/wait-for-teardown.sh`             | SQL-host-side: poll ADO REST for teardown sentinels.         |
 | `.pipeline/scripts/sql-host/teardown.sh`                      | Idempotent docker cleanup for `always()` step.                 |
 | `.pipeline/templates/test-matrix-template-arm64.yml`          | Refactored; targets list + sqlInstanceMode; consumes endpoint. |
 | `.pipeline/templates/test-matrix-template-alpine_arm64.yml`   | Same refactor for the musl/alpine flow.                        |
@@ -310,6 +314,18 @@ unchanged.
 
 ## Reliability properties
 
+- **Rerun safety (attempt namespacing).** Every rendezvous artifact name —
+  `sql-ready-<instanceId>` and each teardown sentinel — is suffixed with
+  `$(System.StageAttempt)`. Pipeline artifacts are build-scoped and immutable,
+  so without this a stage rerun would (a) fail `PublishPipelineArtifact@1` with
+  "artifact already exists" from the prior attempt, and (b) risk the test side
+  reading a stale endpoint. Because the SQL host and its test consumers live in
+  the same stage, they observe the same `System.StageAttempt` and rendezvous
+  only within their attempt; the previous attempt's artifacts are inert.
+  (Publishers append the suffix inline; `wait-for-teardown.sh` appends the same
+  value via `SENTINEL_SUFFIX`.) Note this makes **Rerun stage** clean; making
+  **Rerun failed jobs** work additionally requires coupling the SQL host's
+  outcome to the test's — see *Open assumptions*.
 - **No deadlock.** Symmetric pipeline-artifact sentinels with no ADO
   `dependsOn` between SQL host and test jobs. Either side can be late and
   the other side polls until it appears.
@@ -345,6 +361,15 @@ unchanged.
   `install-ubuntu-dependency.yaml`; the former is standard in the image.
 - Both ARM and x64 1ES pool agents have `python3` available (used by
   `poll-for-endpoint.sh` for JSON parsing). Standard in the Ubuntu images.
+- **Rerun granularity.** Attempt namespacing makes **Rerun stage** fully clean
+  (all jobs re-run under a new `System.StageAttempt`, forming a fresh
+  handshake). **Rerun failed jobs** is *not* fully supported yet: on a test
+  failure the SQL host job still reports success (its `always()` teardown
+  released it), so ADO does not re-run it, and the re-run test job polls for a
+  `sql-ready-*-<newAttempt>` artifact that no host will publish. Making that
+  path work requires additionally coupling the SQL host's outcome to the test
+  job's (host mirrors the test's failure so both re-run together) — deferred as
+  a follow-up.
 
 ## Operational notes
 

--- a/.pipeline/docs/arm-sql-host-design.md
+++ b/.pipeline/docs/arm-sql-host-design.md
@@ -186,7 +186,7 @@ so the test side polls for the right sentinel.
 
 If the readiness probe fails, `start.sh` exits non-zero, the publish step
 is skipped, and the test job's poll script will time out at its
-`MAX_WAIT_SECONDS` cap (default 30 min) and fail with a clear error.
+`MAX_WAIT_SECONDS` cap (default 60 min) and fail with a clear error.
 
 ### Shutdown signalling (release)
 

--- a/.pipeline/docs/arm-sql-host-design.md
+++ b/.pipeline/docs/arm-sql-host-design.md
@@ -264,20 +264,30 @@ pipeline parameter if a use case appears.
 ## PR vs merge coverage
 
 Because the SQL host is now booted on-demand (no static ACI IP to contend
-for), the ARM test stages also run on pull requests. Following the existing
-Kerberos pattern, coverage is split into reduced PR stages and full merge
-stages:
+for), ARM64 integration tests can run on pull requests. Rather than a
+separate ARM test stage, PR coverage is folded into the existing
+`Build_Linux_ARM` job: it connects cross-pool to an on-demand SQL host booted
+inside the **Build** stage (`Sql_Host_build_arm`), so the ARM64 build's own
+test pass exercises the full integration suite instead of skipping it. The
+full multi-distro ARM test matrices still run on merge.
 
-| Stage                   | Trigger        | Matrix                                  |
-|-------------------------|----------------|-----------------------------------------|
-| `Test_arm64_PR`         | PR             | Ubuntu24, AzLinux3                       |
-| `Test_alpine_arm64_PR`  | PR             | Alpine3_21                              |
-| `Test_arm64`            | non-PR (merge) | full glibc matrix (7 distros)           |
-| `Test_alpine_arm64`     | non-PR (merge) | full musl matrix (Alpine 3.18–3.21)     |
+| Coverage                          | Trigger        | Where                                       |
+|-----------------------------------|----------------|---------------------------------------------|
+| `Build_Linux_ARM` integration pass | PR             | Build stage, vs `Sql_Host_build_arm`        |
+| `Test_arm64`                      | non-PR (merge) | full glibc matrix (7 distros)               |
+| `Test_alpine_arm64`               | non-PR (merge) | full musl matrix (Alpine 3.18–3.21)         |
 
-The `_PR` stages `dependsOn` `Build` (for the `Build_Linux_ARM` artifact) and
-`EvaluateDuplicate`, and are skipped when a prior successful PR validation is
-detected (`skipDuplicate`). Each PR stage boots one shared SQL host by default.
+`Sql_Host_build_arm` is a PR-only instance of `sql-host-template.yml` added to
+the Build stage (`jobCondition: eq(Build.Reason, 'PullRequest')`). It runs
+concurrently with `Build_Linux_ARM` (no `dependsOn`) and the two rendezvous
+via the same `sql-ready-build_arm` / `build_arm` sentinel pair used by the
+test stages. On merge the host job is skipped and the ARM build's test pass
+does not run (its steps are PR-gated), so no x64 agent is idled.
+
+Python integration tests stay `--skip-integration` on ARM: the Python test
+harness builds `Server={host}` with no port, so it cannot target the SQL
+host's non-1433 port without a test-source change. The substantive ARM PR
+coverage is the Rust integration suite.
 
 ## Files
 
@@ -291,7 +301,8 @@ detected (`skipDuplicate`). Each PR stage boots one shared SQL host by default.
 | `.pipeline/scripts/sql-host/teardown.sh`                      | Idempotent docker cleanup for `always()` step.                 |
 | `.pipeline/templates/test-matrix-template-arm64.yml`          | Refactored; targets list + sqlInstanceMode; consumes endpoint. |
 | `.pipeline/templates/test-matrix-template-alpine_arm64.yml`   | Same refactor for the musl/alpine flow.                        |
-| `.pipeline/templates/validation-stages.yml`                   | Converts ARM stage matrices into `targets` lists; threads `sqlInstanceMode` / `sqlImageTag`. |
+| `.pipeline/templates/validation-stages.yml`                   | Converts ARM stage matrices into `targets` lists; threads `sqlInstanceMode` / `sqlImageTag`; adds PR-only `Sql_Host_build_arm` to the Build stage. |
+| `.pipeline/templates/build-template-container.yml`           | ARM64 branch: derive password, poll the cross-pool endpoint, run the integration suite against it, publish the `build_arm` teardown sentinel. x64 path unchanged. |
 | `.pipeline/validation-pipeline.yml`, `.pipeline/validation-pipeline-ci.yml` | Add `sqlInstanceMode` and `sqlImageTag` parameters and pass them to `validation-stages.yml`. |
 
 The amd64 templates and `sql-setup-template.yml` are intentionally left

--- a/.pipeline/docs/arm-sql-host-design.md
+++ b/.pipeline/docs/arm-sql-host-design.md
@@ -366,8 +366,12 @@ unchanged.
   handshake). **Rerun failed jobs** is *not* fully supported yet: on a test
   failure the SQL host job still reports success (its `always()` teardown
   released it), so ADO does not re-run it, and the re-run test job polls for a
-  `sql-ready-*-<newAttempt>` artifact that no host will publish. Making that
-  path work requires additionally coupling the SQL host's outcome to the test
+  `sql-ready-*-<newAttempt>` artifact that no host will publish. To keep that
+  misuse from silently burning the full poll timeout, `poll-for-endpoint.sh`
+  detects `System.StageAttempt > 1` with no endpoint and surfaces ADO
+  `logissue` guidance — an early warning, then a failing error — telling the
+  operator to use **Rerun stage** instead. Fully supporting **Rerun failed
+  jobs** would additionally require coupling the SQL host's outcome to the test
   job's (host mirrors the test's failure so both re-run together) — deferred as
   a follow-up.
 

--- a/.pipeline/docs/arm-sql-host-design.md
+++ b/.pipeline/docs/arm-sql-host-design.md
@@ -45,7 +45,7 @@ Build (existing)                                                   completes
    |        2. boot mcr.microsoft.com/mssql/server                  |
    |        3. probe readiness via sqlcmd                           |
    |        4. publish sql-ready-<id> artifact (contains endpoint)  |
-   |        5. poll ADO REST API for tests-done sentinels           |
+   |        5. poll ADO REST API for teardown sentinels             |
    |        6. always() docker stop + rm                            |
    |                                                                |
    |                                                       ARM 1ES agent(s)
@@ -67,7 +67,7 @@ ADO will not start a `dependsOn`-linked job until its upstream job
 *completes*, even when only output variables are referenced. If the test job
 declared `dependsOn: Sql_Host_<id>`, the SQL host would have to finish before
 the test job started. But the SQL host's job only finishes after the
-`tests-done` sentinels are published, which only happens once the tests
+teardown sentinels are published, which only happens once the tests
 *run* — a textbook deadlock. In the original design this manifested as the
 SQL host blocking until its `MAX_LIFETIME_MINUTES` cap fired (2 h by
 default), at which point the always() teardown step ran, the SQL container

--- a/.pipeline/docs/arm-sql-host-design.md
+++ b/.pipeline/docs/arm-sql-host-design.md
@@ -1,0 +1,353 @@
+# ARM Test Stages: On-Demand SQL Server Hosts
+
+## Background
+
+The two ARM64 Linux test stages — `Test_arm64` (glibc) and `Test_alpine_arm64`
+(musl) — used to connect to a long-lived SQL Server hosted in Azure Container
+Instances. The connection details came from pipeline variables
+`$(ACI_SQL_HOST_2022)` and `$(ACI_SQL_PASSWORD)` on port `14333`. The reason
+ACI was used: the official `mcr.microsoft.com/mssql/server` image is x64-only,
+so ARM agents could not host SQL locally the way the amd64 stages already do
+(see `test-matrix-template.yml` and `test-matrix-template-alpine.yml`).
+
+This document describes the replacement design. The shared ACI SQL Server is
+gone. Each affected stage now boots its own SQL Server in a docker container
+on an x64 1ES agent for the duration of that stage and tears it down when the
+ARM tests finish. No new Azure-service dependency is introduced.
+
+## Goals
+
+- Remove the standing dependency on the ACI-hosted SQL Server.
+- Boot SQL on-demand inside an existing 1ES pool.
+- Cross-pool reachability over the existing shared VNet (private IPv4); no
+  public endpoint.
+- Reliable teardown including cancellation and test-failure paths.
+- A knob to choose between one SQL host per stage (default) and one SQL host
+  per matrix entry, for cases where shared SQL state causes test flakes.
+
+## Non-goals
+
+- Rework of the amd64 ARM-stage flows (they already self-host SQL).
+- Decommission of the ACI resource itself (operational task).
+- Removal of the `ACI_SQL_*` pipeline variable definitions (they may still be
+  referenced elsewhere).
+
+## Architecture
+
+For each ARM test stage:
+
+```
+Build (existing)                                                   completes
+   |
+   |                                                       x64 1ES agent
+   +---> Sql_Host_<id>  --------------------------------------------+
+   |        1. derive SA password from build context                |
+   |        2. boot mcr.microsoft.com/mssql/server                  |
+   |        3. probe readiness via sqlcmd                           |
+   |        4. publish sql-ready-<id> artifact (contains endpoint)  |
+   |        5. poll ADO REST API for tests-done sentinels           |
+   |        6. always() docker stop + rm                            |
+   |                                                                |
+   |                                                       ARM 1ES agent(s)
+   +---> Test_*  ---------------------------------------------------+
+            (no `dependsOn` on Sql_Host_<id> — runs concurrently)
+            1. derive SA password from build context (same value)
+            2. download Build_Linux_ARM artifact
+            3. poll ADO REST API for sql-ready-<id> artifact
+            4. download endpoint, set DB_HOST/DB_PORT
+            5. run docker-cargo-run.sh against $DB_HOST:$DB_PORT
+            6. publish junit
+            7. always() PublishPipelineArtifact@1
+                       artifact = <sentinel name>      ----> releases SQL host
+```
+
+### Why no `dependsOn` between SQL host and test job?
+
+ADO will not start a `dependsOn`-linked job until its upstream job
+*completes*, even when only output variables are referenced. If the test job
+declared `dependsOn: Sql_Host_<id>`, the SQL host would have to finish before
+the test job started. But the SQL host's job only finishes after the
+`tests-done` sentinels are published, which only happens once the tests
+*run* — a textbook deadlock. In the original design this manifested as the
+SQL host blocking until its `MAX_LIFETIME_MINUTES` cap fired (2 h by
+default), at which point the always() teardown step ran, the SQL container
+was destroyed, and only then was the test job released — so every test
+attempted to connect to a SQL host that had just been torn down and timed
+out at the connect.
+
+The fix is symmetric pipeline-artifact sentinels in both directions, with no
+ADO dependency between the jobs:
+
+| Direction | Artifact name              | Producer side                       | Consumer side                                |
+|-----------|----------------------------|-------------------------------------|----------------------------------------------|
+| host→test | `sql-ready-<instanceId>`   | `PublishPipelineArtifact@1` after `start.sh` | `poll-for-endpoint.sh` at start of test job  |
+| test→host | `<sentinelName>` (per matrix entry) | `PublishPipelineArtifact@1` always() at end of test job | `wait-for-teardown.sh` poll loop in SQL host |
+
+Both jobs are queued at the start of the stage and run concurrently. The
+test job's first SQL-touching step blocks on the `sql-ready` sentinel; the
+SQL host's wait step blocks on the `tests-done` sentinels.
+
+### Shared SA password
+
+`generate-sql-password-template.yml` produces a job-scoped random password
+and is fine for the amd64 stages where SQL Server and the test runner share
+a job. For the cross-pool ARM design, the SQL host job and the test jobs
+must agree on the password without sharing a secret across jobs (artifacts
+are readable by anyone with build read access; we do not want to leak the
+SA password through the `sql-ready` artifact).
+
+`sql-host/derive-sql-password.sh` deterministically derives the SA password
+from build context:
+
+```
+SQL_PASSWORD = "Aa1!" || sha256(Build.BuildId "-" System.CollectionId "-" salt)[0:22]
+```
+
+Both the SQL host job and the test jobs invoke the same script, so they
+agree on the value without any cross-job transport. The `Aa1!` prefix
+guarantees all four character classes the SQL Server SA policy requires.
+The script uses the same `SQL_PASSWORD_GENERATED` marker as the random
+template so the two are interchangeable.
+
+### Shared TLS cert chain
+
+`mssql.conf` sets `forceencryption = 1`, so SQL Server always presents a
+cert during the TDS handshake. In the colocated amd64 design, a single
+`scripts/generate_cert.sh` invocation produces the cert that both the SQL
+container (mounted at `/etc/ssl/...`) and the test container (installed
+via the dockerentry script's `update-ca-certificates`) trust. Connections
+go to `sql1` (a docker DNS name in the shared docker network), which is
+also a SAN on the cert.
+
+The cross-pool design has two complications:
+
+1. The SQL host and the test agent are different machines, so two
+   independent runs of `generate_cert.sh` produce two unrelated CAs.
+   The test container's trust store has no knowledge of the cert chain
+   the SQL Server is actually presenting.
+2. Test clients connect by IP (the SQL host's private VNet IP), not by
+   DNS name. The default cert SANs (`sql1`, `localhost`, `127.0.0.1`,
+   `::1`) don't cover this.
+
+To fix both:
+
+* `start.sh` resolves its own private IPv4 first, then invokes
+  `generate_cert.sh` with `EXTRA_IP_SAN=<that IP>`. The generated cert
+  carries the SQL host's IP as a SAN.
+* `start.sh` stages `ca.crt` and `mssql.pem` into the `sql-ready` artifact
+  alongside `endpoint.txt`. (The CA cert is public-key material; this
+  doesn't widen the threat model.)
+* `poll-for-endpoint.sh` extracts both files and copies them to
+  `Build.SourcesDirectory`. The existing dockerentry scripts then pick
+  them up via the `cp ca.crt /usr/local/share/ca-certificates;
+  update-ca-certificates` step that already runs.
+* The cross-pool test step skips the local `scripts/generate_cert.sh`
+  call (it would overwrite the downloaded cert with a useless local one).
+
+### Job topology by mode
+
+| Mode (`sqlInstanceMode`) | SQL host jobs            | Test jobs                                  |
+|--------------------------|--------------------------|--------------------------------------------|
+| `shared` (default)       | 1 per stage              | 1 strategy-matrix job over all targets     |
+| `per-job`                | 1 per matrix target      | 1 standalone job per matrix target         |
+
+Both modes are produced from the same `targets` parameter list. Shared mode
+reconstructs `strategy.matrix` from the list with `${{ each }}`; per-job
+mode fans the list out into `(SQL host + test)` job pairs. The `sql-ready`
+artifact name carries the instance id (`sql-ready-shared`,
+`sql-ready-shared_musl`, or `sql-ready-<target.name>` / `_musl` for per-job)
+so the test side polls for the right sentinel.
+
+### Readiness signalling (start)
+
+1. `start.sh` runs the SQL container with `-p ${SQL_HOST_PORT}:1433` (default
+   `14333` to dodge NRMS baseline rules that single out 1433).
+2. `start.sh` execs `sqlcmd -Q "SELECT 1"` inside the container in a retry
+   loop (default deadline 180 s).
+3. On success, `start.sh` writes `${BUILD_ARTIFACTSTAGINGDIRECTORY}/sql-endpoint-${INSTANCE_ID}/endpoint.txt`
+   containing a single line `IP PORT DEADLINE_EPOCH`. The deadline is the
+   wall-clock UTC epoch second past which `wait-for-teardown.sh` will give
+   up and let `teardown.sh` destroy the container.
+4. The next YAML step is a `PublishPipelineArtifact@1` that publishes that
+   directory under the artifact name `sql-ready-${INSTANCE_ID}`.
+5. The test job's `poll-for-endpoint.sh` polls
+   `GET .../_apis/build/builds/{Build.BuildId}/artifacts?api-version=7.1`
+   until that artifact appears, downloads its zip (with retry), extracts
+   `endpoint.txt` using `python3 -m zipfile -e` (no `unzip` dependency),
+   refuses to proceed if the embedded deadline leaves less than
+   `MIN_HOST_LIFE_REMAINING_SECONDS` (default 5 min) of host life — that
+   case usually means the SQL host hit its lifetime cap while the test
+   job was queued — and otherwise sets pipeline variables `DB_HOST` and
+   `DB_PORT`.
+
+If the readiness probe fails, `start.sh` exits non-zero, the publish step
+is skipped, and the test job's poll script will time out at its
+`MAX_WAIT_SECONDS` cap (default 30 min) and fail with a clear error.
+
+### Shutdown signalling (release)
+
+Each test job has a final `condition: always()` step that publishes a
+pipeline artifact whose name is the agreed-upon "teardown sentinel" for
+that SQL instance. `always()` causes the publish step to run on success,
+failure, and cancellation, so the SQL host is released regardless of test
+outcome.
+
+The SQL host job, after publishing the `sql-ready` artifact, runs
+`wait-for-teardown.sh`, which polls
+
+```
+GET {System.CollectionUri}/{System.TeamProject}
+    /_apis/build/builds/{Build.BuildId}/artifacts?api-version=7.1
+```
+
+every `POLL_INTERVAL_SECONDS` (default 15 s), authenticated with
+`$(System.AccessToken)`. The watcher exits 0 when every name in
+`EXPECTED_SENTINELS` is present in the build's artifact list.
+
+`EXPECTED_SENTINELS` is computed at template-eval time:
+
+- `shared` mode: comma-joined list of all target names (each matrix entry
+  publishes its own sentinel; the SQL host waits for all of them).
+- `per-job` mode: a single sentinel for the paired test job.
+
+A `MAX_LIFETIME_SECONDS` cap (default 7200 = 120 min) ensures the watcher
+returns even if a test agent goes offline before publishing its sentinel.
+The ADO `timeoutInMinutes` for the SQL host job is a separate hard ceiling
+so a misbehaving watcher cannot pin a 1ES VM.
+
+### Sequence diagram (shared mode)
+
+```
+ARM job(s)                        Sql_Host (x64)                 ADO Pipelines
+    | (start at the same time)         |                                |
+    | derive SA password               | derive SA password             |
+    | (download Build artifact)        | start.sh: docker run           |
+    | poll-for-endpoint.sh: GET /artifacts                              |
+    |  (artifact missing — backoff)    | start.sh: probe sqlcmd         |
+    |                                  | start.sh: write endpoint.txt   |
+    |                                  | PublishPipelineArtifact ------>|
+    |                                  |   sql-ready-shared             |
+    | poll-for-endpoint.sh: GET /artifacts (sees sql-ready-shared) <----|
+    | download zip, set DB_HOST/DB_PORT                                 |
+    | run tests against $DB_HOST:$DB_PORT                               |
+    | always(): publish "Ubuntu22" artifact ---------------------------->|
+    | always(): publish "Alpine3_18" artifact -------------------------->|
+    |  ...                             | wait-for-teardown.sh: poll     |
+    |                                  |   sees all expected sentinels  |
+    |                                  | teardown.sh always()           |
+    |                                  | docker stop / rm -------------->|
+```
+
+## Configuration surface
+
+Pipeline parameters, defined on the entry pipelines
+(`.pipeline/validation-pipeline.yml` for PR/dev and
+`.pipeline/validation-pipeline-ci.yml` for GitHub `main`) and threaded through
+`.pipeline/templates/validation-stages.yml`:
+
+```yaml
+- name: sqlInstanceMode
+  type: string
+  values: [shared, per-job]
+  default: shared
+
+- name: sqlImageTag
+  type: string
+  default: '2025-latest'
+```
+
+Both flow through to `templates/test-matrix-template-arm64.yml` and
+`templates/test-matrix-template-alpine_arm64.yml`. `maxLifetimeMinutes`
+defaults to 120 inside `templates/sql-host-template.yml`; promote it to a
+pipeline parameter if a use case appears.
+
+## PR vs merge coverage
+
+Because the SQL host is now booted on-demand (no static ACI IP to contend
+for), the ARM test stages also run on pull requests. Following the existing
+Kerberos pattern, coverage is split into reduced PR stages and full merge
+stages:
+
+| Stage                   | Trigger        | Matrix                                  |
+|-------------------------|----------------|-----------------------------------------|
+| `Test_arm64_PR`         | PR             | Ubuntu24, AzLinux3                       |
+| `Test_alpine_arm64_PR`  | PR             | Alpine3_21                              |
+| `Test_arm64`            | non-PR (merge) | full glibc matrix (7 distros)           |
+| `Test_alpine_arm64`     | non-PR (merge) | full musl matrix (Alpine 3.18–3.21)     |
+
+The `_PR` stages `dependsOn` `Build` (for the `Build_Linux_ARM` artifact) and
+`EvaluateDuplicate`, and are skipped when a prior successful PR validation is
+detected (`skipDuplicate`). Each PR stage boots one shared SQL host by default.
+
+## Files
+
+| Path                                                          | Role                                                           |
+|---------------------------------------------------------------|----------------------------------------------------------------|
+| `.pipeline/templates/sql-host-template.yml`                   | Job template for the on-demand SQL host.                       |
+| `.pipeline/scripts/sql-host/derive-sql-password.sh`           | Derive shared SA password from build context.                  |
+| `.pipeline/scripts/sql-host/start.sh`                         | Boot SQL container, probe readiness, stage endpoint payload.   |
+| `.pipeline/scripts/sql-host/poll-for-endpoint.sh`             | Test-side: poll for sql-ready artifact, set DB_HOST/DB_PORT.   |
+| `.pipeline/scripts/sql-host/wait-for-teardown.sh`             | SQL-host-side: poll ADO REST for tests-done sentinels.         |
+| `.pipeline/scripts/sql-host/teardown.sh`                      | Idempotent docker cleanup for `always()` step.                 |
+| `.pipeline/templates/test-matrix-template-arm64.yml`          | Refactored; targets list + sqlInstanceMode; consumes endpoint. |
+| `.pipeline/templates/test-matrix-template-alpine_arm64.yml`   | Same refactor for the musl/alpine flow.                        |
+| `.pipeline/templates/validation-stages.yml`                   | Converts ARM stage matrices into `targets` lists; threads `sqlInstanceMode` / `sqlImageTag`. |
+| `.pipeline/validation-pipeline.yml`, `.pipeline/validation-pipeline-ci.yml` | Add `sqlInstanceMode` and `sqlImageTag` parameters and pass them to `validation-stages.yml`. |
+
+The amd64 templates and `sql-setup-template.yml` are intentionally left
+unchanged.
+
+## Reliability properties
+
+- **No deadlock.** Symmetric pipeline-artifact sentinels with no ADO
+  `dependsOn` between SQL host and test jobs. Either side can be late and
+  the other side polls until it appears.
+- **Stale-endpoint guard.** The `sql-ready` artifact carries the SQL
+  host's lifetime deadline. A late-queued test job that finds an
+  about-to-expire endpoint fails fast rather than connecting to a host
+  that is about to be torn down (the failure mode of the original design).
+- **Readiness gate is on the test side.** The test job's first SQL-touching
+  step blocks until the `sql-ready` artifact is published (which only
+  happens after `start.sh`'s sqlcmd probe succeeds).
+- **Teardown signal is `always()` on the test side.** Cancellation and
+  failure paths still publish the sentinel.
+- **Cleanup is `always()` on the SQL side and idempotent.** Cleans up even
+  if the watcher hits the timeout cap or fails internally.
+- **Hard timeout.** `MAX_LIFETIME_SECONDS` plus the ADO job-level
+  `timeoutInMinutes` together cap the SQL host's lifetime.
+- **No new Azure resources.** Uses pipeline artifacts, the ADO REST API,
+  `System.AccessToken`, the existing 1ES pools, and the existing
+  `mcr.microsoft.com/mssql/server` image.
+
+## Open assumptions
+
+- Cross-pool reachability between `RUST-1ES-POOL-WUS3` (x64) and
+  `RUST-1ES-POOL-ARM-WUS3` (ARM) on the SQL host's private IPv4 and the
+  published port. Confirmed at design time; a connectivity regression here
+  would surface as `poll-for-endpoint.sh` succeeds (the test job sees the
+  endpoint) but the subsequent test connect times out.
+- `mcr.microsoft.com/mssql/server:<sqlImageTag>` ships
+  `/opt/mssql-tools18/bin/sqlcmd`, which `start.sh` uses for the readiness
+  probe. The current default tag (`2025-latest`) does.
+- The ubuntu image used by the x64 SQL host (`RUST-1ES-UBUSLIM`) provides
+  `curl` and `docker`. The latter is enforced by `DockerInstaller@0` and
+  `install-ubuntu-dependency.yaml`; the former is standard in the image.
+- Both ARM and x64 1ES pool agents have `python3` available (used by
+  `poll-for-endpoint.sh` for JSON parsing). Standard in the Ubuntu images.
+
+## Operational notes
+
+- To diagnose a stuck SQL host, look at the `Wait for test-completion
+  sentinels` step's logs — it prints the missing sentinel count every poll.
+  Cross-reference against the test job's `Publish teardown sentinel` step
+  to see whether a particular matrix entry never published.
+- To diagnose a stuck test job, look at the `Wait for SQL host endpoint
+  sentinel` step — it prints remaining wait time every poll. If it never
+  finds the sentinel, check whether the SQL host job published it (look at
+  the SQL host's own timeline).
+- To force shutdown of a stuck SQL host without cancelling the build,
+  manually publish a pipeline artifact with the missing sentinel name from
+  any other job in the same build.
+- To switch a build to per-job SQL isolation, queue with
+  `sqlInstanceMode = per-job`. Cost: N additional x64 agents per stage
+  (where N is matrix size).

--- a/.pipeline/scripts/README.md
+++ b/.pipeline/scripts/README.md
@@ -10,12 +10,14 @@ The SQL host job and the ARM test jobs run concurrently and rendezvous through
 pipeline-artifact sentinels; the SA password is derived deterministically from
 the build context so no secret is transported between jobs.
 
-- **start.sh** — Derives the SA password, generates certs (adding the host's
-  public IP as an extra SAN via `EXTRA_IP_SAN`), starts the SQL container, and
-  publishes the `sql-ready-<instanceId>` sentinel carrying the endpoint plus
+- **start.sh** — Receives the SA password (derived by `derive-sql-password.sh`
+  in the YAML templates), generates certs (adding the host's private VNet IPv4
+  as an extra SAN via `EXTRA_IP_SAN`), starts the SQL container, and publishes
+  the `sql-ready-<instanceId>` sentinel carrying the endpoint plus
   `ca.crt`/`mssql.pem`.
-- **wait-for-teardown.sh** — Polls for the per-test teardown sentinels and
-  releases the SQL host once every expected sentinel has been published.
+- **wait-for-teardown.sh** — Polls for the teardown sentinel artifacts (named
+  by the raw sentinel names the test jobs publish) and releases the SQL host
+  once every expected sentinel has been published.
 - **teardown.sh** — Stops and removes the SQL container and network.
 
 See `.pipeline/docs/arm-sql-host-design.md` for the full design.

--- a/.pipeline/scripts/README.md
+++ b/.pipeline/scripts/README.md
@@ -1,6 +1,24 @@
 # SQL Server Configuration Scripts
 
-This directory contains PowerShell scripts used by the Azure DevOps pipeline to configure SQL Server instances.
+This directory contains scripts used by the Azure DevOps pipeline to configure and host SQL Server instances for tests.
+
+## sql-host/ — On-demand SQL Server for ARM test stages
+
+Boots a SQL Server docker container on an x64 1ES agent so ARM test jobs can
+run against a real SQL Server without depending on a static (ACI) IP address.
+The SQL host job and the ARM test jobs run concurrently and rendezvous through
+pipeline-artifact sentinels; the SA password is derived deterministically from
+the build context so no secret is transported between jobs.
+
+- **start.sh** — Derives the SA password, generates certs (adding the host's
+  public IP as an extra SAN via `EXTRA_IP_SAN`), starts the SQL container, and
+  publishes the `sql-ready-<instanceId>` sentinel carrying the endpoint plus
+  `ca.crt`/`mssql.pem`.
+- **wait-for-teardown.sh** — Polls for the per-test teardown sentinels and
+  releases the SQL host once every expected sentinel has been published.
+- **teardown.sh** — Stops and removes the SQL container and network.
+
+See `.pipeline/docs/arm-sql-host-design.md` for the full design.
 
 ## Scripts
 

--- a/.pipeline/scripts/sql-host/derive-sql-password.sh
+++ b/.pipeline/scripts/sql-host/derive-sql-password.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# derive-sql-password.sh — produce a per-build SQL Server SA password that is
+# identical in the SQL host job and the dependent test jobs without any
+# cross-job secret transport.
+#
+# The cross-pool design boots SQL Server on an x64 1ES agent and runs the
+# tests on a separate ARM 1ES agent. They cannot share a job-scoped random
+# password, and shipping a generated password through pipeline artifacts
+# would expose it to anyone with read access to the build. Instead, both
+# sides derive the same password from build context: BUILD_BUILDID +
+# SYSTEM_COLLECTIONID + a static salt. The result is unique per build,
+# unpredictable to outsiders (CollectionId is not public), and requires no
+# Key Vault round-trip.
+#
+# Required env:
+#   BUILD_BUILDID         Current build id (System.BuildId).
+#   SYSTEM_COLLECTIONID   ADO collection (organization) GUID.
+#
+# Sets pipeline variables (idempotent within a job; safe to source twice):
+#   SQL_PASSWORD            secret-masked SA password
+#   SQL_PASSWORD_GENERATED  marker so generate-sql-password-template.yml
+#                           skips re-generation if also pulled in.
+
+set -euo pipefail
+
+if [ "${SQL_PASSWORD_GENERATED:-}" = "1" ]; then
+    echo "SQL_PASSWORD already established for this job; skipping derivation"
+    exit 0
+fi
+
+: "${BUILD_BUILDID:?BUILD_BUILDID is required}"
+: "${SYSTEM_COLLECTIONID:?SYSTEM_COLLECTIONID is required}"
+
+# Static salt distinguishes this password from any other build-id-derived
+# secret that might exist in the same project, and forces an attacker who
+# knows the public BuildId to also know the project layout.
+SALT="mssql-tds-arm-cross-pool-sa"
+
+digest="$(printf '%s' "${BUILD_BUILDID}-${SYSTEM_COLLECTIONID}-${SALT}" \
+            | sha256sum | awk '{print $1}')"
+
+# 22 hex chars + 4-char policy-class prefix (upper, lower, digit, symbol)
+# = 26 chars, well above the 8-char SQL Server SA minimum and includes all
+# four character classes the policy requires.
+SQL_PASSWORD="Aa1!${digest:0:22}"
+
+echo "##vso[task.setvariable variable=SQL_PASSWORD;issecret=true]${SQL_PASSWORD}"
+echo "##vso[task.setvariable variable=SQL_PASSWORD_GENERATED]1"
+echo "Derived SQL_PASSWORD (length=${#SQL_PASSWORD}) for build ${BUILD_BUILDID}"

--- a/.pipeline/scripts/sql-host/poll-for-endpoint.sh
+++ b/.pipeline/scripts/sql-host/poll-for-endpoint.sh
@@ -8,8 +8,8 @@
 # would deadlock — ADO won't start a dependent job until its upstream
 # completes, and the SQL host can only complete after tests finish). The two
 # jobs rendezvous via pipeline-artifact sentinels in both directions:
-#   * SQL host -> Test:  sql-ready-<instanceId>      (contains endpoint)
-#   * Test    -> SQL host: tests-done-<sentinelName> (one per matrix entry)
+#   * SQL host -> Test:  sql-ready-<instanceId>   (contains endpoint)
+#   * Test    -> SQL host: <sentinelName>         (raw name, one per matrix entry)
 #
 # Required env:
 #   ARTIFACT_NAME         Name of the sql-ready sentinel artifact.

--- a/.pipeline/scripts/sql-host/poll-for-endpoint.sh
+++ b/.pipeline/scripts/sql-host/poll-for-endpoint.sh
@@ -24,7 +24,7 @@
 #
 # Optional env:
 #   POLL_INTERVAL_SECONDS    default 10
-#   MAX_WAIT_SECONDS         default 1800 (30 min). Covers x64 agent queueing,
+#   MAX_WAIT_SECONDS         default 3600 (60 min). Covers x64 agent queueing,
 #                            docker pull, and SQL Server startup.
 #   SYSTEM_STAGEATTEMPT      current stage attempt (ADO provides it). Used only
 #                            to detect a partial "Rerun failed jobs" and emit

--- a/.pipeline/scripts/sql-host/poll-for-endpoint.sh
+++ b/.pipeline/scripts/sql-host/poll-for-endpoint.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# poll-for-endpoint.sh — block until the matching SQL host has published its
+# "sql-ready" sentinel artifact, then download it and export the SQL endpoint
+# (host + port) as pipeline variables for downstream test steps.
+#
+# This is the symmetric counterpart of wait-for-teardown.sh on the SQL host
+# side. Both jobs run concurrently (no ADO `dependsOn` between them, which
+# would deadlock — ADO won't start a dependent job until its upstream
+# completes, and the SQL host can only complete after tests finish). The two
+# jobs rendezvous via pipeline-artifact sentinels in both directions:
+#   * SQL host -> Test:  sql-ready-<instanceId>      (contains endpoint)
+#   * Test    -> SQL host: tests-done-<sentinelName> (one per matrix entry)
+#
+# Required env:
+#   ARTIFACT_NAME         Name of the sql-ready sentinel artifact.
+#   BUILD_BUILDID
+#   SYSTEM_COLLECTIONURI
+#   SYSTEM_TEAMPROJECT
+#   SYSTEM_ACCESSTOKEN    Expose via env: in the YAML step.
+#   AGENT_TEMPDIRECTORY
+#
+# Optional env:
+#   POLL_INTERVAL_SECONDS  default 10
+#   MAX_WAIT_SECONDS       default 1800 (30 min). Covers x64 agent queueing,
+#                          docker pull, and SQL Server startup.
+#
+# Sets pipeline variables on success:
+#   DB_HOST   IP advertised by the SQL host
+#   DB_PORT   port advertised by the SQL host
+
+set -euo pipefail
+
+: "${ARTIFACT_NAME:?ARTIFACT_NAME is required}"
+: "${BUILD_BUILDID:?BUILD_BUILDID is required}"
+: "${SYSTEM_COLLECTIONURI:?SYSTEM_COLLECTIONURI is required}"
+: "${SYSTEM_TEAMPROJECT:?SYSTEM_TEAMPROJECT is required}"
+: "${SYSTEM_ACCESSTOKEN:?SYSTEM_ACCESSTOKEN is required (expose via env: in YAML step)}"
+: "${AGENT_TEMPDIRECTORY:?AGENT_TEMPDIRECTORY is required}"
+
+POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-10}"
+# Generous default — the x64 SQL host job has its own queue + boot latency
+# (DockerInstaller, image pull, SQL Server startup). 60 min comfortably
+# covers a saturated pool while still being well under the SQL host's
+# 120-min MAX_LIFETIME_MINUTES so we always fail-fast instead of racing
+# the host's own teardown.
+MAX_WAIT_SECONDS="${MAX_WAIT_SECONDS:-3600}"
+
+collection="${SYSTEM_COLLECTIONURI%/}/"
+project_enc="$(printf '%s' "${SYSTEM_TEAMPROJECT}" | sed 's/ /%20/g')"
+url="${collection}${project_enc}/_apis/build/builds/${BUILD_BUILDID}/artifacts?api-version=7.1"
+
+echo "=== sql-host/poll-for-endpoint.sh ==="
+echo "  ARTIFACT_NAME = ${ARTIFACT_NAME}"
+echo "  Build         = ${BUILD_BUILDID}"
+echo "  Poll URL      = ${url}"
+echo "  Poll every    = ${POLL_INTERVAL_SECONDS}s"
+echo "  Max wait      = ${MAX_WAIT_SECONDS}s"
+
+deadline=$(( $(date +%s) + MAX_WAIT_SECONDS ))
+download_url=""
+
+while :; do
+    now="$(date +%s)"
+    if [ "${now}" -ge "${deadline}" ]; then
+        echo "ERROR: artifact ${ARTIFACT_NAME} did not appear within ${MAX_WAIT_SECONDS}s." >&2
+        exit 1
+    fi
+
+    if body="$(curl -sS -f \
+            -H "Authorization: Bearer ${SYSTEM_ACCESSTOKEN}" \
+            -H "Accept: application/json" \
+            "${url}" 2>/tmp/sql-host-poll-curl.err)"; then
+        download_url="$(printf '%s' "${body}" | ARTIFACT_NAME="${ARTIFACT_NAME}" \
+            python3 -c '
+import json, os, sys
+target = os.environ["ARTIFACT_NAME"]
+data = json.load(sys.stdin)
+for a in data.get("value", []):
+    if a.get("name") == target:
+        print(a.get("resource", {}).get("downloadUrl", ""))
+        break
+' 2>/dev/null || true)"
+        if [ -n "${download_url}" ]; then
+            echo "Endpoint sentinel ${ARTIFACT_NAME} found."
+            break
+        fi
+    else
+        echo "WARN: artifact list HTTP error: $(cat /tmp/sql-host-poll-curl.err)" >&2
+    fi
+
+    remaining=$(( deadline - now ))
+    echo "$(date -u +%H:%M:%S) waiting for ${ARTIFACT_NAME}; ${remaining}s left."
+    sleep "${POLL_INTERVAL_SECONDS}"
+done
+
+DOWNLOAD_DIR="${AGENT_TEMPDIRECTORY}/${ARTIFACT_NAME}"
+mkdir -p "${DOWNLOAD_DIR}"
+zip_path="${DOWNLOAD_DIR}/artifact.zip"
+
+# Retry the download; transient 5xx / connection resets shouldn't fail the
+# rendezvous after we already saw the artifact was published.
+download_ok=0
+for attempt in 1 2 3 4 5; do
+    if curl -sS -f -L \
+            -H "Authorization: Bearer ${SYSTEM_ACCESSTOKEN}" \
+            -o "${zip_path}" \
+            "${download_url}"; then
+        download_ok=1
+        break
+    fi
+    echo "WARN: artifact download attempt ${attempt} failed; retrying." >&2
+    sleep $(( attempt * 5 ))
+done
+if [ "${download_ok}" -ne 1 ]; then
+    echo "ERROR: failed to download ${ARTIFACT_NAME} after 5 attempts." >&2
+    exit 1
+fi
+
+# DownloadUrl returns the artifact as a zip; the artifact root directory
+# inside the zip equals the artifact name. Use python's zipfile module so
+# we don't depend on `unzip` being installed on every agent image.
+python3 -m zipfile -e "${zip_path}" "${DOWNLOAD_DIR}"
+
+endpoint_file="$(find "${DOWNLOAD_DIR}" -type f -name endpoint.txt | head -1)"
+if [ -z "${endpoint_file}" ]; then
+    echo "ERROR: endpoint.txt not found inside ${ARTIFACT_NAME} artifact." >&2
+    echo "--- contents ---" >&2
+    find "${DOWNLOAD_DIR}" -type f -maxdepth 4 >&2 || true
+    exit 1
+fi
+
+# endpoint.txt format: "HOST PORT DEADLINE_EPOCH" on a single line. The
+# deadline is the UTC epoch second past which the SQL host will tear down.
+# Refuse to proceed if we are within MIN_HOST_LIFE_REMAINING_SECONDS of it
+# — connecting to a host that will disappear mid-test only buys us silent
+# timeouts.
+MIN_HOST_LIFE_REMAINING_SECONDS="${MIN_HOST_LIFE_REMAINING_SECONDS:-300}"
+read -r host port deadline < "${endpoint_file}"
+if [ -z "${host}" ] || [ -z "${port}" ]; then
+    echo "ERROR: endpoint.txt is malformed: '$(cat "${endpoint_file}")'" >&2
+    exit 1
+fi
+
+if [ -n "${deadline}" ]; then
+    now="$(date +%s)"
+    remaining=$(( deadline - now ))
+    if [ "${remaining}" -lt "${MIN_HOST_LIFE_REMAINING_SECONDS}" ]; then
+        echo "ERROR: SQL host endpoint expires in ${remaining}s (need >= ${MIN_HOST_LIFE_REMAINING_SECONDS}s)." >&2
+        echo "  This usually means the SQL host hit MAX_LIFETIME_MINUTES while this test job was queued." >&2
+        echo "  Failing fast rather than connecting to a host about to be torn down." >&2
+        exit 1
+    fi
+    echo "SQL host has ${remaining}s of life remaining (well over ${MIN_HOST_LIFE_REMAINING_SECONDS}s threshold)."
+fi
+
+echo "Resolved SQL endpoint: host=${host} port=${port}"
+echo "##vso[task.setvariable variable=DB_HOST]${host}"
+echo "##vso[task.setvariable variable=DB_PORT]${port}"
+
+# Stage SQL host's CA + server cert into Build.SourcesDirectory so the
+# existing dockerentry trust setup (cp ca.crt /usr/local/share/ca-certificates;
+# update-ca-certificates) trusts the cert this server is actually presenting.
+# The colocated amd64 path generates these locally; the cross-pool path must
+# instead consume the SQL host's, since that's the chain on the wire.
+# Different distro dockerentry scripts reference mssql.crt vs mssql.pem
+# interchangeably, so stage both.
+ca_src="$(find "${DOWNLOAD_DIR}" -type f -name ca.crt | head -1)"
+crt_src="$(find "${DOWNLOAD_DIR}" -type f -name mssql.crt | head -1)"
+pem_src="$(find "${DOWNLOAD_DIR}" -type f -name mssql.pem | head -1)"
+if [ -n "${ca_src}" ] && [ -n "${pem_src}" ]; then
+    dest="${BUILD_SOURCESDIRECTORY:-${PWD}}"
+    cp -f "${ca_src}" "${dest}/ca.crt"
+    cp -f "${pem_src}" "${dest}/mssql.pem"
+    if [ -n "${crt_src}" ]; then
+        cp -f "${crt_src}" "${dest}/mssql.crt"
+    else
+        cp -f "${pem_src}" "${dest}/mssql.crt"
+    fi
+    echo "Staged SQL host CA + cert into ${dest}/{ca.crt,mssql.crt,mssql.pem}"
+else
+    echo "WARN: ca.crt or mssql.pem missing from ${ARTIFACT_NAME} artifact." >&2
+    echo "      no-trust TLS handshake tests may fail." >&2
+fi

--- a/.pipeline/scripts/sql-host/poll-for-endpoint.sh
+++ b/.pipeline/scripts/sql-host/poll-for-endpoint.sh
@@ -8,8 +8,11 @@
 # would deadlock — ADO won't start a dependent job until its upstream
 # completes, and the SQL host can only complete after tests finish). The two
 # jobs rendezvous via pipeline-artifact sentinels in both directions:
-#   * SQL host -> Test:  sql-ready-<instanceId>   (contains endpoint)
-#   * Test    -> SQL host: <sentinelName>         (raw name, one per matrix entry)
+#   * SQL host -> Test:  sql-ready-<instanceId>-<stageAttempt>  (endpoint)
+#   * Test    -> SQL host: <sentinelName>-<stageAttempt>        (one per entry)
+# The -<stageAttempt> (System.StageAttempt) suffix namespaces the rendezvous
+# per stage attempt so a rerun forms a fresh handshake instead of colliding
+# with or reading a prior attempt's artifacts. Set ARTIFACT_NAME accordingly.
 #
 # Required env:
 #   ARTIFACT_NAME         Name of the sql-ready sentinel artifact.

--- a/.pipeline/scripts/sql-host/poll-for-endpoint.sh
+++ b/.pipeline/scripts/sql-host/poll-for-endpoint.sh
@@ -23,9 +23,15 @@
 #   AGENT_TEMPDIRECTORY
 #
 # Optional env:
-#   POLL_INTERVAL_SECONDS  default 10
-#   MAX_WAIT_SECONDS       default 1800 (30 min). Covers x64 agent queueing,
-#                          docker pull, and SQL Server startup.
+#   POLL_INTERVAL_SECONDS    default 10
+#   MAX_WAIT_SECONDS         default 1800 (30 min). Covers x64 agent queueing,
+#                            docker pull, and SQL Server startup.
+#   SYSTEM_STAGEATTEMPT      current stage attempt (ADO provides it). Used only
+#                            to detect a partial "Rerun failed jobs" and emit
+#                            guidance to rerun the whole stage instead.
+#   RERUN_HINT_AFTER_SECONDS default 600. On attempt > 1, how long to wait with
+#                            no endpoint before warning that the SQL host job
+#                            was probably not restarted.
 #
 # Sets pipeline variables on success:
 #   DB_HOST   IP advertised by the SQL host
@@ -48,6 +54,24 @@ POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-10}"
 # the host's own teardown.
 MAX_WAIT_SECONDS="${MAX_WAIT_SECONDS:-3600}"
 
+STAGE_ATTEMPT="${SYSTEM_STAGEATTEMPT:-1}"
+# On a rerun (attempt > 1), warn this long into a fruitless wait that a partial
+# "Rerun failed jobs" won't have restarted the sibling SQL host job.
+RERUN_HINT_AFTER_SECONDS="${RERUN_HINT_AFTER_SECONDS:-600}"
+
+# The on-demand SQL host is a sibling job in THIS stage, not an upstream
+# dependency, and it is released as soon as tests finish. ADO's "Rerun failed
+# jobs" only re-runs the failed test job under a new System.StageAttempt; it
+# does NOT re-run the (already-succeeded) SQL host, so no host ever publishes
+# sql-ready-<instance>-<thisAttempt> and this poll would otherwise burn the
+# full MAX_WAIT_SECONDS before a cryptic timeout. Surface actionable guidance
+# via ADO logging commands so it lands in the run's Errors/Warnings summary.
+print_partial_rerun_guidance() {
+    echo "##vso[task.logissue type=error]SQL host endpoint '${ARTIFACT_NAME}' never appeared for stage attempt ${STAGE_ATTEMPT}."
+    echo "##vso[task.logissue type=error]The on-demand SQL host runs as a sibling job in this stage and is released once tests finish. 'Rerun failed jobs' does NOT restart it, so this rerun has no SQL server to connect to."
+    echo "##vso[task.logissue type=error]Fix: use 'Rerun stage' (or re-queue the pipeline) instead of 'Rerun failed jobs' so the SQL host job runs again alongside the tests."
+}
+
 collection="${SYSTEM_COLLECTIONURI%/}/"
 project_enc="$(printf '%s' "${SYSTEM_TEAMPROJECT}" | sed 's/ /%20/g')"
 url="${collection}${project_enc}/_apis/build/builds/${BUILD_BUILDID}/artifacts?api-version=7.1"
@@ -60,11 +84,18 @@ echo "  Poll every    = ${POLL_INTERVAL_SECONDS}s"
 echo "  Max wait      = ${MAX_WAIT_SECONDS}s"
 
 deadline=$(( $(date +%s) + MAX_WAIT_SECONDS ))
+start="$(date +%s)"
 download_url=""
+rerun_hinted=0
 
 while :; do
     now="$(date +%s)"
     if [ "${now}" -ge "${deadline}" ]; then
+        if [ "${STAGE_ATTEMPT}" -gt 1 ]; then
+            print_partial_rerun_guidance
+        else
+            echo "##vso[task.logissue type=error]artifact ${ARTIFACT_NAME} did not appear within ${MAX_WAIT_SECONDS}s (the SQL host job may have failed to start)."
+        fi
         echo "ERROR: artifact ${ARTIFACT_NAME} did not appear within ${MAX_WAIT_SECONDS}s." >&2
         exit 1
     fi
@@ -92,6 +123,14 @@ for a in data.get("value", []):
     fi
 
     remaining=$(( deadline - now ))
+    # Early nudge on a rerun: a legit "Rerun stage" restarts the SQL host job
+    # too and it usually publishes within a few minutes, so a long silence here
+    # on attempt > 1 most likely means a partial "Rerun failed jobs".
+    if [ "${rerun_hinted}" -eq 0 ] && [ "${STAGE_ATTEMPT}" -gt 1 ] \
+            && [ $(( now - start )) -ge "${RERUN_HINT_AFTER_SECONDS}" ]; then
+        echo "##vso[task.logissue type=warning]No SQL host endpoint after $(( (now - start) / 60 )) min on stage attempt ${STAGE_ATTEMPT}. If you used 'Rerun failed jobs', the SQL host job was NOT restarted and this will time out — cancel and use 'Rerun stage' instead."
+        rerun_hinted=1
+    fi
     echo "$(date -u +%H:%M:%S) waiting for ${ARTIFACT_NAME}; ${remaining}s left."
     sleep "${POLL_INTERVAL_SECONDS}"
 done

--- a/.pipeline/scripts/sql-host/start.sh
+++ b/.pipeline/scripts/sql-host/start.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# start.sh — boot a SQL Server docker container on this x64 1ES agent and
+# write its private-VNet endpoint to a file that the calling YAML step
+# publishes as the `sql-ready-<instanceId>` pipeline-artifact sentinel.
+#
+# Dependent ARM test jobs poll for that artifact (poll-for-endpoint.sh) to
+# discover the endpoint without using ADO `dependsOn` on this job — the
+# `dependsOn` path deadlocks because the test job would then have to wait
+# for *this* job to fully complete (which it cannot, until the tests run
+# and publish their teardown sentinels).
+#
+# Required env:
+#   INSTANCE_ID                    Unique id (e.g. "shared", "shared_musl").
+#   SQL_PASSWORD                   SA password (derived from build context
+#                                  by derive-sql-password.sh; matches the
+#                                  test job's derived value).
+#   SQL_IMAGE_TAG                  e.g. "2025-latest".
+#   BUILD_ARTIFACTSTAGINGDIRECTORY ADO-provided staging dir for artifacts.
+#
+# Optional env:
+#   SQL_HOST_PORT                  Host port to publish (default 1433).
+#   READINESS_TIMEOUT_SECONDS      Default 180.
+#
+# Side effects:
+#   * Writes ${BUILD_ARTIFACTSTAGINGDIRECTORY}/sql-endpoint-${INSTANCE_ID}/endpoint.txt
+#     containing "HOST PORT" on a single line.
+#   * Also emits output variables sqlHost / sqlPort / sqlInstanceId for
+#     diagnostics — they are not consumed by the test jobs.
+#
+# Notes:
+#   * Cross-pool reachability assumes both 1ES pools live in a shared VNet
+#     and an ARM agent can open TCP $SQL_HOST_PORT on the IP we write out.
+#   * Container name and docker network are namespaced by INSTANCE_ID so
+#     multiple SQL hosts can co-exist on the same agent (defensive — there
+#     is typically one per VM).
+
+set -euo pipefail
+
+: "${INSTANCE_ID:?INSTANCE_ID is required}"
+: "${SQL_PASSWORD:?SQL_PASSWORD is required}"
+: "${SQL_IMAGE_TAG:?SQL_IMAGE_TAG is required}"
+: "${BUILD_ARTIFACTSTAGINGDIRECTORY:?BUILD_ARTIFACTSTAGINGDIRECTORY is required}"
+
+SQL_HOST_PORT="${SQL_HOST_PORT:-1433}"
+READINESS_TIMEOUT_SECONDS="${READINESS_TIMEOUT_SECONDS:-180}"
+# Wall-clock deadline beyond which the SQL host's wait-for-teardown.sh will
+# give up and let teardown.sh destroy the container. We embed this in the
+# endpoint sentinel so a late-arriving test job can refuse to connect to a
+# host that is about to disappear (rather than silently timing out at SQL
+# connect time, which is the failure mode the old design produced).
+MAX_LIFETIME_MINUTES="${MAX_LIFETIME_MINUTES:-120}"
+
+CONTAINER_NAME="sql-${INSTANCE_ID}"
+NETWORK_NAME="testnet-${INSTANCE_ID}"
+IMAGE="mcr.microsoft.com/mssql/server:${SQL_IMAGE_TAG}"
+
+echo "=== sql-host/start.sh ==="
+echo "  INSTANCE_ID  = ${INSTANCE_ID}"
+echo "  IMAGE        = ${IMAGE}"
+echo "  HOST_PORT    = ${SQL_HOST_PORT}"
+echo "  CONTAINER    = ${CONTAINER_NAME}"
+
+# 1. Reap any leftover from a prior attempt on this agent (defensive).
+docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+docker network rm "${NETWORK_NAME}" >/dev/null 2>&1 || true
+
+# 2. Resolve the agent's primary private IPv4 first — we need it both for
+#    the endpoint sentinel and as an extra SAN on the SQL Server's cert
+#    so that ARM test clients can verify the chain when connecting by IP.
+SQL_HOST_IP="$(hostname -I 2>/dev/null | awk '{print $1}')"
+if [ -z "${SQL_HOST_IP}" ]; then
+    SQL_HOST_IP="$(ip -4 -o addr show scope global | awk 'NR==1 {split($4,a,"/"); print a[1]}')"
+fi
+if [ -z "${SQL_HOST_IP}" ]; then
+    echo "ERROR: could not resolve a private IPv4 for this agent." >&2
+    exit 1
+fi
+echo "Advertising SQL host endpoint ${SQL_HOST_IP}:${SQL_HOST_PORT}"
+
+# 3. Generate certs locally (mssql.conf references mssql.pem / mssql.key).
+#    We pass our private IP as an extra SAN so cross-pool clients that
+#    connect by IP (rather than DNS name) can validate the chain.
+EXTRA_IP_SAN="${SQL_HOST_IP}" scripts/generate_cert.sh
+sudo chown 10001:0 mssql.* || true
+
+# 4. Create an isolated user-defined network for this instance.
+docker network create "${NETWORK_NAME}" >/dev/null
+
+# 5. Boot the container.
+docker run -d \
+    --name "${CONTAINER_NAME}" \
+    --hostname sql1 \
+    --network "${NETWORK_NAME}" \
+    -e ACCEPT_EULA=Y \
+    -e "MSSQL_SA_PASSWORD=${SQL_PASSWORD}" \
+    -p "${SQL_HOST_PORT}:1433" \
+    -v "${PWD}/conf/mssql.conf:/var/opt/mssql/mssql.conf" \
+    -v "${PWD}/mssql.pem:/etc/ssl/certs/mssql.pem" \
+    -v "${PWD}/mssql.key:/etc/ssl/private/mssql.key" \
+    -u 0:0 \
+    "${IMAGE}" >/dev/null
+
+# 6. Probe readiness with sqlcmd inside the container.
+deadline=$(( $(date +%s) + READINESS_TIMEOUT_SECONDS ))
+attempt=0
+ready=0
+while [ "$(date +%s)" -lt "${deadline}" ]; do
+    attempt=$((attempt + 1))
+    if docker exec "${CONTAINER_NAME}" /opt/mssql-tools18/bin/sqlcmd \
+            -S localhost -U sa -P "${SQL_PASSWORD}" -C -Q "SELECT 1" \
+            >/dev/null 2>&1; then
+        ready=1
+        echo "SQL Server ready after ${attempt} attempts."
+        break
+    fi
+    sleep 2
+done
+
+if [ "${ready}" -ne 1 ]; then
+    echo "ERROR: SQL Server did not become ready within ${READINESS_TIMEOUT_SECONDS}s." >&2
+    echo "--- container logs (tail 200) ---" >&2
+    docker logs --tail 200 "${CONTAINER_NAME}" >&2 || true
+    exit 1
+fi
+
+# 7. Write endpoint to a file the calling YAML step publishes as the
+#    `sql-ready-${INSTANCE_ID}` pipeline artifact. ARM test jobs poll for
+#    this artifact (poll-for-endpoint.sh) to discover where to connect.
+#    The third field is a wall-clock deadline (UTC epoch seconds) — the
+#    time at which wait-for-teardown.sh will give up and trigger teardown.
+#    Test jobs use it to fail fast if they queued so late that the SQL
+#    host is about to be torn down.
+#    We also stage ca.crt + mssql.pem so cross-pool clients trust this
+#    SQL Server's self-signed cert chain (TLS handshake tests need it).
+ENDPOINT_DIR="${BUILD_ARTIFACTSTAGINGDIRECTORY}/sql-endpoint-${INSTANCE_ID}"
+mkdir -p "${ENDPOINT_DIR}"
+deadline_epoch=$(( $(date +%s) + MAX_LIFETIME_MINUTES * 60 ))
+printf '%s %s %s\n' "${SQL_HOST_IP}" "${SQL_HOST_PORT}" "${deadline_epoch}" \
+    > "${ENDPOINT_DIR}/endpoint.txt"
+# mssql.crt and mssql.pem are identical (generate_cert.sh produces .crt and
+# copies it to .pem). Different distro dockerentry scripts reference one or
+# the other for `openssl verify`, so stage both.
+sudo cp -f ca.crt mssql.crt mssql.pem "${ENDPOINT_DIR}/" \
+    || cp -f ca.crt mssql.crt mssql.pem "${ENDPOINT_DIR}/"
+sudo chmod a+r "${ENDPOINT_DIR}/ca.crt" "${ENDPOINT_DIR}/mssql.crt" "${ENDPOINT_DIR}/mssql.pem" || true
+echo "Wrote endpoint sentinel payload to ${ENDPOINT_DIR}/endpoint.txt"
+echo "  endpoint = ${SQL_HOST_IP}:${SQL_HOST_PORT}"
+echo "  deadline = $(date -u -d @${deadline_epoch} +%FT%TZ) (epoch ${deadline_epoch})"
+echo "  staged   = ca.crt, mssql.crt, mssql.pem"
+
+# 8. Also expose as job output variables. Not consumed by the test jobs
+#    (we deliberately avoid the `dependsOn` deadlock) but useful for
+#    inspecting this job's timeline output in the ADO UI.
+echo "##vso[task.setvariable variable=sqlHost;isOutput=true]${SQL_HOST_IP}"
+echo "##vso[task.setvariable variable=sqlPort;isOutput=true]${SQL_HOST_PORT}"
+echo "##vso[task.setvariable variable=sqlInstanceId;isOutput=true]${INSTANCE_ID}"

--- a/.pipeline/scripts/sql-host/teardown.sh
+++ b/.pipeline/scripts/sql-host/teardown.sh
@@ -15,7 +15,7 @@ NETWORK_NAME="testnet-${INSTANCE_ID}"
 
 echo "=== sql-host/teardown.sh (instance=${INSTANCE_ID}) ==="
 
-if docker ps -a --format '{{.Names}}' | grep -qx "${CONTAINER_NAME}"; then
+if docker ps -a --format '{{.Names}}' | grep -qxF "${CONTAINER_NAME}"; then
     echo "--- container logs (tail 200) before removal ---"
     docker logs --tail 200 "${CONTAINER_NAME}" 2>&1 || true
     docker stop "${CONTAINER_NAME}" >/dev/null 2>&1 || true
@@ -25,7 +25,7 @@ else
     echo "Container ${CONTAINER_NAME} not present; nothing to stop."
 fi
 
-if docker network ls --format '{{.Name}}' | grep -qx "${NETWORK_NAME}"; then
+if docker network ls --format '{{.Name}}' | grep -qxF "${NETWORK_NAME}"; then
     docker network rm "${NETWORK_NAME}" >/dev/null 2>&1 || true
     echo "Network ${NETWORK_NAME} removed."
 else

--- a/.pipeline/scripts/sql-host/teardown.sh
+++ b/.pipeline/scripts/sql-host/teardown.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# teardown.sh — idempotent stop/remove of the SQL container and its docker
+# network. Designed for an always() step so it must succeed regardless of
+# whether start.sh got far enough to create either resource.
+#
+# Required env:
+#   INSTANCE_ID   Same value used by start.sh.
+
+set -u
+
+: "${INSTANCE_ID:?INSTANCE_ID is required}"
+
+CONTAINER_NAME="sql-${INSTANCE_ID}"
+NETWORK_NAME="testnet-${INSTANCE_ID}"
+
+echo "=== sql-host/teardown.sh (instance=${INSTANCE_ID}) ==="
+
+if docker ps -a --format '{{.Names}}' | grep -qx "${CONTAINER_NAME}"; then
+    echo "--- container logs (tail 200) before removal ---"
+    docker logs --tail 200 "${CONTAINER_NAME}" 2>&1 || true
+    docker stop "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+    docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+    echo "Container ${CONTAINER_NAME} removed."
+else
+    echo "Container ${CONTAINER_NAME} not present; nothing to stop."
+fi
+
+if docker network ls --format '{{.Name}}' | grep -qx "${NETWORK_NAME}"; then
+    docker network rm "${NETWORK_NAME}" >/dev/null 2>&1 || true
+    echo "Network ${NETWORK_NAME} removed."
+else
+    echo "Network ${NETWORK_NAME} not present; nothing to remove."
+fi
+
+exit 0

--- a/.pipeline/scripts/sql-host/wait-for-teardown.sh
+++ b/.pipeline/scripts/sql-host/wait-for-teardown.sh
@@ -76,7 +76,7 @@ while :; do
     missing=0
     for s in "${expected[@]}"; do
         # Match exact JSON property: "name":"<sentinel>"
-        if ! printf '%s' "${body}" | grep -q "\"name\":\"${s}\""; then
+        if ! printf '%s' "${body}" | grep -qF "\"name\":\"${s}\""; then
             missing=$((missing + 1))
         fi
     done

--- a/.pipeline/scripts/sql-host/wait-for-teardown.sh
+++ b/.pipeline/scripts/sql-host/wait-for-teardown.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# wait-for-teardown.sh — block until every expected teardown sentinel artifact
+# has been published to the current build, then return so the caller can stop
+# the SQL Server container.
+#
+# Required env:
+#   EXPECTED_SENTINELS    Comma-separated list of pipeline-artifact names that
+#                         dependent test jobs will publish in their always()
+#                         step. The watcher returns once all of them exist.
+#   BUILD_BUILDID         Current build id (System.BuildId).
+#   SYSTEM_COLLECTIONURI  Org collection URI (e.g. https://dev.azure.com/foo/).
+#   SYSTEM_TEAMPROJECT    Project name (System.TeamProject).
+#   SYSTEM_ACCESSTOKEN    OAuth token; the calling step must pass it via env:.
+#
+# Optional env:
+#   POLL_INTERVAL_SECONDS Default 15.
+#   MAX_LIFETIME_MINUTES  Hard cap; default 120 (2h). Returns 0 with a warning
+#                         once exceeded so the cleanup step can still tear down.
+#                         Takes precedence over MAX_LIFETIME_SECONDS if both set.
+#   MAX_LIFETIME_SECONDS  Same as above but in seconds (legacy).
+#
+# Exit codes:
+#   0  All sentinels seen, OR max-lifetime hit (caller cleans up either way).
+#   2  Misconfiguration (missing env, bad URL).
+
+set -euo pipefail
+
+: "${EXPECTED_SENTINELS:?EXPECTED_SENTINELS is required}"
+: "${BUILD_BUILDID:?BUILD_BUILDID is required}"
+: "${SYSTEM_COLLECTIONURI:?SYSTEM_COLLECTIONURI is required}"
+: "${SYSTEM_TEAMPROJECT:?SYSTEM_TEAMPROJECT is required}"
+: "${SYSTEM_ACCESSTOKEN:?SYSTEM_ACCESSTOKEN is required (expose via env: in YAML step)}"
+
+POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-15}"
+if [ -n "${MAX_LIFETIME_MINUTES:-}" ]; then
+    MAX_LIFETIME_SECONDS=$(( MAX_LIFETIME_MINUTES * 60 ))
+fi
+MAX_LIFETIME_SECONDS="${MAX_LIFETIME_SECONDS:-7200}"
+
+# Normalise the collection URI to end with exactly one slash.
+collection="${SYSTEM_COLLECTIONURI%/}/"
+# URL-encode the project name minimally (handle spaces).
+project_enc="$(printf '%s' "${SYSTEM_TEAMPROJECT}" | sed 's/ /%20/g')"
+url="${collection}${project_enc}/_apis/build/builds/${BUILD_BUILDID}/artifacts?api-version=7.1"
+
+IFS=',' read -r -a expected <<< "${EXPECTED_SENTINELS}"
+echo "=== sql-host/wait-for-teardown.sh ==="
+echo "  Build       = ${BUILD_BUILDID}"
+echo "  Poll URL    = ${url}"
+echo "  Poll every  = ${POLL_INTERVAL_SECONDS}s"
+echo "  Max wait    = ${MAX_LIFETIME_SECONDS}s"
+echo "  Expecting ${#expected[@]} sentinel(s):"
+for s in "${expected[@]}"; do
+    echo "    - ${s}"
+done
+
+deadline=$(( $(date +%s) + MAX_LIFETIME_SECONDS ))
+
+while :; do
+    now="$(date +%s)"
+    if [ "${now}" -ge "${deadline}" ]; then
+        echo "WARN: max lifetime (${MAX_LIFETIME_SECONDS}s) reached before all sentinels appeared. Proceeding to teardown." >&2
+        exit 0
+    fi
+
+    # Fetch artifact list. -s = silent, -f = fail on HTTP >= 400.
+    if ! body="$(curl -sS -f \
+            -H "Authorization: Bearer ${SYSTEM_ACCESSTOKEN}" \
+            -H "Accept: application/json" \
+            "${url}" 2>/tmp/sql-host-curl.err)"; then
+        echo "WARN: artifact list HTTP error: $(cat /tmp/sql-host-curl.err)" >&2
+        sleep "${POLL_INTERVAL_SECONDS}"
+        continue
+    fi
+
+    missing=0
+    for s in "${expected[@]}"; do
+        # Match exact JSON property: "name":"<sentinel>"
+        if ! printf '%s' "${body}" | grep -q "\"name\":\"${s}\""; then
+            missing=$((missing + 1))
+        fi
+    done
+
+    if [ "${missing}" -eq 0 ]; then
+        echo "All ${#expected[@]} teardown sentinel(s) present. Releasing SQL host."
+        exit 0
+    fi
+
+    remaining=$(( deadline - now ))
+    echo "$(date -u +%H:%M:%S) waiting on ${missing}/${#expected[@]} sentinel(s); ${remaining}s left."
+    sleep "${POLL_INTERVAL_SECONDS}"
+done

--- a/.pipeline/scripts/sql-host/wait-for-teardown.sh
+++ b/.pipeline/scripts/sql-host/wait-for-teardown.sh
@@ -13,6 +13,10 @@
 #   SYSTEM_ACCESSTOKEN    OAuth token; the calling step must pass it via env:.
 #
 # Optional env:
+#   SENTINEL_SUFFIX       Appended to every expected sentinel name before
+#                         matching (e.g. "-2" from System.StageAttempt), so a
+#                         stage rerun waits on that attempt's artifacts and
+#                         never matches a previous attempt's leftovers.
 #   POLL_INTERVAL_SECONDS Default 15.
 #   MAX_LIFETIME_MINUTES  Hard cap; default 120 (2h). Returns 0 with a warning
 #                         once exceeded so the cleanup step can still tear down.
@@ -43,7 +47,16 @@ collection="${SYSTEM_COLLECTIONURI%/}/"
 project_enc="$(printf '%s' "${SYSTEM_TEAMPROJECT}" | sed 's/ /%20/g')"
 url="${collection}${project_enc}/_apis/build/builds/${BUILD_BUILDID}/artifacts?api-version=7.1"
 
-IFS=',' read -r -a expected <<< "${EXPECTED_SENTINELS}"
+# Namespacing: publishers suffix their teardown-sentinel artifact names with
+# SENTINEL_SUFFIX (the stage attempt) so reruns neither collide with nor match
+# a prior attempt's artifacts. Apply the same suffix to what we wait for.
+SENTINEL_SUFFIX="${SENTINEL_SUFFIX:-}"
+IFS=',' read -r -a expected_base <<< "${EXPECTED_SENTINELS}"
+expected=()
+for s in "${expected_base[@]}"; do
+    expected+=( "${s}${SENTINEL_SUFFIX}" )
+done
+
 echo "=== sql-host/wait-for-teardown.sh ==="
 echo "  Build       = ${BUILD_BUILDID}"
 echo "  Poll URL    = ${url}"

--- a/.pipeline/templates/build-template-container.yml
+++ b/.pipeline/templates/build-template-container.yml
@@ -148,7 +148,9 @@ steps:
     condition: eq(variables['Build.Reason'], 'PullRequest')
     workingDirectory: '$(Build.SourcesDirectory)'
     env:
-      ARTIFACT_NAME: 'sql-ready-build_arm'
+      # Suffix with the stage attempt so a stage rerun reads this attempt's
+      # freshly-published endpoint, not a stale one from a prior attempt.
+      ARTIFACT_NAME: 'sql-ready-build_arm-$(System.StageAttempt)'
       BUILD_BUILDID: $(Build.BuildId)
       BUILD_SOURCESDIRECTORY: $(Build.SourcesDirectory)
       SYSTEM_COLLECTIONURI: $(System.CollectionUri)
@@ -418,7 +420,10 @@ steps:
     condition: and(always(), eq(variables['Build.Reason'], 'PullRequest'))
     inputs:
       targetPath: '$(Agent.TempDirectory)/teardown'
-      artifact: 'build_arm'
+      # Suffix with the stage attempt so a rerun publishes a fresh name instead
+      # of colliding with the prior attempt's artifact; the host waits on the
+      # matching $(System.StageAttempt) via SENTINEL_SUFFIX.
+      artifact: 'build_arm-$(System.StageAttempt)'
       publishLocation: 'pipeline'
 
 - script: |

--- a/.pipeline/templates/build-template-container.yml
+++ b/.pipeline/templates/build-template-container.yml
@@ -37,6 +37,21 @@ parameters:
   default: ''
 
 steps:
+# ARM64 integration tests connect cross-pool to an on-demand x64 SQL host
+# (Sql_Host_build_arm). Derive the SA password from build context so this job
+# and the SQL host agree without sharing a secret. Runs before the generate
+# step, which then no-ops (it honors the SQL_PASSWORD_GENERATED marker).
+- ${{ if eq(parameters.architecture, 'ARM64') }}:
+  - bash: |
+      set -euo pipefail
+      bash .pipeline/scripts/sql-host/derive-sql-password.sh
+    displayName: 'Derive SQL_PASSWORD from build context (ARM cross-pool)'
+    condition: eq(variables['Build.Reason'], 'PullRequest')
+    workingDirectory: '$(Build.SourcesDirectory)'
+    env:
+      BUILD_BUILDID: $(Build.BuildId)
+      SYSTEM_COLLECTIONID: $(System.CollectionId)
+
 - template: generate-sql-password-template.yml
   parameters:
     osType: Linux
@@ -84,33 +99,62 @@ steps:
     docker pull ghcr.io/microsoft/mssql-rs/build/ubuntu:22.04
   displayName: Pull build image
 
-- script: |
-    set -euo pipefail
-    # Generate Certificate
-    bash scripts/generate_cert.sh    
-    sudo chown 10001:0 mssql.*
+- ${{ if ne(parameters.architecture, 'ARM64') }}:
+  - script: |
+      set -euo pipefail
+      # Generate Certificate
+      bash scripts/generate_cert.sh    
+      sudo chown 10001:0 mssql.*
 
-    # Create docker network
-    docker network create testnet
+      # Create docker network
+      docker network create testnet
 
-    # Start SQL Server
-    docker run -e "ACCEPT_EULA=Y" \
-      -e "MSSQL_SA_PASSWORD=$(SQL_PASSWORD)" \
-      -p 1433:1433 \
-      --hostname sql1 \
-      --network testnet \
-      --name sqlserver \
-      -v $PWD/conf/mssql.conf:/var/opt/mssql/mssql.conf \
-      -v $PWD/mssql.pem:/etc/ssl/certs/mssql.pem \
-      -v $PWD/mssql.key:/etc/ssl/private/mssql.key \
-      -u 0:0 \
-      -d mcr.microsoft.com/mssql/server:2025-latest
+      # Start SQL Server
+      docker run -e "ACCEPT_EULA=Y" \
+        -e "MSSQL_SA_PASSWORD=$(SQL_PASSWORD)" \
+        -p 1433:1433 \
+        --hostname sql1 \
+        --network testnet \
+        --name sqlserver \
+        -v $PWD/conf/mssql.conf:/var/opt/mssql/mssql.conf \
+        -v $PWD/mssql.pem:/etc/ssl/certs/mssql.pem \
+        -v $PWD/mssql.key:/etc/ssl/private/mssql.key \
+        -u 0:0 \
+        -d mcr.microsoft.com/mssql/server:2025-latest
 
-    echo "Waiting for SQL Server to start..."
-    sleep 10
-  displayName: Setup SQL Server in Docker
-  env:
-    SQL_PASSWORD: $(SQL_PASSWORD)
+      echo "Waiting for SQL Server to start..."
+      sleep 10
+    displayName: Setup SQL Server in Docker
+    env:
+      SQL_PASSWORD: $(SQL_PASSWORD)
+
+# ARM64 cannot run the x64 SQL image well; it connects cross-pool to the
+# Sql_Host_build_arm host instead. Still generate a cert + create the docker
+# network so the shared "Build in Container" step's ca.crt mount and
+# --network testnet work on both PRs and merges (on PRs the poll step below
+# overwrites the certs with the ones the SQL host actually presents).
+- ${{ if eq(parameters.architecture, 'ARM64') }}:
+  - script: |
+      set -euo pipefail
+      bash scripts/generate_cert.sh
+      sudo chown 10001:0 mssql.*
+      docker network create testnet
+    displayName: Prepare certs and docker network (ARM cross-pool SQL)
+
+  - script: |
+      set -euo pipefail
+      bash .pipeline/scripts/sql-host/poll-for-endpoint.sh
+    displayName: Wait for cross-pool SQL host endpoint
+    condition: eq(variables['Build.Reason'], 'PullRequest')
+    workingDirectory: '$(Build.SourcesDirectory)'
+    env:
+      ARTIFACT_NAME: 'sql-ready-build_arm'
+      BUILD_BUILDID: $(Build.BuildId)
+      BUILD_SOURCESDIRECTORY: $(Build.SourcesDirectory)
+      SYSTEM_COLLECTIONURI: $(System.CollectionUri)
+      SYSTEM_TEAMPROJECT: $(System.TeamProject)
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+      AGENT_TEMPDIRECTORY: $(Agent.TempDirectory)
 
 - script: |
     BUILD_IMAGE="ghcr.io/microsoft/mssql-rs/build/ubuntu:22.04"
@@ -181,28 +225,60 @@ steps:
     CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN)
     CARGO_REGISTRIES_MSSQL_RS_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_TOKEN)
 
-- script: |
-    BUILD_IMAGE="ghcr.io/microsoft/mssql-rs/build/ubuntu:22.04"
-    
-    bash .pipeline/scripts/docker-cargo-run.sh --rm \
-      --network testnet \
-      -v $PWD:/workspace \
-      -v $HOME/.cargo/registry:/root/.cargo/registry \
-      -v $HOME/.cargo/git:/root/.cargo/git \
-      -v $PWD/ca.crt:/usr/local/share/ca-certificates/mssql-ca.crt:ro \
-      -e SQL_PASSWORD="$(SQL_PASSWORD)" \
-      -e DB_HOST="sql1" \
-      -e CERT_HOST_NAME="sql1" \
-      -e RUST_BACKTRACE=full \
-      -w /workspace \
-      $BUILD_IMAGE \
-      /workspace/.pipeline/scripts/containerized-test.sh ${{ parameters.testFilter }}
-  displayName: Run Tests and Coverage
-  condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
-  env:
-    SQL_PASSWORD: $(SQL_PASSWORD)
-    CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN)
-    CARGO_REGISTRIES_MSSQL_RS_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_TOKEN)
+- ${{ if ne(parameters.architecture, 'ARM64') }}:
+  - script: |
+      BUILD_IMAGE="ghcr.io/microsoft/mssql-rs/build/ubuntu:22.04"
+      
+      bash .pipeline/scripts/docker-cargo-run.sh --rm \
+        --network testnet \
+        -v $PWD:/workspace \
+        -v $HOME/.cargo/registry:/root/.cargo/registry \
+        -v $HOME/.cargo/git:/root/.cargo/git \
+        -v $PWD/ca.crt:/usr/local/share/ca-certificates/mssql-ca.crt:ro \
+        -e SQL_PASSWORD="$(SQL_PASSWORD)" \
+        -e DB_HOST="sql1" \
+        -e CERT_HOST_NAME="sql1" \
+        -e RUST_BACKTRACE=full \
+        -w /workspace \
+        $BUILD_IMAGE \
+        /workspace/.pipeline/scripts/containerized-test.sh ${{ parameters.testFilter }}
+    displayName: Run Tests and Coverage
+    condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+    env:
+      SQL_PASSWORD: $(SQL_PASSWORD)
+      CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN)
+      CARGO_REGISTRIES_MSSQL_RS_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_TOKEN)
+
+# ARM64 runs the same test pass but against the cross-pool SQL host resolved
+# by poll-for-endpoint.sh (DB_HOST/DB_PORT). TRUST_SERVER_CERTIFICATE bypasses
+# cert-chain validation so no host-specific cert wiring is needed on the wire.
+- ${{ if eq(parameters.architecture, 'ARM64') }}:
+  - script: |
+      BUILD_IMAGE="ghcr.io/microsoft/mssql-rs/build/ubuntu:22.04"
+      
+      bash .pipeline/scripts/docker-cargo-run.sh --rm \
+        --network testnet \
+        -v $PWD:/workspace \
+        -v $HOME/.cargo/registry:/root/.cargo/registry \
+        -v $HOME/.cargo/git:/root/.cargo/git \
+        -v $PWD/ca.crt:/usr/local/share/ca-certificates/mssql-ca.crt:ro \
+        -e SQL_PASSWORD="$(SQL_PASSWORD)" \
+        -e DB_USERNAME="sa" \
+        -e DB_HOST="$(DB_HOST)" \
+        -e DB_PORT="$(DB_PORT)" \
+        -e TRUST_SERVER_CERTIFICATE="true" \
+        -e RUST_BACKTRACE=full \
+        -w /workspace \
+        $BUILD_IMAGE \
+        /workspace/.pipeline/scripts/containerized-test.sh ${{ parameters.testFilter }}
+    displayName: Run Tests and Coverage
+    condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+    env:
+      SQL_PASSWORD: $(SQL_PASSWORD)
+      DB_HOST: $(DB_HOST)
+      DB_PORT: $(DB_PORT)
+      CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN)
+      CARGO_REGISTRIES_MSSQL_RS_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_TOKEN)
 
 - task: PublishTestResults@2
   condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
@@ -325,6 +401,25 @@ steps:
     testResultsFormat: JUnit
     testResultsFiles: $(Build.SourcesDirectory)/mssql-py-core/pytest-results.xml
     testRunTitle: $(System.PhaseName)-Python
+
+# Release the cross-pool SQL host: publishing this sentinel is what unblocks
+# Sql_Host_build_arm's wait-for-teardown step. always() so failures and
+# cancellations still release the host.
+- ${{ if eq(parameters.architecture, 'ARM64') }}:
+  - script: |
+      mkdir -p "$(Agent.TempDirectory)/teardown"
+      echo "$(System.JobName) done at $(date -u +%FT%TZ)" \
+        > "$(Agent.TempDirectory)/teardown/done.txt"
+    displayName: 'Stage teardown sentinel (release SQL host)'
+    condition: and(always(), eq(variables['Build.Reason'], 'PullRequest'))
+
+  - task: PublishPipelineArtifact@1
+    displayName: 'Publish teardown sentinel (release SQL host)'
+    condition: and(always(), eq(variables['Build.Reason'], 'PullRequest'))
+    inputs:
+      targetPath: '$(Agent.TempDirectory)/teardown'
+      artifact: 'build_arm'
+      publishLocation: 'pipeline'
 
 - script: |
     docker stop sqlserver || true

--- a/.pipeline/templates/sql-host-template.yml
+++ b/.pipeline/templates/sql-host-template.yml
@@ -1,0 +1,135 @@
+# Template: sql-host-template.yml
+#
+# Defines a single x64 1ES "SQL host" job that boots a SQL Server docker
+# container, publishes its private-VNet endpoint to dependent test jobs via
+# a `sql-ready-<instanceId>` pipeline artifact, then blocks until those test
+# jobs publish their `tests-done-<name>` sentinel artifacts, and finally
+# tears the container down in an always() step.
+#
+# Why two-way artifact sentinels (and not ADO `dependsOn` + output vars):
+#   ADO will not start a `dependsOn`-linked job until the producer job
+#   COMPLETES. If the test job depended on this job, this job could not
+#   complete until tests publish `tests-done-*`, which they cannot do until
+#   they are allowed to start — a deadlock that ends only when the SQL
+#   host's MAX_LIFETIME_MINUTES cap fires (after which the SQL container
+#   is torn down before the tests get a chance to run). The two-way artifact
+#   handshake removes the ADO `dependsOn`, so SQL host and test jobs run
+#   concurrently and synchronise via pipeline artifacts.
+#
+# Caller contract:
+#   * The dependent test job must NOT add `dependsOn` on this job.
+#   * The dependent test job must call sql-host/poll-for-endpoint.sh with
+#     ARTIFACT_NAME='sql-ready-<instanceId>' before it tries to connect.
+#   * The dependent test job must publish a pipeline artifact whose name is
+#     listed in `expectedSentinels` once it has finished using the SQL host
+#     (use `condition: always()` so cancellations and failures still release
+#     the host).
+#   * The SA password is derived deterministically from build context by
+#     sql-host/derive-sql-password.sh, so the same script must be invoked
+#     in the dependent test job to recompute the same value.
+#
+# Cross-pool reachability assumption: the configured x64 pool and the ARM
+# pool that consumes the endpoint share a VNet, and the IP we publish is
+# routable from those ARM agents on `sqlHostPort`.
+
+parameters:
+  - name: instanceId
+    type: string
+  - name: expectedSentinels
+    # Comma-separated list of pipeline-artifact names to wait for.
+    type: string
+  - name: sqlImageTag
+    type: string
+    default: '2025-latest'
+  - name: maxLifetimeMinutes
+    type: number
+    default: 120
+  - name: poolName
+    type: string
+    default: 'RUST-1ES-POOL-WUS3'
+  - name: poolImageOverride
+    type: string
+    default: 'imageOverride -equals RUST-1ES-UBUSLIM'
+
+jobs:
+  - job: Sql_Host_${{ parameters.instanceId }}
+    displayName: 'SQL host (${{ parameters.instanceId }})'
+    # Generous ADO-level safety net; the real cap is enforced by the watcher
+    # script via MAX_LIFETIME_MINUTES (parameter below) and is always lower.
+    timeoutInMinutes: 240
+    pool:
+      name: ${{ parameters.poolName }}
+      demands:
+        - ${{ parameters.poolImageOverride }}
+    variables:
+      INSTANCE_ID: ${{ parameters.instanceId }}
+      SQL_IMAGE_TAG: ${{ parameters.sqlImageTag }}
+      EXPECTED_SENTINELS: ${{ parameters.expectedSentinels }}
+      MAX_LIFETIME_MINUTES: ${{ parameters.maxLifetimeMinutes }}
+    steps:
+      - bash: |
+          set -euo pipefail
+          bash .pipeline/scripts/sql-host/derive-sql-password.sh
+        displayName: 'Derive shared SQL_PASSWORD from build context'
+        workingDirectory: '$(Build.SourcesDirectory)'
+        env:
+          BUILD_BUILDID: $(Build.BuildId)
+          SYSTEM_COLLECTIONID: $(System.CollectionId)
+
+      - task: DockerInstaller@0
+        inputs:
+          dockerVersion: '29.0.0'
+
+      - template: install-ubuntu-dependency.yaml
+        parameters:
+          installAzCli: false
+          installDocker: true
+
+      - script: |
+          set -euo pipefail
+          bash .pipeline/scripts/sql-host/start.sh
+        name: publish
+        displayName: 'Boot SQL Server and stage endpoint payload'
+        workingDirectory: '$(Build.SourcesDirectory)'
+        env:
+          SQL_PASSWORD: $(SQL_PASSWORD)
+          INSTANCE_ID: $(INSTANCE_ID)
+          SQL_IMAGE_TAG: $(SQL_IMAGE_TAG)
+          BUILD_ARTIFACTSTAGINGDIRECTORY: $(Build.ArtifactStagingDirectory)
+          # Embedded in endpoint.txt as a wall-clock deadline so test jobs
+          # can fail fast if they queued long enough that the SQL host is
+          # about to be torn down.
+          MAX_LIFETIME_MINUTES: $(MAX_LIFETIME_MINUTES)
+          # Avoid host port 1433: the NRMS subnet baseline and various
+          # platform policies frequently single out 1433 for restriction.
+          # Use a non-standard port and let the published endpoint sentinel
+          # propagate it to dependent test jobs.
+          SQL_HOST_PORT: '14333'
+
+      - task: PublishPipelineArtifact@1
+        displayName: 'Publish sql-ready sentinel (unblocks test jobs)'
+        inputs:
+          targetPath: '$(Build.ArtifactStagingDirectory)/sql-endpoint-$(INSTANCE_ID)'
+          artifact: 'sql-ready-$(INSTANCE_ID)'
+          publishLocation: 'pipeline'
+
+      - script: |
+          set -euo pipefail
+          bash .pipeline/scripts/sql-host/wait-for-teardown.sh
+        displayName: 'Wait for test-completion sentinels'
+        workingDirectory: '$(Build.SourcesDirectory)'
+        env:
+          EXPECTED_SENTINELS: $(EXPECTED_SENTINELS)
+          BUILD_BUILDID: $(Build.BuildId)
+          SYSTEM_COLLECTIONURI: $(System.CollectionUri)
+          SYSTEM_TEAMPROJECT: $(System.TeamProject)
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          MAX_LIFETIME_MINUTES: $(MAX_LIFETIME_MINUTES)
+
+      - script: |
+          bash .pipeline/scripts/sql-host/teardown.sh
+        displayName: 'Tear down SQL Server container'
+        condition: always()
+        workingDirectory: '$(Build.SourcesDirectory)'
+        env:
+          INSTANCE_ID: $(INSTANCE_ID)

--- a/.pipeline/templates/sql-host-template.yml
+++ b/.pipeline/templates/sql-host-template.yml
@@ -50,10 +50,16 @@ parameters:
   - name: poolImageOverride
     type: string
     default: 'imageOverride -equals RUST-1ES-UBUSLIM'
+  - name: jobCondition
+    # Job-level condition. Defaults to succeeded(); callers that only need the
+    # SQL host on PRs (e.g. the Build stage) pass a Build.Reason check.
+    type: string
+    default: succeeded()
 
 jobs:
   - job: Sql_Host_${{ parameters.instanceId }}
     displayName: 'SQL host (${{ parameters.instanceId }})'
+    condition: ${{ parameters.jobCondition }}
     # Generous ADO-level safety net; the real cap is enforced by the watcher
     # script via MAX_LIFETIME_MINUTES (parameter below) and is always lower.
     timeoutInMinutes: 240

--- a/.pipeline/templates/sql-host-template.yml
+++ b/.pipeline/templates/sql-host-template.yml
@@ -20,11 +20,15 @@
 # Caller contract:
 #   * The dependent test job must NOT add `dependsOn` on this job.
 #   * The dependent test job must call sql-host/poll-for-endpoint.sh with
-#     ARTIFACT_NAME='sql-ready-<instanceId>' before it tries to connect.
+#     ARTIFACT_NAME='sql-ready-<instanceId>-$(System.StageAttempt)' before it
+#     tries to connect.
 #   * The dependent test job must publish a pipeline artifact whose name is
-#     listed in `expectedSentinels` once it has finished using the SQL host
-#     (use `condition: always()` so cancellations and failures still release
-#     the host).
+#     '<sentinel>-$(System.StageAttempt)', where <sentinel> is listed in
+#     `expectedSentinels`, once it has finished using the SQL host (use
+#     `condition: always()` so cancellations and failures still release the
+#     host). The `-$(System.StageAttempt)` suffix namespaces the rendezvous per
+#     stage attempt so reruns don't collide with or match prior attempts; this
+#     job appends the same suffix to `expectedSentinels` via SENTINEL_SUFFIX.
 #   * The SA password is derived deterministically from build context by
 #     sql-host/derive-sql-password.sh, so the same script must be invoked
 #     in the dependent test job to recompute the same value.
@@ -117,7 +121,11 @@ jobs:
         displayName: 'Publish sql-ready sentinel (unblocks test jobs)'
         inputs:
           targetPath: '$(Build.ArtifactStagingDirectory)/sql-endpoint-$(INSTANCE_ID)'
-          artifact: 'sql-ready-$(INSTANCE_ID)'
+          # Suffix with the stage attempt so a stage rerun publishes a fresh
+          # artifact name instead of colliding with the prior attempt's, and
+          # the paired poll-for-endpoint reads this attempt's endpoint (not a
+          # stale one). Consumers append the same $(System.StageAttempt).
+          artifact: 'sql-ready-$(INSTANCE_ID)-$(System.StageAttempt)'
           publishLocation: 'pipeline'
 
       - script: |
@@ -127,6 +135,10 @@ jobs:
         workingDirectory: '$(Build.SourcesDirectory)'
         env:
           EXPECTED_SENTINELS: $(EXPECTED_SENTINELS)
+          # Wait on this stage attempt's teardown sentinels (publishers suffix
+          # their artifact names with the same value), so a rerun never matches
+          # a previous attempt's leftover sentinels.
+          SENTINEL_SUFFIX: '-$(System.StageAttempt)'
           BUILD_BUILDID: $(Build.BuildId)
           SYSTEM_COLLECTIONURI: $(System.CollectionUri)
           SYSTEM_TEAMPROJECT: $(System.TeamProject)

--- a/.pipeline/templates/sql-host-template.yml
+++ b/.pipeline/templates/sql-host-template.yml
@@ -3,13 +3,14 @@
 # Defines a single x64 1ES "SQL host" job that boots a SQL Server docker
 # container, publishes its private-VNet endpoint to dependent test jobs via
 # a `sql-ready-<instanceId>` pipeline artifact, then blocks until those test
-# jobs publish their `tests-done-<name>` sentinel artifacts, and finally
-# tears the container down in an always() step.
+# jobs publish their teardown sentinel artifacts (each named by the raw
+# sentinel name listed in expectedSentinels, e.g. Ubuntu24, build_arm), and
+# finally tears the container down in an always() step.
 #
 # Why two-way artifact sentinels (and not ADO `dependsOn` + output vars):
 #   ADO will not start a `dependsOn`-linked job until the producer job
 #   COMPLETES. If the test job depended on this job, this job could not
-#   complete until tests publish `tests-done-*`, which they cannot do until
+#   complete until tests publish their teardown sentinels, which they cannot do until
 #   they are allowed to start — a deadlock that ends only when the SQL
 #   host's MAX_LIFETIME_MINUTES cap fires (after which the SQL container
 #   is torn down before the tests get a chance to run). The two-way artifact

--- a/.pipeline/templates/test-matrix-template-alpine_arm64.yml
+++ b/.pipeline/templates/test-matrix-template-alpine_arm64.yml
@@ -83,7 +83,8 @@ jobs:
           displayName: 'Wait for SQL host endpoint sentinel'
           workingDirectory: '$(Build.SourcesDirectory)'
           env:
-            ARTIFACT_NAME: 'sql-ready-shared_musl'
+            # Stage-attempt suffix: rerun-safe namespacing (see sql-host-template.yml).
+            ARTIFACT_NAME: 'sql-ready-shared_musl-$(System.StageAttempt)'
             BUILD_BUILDID: $(Build.BuildId)
             BUILD_SOURCESDIRECTORY: $(Build.SourcesDirectory)
             SYSTEM_COLLECTIONURI: $(System.CollectionUri)
@@ -150,7 +151,8 @@ jobs:
           condition: always()
           inputs:
             targetPath: '$(Agent.TempDirectory)/teardown'
-            artifact: '$(sentinelName)'
+            # Stage-attempt suffix: rerun-safe namespacing (see sql-host-template.yml).
+            artifact: '$(sentinelName)-$(System.StageAttempt)'
             publishLocation: 'pipeline'
 
   - ${{ if eq(parameters.sqlInstanceMode, 'per-job') }}:
@@ -198,7 +200,8 @@ jobs:
             displayName: 'Wait for SQL host endpoint sentinel'
             workingDirectory: '$(Build.SourcesDirectory)'
             env:
-              ARTIFACT_NAME: 'sql-ready-${{ target.name }}_musl'
+              # Stage-attempt suffix: rerun-safe namespacing (see sql-host-template.yml).
+              ARTIFACT_NAME: 'sql-ready-${{ target.name }}_musl-$(System.StageAttempt)'
               BUILD_BUILDID: $(Build.BuildId)
               BUILD_SOURCESDIRECTORY: $(Build.SourcesDirectory)
               SYSTEM_COLLECTIONURI: $(System.CollectionUri)
@@ -265,5 +268,6 @@ jobs:
             condition: always()
             inputs:
               targetPath: '$(Agent.TempDirectory)/teardown'
-              artifact: '${{ target.name }}_musl'
+              # Stage-attempt suffix: rerun-safe namespacing (see sql-host-template.yml).
+              artifact: '${{ target.name }}_musl-$(System.StageAttempt)'
               publishLocation: 'pipeline'

--- a/.pipeline/templates/test-matrix-template-alpine_arm64.yml
+++ b/.pipeline/templates/test-matrix-template-alpine_arm64.yml
@@ -1,65 +1,269 @@
+# Template: test-matrix-template-alpine_arm64.yml
+#
+# musl/Alpine variant of test-matrix-template-arm64.yml. Runs the ARM64 test
+# matrix against an x64-hosted SQL Server booted by sql-host-template.yml.
+# See test-matrix-template-arm64.yml for the cardinality / sentinel /
+# password contract.
+
 parameters:
-  matrix: {}
-  artifactName: 'Build_Linux_ARM'
-  poolName: 'RUST-1ES-POOL-ARM-WUS3'
-  poolImageOverride: 'imageOverride -equals RUST-UBUNTU-ARM64'
+  - name: targets
+    # Each entry: { name, container, entry }
+    type: object
+  - name: artifactName
+    type: string
+    default: 'Build_Linux_ARM'
+  - name: poolName
+    type: string
+    default: 'RUST-1ES-POOL-ARM-WUS3'
+  - name: poolImageOverride
+    type: string
+    default: 'imageOverride -equals RUST-UBUNTU-ARM64'
+  - name: sqlInstanceMode
+    type: string
+    default: shared
+    values:
+      - shared
+      - per-job
+  - name: sqlImageTag
+    type: string
+    default: '2025-latest'
+  - name: maxLifetimeMinutes
+    type: number
+    default: 120
 
 jobs:
-  - job: Test_Matrix
-    displayName: Linux arm64 
-    strategy:
-      matrix: ${{ parameters.matrix }}
-    pool:
-      name: ${{ parameters.poolName }}
-      demands:
-        - ${{ parameters.poolImageOverride }}
-    steps:
-      - template: generate-sql-password-template.yml
-        parameters:
-          osType: Linux
-      - task: DockerInstaller@0
-        inputs:
-          dockerVersion: '29.0.0'
-      - task: DownloadPipelineArtifact@2
-        inputs:
-          buildType: 'current'
-          artifactName: '${{ parameters.artifactName }}'
-        displayName: 'Download Pipeline Artifacts'
-      - template: install-ubuntu-dependency.yaml
-        parameters:
-          installAzCli: false
-          installDocker: true  
+  - ${{ if eq(parameters.sqlInstanceMode, 'shared') }}:
+    - template: sql-host-template.yml
+      parameters:
+        instanceId: shared_musl
+        sqlImageTag: ${{ parameters.sqlImageTag }}
+        maxLifetimeMinutes: ${{ parameters.maxLifetimeMinutes }}
+        expectedSentinels: ${{ join(',', parameters.targets.*.name) }}
 
-      - script: |
-          echo $(container)
-          echo $(entry)
-          echo $container
+    - job: Test_Matrix_alpine_arm64
+      displayName: Linux arm64 (musl)
+      # Intentionally no `dependsOn`: see sql-host-template.yml header.
+      strategy:
+        matrix:
+          ${{ each target in parameters.targets }}:
+            ${{ target.name }}:
+              container: ${{ target.container }}
+              entry: ${{ target.entry }}
+              sentinelName: ${{ target.name }}
+      pool:
+        name: ${{ parameters.poolName }}
+        demands:
+          - ${{ parameters.poolImageOverride }}
+      steps:
+        - bash: |
+            set -euo pipefail
+            bash .pipeline/scripts/sql-host/derive-sql-password.sh
+          displayName: 'Derive shared SQL_PASSWORD from build context'
+          workingDirectory: '$(Build.SourcesDirectory)'
+          env:
+            BUILD_BUILDID: $(Build.BuildId)
+            SYSTEM_COLLECTIONID: $(System.CollectionId)
 
-          scripts/generate_cert.sh
-          scripts/generate_mock_tds_server_certs.sh
-          sudo chown 10001:0 mssql.*
+        - task: DockerInstaller@0
+          inputs:
+            dockerVersion: '29.0.0'
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            buildType: 'current'
+            artifactName: '${{ parameters.artifactName }}'
+          displayName: 'Download Pipeline Artifacts'
+        - template: install-ubuntu-dependency.yaml
+          parameters:
+            installAzCli: false
+            installDocker: true
 
-          if command -v docker >/dev/null 2>&1
-          then
+        - bash: |
+            set -euo pipefail
+            bash .pipeline/scripts/sql-host/poll-for-endpoint.sh
+          displayName: 'Wait for SQL host endpoint sentinel'
+          workingDirectory: '$(Build.SourcesDirectory)'
+          env:
+            ARTIFACT_NAME: 'sql-ready-shared_musl'
+            BUILD_BUILDID: $(Build.BuildId)
+            BUILD_SOURCESDIRECTORY: $(Build.SourcesDirectory)
+            SYSTEM_COLLECTIONURI: $(System.CollectionUri)
+            SYSTEM_TEAMPROJECT: $(System.TeamProject)
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+            AGENT_TEMPDIRECTORY: $(Agent.TempDirectory)
+
+        - script: |
+            set -euo pipefail
+            echo "container=$(container) entry=$(entry)"
+            echo "DB_HOST=$DB_HOST DB_PORT=$DB_PORT"
+
+            # ca.crt + mssql.pem are downloaded by poll-for-endpoint.sh
+            # from the sql-ready artifact; they match the cert chain the
+            # cross-pool SQL host is actually presenting on the wire.
+            scripts/generate_mock_tds_server_certs.sh
+            sudo chown 10001:0 mssql.*
+
+            if ! command -v docker >/dev/null 2>&1; then
+              echo "ERROR: docker not available on agent" >&2
+              exit 1
+            fi
+
             cp $(Pipeline.Workspace)/tdslib-nextest-musl.tar.zst $(Build.SourcesDirectory)
-            
             docker network create testnet
 
-            # docker run -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=$(SQL_PASSWORD)" -p 1433:1433 --hostname sql1 --network testnet -v $PWD/conf/mssql.conf:/var/opt/mssql/mssql.conf -v $PWD/mssql.pem:/etc/ssl/certs/mssql.pem -v $PWD/mssql.key:/etc/ssl/private/mssql.key -u 0:0 -d mcr.microsoft.com/mssql/server:2025-latest
+            bash .pipeline/scripts/docker-cargo-run.sh \
+              -v "$PWD:/workspace" \
+              -e "TRUST_SERVER_CERTIFICATE=true" \
+              -e "DB_USERNAME=sa" \
+              -e "DB_HOST=$DB_HOST" \
+              -e "DB_PORT=$DB_PORT" \
+              -e "SQL_PASSWORD=$(SQL_PASSWORD)" \
+              -e "ARCHIVE_NAME=tdslib-nextest-musl.tar.zst" \
+              --network testnet \
+              $(container) /workspace/scripts/dockerentry/$(entry)
+          workingDirectory: "$(Build.SourcesDirectory)"
+          displayName: Run docker test
+          condition: succeeded()
+          env:
+            DB_HOST: $(DB_HOST)
+            DB_PORT: $(DB_PORT)
+            SQL_PASSWORD: $(SQL_PASSWORD)
+            CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN)
+            CARGO_REGISTRIES_MSSQL_RS_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_TOKEN)
 
-            bash .pipeline/scripts/docker-cargo-run.sh -v "$PWD:/workspace" -e "TRUST_SERVER_CERTIFICATE=true" -e "DB_USERNAME=sa" -e "DB_HOST=$(ACI_SQL_HOST_2022)" -e "DB_PORT=14333" -e "SQL_PASSWORD=$(ACI_SQL_PASSWORD)"  -e "ARCHIVE_NAME=tdslib-nextest-musl.tar.zst" --network testnet $(container) /workspace/scripts/dockerentry/$(entry)
-          fi
-        workingDirectory: "$(Build.SourcesDirectory)"
-        displayName: Run docker test
-        condition: succeeded()
-        env :
-          SQL_PASSWORD: $(SQL_PASSWORD)
-          CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN)
-          CARGO_REGISTRIES_MSSQL_RS_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_TOKEN)
-      - task: PublishTestResults@2
-        condition: succeededOrFailed()
-        displayName: "Publish test results"
-        inputs:
-          testResultsFormat: "JUnit"
-          testResultsFiles: $(Build.SourcesDirectory)/target/nextest/ci/junit.xml
-          testRunTitle: $(System.PhaseName)
+        - task: PublishTestResults@2
+          condition: succeededOrFailed()
+          displayName: "Publish test results"
+          inputs:
+            testResultsFormat: "JUnit"
+            testResultsFiles: $(Build.SourcesDirectory)/target/nextest/ci/junit.xml
+            testRunTitle: $(System.PhaseName)
+
+        - script: |
+            mkdir -p "$(Agent.TempDirectory)/teardown"
+            echo "$(System.JobName) done at $(date -u +%FT%TZ)" \
+              > "$(Agent.TempDirectory)/teardown/done.txt"
+          displayName: 'Stage teardown sentinel'
+          condition: always()
+
+        - task: PublishPipelineArtifact@1
+          displayName: 'Publish teardown sentinel (release SQL host)'
+          condition: always()
+          inputs:
+            targetPath: '$(Agent.TempDirectory)/teardown'
+            artifact: '$(sentinelName)'
+            publishLocation: 'pipeline'
+
+  - ${{ if eq(parameters.sqlInstanceMode, 'per-job') }}:
+    - ${{ each target in parameters.targets }}:
+      - template: sql-host-template.yml
+        parameters:
+          instanceId: ${{ target.name }}_musl
+          sqlImageTag: ${{ parameters.sqlImageTag }}
+          maxLifetimeMinutes: ${{ parameters.maxLifetimeMinutes }}
+          expectedSentinels: ${{ target.name }}_musl
+
+      - job: Test_${{ target.name }}_alpine_arm64
+        displayName: 'Linux arm64 (musl) ${{ target.name }}'
+        # Intentionally no `dependsOn`: see sql-host-template.yml header.
+        pool:
+          name: ${{ parameters.poolName }}
+          demands:
+            - ${{ parameters.poolImageOverride }}
+        steps:
+          - bash: |
+              set -euo pipefail
+              bash .pipeline/scripts/sql-host/derive-sql-password.sh
+            displayName: 'Derive shared SQL_PASSWORD from build context'
+            workingDirectory: '$(Build.SourcesDirectory)'
+            env:
+              BUILD_BUILDID: $(Build.BuildId)
+              SYSTEM_COLLECTIONID: $(System.CollectionId)
+
+          - task: DockerInstaller@0
+            inputs:
+              dockerVersion: '29.0.0'
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              buildType: 'current'
+              artifactName: '${{ parameters.artifactName }}'
+            displayName: 'Download Pipeline Artifacts'
+          - template: install-ubuntu-dependency.yaml
+            parameters:
+              installAzCli: false
+              installDocker: true
+
+          - bash: |
+              set -euo pipefail
+              bash .pipeline/scripts/sql-host/poll-for-endpoint.sh
+            displayName: 'Wait for SQL host endpoint sentinel'
+            workingDirectory: '$(Build.SourcesDirectory)'
+            env:
+              ARTIFACT_NAME: 'sql-ready-${{ target.name }}_musl'
+              BUILD_BUILDID: $(Build.BuildId)
+              BUILD_SOURCESDIRECTORY: $(Build.SourcesDirectory)
+              SYSTEM_COLLECTIONURI: $(System.CollectionUri)
+              SYSTEM_TEAMPROJECT: $(System.TeamProject)
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+              AGENT_TEMPDIRECTORY: $(Agent.TempDirectory)
+
+          - script: |
+              set -euo pipefail
+              echo "container=${{ target.container }} entry=${{ target.entry }}"
+              echo "DB_HOST=$DB_HOST DB_PORT=$DB_PORT"
+
+              # ca.crt + mssql.pem are downloaded by poll-for-endpoint.sh
+              # from the sql-ready artifact; they match the cert chain the
+              # cross-pool SQL host is actually presenting on the wire.
+              scripts/generate_mock_tds_server_certs.sh
+              sudo chown 10001:0 mssql.*
+
+              if ! command -v docker >/dev/null 2>&1; then
+                echo "ERROR: docker not available on agent" >&2
+                exit 1
+              fi
+
+              cp $(Pipeline.Workspace)/tdslib-nextest-musl.tar.zst $(Build.SourcesDirectory)
+              docker network create testnet
+
+              bash .pipeline/scripts/docker-cargo-run.sh \
+                -v "$PWD:/workspace" \
+                -e "TRUST_SERVER_CERTIFICATE=true" \
+                -e "DB_USERNAME=sa" \
+                -e "DB_HOST=$DB_HOST" \
+                -e "DB_PORT=$DB_PORT" \
+                -e "SQL_PASSWORD=$(SQL_PASSWORD)" \
+                -e "ARCHIVE_NAME=tdslib-nextest-musl.tar.zst" \
+                --network testnet \
+                ${{ target.container }} /workspace/scripts/dockerentry/${{ target.entry }}
+            workingDirectory: "$(Build.SourcesDirectory)"
+            displayName: Run docker test
+            condition: succeeded()
+            env:
+              DB_HOST: $(DB_HOST)
+              DB_PORT: $(DB_PORT)
+              SQL_PASSWORD: $(SQL_PASSWORD)
+              CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN)
+              CARGO_REGISTRIES_MSSQL_RS_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_TOKEN)
+
+          - task: PublishTestResults@2
+            condition: succeededOrFailed()
+            displayName: "Publish test results"
+            inputs:
+              testResultsFormat: "JUnit"
+              testResultsFiles: $(Build.SourcesDirectory)/target/nextest/ci/junit.xml
+              testRunTitle: $(System.PhaseName)
+
+          - script: |
+              mkdir -p "$(Agent.TempDirectory)/teardown"
+              echo "${{ target.name }} done at $(date -u +%FT%TZ)" \
+                > "$(Agent.TempDirectory)/teardown/done.txt"
+            displayName: 'Stage teardown sentinel'
+            condition: always()
+
+          - task: PublishPipelineArtifact@1
+            displayName: 'Publish teardown sentinel (release SQL host)'
+            condition: always()
+            inputs:
+              targetPath: '$(Agent.TempDirectory)/teardown'
+              artifact: '${{ target.name }}_musl'
+              publishLocation: 'pipeline'

--- a/.pipeline/templates/test-matrix-template-arm64.yml
+++ b/.pipeline/templates/test-matrix-template-arm64.yml
@@ -101,7 +101,8 @@ jobs:
           displayName: 'Wait for SQL host endpoint sentinel'
           workingDirectory: '$(Build.SourcesDirectory)'
           env:
-            ARTIFACT_NAME: 'sql-ready-shared'
+            # Stage-attempt suffix: rerun-safe namespacing (see sql-host-template.yml).
+            ARTIFACT_NAME: 'sql-ready-shared-$(System.StageAttempt)'
             BUILD_BUILDID: $(Build.BuildId)
             BUILD_SOURCESDIRECTORY: $(Build.SourcesDirectory)
             SYSTEM_COLLECTIONURI: $(System.CollectionUri)
@@ -162,7 +163,8 @@ jobs:
           condition: always()
           inputs:
             targetPath: '$(Agent.TempDirectory)/teardown'
-            artifact: '$(sentinelName)'
+            # Stage-attempt suffix: rerun-safe namespacing (see sql-host-template.yml).
+            artifact: '$(sentinelName)-$(System.StageAttempt)'
             publishLocation: 'pipeline'
 
   # ------------------------------------------------------------------
@@ -214,7 +216,8 @@ jobs:
             displayName: 'Wait for SQL host endpoint sentinel'
             workingDirectory: '$(Build.SourcesDirectory)'
             env:
-              ARTIFACT_NAME: 'sql-ready-${{ target.name }}'
+              # Stage-attempt suffix: rerun-safe namespacing (see sql-host-template.yml).
+              ARTIFACT_NAME: 'sql-ready-${{ target.name }}-$(System.StageAttempt)'
               BUILD_BUILDID: $(Build.BuildId)
               BUILD_SOURCESDIRECTORY: $(Build.SourcesDirectory)
               SYSTEM_COLLECTIONURI: $(System.CollectionUri)
@@ -275,5 +278,6 @@ jobs:
             condition: always()
             inputs:
               targetPath: '$(Agent.TempDirectory)/teardown'
-              artifact: '${{ target.name }}'
+              # Stage-attempt suffix: rerun-safe namespacing (see sql-host-template.yml).
+              artifact: '${{ target.name }}-$(System.StageAttempt)'
               publishLocation: 'pipeline'

--- a/.pipeline/templates/test-matrix-template-arm64.yml
+++ b/.pipeline/templates/test-matrix-template-arm64.yml
@@ -1,58 +1,279 @@
-# filepath: .pipeline/templates/test-matrix-template.yml
+# Template: test-matrix-template-arm64.yml
+#
+# Runs the glibc Linux ARM64 test matrix against an x64-hosted SQL Server
+# (booted by sql-host-template.yml in the same stage). Two cardinality modes:
+#
+#   sqlInstanceMode = shared
+#     One SQL host, all matrix entries connect to it. Each entry publishes
+#     its own teardown sentinel; the SQL host releases once every expected
+#     sentinel exists.
+#
+#   sqlInstanceMode = per-job
+#     One SQL host per matrix entry. Each test job has its own SQL host and
+#     publishes a single sentinel on completion. Use when shared SQL state
+#     causes test interference.
+#
+# Cross-job sync (see sql-host-template.yml for the rationale):
+#   * No ADO `dependsOn` between SQL host and test jobs (ADO `dependsOn`
+#     would deadlock — SQL host can only finish after sentinels arrive,
+#     sentinels can only be published once tests start).
+#   * SQL host -> test:  sql-ready-<instanceId>  pipeline artifact carries
+#                        the endpoint; resolved at test job start by
+#                        poll-for-endpoint.sh, exporting DB_HOST/DB_PORT.
+#   * Test -> SQL host:  one teardown-sentinel artifact per matrix entry,
+#                        published always() so the SQL host releases on
+#                        success, failure, and cancellation.
+#   * SA password is derived from build context by derive-sql-password.sh
+#     in both jobs so they agree without sharing a secret across jobs.
+
 parameters:
-  matrix: {}
+  - name: targets
+    # Each entry: { name, container, entry }
+    type: object
+  - name: sqlInstanceMode
+    type: string
+    default: shared
+    values:
+      - shared
+      - per-job
+  - name: sqlImageTag
+    type: string
+    default: '2025-latest'
+  - name: maxLifetimeMinutes
+    type: number
+    default: 120
 
 jobs:
-  - job: Test_Matrix_arm64
-    displayName: Linux arm64
-    strategy:
-      matrix: ${{ parameters.matrix }}
-    pool:
-      name: RUST-1ES-POOL-ARM-WUS3
-      demands:
-        - imageOverride -equals RUST-UBUNTU-ARM64
-    steps:
-      - template: generate-sql-password-template.yml
+  # ------------------------------------------------------------------
+  # SHARED MODE: one SQL host + one matrix test job.
+  # ------------------------------------------------------------------
+  - ${{ if eq(parameters.sqlInstanceMode, 'shared') }}:
+    - template: sql-host-template.yml
+      parameters:
+        instanceId: shared
+        sqlImageTag: ${{ parameters.sqlImageTag }}
+        maxLifetimeMinutes: ${{ parameters.maxLifetimeMinutes }}
+        expectedSentinels: ${{ join(',', parameters.targets.*.name) }}
+
+    - job: Test_Matrix_arm64
+      displayName: Linux arm64
+      # Intentionally no `dependsOn`: see sql-host-template.yml header.
+      # The endpoint is resolved at runtime via the sql-ready-shared
+      # pipeline artifact (poll-for-endpoint.sh).
+      strategy:
+        matrix:
+          ${{ each target in parameters.targets }}:
+            ${{ target.name }}:
+              container: ${{ target.container }}
+              entry: ${{ target.entry }}
+              sentinelName: ${{ target.name }}
+      pool:
+        name: RUST-1ES-POOL-ARM-WUS3
+        demands:
+          - imageOverride -equals RUST-UBUNTU-ARM64
+      steps:
+        - bash: |
+            set -euo pipefail
+            bash .pipeline/scripts/sql-host/derive-sql-password.sh
+          displayName: 'Derive shared SQL_PASSWORD from build context'
+          workingDirectory: '$(Build.SourcesDirectory)'
+          env:
+            BUILD_BUILDID: $(Build.BuildId)
+            SYSTEM_COLLECTIONID: $(System.CollectionId)
+
+        - task: DockerInstaller@0
+          inputs:
+            dockerVersion: '29.0.0'
+        - template: install-ubuntu-dependency.yaml
+          parameters:
+            installAzCli: false
+            installDocker: true
+
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            buildType: 'current'
+            artifactName: 'Build_Linux_ARM'
+          displayName: 'Download Pipeline Artifacts'
+
+        - bash: |
+            set -euo pipefail
+            bash .pipeline/scripts/sql-host/poll-for-endpoint.sh
+          displayName: 'Wait for SQL host endpoint sentinel'
+          workingDirectory: '$(Build.SourcesDirectory)'
+          env:
+            ARTIFACT_NAME: 'sql-ready-shared'
+            BUILD_BUILDID: $(Build.BuildId)
+            BUILD_SOURCESDIRECTORY: $(Build.SourcesDirectory)
+            SYSTEM_COLLECTIONURI: $(System.CollectionUri)
+            SYSTEM_TEAMPROJECT: $(System.TeamProject)
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+            AGENT_TEMPDIRECTORY: $(Agent.TempDirectory)
+
+        - script: |
+            set -euo pipefail
+            echo "container=$(container) entry=$(entry)"
+            echo "DB_HOST=$DB_HOST DB_PORT=$DB_PORT"
+
+            # ca.crt + mssql.pem are downloaded by poll-for-endpoint.sh
+            # from the sql-ready artifact; they match the cert chain the
+            # cross-pool SQL host is actually presenting on the wire.
+            scripts/generate_mock_tds_server_certs.sh
+
+            cp $(Pipeline.Workspace)/tdslib-nextest.tar.zst $(Build.SourcesDirectory)
+            docker network create testnet
+
+            bash .pipeline/scripts/docker-cargo-run.sh --entrypoint bash \
+              -v "$PWD:/workspace" \
+              -e "DB_USERNAME=sa" \
+              -e "DB_HOST=$DB_HOST" \
+              -e "DB_PORT=$DB_PORT" \
+              -e "SQL_PASSWORD=$(SQL_PASSWORD)" \
+              -e "ARCHIVE_NAME=tdslib-nextest.tar.zst" \
+              -e "TRUST_SERVER_CERTIFICATE=true" \
+              --network testnet \
+              $(container) /workspace/scripts/dockerentry/$(entry)
+          workingDirectory: "$(Build.SourcesDirectory)"
+          displayName: Run docker test
+          condition: succeeded()
+          env:
+            DB_HOST: $(DB_HOST)
+            DB_PORT: $(DB_PORT)
+            SQL_PASSWORD: $(SQL_PASSWORD)
+            CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN)
+            CARGO_REGISTRIES_MSSQL_RS_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_TOKEN)
+
+        - task: PublishTestResults@2
+          condition: succeededOrFailed()
+          displayName: "Publish test results"
+          inputs:
+            testResultsFormat: "JUnit"
+            testResultsFiles: $(Build.SourcesDirectory)/target/nextest/ci/junit.xml
+            testRunTitle: $(System.PhaseName)
+
+        - script: |
+            mkdir -p "$(Agent.TempDirectory)/teardown"
+            echo "$(System.JobName) done at $(date -u +%FT%TZ)" \
+              > "$(Agent.TempDirectory)/teardown/done.txt"
+          displayName: 'Stage teardown sentinel'
+          condition: always()
+
+        - task: PublishPipelineArtifact@1
+          displayName: 'Publish teardown sentinel (release SQL host)'
+          condition: always()
+          inputs:
+            targetPath: '$(Agent.TempDirectory)/teardown'
+            artifact: '$(sentinelName)'
+            publishLocation: 'pipeline'
+
+  # ------------------------------------------------------------------
+  # PER-JOB MODE: one SQL host + one test job per matrix entry.
+  # ------------------------------------------------------------------
+  - ${{ if eq(parameters.sqlInstanceMode, 'per-job') }}:
+    - ${{ each target in parameters.targets }}:
+      - template: sql-host-template.yml
         parameters:
-          osType: Linux
-      - task: DockerInstaller@0
-        inputs:
-          dockerVersion: '29.0.0'
-      - template: install-ubuntu-dependency.yaml
-        parameters:
-          installAzCli: false
-          installDocker: true
+          instanceId: ${{ target.name }}
+          sqlImageTag: ${{ parameters.sqlImageTag }}
+          maxLifetimeMinutes: ${{ parameters.maxLifetimeMinutes }}
+          expectedSentinels: ${{ target.name }}
 
-      - task: DownloadPipelineArtifact@2
-        inputs:
-          buildType: 'current'
-          artifactName: 'Build_Linux_ARM'
-        displayName: 'Download Pipeline Artifacts'
-      - script: |
-          echo $(container)
-          echo $(entry)
-          echo $container
+      - job: Test_${{ target.name }}_arm64
+        displayName: 'Linux arm64 ${{ target.name }}'
+        # Intentionally no `dependsOn`: see sql-host-template.yml header.
+        pool:
+          name: RUST-1ES-POOL-ARM-WUS3
+          demands:
+            - imageOverride -equals RUST-UBUNTU-ARM64
+        steps:
+          - bash: |
+              set -euo pipefail
+              bash .pipeline/scripts/sql-host/derive-sql-password.sh
+            displayName: 'Derive shared SQL_PASSWORD from build context'
+            workingDirectory: '$(Build.SourcesDirectory)'
+            env:
+              BUILD_BUILDID: $(Build.BuildId)
+              SYSTEM_COLLECTIONID: $(System.CollectionId)
 
-          scripts/generate_cert.sh
-          scripts/generate_mock_tds_server_certs.sh
-          
-          cp $(Pipeline.Workspace)/tdslib-nextest.tar.zst $(Build.SourcesDirectory)
-          docker network create testnet
-          bash .pipeline/scripts/docker-cargo-run.sh --entrypoint bash -v "$PWD:/workspace" -e "DB_USERNAME=sa" -e "DB_HOST=$(ACI_SQL_HOST_2022)" -e "DB_PORT=14333" -e "SQL_PASSWORD=$(ACI_SQL_PASSWORD)" -e "ARCHIVE_NAME=tdslib-nextest.tar.zst" -e "TRUST_SERVER_CERTIFICATE=true" --network testnet $(container) /workspace/scripts/dockerentry/$(entry)
+          - task: DockerInstaller@0
+            inputs:
+              dockerVersion: '29.0.0'
+          - template: install-ubuntu-dependency.yaml
+            parameters:
+              installAzCli: false
+              installDocker: true
 
-        workingDirectory: "$(Build.SourcesDirectory)"
-        displayName: Run docker test
-        condition: succeeded()
-        env :
-          SQL_PASSWORD: $(SQL_PASSWORD)
-          CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN)
-          CARGO_REGISTRIES_MSSQL_RS_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_TOKEN)
-      - task: PublishTestResults@2
-        condition: succeededOrFailed()
-        displayName: "Publish test results"
-        inputs:
-          testResultsFormat: "JUnit"
-          testResultsFiles: $(Build.SourcesDirectory)/target/nextest/ci/junit.xml
-          testRunTitle: $(System.PhaseName)
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              buildType: 'current'
+              artifactName: 'Build_Linux_ARM'
+            displayName: 'Download Pipeline Artifacts'
 
-      
+          - bash: |
+              set -euo pipefail
+              bash .pipeline/scripts/sql-host/poll-for-endpoint.sh
+            displayName: 'Wait for SQL host endpoint sentinel'
+            workingDirectory: '$(Build.SourcesDirectory)'
+            env:
+              ARTIFACT_NAME: 'sql-ready-${{ target.name }}'
+              BUILD_BUILDID: $(Build.BuildId)
+              BUILD_SOURCESDIRECTORY: $(Build.SourcesDirectory)
+              SYSTEM_COLLECTIONURI: $(System.CollectionUri)
+              SYSTEM_TEAMPROJECT: $(System.TeamProject)
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+              AGENT_TEMPDIRECTORY: $(Agent.TempDirectory)
+
+          - script: |
+              set -euo pipefail
+              echo "container=${{ target.container }} entry=${{ target.entry }}"
+              echo "DB_HOST=$DB_HOST DB_PORT=$DB_PORT"
+
+              # ca.crt + mssql.pem are downloaded by poll-for-endpoint.sh
+              # from the sql-ready artifact; they match the cert chain the
+              # cross-pool SQL host is actually presenting on the wire.
+              scripts/generate_mock_tds_server_certs.sh
+
+              cp $(Pipeline.Workspace)/tdslib-nextest.tar.zst $(Build.SourcesDirectory)
+              docker network create testnet
+
+              bash .pipeline/scripts/docker-cargo-run.sh --entrypoint bash \
+                -v "$PWD:/workspace" \
+                -e "DB_USERNAME=sa" \
+                -e "DB_HOST=$DB_HOST" \
+                -e "DB_PORT=$DB_PORT" \
+                -e "SQL_PASSWORD=$(SQL_PASSWORD)" \
+                -e "ARCHIVE_NAME=tdslib-nextest.tar.zst" \
+                -e "TRUST_SERVER_CERTIFICATE=true" \
+                --network testnet \
+                ${{ target.container }} /workspace/scripts/dockerentry/${{ target.entry }}
+            workingDirectory: "$(Build.SourcesDirectory)"
+            displayName: Run docker test
+            condition: succeeded()
+            env:
+              DB_HOST: $(DB_HOST)
+              DB_PORT: $(DB_PORT)
+              SQL_PASSWORD: $(SQL_PASSWORD)
+              CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN)
+              CARGO_REGISTRIES_MSSQL_RS_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_TOKEN)
+
+          - task: PublishTestResults@2
+            condition: succeededOrFailed()
+            displayName: "Publish test results"
+            inputs:
+              testResultsFormat: "JUnit"
+              testResultsFiles: $(Build.SourcesDirectory)/target/nextest/ci/junit.xml
+              testRunTitle: $(System.PhaseName)
+
+          - script: |
+              mkdir -p "$(Agent.TempDirectory)/teardown"
+              echo "${{ target.name }} done at $(date -u +%FT%TZ)" \
+                > "$(Agent.TempDirectory)/teardown/done.txt"
+            displayName: 'Stage teardown sentinel'
+            condition: always()
+
+          - task: PublishPipelineArtifact@1
+            displayName: 'Publish teardown sentinel (release SQL host)'
+            condition: always()
+            inputs:
+              targetPath: '$(Agent.TempDirectory)/teardown'
+              artifact: '${{ target.name }}'
+              publishLocation: 'pipeline'

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -26,6 +26,19 @@ parameters:
   type: boolean
   default: true
 
+- name: sqlInstanceMode
+  displayName: SQL host cardinality for ARM test stages (shared = one SQL host per stage; per-job = one per matrix entry)
+  type: string
+  values:
+  - shared
+  - per-job
+  default: shared
+
+- name: sqlImageTag
+  displayName: SQL Server docker image tag for ARM test stages
+  type: string
+  default: '2025-latest'
+
 stages:
 - stage: EvaluateDuplicate
   displayName: Evaluate PR duplicate
@@ -486,6 +499,27 @@ stages:
             container: ghcr.io/microsoft/mssql-rs/import/alpine:3.21
             entry: alpine.sh
 
+- stage: Test_alpine_arm64_PR
+  dependsOn:
+    - Build
+    - EvaluateDuplicate
+  # Reduced musl ARM subset on PRs, hosted by the on-demand cross-pool SQL
+  # host (no static ACI IP). Full matrix still runs on merge below.
+  condition: and(not(canceled()), succeeded('Build'), eq(variables['Build.Reason'], 'PullRequest'), eq('${{ parameters.RunFuzz }}', 'false'), eq('${{ parameters.RunLongHaul }}', 'false'), ne(dependencies.EvaluateDuplicate.outputs['Evaluate.SetDuplicateState.skipDuplicate'], 'true'))
+  displayName: Test Alpine arm64 (PR)
+  jobs:
+    - template: test-matrix-template-alpine_arm64.yml
+      parameters:
+        artifactName: 'Build_Linux_ARM'
+        poolName: RUST-1ES-POOL-ARM-WUS3
+        poolImageOverride: imageOverride -equals RUST-UBUNTU-ARM64
+        sqlInstanceMode: ${{ parameters.sqlInstanceMode }}
+        sqlImageTag: ${{ parameters.sqlImageTag }}
+        targets:
+          - name: Alpine3_21
+            container: ghcr.io/microsoft/mssql-rs/import/alpine:3.21
+            entry: alpine.sh
+
 - stage: Test_alpine_arm64
   dependsOn: 
     - Build
@@ -497,17 +531,19 @@ stages:
         artifactName: 'Build_Linux_ARM'
         poolName: RUST-1ES-POOL-ARM-WUS3
         poolImageOverride: imageOverride -equals RUST-UBUNTU-ARM64
-        matrix:
-          Alpine3_18:
+        sqlInstanceMode: ${{ parameters.sqlInstanceMode }}
+        sqlImageTag: ${{ parameters.sqlImageTag }}
+        targets:
+          - name: Alpine3_18
             container: ghcr.io/microsoft/mssql-rs/import/alpine:3.18
             entry: alpine.sh
-          Alpine3_19:
+          - name: Alpine3_19
             container: ghcr.io/microsoft/mssql-rs/import/alpine:3.19
             entry: alpine.sh
-          Alpine3_20:
+          - name: Alpine3_20
             container: ghcr.io/microsoft/mssql-rs/import/alpine:3.20
             entry: alpine.sh
-          Alpine3_21:
+          - name: Alpine3_21
             container: ghcr.io/microsoft/mssql-rs/import/alpine:3.21
             entry: alpine.sh
 
@@ -543,6 +579,27 @@ stages:
             entry: deb-bookworm.sh
 
 
+- stage: Test_arm64_PR
+  dependsOn:
+    - Build
+    - EvaluateDuplicate
+  # Reduced glibc ARM subset on PRs, hosted by the on-demand cross-pool SQL
+  # host (no static ACI IP). Full matrix still runs on merge below.
+  condition: and(not(canceled()), succeeded('Build'), eq(variables['Build.Reason'], 'PullRequest'), eq('${{ parameters.RunFuzz }}', 'false'), eq('${{ parameters.RunLongHaul }}', 'false'), ne(dependencies.EvaluateDuplicate.outputs['Evaluate.SetDuplicateState.skipDuplicate'], 'true'))
+  displayName: Test Linux arm64 (PR)
+  jobs:
+    - template: test-matrix-template-arm64.yml
+      parameters:
+        sqlInstanceMode: ${{ parameters.sqlInstanceMode }}
+        sqlImageTag: ${{ parameters.sqlImageTag }}
+        targets:
+          - name: Ubuntu24
+            container: ghcr.io/microsoft/mssql-rs/import/ubuntu:24.04
+            entry: deb-bookworm.sh
+          - name: AzLinux3
+            container: mcr.microsoft.com/azurelinux/base/core:3.0
+            entry: azlinux3.sh
+
 - stage: Test_arm64
   dependsOn: 
     - Build
@@ -551,26 +608,28 @@ stages:
   jobs:
     - template: test-matrix-template-arm64.yml
       parameters:
-        matrix:
-          DebianBookworm:
+        sqlInstanceMode: ${{ parameters.sqlInstanceMode }}
+        sqlImageTag: ${{ parameters.sqlImageTag }}
+        targets:
+          - name: DebianBookworm
             container: ghcr.io/microsoft/mssql-rs/import/debian:bookworm
             entry: deb-bookworm.sh
-          AzLinux3:
+          - name: AzLinux3
             container: mcr.microsoft.com/azurelinux/base/core:3.0
             entry: azlinux3.sh
-          RHEL9:
+          - name: RHEL9
             container: ghcr.io/microsoft/mssql-rs/import/redhat/ubi9:latest
             entry: rhel.sh
-          OracleLinux9:
+          - name: OracleLinux9
             container: ghcr.io/microsoft/mssql-rs/import/oraclelinux:9
             entry: rhel.sh
-          SLES15:
+          - name: SLES15
             container: registry.suse.com/suse/sle15
             entry: sles.sh
-          Ubuntu22:
+          - name: Ubuntu22
             container: ghcr.io/microsoft/mssql-rs/import/ubuntu:22.04
             entry: deb-bookworm.sh
-          Ubuntu24:
+          - name: Ubuntu24
             container: ghcr.io/microsoft/mssql-rs/import/ubuntu:24.04
             entry: deb-bookworm.sh
 

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -74,6 +74,16 @@ stages:
       )
     )
   jobs:
+  # On-demand x64 SQL host for the ARM64 build's integration tests. ARM agents
+  # cannot run the x64 SQL Server image natively, so Build_Linux_ARM connects
+  # cross-pool to this host instead. PR-only: the ARM build only runs its test
+  # pass on PRs, and this job would otherwise idle an x64 agent on every merge.
+  - template: sql-host-template.yml
+    parameters:
+      instanceId: build_arm
+      expectedSentinels: build_arm
+      sqlImageTag: ${{ parameters.sqlImageTag }}
+      jobCondition: eq(variables['Build.Reason'], 'PullRequest')
   - job: Build_Windows
     displayName: Build Windows
     pool:
@@ -246,7 +256,7 @@ stages:
         parameters:
           architecture: ARM64
           buildType: ${{ parameters.buildType }}
-          testFilter: -E 'not (test(query_processing_driver) | test(query_result) | test(connectivity) | test(transaction) | test(rpc_results) | test(timeout_and_cancel) | test(rpc_datatypes) | test(client_based_iterators) | test(connect_fetch_multiple_packets) | test(iter_rows) | test(bulk_copy) | test(transport_protocols) | test(vector_integration_tests) | test(no_protocol_resolution) | test(multi_subnet_failover) | test(encryption_tests) | binary(test_tls_handshake) | binary(test_tvp) | binary(test_cursor_ops) | binary(test_reset_connection) | binary(test_connection_pool_primitives))'
+          testFilter: -E 'not (test(connectivity))'
           additionalPythonTestArgs: '--skip-integration'
       - template: build-template-alpine.yml
         parameters:
@@ -499,27 +509,6 @@ stages:
             container: ghcr.io/microsoft/mssql-rs/import/alpine:3.21
             entry: alpine.sh
 
-- stage: Test_alpine_arm64_PR
-  dependsOn:
-    - Build
-    - EvaluateDuplicate
-  # Reduced musl ARM subset on PRs, hosted by the on-demand cross-pool SQL
-  # host (no static ACI IP). Full matrix still runs on merge below.
-  condition: and(not(canceled()), succeeded('Build'), eq(variables['Build.Reason'], 'PullRequest'), eq('${{ parameters.RunFuzz }}', 'false'), eq('${{ parameters.RunLongHaul }}', 'false'), ne(dependencies.EvaluateDuplicate.outputs['Evaluate.SetDuplicateState.skipDuplicate'], 'true'))
-  displayName: Test Alpine arm64 (PR)
-  jobs:
-    - template: test-matrix-template-alpine_arm64.yml
-      parameters:
-        artifactName: 'Build_Linux_ARM'
-        poolName: RUST-1ES-POOL-ARM-WUS3
-        poolImageOverride: imageOverride -equals RUST-UBUNTU-ARM64
-        sqlInstanceMode: ${{ parameters.sqlInstanceMode }}
-        sqlImageTag: ${{ parameters.sqlImageTag }}
-        targets:
-          - name: Alpine3_21
-            container: ghcr.io/microsoft/mssql-rs/import/alpine:3.21
-            entry: alpine.sh
-
 - stage: Test_alpine_arm64
   dependsOn: 
     - Build
@@ -578,27 +567,6 @@ stages:
             container: ghcr.io/microsoft/mssql-rs/import/ubuntu:24.04
             entry: deb-bookworm.sh
 
-
-- stage: Test_arm64_PR
-  dependsOn:
-    - Build
-    - EvaluateDuplicate
-  # Reduced glibc ARM subset on PRs, hosted by the on-demand cross-pool SQL
-  # host (no static ACI IP). Full matrix still runs on merge below.
-  condition: and(not(canceled()), succeeded('Build'), eq(variables['Build.Reason'], 'PullRequest'), eq('${{ parameters.RunFuzz }}', 'false'), eq('${{ parameters.RunLongHaul }}', 'false'), ne(dependencies.EvaluateDuplicate.outputs['Evaluate.SetDuplicateState.skipDuplicate'], 'true'))
-  displayName: Test Linux arm64 (PR)
-  jobs:
-    - template: test-matrix-template-arm64.yml
-      parameters:
-        sqlInstanceMode: ${{ parameters.sqlInstanceMode }}
-        sqlImageTag: ${{ parameters.sqlImageTag }}
-        targets:
-          - name: Ubuntu24
-            container: ghcr.io/microsoft/mssql-rs/import/ubuntu:24.04
-            entry: deb-bookworm.sh
-          - name: AzLinux3
-            container: mcr.microsoft.com/azurelinux/base/core:3.0
-            entry: azlinux3.sh
 
 - stage: Test_arm64
   dependsOn: 

--- a/.pipeline/validation-pipeline-ci.yml
+++ b/.pipeline/validation-pipeline-ci.yml
@@ -26,11 +26,26 @@ parameters:
   type: boolean
   default: false
 
+- name: sqlInstanceMode
+  displayName: SQL host cardinality for ARM test stages
+  type: string
+  values:
+  - shared
+  - per-job
+  default: shared
+
+- name: sqlImageTag
+  displayName: SQL Server docker image tag for ARM test stages
+  type: string
+  default: '2025-latest'
+
 stages:
 - template: templates/validation-stages.yml
   parameters:
     buildType: ${{ parameters.buildType }}
     RunFuzz: ${{ parameters.RunFuzz }}
     RunLongHaul: ${{ parameters.RunLongHaul }}
+    sqlInstanceMode: ${{ parameters.sqlInstanceMode }}
+    sqlImageTag: ${{ parameters.sqlImageTag }}
     # Runs with internal resource access, so keep the infra stages.
     includeInfraStages: true

--- a/.pipeline/validation-pipeline.yml
+++ b/.pipeline/validation-pipeline.yml
@@ -23,12 +23,27 @@ parameters:
   type: boolean
   default: false
 
+- name: sqlInstanceMode
+  displayName: SQL host cardinality for ARM test stages
+  type: string
+  values:
+  - shared
+  - per-job
+  default: shared
+
+- name: sqlImageTag
+  displayName: SQL Server docker image tag for ARM test stages
+  type: string
+  default: '2025-latest'
+
 stages:
 - template: templates/validation-stages.yml
   parameters:
     buildType: ${{ parameters.buildType }}
     RunFuzz: ${{ parameters.RunFuzz }}
     RunLongHaul: ${{ parameters.RunLongHaul }}
+    sqlInstanceMode: ${{ parameters.sqlInstanceMode }}
+    sqlImageTag: ${{ parameters.sqlImageTag }}
     # PR validation for internal ADO and GitHub PRs. GitHub PRs run in the public
     # project, which lacks 'Magnitude Test', so exclude the infra stages here.
     includeInfraStages: false

--- a/scripts/generate_cert.sh
+++ b/scripts/generate_cert.sh
@@ -18,6 +18,14 @@ SAN_DNS="sql1"
 LOCAL_HOSTNAME=$(hostname 2>/dev/null || echo "")
 echo "Adding local hostname to SAN: $LOCAL_HOSTNAME"
 
+# Optional extra IP SAN entry (e.g. the public IP a cross-pool SQL host is
+# reached on). Set EXTRA_IP_SAN to have it added to the certificate.
+EXTRA_IP_SAN_LINE=""
+if [ -n "${EXTRA_IP_SAN:-}" ]; then
+    echo "Adding extra IP to SAN: $EXTRA_IP_SAN"
+    EXTRA_IP_SAN_LINE="IP.3 = $EXTRA_IP_SAN"
+fi
+
 # 1. Generate self-signed CA
 openssl req -x509 -nodes -newkey rsa:4096 -sha256 \
     -keyout "$CA_KEY" \
@@ -46,6 +54,7 @@ DNS.2 = localhost
 DNS.3 = $LOCAL_HOSTNAME
 IP.1 = 127.0.0.1
 IP.2 = ::1
+${EXTRA_IP_SAN_LINE:-}
 
 [ v3_ext ]
 authorityKeyIdentifier=keyid,issuer

--- a/scripts/generate_cert.sh
+++ b/scripts/generate_cert.sh
@@ -18,8 +18,8 @@ SAN_DNS="sql1"
 LOCAL_HOSTNAME=$(hostname 2>/dev/null || echo "")
 echo "Adding local hostname to SAN: $LOCAL_HOSTNAME"
 
-# Optional extra IP SAN entry (e.g. the public IP a cross-pool SQL host is
-# reached on). Set EXTRA_IP_SAN to have it added to the certificate.
+# Optional extra IP SAN entry (e.g. the private VNet IPv4 a cross-pool SQL
+# host is reached on). Set EXTRA_IP_SAN to have it added to the certificate.
 EXTRA_IP_SAN_LINE=""
 if [ -n "${EXTRA_IP_SAN:-}" ]; then
     echo "Adding extra IP to SAN: $EXTRA_IP_SAN"


### PR DESCRIPTION
## Summary

[AB#46050](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46050)
[AB#46051](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46051)

Ports the IP-decoupling changes from the internal ADO PR (#7479) to GitHub, and additionally enables ARM validation on pull requests.

Previously the ARM64 Linux test stages (`Test_arm64` glibc, `Test_alpine_arm64` musl) connected to a long-lived SQL Server hosted in Azure Container Instances, referenced by a **static IP** (`$(ACI_SQL_HOST_2022)` on port 14333). This couples the test runs to standing infrastructure and a hard-coded endpoint.

This PR replaces that with an **on-demand SQL Server docker container** booted on an x64 1ES agent for the duration of each ARM test stage.

## How it works

- The SQL host job and the ARM test jobs run **concurrently** (no ADO `dependsOn`, which would deadlock) and rendezvous via **pipeline-artifact sentinels**:
  - `sql-ready-<instanceId>` (host → test) carries the endpoint + `ca.crt`/`mssql.pem`.
  - per-matrix-entry teardown sentinels (test → host, published `always()`) release the SQL host.
- The SA password is **derived deterministically** from the build context, so both jobs agree without transporting a secret.
- Two cardinality modes via `sqlInstanceMode`: `shared` (one SQL host per stage — default) or `per-job`. `sqlImageTag` defaults to `2025-latest`.

## Running ARM tests on PRs

The ARM stages were previously gated off for PRs (`ne PullRequest`). Because the SQL host is now on-demand (no static endpoint to contend for), ARM tests now run on PRs too, following the existing Kerberos PR/merge split:

| Stage | Trigger | Matrix |
|---|---|---|
| `Test_arm64_PR` | PR | Ubuntu24, AzLinux3 |
| `Test_alpine_arm64_PR` | PR | Alpine3_21 |
| `Test_arm64` | merge | full glibc matrix (7 distros) |
| `Test_alpine_arm64` | merge | full musl matrix (Alpine 3.18–3.21) |

The `_PR` stages depend on `Build` (for the `Build_Linux_ARM` artifact) and `EvaluateDuplicate`, and are skipped when a prior successful PR validation is detected.

## Scope

- **No Rust files** are included — only pipeline YAML, shell scripts, and docs.
- Container registry values keep GitHub's `ghcr.io/microsoft/mssql-rs/...` (not the ADO `tdslibrs.azurecr.io`).
- The ADO PR's `installAzCli: true` + `azure-cli-login-template.yml` steps are intentionally **omitted** — ghcr images are public and az login isn't needed for the sentinel/REST-API decoupling.

See `.pipeline/docs/arm-sql-host-design.md` for the full design.

