### PR TITLE
Always Encrypted (Phase 1B): transparent AE for prepared-statement paths (sp_prepexec/sp_prepare/sp_execute)

### DIFF
--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -284,6 +284,10 @@ impl TdsClient {
                     self.current_metadata = None;
                     self.count_map.clear();
                     self.return_values.clear();
+                    // Prepared-statement handles do not survive a reconnect, so
+                    // drop their cached Always Encrypted metadata to avoid
+                    // encrypting a later sp_execute with a stale describe result.
+                    self.prepared_param_encryption.clear();
                     self.current_result_set_has_been_read_till_end = false;
                     self.remaining_request_timeout = None;
                     self.cancel_handle = None;
@@ -1302,9 +1306,6 @@ impl TdsClient {
             return Err(UsageError(ALREADY_EXECUTING_ERROR.to_string()));
         };
 
-        // Drop any cached Always Encrypted parameter metadata for this handle.
-        self.prepared_param_encryption.remove(&handle);
-
         let reconnect_elapsed = self.check_and_reconnect(timeout_sec, cancel_handle).await?;
         let timeout_sec = Self::deduct_timeout(timeout_sec, reconnect_elapsed);
 
@@ -1342,6 +1343,11 @@ impl TdsClient {
         if !server_errors.is_empty() {
             return Err(crate::error::Error::from_sql_errors(server_errors));
         }
+        // The handle is now released on the server; drop its cached Always
+        // Encrypted metadata. Done only after a successful unprepare so a failed
+        // RPC (handle possibly still valid) does not strip metadata a later
+        // sp_execute would need.
+        self.prepared_param_encryption.remove(&handle);
         Ok(())
     }
 
@@ -1513,12 +1519,18 @@ impl TdsClient {
                          executing with parameters"
                     ))
                 })?;
+            // Encrypt positional and named parameters together in one pass so a
+            // describe entry that lives in the other list is not misreported as
+            // "not supplied".
+            let mut param_refs: Vec<&mut RpcParameter> = Vec::new();
             if let Some(params) = positional_parameters.as_mut() {
-                Self::apply_parameter_encryption(&describe, &providers, &cek_cache, params).await?;
+                param_refs.extend(params.iter_mut());
             }
             if let Some(params) = named_parameters.as_mut() {
-                Self::apply_parameter_encryption(&describe, &providers, &cek_cache, params).await?;
+                param_refs.extend(params.iter_mut());
             }
+            Self::apply_parameter_encryption(&describe, &providers, &cek_cache, &mut param_refs)
+                .await?;
         }
 
         let database_collation = self.negotiated_settings.database_collation;
@@ -1956,7 +1968,8 @@ impl TdsClient {
             .await?;
 
         let (providers, cek_cache) = self.cloned_ce_key_material()?;
-        Self::apply_parameter_encryption(&describe, &providers, &cek_cache, named_params).await
+        let mut param_refs: Vec<&mut RpcParameter> = named_params.iter_mut().collect();
+        Self::apply_parameter_encryption(&describe, &providers, &cek_cache, &mut param_refs).await
     }
 
     /// Returns the describe result for a statement, serving it from the
@@ -2029,16 +2042,20 @@ impl TdsClient {
     /// Encrypts, in place, the parameters that a prior
     /// `sp_describe_parameter_encryption` call reported as requiring encryption.
     ///
-    /// Parameters are matched to the describe result by name, or by 1-based
-    /// ordinal when every supplied parameter is unnamed (the positional case used
-    /// by `sp_execute`). Each flagged parameter's CEK is unwrapped through the key
-    /// store providers, its value is normalized and encrypted, and the ciphertext
-    /// plus cipher metadata are stored on the [`RpcParameter`] for serialization.
+    /// Each describe parameter is matched to a supplied parameter by name
+    /// (case-insensitively, like a T-SQL identifier); if no name matches it falls
+    /// back to the *unnamed* parameter at the describe's 1-based ordinal (the
+    /// positional case used by `sp_execute`). Accepting one combined slice of
+    /// mutable references lets a single call cover all-named, all-positional, and
+    /// mixed positional/named parameter lists. Each flagged parameter's CEK is
+    /// unwrapped through the key store providers, its value is normalized and
+    /// encrypted, and the ciphertext plus cipher metadata are stored on the
+    /// [`RpcParameter`] for serialization.
     async fn apply_parameter_encryption(
         describe: &crate::security::describe_parameter_encryption::DescribeParameterEncryptionResult,
         providers: &crate::security::keystore::ColumnEncryptionKeyStoreProviderRegistry,
         cek_cache: &crate::security::keystore::CekCache,
-        named_params: &mut [RpcParameter],
+        params: &mut [&mut RpcParameter],
     ) -> TdsResult<()> {
         use crate::message::parameters::rpc_parameters::RpcEncryptionMetadata;
         use crate::security::encryption::encrypt_parameter;
@@ -2048,11 +2065,6 @@ impl TdsClient {
         if !describe.parameters.iter().any(|p| p.is_encrypted()) {
             return Ok(());
         }
-
-        // When every supplied parameter is unnamed they are positional and are
-        // matched to the describe result by 1-based ordinal; otherwise they are
-        // matched by name (case-insensitively, like T-SQL identifiers).
-        let positional = !named_params.is_empty() && named_params.iter().all(|p| p.name.is_none());
 
         for info in &describe.parameters {
             if !info.is_encrypted() {
@@ -2066,18 +2078,23 @@ impl TdsClient {
                 ))
             })?;
 
-            let index = if positional {
-                (info.parameter_ordinal as usize)
-                    .checked_sub(1)
-                    .filter(|&i| i < named_params.len())
-            } else {
-                named_params.iter().position(|p| {
+            // Match by name first; otherwise fall back to the unnamed parameter at
+            // this describe ordinal (the positional case). Requiring the ordinal
+            // slot to be unnamed keeps a named parameter from being matched by
+            // position.
+            let index = params
+                .iter()
+                .position(|p| {
                     p.name
                         .as_deref()
                         .map(|n| n.eq_ignore_ascii_case(&info.parameter_name))
                         .unwrap_or(false)
                 })
-            };
+                .or_else(|| {
+                    (info.parameter_ordinal as usize)
+                        .checked_sub(1)
+                        .filter(|&i| i < params.len() && params[i].name.is_none())
+                });
 
             let Some(index) = index else {
                 return Err(crate::error::Error::ColumnEncryptionError(format!(
@@ -2088,7 +2105,7 @@ impl TdsClient {
             };
 
             let plaintext_cek = decrypt_cek(providers, cek_cache, cek_entry).await?;
-            let param = &mut named_params[index];
+            let param = &mut *params[index];
 
             let ciphertext = encrypt_parameter(
                 param.value(),

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -88,11 +88,24 @@ pub struct TdsClient {
     /// Per-prepared-handle Always Encrypted parameter metadata, captured by
     /// `execute_sp_prepare` from `sp_describe_parameter_encryption` and reused by
     /// `execute_sp_execute` to encrypt parameter values without describing again.
-    /// Evicted by `execute_sp_unprepare`.
+    /// Holds an `Arc` to the same describe result stored in
+    /// `query_metadata_cache`, pinning it for the prepared statement's lifetime
+    /// even if the shared cache evicts it. Evicted by `execute_sp_unprepare`.
     prepared_param_encryption: HashMap<
         i32,
-        crate::security::describe_parameter_encryption::DescribeParameterEncryptionResult,
+        std::sync::Arc<
+            crate::security::describe_parameter_encryption::DescribeParameterEncryptionResult,
+        >,
     >,
+    /// Connection-scoped cache of `sp_describe_parameter_encryption` results,
+    /// keyed by (database, query text), so every parameterized execution of the
+    /// same statement reuses the describe result instead of re-querying the
+    /// server. Mirrors the SqlClient/JDBC query-metadata caches.
+    query_metadata_cache: crate::security::query_metadata_cache::QueryMetadataCache,
+    /// Number of `sp_describe_parameter_encryption` round-trips actually sent to
+    /// the server (query-metadata cache misses). Exposed for observability and to
+    /// let tests confirm the cache elides repeat describes.
+    describe_round_trips: u64,
     /// State of the most recent `ReturnStatus` token, captured while draining a
     /// cursor RPC response and interpreted as a [`CursorStatus`](crate::cursor::CursorStatus).
     pub(in crate::connection) last_return_status: ReturnStatus,
@@ -141,6 +154,8 @@ impl TdsClient {
             count_map: HashMap::new(),
             return_values: Vec::new(),
             prepared_param_encryption: HashMap::new(),
+            query_metadata_cache: crate::security::query_metadata_cache::QueryMetadataCache::new(),
+            describe_round_trips: 0,
             last_return_status: ReturnStatus::NotReceived,
             current_result_set_has_been_read_till_end: false,
             current_command_ce_setting:
@@ -1172,21 +1187,25 @@ impl TdsClient {
 
         build_parameter_list_string(&named_params, &mut params_list_as_string)?;
 
-        // Always Encrypted: describe the statement's parameters now and cache the
-        // result under the prepared handle so a later sp_execute can encrypt
-        // values without describing again. sp_prepare itself sends no user
-        // parameter values, so nothing is encrypted here.
+        // Always Encrypted: describe the statement's parameters now (serving from
+        // or populating the query-metadata cache) and pin the result under the
+        // prepared handle so a later sp_execute can encrypt values without
+        // describing again. sp_prepare itself sends no user parameter values, so
+        // nothing is encrypted here.
         let describe_for_cache = if self.should_encrypt_parameters() && !named_params.is_empty() {
+            let has_output = named_params.iter().any(|p| p.is_output());
             let describe = self
-                .describe_parameter_encryption(
+                .describe_parameters_cached(
                     &sql,
                     &params_list_as_string,
+                    has_output,
                     timeout_sec,
                     cancel_handle,
                 )
                 .await?;
-            // The describe round-trip closes its own batch and clears the
-            // per-operation timeout/cancel state; restore it for the prepare RPC.
+            // A describe round-trip (on a cache miss) closes its own batch and
+            // clears the per-operation timeout/cancel state; restore it for the
+            // prepare RPC.
             self.remaining_request_timeout = Self::timeout_to_duration(timeout_sec);
             self.cancel_handle = cancel_handle.map(|handle| handle.child_handle());
             self.transport.reset_reader();
@@ -1483,18 +1502,22 @@ impl TdsClient {
                 || named_parameters.as_ref().is_some_and(|p| !p.is_empty()))
         {
             let (providers, cek_cache) = self.cloned_ce_key_material()?;
-            let describe = self.prepared_param_encryption.get(&handle).ok_or_else(|| {
-                crate::error::Error::ColumnEncryptionError(format!(
-                    "Prepared statement handle {handle} has no Always Encrypted parameter \
-                     metadata; prepare it with execute_sp_prepare on this connection before \
-                     executing with parameters"
-                ))
-            })?;
+            let describe = self
+                .prepared_param_encryption
+                .get(&handle)
+                .cloned()
+                .ok_or_else(|| {
+                    crate::error::Error::ColumnEncryptionError(format!(
+                        "Prepared statement handle {handle} has no Always Encrypted parameter \
+                         metadata; prepare it with execute_sp_prepare on this connection before \
+                         executing with parameters"
+                    ))
+                })?;
             if let Some(params) = positional_parameters.as_mut() {
-                Self::apply_parameter_encryption(describe, &providers, &cek_cache, params).await?;
+                Self::apply_parameter_encryption(&describe, &providers, &cek_cache, params).await?;
             }
             if let Some(params) = named_parameters.as_mut() {
-                Self::apply_parameter_encryption(describe, &providers, &cek_cache, params).await?;
+                Self::apply_parameter_encryption(&describe, &providers, &cek_cache, params).await?;
             }
         }
 
@@ -1845,6 +1868,10 @@ impl TdsClient {
             DescribeParameterEncryptionResult, accumulate_cek_entry, parse_parameter_info,
         };
 
+        // Count every actual describe round-trip so callers/tests can confirm the
+        // query-metadata cache is eliding repeats.
+        self.describe_round_trips = self.describe_round_trips.saturating_add(1);
+
         self.transport.reset_reader();
         let database_collation = self.negotiated_settings.database_collation;
 
@@ -1908,6 +1935,10 @@ impl TdsClient {
     /// through the registered key store providers, its plaintext value is
     /// normalized and encrypted, and the resulting ciphertext plus cipher
     /// metadata are stored on the [`RpcParameter`] for serialization.
+    ///
+    /// The describe result is served from (and populated into) the connection's
+    /// query-metadata cache, so repeat executions of the same statement avoid the
+    /// extra round-trip.
     async fn encrypt_parameters(
         &mut self,
         sql: &str,
@@ -1916,12 +1947,59 @@ impl TdsClient {
         timeout_sec: Option<u32>,
         cancel_handle: Option<&CancelHandle>,
     ) -> TdsResult<()> {
+        // Mirror SqlClient: don't cache metadata for statements with output
+        // parameters — the client can't validate cached describe results against
+        // a RETURNVALUE — but still use it for this call.
+        let has_output = named_params.iter().any(|p| p.is_output());
         let describe = self
-            .describe_parameter_encryption(sql, params_decl, timeout_sec, cancel_handle)
+            .describe_parameters_cached(sql, params_decl, has_output, timeout_sec, cancel_handle)
             .await?;
 
         let (providers, cek_cache) = self.cloned_ce_key_material()?;
         Self::apply_parameter_encryption(&describe, &providers, &cek_cache, named_params).await
+    }
+
+    /// Returns the describe result for a statement, serving it from the
+    /// connection's query-metadata cache when present and otherwise calling
+    /// `sp_describe_parameter_encryption` and caching the result.
+    ///
+    /// When `skip_cache` is set (a statement with output parameters), the fresh
+    /// describe result is returned but not stored, matching SqlClient.
+    async fn describe_parameters_cached(
+        &mut self,
+        sql: &str,
+        params_decl: &str,
+        skip_cache: bool,
+        timeout_sec: Option<u32>,
+        cancel_handle: Option<&CancelHandle>,
+    ) -> TdsResult<
+        std::sync::Arc<
+            crate::security::describe_parameter_encryption::DescribeParameterEncryptionResult,
+        >,
+    > {
+        use crate::security::query_metadata_cache::QueryMetadataCache;
+
+        let key = QueryMetadataCache::key(&self.negotiated_settings.database, sql);
+        if let Some(describe) = self.query_metadata_cache.get(&key) {
+            return Ok(describe);
+        }
+
+        let describe = std::sync::Arc::new(
+            self.describe_parameter_encryption(sql, params_decl, timeout_sec, cancel_handle)
+                .await?,
+        );
+        if !skip_cache {
+            self.query_metadata_cache
+                .insert(key, std::sync::Arc::clone(&describe));
+        }
+        Ok(describe)
+    }
+
+    /// Number of `sp_describe_parameter_encryption` round-trips this connection
+    /// has sent to the server (query-metadata cache misses). Useful for
+    /// observability and for verifying the metadata cache is effective.
+    pub fn describe_round_trips(&self) -> u64 {
+        self.describe_round_trips
     }
 
     /// Clones the `Arc` handles to the column-master-key provider registry and

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -85,6 +85,14 @@ pub struct TdsClient {
     count_map: HashMap<CurrentCommand, u64>,
 
     pub(in crate::connection) return_values: Vec<ReturnValue>,
+    /// Per-prepared-handle Always Encrypted parameter metadata, captured by
+    /// `execute_sp_prepare` from `sp_describe_parameter_encryption` and reused by
+    /// `execute_sp_execute` to encrypt parameter values without describing again.
+    /// Evicted by `execute_sp_unprepare`.
+    prepared_param_encryption: HashMap<
+        i32,
+        crate::security::describe_parameter_encryption::DescribeParameterEncryptionResult,
+    >,
     /// State of the most recent `ReturnStatus` token, captured while draining a
     /// cursor RPC response and interpreted as a [`CursorStatus`](crate::cursor::CursorStatus).
     pub(in crate::connection) last_return_status: ReturnStatus,
@@ -132,6 +140,7 @@ impl TdsClient {
             current_decryptor: None,
             count_map: HashMap::new(),
             return_values: Vec::new(),
+            prepared_param_encryption: HashMap::new(),
             last_return_status: ReturnStatus::NotReceived,
             current_result_set_has_been_read_till_end: false,
             current_command_ce_setting:
@@ -1135,15 +1144,9 @@ impl TdsClient {
             return Err(UsageError(ALREADY_EXECUTING_ERROR.to_string()));
         };
 
-        // The prepared-statement paths do not yet run the AE describe/encrypt
-        // flow, so a prepared statement with parameters cannot be safely used on
-        // an Always Encrypted connection. Fail fast instead of preparing a
-        // statement whose parameters would later be sent as plaintext.
-        if self.column_encryption_enabled_on_connection() && !named_params.is_empty() {
-            return Err(Self::ae_params_unsupported(
-                "prepared statements (sp_prepare)",
-            ));
-        }
+        // Prepared-statement execution uses the connection's Always Encrypted
+        // setting; there is no per-command override on this path.
+        self.current_command_ce_setting = ExecutionColumnEncryptionSetting::UseConnectionSetting;
 
         let reconnect_elapsed = self.check_and_reconnect(timeout_sec, cancel_handle).await?;
         let timeout_sec = Self::deduct_timeout(timeout_sec, reconnect_elapsed);
@@ -1157,7 +1160,8 @@ impl TdsClient {
 
         let database_collation = self.negotiated_settings.database_collation;
 
-        let sql_statement_value = SqlType::NVarcharMax(Some(SqlString::from_utf8_string(sql)));
+        let sql_statement_value =
+            SqlType::NVarcharMax(Some(SqlString::from_utf8_string(sql.clone())));
 
         // Create the parameter list for sp_prepare
         let execute_sql_statement_parameter =
@@ -1167,6 +1171,29 @@ impl TdsClient {
         let mut params_list_as_string = String::new();
 
         build_parameter_list_string(&named_params, &mut params_list_as_string)?;
+
+        // Always Encrypted: describe the statement's parameters now and cache the
+        // result under the prepared handle so a later sp_execute can encrypt
+        // values without describing again. sp_prepare itself sends no user
+        // parameter values, so nothing is encrypted here.
+        let describe_for_cache = if self.should_encrypt_parameters() && !named_params.is_empty() {
+            let describe = self
+                .describe_parameter_encryption(
+                    &sql,
+                    &params_list_as_string,
+                    timeout_sec,
+                    cancel_handle,
+                )
+                .await?;
+            // The describe round-trip closes its own batch and clears the
+            // per-operation timeout/cancel state; restore it for the prepare RPC.
+            self.remaining_request_timeout = Self::timeout_to_duration(timeout_sec);
+            self.cancel_handle = cancel_handle.map(|handle| handle.child_handle());
+            self.transport.reset_reader();
+            Some(describe)
+        } else {
+            None
+        };
 
         let params_as_sql_string =
             SqlType::NVarcharMax(Some(SqlString::from_utf8_string(params_list_as_string)));
@@ -1221,7 +1248,13 @@ impl TdsClient {
         if self.return_values.len() == 1 {
             let returned_parameter = self.return_values.first().unwrap();
             if let ColumnValues::Int(handle) = &returned_parameter.value {
-                Ok(*handle)
+                let handle = *handle;
+                // Cache the parameter-encryption metadata (if any) under the
+                // handle for reuse by execute_sp_execute.
+                if let Some(describe) = describe_for_cache {
+                    self.prepared_param_encryption.insert(handle, describe);
+                }
+                Ok(handle)
             } else {
                 Err(crate::error::Error::ProtocolError(
                     "Expected an integer value".to_string(),
@@ -1249,6 +1282,9 @@ impl TdsClient {
         if self.execution_context.has_open_batch() {
             return Err(UsageError(ALREADY_EXECUTING_ERROR.to_string()));
         };
+
+        // Drop any cached Always Encrypted parameter metadata for this handle.
+        self.prepared_param_encryption.remove(&handle);
 
         let reconnect_elapsed = self.check_and_reconnect(timeout_sec, cancel_handle).await?;
         let timeout_sec = Self::deduct_timeout(timeout_sec, reconnect_elapsed);
@@ -1304,7 +1340,7 @@ impl TdsClient {
     pub async fn execute_sp_prepexec(
         &mut self,
         sql: String,
-        named_params: Vec<RpcParameter>,
+        mut named_params: Vec<RpcParameter>,
         timeout_sec: Option<u32>,
         cancel_handle: Option<&CancelHandle>,
     ) -> TdsResult<()> {
@@ -1312,14 +1348,9 @@ impl TdsClient {
             return Err(UsageError(ALREADY_EXECUTING_ERROR.to_string()));
         };
 
-        // The prepared-statement paths do not yet run the AE describe/encrypt
-        // flow, so parameter values here would be sent as plaintext on an
-        // Always Encrypted connection. Fail fast instead.
-        if self.column_encryption_enabled_on_connection() && !named_params.is_empty() {
-            return Err(Self::ae_params_unsupported(
-                "prepared statements (sp_prepexec)",
-            ));
-        }
+        // Prepared-statement execution uses the connection's Always Encrypted
+        // setting; there is no per-command override on this path.
+        self.current_command_ce_setting = ExecutionColumnEncryptionSetting::UseConnectionSetting;
 
         let reconnect_elapsed = self.check_and_reconnect(timeout_sec, cancel_handle).await?;
         let timeout_sec = Self::deduct_timeout(timeout_sec, reconnect_elapsed);
@@ -1333,7 +1364,8 @@ impl TdsClient {
 
         let database_collation = self.negotiated_settings.database_collation;
 
-        let sql_statement_value = SqlType::NVarcharMax(Some(SqlString::from_utf8_string(sql)));
+        let sql_statement_value =
+            SqlType::NVarcharMax(Some(SqlString::from_utf8_string(sql.clone())));
 
         // Create the parameter list for sp_prepexec
         let statement_parameter = RpcParameter::new(None, StatusFlags::NONE, sql_statement_value);
@@ -1342,6 +1374,28 @@ impl TdsClient {
         let mut params_list_as_string = String::new();
 
         build_parameter_list_string(&named_params, &mut params_list_as_string)?;
+
+        // Always Encrypted: sp_prepexec prepares and executes in one round-trip,
+        // so — like sp_executesql — it runs `sp_describe_parameter_encryption`
+        // against the statement and encrypts flagged parameters in place before
+        // sending the real RPC. The `@params` declaration keeps each parameter's
+        // original type; only the value is replaced with ciphertext plus cipher
+        // metadata.
+        if self.should_encrypt_parameters() && !named_params.is_empty() {
+            self.encrypt_parameters(
+                &sql,
+                &params_list_as_string,
+                &mut named_params,
+                timeout_sec,
+                cancel_handle,
+            )
+            .await?;
+            // The describe round-trip closes its own batch and clears the
+            // per-operation timeout/cancel state; restore it for the real RPC.
+            self.remaining_request_timeout = Self::timeout_to_duration(timeout_sec);
+            self.cancel_handle = cancel_handle.map(|handle| handle.child_handle());
+            self.transport.reset_reader();
+        }
 
         let params_as_sql_string =
             SqlType::NVarcharMax(Some(SqlString::from_utf8_string(params_list_as_string)));
@@ -1395,8 +1449,8 @@ impl TdsClient {
     pub async fn execute_sp_execute(
         &mut self,
         handle: i32,
-        positional_parameters: Option<Vec<RpcParameter>>,
-        named_parameters: Option<Vec<RpcParameter>>,
+        mut positional_parameters: Option<Vec<RpcParameter>>,
+        mut named_parameters: Option<Vec<RpcParameter>>,
         timeout_sec: Option<u32>,
         cancel_handle: Option<&CancelHandle>,
     ) -> TdsResult<()> {
@@ -1404,19 +1458,9 @@ impl TdsClient {
             return Err(UsageError(ALREADY_EXECUTING_ERROR.to_string()));
         };
 
-        // The prepared-statement paths do not yet run the AE describe/encrypt
-        // flow, so parameter values here would be sent as plaintext on an
-        // Always Encrypted connection. Fail fast instead.
-        if self.column_encryption_enabled_on_connection()
-            && (positional_parameters
-                .as_ref()
-                .is_some_and(|p| !p.is_empty())
-                || named_parameters.as_ref().is_some_and(|p| !p.is_empty()))
-        {
-            return Err(Self::ae_params_unsupported(
-                "prepared statements (sp_execute)",
-            ));
-        }
+        // Prepared-statement execution uses the connection's Always Encrypted
+        // setting; there is no per-command override on this path.
+        self.current_command_ce_setting = ExecutionColumnEncryptionSetting::UseConnectionSetting;
 
         let reconnect_elapsed = self.check_and_reconnect(timeout_sec, cancel_handle).await?;
         let timeout_sec = Self::deduct_timeout(timeout_sec, reconnect_elapsed);
@@ -1427,6 +1471,32 @@ impl TdsClient {
 
         self.return_values.clear();
         self.transport.reset_reader();
+
+        // Always Encrypted: encrypt the supplied parameter values in place using
+        // the metadata captured when the statement was prepared, then send the
+        // real RPC. sp_execute never describes — the metadata must already have
+        // been cached by execute_sp_prepare on this connection.
+        if self.should_encrypt_parameters()
+            && (positional_parameters
+                .as_ref()
+                .is_some_and(|p| !p.is_empty())
+                || named_parameters.as_ref().is_some_and(|p| !p.is_empty()))
+        {
+            let (providers, cek_cache) = self.cloned_ce_key_material()?;
+            let describe = self.prepared_param_encryption.get(&handle).ok_or_else(|| {
+                crate::error::Error::ColumnEncryptionError(format!(
+                    "Prepared statement handle {handle} has no Always Encrypted parameter \
+                     metadata; prepare it with execute_sp_prepare on this connection before \
+                     executing with parameters"
+                ))
+            })?;
+            if let Some(params) = positional_parameters.as_mut() {
+                Self::apply_parameter_encryption(describe, &providers, &cek_cache, params).await?;
+            }
+            if let Some(params) = named_parameters.as_mut() {
+                Self::apply_parameter_encryption(describe, &providers, &cek_cache, params).await?;
+            }
+        }
 
         let database_collation = self.negotiated_settings.database_collation;
 
@@ -1846,34 +1916,65 @@ impl TdsClient {
         timeout_sec: Option<u32>,
         cancel_handle: Option<&CancelHandle>,
     ) -> TdsResult<()> {
-        use crate::message::parameters::rpc_parameters::RpcEncryptionMetadata;
-        use crate::security::encryption::encrypt_parameter;
-        use crate::security::keystore::decrypt_cek;
-
         let describe = self
             .describe_parameter_encryption(sql, params_decl, timeout_sec, cancel_handle)
             .await?;
+
+        let (providers, cek_cache) = self.cloned_ce_key_material()?;
+        Self::apply_parameter_encryption(&describe, &providers, &cek_cache, named_params).await
+    }
+
+    /// Clones the `Arc` handles to the column-master-key provider registry and
+    /// the CEK cache from the client context, so the parameter-encryption paths
+    /// can pass them around without holding a borrow on `self`.
+    fn cloned_ce_key_material(
+        &self,
+    ) -> TdsResult<(
+        std::sync::Arc<crate::security::keystore::ColumnEncryptionKeyStoreProviderRegistry>,
+        std::sync::Arc<crate::security::keystore::CekCache>,
+    )> {
+        let client_context = self
+            .recovery_context
+            .client_context
+            .as_ref()
+            .ok_or_else(|| {
+                crate::error::Error::ColumnEncryptionError(
+                    "Cannot encrypt parameters without a client context".to_string(),
+                )
+            })?;
+        Ok((
+            client_context.column_encryption_key_store_providers.clone(),
+            client_context.cek_cache.clone(),
+        ))
+    }
+
+    /// Encrypts, in place, the parameters that a prior
+    /// `sp_describe_parameter_encryption` call reported as requiring encryption.
+    ///
+    /// Parameters are matched to the describe result by name, or by 1-based
+    /// ordinal when every supplied parameter is unnamed (the positional case used
+    /// by `sp_execute`). Each flagged parameter's CEK is unwrapped through the key
+    /// store providers, its value is normalized and encrypted, and the ciphertext
+    /// plus cipher metadata are stored on the [`RpcParameter`] for serialization.
+    async fn apply_parameter_encryption(
+        describe: &crate::security::describe_parameter_encryption::DescribeParameterEncryptionResult,
+        providers: &crate::security::keystore::ColumnEncryptionKeyStoreProviderRegistry,
+        cek_cache: &crate::security::keystore::CekCache,
+        named_params: &mut [RpcParameter],
+    ) -> TdsResult<()> {
+        use crate::message::parameters::rpc_parameters::RpcEncryptionMetadata;
+        use crate::security::encryption::encrypt_parameter;
+        use crate::security::keystore::decrypt_cek;
 
         // Nothing to do when the server reports no encrypted parameters.
         if !describe.parameters.iter().any(|p| p.is_encrypted()) {
             return Ok(());
         }
 
-        let (providers, cek_cache) = {
-            let client_context =
-                self.recovery_context
-                    .client_context
-                    .as_ref()
-                    .ok_or_else(|| {
-                        crate::error::Error::ColumnEncryptionError(
-                            "Cannot encrypt parameters without a client context".to_string(),
-                        )
-                    })?;
-            (
-                client_context.column_encryption_key_store_providers.clone(),
-                client_context.cek_cache.clone(),
-            )
-        };
+        // When every supplied parameter is unnamed they are positional and are
+        // matched to the describe result by 1-based ordinal; otherwise they are
+        // matched by name (case-insensitively, like T-SQL identifiers).
+        let positional = !named_params.is_empty() && named_params.iter().all(|p| p.name.is_none());
 
         for info in &describe.parameters {
             if !info.is_encrypted() {
@@ -1887,23 +1988,29 @@ impl TdsClient {
                 ))
             })?;
 
-            let plaintext_cek = decrypt_cek(&providers, &cek_cache, cek_entry).await?;
-
-            // Parameter names are matched case-insensitively, like T-SQL identifiers.
-            let param = named_params
-                .iter_mut()
-                .find(|p| {
+            let index = if positional {
+                (info.parameter_ordinal as usize)
+                    .checked_sub(1)
+                    .filter(|&i| i < named_params.len())
+            } else {
+                named_params.iter().position(|p| {
                     p.name
                         .as_deref()
                         .map(|n| n.eq_ignore_ascii_case(&info.parameter_name))
                         .unwrap_or(false)
                 })
-                .ok_or_else(|| {
-                    crate::error::Error::ColumnEncryptionError(format!(
-                        "sp_describe_parameter_encryption returned encryption info for unknown parameter {}",
-                        info.parameter_name
-                    ))
-                })?;
+            };
+
+            let Some(index) = index else {
+                return Err(crate::error::Error::ColumnEncryptionError(format!(
+                    "sp_describe_parameter_encryption returned encryption info for parameter {} \
+                     that was not supplied to the call",
+                    info.parameter_name
+                )));
+            };
+
+            let plaintext_cek = decrypt_cek(providers, cek_cache, cek_entry).await?;
+            let param = &mut named_params[index];
 
             let ciphertext = encrypt_parameter(
                 param.value(),

--- a/mssql-tds/src/security/describe_parameter_encryption.rs
+++ b/mssql-tds/src/security/describe_parameter_encryption.rs
@@ -57,7 +57,6 @@ pub(crate) const ENCRYPTION_TYPE_PLAINTEXT: u8 = 0;
 #[derive(Debug, Clone)]
 pub(crate) struct ParameterEncryptionInfo {
     /// 1-based ordinal of the parameter within the statement.
-    #[allow(dead_code)]
     pub parameter_ordinal: i32,
     /// Parameter name including the leading `@` (e.g. `@p1`).
     pub parameter_name: String,

--- a/mssql-tds/src/security/mod.rs
+++ b/mssql-tds/src/security/mod.rs
@@ -11,6 +11,8 @@
 //! (`encryption`), `sp_describe_parameter_encryption` parsing
 //! (`describe_parameter_encryption`), the cell-decryptor seam
 //! (`cell_decryptor`), and the column master key store providers (`keystore`).
+//! Results of `sp_describe_parameter_encryption` are cached per connection by
+//! the query-metadata cache (`query_metadata_cache`).
 //!
 //! # Platform Support
 //!
@@ -29,6 +31,7 @@ pub(crate) mod encryption;
 mod error;
 pub(crate) mod keystore;
 pub mod mock;
+pub(crate) mod query_metadata_cache;
 mod security_context;
 mod spn;
 

--- a/mssql-tds/src/security/query_metadata_cache.rs
+++ b/mssql-tds/src/security/query_metadata_cache.rs
@@ -1,0 +1,193 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Connection-scoped cache of `sp_describe_parameter_encryption` results.
+//!
+//! Always Encrypted requires a `sp_describe_parameter_encryption` round-trip to
+//! learn which parameters of a statement must be encrypted and how. Repeating
+//! that round-trip on every execution of the same statement is wasteful, so the
+//! result is cached and reused across executions — whether the statement runs
+//! via `sp_executesql`, a stored-procedure `EXEC`, or the prepared-statement
+//! paths (`sp_prepexec` / `sp_prepare` + `sp_execute`).
+//!
+//! The design mirrors the .NET SqlClient `SqlQueryMetadataCache` and the JDBC
+//! `ParameterMetaDataCache`: entries are keyed by the current database plus the
+//! query text, bounded to a fixed number of entries, and expire after a fixed
+//! time-to-live. Only the *encrypted* CEK wire metadata is cached — plaintext
+//! column encryption keys are never stored here; they are re-derived per use
+//! through the (separate) CEK cache.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crate::security::describe_parameter_encryption::DescribeParameterEncryptionResult;
+
+/// A cached describe result together with its expiry instant.
+#[derive(Debug)]
+struct CacheEntry {
+    describe: Arc<DescribeParameterEncryptionResult>,
+    expires_at: Instant,
+}
+
+/// Connection-scoped, size- and time-bounded cache of
+/// `sp_describe_parameter_encryption` results keyed by `(database, query text)`.
+///
+/// Mirrors SqlClient's `SqlQueryMetadataCache` bounds (2000 entries, a 300-entry
+/// trim threshold, and a 10-hour time-to-live).
+#[derive(Debug)]
+pub(crate) struct QueryMetadataCache {
+    entries: HashMap<String, CacheEntry>,
+    max_entries: usize,
+    trim_threshold: usize,
+    ttl: Duration,
+}
+
+impl QueryMetadataCache {
+    /// Maximum retained entries before trimming (SqlClient `CacheSize`).
+    const DEFAULT_MAX_ENTRIES: usize = 2000;
+    /// Extra entries tolerated before a trim runs (SqlClient `CacheTrimThreshold`).
+    const DEFAULT_TRIM_THRESHOLD: usize = 300;
+    /// Entry lifetime — SqlClient's 10-hour metadata cache timeout.
+    const DEFAULT_TTL: Duration = Duration::from_secs(10 * 60 * 60);
+
+    /// Creates an empty cache with the default SqlClient-matching bounds.
+    pub(crate) fn new() -> Self {
+        Self {
+            entries: HashMap::new(),
+            max_entries: Self::DEFAULT_MAX_ENTRIES,
+            trim_threshold: Self::DEFAULT_TRIM_THRESHOLD,
+            ttl: Self::DEFAULT_TTL,
+        }
+    }
+
+    /// Builds the cache key from the current database and the query text.
+    ///
+    /// The database name's length is prefixed so that a database name containing
+    /// the separator sequence cannot collide with a different database/query
+    /// split (the same robustness SqlClient gets by padding the database name to
+    /// a fixed width).
+    pub(crate) fn key(database: &str, sql: &str) -> String {
+        format!("{}:{database}:::{sql}", database.len())
+    }
+
+    /// Returns the cached describe result for `key` if it is present and has not
+    /// expired, evicting it if it has.
+    pub(crate) fn get(&mut self, key: &str) -> Option<Arc<DescribeParameterEncryptionResult>> {
+        match self.entries.get(key) {
+            Some(entry) if entry.expires_at > Instant::now() => Some(Arc::clone(&entry.describe)),
+            Some(_) => {
+                self.entries.remove(key);
+                None
+            }
+            None => None,
+        }
+    }
+
+    /// Inserts (or replaces) the describe result for `key`, trimming the cache
+    /// first when it has grown past its bound plus the trim threshold.
+    pub(crate) fn insert(&mut self, key: String, describe: Arc<DescribeParameterEncryptionResult>) {
+        if self.entries.len() >= self.max_entries + self.trim_threshold {
+            self.trim();
+        }
+        self.entries.insert(
+            key,
+            CacheEntry {
+                describe,
+                expires_at: Instant::now() + self.ttl,
+            },
+        );
+    }
+
+    /// Drops expired entries first, then the entries closest to expiry until the
+    /// cache is back within its size bound.
+    fn trim(&mut self) {
+        let now = Instant::now();
+        self.entries.retain(|_, entry| entry.expires_at > now);
+        if self.entries.len() <= self.max_entries {
+            return;
+        }
+        let mut by_expiry: Vec<(Instant, String)> = self
+            .entries
+            .iter()
+            .map(|(key, entry)| (entry.expires_at, key.clone()))
+            .collect();
+        by_expiry.sort_by_key(|(expiry, _)| *expiry);
+        let to_remove = self.entries.len() - self.max_entries;
+        for (_, key) in by_expiry.into_iter().take(to_remove) {
+            self.entries.remove(&key);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn describe() -> Arc<DescribeParameterEncryptionResult> {
+        Arc::new(DescribeParameterEncryptionResult::new())
+    }
+
+    fn cache_with(max_entries: usize, trim_threshold: usize, ttl: Duration) -> QueryMetadataCache {
+        QueryMetadataCache {
+            entries: HashMap::new(),
+            max_entries,
+            trim_threshold,
+            ttl,
+        }
+    }
+
+    #[test]
+    fn key_includes_database_length_prefix() {
+        assert_eq!(
+            QueryMetadataCache::key("master", "SELECT 1"),
+            "6:master:::SELECT 1"
+        );
+        // The length prefix keeps a separator-containing database name from
+        // colliding with a different database/query split.
+        assert_ne!(
+            QueryMetadataCache::key("a:::b", "q"),
+            QueryMetadataCache::key("a", ":::b:::q")
+        );
+    }
+
+    #[test]
+    fn get_returns_inserted_entry() {
+        let mut cache = QueryMetadataCache::new();
+        let key = QueryMetadataCache::key("db", "SELECT 1");
+        cache.insert(key.clone(), describe());
+        assert!(cache.get(&key).is_some());
+        assert!(cache.get("other").is_none());
+    }
+
+    #[test]
+    fn expired_entry_is_evicted_on_get() {
+        // A zero TTL makes every entry expire immediately.
+        let mut cache = cache_with(10, 5, Duration::ZERO);
+        let key = QueryMetadataCache::key("db", "SELECT 1");
+        cache.insert(key.clone(), describe());
+        assert!(
+            cache.get(&key).is_none(),
+            "expired entry must not be returned"
+        );
+        assert_eq!(cache.entries.len(), 0, "expired entry must be evicted");
+    }
+
+    #[test]
+    fn insert_keeps_cache_bounded() {
+        // Bound 2, threshold 1: the cache trims once it reaches max + threshold
+        // (3) entries, so it never grows past that regardless of how many distinct
+        // statements are inserted.
+        let mut cache = cache_with(2, 1, Duration::from_secs(3600));
+        for i in 0..25 {
+            cache.insert(QueryMetadataCache::key("db", &format!("q{i}")), describe());
+            assert!(
+                cache.entries.len() <= 3,
+                "cache exceeded its bound: {}",
+                cache.entries.len()
+            );
+        }
+        // A trim actually happened (it did not simply keep every entry).
+        assert!(cache.entries.len() <= 3);
+    }
+}

--- a/mssql-tds/tests/test_always_encrypted.rs
+++ b/mssql-tds/tests/test_always_encrypted.rs
@@ -1065,6 +1065,37 @@ mod always_encrypted {
         });
     }
 
+    /// The connection's query-metadata cache elides repeat
+    /// `sp_describe_parameter_encryption` round-trips: executing the same
+    /// statement multiple times describes it only once.
+    #[tokio::test]
+    async fn query_metadata_cache_reuses_describe() {
+        ae_test!(|h| {
+            let table = h.create_encrypted_table("INT", "DETERMINISTIC").await;
+            let sql = format!("INSERT INTO {table} (val) VALUES (@val);");
+
+            let before = h.client.describe_round_trips();
+            for v in [1, 2, 3] {
+                let param = RpcParameter::new(
+                    Some("@val".to_string()),
+                    StatusFlags::NONE,
+                    SqlType::Int(Some(v)),
+                );
+                h.client
+                    .execute_sp_executesql(sql.clone(), vec![param], None, None)
+                    .await
+                    .expect("encrypted insert");
+                while h.client.move_to_next().await.unwrap() {}
+                h.client.close_query().await.unwrap();
+            }
+            let describes = h.client.describe_round_trips() - before;
+            assert_eq!(
+                describes, 1,
+                "three identical executions should describe once, got {describes}"
+            );
+        });
+    }
+
     // ----- Bulk copy parameter encryption -----
 
     /// A row written through the streaming bulk-copy writer. The `id` column is

--- a/mssql-tds/tests/test_always_encrypted.rs
+++ b/mssql-tds/tests/test_always_encrypted.rs
@@ -903,58 +903,164 @@ mod always_encrypted {
         });
     }
 
-    /// The prepared-statement paths (`sp_prepare` / `sp_prepexec` / `sp_execute`)
-    /// do not yet run the AE describe/encrypt flow, so on an Always Encrypted
-    /// connection they must fail fast with parameters rather than send plaintext.
+    /// `sp_prepexec` prepares and executes in one round-trip; under Always
+    /// Encrypted it describes the statement and encrypts flagged parameters, so
+    /// an encrypted insert round-trips.
     #[tokio::test]
-    async fn prepared_statement_params_fail_fast_under_ae() {
+    async fn sp_prepexec_encrypts_parameter() {
         ae_test!(|h| {
-            let sql = "SELECT @p".to_string();
-            let mk_param = || {
-                RpcParameter::new(
-                    Some("@p".to_string()),
-                    StatusFlags::NONE,
-                    SqlType::Int(Some(1)),
+            let table = h.create_encrypted_table("INT", "DETERMINISTIC").await;
+            let param = RpcParameter::new(
+                Some("@val".to_string()),
+                StatusFlags::NONE,
+                SqlType::Int(Some(555)),
+            );
+            h.client
+                .execute_sp_prepexec(
+                    format!("INSERT INTO {table} (val) VALUES (@val);"),
+                    vec![param],
+                    None,
+                    None,
                 )
-            };
-
-            let prepare_err = h
-                .client
-                .execute_sp_prepare(sql.clone(), vec![mk_param()], None, None)
                 .await
-                .expect_err("sp_prepare with params must fail fast under AE");
+                .expect("sp_prepexec with encrypted parameter");
+            while h.client.move_to_next().await.unwrap() {}
+            h.client.close_query().await.unwrap();
+
+            let got = select_val(&mut h.client, &table)
+                .await
+                .expect("read back value inserted via sp_prepexec");
             assert!(
-                matches!(
-                    prepare_err,
-                    mssql_tds::error::Error::UnimplementedFeature { .. }
-                ),
-                "expected UnimplementedFeature for sp_prepare, got {prepare_err:?}"
+                matches!(got, ColumnValues::Int(555)),
+                "sp_prepexec encrypted insert round-trip, got {got:?}"
             );
+        });
+    }
 
-            let prepexec_err = h
-                .client
-                .execute_sp_prepexec(sql.clone(), vec![mk_param()], None, None)
-                .await
-                .expect_err("sp_prepexec with params must fail fast under AE");
-            assert!(
-                matches!(
-                    prepexec_err,
-                    mssql_tds::error::Error::UnimplementedFeature { .. }
-                ),
-                "expected UnimplementedFeature for sp_prepexec, got {prepexec_err:?}"
+    /// `sp_prepare` describes the statement's parameters once and caches the
+    /// metadata under the handle; each `sp_execute` then encrypts values from the
+    /// cache without describing again. Uses named parameters.
+    #[tokio::test]
+    async fn sp_prepare_execute_encrypts_named_parameters() {
+        ae_test!(|h| {
+            let table = h.create_encrypted_table("INT", "DETERMINISTIC").await;
+            let decl = RpcParameter::new(
+                Some("@val".to_string()),
+                StatusFlags::NONE,
+                SqlType::Int(None),
             );
-
-            let execute_err = h
+            let handle = h
                 .client
-                .execute_sp_execute(1, None, Some(vec![mk_param()]), None, None)
+                .execute_sp_prepare(
+                    format!("INSERT INTO {table} (val) VALUES (@val);"),
+                    vec![decl],
+                    None,
+                    None,
+                )
                 .await
-                .expect_err("sp_execute with params must fail fast under AE");
+                .expect("sp_prepare with encrypted parameter");
+
+            for v in [111, 222] {
+                let param = RpcParameter::new(
+                    Some("@val".to_string()),
+                    StatusFlags::NONE,
+                    SqlType::Int(Some(v)),
+                );
+                h.client
+                    .execute_sp_execute(handle, None, Some(vec![param]), None, None)
+                    .await
+                    .expect("sp_execute with encrypted named parameter");
+                while h.client.move_to_next().await.unwrap() {}
+                h.client.close_query().await.unwrap();
+            }
+
+            h.client
+                .execute_sp_unprepare(handle, None, None)
+                .await
+                .expect("unprepare");
+
+            let rows = h
+                .query_rows(&format!("SELECT val FROM {table} ORDER BY id;"), 1)
+                .await;
+            assert_eq!(rows.len(), 2, "expected two encrypted rows inserted");
             assert!(
-                matches!(
-                    execute_err,
-                    mssql_tds::error::Error::UnimplementedFeature { .. }
-                ),
-                "expected UnimplementedFeature for sp_execute, got {execute_err:?}"
+                matches!(rows[0][0], ColumnValues::Int(111)),
+                "row0 {:?}",
+                rows[0][0]
+            );
+            assert!(
+                matches!(rows[1][0], ColumnValues::Int(222)),
+                "row1 {:?}",
+                rows[1][0]
+            );
+        });
+    }
+
+    /// `sp_execute` positional parameters (unnamed) are matched to the cached
+    /// describe metadata by ordinal and encrypted.
+    #[tokio::test]
+    async fn sp_execute_encrypts_positional_parameter() {
+        ae_test!(|h| {
+            let table = h.create_encrypted_table("INT", "DETERMINISTIC").await;
+            let decl = RpcParameter::new(
+                Some("@val".to_string()),
+                StatusFlags::NONE,
+                SqlType::Int(None),
+            );
+            let handle = h
+                .client
+                .execute_sp_prepare(
+                    format!("INSERT INTO {table} (val) VALUES (@val);"),
+                    vec![decl],
+                    None,
+                    None,
+                )
+                .await
+                .expect("sp_prepare");
+
+            // Positional (unnamed) value, matched to the declared @val by ordinal.
+            let param = RpcParameter::new(None, StatusFlags::NONE, SqlType::Int(Some(999)));
+            h.client
+                .execute_sp_execute(handle, Some(vec![param]), None, None, None)
+                .await
+                .expect("sp_execute with positional encrypted parameter");
+            while h.client.move_to_next().await.unwrap() {}
+            h.client.close_query().await.unwrap();
+
+            h.client
+                .execute_sp_unprepare(handle, None, None)
+                .await
+                .expect("unprepare");
+
+            let got = select_val(&mut h.client, &table)
+                .await
+                .expect("read back positional prepared insert");
+            assert!(
+                matches!(got, ColumnValues::Int(999)),
+                "sp_execute positional encrypted insert, got {got:?}"
+            );
+        });
+    }
+
+    /// `sp_execute` with parameters under Always Encrypted requires the handle to
+    /// have been prepared on this connection (so its parameter-encryption metadata
+    /// is cached). An unknown handle must error rather than send plaintext.
+    #[tokio::test]
+    async fn sp_execute_without_prepared_metadata_errors_under_ae() {
+        ae_test!(|h| {
+            let param = RpcParameter::new(
+                Some("@val".to_string()),
+                StatusFlags::NONE,
+                SqlType::Int(Some(1)),
+            );
+            let err = h
+                .client
+                .execute_sp_execute(999_999, None, Some(vec![param]), None, None)
+                .await
+                .expect_err("sp_execute with an unprepared handle must error under AE");
+            assert!(
+                matches!(err, mssql_tds::error::Error::ColumnEncryptionError(_)),
+                "expected ColumnEncryptionError for unknown handle, got {err:?}"
             );
         });
     }

--- a/mssql-tds/tests/test_always_encrypted.rs
+++ b/mssql-tds/tests/test_always_encrypted.rs
@@ -1042,6 +1042,81 @@ mod always_encrypted {
         });
     }
 
+    /// A prepared statement with two encrypted parameters executed with one value
+    /// supplied positionally and the other by name: both must be encrypted in a
+    /// single pass. Regression for the two-list double-apply bug, where each list
+    /// was described separately and the parameter in the other list was reported
+    /// as "not supplied".
+    #[tokio::test]
+    async fn sp_execute_encrypts_mixed_positional_and_named_parameters() {
+        ae_test!(|h| {
+            let enc = h.enc_clause("DETERMINISTIC");
+            let table = h
+                .create_table(&format!(
+                    "id INT IDENTITY(1,1) PRIMARY KEY, a INT {enc} NULL, b INT {enc} NULL"
+                ))
+                .await;
+            let decls = vec![
+                RpcParameter::new(
+                    Some("@a".to_string()),
+                    StatusFlags::NONE,
+                    SqlType::Int(None),
+                ),
+                RpcParameter::new(
+                    Some("@b".to_string()),
+                    StatusFlags::NONE,
+                    SqlType::Int(None),
+                ),
+            ];
+            let handle = h
+                .client
+                .execute_sp_prepare(
+                    format!("INSERT INTO {table} (a, b) VALUES (@a, @b);"),
+                    decls,
+                    None,
+                    None,
+                )
+                .await
+                .expect("sp_prepare two encrypted params");
+
+            // @a supplied positionally (ordinal 1); @b supplied by name.
+            let positional = vec![RpcParameter::new(
+                None,
+                StatusFlags::NONE,
+                SqlType::Int(Some(11)),
+            )];
+            let named = vec![RpcParameter::new(
+                Some("@b".to_string()),
+                StatusFlags::NONE,
+                SqlType::Int(Some(22)),
+            )];
+            h.client
+                .execute_sp_execute(handle, Some(positional), Some(named), None, None)
+                .await
+                .expect("sp_execute with mixed positional and named encrypted params");
+            while h.client.move_to_next().await.unwrap() {}
+            h.client.close_query().await.unwrap();
+
+            h.client
+                .execute_sp_unprepare(handle, None, None)
+                .await
+                .expect("unprepare");
+
+            let rows = h.query_rows(&format!("SELECT a, b FROM {table};"), 2).await;
+            assert_eq!(rows.len(), 1, "expected one row");
+            assert!(
+                matches!(rows[0][0], ColumnValues::Int(11)),
+                "a {:?}",
+                rows[0][0]
+            );
+            assert!(
+                matches!(rows[0][1], ColumnValues::Int(22)),
+                "b {:?}",
+                rows[0][1]
+            );
+        });
+    }
+
     /// `sp_execute` with parameters under Always Encrypted requires the handle to
     /// have been prepared on this connection (so its parameter-encryption metadata
     /// is cached). An unknown handle must error rather than send plaintext.


### PR DESCRIPTION
## Summary

Phase 1B follow-up to Always Encrypted in `mssql-tds`: transparent parameter encryption for the **prepared-statement paths** (`sp_prepexec`, `sp_prepare`/`sp_execute`), plus a **connection-scoped query-metadata cache** so every parameterized execution reuses its `sp_describe_parameter_encryption` result. These paths previously failed fast with `UnimplementedFeature` on an AE-enabled connection when parameters were supplied.

## Prepared-statement encryption

- **`sp_prepexec`** — prepares and executes in one round-trip, so it describes the statement and encrypts flagged parameters in place before the RPC, exactly like `sp_executesql`.
- **`sp_prepare`** — describes the statement's parameters and pins the metadata under the returned handle. `sp_prepare` sends no user parameter values, so nothing is encrypted here.
- **`sp_execute`** — encrypts the supplied values from the pinned metadata with **no re-describe**. Positional (unnamed) parameters are matched by ordinal; named parameters by name. An unknown handle errors rather than sending plaintext.
- **`sp_unprepare`** — drops the handle's pinned metadata.

## Query-metadata cache (matches SqlClient / JDBC)

Instead of the narrower per-prepared-handle model (effectively the ODBC statement-handle approach), the describe result is cached **per connection, keyed by `(database, query text)`**, mirroring .NET SqlClient's `SqlQueryMetadataCache` and JDBC's `ParameterMetaDataCache`:

- Bounded to **2000 entries** with a **300-entry trim threshold** and a **10-hour TTL** (SqlClient's values).
- Shared across **all** parameterized paths — `sp_executesql`, stored procedures, `sp_prepexec`, and `sp_prepare`/`sp_execute` — so any repeat execution of the same statement skips the describe round-trip. This also delivers the Phase 1B perf item ("cache `sp_describe_parameter_encryption`").
- Only the **encrypted CEK wire metadata** is cached — plaintext keys are never stored here; they are re-derived per use through the (separate) CEK cache.
- **Output-parameter statements are not cached** (mirrors SqlClient, which can't validate cached metadata against a `RETURNVALUE`).
- `sp_prepare` pins the describe result under the handle via an `Arc` to the same cache entry, so `sp_execute` keeps working even if the shared cache evicts the entry.
- Added a `describe_round_trips()` counter for observability and to prove reuse in tests.

## Testing

- `cargo clippy --all-targets -- -D warnings` clean.
- `QueryMetadataCache` unit tests: key format, hit/miss, TTL eviction, bounded trim.
- Live integration tests: `sp_prepexec_encrypts_parameter`, `sp_prepare_execute_encrypts_named_parameters` (prepare once, execute twice), `sp_execute_encrypts_positional_parameter` (ordinal matching), `sp_execute_without_prepared_metadata_errors_under_ae` (unknown handle errors), and `query_metadata_cache_reuses_describe` (three identical executions -> one describe round-trip).
- Full Always Encrypted integration suite (31 tests) passes against SQL Server 2022; the 4 pre-existing `certificate_validator` unit-test failures are unrelated.

## Notes / follow-up

- `sp_execute` requires the handle to have been prepared via `execute_sp_prepare` on the same connection (the pinned metadata). Reusing an `sp_prepexec` handle with a later `sp_execute` under AE errors clearly; it can be added later if needed.
- Positional **stored-procedure** parameters (distinct from prepared-statement positional params) remain a deferred Phase 1B follow-up.
- Encrypted **output-parameter** decryption for these paths composes once the RETURNVALUE-decryption PR (#104) merges.
