### PR TITLE
Add Windows Python wheel signing

### DIFF
--- a/.pipeline/OneBranch/OfficialPythonWheelsRelease.yml
+++ b/.pipeline/OneBranch/OfficialPythonWheelsRelease.yml
@@ -149,12 +149,13 @@ extends:
             # Collect wheels
             $wheelsDir = "$(Build.StagingDirectory)/wheels"
             New-Item -ItemType Directory -Force -Path $wheelsDir | Out-Null
-            $wheels = Get-ChildItem "$(Pipeline.Workspace)/officialBuild" -Filter *.whl -Recurse
+            $wheels = Get-ChildItem "$(Pipeline.Workspace)/officialBuild" -Filter *.whl -Recurse |
+              Where-Object { $_.FullName -match '[\\/]+wheels[\\/][^\\/]+\.whl$' }
             if ($wheels.Count -eq 0) {
               Write-Error "No wheels found to package. Aborting."
               exit 1
             }
-            $wheels | Copy-Item -Destination $wheelsDir
+            $wheels | Copy-Item -Destination $wheelsDir -Force
             Write-Host "Collected $($wheels.Count) wheels"
 
             # Create .nuspec

--- a/.pipeline/OneBranch/stages.yml
+++ b/.pipeline/OneBranch/stages.yml
@@ -52,9 +52,14 @@ stages:
       demands:
         - imageOverride -equals RUST-Win22-Sql25-1P
     variables:
-      ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
-      ob_artifactSuffix: '_windows_x64'
-      CARGO_TARGET_DIR: C:\cargo_target_dir
+    - ${{ if eq(parameters.isOfficial, true) }}:
+      - group: 'ESRP Federated Creds (AME)'
+    - name: ob_outputDirectory
+      value: '$(Build.ArtifactStagingDirectory)'
+    - name: ob_artifactSuffix
+      value: '_windows_x64'
+    - name: CARGO_TARGET_DIR
+      value: C:\cargo_target_dir
     steps:
     - template: /.pipeline/templates/cargo-authenticate-template.yml
       parameters:
@@ -71,6 +76,7 @@ stages:
           osType: Windows
           architecture: x64
           publishArtifacts: false
+          signWindowsWheels: ${{ parameters.isOfficial }}
     - task: PublishPipelineArtifact@1
       displayName: 'Publish Windows x64 Artifacts'
       inputs:
@@ -91,9 +97,14 @@ stages:
         demands:
           - imageOverride -equals RUST-WINSRV-ARM
       variables:
-        ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
-        ob_artifactSuffix: '_windows_arm64'
-        CARGO_TARGET_DIR: C:\cargo_target_dir
+      - ${{ if eq(parameters.isOfficial, true) }}:
+        - group: 'ESRP Federated Creds (AME)'
+      - name: ob_outputDirectory
+        value: '$(Build.ArtifactStagingDirectory)'
+      - name: ob_artifactSuffix
+        value: '_windows_arm64'
+      - name: CARGO_TARGET_DIR
+        value: C:\cargo_target_dir
       steps:
       # Node.js workaround for ARM64 ADO tasks
       - pwsh: ./scripts/setup-nodejs-path.ps1
@@ -115,6 +126,7 @@ stages:
             osType: Windows
             architecture: arm64
             publishArtifacts: false
+            signWindowsWheels: ${{ parameters.isOfficial }}
             # Python 3.10 excluded - limited ARM64 support
             pythonVersions:
             - '3.11'

--- a/.pipeline/templates/build-python-wheels-template.yml
+++ b/.pipeline/templates/build-python-wheels-template.yml
@@ -178,7 +178,7 @@ steps:
         Write-Host "Building Python wheel for Python ${{ pythonVersion }}..."
         python --version
         
-        # Install build and wheel repair tools for this Python version
+        # Install build tooling (maturin) and wheel utilities for this Python version
         pip install maturin wheel
         
         # Create wheels output directory

--- a/.pipeline/templates/build-python-wheels-template.yml
+++ b/.pipeline/templates/build-python-wheels-template.yml
@@ -22,6 +22,13 @@ parameters:
   type: boolean
   default: true
   displayName: 'Publish wheel artifacts (disable for OneBranch pipeline)'
+- name: signWindowsWheels
+  type: boolean
+  default: false
+  displayName: 'Sign Windows native extensions inside Python wheels'
+- name: esrpConnectedServiceName
+  type: string
+  default: 'ESRP Managed Identity federated auth - AME tenant-mssql-rs'
 
 steps:
 # Container-based builds for Linux (glibc - manylinux)
@@ -171,8 +178,8 @@ steps:
         Write-Host "Building Python wheel for Python ${{ pythonVersion }}..."
         python --version
         
-        # Install maturin for this Python version
-        pip install maturin
+        # Install build and wheel repair tools for this Python version
+        pip install maturin wheel
         
         # Create wheels output directory
         New-Item -ItemType Directory -Force -Path "$(ob_outputDirectory)\wheels"
@@ -183,6 +190,162 @@ steps:
         
         Write-Host "Wheel built successfully for Python ${{ pythonVersion }}"
       displayName: 'Build wheel for Python ${{ pythonVersion }} (Windows ${{ parameters.architecture }})'
+
+  - ${{ if eq(parameters.signWindowsWheels, true) }}:
+    - pwsh: |
+        $ErrorActionPreference = 'Stop'
+
+        $wheelsDir = "$(ob_outputDirectory)\wheels"
+        $unsignedDir = "$(ob_outputDirectory)\unsigned-wheels"
+        $unpackedRoot = "$(ob_outputDirectory)\wheel-unpacked"
+
+        Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $unsignedDir, $unpackedRoot
+        New-Item -ItemType Directory -Force -Path $unsignedDir, $unpackedRoot | Out-Null
+
+        $wheels = @(Get-ChildItem $wheelsDir -Filter *.whl -File)
+        if ($wheels.Count -eq 0) {
+          Write-Error "No Windows wheels found to sign in $wheelsDir"
+          exit 1
+        }
+
+        foreach ($wheel in $wheels) {
+          Move-Item -Path $wheel.FullName -Destination $unsignedDir
+        }
+
+        foreach ($wheel in Get-ChildItem $unsignedDir -Filter *.whl -File) {
+          Write-Host "Unpacking $($wheel.Name)"
+          $wheelUnpackDir = Join-Path $unpackedRoot $wheel.BaseName
+          New-Item -ItemType Directory -Force -Path $wheelUnpackDir | Out-Null
+          python -m wheel unpack "$($wheel.FullName)" --dest "$wheelUnpackDir"
+        }
+
+        $nativeFiles = @(Get-ChildItem $unpackedRoot -Recurse -Include *.pyd,*.dll -File)
+        if ($nativeFiles.Count -eq 0) {
+          Write-Error "No native Windows binaries (*.pyd, *.dll) found in unpacked wheels"
+          exit 1
+        }
+
+        Write-Host "Native binaries to sign:"
+        $nativeFiles | ForEach-Object { Write-Host "  $($_.FullName)" }
+      displayName: 'Unpack Windows wheels for ESRP signing'
+
+    - task: EsrpMalwareScanning@6
+      displayName: 'ESRP Malware Scanning Windows wheel binaries'
+      inputs:
+        ConnectedServiceName: '${{ parameters.esrpConnectedServiceName }}'
+        AppRegistrationClientId: '$(appRegistrationClientId)'
+        AppRegistrationTenantId: '$(appRegistrationTenantId)'
+        EsrpClientId: '$(EsrpClientId)'
+        FolderPath: '$(ob_outputDirectory)\wheel-unpacked'
+        Pattern: |
+          **/*.pyd
+          **/*.dll
+        UseMinimatch: true
+        UseMSIAuthentication: true
+        CleanupTempStorage: true
+        VerboseLogin: true
+
+    - task: EsrpCodeSigning@6
+      displayName: 'ESRP CodeSigning Windows wheel binaries'
+      inputs:
+        ConnectedServiceName: '${{ parameters.esrpConnectedServiceName }}'
+        UseMSIAuthentication: true
+        AppRegistrationClientId: '$(appRegistrationClientId)'
+        AppRegistrationTenantId: '$(appRegistrationTenantId)'
+        EsrpClientId: '$(EsrpClientId)'
+        AuthAKVName: '$(AuthAKVName)'
+        AuthSignCertName: '$(AuthSignCertName)'
+        FolderPath: '$(ob_outputDirectory)\wheel-unpacked'
+        Pattern: |
+          **/*.pyd
+          **/*.dll
+        UseMinimatch: true
+        signConfigType: inlineSignParams
+        inlineOperation: |
+          [
+            {
+              "KeyCode": "CP-230012",
+              "OperationCode": "SigntoolSign",
+              "ToolName": "sign",
+              "ToolVersion": "1.0",
+              "Parameters": {
+                "OpusName": "Microsoft",
+                "OpusInfo": "https://www.microsoft.com",
+                "FileDigest": "/fd SHA256",
+                "PageHash": "/NPH",
+                "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+              }
+            },
+            {
+              "KeyCode": "CP-230012",
+              "OperationCode": "SigntoolVerify",
+              "ToolName": "sign",
+              "ToolVersion": "1.0",
+              "Parameters": {}
+            }
+          ]
+        VerboseLogin: true
+
+    - pwsh: |
+        $ErrorActionPreference = 'Stop'
+
+        $wheelsDir = "$(ob_outputDirectory)\wheels"
+        $unpackedRoot = "$(ob_outputDirectory)\wheel-unpacked"
+        $signedDir = "$(ob_outputDirectory)\signed-wheels"
+        $verifyRoot = "$(ob_outputDirectory)\wheel-verify"
+
+        Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $wheelsDir, $signedDir, $verifyRoot
+        New-Item -ItemType Directory -Force -Path $wheelsDir, $signedDir, $verifyRoot | Out-Null
+
+        foreach ($wheelRoot in Get-ChildItem $unpackedRoot -Directory) {
+          $wheelDirs = @(Get-ChildItem $wheelRoot.FullName -Directory)
+          if ($wheelDirs.Count -ne 1) {
+            Write-Error "Expected one unpacked wheel directory under $($wheelRoot.FullName), found $($wheelDirs.Count)"
+            exit 1
+          }
+
+          Write-Host "Repacking signed wheel from $($wheelDirs[0].FullName)"
+          python -m wheel pack "$($wheelDirs[0].FullName)" --dest-dir "$signedDir"
+        }
+
+        $signedWheels = @(Get-ChildItem $signedDir -Filter *.whl -File)
+        $unpackedWheels = @(Get-ChildItem $unpackedRoot -Directory)
+        if ($signedWheels.Count -ne $unpackedWheels.Count) {
+          Write-Error "Expected $($unpackedWheels.Count) signed wheels, found $($signedWheels.Count)"
+          exit 1
+        }
+
+        Copy-Item -Path "$signedDir\*.whl" -Destination $wheelsDir
+
+        foreach ($wheel in Get-ChildItem $wheelsDir -Filter *.whl -File) {
+          Write-Host "Verifying signed wheel $($wheel.Name)"
+          $wheelVerifyDir = Join-Path $verifyRoot $wheel.BaseName
+          New-Item -ItemType Directory -Force -Path $wheelVerifyDir | Out-Null
+          python -m wheel unpack "$($wheel.FullName)" --dest "$wheelVerifyDir"
+        }
+
+        $nativeFiles = @(Get-ChildItem $verifyRoot -Recurse -Include *.pyd,*.dll -File)
+        if ($nativeFiles.Count -eq 0) {
+          Write-Error "No native Windows binaries found after repacking signed wheels"
+          exit 1
+        }
+
+        $invalid = @()
+        foreach ($file in $nativeFiles) {
+          $signature = Get-AuthenticodeSignature $file.FullName
+          Write-Host "$($file.Name): $($signature.Status)"
+          if ($signature.Status -ne 'Valid') {
+            $invalid += $file.FullName
+          }
+        }
+
+        if ($invalid.Count -gt 0) {
+          Write-Error "Unsigned or invalid native binaries:`n$($invalid -join "`n")"
+          exit 1
+        }
+
+        Remove-Item -Recurse -Force $unpackedRoot, $signedDir, $verifyRoot
+      displayName: 'Repack and verify signed Windows wheels'
   
   - pwsh: |
       Write-Host "All wheels built:"


### PR DESCRIPTION
## Summary

[AB#46328](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46328)

Adds official-build signing for Windows Python wheels produced by `mssql-py-core` and adjusts the wheel artifact layout so the release pipeline packages the intended signed wheels.

This is not just a branch sync. The main functional change is that Windows `.pyd` files inside the generated `.whl` files are signed through ESRP before the wheels are repacked and published as build artifacts.

## What changed

### Windows wheel signing

For official OneBranch builds, the Windows wheel jobs now:

1. Build the Python wheels with `maturin` as before.
2. Move the original wheels into `unsigned-wheels/` so they are retained as evidence/input artifacts.
3. Unpack each wheel into its own unique directory based on the wheel filename. This avoids collisions across Python-version-specific wheels that share the same package name/version.
4. Run `EsrpMalwareScanning@6` over unpacked native files.
5. Run `EsrpCodeSigning@6` over native `*.pyd` / `*.dll` files using the ESRP-provided `.pyd` signing operation shape, with the authorized `CP-230012` key code.
6. Repack each wheel so wheel `RECORD` hashes are regenerated after signing.
7. Verify Authenticode signatures from freshly unpacked signed wheels.
8. Publish signed wheels from the canonical `wheels/` folder.

### Artifact layout

The build artifact now intentionally keeps:

- `wheels/`: signed wheels consumed by release
- `unsigned-wheels/`: original unsigned wheels retained for comparison/evidence

Transient work folders are removed after verification:

- `wheel-unpacked/`
- `signed-wheels/`
- `wheel-verify/`

### Release pipeline collection

The release pipeline now collects only wheels under `*/wheels/*.whl` instead of recursively collecting every `.whl` under the build artifacts. This prevents accidentally packaging duplicate wheels or unsigned wheels from `unsigned-wheels/`.

## Validation context

The signing flow was iterated and validated through the ADO `Official Python Wheels Build` pipeline on `dev/stabletest`. A passing signed build confirmed that the ESRP signing path can sign the Windows `.pyd` files successfully. Follow-up changes narrow the artifact contract so the release pipeline consumes only the signed canonical wheels.
Example run 
https://sqlclientdrivers.visualstudio.com/mssql-rs/_build/results?buildId=160017&pathAsName=false&view=results

Release pipeline run from this build

https://sqlclientdrivers.visualstudio.com/mssql-rs/_build/results?buildId=160045&view=results