### PR TITLE
Always Encrypted (Phase 1B): fixed 16-byte decimal magnitude + length-tolerant reader

### DIFF
--- a/mssql-tds/src/security/encryption/cell.rs
+++ b/mssql-tds/src/security/encryption/cell.rs
@@ -21,7 +21,8 @@
 //! * `real`/`float` keep their 4- or 8-byte IEEE form.
 //! * `smallmoney`/`money` are normalized to the 8-byte `money` form (high dword
 //!   then low dword); `smallmoney` is sign-extended into that form.
-//! * `decimal`/`numeric` are a sign byte followed by the little-endian magnitude.
+//! * `decimal`/`numeric` are a sign byte followed by a fixed 16-byte
+//!   little-endian magnitude (four 32-bit words, zero-extended).
 //! * `binary`/`varbinary` and `uniqueidentifier` keep their raw bytes.
 //! * Character types keep their encoded bytes (UTF-16LE for the `n` types, the
 //!   collation code page otherwise).
@@ -53,6 +54,18 @@ use crate::security::encryption::ColumnEncryptionType;
 const AEAD_AES_256_CBC_HMAC_SHA256_ALGORITHM_ID: u8 = 0x02;
 /// The only cell-normalization rule version defined by SQL Server today.
 const SUPPORTED_NORMALIZATION_VERSION: u8 = 0x01;
+/// Number of 32-bit words in the canonical `decimal`/`numeric` magnitude.
+///
+/// The Always Encrypted normalized form for `decimal`/`numeric` is a sign byte
+/// followed by a fixed 16-byte magnitude (four 32-bit little-endian words,
+/// zero-extended). This matches SQL Server and the reference drivers (.NET
+/// `SerializeDecimal`/`SerializeSqlDecimal`, msodbcsql), so deterministic
+/// ciphertext is byte-compatible across drivers. A valid decimal magnitude
+/// (precision <= 38) always fits in 128 bits.
+const DECIMAL_MAGNITUDE_WORDS: usize = 4;
+/// Total length of the normalized `decimal`/`numeric` form: 1 sign byte plus the
+/// fixed 16-byte magnitude.
+const DECIMAL_NORMALIZED_LEN: usize = 1 + DECIMAL_MAGNITUDE_WORDS * 4;
 
 /// Decrypts an encrypted cell blob and denormalizes it into a typed value.
 ///
@@ -332,16 +345,18 @@ fn read_decimal(bytes: &[u8], base_type_info: &TypeInfo) -> TdsResult<DecimalPar
         .split_first()
         .ok_or_else(|| length_error("decimal sign byte", bytes.len()))?;
 
-    if magnitude.len() % 4 != 0 {
-        return Err(Error::ColumnEncryptionError(format!(
-            "Invalid decimal magnitude length {} (must be a multiple of 4)",
-            magnitude.len()
-        )));
-    }
-
+    // Reference AE readers are length-tolerant: .NET reads `length >> 2` 32-bit
+    // groups and ignores any trailing partial group, and JDBC uses the actual
+    // length (its bulk-copy path writes a 15-byte magnitude). Zero-pad a short
+    // trailing group into a full 32-bit word rather than rejecting it, so we can
+    // read magnitudes produced by every reference driver.
     let int_parts = magnitude
-        .chunks_exact(4)
-        .map(|chunk| i32::from_le_bytes(chunk.try_into().expect("chunk is exactly 4 bytes")))
+        .chunks(4)
+        .map(|chunk| {
+            let mut word = [0u8; 4];
+            word[..chunk.len()].copy_from_slice(chunk);
+            i32::from_le_bytes(word)
+        })
         .collect();
 
     Ok(DecimalParts {
@@ -712,12 +727,21 @@ fn normalize_small_money(m: &SqlSmallMoney) -> Vec<u8> {
 }
 
 /// Normalizes a `decimal`/`numeric` value: a sign byte (`1` = positive) followed
-/// by the little-endian magnitude in 32-bit groups.
+/// by a fixed 16-byte little-endian magnitude (four 32-bit words, zero-extended).
+///
+/// The fixed-width magnitude matches SQL Server's canonical form and the
+/// reference drivers (.NET `SerializeDecimal`/`SerializeSqlDecimal`, msodbcsql),
+/// so deterministically-encrypted decimal values are byte-compatible across
+/// drivers. The value's magnitude is scaled to its own `scale`, which the RPC
+/// parameter also declares on the wire, so both sides agree on the scale.
 fn normalize_decimal(d: &DecimalParts) -> Vec<u8> {
-    let mut out = Vec::with_capacity(1 + d.int_parts.len() * 4);
+    let mut out = Vec::with_capacity(DECIMAL_NORMALIZED_LEN);
     out.push(u8::from(d.is_positive));
-    for part in &d.int_parts {
-        out.extend_from_slice(&part.to_le_bytes());
+    // A valid decimal/numeric magnitude (precision <= 38) fits in four 32-bit
+    // words, so any words beyond the first four are zero.
+    for i in 0..DECIMAL_MAGNITUDE_WORDS {
+        let word = d.int_parts.get(i).copied().unwrap_or(0);
+        out.extend_from_slice(&word.to_le_bytes());
     }
     out
 }
@@ -1247,6 +1271,9 @@ mod tests {
 
     #[test]
     fn normalize_decimal_layout() {
+        // The magnitude is emitted as a fixed 16-byte (four 32-bit words),
+        // zero-extended form, so two significant words are followed by two zero
+        // words. Total length is 1 sign byte + 16 magnitude bytes = 17.
         let d = DecimalParts {
             is_positive: false,
             scale: 2,
@@ -1256,10 +1283,83 @@ mod tests {
         let mut expected = vec![0u8];
         expected.extend_from_slice(&1i32.to_le_bytes());
         expected.extend_from_slice(&2i32.to_le_bytes());
+        expected.extend_from_slice(&0i32.to_le_bytes());
+        expected.extend_from_slice(&0i32.to_le_bytes());
+        let actual = normalize(&SqlType::Decimal(Some(d))).unwrap().unwrap();
+        assert_eq!(actual.len(), 17);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn normalize_decimal_pads_small_value_to_fixed_width() {
+        // A value that needs only one 32-bit word must still be emitted as the
+        // canonical 17-byte form (sign + four words) so deterministic ciphertext
+        // matches .NET/msodbcsql, which always zero-extend to 16 magnitude bytes.
+        let d = DecimalParts {
+            is_positive: true,
+            scale: 2,
+            precision: 5,
+            int_parts: vec![12345],
+        };
+        let mut expected = vec![1u8];
+        expected.extend_from_slice(&12345i32.to_le_bytes());
+        expected.extend_from_slice(&0i32.to_le_bytes());
+        expected.extend_from_slice(&0i32.to_le_bytes());
+        expected.extend_from_slice(&0i32.to_le_bytes());
         assert_eq!(
-            normalize(&SqlType::Decimal(Some(d))).unwrap().unwrap(),
+            normalize(&SqlType::Numeric(Some(d))).unwrap().unwrap(),
             expected
         );
+    }
+
+    #[test]
+    fn read_decimal_is_length_tolerant() {
+        // A 15-byte magnitude (JDBC bulk-copy writes this form) must be accepted,
+        // zero-padding the short trailing group into a full 32-bit word rather
+        // than being rejected. Value 12345 with scale 2 => 123.45.
+        let info = type_info(
+            TdsDataType::DecimalN,
+            5,
+            TypeInfoVariant::VarLenPrecisionScale(VariableLengthTypes::DecimalN, 17, 5, 2),
+        );
+        let mut bytes = vec![1u8]; // positive sign
+        bytes.extend_from_slice(&12345i32.to_le_bytes()); // first 32-bit word
+        bytes.extend_from_slice(&[0u8; 11]); // 11 more bytes => 15-byte magnitude
+        let value = denormalize(&bytes, TdsDataType::DecimalN, &info, 1).unwrap();
+        match value {
+            ColumnValues::Decimal(parts) => {
+                assert!(parts.is_positive);
+                assert_eq!(parts.scale, 2);
+                assert_eq!(parts.to_string(), "123.45");
+            }
+            other => panic!("expected Decimal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn normalize_then_read_decimal_roundtrips() {
+        // The fixed-width write form must read back to the same value through the
+        // (now length-tolerant) reader.
+        let d = DecimalParts {
+            is_positive: false,
+            scale: 3,
+            precision: 12,
+            int_parts: vec![987654],
+        };
+        let normalized = normalize(&SqlType::Decimal(Some(d))).unwrap().unwrap();
+        let info = type_info(
+            TdsDataType::DecimalN,
+            12,
+            TypeInfoVariant::VarLenPrecisionScale(VariableLengthTypes::DecimalN, 17, 12, 3),
+        );
+        let value = denormalize(&normalized, TdsDataType::DecimalN, &info, 1).unwrap();
+        match value {
+            ColumnValues::Decimal(parts) => {
+                assert!(!parts.is_positive);
+                assert_eq!(parts.to_string(), "-987.654");
+            }
+            other => panic!("expected Decimal, got {other:?}"),
+        }
     }
 
     #[test]

--- a/mssql-tds/src/security/encryption/cell.rs
+++ b/mssql-tds/src/security/encryption/cell.rs
@@ -363,9 +363,11 @@ fn read_decimal(bytes: &[u8], base_type_info: &TypeInfo) -> TdsResult<DecimalPar
 
     // Reference AE readers are length-tolerant: .NET reads `length >> 2` 32-bit
     // groups and ignores any trailing partial group, and JDBC uses the actual
-    // length (its bulk-copy path writes a 15-byte magnitude). Zero-pad a short
-    // trailing group into a full 32-bit word rather than rejecting it, so we can
-    // read magnitudes produced by every reference driver.
+    // length (its bulk-copy path writes a 15-byte magnitude). We zero-pad a
+    // short trailing group into a full 32-bit word rather than rejecting it, and
+    // — unlike .NET — we preserve those trailing bytes instead of dropping them,
+    // so no significant magnitude bits are lost. This lets us read magnitudes
+    // produced by every reference driver.
     let int_parts = magnitude
         .chunks(4)
         .map(|chunk| {
@@ -754,7 +756,18 @@ fn normalize_decimal(d: &DecimalParts) -> Vec<u8> {
     let mut out = Vec::with_capacity(DECIMAL_NORMALIZED_LEN);
     out.push(u8::from(d.is_positive));
     // A valid decimal/numeric magnitude (precision <= 38) fits in four 32-bit
-    // words, so any words beyond the first four are zero.
+    // words, so any words beyond the first four are zero. Emitting only the
+    // first four therefore never loses data for a valid value; assert that
+    // invariant in debug/test builds so a malformed `DecimalParts` (e.g. built
+    // for a > 38-digit value) is caught here rather than silently truncated into
+    // wrong ciphertext. The reader rejects the oversized case at runtime.
+    debug_assert!(
+        d.int_parts
+            .get(DECIMAL_MAGNITUDE_WORDS..)
+            .is_none_or(|extra| extra.iter().all(|&word| word == 0)),
+        "decimal magnitude exceeds 128 bits (precision <= 38): {:?}",
+        d.int_parts
+    );
     for i in 0..DECIMAL_MAGNITUDE_WORDS {
         let word = d.int_parts.get(i).copied().unwrap_or(0);
         out.extend_from_slice(&word.to_le_bytes());
@@ -1326,6 +1339,22 @@ mod tests {
             normalize(&SqlType::Numeric(Some(d))).unwrap().unwrap(),
             expected
         );
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "decimal magnitude exceeds 128 bits")]
+    fn normalize_decimal_asserts_bounded_magnitude() {
+        // A malformed DecimalParts carrying a non-zero word beyond the 128-bit
+        // limit must trip the debug-only invariant check rather than silently
+        // truncating into wrong ciphertext.
+        let d = DecimalParts {
+            is_positive: true,
+            scale: 0,
+            precision: 38,
+            int_parts: vec![0, 0, 0, 0, 1],
+        };
+        let _ = normalize(&SqlType::Decimal(Some(d)));
     }
 
     #[test]

--- a/mssql-tds/src/security/encryption/cell.rs
+++ b/mssql-tds/src/security/encryption/cell.rs
@@ -63,9 +63,12 @@ const SUPPORTED_NORMALIZATION_VERSION: u8 = 0x01;
 /// ciphertext is byte-compatible across drivers. A valid decimal magnitude
 /// (precision <= 38) always fits in 128 bits.
 const DECIMAL_MAGNITUDE_WORDS: usize = 4;
+/// The fixed magnitude width in bytes (four 32-bit words = 128 bits). A valid
+/// `decimal`/`numeric` (precision <= 38) never needs more than this.
+const DECIMAL_MAGNITUDE_BYTES: usize = DECIMAL_MAGNITUDE_WORDS * 4;
 /// Total length of the normalized `decimal`/`numeric` form: 1 sign byte plus the
 /// fixed 16-byte magnitude.
-const DECIMAL_NORMALIZED_LEN: usize = 1 + DECIMAL_MAGNITUDE_WORDS * 4;
+const DECIMAL_NORMALIZED_LEN: usize = 1 + DECIMAL_MAGNITUDE_BYTES;
 
 /// Decrypts an encrypted cell blob and denormalizes it into a typed value.
 ///
@@ -344,6 +347,19 @@ fn read_decimal(bytes: &[u8], base_type_info: &TypeInfo) -> TdsResult<DecimalPar
     let (sign, magnitude) = bytes
         .split_first()
         .ok_or_else(|| length_error("decimal sign byte", bytes.len()))?;
+
+    // A valid decimal/numeric magnitude (precision <= 38) fits in 128 bits, so
+    // it is at most 16 bytes (four 32-bit words). Reject anything longer: it
+    // signals wire-format drift or corrupted plaintext, would allocate an
+    // unbounded `int_parts`, and would break the downstream `DecimalParts`
+    // formatting, which folds `int_parts` into a `u128` (only four words wide).
+    if magnitude.len() > DECIMAL_MAGNITUDE_BYTES {
+        return Err(Error::ColumnEncryptionError(format!(
+            "Invalid decimal magnitude length {} (max {DECIMAL_MAGNITUDE_BYTES} bytes for \
+             precision <= 38)",
+            magnitude.len()
+        )));
+    }
 
     // Reference AE readers are length-tolerant: .NET reads `length >> 2` 32-bit
     // groups and ignores any trailing partial group, and JDBC uses the actual
@@ -1334,6 +1350,22 @@ mod tests {
             }
             other => panic!("expected Decimal, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn read_decimal_rejects_oversized_magnitude() {
+        // A valid decimal magnitude is at most 16 bytes (128 bits). A longer
+        // magnitude must be rejected rather than allocating an unbounded
+        // `int_parts` or overflowing the downstream `u128` fold.
+        let info = type_info(
+            TdsDataType::DecimalN,
+            5,
+            TypeInfoVariant::VarLenPrecisionScale(VariableLengthTypes::DecimalN, 17, 5, 2),
+        );
+        let mut bytes = vec![1u8]; // positive sign
+        bytes.extend_from_slice(&[0u8; 17]); // 17-byte magnitude => too long
+        let error = denormalize(&bytes, TdsDataType::DecimalN, &info, 1).unwrap_err();
+        assert!(matches!(error, Error::ColumnEncryptionError(_)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Phase 1B follow-up to the Always Encrypted work in #83, addressing the two `decimal`/`numeric` deterministic-normalization review comments from @Vahid-b. No behavior changes outside encrypted `decimal`/`numeric` normalization.

## Changes

Both in `mssql-tds/src/security/encryption/cell.rs`:

- **Write path (`normalize_decimal`)** — emit the canonical Always Encrypted form for `decimal`/`numeric`: a sign byte followed by a **fixed 16-byte magnitude** (four 32-bit little-endian words, zero-extended) = 17 bytes total. Previously we emitted a minimal-width magnitude (`1 + int_parts.len()*4` bytes), so we only produced identical bytes when the value needed all four words. The fixed-width form matches SQL Server's canonical normalization and the reference drivers (.NET `SerializeDecimal`/`SerializeSqlDecimal`, msodbcsql), so **deterministically-encrypted decimal values are now byte-compatible across drivers** — equality/join/unique-index lookups on a deterministic decimal column match rows inserted by .NET/SSMS/msodbcsql. Randomized encryption and same-driver round-trips were already correct and are unchanged.
- **Read path (`read_decimal`)** — stop hard-erroring on a magnitude length that isn't a multiple of 4. Reference readers are length-tolerant (.NET reads `length >> 2` groups and ignores the remainder; JDBC uses the actual length and its bulk-copy path writes a 15-byte magnitude). We now zero-pad a short trailing group into a full 32-bit word, so we can read magnitudes produced by every reference driver.

## On "rescale to the column's scale"

The review also suggested rescaling to the column's scale rather than the parameter's. For the `sp_executesql` path this is not a separate step: the `decimal` RPC parameter serializes its own precision/scale (`sqltypes.rs` `write_type_info`, from `DecimalParts`), and `int_parts` are built at that same scale, so the declared scale equals the normalized scale. `sp_describe_parameter_encryption` does not return a distinct target-column scale to rescale to. The fixed-width magnitude is therefore the actual interop fix; no scale change is needed here.

## Testing

- `cargo clippy --all-targets -- -D warnings` clean.
- New/updated unit tests in `cell.rs`: pinned 17-byte layout, small-value zero-extension padding, 15-byte length-tolerant read (JDBC bulk-copy form), and a `normalize` → `read` round-trip (incl. a negative value). All 41 `cell` unit tests pass.
- Live `roundtrip_decimal_and_money_types` Always Encrypted integration test passes against SQL Server 2022.

## Follow-up (still Phase 1B)

- Deterministic normalization to the target column's **collation/code page** for `char`/`varchar` — still needs research (partly a shared server-side limitation of `sp_describe_parameter_encryption` for `sp_executesql`).
