### PR TITLE
Add PR check for linked GitHub issue or ADO work item

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,12 @@ contribution guide.
 
 ## Related Issues
 
-<!-- Link to related issues: Fixes #123, Related to #456 -->
+<!--
+Required: link a GitHub issue OR an Azure DevOps work item. The PR check will
+fail without one.
+GitHub issue: Fixes #123 (or https://github.com/microsoft/mssql-rs/issues/123)
+ADO work item: https://sqlclientdrivers.visualstudio.com/<project>/_workitems/edit/<ID>
+-->
 
 ## Checklist
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,9 @@ contribution guide.
 Required: link a GitHub issue OR an Azure DevOps work item. The PR check will
 fail without one.
 GitHub issue: Fixes #123 (or https://github.com/microsoft/mssql-rs/issues/123)
-ADO work item: https://sqlclientdrivers.visualstudio.com/<project>/_workitems/edit/<ID>
+ADO work item: https://sqlclientdrivers.visualstudio.com/<...>/_workitems/edit/<ID>
+  (any project/collection path is accepted, e.g. .../<project>/_workitems/edit/123
+  or .../DefaultCollection/<project>/_workitems/edit/123)
 -->
 
 ## Checklist

--- a/.github/workflows/pr-code-coverage.yml
+++ b/.github/workflows/pr-code-coverage.yml
@@ -24,6 +24,19 @@ on:
   pull_request:
     branches:
       - main
+    # Mirror the ADO PR validation build policy path excludes so this coverage
+    # report is skipped when that build is skipped (otherwise it fails waiting
+    # for a build that never runs). The issue_comment `/coverage` path below is
+    # unaffected and can still be used to run the report manually.
+    paths-ignore:
+      - 'docs/**'
+      - '.github/**'
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - 'CONTRIBUTING.md'
+      - 'SECURITY.md'
+      - 'LICENSE'
+      - 'es-metadata.yml'
   issue_comment:
     types:
       - created

--- a/.github/workflows/pr-linked-issue-check.yml
+++ b/.github/workflows/pr-linked-issue-check.yml
@@ -1,0 +1,45 @@
+name: PR Linked Issue Check
+
+# Ensures every pull request references either a GitHub issue or an Azure
+# DevOps work item in its description, mirroring the check used in
+# microsoft/mssql-python.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Validate linked GitHub issue or ADO work item
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+
+            const githubIssueLinkPattern =
+              /(https:\/\/github\.com\/microsoft\/mssql-rs\/issues\/\d+|#\d+)/i;
+            const azureWorkItemLinkPattern =
+              /https:\/\/sqlclientdrivers\.visualstudio\.com\/[^\/]+\/_workitems\/edit\/\d+/i;
+
+            const hasGitHubIssueLink = githubIssueLinkPattern.test(body);
+            const hasWorkItemLink = azureWorkItemLinkPattern.test(body);
+
+            if (!hasGitHubIssueLink && !hasWorkItemLink) {
+              core.setFailed(
+                '❌ PR must reference either a GitHub issue OR an Azure DevOps work item in its description.\n' +
+                'GitHub issue format: https://github.com/microsoft/mssql-rs/issues/XXX or #XXX\n' +
+                'ADO work item format: https://sqlclientdrivers.visualstudio.com/.../_workitems/edit/<ID>\n' +
+                'Please add at least one reference under the "## Related Issues" section.'
+              );
+              return;
+            }
+
+            core.info('✅ PR references a GitHub issue or ADO work item.');

--- a/.github/workflows/pr-linked-issue-check.yml
+++ b/.github/workflows/pr-linked-issue-check.yml
@@ -27,7 +27,7 @@ jobs:
             const githubIssueLinkPattern =
               /(https:\/\/github\.com\/microsoft\/mssql-rs\/issues\/\d+|#\d+)/i;
             const azureWorkItemLinkPattern =
-              /https:\/\/sqlclientdrivers\.visualstudio\.com\/[^\/]+\/_workitems\/edit\/\d+/i;
+              /https:\/\/sqlclientdrivers\.visualstudio\.com\/(?:[^\/\s]+\/)+_workitems\/edit\/\d+/i;
 
             const hasGitHubIssueLink = githubIssueLinkPattern.test(body);
             const hasWorkItemLink = azureWorkItemLinkPattern.test(body);


### PR DESCRIPTION
## Description

Adds a PR validation workflow that requires every pull request to reference **either** a GitHub issue **or** an Azure DevOps work item in its description, mirroring the check in `microsoft/mssql-python`.

- New workflow `.github/workflows/pr-linked-issue-check.yml`: runs on `pull_request` (`opened`/`edited`/`reopened`/`synchronize`) against `main`, uses `actions/github-script@v7` to regex-match the PR body for a GitHub issue (`microsoft/mssql-rs/issues/N` or `#N`) or an ADO work item (`sqlclientdrivers.visualstudio.com/.../_workitems/edit/N`), and fails with a clear message if neither is present. Least-privilege (`pull-requests: read`) and guards against a null body.
- Updated `PULL_REQUEST_TEMPLATE.md` to spell out the linkage requirement and accepted formats under `## Related Issues`.

## Coverage workflow path-filter fix

While testing, we hit a related issue: the ADO PR validation build (definition 2267) has path-exclude filters, so PRs that only touch excluded paths (e.g. docs, `.github`) skip that build. The `pr-code-coverage.yml` workflow polls for that ADO build and **fails** when no build ever starts, producing a spurious failure on such PRs.

Fix: added a matching `paths-ignore` list to the `pull_request` trigger in `pr-code-coverage.yml` so the coverage report is skipped exactly when the ADO build is skipped. The excludes mirror the ADO build policy: `docs/**`, `.github/**`, `README.md`, `CHANGELOG.md`, `CONTRIBUTING.md`, `SECURITY.md`, `LICENSE`, `es-metadata.yml`. The `issue_comment` `/coverage` trigger is unaffected, so the report can still be run manually.

## Related Issues

Fixes https://github.com/microsoft/mssql-rs/issues/121

## Follow-up

To enforce, add the `check` job of this workflow to the required status checks in branch protection for `main` (repo admin action).
