### PR TITLE
Wire baseline authentication in mssql-odbc SQLDriverConnect (T1)

### DIFF
--- a/mssql-odbc/src/api/driver_connect.rs
+++ b/mssql-odbc/src/api/driver_connect.rs
@@ -223,13 +223,12 @@ fn do_connect(
     // Resolve authentication. Validate the ODBC keyword/credential combination,
     // then transform it into a concrete method with cleaned credentials. Any
     // access token was supplied before connect via SQL_COPT_SS_ACCESS_TOKEN.
-    let access_token = state.access_token.clone();
     if let Err(e) = validate_auth(
         params.authentication.as_deref(),
         params.trusted_connection,
         &params.uid,
         &params.pwd,
-        access_token.as_deref(),
+        state.access_token.as_deref(),
     ) {
         error!(%e, "SQLDriverConnectW: authentication validation failed");
         post_sql_error(state, SQLSTATE_HY024, 0, e.to_string());
@@ -240,7 +239,7 @@ fn do_connect(
         params.trusted_connection,
         &params.uid,
         &params.pwd,
-        access_token.as_deref(),
+        state.access_token.as_deref(),
     );
 
     // T1 wires SQL password, integrated (SSPI/GSSAPI), and pre-acquired access

--- a/mssql-odbc/src/api/driver_connect.rs
+++ b/mssql-odbc/src/api/driver_connect.rs
@@ -11,8 +11,8 @@ use crate::api::odbc_types::{
 };
 use crate::api::sqlstate::{
     ERR_FUNCTION_SEQUENCE, ERR_INVALID_CONNECTION_STRING_ATTRIBUTE, ERR_INVALID_NULL_POINTER,
-    ERR_STRING_RIGHT_TRUNCATION, SQLSTATE_08001, SQLSTATE_HY024, SQLSTATE_HY110, post_diag,
-    post_tds_error,
+    ERR_STRING_RIGHT_TRUNCATION, SQLSTATE_08001, SQLSTATE_HY024, SQLSTATE_HY110, SQLSTATE_HYC00,
+    post_diag, post_tds_error,
 };
 use crate::api::util::{copy_with_nul, write_if_some};
 use crate::error::{free_errors, post_sql_error};
@@ -25,6 +25,8 @@ use mssql_tds::connection_provider::tds_connection_provider::TdsConnectionProvid
 use mssql_tds::core::{EncryptionOptions, EncryptionSetting};
 
 use super::util::read_utf16;
+use crate::connection::odbc_authentication_transformer::transform_auth;
+use crate::connection::odbc_authentication_validator::validate_auth;
 use crate::connection::parse_connection_string;
 
 /// Implementation of `SQLDriverConnectW`.
@@ -218,12 +220,57 @@ fn do_connect(
         return SQL_ERROR;
     }
 
+    // Resolve authentication. Validate the ODBC keyword/credential combination,
+    // then transform it into a concrete method with cleaned credentials. Any
+    // access token was supplied before connect via SQL_COPT_SS_ACCESS_TOKEN.
+    let access_token = state.access_token.clone();
+    if let Err(e) = validate_auth(
+        params.authentication.as_deref(),
+        params.trusted_connection,
+        &params.uid,
+        &params.pwd,
+        access_token.as_deref(),
+    ) {
+        error!(%e, "SQLDriverConnectW: authentication validation failed");
+        post_sql_error(state, SQLSTATE_HY024, 0, e.to_string());
+        return SQL_ERROR;
+    }
+    let resolved = transform_auth(
+        params.authentication.as_deref(),
+        params.trusted_connection,
+        &params.uid,
+        &params.pwd,
+        access_token.as_deref(),
+    );
+
+    // T1 wires SQL password, integrated (SSPI/GSSAPI), and pre-acquired access
+    // tokens. Entra methods that require token acquisition are not yet available.
+    match &resolved.method {
+        TdsAuthenticationMethod::Password
+        | TdsAuthenticationMethod::SSPI
+        | TdsAuthenticationMethod::AccessToken => {}
+        other => {
+            error!(
+                ?other,
+                "SQLDriverConnectW: authentication method not implemented"
+            );
+            post_sql_error(
+                state,
+                SQLSTATE_HYC00,
+                0,
+                format!("Authentication method {other:?} is not yet supported"),
+            );
+            return SQL_ERROR;
+        }
+    }
+
     // Build ClientContext
     let mut context = ClientContext::default();
-    context.user_name = params.uid.clone();
-    context.password = params.pwd.clone();
+    context.user_name = resolved.user_name;
+    context.password = resolved.password;
+    context.access_token = resolved.access_token;
     context.database = params.database.clone();
-    context.tds_authentication_method = TdsAuthenticationMethod::Password;
+    context.tds_authentication_method = resolved.method;
     context.encryption_options = EncryptionOptions {
         trust_server_certificate: params.trust_server_certificate,
         mode: match params.encrypt.as_deref() {
@@ -392,6 +439,58 @@ mod tests {
         };
         assert_eq!(ret, SQL_ERROR);
         assert_eq!(unsafe { diag_sqlstate(dbc, 1) }, "HY009");
+    }
+
+    #[test]
+    fn entra_method_not_implemented_returns_hyc00() {
+        // ActiveDirectoryMSI validates fine but needs token acquisition (T2);
+        // the gate must reject it with HYC00 before any network activity.
+        let h = TestHandles::with_env_dbc();
+        let dbc = h.dbc;
+        let conn_str: Vec<u16> = cs("Server=s;Authentication=ActiveDirectoryMSI")
+            .encode_utf16()
+            .chain(std::iter::once(0))
+            .collect();
+        let ret = unsafe {
+            sql_driver_connect_w(
+                dbc,
+                std::ptr::null_mut(),
+                conn_str.as_ptr(),
+                SQL_NTS,
+                std::ptr::null_mut(),
+                0,
+                std::ptr::null_mut(),
+                SQL_DRIVER_NOPROMPT,
+            )
+        };
+        assert_eq!(ret, SQL_ERROR);
+        assert_eq!(unsafe { diag_sqlstate(dbc, 1) }, "HYC00");
+    }
+
+    #[test]
+    fn authentication_with_trusted_connection_conflicts() {
+        // Authentication and Trusted_Connection are mutually exclusive; the
+        // validator must reject the combination (HY024) before connecting.
+        let h = TestHandles::with_env_dbc();
+        let dbc = h.dbc;
+        let conn_str: Vec<u16> = cs("Server=s;Authentication=SqlPassword;Trusted_Connection=yes")
+            .encode_utf16()
+            .chain(std::iter::once(0))
+            .collect();
+        let ret = unsafe {
+            sql_driver_connect_w(
+                dbc,
+                std::ptr::null_mut(),
+                conn_str.as_ptr(),
+                SQL_NTS,
+                std::ptr::null_mut(),
+                0,
+                std::ptr::null_mut(),
+                SQL_DRIVER_NOPROMPT,
+            )
+        };
+        assert_eq!(ret, SQL_ERROR);
+        assert_eq!(unsafe { diag_sqlstate(dbc, 1) }, "HY024");
     }
 
     #[test]

--- a/mssql-odbc/src/api/exports.rs
+++ b/mssql-odbc/src/api/exports.rs
@@ -394,13 +394,20 @@ pub unsafe extern "C" fn SQLRowCount(
 /// - `string_length` is used only for string-type attributes.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn SQLSetConnectAttrW(
-    _connection_handle: SqlHandle,
-    _attribute: SqlInteger,
-    _value_ptr: SqlPointer,
-    _string_length: SqlInteger,
+    connection_handle: SqlHandle,
+    attribute: SqlInteger,
+    value_ptr: SqlPointer,
+    string_length: SqlInteger,
 ) -> SqlReturn {
     crate::init_tracing();
-    SQL_SUCCESS
+    unsafe {
+        super::set_connect_attr::sql_set_connect_attr_w(
+            connection_handle,
+            attribute,
+            value_ptr,
+            string_length,
+        )
+    }
 }
 
 /// Retrieves a connection attribute.

--- a/mssql-odbc/src/api/mod.rs
+++ b/mssql-odbc/src/api/mod.rs
@@ -15,6 +15,7 @@ mod more_results;
 mod num_result_cols;
 pub(crate) mod odbc_types;
 mod prepare;
+pub(crate) mod set_connect_attr;
 pub(crate) mod set_env_attr;
 pub(crate) mod sqlstate;
 pub(crate) mod util;

--- a/mssql-odbc/src/api/odbc_types.rs
+++ b/mssql-odbc/src/api/odbc_types.rs
@@ -56,6 +56,16 @@ pub const SQL_OV_ODBC3_80: u32 = 380;
 // of the UTF-16-LE-encoded token.
 pub const SQL_COPT_SS_ACCESS_TOKEN: SqlInteger = 1256;
 
+// Standard ODBC connection attributes the Driver Manager commonly sets before
+// connecting. Accepted (currently ignored) so the DM handshake is not broken.
+pub const SQL_ATTR_ACCESS_MODE: SqlInteger = 101;
+pub const SQL_ATTR_LOGIN_TIMEOUT: SqlInteger = 103;
+pub const SQL_ATTR_PACKET_SIZE: SqlInteger = 112;
+pub const SQL_ATTR_CONNECTION_TIMEOUT: SqlInteger = 113;
+
+// Sentinel `StringLength` meaning "the value is a pointer" (ODBC).
+pub const SQL_IS_POINTER: SqlInteger = -4;
+
 // DriverCompletion constants for SQLDriverConnect
 pub const SQL_DRIVER_NOPROMPT: SqlUSmallInt = 0;
 pub const SQL_DRIVER_COMPLETE: SqlUSmallInt = 1;

--- a/mssql-odbc/src/api/odbc_types.rs
+++ b/mssql-odbc/src/api/odbc_types.rs
@@ -50,6 +50,12 @@ pub const SQL_OV_ODBC2: u32 = 2;
 pub const SQL_OV_ODBC3: u32 = 3;
 pub const SQL_OV_ODBC3_80: u32 = 380;
 
+// Connection attribute identifiers (SQLSetConnectAttr / SQLGetConnectAttr).
+// msodbcsql-specific: pre-connect Entra access token. `value_ptr` points to an
+// ACCESSTOKEN struct: a 4-byte little-endian length followed by that many bytes
+// of the UTF-16-LE-encoded token.
+pub const SQL_COPT_SS_ACCESS_TOKEN: SqlInteger = 1256;
+
 // DriverCompletion constants for SQLDriverConnect
 pub const SQL_DRIVER_NOPROMPT: SqlUSmallInt = 0;
 pub const SQL_DRIVER_COMPLETE: SqlUSmallInt = 1;

--- a/mssql-odbc/src/api/set_connect_attr.rs
+++ b/mssql-odbc/src/api/set_connect_attr.rs
@@ -1,0 +1,209 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Implementation of SQLSetConnectAttrW.
+//!
+//! Currently handles the msodbcsql-specific `SQL_COPT_SS_ACCESS_TOKEN`
+//! attribute, which supplies a pre-acquired Entra access token before
+//! connecting. Other attributes are accepted as no-ops for now.
+
+use tracing::{debug, error};
+
+use super::sqlstate::*;
+use crate::api::odbc_types::{
+    SQL_COPT_SS_ACCESS_TOKEN, SQL_ERROR, SQL_INVALID_HANDLE, SQL_SUCCESS, SqlHandle, SqlInteger,
+    SqlPointer, SqlReturn,
+};
+use crate::error::{free_errors, post_sql_error};
+use crate::handles::dbc::ConnectionState;
+use crate::handles::{DbcHandle, HandleType, handle_from_raw};
+
+/// Sets a connection attribute.
+///
+/// # Safety
+/// - `connection_handle` must be a valid `DbcHandle` from `SQLAllocHandle`.
+/// - For `SQL_COPT_SS_ACCESS_TOKEN`, `value_ptr` must point to an ACCESSTOKEN
+///   struct: a 4-byte little-endian length prefix followed by that many bytes
+///   of the UTF-16-LE-encoded access token.
+pub(crate) unsafe fn sql_set_connect_attr_w(
+    connection_handle: SqlHandle,
+    attribute: SqlInteger,
+    value_ptr: SqlPointer,
+    string_length: SqlInteger,
+) -> SqlReturn {
+    debug!(
+        ?connection_handle,
+        attribute,
+        ?value_ptr,
+        "SQLSetConnectAttrW called",
+    );
+
+    crate::ffi_entry!("SQLSetConnectAttrW", unsafe {
+        sql_set_connect_attr_w_impl(connection_handle, attribute, value_ptr, string_length)
+    })
+}
+
+unsafe fn sql_set_connect_attr_w_impl(
+    connection_handle: SqlHandle,
+    attribute: SqlInteger,
+    value_ptr: SqlPointer,
+    _string_length: SqlInteger,
+) -> SqlReturn {
+    if connection_handle.is_null() {
+        error!("SQLSetConnectAttrW: connection_handle is null");
+        return SQL_INVALID_HANDLE;
+    }
+
+    let dbc = unsafe { handle_from_raw::<DbcHandle>(connection_handle) };
+    debug_assert_eq!(
+        dbc.object_type,
+        HandleType::Dbc,
+        "SQLSetConnectAttrW: handle is not a DBC"
+    );
+
+    let Ok(mut state) = dbc.inner.lock() else {
+        error!("SQLSetConnectAttrW: dbc mutex poisoned");
+        return SQL_ERROR;
+    };
+    free_errors(&mut state);
+
+    match attribute {
+        SQL_COPT_SS_ACCESS_TOKEN => {
+            // The access token is a pre-connect attribute; reject it once a
+            // connection attempt has started. msodbcsql posts HY011 ("attribute
+            // cannot be set now") for this case (sqlcmisc.cpp), not HY010.
+            if state.connection_state != ConnectionState::Disconnected {
+                error!("SQLSetConnectAttrW: SQL_COPT_SS_ACCESS_TOKEN set after connect");
+                post_sql_error(
+                    &mut state,
+                    SQLSTATE_HY011,
+                    0,
+                    "SQL_COPT_SS_ACCESS_TOKEN must be set before connecting",
+                );
+                return SQL_ERROR;
+            }
+            if value_ptr.is_null() {
+                error!("SQLSetConnectAttrW: SQL_COPT_SS_ACCESS_TOKEN value is null");
+                post_sql_error(
+                    &mut state,
+                    SQLSTATE_HY009,
+                    0,
+                    "SQL_COPT_SS_ACCESS_TOKEN value pointer is null",
+                );
+                return SQL_ERROR;
+            }
+            match unsafe { decode_access_token(value_ptr) } {
+                Some(token) => {
+                    state.access_token = Some(token);
+                    debug!("SQLSetConnectAttrW: access token stored");
+                    SQL_SUCCESS
+                }
+                None => {
+                    error!("SQLSetConnectAttrW: malformed SQL_COPT_SS_ACCESS_TOKEN structure");
+                    post_sql_error(
+                        &mut state,
+                        SQLSTATE_HY024,
+                        0,
+                        "Malformed SQL_COPT_SS_ACCESS_TOKEN structure",
+                    );
+                    SQL_ERROR
+                }
+            }
+        }
+        // Other connection attributes are accepted as no-ops for now.
+        _ => SQL_SUCCESS,
+    }
+}
+
+/// Decodes the msodbcsql `SQL_COPT_SS_ACCESS_TOKEN` structure into the raw JWT.
+///
+/// Layout: a 4-byte little-endian length `n`, followed by `n` bytes of the
+/// access token encoded as UTF-16-LE. Returns `None` if the length is zero,
+/// odd, or the bytes are not valid UTF-16. The raw JWT is re-encoded to
+/// UTF-16-LE by mssql-tds for the TDS wire format.
+///
+/// # Safety
+/// `value_ptr` must point to a valid ACCESSTOKEN struct whose declared length
+/// does not exceed the allocation.
+unsafe fn decode_access_token(value_ptr: SqlPointer) -> Option<String> {
+    let base = value_ptr as *const u8;
+    let mut len_bytes = [0u8; 4];
+    unsafe { std::ptr::copy_nonoverlapping(base, len_bytes.as_mut_ptr(), 4) };
+    let data_size = u32::from_le_bytes(len_bytes) as usize;
+    if data_size == 0 || !data_size.is_multiple_of(2) {
+        return None;
+    }
+    let data = unsafe { std::slice::from_raw_parts(base.add(4), data_size) };
+    let units: Vec<u16> = data
+        .chunks_exact(2)
+        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+        .collect();
+    String::from_utf16(&units).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::TestHandles;
+
+    /// Build a `SQL_COPT_SS_ACCESS_TOKEN` struct the way msodbcsql apps do:
+    /// a 4-byte little-endian length followed by UTF-16-LE token bytes.
+    fn make_token_struct(jwt: &str) -> Vec<u8> {
+        let token_bytes: Vec<u8> = jwt.encode_utf16().flat_map(|u| u.to_le_bytes()).collect();
+        let mut buf = (token_bytes.len() as u32).to_le_bytes().to_vec();
+        buf.extend_from_slice(&token_bytes);
+        buf
+    }
+
+    #[test]
+    fn decode_round_trips_jwt() {
+        let jwt = "eyJhbGciOiJ.header.sig";
+        let buf = make_token_struct(jwt);
+        let decoded = unsafe { decode_access_token(buf.as_ptr() as SqlPointer) };
+        assert_eq!(decoded.as_deref(), Some(jwt));
+    }
+
+    #[test]
+    fn decode_rejects_odd_length() {
+        // Declared length 3 is odd -> not valid UTF-16-LE.
+        let buf: Vec<u8> = vec![3, 0, 0, 0, b'a', 0, b'b'];
+        let decoded = unsafe { decode_access_token(buf.as_ptr() as SqlPointer) };
+        assert_eq!(decoded, None);
+    }
+
+    #[test]
+    fn set_before_connect_stores_token() {
+        let h = TestHandles::with_env_dbc();
+        let jwt = "abc.def.ghi";
+        let buf = make_token_struct(jwt);
+        let ret = unsafe {
+            sql_set_connect_attr_w(
+                h.dbc,
+                SQL_COPT_SS_ACCESS_TOKEN,
+                buf.as_ptr() as SqlPointer,
+                buf.len() as SqlInteger,
+            )
+        };
+        assert_eq!(ret, SQL_SUCCESS);
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        let state = dbc.inner.lock().unwrap();
+        assert_eq!(state.access_token.as_deref(), Some(jwt));
+    }
+
+    #[test]
+    fn null_token_pointer_is_rejected() {
+        let h = TestHandles::with_env_dbc();
+        let ret = unsafe {
+            sql_set_connect_attr_w(h.dbc, SQL_COPT_SS_ACCESS_TOKEN, std::ptr::null_mut(), 0)
+        };
+        assert_eq!(ret, SQL_ERROR);
+    }
+
+    #[test]
+    fn unknown_attribute_is_accepted_as_noop() {
+        let h = TestHandles::with_env_dbc();
+        // 1234 is an arbitrary unhandled attribute id.
+        let ret = unsafe { sql_set_connect_attr_w(h.dbc, 1234, std::ptr::null_mut(), 0) };
+        assert_eq!(ret, SQL_SUCCESS);
+    }
+}

--- a/mssql-odbc/src/api/set_connect_attr.rs
+++ b/mssql-odbc/src/api/set_connect_attr.rs
@@ -126,11 +126,14 @@ unsafe fn sql_set_connect_attr_w_impl(
 /// `value_ptr` must point to a valid ACCESSTOKEN struct whose declared length
 /// does not exceed the allocation.
 unsafe fn decode_access_token(value_ptr: SqlPointer) -> Option<String> {
+    // Entra JWTs are only a few KB; reject an implausibly large declared length
+    // so a malformed struct fails closed instead of a huge read/allocation.
+    const MAX_ACCESS_TOKEN_BYTES: usize = 64 * 1024;
     let base = value_ptr as *const u8;
     let mut len_bytes = [0u8; 4];
     unsafe { std::ptr::copy_nonoverlapping(base, len_bytes.as_mut_ptr(), 4) };
     let data_size = u32::from_le_bytes(len_bytes) as usize;
-    if data_size == 0 || !data_size.is_multiple_of(2) {
+    if data_size == 0 || !data_size.is_multiple_of(2) || data_size > MAX_ACCESS_TOKEN_BYTES {
         return None;
     }
     let data = unsafe { std::slice::from_raw_parts(base.add(4), data_size) };
@@ -167,6 +170,14 @@ mod tests {
     fn decode_rejects_odd_length() {
         // Declared length 3 is odd -> not valid UTF-16-LE.
         let buf: Vec<u8> = vec![3, 0, 0, 0, b'a', 0, b'b'];
+        let decoded = unsafe { decode_access_token(buf.as_ptr() as SqlPointer) };
+        assert_eq!(decoded, None);
+    }
+
+    #[test]
+    fn decode_rejects_oversized_length() {
+        // A declared length far above the cap is rejected before any read.
+        let buf: Vec<u8> = 200_000u32.to_le_bytes().to_vec();
         let decoded = unsafe { decode_access_token(buf.as_ptr() as SqlPointer) };
         assert_eq!(decoded, None);
     }

--- a/mssql-odbc/src/api/set_connect_attr.rs
+++ b/mssql-odbc/src/api/set_connect_attr.rs
@@ -11,14 +11,20 @@ use tracing::{debug, error};
 
 use super::sqlstate::*;
 use crate::api::odbc_types::{
-    SQL_COPT_SS_ACCESS_TOKEN, SQL_ERROR, SQL_INVALID_HANDLE, SQL_SUCCESS, SqlHandle, SqlInteger,
-    SqlPointer, SqlReturn,
+    SQL_ATTR_ACCESS_MODE, SQL_ATTR_CONNECTION_TIMEOUT, SQL_ATTR_LOGIN_TIMEOUT,
+    SQL_ATTR_PACKET_SIZE, SQL_COPT_SS_ACCESS_TOKEN, SQL_ERROR, SQL_INVALID_HANDLE, SQL_SUCCESS,
+    SqlHandle, SqlInteger, SqlPointer, SqlReturn,
 };
 use crate::error::{free_errors, post_sql_error};
 use crate::handles::dbc::ConnectionState;
 use crate::handles::{DbcHandle, HandleType, handle_from_raw};
 
 /// Sets a connection attribute.
+///
+/// For `SQL_COPT_SS_ACCESS_TOKEN`, `string_length` is ignored: real ODBC callers
+/// pass `SQL_IS_POINTER` and the token length comes from the `ACCESSTOKEN`
+/// struct's own `dataSize` field (matching msodbcsql). Unrecognized attributes
+/// return `HYC00` rather than silently succeeding.
 ///
 /// # Safety
 /// - `connection_handle` must be a valid `DbcHandle` from `SQLAllocHandle`.
@@ -110,17 +116,37 @@ unsafe fn sql_set_connect_attr_w_impl(
                 }
             }
         }
-        // Other connection attributes are accepted as no-ops for now.
-        _ => SQL_SUCCESS,
+        // Standard attributes the Driver Manager sets before connecting that we
+        // accept (and currently ignore) so the connect handshake is not broken.
+        // TODO: honor these (timeouts, packet size, access mode) once wired.
+        SQL_ATTR_ACCESS_MODE
+        | SQL_ATTR_LOGIN_TIMEOUT
+        | SQL_ATTR_CONNECTION_TIMEOUT
+        | SQL_ATTR_PACKET_SIZE => SQL_SUCCESS,
+        // Any other attribute is genuinely unsupported: surface a clear error
+        // (HYC00) instead of silently pretending it took effect.
+        _ => {
+            error!(
+                attribute,
+                "SQLSetConnectAttrW: unsupported connection attribute"
+            );
+            post_sql_error(
+                &mut state,
+                SQLSTATE_HYC00,
+                0,
+                "Connection attribute not supported",
+            );
+            SQL_ERROR
+        }
     }
 }
 
 /// Decodes the msodbcsql `SQL_COPT_SS_ACCESS_TOKEN` structure into the raw JWT.
 ///
-/// Layout: a 4-byte little-endian length `n`, followed by `n` bytes of the
-/// access token encoded as UTF-16-LE. Returns `None` if the length is zero,
-/// odd, or the bytes are not valid UTF-16. The raw JWT is re-encoded to
-/// UTF-16-LE by mssql-tds for the TDS wire format.
+/// Layout: a 4-byte native-endian length `n` (an `unsigned int`), followed by
+/// `n` bytes of the access token encoded as UTF-16-LE. Returns `None` if the
+/// length is zero, odd, exceeds the size cap, or the bytes are not valid
+/// UTF-16. The raw JWT is re-encoded to UTF-16-LE by mssql-tds for the wire.
 ///
 /// # Safety
 /// `value_ptr` must point to a valid ACCESSTOKEN struct whose declared length
@@ -130,12 +156,19 @@ unsafe fn decode_access_token(value_ptr: SqlPointer) -> Option<String> {
     // so a malformed struct fails closed instead of a huge read/allocation.
     const MAX_ACCESS_TOKEN_BYTES: usize = 64 * 1024;
     let base = value_ptr as *const u8;
+    // SAFETY: the caller guarantees `value_ptr` points to a readable ACCESSTOKEN
+    // whose first 4 bytes are the `dataSize` field. Copying avoids assuming the
+    // pointer is aligned for a `*const u32` read.
     let mut len_bytes = [0u8; 4];
     unsafe { std::ptr::copy_nonoverlapping(base, len_bytes.as_mut_ptr(), 4) };
-    let data_size = u32::from_le_bytes(len_bytes) as usize;
+    // `dataSize` is a native `unsigned int` written by the caller in host byte
+    // order; the UTF-16 payload below is explicitly little-endian.
+    let data_size = u32::from_ne_bytes(len_bytes) as usize;
     if data_size == 0 || !data_size.is_multiple_of(2) || data_size > MAX_ACCESS_TOKEN_BYTES {
         return None;
     }
+    // SAFETY: `data_size` is bounded to <= MAX_ACCESS_TOKEN_BYTES and the caller
+    // guarantees the payload is `dataSize` bytes after the 4-byte length prefix.
     let data = unsafe { std::slice::from_raw_parts(base.add(4), data_size) };
     let units: Vec<u16> = data
         .chunks_exact(2)
@@ -147,6 +180,7 @@ unsafe fn decode_access_token(value_ptr: SqlPointer) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::odbc_types::SQL_IS_POINTER;
     use crate::test_support::TestHandles;
 
     /// Build a `SQL_COPT_SS_ACCESS_TOKEN` struct the way msodbcsql apps do:
@@ -192,7 +226,7 @@ mod tests {
                 h.dbc,
                 SQL_COPT_SS_ACCESS_TOKEN,
                 buf.as_ptr() as SqlPointer,
-                buf.len() as SqlInteger,
+                SQL_IS_POINTER,
             )
         };
         assert_eq!(ret, SQL_SUCCESS);
@@ -211,10 +245,20 @@ mod tests {
     }
 
     #[test]
-    fn unknown_attribute_is_accepted_as_noop() {
+    fn unsupported_attribute_returns_error() {
         let h = TestHandles::with_env_dbc();
-        // 1234 is an arbitrary unhandled attribute id.
+        // 1234 is an arbitrary unhandled attribute id -> HYC00, not silent success.
         let ret = unsafe { sql_set_connect_attr_w(h.dbc, 1234, std::ptr::null_mut(), 0) };
+        assert_eq!(ret, SQL_ERROR);
+    }
+
+    #[test]
+    fn accepted_standard_attribute_is_noop() {
+        let h = TestHandles::with_env_dbc();
+        // A standard connection attribute the DM sets pre-connect is accepted.
+        let ret = unsafe {
+            sql_set_connect_attr_w(h.dbc, SQL_ATTR_LOGIN_TIMEOUT, std::ptr::null_mut(), 0)
+        };
         assert_eq!(ret, SQL_SUCCESS);
     }
 }

--- a/mssql-odbc/src/api/sqlstate.rs
+++ b/mssql-odbc/src/api/sqlstate.rs
@@ -16,6 +16,7 @@ pub(crate) const SQLSTATE_HY000: [u8; 5] = *b"HY000";
 pub(crate) const SQLSTATE_HYC00: [u8; 5] = *b"HYC00";
 pub(crate) const SQLSTATE_HY009: [u8; 5] = *b"HY009";
 pub(crate) const SQLSTATE_HY010: [u8; 5] = *b"HY010";
+pub(crate) const SQLSTATE_HY011: [u8; 5] = *b"HY011";
 pub(crate) const SQLSTATE_HY024: [u8; 5] = *b"HY024";
 pub(crate) const SQLSTATE_HY092: [u8; 5] = *b"HY092";
 pub(crate) const SQLSTATE_HY110: [u8; 5] = *b"HY110";

--- a/mssql-odbc/src/connection/mod.rs
+++ b/mssql-odbc/src/connection/mod.rs
@@ -11,6 +11,8 @@ use std::fmt;
 use crate::connection::odbc_supported_auth_keywords::is_recognized_keyword;
 use tracing::warn;
 
+pub(crate) mod odbc_authentication_transformer;
+pub(crate) mod odbc_authentication_validator;
 mod odbc_supported_auth_keywords;
 
 // Connection string keys (lowercase for matching)

--- a/mssql-odbc/src/connection/odbc_authentication_transformer.rs
+++ b/mssql-odbc/src/connection/odbc_authentication_transformer.rs
@@ -10,15 +10,15 @@ use mssql_tds::connection::client_context::TdsAuthenticationMethod;
 /// populating the remaining connection fields on `ClientContext` or
 /// wherever they are needed.
 #[derive(Debug, Clone)]
-pub struct TransformedAuth {
+pub(crate) struct TransformedAuth {
     /// Resolved authentication method.
-    pub method: TdsAuthenticationMethod,
+    pub(crate) method: TdsAuthenticationMethod,
     /// User name (may be empty if not applicable).
-    pub user_name: String,
+    pub(crate) user_name: String,
     /// Password (may be empty if not applicable).
-    pub password: String,
+    pub(crate) password: String,
     /// Pre-acquired access token, if any.
-    pub access_token: Option<String>,
+    pub(crate) access_token: Option<String>,
 }
 
 /// Clears credentials that the resolved auth method does not use.
@@ -59,7 +59,7 @@ fn apply_silent_clears(method: &TdsAuthenticationMethod, uid: &mut String, pwd: 
 ///
 /// After resolution, silent clears remove credentials the selected method
 /// doesn't use.
-pub fn transform_auth(
+pub(crate) fn transform_auth(
     auth: Option<&str>,
     tc: Option<bool>,
     uid: &str,

--- a/mssql-odbc/src/connection/odbc_authentication_transformer.rs
+++ b/mssql-odbc/src/connection/odbc_authentication_transformer.rs
@@ -1,0 +1,373 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use super::odbc_supported_auth_keywords::auth_method_from_keyword;
+use mssql_tds::connection::client_context::TdsAuthenticationMethod;
+
+/// Transformed authentication output produced by [`transform_auth`].
+///
+/// Contains only auth-related fields. The caller is responsible for
+/// populating the remaining connection fields on `ClientContext` or
+/// wherever they are needed.
+#[derive(Debug, Clone)]
+pub struct TransformedAuth {
+    /// Resolved authentication method.
+    pub method: TdsAuthenticationMethod,
+    /// User name (may be empty if not applicable).
+    pub user_name: String,
+    /// Password (may be empty if not applicable).
+    pub password: String,
+    /// Pre-acquired access token, if any.
+    pub access_token: Option<String>,
+}
+
+/// Clears credentials that the resolved auth method does not use.
+///
+/// - **SSPI / ADIntegrated**: both uid and pwd cleared
+/// - **ADInteractive / ADMSI / ADDefault / ADDeviceCode / ADWorkloadIdentity**: pwd cleared, uid kept as hint/client_id
+/// - **AccessToken**: both uid and pwd cleared (handled before this is called)
+fn apply_silent_clears(method: &TdsAuthenticationMethod, uid: &mut String, pwd: &mut String) {
+    match method {
+        TdsAuthenticationMethod::SSPI | TdsAuthenticationMethod::ActiveDirectoryIntegrated => {
+            uid.clear();
+            pwd.clear();
+        }
+        TdsAuthenticationMethod::ActiveDirectoryInteractive
+        | TdsAuthenticationMethod::ActiveDirectoryMSI
+        | TdsAuthenticationMethod::ActiveDirectoryDefault
+        | TdsAuthenticationMethod::ActiveDirectoryDeviceCodeFlow
+        | TdsAuthenticationMethod::ActiveDirectoryWorkloadIdentity => {
+            pwd.clear();
+        }
+        _ => {}
+    }
+}
+
+/// Resolves raw auth inputs into a [`TransformedAuth`] using ODBC-equivalent
+/// precedence rules.
+///
+/// **Expects validated inputs.** If the caller skips validation and passes
+/// conflicting values, the transformer resolves best-effort (same as ODBC's
+/// internal flow after validation passes).
+///
+/// # Precedence (checked in order)
+///
+/// 1. `access_token` present → [`AccessToken`], uid/pwd cleared
+/// 2. `trusted_connection == Some(true)` → [`SSPI`], uid/pwd cleared
+/// 3. `authentication` keyword → mapped enum (SqlPassword → Password)
+/// 4. Default → [`Password`], uid/pwd as-is
+///
+/// After resolution, silent clears remove credentials the selected method
+/// doesn't use.
+pub fn transform_auth(
+    auth: Option<&str>,
+    tc: Option<bool>,
+    uid: &str,
+    pwd: &str,
+    token: Option<&str>,
+) -> TransformedAuth {
+    let mut user_name = uid.to_string();
+    let mut password = pwd.to_string();
+
+    // Access token takes highest precedence
+    if let Some(tok) = token {
+        return TransformedAuth {
+            method: TdsAuthenticationMethod::AccessToken,
+            user_name: String::new(),
+            password: String::new(),
+            access_token: Some(tok.to_string()),
+        };
+    }
+
+    // Trusted_Connection=Yes → SSPI
+    if tc == Some(true) {
+        return TransformedAuth {
+            method: TdsAuthenticationMethod::SSPI,
+            user_name: String::new(),
+            password: String::new(),
+            access_token: None,
+        };
+    }
+
+    // Authentication keyword → enum
+    if let Some(auth_val) = auth
+        && !auth_val.is_empty()
+    {
+        // auth_method_from_keyword handles SqlPassword → Password collapse
+        let method =
+            auth_method_from_keyword(auth_val).unwrap_or(TdsAuthenticationMethod::Password);
+
+        // Silent clears per method
+        apply_silent_clears(&method, &mut user_name, &mut password);
+
+        return TransformedAuth {
+            method,
+            user_name,
+            password,
+            access_token: None,
+        };
+    }
+    // auth == Some("") → intentional reset, fall through to default
+
+    // Default → Password, no auto-promote to SSPI
+    TransformedAuth {
+        method: TdsAuthenticationMethod::Password,
+        user_name,
+        password,
+        access_token: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Access Token path ───────────────────────────────────────
+
+    #[test]
+    fn access_token_resolves_to_access_token_method() {
+        let r = transform_auth(None, None, "", "", Some("jwt123"));
+        assert_eq!(r.method, TdsAuthenticationMethod::AccessToken);
+        assert_eq!(r.access_token.as_deref(), Some("jwt123"));
+        assert!(r.user_name.is_empty());
+        assert!(r.password.is_empty());
+    }
+
+    #[test]
+    fn access_token_takes_precedence_over_auth_keyword() {
+        let r = transform_auth(Some("SqlPassword"), None, "sa", "pwd", Some("jwt"));
+        assert_eq!(r.method, TdsAuthenticationMethod::AccessToken);
+        assert!(r.user_name.is_empty());
+    }
+
+    #[test]
+    fn access_token_takes_precedence_over_tc() {
+        let r = transform_auth(None, Some(true), "sa", "pwd", Some("jwt"));
+        assert_eq!(r.method, TdsAuthenticationMethod::AccessToken);
+    }
+
+    // ── Trusted_Connection → SSPI ────────────────────────────────
+
+    #[test]
+    fn tc_true_resolves_to_sspi() {
+        let r = transform_auth(None, Some(true), "", "", None);
+        assert_eq!(r.method, TdsAuthenticationMethod::SSPI);
+        assert!(r.user_name.is_empty());
+        assert!(r.password.is_empty());
+    }
+
+    #[test]
+    fn tc_true_clears_uid_pwd() {
+        let r = transform_auth(None, Some(true), "sa", "secret", None);
+        assert_eq!(r.method, TdsAuthenticationMethod::SSPI);
+        assert!(r.user_name.is_empty());
+        assert!(r.password.is_empty());
+    }
+
+    #[test]
+    fn tc_false_falls_through_to_default() {
+        let r = transform_auth(None, Some(false), "sa", "secret", None);
+        assert_eq!(r.method, TdsAuthenticationMethod::Password);
+        assert_eq!(r.user_name, "sa");
+        assert_eq!(r.password, "secret");
+    }
+
+    // ── Authentication keyword mapping ───────────────────────────
+
+    #[test]
+    fn ad_password_resolves() {
+        let r = transform_auth(Some("ActiveDirectoryPassword"), None, "u", "p", None);
+        assert_eq!(r.method, TdsAuthenticationMethod::ActiveDirectoryPassword);
+        assert_eq!(r.user_name, "u");
+        assert_eq!(r.password, "p");
+    }
+
+    #[test]
+    fn ad_interactive_resolves_and_clears_pwd() {
+        let r = transform_auth(
+            Some("ActiveDirectoryInteractive"),
+            None,
+            "user@domain.com",
+            "p",
+            None,
+        );
+        assert_eq!(
+            r.method,
+            TdsAuthenticationMethod::ActiveDirectoryInteractive
+        );
+        assert_eq!(r.user_name, "user@domain.com");
+        assert!(r.password.is_empty());
+    }
+
+    #[test]
+    fn ad_interactive_no_hint() {
+        let r = transform_auth(Some("ActiveDirectoryInteractive"), None, "", "", None);
+        assert_eq!(
+            r.method,
+            TdsAuthenticationMethod::ActiveDirectoryInteractive
+        );
+        assert!(r.user_name.is_empty());
+    }
+
+    #[test]
+    fn ad_msi_resolves_and_clears_pwd() {
+        let r = transform_auth(Some("ActiveDirectoryMSI"), None, "", "leftover", None);
+        assert_eq!(r.method, TdsAuthenticationMethod::ActiveDirectoryMSI);
+        assert!(r.password.is_empty());
+    }
+
+    #[test]
+    fn ad_msi_keeps_uid_as_client_id() {
+        let r = transform_auth(Some("ActiveDirectoryMSI"), None, "client-id-123", "", None);
+        assert_eq!(r.method, TdsAuthenticationMethod::ActiveDirectoryMSI);
+        assert_eq!(r.user_name, "client-id-123");
+    }
+
+    #[test]
+    fn ad_service_principal_resolves() {
+        let r = transform_auth(
+            Some("ActiveDirectoryServicePrincipal"),
+            None,
+            "cid",
+            "sec",
+            None,
+        );
+        assert_eq!(
+            r.method,
+            TdsAuthenticationMethod::ActiveDirectoryServicePrincipal
+        );
+        assert_eq!(r.user_name, "cid");
+        assert_eq!(r.password, "sec");
+    }
+
+    #[test]
+    fn ad_default_resolves_and_clears_pwd() {
+        let r = transform_auth(Some("ActiveDirectoryDefault"), None, "", "leftover", None);
+        assert_eq!(r.method, TdsAuthenticationMethod::ActiveDirectoryDefault);
+        assert!(r.password.is_empty());
+    }
+
+    #[test]
+    fn ad_device_code_flow_resolves_and_clears_pwd() {
+        let r = transform_auth(
+            Some("ActiveDirectoryDeviceCodeFlow"),
+            None,
+            "",
+            "leftover",
+            None,
+        );
+        assert_eq!(
+            r.method,
+            TdsAuthenticationMethod::ActiveDirectoryDeviceCodeFlow
+        );
+        assert!(r.password.is_empty());
+    }
+
+    #[test]
+    fn ad_workload_identity_resolves_and_clears_pwd() {
+        let r = transform_auth(
+            Some("ActiveDirectoryWorkloadIdentity"),
+            None,
+            "",
+            "leftover",
+            None,
+        );
+        assert_eq!(
+            r.method,
+            TdsAuthenticationMethod::ActiveDirectoryWorkloadIdentity
+        );
+        assert!(r.password.is_empty());
+    }
+
+    // ── SqlPassword → Password collapse ──────────────────────────
+
+    #[test]
+    fn sql_password_collapses_to_password() {
+        let r = transform_auth(Some("SqlPassword"), None, "sa", "secret", None);
+        assert_eq!(r.method, TdsAuthenticationMethod::Password);
+        assert_eq!(r.user_name, "sa");
+        assert_eq!(r.password, "secret");
+    }
+
+    // ── ADIntegrated clears uid + pwd ────────────────────────────
+
+    #[test]
+    fn ad_integrated_clears_uid_and_pwd() {
+        let r = transform_auth(
+            Some("ActiveDirectoryIntegrated"),
+            None,
+            "user@domain.com",
+            "pass",
+            None,
+        );
+        assert_eq!(r.method, TdsAuthenticationMethod::ActiveDirectoryIntegrated);
+        assert!(r.user_name.is_empty());
+        assert!(r.password.is_empty());
+    }
+
+    #[test]
+    fn ad_integrated_no_credentials() {
+        let r = transform_auth(Some("ActiveDirectoryIntegrated"), None, "", "", None);
+        assert_eq!(r.method, TdsAuthenticationMethod::ActiveDirectoryIntegrated);
+        assert!(r.user_name.is_empty());
+    }
+
+    // ── Default path ────────────────────────────────────────────
+
+    #[test]
+    fn default_no_inputs_resolves_to_password() {
+        let r = transform_auth(None, None, "", "", None);
+        assert_eq!(r.method, TdsAuthenticationMethod::Password);
+        assert!(r.user_name.is_empty());
+        assert!(r.password.is_empty());
+    }
+
+    #[test]
+    fn uid_pwd_only_resolves_to_password() {
+        let r = transform_auth(None, None, "sa", "secret", None);
+        assert_eq!(r.method, TdsAuthenticationMethod::Password);
+        assert_eq!(r.user_name, "sa");
+        assert_eq!(r.password, "secret");
+    }
+
+    #[test]
+    fn tc_none_uid_pwd_resolves_to_password() {
+        let r = transform_auth(None, None, "sa", "secret", None);
+        assert_eq!(r.method, TdsAuthenticationMethod::Password);
+    }
+
+    #[test]
+    fn empty_auth_string_falls_through_to_default() {
+        let r = transform_auth(Some(""), None, "sa", "secret", None);
+        assert_eq!(r.method, TdsAuthenticationMethod::Password);
+        assert_eq!(r.user_name, "sa");
+        assert_eq!(r.password, "secret");
+    }
+
+    // ── Case insensitivity ──────────────────────────────────────
+
+    #[test]
+    fn auth_keyword_case_insensitive() {
+        let r = transform_auth(Some("SQLPASSWORD"), None, "sa", "pwd", None);
+        assert_eq!(r.method, TdsAuthenticationMethod::Password);
+    }
+
+    #[test]
+    fn mixed_case_ad_interactive() {
+        let r = transform_auth(Some("activedirectoryINTERACTIVE"), None, "u", "", None);
+        assert_eq!(
+            r.method,
+            TdsAuthenticationMethod::ActiveDirectoryInteractive
+        );
+    }
+
+    // ── Unknown auth keyword (best-effort) ──────────────────────
+
+    #[test]
+    fn unknown_auth_keyword_falls_back_to_password() {
+        let r = transform_auth(Some("BogusValue"), None, "sa", "pwd", None);
+        assert_eq!(r.method, TdsAuthenticationMethod::Password);
+        assert_eq!(r.user_name, "sa");
+        assert_eq!(r.password, "pwd");
+    }
+}

--- a/mssql-odbc/src/connection/odbc_authentication_validator.rs
+++ b/mssql-odbc/src/connection/odbc_authentication_validator.rs
@@ -10,7 +10,7 @@ use mssql_tds::error::Error;
 /// Returns `Ok(())` if valid, or a `TdsError` listing all detected conflicts.
 ///
 /// Standalone function — does not depend on `ClientContext`.
-pub fn validate_auth(
+pub(crate) fn validate_auth(
     authentication: Option<&str>,
     trusted_connection: Option<bool>,
     user_name: &str,

--- a/mssql-odbc/src/connection/odbc_authentication_validator.rs
+++ b/mssql-odbc/src/connection/odbc_authentication_validator.rs
@@ -1,0 +1,376 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use super::odbc_supported_auth_keywords::{auth_method_from_keyword, is_recognized_keyword};
+use mssql_tds::connection::client_context::TdsAuthenticationMethod;
+use mssql_tds::core::TdsResult;
+use mssql_tds::error::Error;
+
+/// Validates the connection string key values for conflicts (ODBC-equivalent checks).
+/// Returns `Ok(())` if valid, or a `TdsError` listing all detected conflicts.
+///
+/// Standalone function — does not depend on `ClientContext`.
+pub fn validate_auth(
+    authentication: Option<&str>,
+    trusted_connection: Option<bool>,
+    user_name: &str,
+    password: &str,
+    access_token: Option<&str>,
+) -> TdsResult<()> {
+    // Access Token isolation — collect all conflicts
+    if access_token.is_some() {
+        let mut conflicts = Vec::new();
+        if trusted_connection == Some(true) {
+            conflicts.push("Trusted_Connection is set");
+        }
+        if authentication.is_some_and(|a| !a.is_empty()) {
+            conflicts.push("Authentication keyword is provided");
+        }
+        if !user_name.is_empty() {
+            conflicts.push("User is provided");
+        }
+        if !password.is_empty() {
+            conflicts.push("Password is provided");
+        }
+        if !conflicts.is_empty() {
+            return Err(Error::UsageError(format!(
+                "Access Token cannot be used when: {}.",
+                conflicts.join(", ")
+            )));
+        }
+    }
+
+    // Authentication + Trusted_Connection mutual exclusion
+    if authentication.is_some_and(|a| !a.is_empty()) && trusted_connection == Some(true) {
+        return Err(Error::UsageError(
+            "Cannot use Authentication with Trusted_Connection.".to_string(),
+        ));
+    }
+
+    if let Some(auth) = authentication
+        && !auth.is_empty()
+    {
+        // Unknown keyword → reject before credential rules
+        // so we don't give misleading "missing UID/PWD" for a bogus keyword
+        if !is_recognized_keyword(auth) {
+            return Err(Error::UsageError(format!(
+                "Unsupported Authentication value: '{auth}'.",
+            )));
+        }
+
+        match auth_method_from_keyword(auth) {
+            // SqlPassword / ADPassword / ADSPA require UID + PWD
+            Some(
+                TdsAuthenticationMethod::Password
+                | TdsAuthenticationMethod::ActiveDirectoryPassword
+                | TdsAuthenticationMethod::ActiveDirectoryServicePrincipal,
+            ) if user_name.is_empty() || password.is_empty() => {
+                return Err(Error::UsageError(format!(
+                    "Both User and Password must be specified when Authentication is '{auth}'."
+                )));
+            }
+            _ => {}
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---------------------------------------------------------------
+    // Happy paths (validator should pass)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn happy_uid_pwd_only() {
+        assert!(validate_auth(None, None, "sa", "secret", None).is_ok());
+    }
+
+    #[test]
+    fn happy_nothing_set() {
+        assert!(validate_auth(None, None, "", "", None).is_ok());
+    }
+
+    #[test]
+    fn happy_tc_true() {
+        assert!(validate_auth(None, Some(true), "", "", None).is_ok());
+    }
+
+    #[test]
+    fn happy_tc_true_with_uid_pwd() {
+        assert!(validate_auth(None, Some(true), "sa", "secret", None).is_ok());
+    }
+
+    #[test]
+    fn happy_tc_false_with_uid_pwd() {
+        assert!(validate_auth(None, Some(false), "sa", "secret", None).is_ok());
+    }
+
+    #[test]
+    fn happy_sqlpassword_with_uid_pwd() {
+        assert!(validate_auth(Some("SqlPassword"), None, "sa", "secret", None).is_ok());
+    }
+
+    #[test]
+    fn happy_ad_password_with_uid_pwd() {
+        assert!(validate_auth(Some("ActiveDirectoryPassword"), None, "u", "p", None).is_ok());
+    }
+
+    #[test]
+    fn happy_ad_integrated_alone() {
+        assert!(validate_auth(Some("ActiveDirectoryIntegrated"), None, "", "", None).is_ok());
+    }
+
+    #[test]
+    fn happy_ad_interactive_with_uid() {
+        assert!(validate_auth(Some("ActiveDirectoryInteractive"), None, "u", "", None).is_ok());
+    }
+
+    #[test]
+    fn happy_ad_interactive_alone() {
+        assert!(validate_auth(Some("ActiveDirectoryInteractive"), None, "", "", None).is_ok());
+    }
+
+    #[test]
+    fn happy_admsi_alone() {
+        assert!(validate_auth(Some("ActiveDirectoryMSI"), None, "", "", None).is_ok());
+    }
+
+    #[test]
+    fn happy_admsi_with_client_id() {
+        assert!(validate_auth(Some("ActiveDirectoryMSI"), None, "cid", "", None).is_ok());
+    }
+
+    #[test]
+    fn happy_adspa_with_uid_pwd() {
+        assert!(
+            validate_auth(
+                Some("ActiveDirectoryServicePrincipal"),
+                None,
+                "cid",
+                "sec",
+                None
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn happy_access_token_alone() {
+        assert!(validate_auth(None, None, "", "", Some("jwt")).is_ok());
+    }
+
+    #[test]
+    fn happy_empty_auth_keyword() {
+        assert!(validate_auth(Some(""), None, "sa", "secret", None).is_ok());
+    }
+
+    #[test]
+    fn happy_access_token_plus_empty_auth() {
+        assert!(validate_auth(Some(""), None, "", "", Some("jwt")).is_ok());
+    }
+
+    #[test]
+    fn happy_empty_auth_plus_tc() {
+        assert!(validate_auth(Some(""), Some(true), "", "", None).is_ok());
+    }
+
+    #[test]
+    fn happy_ad_default_alone() {
+        assert!(validate_auth(Some("ActiveDirectoryDefault"), None, "", "", None).is_ok());
+    }
+
+    #[test]
+    fn happy_ad_device_code_flow_alone() {
+        assert!(validate_auth(Some("ActiveDirectoryDeviceCodeFlow"), None, "", "", None).is_ok());
+    }
+
+    #[test]
+    fn happy_ad_workload_identity_alone() {
+        assert!(validate_auth(Some("ActiveDirectoryWorkloadIdentity"), None, "", "", None).is_ok());
+    }
+
+    // ---------------------------------------------------------------
+    // Access Token isolation
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn access_token_plus_tc() {
+        let err = validate_auth(None, Some(true), "", "", Some("jwt")).unwrap_err();
+        assert!(err.to_string().contains("Access Token cannot be used"));
+        assert!(err.to_string().contains("Trusted_Connection is set"));
+    }
+
+    #[test]
+    fn access_token_plus_auth() {
+        let err = validate_auth(Some("SqlPassword"), None, "", "", Some("jwt")).unwrap_err();
+        assert!(err.to_string().contains("Access Token cannot be used"));
+        assert!(
+            err.to_string()
+                .contains("Authentication keyword is provided")
+        );
+    }
+
+    #[test]
+    fn access_token_plus_uid() {
+        let err = validate_auth(None, None, "sa", "", Some("jwt")).unwrap_err();
+        assert!(err.to_string().contains("Access Token cannot be used"));
+        assert!(err.to_string().contains("User is provided"));
+    }
+
+    #[test]
+    fn access_token_plus_pwd() {
+        let err = validate_auth(None, None, "", "secret", Some("jwt")).unwrap_err();
+        assert!(err.to_string().contains("Access Token cannot be used"));
+        assert!(err.to_string().contains("Password is provided"));
+    }
+
+    #[test]
+    fn access_token_multiple_conflicts() {
+        let err =
+            validate_auth(Some("SqlPassword"), Some(true), "sa", "pwd", Some("jwt")).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("Trusted_Connection is set"));
+        assert!(msg.contains("Authentication keyword is provided"));
+        assert!(msg.contains("User is provided"));
+        assert!(msg.contains("Password is provided"));
+    }
+
+    // ---------------------------------------------------------------
+    // Authentication + TC mutual exclusion
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn tc_plus_sqlpassword() {
+        let err = validate_auth(Some("SqlPassword"), Some(true), "sa", "secret", None).unwrap_err();
+        assert!(err.to_string().contains("Trusted_Connection"));
+    }
+
+    #[test]
+    fn tc_plus_ad_password() {
+        let err =
+            validate_auth(Some("ActiveDirectoryPassword"), Some(true), "u", "p", None).unwrap_err();
+        assert!(err.to_string().contains("Trusted_Connection"));
+    }
+
+    #[test]
+    fn tc_plus_ad_integrated() {
+        let err =
+            validate_auth(Some("ActiveDirectoryIntegrated"), Some(true), "", "", None).unwrap_err();
+        assert!(err.to_string().contains("Trusted_Connection"));
+    }
+
+    // ---------------------------------------------------------------
+    // SqlPassword requires UID + PWD
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn sqlpassword_no_uid_no_pwd() {
+        let err = validate_auth(Some("SqlPassword"), None, "", "", None).unwrap_err();
+        assert!(err.to_string().contains("Both User and Password"));
+    }
+
+    #[test]
+    fn sqlpassword_uid_no_pwd() {
+        let err = validate_auth(Some("SqlPassword"), None, "sa", "", None).unwrap_err();
+        assert!(err.to_string().contains("Both User and Password"));
+    }
+
+    #[test]
+    fn sqlpassword_pwd_no_uid() {
+        let err = validate_auth(Some("SqlPassword"), None, "", "secret", None).unwrap_err();
+        assert!(err.to_string().contains("Both User and Password"));
+    }
+
+    // ---------------------------------------------------------------
+    // ADPassword requires UID + PWD
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn ad_password_no_uid_no_pwd() {
+        let err = validate_auth(Some("ActiveDirectoryPassword"), None, "", "", None).unwrap_err();
+        assert!(err.to_string().contains("Both User and Password"));
+    }
+
+    #[test]
+    fn ad_password_uid_no_pwd() {
+        let err = validate_auth(Some("ActiveDirectoryPassword"), None, "u", "", None).unwrap_err();
+        assert!(err.to_string().contains("Both User and Password"));
+    }
+
+    #[test]
+    fn ad_password_pwd_no_uid() {
+        let err = validate_auth(Some("ActiveDirectoryPassword"), None, "", "p", None).unwrap_err();
+        assert!(err.to_string().contains("Both User and Password"));
+    }
+
+    // ---------------------------------------------------------------
+    // ADSPA requires UID + PWD
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn adspa_no_uid_no_pwd() {
+        let err =
+            validate_auth(Some("ActiveDirectoryServicePrincipal"), None, "", "", None).unwrap_err();
+        assert!(err.to_string().contains("Both User and Password"));
+    }
+
+    #[test]
+    fn adspa_uid_no_pwd() {
+        let err = validate_auth(
+            Some("ActiveDirectoryServicePrincipal"),
+            None,
+            "cid",
+            "",
+            None,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("Both User and Password"));
+    }
+
+    #[test]
+    fn adspa_pwd_no_uid() {
+        let err = validate_auth(
+            Some("ActiveDirectoryServicePrincipal"),
+            None,
+            "",
+            "sec",
+            None,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("Both User and Password"));
+    }
+
+    // ---------------------------------------------------------------
+    // ADIntegrated with UID/PWD — validator passes, transformer clears
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn happy_ad_integrated_with_uid() {
+        assert!(validate_auth(Some("ActiveDirectoryIntegrated"), None, "u", "", None).is_ok());
+    }
+
+    #[test]
+    fn happy_ad_integrated_with_pwd() {
+        assert!(validate_auth(Some("ActiveDirectoryIntegrated"), None, "", "p", None).is_ok());
+    }
+
+    #[test]
+    fn happy_ad_integrated_with_uid_and_pwd() {
+        assert!(validate_auth(Some("ActiveDirectoryIntegrated"), None, "u", "p", None).is_ok());
+    }
+
+    // ---------------------------------------------------------------
+    // Unknown Authentication value
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn bogus_auth_value() {
+        let err = validate_auth(Some("BogusValue"), None, "", "", None).unwrap_err();
+        assert!(err.to_string().contains("Unsupported Authentication value"));
+        assert!(err.to_string().contains("BogusValue"));
+    }
+}

--- a/mssql-odbc/src/handles/dbc.rs
+++ b/mssql-odbc/src/handles/dbc.rs
@@ -48,7 +48,6 @@ unsafe impl Send for DbcHandle {}
 unsafe impl Sync for DbcHandle {}
 
 /// Mutable state within a connection handle, protected by `inner`.
-#[derive(Debug)]
 pub(crate) struct DbcState {
     pub(crate) diag_records: Vec<DiagRecord>,
     pub(crate) connection_state: ConnectionState,
@@ -61,6 +60,27 @@ pub(crate) struct DbcState {
     pub(crate) active_stmt: Option<*mut c_void>,
     /// Active TDS connection, present only when `connection_state == Connected`.
     pub(crate) client: Option<TdsClient>,
+    /// Pre-connect access token set via `SQL_COPT_SS_ACCESS_TOKEN`.
+    /// Consumed by `SQLDriverConnect` to select `AccessToken` authentication.
+    pub(crate) access_token: Option<String>,
+}
+
+// Manual `Debug` so the bearer access token is never rendered in logs or panic
+// messages; presence is shown, the value is redacted (mirrors `ConnectionParams`).
+impl std::fmt::Debug for DbcState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DbcState")
+            .field("diag_records", &self.diag_records)
+            .field("connection_state", &self.connection_state)
+            .field("statements", &self.statements)
+            .field("active_stmt", &self.active_stmt)
+            .field("client", &self.client)
+            .field(
+                "access_token",
+                &self.access_token.as_ref().map(|_| "<REDACTED>"),
+            )
+            .finish()
+    }
 }
 
 impl HasDiagnostics for DbcState {
@@ -84,6 +104,7 @@ impl DbcHandle {
                 statements: Vec::new(),
                 active_stmt: None,
                 client: None,
+                access_token: None,
             }),
         }
     }


### PR DESCRIPTION
Wires baseline authentication end-to-end in `mssql-odbc`'s `SQLDriverConnect` so the driver resolves the auth method instead of hardcoding SQL password. Builds on T0 (connection-string parsing) and #102 (auth modules relocated into the bindings).

### What changed
- **`do_connect`** now runs `validate_auth` → `transform_auth` → a supported-method gate, then populates `ClientContext` from the resolved method (removed the hardcoded `Password`).
- **Supported end-to-end:** SQL password, integrated (SSPI / GSSAPI via `Trusted_Connection`), and pre-acquired access tokens.
- **Fail-closed:** Entra methods that require token acquisition return `HYC00` ("optional feature not implemented") until they land in T2–T4, rather than silently mis-authenticating.
- **`SQLSetConnectAttrW` for `SQL_COPT_SS_ACCESS_TOKEN`** (was a stub): decodes the `ACCESSTOKEN` struct (4-byte LE length + UTF-16-LE token) into the JWT and stores it on the connection. Set-after-connect → `HY011`, null → `HY009`, malformed → `HY024`.
- **mssql-odbc owns** its own copies of the auth validator and transformer (completes the #102 split).

### Cross-driver parity (msodbcsql)
- Attribute id `1256`, `ACCESSTOKEN` layout, UTF-16-LE payload, and `SQL_IS_POINTER` string-length all match the C++ driver.
- Set-after-connect uses `HY011` to match msodbcsql (`sqlcmisc.cpp`).
- The token is **copied at set-time** rather than storing the caller's raw pointer, avoiding msodbcsql's dangling-pointer window if the app frees the buffer before connecting.

### Security
- Access token is supplied only via the attribute (never a connection-string keyword), and `DbcState`'s `Debug` redacts it.

### Verification
- `cargo bfmt` + `cargo bclippy` clean
- `cargo nextest -p mssql-odbc`: 225 passed (auth conflict matrix, transformer precedence, access-token struct, and two new `do_connect` gate/conflict tests)
- `cargo btest` (DB-backed): 2134 passed, 8 failed (`mssql-tds::connectivity` TLS baseline, excluded in CI), 21 skipped
- No `Cargo.toml` / `Cargo.lock` changes

[AB#45485](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/45485)
