### PR TITLE
Document the classic C++ msodbcsql driver as the parity reference

### DIFF
--- a/.github/instructions/mssql-odbc.instructions.md
+++ b/.github/instructions/mssql-odbc.instructions.md
@@ -30,6 +30,12 @@ authoritative parity reference for this crate. Its source lives in the
   from** msodbcsql so the trade-off is visible.
 - Deliberate deviations (exceed-parity) are allowed with product-owner sign-off;
   record the rationale in code comments and the tracking work item.
+- Deliberate deviations are listed below:
+  - `ActiveDirectoryManagedIdentity` is accepted as an alias for managed-identity
+    authentication. msodbcsql recognizes only `ActiveDirectoryMSI`
+    (`Sql/Ntdbms/sqlncli/msdart/inc/dlgattr.h` → `OPTIONADMSI L"ActiveDirectoryMSI"`);
+    `ActiveDirectoryManagedIdentity` does not appear anywhere in the msodbcsql source.
+    Added to match MS Learn and the sibling drivers (JDBC/.NET/go-sqlcmd). Tracked in AB#46066.
 
 ## No panics
 

--- a/.github/instructions/mssql-odbc.instructions.md
+++ b/.github/instructions/mssql-odbc.instructions.md
@@ -14,6 +14,23 @@ fatal and unrecoverable.
 Before making changes, also read [mssql-odbc/README.md](../../mssql-odbc/README.md)
 for architecture, supported features, and build/run instructions.
 
+## Parity reference: the classic C++ msodbcsql driver
+
+The classic C++ **msodbcsql** driver (Microsoft ODBC Driver for SQL Server) is the
+authoritative parity reference for this crate. Its source lives in the
+`SqlClientDrivers` Azure DevOps org (`msodbcsql` project/repo, `master`).
+
+- Before adding, changing, or **rejecting** any behavior for parity reasons — auth
+  keywords, connection-string attributes, error/SQLSTATE mapping, Driver Manager
+  interaction — verify it against the actual msodbcsql source. Do **not** rely on
+  MS Learn docs or sibling drivers (JDBC/.NET/go-sqlcmd), which frequently differ
+  from what the C++ driver actually does.
+- When reporting a parity finding, cite the msodbcsql source (file + what it does),
+  and state explicitly whether the decision **matches**, **exceeds**, or **diverges
+  from** msodbcsql so the trade-off is visible.
+- Deliberate deviations (exceed-parity) are allowed with product-owner sign-off;
+  record the rationale in code comments and the tracking work item.
+
 ## No panics
 
 - **Never** use `.unwrap()` or `.expect()` on `Result` or `Option` in


### PR DESCRIPTION
Adds an explicit **parity-reference rule** to `.github/instructions/mssql-odbc.instructions.md`: the classic C++ **msodbcsql** driver is the authoritative parity reference, and behavior decisions (auth keywords, connection-string attributes, error/SQLSTATE mapping, Driver Manager interaction) must be verified against its actual source — not MS Learn or sibling drivers (JDBC/.NET/go-sqlcmd), which frequently differ.

Also codifies how to report findings (cite the source; state whether a decision **matches**, **exceeds**, or **diverges from** msodbcsql) and that deliberate exceed-parity deviations are allowed with product-owner sign-off + documented rationale.

Motivated by the T2 Entra-auth review (#110 / [AB#46066](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46066)), where docs said `ActiveDirectoryManagedIdentity` was a valid keyword and SP-certificate was supported, but the C++ source showed only `ActiveDirectoryMSI` and secret-only service principals.

Docs-only change; no code affected.