### PR TITLE
Include mssql-py-core Rust unit tests in its coverage report

### DIFF
--- a/dev/test-python.sh
+++ b/dev/test-python.sh
@@ -198,6 +198,20 @@ if [ "$COVERAGE" = true ]; then
     echo "Generating mssql-py-core coverage report"
     echo "==================================="
     cd "$PY_CORE_DIR"
+
+    # Run the crate's own #[cfg(test)] Rust unit tests inside this same
+    # instrumented environment (shared target dir + LLVM_PROFILE_FILE exported by
+    # `cargo llvm-cov show-env` above) so their .profraw files co-locate with the
+    # ones the Python tests produced and get rolled into the report below. Without
+    # this, lines exercised only by these unit tests (e.g. in types.rs /
+    # tracing_init.rs) show as uncovered even though they are tested. Best-effort:
+    # the gating unit-test run is a separate pipeline step, so a coverage-only
+    # failure here must not fail the Python test run.
+    echo "Running mssql-py-core Rust unit tests for coverage..."
+    if ! cargo test --frozen; then
+        echo "WARNING: mssql-py-core Rust unit tests failed during coverage collection" >&2
+    fi
+
     mkdir -p "$(dirname "$COVERAGE_OUTPUT")"
     # Report generation is best-effort: the tests already ran and passed, so a
     # coverage tooling hiccup should not fail the test run.


### PR DESCRIPTION
## Summary

The PR validation pipeline measures mssql-py-core coverage by instrumenting the compiled native extension and running the Python test suite against it. The crate's own inline `#[cfg(test)]` Rust unit tests (in `mssql-py-core/src/types.rs` and `mssql-py-core/src/tracing_init.rs`) were never executed during coverage collection, so lines exercised only by those unit tests showed as uncovered in the merged report.

## Changes

- In `dev/test-python.sh`, within the `--coverage` block, run the mssql-py-core crate's Rust unit tests (`cargo test --frozen`) from the mssql-py-core directory before the `cargo llvm-cov report` step.
- The unit tests run inside the same LLVM-instrumented environment already exported by `cargo llvm-cov show-env` (shared target dir and `LLVM_PROFILE_FILE` pattern), so their `.profraw` files co-locate with the ones produced by the Python tests and are merged into the same Cobertura report.
- The unit-test run is best-effort (non-fatal): the gating unit-test execution remains a separate pipeline step, so a coverage-only failure here does not fail the Python test run.

## Notes

- No `Cargo.toml` feature changes were needed. The pipeline already runs `cd mssql-py-core && cargo test --frozen` on Linux (see `.pipeline/templates/build-template.yml`), confirming the crate's test binary links there despite the pyo3 `extension-module` feature.
- No pipeline template changes were required. The existing templates already pass `--coverage` and publish the `CoberturaCoveragePython` artifact unioned by `.pipeline/scripts/merge-cobertura.py`.
- Behavior is unchanged when `--coverage` is not passed.
