### PR TITLE
Resolve ActiveDirectoryMSI to ManagedIdentity in the ODBC binding

### DIFF
--- a/mssql-odbc/src/connection/mod.rs
+++ b/mssql-odbc/src/connection/mod.rs
@@ -598,6 +598,17 @@ mod tests {
     }
 
     #[test]
+    fn authentication_managed_identity_is_rejected() {
+        // ActiveDirectoryManagedIdentity is NOT an ODBC keyword — msodbcsql only
+        // accepts ActiveDirectoryMSI (dlgattr.h), which maps to the same method.
+        // Matches the mssql-python driver's behavior. See bug #46177.
+        let err = parse_connection_string("Server=h;Authentication=ActiveDirectoryManagedIdentity")
+            .unwrap_err();
+        assert_eq!(err.key, "authentication");
+        assert_eq!(err.value, "ActiveDirectoryManagedIdentity");
+    }
+
+    #[test]
     fn authentication_empty_is_reset_ok() {
         // Empty Authentication is an intentional reset (mssql-tds treats it as
         // recognized); stored as Some("") to preserve the distinction from unset.

--- a/mssql-odbc/src/connection/odbc_authentication_transformer.rs
+++ b/mssql-odbc/src/connection/odbc_authentication_transformer.rs
@@ -24,7 +24,7 @@ pub(crate) struct TransformedAuth {
 /// Clears credentials that the resolved auth method does not use.
 ///
 /// - **SSPI / ADIntegrated**: both uid and pwd cleared
-/// - **ADInteractive / ADMSI / ADDefault / ADDeviceCode / ADWorkloadIdentity**: pwd cleared, uid kept as hint/client_id
+/// - **ADInteractive / ADManagedIdentity / ADDefault / ADDeviceCode / ADWorkloadIdentity**: pwd cleared, uid kept as hint/client_id
 /// - **AccessToken**: both uid and pwd cleared (handled before this is called)
 fn apply_silent_clears(method: &TdsAuthenticationMethod, uid: &mut String, pwd: &mut String) {
     match method {
@@ -33,7 +33,7 @@ fn apply_silent_clears(method: &TdsAuthenticationMethod, uid: &mut String, pwd: 
             pwd.clear();
         }
         TdsAuthenticationMethod::ActiveDirectoryInteractive
-        | TdsAuthenticationMethod::ActiveDirectoryMSI
+        | TdsAuthenticationMethod::ActiveDirectoryManagedIdentity
         | TdsAuthenticationMethod::ActiveDirectoryDefault
         | TdsAuthenticationMethod::ActiveDirectoryDeviceCodeFlow
         | TdsAuthenticationMethod::ActiveDirectoryWorkloadIdentity => {
@@ -211,15 +211,22 @@ mod tests {
 
     #[test]
     fn ad_msi_resolves_and_clears_pwd() {
+        // The ActiveDirectoryMSI keyword resolves to the canonical ManagedIdentity method.
         let r = transform_auth(Some("ActiveDirectoryMSI"), None, "", "leftover", None);
-        assert_eq!(r.method, TdsAuthenticationMethod::ActiveDirectoryMSI);
+        assert_eq!(
+            r.method,
+            TdsAuthenticationMethod::ActiveDirectoryManagedIdentity
+        );
         assert!(r.password.is_empty());
     }
 
     #[test]
     fn ad_msi_keeps_uid_as_client_id() {
         let r = transform_auth(Some("ActiveDirectoryMSI"), None, "client-id-123", "", None);
-        assert_eq!(r.method, TdsAuthenticationMethod::ActiveDirectoryMSI);
+        assert_eq!(
+            r.method,
+            TdsAuthenticationMethod::ActiveDirectoryManagedIdentity
+        );
         assert_eq!(r.user_name, "client-id-123");
     }
 

--- a/mssql-odbc/src/connection/odbc_supported_auth_keywords.rs
+++ b/mssql-odbc/src/connection/odbc_supported_auth_keywords.rs
@@ -7,13 +7,16 @@ use mssql_tds::connection::client_context::TdsAuthenticationMethod;
 ///
 /// Case-insensitive. Returns `None` for unrecognized or empty values.
 /// `SqlPassword` collapses to `Password` (same Login7 on the wire).
+/// `ActiveDirectoryMSI` collapses to `ActiveDirectoryManagedIdentity` (legacy alias).
 pub fn auth_method_from_keyword(value: &str) -> Option<TdsAuthenticationMethod> {
     match value.to_lowercase().as_str() {
         "sqlpassword" => Some(TdsAuthenticationMethod::Password),
         "activedirectoryintegrated" => Some(TdsAuthenticationMethod::ActiveDirectoryIntegrated),
         "activedirectorypassword" => Some(TdsAuthenticationMethod::ActiveDirectoryPassword),
         "activedirectoryinteractive" => Some(TdsAuthenticationMethod::ActiveDirectoryInteractive),
-        "activedirectorymsi" => Some(TdsAuthenticationMethod::ActiveDirectoryMSI),
+        // msodbcsql exposes only the ActiveDirectoryMSI keyword; it resolves to the
+        // canonical ManagedIdentity method (mssql-tds has no separate MSI workflow). #46177
+        "activedirectorymsi" => Some(TdsAuthenticationMethod::ActiveDirectoryManagedIdentity),
         "activedirectoryserviceprincipal" => {
             Some(TdsAuthenticationMethod::ActiveDirectoryServicePrincipal)
         }
@@ -65,5 +68,15 @@ mod tests {
     #[test]
     fn empty_returns_none() {
         assert_eq!(auth_method_from_keyword(""), None);
+    }
+
+    #[test]
+    fn msi_collapses_to_managed_identity() {
+        // msodbcsql exposes only the ActiveDirectoryMSI keyword; it maps to the
+        // canonical ManagedIdentity method (no separate MSI workflow in mssql-tds).
+        assert_eq!(
+            auth_method_from_keyword("ActiveDirectoryMSI"),
+            Some(TdsAuthenticationMethod::ActiveDirectoryManagedIdentity)
+        );
     }
 }

--- a/mssql-tds/src/message/features/fedauth.rs
+++ b/mssql-tds/src/message/features/fedauth.rs
@@ -101,10 +101,9 @@ impl FedAuthFeature {
             TdsAuthenticationMethod::ActiveDirectoryDeviceCodeFlow => {
                 Ok(active_directory_device_code_flow)
             }
-            // MSI is a legacy alias for ManagedIdentity; both use the same workflow
-            // byte (matches .NET SqlClient TdsEnums). See bug #46177.
-            TdsAuthenticationMethod::ActiveDirectoryManagedIdentity
-            | TdsAuthenticationMethod::ActiveDirectoryMSI => Ok(active_directory_managed_identity),
+            TdsAuthenticationMethod::ActiveDirectoryManagedIdentity => {
+                Ok(active_directory_managed_identity)
+            }
             TdsAuthenticationMethod::ActiveDirectoryWorkloadIdentity => {
                 Ok(active_directory_workload_identity)
             }
@@ -235,20 +234,16 @@ mod unittests {
     }
 
     #[test]
-    fn test_get_work_flow_identifier_msi_matches_managed_identity() {
-        // Regression for #46177: MSI is a legacy alias for ManagedIdentity and must
-        // resolve to the same workflow byte instead of falling through to an error.
-        let msi = FedAuthFeature::new(TdsAuthenticationMethod::ActiveDirectoryMSI, None, false);
+    fn test_get_work_flow_identifier_managed_identity() {
+        // #46177: managed identity uses the interactive workflow byte (0x03), matching
+        // .NET SqlClient. The activedirectorymsi keyword is mapped to this method by the
+        // ODBC binding, so mssql-tds only ever sees ActiveDirectoryManagedIdentity here.
         let managed = FedAuthFeature::new(
             TdsAuthenticationMethod::ActiveDirectoryManagedIdentity,
             None,
             false,
         );
-        assert_eq!(msi.get_work_flow_identifier().unwrap(), 0x03);
-        assert_eq!(
-            msi.get_work_flow_identifier().unwrap(),
-            managed.get_work_flow_identifier().unwrap()
-        );
+        assert_eq!(managed.get_work_flow_identifier().unwrap(), 0x03);
     }
 
     #[test]

--- a/mssql-tds/src/message/features/fedauth.rs
+++ b/mssql-tds/src/message/features/fedauth.rs
@@ -101,9 +101,10 @@ impl FedAuthFeature {
             TdsAuthenticationMethod::ActiveDirectoryDeviceCodeFlow => {
                 Ok(active_directory_device_code_flow)
             }
-            TdsAuthenticationMethod::ActiveDirectoryManagedIdentity => {
-                Ok(active_directory_managed_identity)
-            }
+            // MSI is a legacy alias for ManagedIdentity; both use the same workflow
+            // byte (matches .NET SqlClient TdsEnums). See bug #46177.
+            TdsAuthenticationMethod::ActiveDirectoryManagedIdentity
+            | TdsAuthenticationMethod::ActiveDirectoryMSI => Ok(active_directory_managed_identity),
             TdsAuthenticationMethod::ActiveDirectoryWorkloadIdentity => {
                 Ok(active_directory_workload_identity)
             }
@@ -231,6 +232,23 @@ mod unittests {
     fn test_get_work_flow_identifier_unsupported() {
         let feature = FedAuthFeature::new(TdsAuthenticationMethod::Password, None, false);
         assert!(feature.get_work_flow_identifier().is_err());
+    }
+
+    #[test]
+    fn test_get_work_flow_identifier_msi_matches_managed_identity() {
+        // Regression for #46177: MSI is a legacy alias for ManagedIdentity and must
+        // resolve to the same workflow byte instead of falling through to an error.
+        let msi = FedAuthFeature::new(TdsAuthenticationMethod::ActiveDirectoryMSI, None, false);
+        let managed = FedAuthFeature::new(
+            TdsAuthenticationMethod::ActiveDirectoryManagedIdentity,
+            None,
+            false,
+        );
+        assert_eq!(msi.get_work_flow_identifier().unwrap(), 0x03);
+        assert_eq!(
+            msi.get_work_flow_identifier().unwrap(),
+            managed.get_work_flow_identifier().unwrap()
+        );
     }
 
     #[test]


### PR DESCRIPTION
Resolves the FedAuth managed-identity gap behind `Authentication=ActiveDirectoryMSI`.

## Background
`ActiveDirectoryMSI` is the legacy connection-string keyword for managed identity — msodbcsql (dlgattr.h) exposes only this keyword; there is no `ActiveDirectoryManagedIdentity` keyword. It previously resolved to a distinct `TdsAuthenticationMethod::ActiveDirectoryMSI` variant that `get_work_flow_identifier` did not handle, so it fell through to the catch-all and returned a `ProtocolError` on the LOGIN7 request-workflow path (the token-acquisition path mssql-odbc T2 managed identity uses).

## Approach (updated per review)
The MSI-vs-ManagedIdentity alias is a connection-string concept, so the mapping lives in the binding rather than the protocol layer:
- **mssql-odbc** now resolves the `ActiveDirectoryMSI` keyword to the canonical `ActiveDirectoryManagedIdentity` method. Wire behavior is unchanged (workflow byte `0x03`), and `ActiveDirectoryMSI` remains the only accepted managed-identity keyword (msodbcsql parity).
- **mssql-tds** no longer special-cases MSI in `get_work_flow_identifier` — it only ever sees `ActiveDirectoryManagedIdentity`.
- The `ActiveDirectoryMSI` enum variant is kept for now because mssql-py-core still references it; removing it from mssql-tds is a separate, py-core-coordinated cleanup.

## Tests
- mssql-tds: `get_work_flow_identifier` returns `0x03` for managed identity.
- mssql-odbc: the `ActiveDirectoryMSI` keyword resolves to `ActiveDirectoryManagedIdentity` (+ credential clearing); `ActiveDirectoryManagedIdentity` is rejected as a keyword (msodbcsql / mssql-python parity).

## Verified
- Service-principal workflow byte `0x01` confirmed correct against .NET SqlClient `TdsEnums` (no change).
- mssql-py-core untouched and unaffected (self-acquires the token, so it never calls `get_work_flow_identifier`).
- `cargo bfmt` / `cargo bclippy` clean; full DB `btest` green apart from the known connectivity environmental baseline.

[AB#46177](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46177)
