### PR TITLE
Move ODBC auth keyword modules out of mssql-tds into bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   parameters.
 
 - Initial public release of the mssql-rs workspace.
+
+### Removed
+
+- `mssql-tds`: the public `connection::odbc_authentication_transformer`,
+  `connection::odbc_authentication_validator`, and
+  `connection::odbc_supported_auth_keywords` modules. The ODBC `Authentication=`
+  keyword mapping, validation, and precedence resolution now live in each
+  binding (`mssql-odbc` and `mssql-py-core`); `mssql-tds` retains only the
+  `TdsAuthenticationMethod` seam and takes (or asks for) a token for the
+  federated-auth flows.

--- a/mssql-odbc/src/connection/mod.rs
+++ b/mssql-odbc/src/connection/mod.rs
@@ -8,8 +8,10 @@
 
 use std::fmt;
 
-use mssql_tds::connection::odbc_supported_auth_keywords::is_recognized_keyword;
+use crate::connection::odbc_supported_auth_keywords::is_recognized_keyword;
 use tracing::warn;
+
+mod odbc_supported_auth_keywords;
 
 // Connection string keys (lowercase for matching)
 const KEY_SERVER: &str = "server";
@@ -49,7 +51,7 @@ const KNOWN_IGNORED_KEYS: &[&str] = &[
 const YES_NO: &[&str] = &["yes", "no"];
 const ENCRYPT_VALUES: &[&str] = &["yes", "mandatory", "no", "optional", "strict"];
 
-// Recognized `Authentication=` keywords (mirrors mssql-tds `auth_method_from_keyword`).
+// Recognized `Authentication=` keywords (mirrors `auth_method_from_keyword`).
 // Used only for the diagnostic hint; the accept/reject decision is delegated to
 // `is_recognized_keyword` so the two never drift.
 const AUTHENTICATION_VALUES: &[&str] = &[

--- a/mssql-odbc/src/connection/odbc_supported_auth_keywords.rs
+++ b/mssql-odbc/src/connection/odbc_supported_auth_keywords.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use super::client_context::TdsAuthenticationMethod;
+use mssql_tds::connection::client_context::TdsAuthenticationMethod;
 
 /// Maps an ODBC connection-string `Authentication=` value to a [`TdsAuthenticationMethod`].
 ///

--- a/mssql-py-core/src/connection.rs
+++ b/mssql-py-core/src/connection.rs
@@ -8,11 +8,11 @@ use std::{path::PathBuf, sync::Arc};
 use tokio::runtime::Runtime;
 use tokio::sync::Mutex;
 
+use crate::odbc_auth::odbc_authentication_transformer::transform_auth;
+use crate::odbc_auth::odbc_authentication_validator::validate_auth;
 use crate::python_logger_adapter::scoped_tracing_bridge;
 use mssql_tds::{
     connection::client_context::{ClientContext, IPAddressPreference},
-    connection::odbc_authentication_transformer::transform_auth,
-    connection::odbc_authentication_validator::validate_auth,
     connection::tds_client::TdsClient,
     connection_provider::tds_connection_provider::TdsConnectionProvider,
     core::{EncryptionOptions, EncryptionSetting},

--- a/mssql-py-core/src/lib.rs
+++ b/mssql-py-core/src/lib.rs
@@ -9,6 +9,7 @@ use mssql_tds::connection::client_context::DriverVersion;
 mod bulkcopy;
 mod connection;
 mod cursor;
+mod odbc_auth;
 mod python_entra_token_factory;
 mod python_logger_adapter;
 mod row_writer;

--- a/mssql-py-core/src/odbc_auth/mod.rs
+++ b/mssql-py-core/src/odbc_auth/mod.rs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! ODBC-style authentication keyword handling, owned by the Python binding.
+//!
+//! These modules were moved out of `mssql-tds` so each binding controls its
+//! own supported authentication method set. `mssql-tds` only takes (or asks
+//! for) a token for the federated-auth flows; the keyword vocabulary,
+//! validation, and precedence rules live here.
+
+pub mod odbc_authentication_transformer;
+pub mod odbc_authentication_validator;
+pub mod odbc_supported_auth_keywords;

--- a/mssql-py-core/src/odbc_auth/odbc_authentication_transformer.rs
+++ b/mssql-py-core/src/odbc_auth/odbc_authentication_transformer.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use super::client_context::TdsAuthenticationMethod;
 use super::odbc_supported_auth_keywords::auth_method_from_keyword;
+use mssql_tds::connection::client_context::TdsAuthenticationMethod;
 
 /// Transformed authentication output produced by [`transform_auth`].
 ///

--- a/mssql-py-core/src/odbc_auth/odbc_authentication_validator.rs
+++ b/mssql-py-core/src/odbc_auth/odbc_authentication_validator.rs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use super::client_context::TdsAuthenticationMethod;
 use super::odbc_supported_auth_keywords::{auth_method_from_keyword, is_recognized_keyword};
-use crate::core::TdsResult;
-use crate::error::Error;
+use mssql_tds::connection::client_context::TdsAuthenticationMethod;
+use mssql_tds::core::TdsResult;
+use mssql_tds::error::Error;
 
 /// Validates the connection string key values for conflicts (ODBC-equivalent checks).
 /// Returns `Ok(())` if valid, or a `TdsError` listing all detected conflicts.

--- a/mssql-py-core/src/odbc_auth/odbc_supported_auth_keywords.rs
+++ b/mssql-py-core/src/odbc_auth/odbc_supported_auth_keywords.rs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use mssql_tds::connection::client_context::TdsAuthenticationMethod;
+
+/// Maps an ODBC connection-string `Authentication=` value to a [`TdsAuthenticationMethod`].
+///
+/// Case-insensitive. Returns `None` for unrecognized or empty values.
+/// `SqlPassword` collapses to `Password` (same Login7 on the wire).
+pub fn auth_method_from_keyword(value: &str) -> Option<TdsAuthenticationMethod> {
+    match value.to_lowercase().as_str() {
+        "sqlpassword" => Some(TdsAuthenticationMethod::Password),
+        "activedirectoryintegrated" => Some(TdsAuthenticationMethod::ActiveDirectoryIntegrated),
+        "activedirectorypassword" => Some(TdsAuthenticationMethod::ActiveDirectoryPassword),
+        "activedirectoryinteractive" => Some(TdsAuthenticationMethod::ActiveDirectoryInteractive),
+        "activedirectorymsi" => Some(TdsAuthenticationMethod::ActiveDirectoryMSI),
+        "activedirectoryserviceprincipal" => {
+            Some(TdsAuthenticationMethod::ActiveDirectoryServicePrincipal)
+        }
+        "activedirectorydefault" => Some(TdsAuthenticationMethod::ActiveDirectoryDefault),
+        "activedirectorydevicecodeflow" => {
+            Some(TdsAuthenticationMethod::ActiveDirectoryDeviceCodeFlow)
+        }
+        "activedirectoryworkloadidentity" => {
+            Some(TdsAuthenticationMethod::ActiveDirectoryWorkloadIdentity)
+        }
+        _ => None,
+    }
+}
+
+/// Returns `true` if `value` is a recognized ODBC `Authentication=` keyword (case-insensitive).
+/// An empty string is considered recognized (intentional reset).
+pub fn is_recognized_keyword(value: &str) -> bool {
+    value.is_empty() || auth_method_from_keyword(value).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognized_keywords_case_insensitive() {
+        assert!(is_recognized_keyword("SqlPassword"));
+        assert!(is_recognized_keyword("SQLPASSWORD"));
+        assert!(is_recognized_keyword("sqlpassword"));
+        assert!(is_recognized_keyword("ActiveDirectoryIntegrated"));
+        assert!(is_recognized_keyword("activedirectoryintegrated"));
+        assert!(is_recognized_keyword(""));
+    }
+
+    #[test]
+    fn unrecognized_keyword() {
+        assert!(!is_recognized_keyword("NotARealAuth"));
+        assert!(!is_recognized_keyword("Sql Password"));
+    }
+
+    #[test]
+    fn sqlpassword_collapses_to_password() {
+        assert_eq!(
+            auth_method_from_keyword("SqlPassword"),
+            Some(TdsAuthenticationMethod::Password)
+        );
+    }
+
+    #[test]
+    fn empty_returns_none() {
+        assert_eq!(auth_method_from_keyword(""), None);
+    }
+}

--- a/mssql-tds/src/connection.rs
+++ b/mssql-tds/src/connection.rs
@@ -20,12 +20,6 @@ pub(crate) mod datasource_parser;
 pub(crate) mod execution_context;
 pub(crate) mod instance_cache;
 pub(crate) mod metadata_retriever;
-/// ODBC-style authentication keyword transform.
-pub mod odbc_authentication_transformer;
-/// ODBC-style authentication keyword validation.
-pub mod odbc_authentication_validator;
-/// Recognized ODBC `Authentication=` keywords and their `TdsAuthenticationMethod` mapping.
-pub mod odbc_supported_auth_keywords;
 pub(crate) mod session_recovery;
 /// Primary client type and result set traits.
 pub mod tds_client;


### PR DESCRIPTION
Addresses review feedback on #96: the ODBC `Authentication=` keyword machinery is a driver-surface concern, not wire protocol. `mssql-tds` should only take (or ask for) a token for the federated-auth flows.

### What changed
- **mssql-odbc** now owns `connection/odbc_supported_auth_keywords.rs` (the keyword map + `is_recognized_keyword`, used by the T0 parser).
- **mssql-py-core** gets a new `odbc_auth` module with its own copy of the keyword map, `validate_auth`, and `transform_auth`.
- **mssql-tds** drops the three `odbc_*` modules and their `pub mod` declarations, keeping only the `TdsAuthenticationMethod` seam.

### Why per-binding copies
Each binding supports a different authentication method set, so a single shared table in `mssql-tds` was the wrong coupling. The duplication is intentional and was agreed on the #96 thread.

### No Python behavior change
The py-core copies are verbatim (git reports 98–99% rename similarity; only import lines differ). `validate_auth` still returns the same `mssql_tds` `TdsResult` / `Error::UsageError`, so the surfaced `PyRuntimeError` text is unchanged, and `TransformedAuth.method` is still the `mssql_tds` `TdsAuthenticationMethod`. The call sites in `connection.rs` are untouched.

### Verification
- `cargo bfmt` + `cargo bclippy` clean (workspace and mssql-py-core)
- `cargo btest`: 2056 passed, 8 failed (all `mssql-tds::connectivity` TLS baseline, excluded in CI), 21 skipped
- `cargo test -p mssql-py-core --lib`: 91 passed (includes the relocated auth-module tests)
- No Cargo.toml / Cargo.lock changes

[AB#46289](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46289)
