### PR TITLE
Merge mssql-py-core Python and Windows Rust coverage into one ADO report

### DIFF
--- a/.github/actions/post-coverage-comment/action.yml
+++ b/.github/actions/post-coverage-comment/action.yml
@@ -45,7 +45,7 @@ runs:
           </td>
           <td>
 
-          **📦 Project:** `mssql-tds`
+          **📦 Project:** `mssql-tds + mssql-py-core`
           **ℹ️ Note:** diff coverage is reported, not enforced.
 
           </td>

--- a/.pipeline/scripts/containerized-test.sh
+++ b/.pipeline/scripts/containerized-test.sh
@@ -14,3 +14,4 @@ cargo llvm-cov nextest "$@" --frozen --no-report --all-targets --package mssql-t
 
 echo '==> Generating coverage report...'
 cargo llvm-cov report --package mssql-tds --lcov --output-path /workspace/target/lcov.info
+cargo llvm-cov report --package mssql-tds --cobertura --output-path /workspace/target/cobertura.xml

--- a/.pipeline/scripts/merge-cobertura.py
+++ b/.pipeline/scripts/merge-cobertura.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Merge multiple Cobertura coverage reports into a single report.
+
+Azure DevOps does not merge coverage produced by different pipeline stages or
+jobs, so the mssql-tds Rust coverage (Windows) and the mssql-py-core coverage
+(Python tests on Linux) are combined here into one Cobertura file that the ADO
+coverage tab and the GitHub diff-cover workflow can consume.
+
+Merge semantics: line hits are unioned across inputs (a line covered by either
+report is covered in the result), keyed by (filename, line number). This is the
+correct semantic for combining coverage from independent test runs and safely
+handles files that appear in more than one input (for example mssql-tds, which
+both the Rust suite and the Python bindings exercise).
+
+Usage:
+    merge-cobertura.py --output OUT.xml INPUT[::PREFIX] [INPUT[::PREFIX] ...]
+
+INPUT is a path to a Cobertura XML file. Missing inputs are skipped with a
+warning so the merge stays resilient when an upstream job did not publish
+coverage. An optional ``::PREFIX`` prepends PREFIX to every relative filename in
+that input before normalization, which is used to make paths from a crate that
+was measured in its own directory (mssql-py-core) repo-root relative.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import xml.etree.ElementTree as ET
+from xml.dom import minidom
+
+
+def normalize_path(filename: str, prefix: str) -> str:
+    """Return a repo-root-relative, forward-slash path for a source file."""
+    fn = filename.replace("\\", "/")
+    if prefix and not fn.startswith("/") and len(fn) > 1 and fn[1] != ":":
+        fn = f"{prefix.rstrip('/')}/{fn}"
+
+    parts: list[str] = []
+    for part in fn.split("/"):
+        if part in ("", "."):
+            continue
+        if part == "..":
+            if parts:
+                parts.pop()
+            continue
+        parts.append(part)
+
+    # Absolute agent paths look like /workspace/<repo>/... - keep only the
+    # portion after the last "workspace" segment so paths become repo relative.
+    if "workspace" in parts:
+        idx = len(parts) - 1 - parts[::-1].index("workspace")
+        parts = parts[idx + 1:]
+
+    return "/".join(parts)
+
+
+class LineData:
+    __slots__ = ("hits", "branch", "conditions")
+
+    def __init__(self, hits: int, branch: bool, conditions: str | None):
+        self.hits = hits
+        self.branch = branch
+        self.conditions = conditions
+
+    def merge(self, hits: int, branch: bool, conditions: str | None) -> None:
+        # Union of hits: covered by either run counts as covered.
+        if hits > self.hits:
+            self.hits = hits
+            # Prefer condition data from the run that actually exercised the line.
+            if conditions:
+                self.conditions = conditions
+        if branch:
+            self.branch = True
+            if conditions and not self.conditions:
+                self.conditions = conditions
+
+
+class ClassData:
+    def __init__(self, name: str, filename: str):
+        self.name = name
+        self.filename = filename
+        self.lines: dict[int, LineData] = {}
+
+
+def parse_input(path: str, prefix: str, classes: dict[str, ClassData]) -> bool:
+    try:
+        tree = ET.parse(path)
+    except FileNotFoundError:
+        print(f"warning: coverage input not found, skipping: {path}", file=sys.stderr)
+        return False
+    except ET.ParseError as exc:
+        print(f"warning: could not parse {path}: {exc}", file=sys.stderr)
+        return False
+
+    root = tree.getroot()
+    for cls in root.iter("class"):
+        filename = cls.get("filename", "")
+        if not filename:
+            continue
+        norm = normalize_path(filename, prefix)
+        entry = classes.get(norm)
+        if entry is None:
+            entry = ClassData(cls.get("name", norm), norm)
+            classes[norm] = entry
+
+        for line in cls.iter("line"):
+            try:
+                number = int(line.get("number", "0"))
+            except ValueError:
+                continue
+            try:
+                hits = int(line.get("hits", "0"))
+            except ValueError:
+                hits = 0
+            branch = line.get("branch", "false") == "true"
+            conditions = line.get("condition-coverage")
+
+            existing = entry.lines.get(number)
+            if existing is None:
+                entry.lines[number] = LineData(hits, branch, conditions)
+            else:
+                existing.merge(hits, branch, conditions)
+
+    return True
+
+
+def package_name(filename: str) -> str:
+    """Derive a package name (top-level directory) for grouping classes."""
+    head = filename.split("/", 1)[0]
+    return head or "."
+
+
+def rate(covered: int, total: int) -> float:
+    return (covered / total) if total else 0.0
+
+
+def build_document(classes: dict[str, ClassData]) -> ET.Element:
+    packages: dict[str, list[ClassData]] = {}
+    for cls in classes.values():
+        packages.setdefault(package_name(cls.filename), []).append(cls)
+
+    total_lines = 0
+    covered_lines = 0
+
+    coverage = ET.Element("coverage")
+    sources = ET.SubElement(coverage, "sources")
+    ET.SubElement(sources, "source").text = "."
+    packages_el = ET.SubElement(coverage, "packages")
+
+    for pkg_name in sorted(packages):
+        pkg_classes = packages[pkg_name]
+        pkg_total = 0
+        pkg_covered = 0
+        package_el = ET.SubElement(packages_el, "package", {"name": pkg_name})
+        classes_el = ET.SubElement(package_el, "classes")
+
+        for cls in sorted(pkg_classes, key=lambda c: c.filename):
+            cls_total = len(cls.lines)
+            cls_covered = sum(1 for ln in cls.lines.values() if ln.hits > 0)
+            pkg_total += cls_total
+            pkg_covered += cls_covered
+
+            class_el = ET.SubElement(
+                classes_el,
+                "class",
+                {
+                    "name": cls.name,
+                    "filename": cls.filename,
+                    "line-rate": f"{rate(cls_covered, cls_total):.4f}",
+                    "branch-rate": "0",
+                    "complexity": "0",
+                },
+            )
+            ET.SubElement(class_el, "methods")
+            lines_el = ET.SubElement(class_el, "lines")
+            for number in sorted(cls.lines):
+                ln = cls.lines[number]
+                attrs = {
+                    "number": str(number),
+                    "hits": str(ln.hits),
+                    "branch": "true" if ln.branch else "false",
+                }
+                if ln.conditions:
+                    attrs["condition-coverage"] = ln.conditions
+                ET.SubElement(lines_el, "line", attrs)
+
+        package_el.set("line-rate", f"{rate(pkg_covered, pkg_total):.4f}")
+        package_el.set("branch-rate", "0")
+        package_el.set("complexity", "0")
+        total_lines += pkg_total
+        covered_lines += pkg_covered
+
+    coverage.set("line-rate", f"{rate(covered_lines, total_lines):.4f}")
+    coverage.set("branch-rate", "0")
+    coverage.set("lines-covered", str(covered_lines))
+    coverage.set("lines-valid", str(total_lines))
+    coverage.set("branches-covered", "0")
+    coverage.set("branches-valid", "0")
+    coverage.set("complexity", "0")
+    coverage.set("version", "0")
+    coverage.set("timestamp", "0")
+    return coverage
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True, help="Path to the merged Cobertura XML.")
+    parser.add_argument(
+        "inputs",
+        nargs="+",
+        help="Input Cobertura files, each optionally suffixed with ::PREFIX.",
+    )
+    args = parser.parse_args(argv)
+
+    classes: dict[str, ClassData] = {}
+    merged_any = False
+    for item in args.inputs:
+        if "::" in item:
+            path, prefix = item.split("::", 1)
+        else:
+            path, prefix = item, ""
+        if parse_input(path, prefix, classes):
+            merged_any = True
+            print(f"merged coverage input: {path}" + (f" (prefix {prefix})" if prefix else ""))
+
+    if not merged_any:
+        print("error: no coverage inputs could be read", file=sys.stderr)
+        return 1
+
+    document = build_document(classes)
+    xml_bytes = ET.tostring(document, encoding="utf-8")
+    pretty = minidom.parseString(xml_bytes).toprettyxml(indent="  ", encoding="utf-8")
+    with open(args.output, "wb") as handle:
+        handle.write(pretty)
+
+    covered = int(document.get("lines-covered", "0"))
+    valid = int(document.get("lines-valid", "0"))
+    pct = (covered / valid * 100) if valid else 0.0
+    print(f"wrote {args.output}: {covered}/{valid} lines covered ({pct:.1f}%)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.pipeline/scripts/merge-cobertura.py
+++ b/.pipeline/scripts/merge-cobertura.py
@@ -59,24 +59,15 @@ def normalize_path(filename: str, prefix: str) -> str:
 
 
 class LineData:
-    __slots__ = ("hits", "branch", "conditions")
+    __slots__ = ("hits",)
 
-    def __init__(self, hits: int, branch: bool, conditions: str | None):
+    def __init__(self, hits: int):
         self.hits = hits
-        self.branch = branch
-        self.conditions = conditions
 
-    def merge(self, hits: int, branch: bool, conditions: str | None) -> None:
+    def merge(self, hits: int) -> None:
         # Union of hits: covered by either run counts as covered.
         if hits > self.hits:
             self.hits = hits
-            # Prefer condition data from the run that actually exercised the line.
-            if conditions:
-                self.conditions = conditions
-        if branch:
-            self.branch = True
-            if conditions and not self.conditions:
-                self.conditions = conditions
 
 
 class ClassData:
@@ -116,14 +107,12 @@ def parse_input(path: str, prefix: str, classes: dict[str, ClassData]) -> bool:
                 hits = int(line.get("hits", "0"))
             except ValueError:
                 hits = 0
-            branch = line.get("branch", "false") == "true"
-            conditions = line.get("condition-coverage")
 
             existing = entry.lines.get(number)
             if existing is None:
-                entry.lines[number] = LineData(hits, branch, conditions)
+                entry.lines[number] = LineData(hits)
             else:
-                existing.merge(hits, branch, conditions)
+                existing.merge(hits)
 
     return True
 
@@ -171,7 +160,6 @@ def build_document(classes: dict[str, ClassData]) -> ET.Element:
                     "name": cls.name,
                     "filename": cls.filename,
                     "line-rate": f"{rate(cls_covered, cls_total):.4f}",
-                    "branch-rate": "0",
                     "complexity": "0",
                 },
             )
@@ -179,27 +167,20 @@ def build_document(classes: dict[str, ClassData]) -> ET.Element:
             lines_el = ET.SubElement(class_el, "lines")
             for number in sorted(cls.lines):
                 ln = cls.lines[number]
-                attrs = {
-                    "number": str(number),
-                    "hits": str(ln.hits),
-                    "branch": "true" if ln.branch else "false",
-                }
-                if ln.conditions:
-                    attrs["condition-coverage"] = ln.conditions
-                ET.SubElement(lines_el, "line", attrs)
+                ET.SubElement(
+                    lines_el,
+                    "line",
+                    {"number": str(number), "hits": str(ln.hits)},
+                )
 
         package_el.set("line-rate", f"{rate(pkg_covered, pkg_total):.4f}")
-        package_el.set("branch-rate", "0")
         package_el.set("complexity", "0")
         total_lines += pkg_total
         covered_lines += pkg_covered
 
     coverage.set("line-rate", f"{rate(covered_lines, total_lines):.4f}")
-    coverage.set("branch-rate", "0")
     coverage.set("lines-covered", str(covered_lines))
     coverage.set("lines-valid", str(total_lines))
-    coverage.set("branches-covered", "0")
-    coverage.set("branches-valid", "0")
     coverage.set("complexity", "0")
     coverage.set("version", "0")
     coverage.set("timestamp", "0")

--- a/.pipeline/templates/build-template-container.yml
+++ b/.pipeline/templates/build-template-container.yml
@@ -36,6 +36,11 @@ parameters:
   type: string
   default: ''
 
+- name: collectPythonCoverage
+  displayName: Collect Cobertura coverage for mssql-py-core from the Python tests
+  type: boolean
+  default: false
+
 steps:
 # ARM64 integration tests connect cross-pool to an on-demand x64 SQL host
 # (Sql_Host_build_arm). Derive the SA password from build context so this job
@@ -403,6 +408,18 @@ steps:
     testResultsFormat: JUnit
     testResultsFiles: $(Build.SourcesDirectory)/mssql-py-core/pytest-results.xml
     testRunTitle: $(System.PhaseName)-Python
+
+# Publish the mssql-py-core Cobertura coverage produced by the Python tests
+# (test-python.sh --coverage). Merged with the Windows Rust coverage in the
+# Coverage stage, since ADO does not merge coverage across stages/jobs.
+- ${{ if eq(parameters.collectPythonCoverage, true) }}:
+  - task: PublishPipelineArtifact@1
+    condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+    displayName: Publish mssql-py-core Cobertura coverage artifact
+    continueOnError: true
+    inputs:
+      targetPath: $(Build.SourcesDirectory)/target/pycore-cobertura.xml
+      artifactName: CoberturaCoveragePython
 
 # Release the cross-pool SQL host: publishing this sentinel is what unblocks
 # Sql_Host_build_arm's wait-for-teardown step. always() so failures and

--- a/.pipeline/templates/build-template-container.yml
+++ b/.pipeline/templates/build-template-container.yml
@@ -41,6 +41,11 @@ parameters:
   type: boolean
   default: false
 
+- name: collectRustCoverage
+  displayName: Publish the mssql-tds Rust Cobertura coverage as a per-OS artifact for merging
+  type: boolean
+  default: false
+
 steps:
 # ARM64 integration tests connect cross-pool to an on-demand x64 SQL host
 # (Sql_Host_build_arm). Derive the SA password from build context so this job
@@ -297,12 +302,19 @@ steps:
     failTaskOnFailedTests: false
     publishRunAttachments: true
 
-- task: PublishCodeCoverageResults@2
-  condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
-  displayName: Publish coverage results
-  inputs:
-    summaryFileLocation: $(Build.SourcesDirectory)/target/lcov.info
-    pathToSources: $(Build.SourcesDirectory)
+# Coverage is not published to the ADO coverage tab from this job. The Linux
+# mssql-tds Rust Cobertura report is published as a per-OS artifact; the
+# Coverage stage merges the Windows/Linux/macOS Rust reports with the
+# mssql-py-core Python report and publishes the single combined report to the
+# ADO coverage tab, because ADO does not merge coverage across stages/jobs.
+- ${{ if eq(parameters.collectRustCoverage, true) }}:
+  - task: PublishPipelineArtifact@1
+    condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
+    displayName: Publish mssql-tds Linux Cobertura coverage artifact
+    continueOnError: true
+    inputs:
+      targetPath: $(Build.SourcesDirectory)/target/cobertura.xml
+      artifactName: CoberturaCoverageRust_Linux
 
 - task: CopyFiles@2
   displayName: Copy Rust Debug Build

--- a/.pipeline/templates/build-template.yml
+++ b/.pipeline/templates/build-template.yml
@@ -167,23 +167,23 @@ steps:
       env:
         SQL_PASSWORD: $(SQL_PASSWORD)
 
-  - ${{ if eq(parameters.osType, 'Windows') }}:
-    # Coverage is not published to the ADO coverage tab here. The Windows run
-    # only produces the Rust Cobertura report as an artifact; the Coverage stage
-    # merges it with the Python (mssql-py-core) report and publishes the single
-    # combined report to the ADO coverage tab.
-    # Cobertura report consumed by the GitHub PR diff-coverage workflow (diff-cover).
-    - script: cargo llvm-cov report --package mssql-tds --cobertura --output-path "$(Build.SourcesDirectory)/target/cobertura.xml"
-      condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
-      workingDirectory: "$(Build.SourcesDirectory)"
-      displayName: Save code coverage in Cobertura format (mssql-tds package only)
+  # Coverage is not published to the ADO coverage tab from the individual OS
+  # jobs. Each OS produces its own mssql-tds Rust Cobertura report as a per-OS
+  # artifact; the Coverage stage merges the Windows/Linux/macOS Rust reports
+  # with the mssql-py-core Python report and publishes the single combined
+  # report to the ADO coverage tab, because ADO does not merge coverage across
+  # stages/jobs. The merged report is what the GitHub diff-cover workflow uses.
+  - script: cargo llvm-cov report --package mssql-tds --cobertura --output-path "$(Build.SourcesDirectory)/target/cobertura.xml"
+    condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
+    workingDirectory: "$(Build.SourcesDirectory)"
+    displayName: Save code coverage in Cobertura format (mssql-tds package only)
 
-    - task: PublishPipelineArtifact@1
-      condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
-      displayName: "Publish Cobertura coverage artifact"
-      inputs:
-        targetPath: "$(Build.SourcesDirectory)/target/cobertura.xml"
-        artifactName: "CoberturaCoverageRust"
+  - task: PublishPipelineArtifact@1
+    condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
+    displayName: "Publish Cobertura coverage artifact"
+    inputs:
+      targetPath: "$(Build.SourcesDirectory)/target/cobertura.xml"
+      artifactName: "CoberturaCoverageRust_${{ parameters.osType }}"
 
 - ${{ if eq(parameters.enableRustBuild, true) }}:
   - task: CopyFiles@2

--- a/.pipeline/templates/build-template.yml
+++ b/.pipeline/templates/build-template.yml
@@ -186,7 +186,7 @@ steps:
       displayName: "Publish Cobertura coverage artifact"
       inputs:
         targetPath: "$(Build.SourcesDirectory)/target/cobertura.xml"
-        artifactName: "CoberturaCoverage"
+        artifactName: "CoberturaCoverageRust"
 
 - ${{ if eq(parameters.enableRustBuild, true) }}:
   - task: CopyFiles@2

--- a/.pipeline/templates/build-template.yml
+++ b/.pipeline/templates/build-template.yml
@@ -168,13 +168,10 @@ steps:
         SQL_PASSWORD: $(SQL_PASSWORD)
 
   - ${{ if eq(parameters.osType, 'Windows') }}:
-    - task: PublishCodeCoverageResults@2
-      condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
-      displayName: "Publish coverage results"
-      inputs:
-        summaryFileLocation: "$(Build.SourcesDirectory)/target/lcov.info"
-        pathToSources: "$(Build.SourcesDirectory)"
-
+    # Coverage is not published to the ADO coverage tab here. The Windows run
+    # only produces the Rust Cobertura report as an artifact; the Coverage stage
+    # merges it with the Python (mssql-py-core) report and publishes the single
+    # combined report to the ADO coverage tab.
     # Cobertura report consumed by the GitHub PR diff-coverage workflow (diff-cover).
     - script: cargo llvm-cov report --package mssql-tds --cobertura --output-path "$(Build.SourcesDirectory)/target/cobertura.xml"
       condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -223,6 +223,7 @@ stages:
           enableJsTest: true
           additionalPythonTestArgs: '--coverage'
           collectPythonCoverage: true
+          collectRustCoverage: true
       - template: build-template-alpine.yml
         parameters:
           osType: Linux
@@ -603,11 +604,12 @@ stages:
             container: ghcr.io/microsoft/mssql-rs/import/ubuntu:24.04
             entry: deb-bookworm.sh
 
-# Merge the mssql-tds Rust coverage (Build_Windows) and the mssql-py-core
-# coverage from the Python tests (Build_Linux) into one Cobertura report. ADO
-# does not merge coverage across stages/jobs, so it is combined here and
-# published as CoberturaCoverage (the artifact the GitHub diff-cover workflow
-# consumes) and to the ADO coverage tab.
+# Merge the mssql-tds Rust coverage from every OS that runs the tests
+# (Build_Windows, Build_Linux, Test_MacOS) and the mssql-py-core coverage from
+# the Python tests (Build_Linux) into one Cobertura report. ADO does not merge
+# coverage across stages/jobs, so it is combined here and published as
+# CoberturaCoverage (the artifact the GitHub diff-cover workflow consumes) and
+# to the ADO coverage tab.
 - stage: Coverage
   displayName: Merge Coverage
   dependsOn:
@@ -623,12 +625,26 @@ stages:
     steps:
       - checkout: self
       - task: DownloadPipelineArtifact@2
-        displayName: Download Rust (mssql-tds) coverage
+        displayName: Download Rust (mssql-tds) Windows coverage
         continueOnError: true
         inputs:
           buildType: 'current'
-          artifactName: 'CoberturaCoverageRust'
-          targetPath: '$(Pipeline.Workspace)/cov-rust'
+          artifactName: 'CoberturaCoverageRust_Windows'
+          targetPath: '$(Pipeline.Workspace)/cov-rust-windows'
+      - task: DownloadPipelineArtifact@2
+        displayName: Download Rust (mssql-tds) Linux coverage
+        continueOnError: true
+        inputs:
+          buildType: 'current'
+          artifactName: 'CoberturaCoverageRust_Linux'
+          targetPath: '$(Pipeline.Workspace)/cov-rust-linux'
+      - task: DownloadPipelineArtifact@2
+        displayName: Download Rust (mssql-tds) macOS coverage
+        continueOnError: true
+        inputs:
+          buildType: 'current'
+          artifactName: 'CoberturaCoverageRust_MacOS'
+          targetPath: '$(Pipeline.Workspace)/cov-rust-macos'
       - task: DownloadPipelineArtifact@2
         displayName: Download Python (mssql-py-core) coverage
         continueOnError: true
@@ -639,13 +655,20 @@ stages:
       - bash: |
           set -euo pipefail
           mkdir -p "$(Build.SourcesDirectory)/target"
-          rust="$(Pipeline.Workspace)/cov-rust/cobertura.xml"
-          py="$(Pipeline.Workspace)/cov-python/pycore-cobertura.xml"
           inputs=()
-          [ -f "$rust" ] && inputs+=("$rust")
+          # Each OS emits its mssql-tds report with repo-root-relative paths, so
+          # the same source file lines up across reports and coverage is unioned:
+          # a line covered on any OS counts as covered in the merged result.
+          for report in \
+            "$(Pipeline.Workspace)/cov-rust-windows/cobertura.xml" \
+            "$(Pipeline.Workspace)/cov-rust-linux/cobertura.xml" \
+            "$(Pipeline.Workspace)/cov-rust-macos/cobertura.xml"; do
+            [ -f "$report" ] && inputs+=("$report")
+          done
           # mssql-py-core coverage is measured from within its own crate
           # directory, so prefix its relative filenames to make them repo-root
           # relative in the merged report.
+          py="$(Pipeline.Workspace)/cov-python/pycore-cobertura.xml"
           [ -f "$py" ] && inputs+=("$py::mssql-py-core")
           if [ ${#inputs[@]} -eq 0 ]; then
             echo "##vso[task.logissue type=warning]No coverage inputs found to merge"

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -221,6 +221,8 @@ stages:
           testFilter: -E 'not (test(connectivity))'
           enableJsBuild: true
           enableJsTest: true
+          additionalPythonTestArgs: '--coverage'
+          collectPythonCoverage: true
       - template: build-template-alpine.yml
         parameters:
           osType: Linux
@@ -600,6 +602,72 @@ stages:
           - name: Ubuntu24
             container: ghcr.io/microsoft/mssql-rs/import/ubuntu:24.04
             entry: deb-bookworm.sh
+
+# Merge the mssql-tds Rust coverage (Build_Windows) and the mssql-py-core
+# coverage from the Python tests (Build_Linux) into one Cobertura report. ADO
+# does not merge coverage across stages/jobs, so it is combined here and
+# published as CoberturaCoverage (the artifact the GitHub diff-cover workflow
+# consumes) and to the ADO coverage tab.
+- stage: Coverage
+  displayName: Merge Coverage
+  dependsOn:
+    - Build
+  condition: and(succeeded('Build'), eq(variables['Build.Reason'], 'PullRequest'), eq('${{ parameters.RunFuzz }}', 'false'), eq('${{ parameters.RunLongHaul }}', 'false'))
+  jobs:
+  - job: Merge_Coverage
+    displayName: Merge Rust and Python coverage
+    pool:
+      name: RUST-1ES-POOL-WUS3
+      demands:
+        - imageOverride -equals RUST-1ES-UBUSLIM
+    steps:
+      - checkout: self
+      - task: DownloadPipelineArtifact@2
+        displayName: Download Rust (mssql-tds) coverage
+        continueOnError: true
+        inputs:
+          buildType: 'current'
+          artifactName: 'CoberturaCoverageRust'
+          targetPath: '$(Pipeline.Workspace)/cov-rust'
+      - task: DownloadPipelineArtifact@2
+        displayName: Download Python (mssql-py-core) coverage
+        continueOnError: true
+        inputs:
+          buildType: 'current'
+          artifactName: 'CoberturaCoveragePython'
+          targetPath: '$(Pipeline.Workspace)/cov-python'
+      - bash: |
+          set -euo pipefail
+          mkdir -p "$(Build.SourcesDirectory)/target"
+          rust="$(Pipeline.Workspace)/cov-rust/cobertura.xml"
+          py="$(Pipeline.Workspace)/cov-python/pycore-cobertura.xml"
+          inputs=()
+          [ -f "$rust" ] && inputs+=("$rust")
+          # mssql-py-core coverage is measured from within its own crate
+          # directory, so prefix its relative filenames to make them repo-root
+          # relative in the merged report.
+          [ -f "$py" ] && inputs+=("$py::mssql-py-core")
+          if [ ${#inputs[@]} -eq 0 ]; then
+            echo "##vso[task.logissue type=warning]No coverage inputs found to merge"
+            exit 0
+          fi
+          python3 .pipeline/scripts/merge-cobertura.py \
+            --output "$(Build.SourcesDirectory)/target/cobertura.xml" \
+            "${inputs[@]}"
+          echo "##vso[task.setvariable variable=coverageMerged]true"
+        displayName: Merge Cobertura reports
+      - task: PublishPipelineArtifact@1
+        condition: and(succeeded(), eq(variables['coverageMerged'], 'true'))
+        displayName: Publish merged Cobertura coverage artifact
+        inputs:
+          targetPath: '$(Build.SourcesDirectory)/target/cobertura.xml'
+          artifactName: 'CoberturaCoverage'
+      - task: PublishCodeCoverageResults@2
+        condition: and(succeeded(), eq(variables['coverageMerged'], 'true'))
+        displayName: Publish merged coverage results
+        inputs:
+          summaryFileLocation: '$(Build.SourcesDirectory)/target/cobertura.xml'
+          pathToSources: '$(Build.SourcesDirectory)'
 
 - ${{ if eq(parameters.includeInfraStages, true) }}:
   # Long-haul BCP test stage (30 minutes)

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -662,6 +662,16 @@ stages:
         inputs:
           targetPath: '$(Build.SourcesDirectory)/target/cobertura.xml'
           artifactName: 'CoberturaCoverage'
+      # PublishCodeCoverageResults@2 renders the ADO coverage tab HTML with
+      # ReportGenerator, which requires .NET. The slim Linux agent does not ship
+      # it, so install it explicitly; otherwise the coverage tab reports that the
+      # HTML report was not found.
+      - task: UseDotNet@2
+        condition: and(succeeded(), eq(variables['coverageMerged'], 'true'))
+        displayName: Install .NET for coverage HTML rendering
+        inputs:
+          packageType: 'sdk'
+          version: '8.x'
       - task: PublishCodeCoverageResults@2
         condition: and(succeeded(), eq(variables['coverageMerged'], 'true'))
         displayName: Publish merged coverage results

--- a/dev/test-python.sh
+++ b/dev/test-python.sh
@@ -3,7 +3,7 @@ set -e
 
 # Script to run Python tests for mssql-py-core
 # This script sets up a Python virtual environment, installs dependencies, and runs pytest
-# Usage: test-python.sh [--skip-integration] [--mssql-python] [--smoke]
+# Usage: test-python.sh [--skip-integration] [--mssql-python] [--smoke] [--coverage]
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -16,13 +16,20 @@ VENV_DIR="$PROJECT_ROOT/.venv-pycore"
 SKIP_INTEGRATION=false
 RUN_MSSQL_PYTHON=false
 RUN_SMOKE_ONLY=false
+COVERAGE=false
 for arg in "$@"; do
     case $arg in
         --skip-integration) SKIP_INTEGRATION=true ;;
         --mssql-python) RUN_MSSQL_PYTHON=true ;;
         --smoke) RUN_SMOKE_ONLY=true ;;
+        --coverage) COVERAGE=true ;;
     esac
 done
+
+# When --coverage is set, the mssql-py-core native extension is built with LLVM
+# source-based instrumentation so the Rust code exercised by the Python tests is
+# measured. Coverage output (Cobertura) is written to $COVERAGE_OUTPUT.
+COVERAGE_OUTPUT="${COVERAGE_OUTPUT:-$PROJECT_ROOT/target/pycore-cobertura.xml}"
 
 echo "==================================="
 echo "Python Test Runner for mssql-py-core"
@@ -62,6 +69,17 @@ pip install maturin pytest pytest-asyncio python-dotenv patchelf -q
 
 # Navigate to mssql-py-core directory
 cd "$PY_CORE_DIR"
+
+# Enable LLVM source-based coverage instrumentation for the native extension.
+# `cargo llvm-cov show-env` exports RUSTFLAGS (-C instrument-coverage), a target
+# dir and an LLVM_PROFILE_FILE pattern; maturin then builds an instrumented .so
+# and the Python test process writes .profraw files as it runs.
+if [ "$COVERAGE" = true ]; then
+    echo "Enabling coverage instrumentation for mssql-py-core..."
+    cargo llvm-cov clean --workspace
+    # shellcheck disable=SC1090
+    source <(cargo llvm-cov show-env --export-prefix)
+fi
 
 # Build and install the module in development mode
 echo "Building mssql-py-core with maturin develop..."
@@ -165,4 +183,23 @@ if [ "$RUN_MSSQL_PYTHON" = true ]; then
     echo "==================================="
     echo "mssql-python tests completed!"
     echo "==================================="
+fi
+
+# Generate the Cobertura coverage report for the instrumented native extension.
+# Runs from the mssql-py-core directory so cargo-llvm-cov reads the profraw files
+# produced while the Python tests exercised the compiled .so.
+if [ "$COVERAGE" = true ]; then
+    echo ""
+    echo "==================================="
+    echo "Generating mssql-py-core coverage report"
+    echo "==================================="
+    cd "$PY_CORE_DIR"
+    mkdir -p "$(dirname "$COVERAGE_OUTPUT")"
+    # Report generation is best-effort: the tests already ran and passed, so a
+    # coverage tooling hiccup should not fail the test run.
+    if cargo llvm-cov report --cobertura --output-path "$COVERAGE_OUTPUT"; then
+        echo "Coverage report written to $COVERAGE_OUTPUT"
+    else
+        echo "WARNING: failed to generate mssql-py-core coverage report" >&2
+    fi
 fi

--- a/dev/test-python.sh
+++ b/dev/test-python.sh
@@ -77,8 +77,12 @@ cd "$PY_CORE_DIR"
 if [ "$COVERAGE" = true ]; then
     echo "Enabling coverage instrumentation for mssql-py-core..."
     cargo llvm-cov clean --workspace
-    # shellcheck disable=SC1090
-    source <(cargo llvm-cov show-env --export-prefix)
+    # Warm up the tooling first so any one-time rustup component install output
+    # (e.g. downloading llvm-tools) does not get sourced into the shell.
+    cargo llvm-cov show-env --export-prefix >/dev/null 2>&1 || true
+    # Source only the export statements; discard rustup/info chatter that would
+    # otherwise be evaluated as commands.
+    eval "$(cargo llvm-cov show-env --export-prefix 2>/dev/null | grep '^export ')"
 fi
 
 # Build and install the module in development mode


### PR DESCRIPTION
## Summary

Adds code coverage measurement for the `mssql-py-core` native extension driven by the Python tests, and merges it with the existing Windows Rust (`mssql-tds`) coverage into a single Cobertura report. Azure DevOps does not merge coverage produced across separate pipeline stages or jobs, so the reports are combined in a dedicated stage and published as one report.

## Changes

- Add a `--coverage` option to `dev/test-python.sh` that builds the `mssql-py-core` extension under LLVM source-based instrumentation using `cargo llvm-cov show-env`, so the Rust code exercised by the Python tests is measured. After the tests run, it emits a Cobertura report for the extension. Report generation is best-effort so a coverage tooling issue does not fail the test run.
- Add a `collectPythonCoverage` parameter to the Linux container build template and enable it for the x64 `Build_Linux` job. When enabled, the Python tests run with `--coverage` and the resulting Cobertura file is published as the `CoberturaCoveragePython` pipeline artifact.
- Rename the Windows Rust coverage artifact from `CoberturaCoverage` to `CoberturaCoverageRust` so the merged report can take the original name.
- Add a `Coverage` stage that runs on pull requests after the `Build` stage. It downloads the Rust and Python coverage artifacts, merges them, and publishes the combined report as the `CoberturaCoverage` artifact and to the Azure DevOps coverage tab.
- Add `.pipeline/scripts/merge-cobertura.py`, which merges multiple Cobertura reports by unioning per-line hits keyed on file and line number. This handles files that appear in more than one input (such as `mssql-tds`, exercised by both suites) and normalizes paths to be repo-root relative so downstream diff coverage keeps working.

## Compatibility

- The GitHub `PR Code Coverage` workflow continues to consume the `CoberturaCoverage` artifact; it now receives the merged report.
- Coverage steps remain pull-request only, so merge and CI runs are unaffected.
- The merge stage tolerates a missing input and publishes whatever coverage is available.