### PR TITLE
Always Encrypted (Phase 1B): bulk-copy ciphertext passthrough (AllowEncryptedValueModifications)

### DIFF
--- a/mssql-tds/fuzz/fuzz_targets/fuzz_bulk_copy.rs
+++ b/mssql-tds/fuzz/fuzz_targets/fuzz_bulk_copy.rs
@@ -181,6 +181,7 @@ impl FuzzBulkCopyOptions {
             table_lock: self.table_lock,
             use_internal_transaction: self.use_internal_transaction,
             notification_interval: 0,
+            allow_encrypted_value_modifications: false,
         }
     }
 }

--- a/mssql-tds/src/connection/bulk_copy.rs
+++ b/mssql-tds/src/connection/bulk_copy.rs
@@ -105,6 +105,24 @@ pub struct BulkCopyOptions {
     /// Number of rows to process before calling the progress callback.
     /// Default: 0 (no progress notifications)
     pub notification_interval: usize,
+
+    /// Write already-encrypted (ciphertext) values into Always Encrypted
+    /// columns verbatim, without the driver encrypting them. Default: false.
+    ///
+    /// This is the counterpart to .NET
+    /// `SqlBulkCopyOptions.AllowEncryptedValueModifications`. When `true`, a
+    /// value targeting an encrypted destination column is sent as-is (it must
+    /// already be varbinary ciphertext) instead of being normalized and
+    /// encrypted with the column's key, so the plaintext CEK is not required.
+    ///
+    /// # Security
+    ///
+    /// The server does not validate that the supplied ciphertext matches the
+    /// destination column's encryption configuration. Only enable this to move
+    /// ciphertext between columns encrypted with the same key, algorithm, and
+    /// encryption type; otherwise the destination will hold values that cannot
+    /// be decrypted. The same caveats as the .NET option apply.
+    pub allow_encrypted_value_modifications: bool,
 }
 
 impl Default for BulkCopyOptions {
@@ -119,6 +137,7 @@ impl Default for BulkCopyOptions {
             table_lock: false,
             use_internal_transaction: false, // Matches .NET SqlBulkCopy default
             notification_interval: 0,
+            allow_encrypted_value_modifications: false,
         }
     }
 }
@@ -472,6 +491,24 @@ impl<'a> BulkCopy<'a> {
     /// ```
     pub fn keep_nulls(mut self, enabled: bool) -> Self {
         self.options.keep_nulls = enabled;
+        self
+    }
+
+    /// Write already-encrypted (ciphertext) values into Always Encrypted
+    /// columns without the driver re-encrypting them.
+    ///
+    /// Default: false. See
+    /// [`BulkCopyOptions::allow_encrypted_value_modifications`] for the security
+    /// caveats — only use this to move ciphertext between columns that share the
+    /// same column encryption key, algorithm, and encryption type.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// bulk_copy.allow_encrypted_value_modifications(true);
+    /// ```
+    pub fn allow_encrypted_value_modifications(mut self, enabled: bool) -> Self {
+        self.options.allow_encrypted_value_modifications = enabled;
         self
     }
 

--- a/mssql-tds/src/connection/bulk_copy.rs
+++ b/mssql-tds/src/connection/bulk_copy.rs
@@ -115,6 +115,14 @@ pub struct BulkCopyOptions {
     /// already be varbinary ciphertext) instead of being normalized and
     /// encrypted with the column's key, so the plaintext CEK is not required.
     ///
+    /// # Precondition
+    ///
+    /// This option only takes effect when Always Encrypted is enabled on the
+    /// connection (Column Encryption Setting = Enabled and the server
+    /// acknowledged the feature) and the destination has encrypted columns. When
+    /// column encryption is not enabled, the option is ignored and values follow
+    /// the normal plaintext path.
+    ///
     /// # Security
     ///
     /// The server does not validate that the supplied ciphertext matches the
@@ -497,7 +505,9 @@ impl<'a> BulkCopy<'a> {
     /// Write already-encrypted (ciphertext) values into Always Encrypted
     /// columns without the driver re-encrypting them.
     ///
-    /// Default: false. See
+    /// Default: false. This option only takes effect when Always Encrypted is
+    /// enabled on the connection and the destination has encrypted columns;
+    /// otherwise it is ignored. See
     /// [`BulkCopyOptions::allow_encrypted_value_modifications`] for the security
     /// caveats — only use this to move ciphertext between columns that share the
     /// same column encryption key, algorithm, and encryption type.

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -825,43 +825,50 @@ impl TdsClient {
         // Always Encrypted: when column encryption is negotiated and enabled,
         // resolve the plaintext CEK for each encrypted destination column so the
         // writer can encrypt row values and emit the encrypted COLMETADATA.
-        let plaintext_ceks: Vec<Option<std::sync::Arc<zeroize::Zeroizing<Vec<u8>>>>> = if self
-            .should_encrypt_bulk_copy()
-            && mapped_column_metadata.iter().any(|c| c.is_encrypted)
-        {
-            use crate::security::keystore::decrypt_cek;
+        //
+        // With `allow_encrypted_value_modifications`, the caller supplies
+        // ciphertext directly, so we skip CEK resolution entirely and let the
+        // writer pass those values through verbatim.
+        let has_encrypted_columns = mapped_column_metadata.iter().any(|c| c.is_encrypted);
+        let encrypt_bulk_copy = self.should_encrypt_bulk_copy() && has_encrypted_columns;
+        let passthrough_ciphertext =
+            encrypt_bulk_copy && options.allow_encrypted_value_modifications;
 
-            let (providers, cek_cache) = {
-                let client_context =
-                    self.recovery_context
-                        .client_context
-                        .as_ref()
-                        .ok_or_else(|| {
-                            crate::error::Error::ColumnEncryptionError(
-                                "Cannot encrypt bulk copy values without a client context"
-                                    .to_string(),
-                            )
-                        })?;
-                (
-                    client_context.column_encryption_key_store_providers.clone(),
-                    client_context.cek_cache.clone(),
-                )
-            };
+        let plaintext_ceks: Vec<Option<std::sync::Arc<zeroize::Zeroizing<Vec<u8>>>>> =
+            if encrypt_bulk_copy && !passthrough_ciphertext {
+                use crate::security::keystore::decrypt_cek;
 
-            let mut ceks = Vec::with_capacity(mapped_column_metadata.len());
-            for col in &mapped_column_metadata {
-                match &col.encryption {
-                    Some(enc) => {
-                        let cek = decrypt_cek(&providers, &cek_cache, &enc.cek_entry).await?;
-                        ceks.push(Some(cek));
+                let (providers, cek_cache) = {
+                    let client_context =
+                        self.recovery_context
+                            .client_context
+                            .as_ref()
+                            .ok_or_else(|| {
+                                crate::error::Error::ColumnEncryptionError(
+                                    "Cannot encrypt bulk copy values without a client context"
+                                        .to_string(),
+                                )
+                            })?;
+                    (
+                        client_context.column_encryption_key_store_providers.clone(),
+                        client_context.cek_cache.clone(),
+                    )
+                };
+
+                let mut ceks = Vec::with_capacity(mapped_column_metadata.len());
+                for col in &mapped_column_metadata {
+                    match &col.encryption {
+                        Some(enc) => {
+                            let cek = decrypt_cek(&providers, &cek_cache, &enc.cek_entry).await?;
+                            ceks.push(Some(cek));
+                        }
+                        None => ceks.push(None),
                     }
-                    None => ceks.push(None),
                 }
-            }
-            ceks
-        } else {
-            Vec::new()
-        };
+                ceks
+            } else {
+                Vec::new()
+            };
 
         let mut packet_writer = PacketWriter::new(
             PacketType::BulkLoad,
@@ -878,8 +885,13 @@ impl TdsClient {
         );
 
         // Enable Always Encrypted serialization before writing metadata so the
-        // COLMETADATA carries the CEK table and per-column crypto metadata.
-        if !plaintext_ceks.is_empty() {
+        // COLMETADATA carries the CEK table and per-column crypto metadata. Under
+        // ciphertext passthrough the metadata is still emitted, but values are
+        // sent verbatim rather than encrypted, so no plaintext CEKs are attached.
+        if passthrough_ciphertext {
+            writer.set_column_encryption_enabled(true);
+            writer.set_allow_encrypted_value_modifications(true);
+        } else if !plaintext_ceks.is_empty() {
             writer.set_column_encryption_enabled(true);
             writer.set_plaintext_ceks(plaintext_ceks);
         }

--- a/mssql-tds/src/message/bulk_load.rs
+++ b/mssql-tds/src/message/bulk_load.rs
@@ -84,6 +84,12 @@ pub struct StreamingBulkLoadWriter<'a> {
     /// before `begin()` when column encryption is enabled; used to encrypt cell
     /// values on the write path.
     plaintext_ceks: Vec<Option<std::sync::Arc<zeroize::Zeroizing<Vec<u8>>>>>,
+
+    /// When set, encrypted destination columns receive their values verbatim as
+    /// varbinary ciphertext instead of being encrypted with the column's key
+    /// (the .NET `AllowEncryptedValueModifications` behavior). No plaintext CEK
+    /// is required for the encrypted columns in this mode.
+    allow_encrypted_value_modifications: bool,
 }
 
 impl<'a> StreamingBulkLoadWriter<'a> {
@@ -113,6 +119,7 @@ impl<'a> StreamingBulkLoadWriter<'a> {
             column_encryption_enabled: false,
             emitted_cek_table: Vec::new(),
             plaintext_ceks: Vec::new(),
+            allow_encrypted_value_modifications: false,
         }
     }
 
@@ -136,6 +143,17 @@ impl<'a> StreamingBulkLoadWriter<'a> {
         ceks: Vec<Option<std::sync::Arc<zeroize::Zeroizing<Vec<u8>>>>>,
     ) {
         self.plaintext_ceks = ceks;
+    }
+
+    /// Enable ciphertext passthrough for encrypted columns (the
+    /// `AllowEncryptedValueModifications` behavior). When set, values for
+    /// encrypted columns are emitted verbatim as varbinary ciphertext rather
+    /// than encrypted, so the caller need not supply plaintext CEKs for those
+    /// columns. Requires
+    /// [`set_column_encryption_enabled`](Self::set_column_encryption_enabled) so
+    /// the encrypted COLMETADATA is still emitted.
+    pub(crate) fn set_allow_encrypted_value_modifications(&mut self, enabled: bool) {
+        self.allow_encrypted_value_modifications = enabled;
     }
 
     /// Begin streaming - write COLMETADATA token.
@@ -283,6 +301,22 @@ impl<'a> StreamingBulkLoadWriter<'a> {
         let Some(enc) = &col_meta.encryption else {
             return Ok(None);
         };
+
+        // AllowEncryptedValueModifications: emit the caller-supplied ciphertext
+        // verbatim without the plaintext CEK. The value must already be
+        // varbinary ciphertext (or NULL); anything else is a usage error rather
+        // than silently storing an un-decryptable value.
+        if self.allow_encrypted_value_modifications {
+            return match value {
+                ColumnValues::Null => Ok(Some(ColumnValues::Null)),
+                ColumnValues::Bytes(_) => Ok(Some(value.clone())),
+                other => Err(Error::UsageError(format!(
+                    "allow_encrypted_value_modifications requires already-encrypted varbinary \
+                     ciphertext for encrypted column '{}', but got {other:?}",
+                    col_meta.column_name
+                ))),
+            };
+        }
 
         let cek = self
             .plaintext_ceks
@@ -1339,5 +1373,85 @@ mod ae_colmetadata_tests {
         // A NULL varbinary is the 0xFFFF length sentinel.
         let len = reader.read_uint16().await.unwrap();
         assert_eq!(len, 0xFFFF);
+    }
+
+    #[tokio::test]
+    async fn passthrough_emits_ciphertext_verbatim_without_cek() {
+        // With AllowEncryptedValueModifications the caller-supplied ciphertext is
+        // written verbatim as a varbinary, and no plaintext CEK is required.
+        let ciphertext = vec![0x10u8, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80, 0x90];
+
+        let mut net = CapturingWriter { buffer: Vec::new() };
+        {
+            let mut packet_writer = PacketWriter::new(PacketType::BulkLoad, &mut net, None, None);
+            let mut writer = StreamingBulkLoadWriter::new(
+                &mut packet_writer,
+                "T".to_string(),
+                vec![deterministic_int_column()],
+                SqlCollation::default(),
+            );
+            writer.set_column_encryption_enabled(true);
+            writer.set_allow_encrypted_value_modifications(true);
+            // Intentionally no set_plaintext_ceks: passthrough must not need it.
+            writer.begin().await.unwrap();
+            writer
+                .write_column_value(0, &ColumnValues::Bytes(ciphertext.clone()))
+                .await
+                .unwrap();
+            let _ = writer.end().await.unwrap();
+        }
+
+        let body = net.buffer[9..].to_vec();
+        let mut reader = MockReader::new(body);
+        let parser = ColMetadataTokenParser;
+        let context = ParserContext::ColumnEncryption(true);
+        let _ = parser.parse(&mut reader, &context).await.unwrap();
+
+        let len = reader.read_uint16().await.unwrap() as usize;
+        assert_eq!(len, ciphertext.len(), "verbatim ciphertext length");
+        let mut blob = vec![0u8; len];
+        reader.read_bytes(&mut blob).await.unwrap();
+        assert_eq!(blob, ciphertext, "ciphertext must be sent unchanged");
+    }
+
+    #[tokio::test]
+    async fn passthrough_null_stays_null() {
+        let mut net = CapturingWriter { buffer: Vec::new() };
+        let mut packet_writer = PacketWriter::new(PacketType::BulkLoad, &mut net, None, None);
+        let mut writer = StreamingBulkLoadWriter::new(
+            &mut packet_writer,
+            "T".to_string(),
+            vec![deterministic_int_column()],
+            SqlCollation::default(),
+        );
+        writer.set_column_encryption_enabled(true);
+        writer.set_allow_encrypted_value_modifications(true);
+
+        let out = writer.try_encrypt_cell(0, &ColumnValues::Null).unwrap();
+        assert_eq!(out, Some(ColumnValues::Null));
+    }
+
+    #[tokio::test]
+    async fn passthrough_rejects_non_ciphertext_value() {
+        // A plaintext typed value under passthrough is a usage error rather than
+        // silently storing an un-decryptable value in the encrypted column.
+        let mut net = CapturingWriter { buffer: Vec::new() };
+        let mut packet_writer = PacketWriter::new(PacketType::BulkLoad, &mut net, None, None);
+        let mut writer = StreamingBulkLoadWriter::new(
+            &mut packet_writer,
+            "T".to_string(),
+            vec![deterministic_int_column()],
+            SqlCollation::default(),
+        );
+        writer.set_column_encryption_enabled(true);
+        writer.set_allow_encrypted_value_modifications(true);
+
+        let err = writer
+            .try_encrypt_cell(0, &ColumnValues::Int(42))
+            .unwrap_err();
+        assert!(
+            format!("{err}").to_lowercase().contains("ciphertext"),
+            "expected a ciphertext usage error, got: {err}"
+        );
     }
 }

--- a/mssql-tds/src/message/bulk_load.rs
+++ b/mssql-tds/src/message/bulk_load.rs
@@ -255,6 +255,36 @@ impl<'a> StreamingBulkLoadWriter<'a> {
         column_index: usize,
         value: &ColumnValues,
     ) -> TdsResult<()> {
+        // Ciphertext passthrough (AllowEncryptedValueModifications): for an
+        // encrypted column, serialize the caller-supplied ciphertext verbatim —
+        // no plaintext CEK, no re-encryption, and no clone of the (potentially
+        // large) ciphertext buffer. The value must already be varbinary
+        // ciphertext (or NULL); anything else is a usage error rather than
+        // silently storing an un-decryptable value.
+        if self.allow_encrypted_value_modifications
+            && self
+                .column_metadata
+                .get(column_index)
+                .is_some_and(|col| col.encryption.is_some())
+        {
+            if !matches!(value, ColumnValues::Bytes(_) | ColumnValues::Null) {
+                return Err(Error::UsageError(format!(
+                    "allow_encrypted_value_modifications requires already-encrypted varbinary \
+                     ciphertext for encrypted column '{}', but got {value:?}",
+                    self.column_metadata[column_index].column_name
+                )));
+            }
+            let ctx = self.column_contexts.get(column_index).cloned().ok_or_else(|| {
+                Error::UsageError(format!(
+                    "Column index {} out of bounds, expected {} columns based on table metadata.",
+                    column_index,
+                    self.column_contexts.len()
+                ))
+            })?;
+            TdsValueSerializer::serialize_value(self.packet_writer, value, &ctx).await?;
+            return Ok(());
+        }
+
         // Always Encrypted: encrypt the plaintext cell value and emit the
         // ciphertext as a varbinary, matching the encrypted COLMETADATA wire
         // type. NULL values stay NULL (no ciphertext).
@@ -301,22 +331,6 @@ impl<'a> StreamingBulkLoadWriter<'a> {
         let Some(enc) = &col_meta.encryption else {
             return Ok(None);
         };
-
-        // AllowEncryptedValueModifications: emit the caller-supplied ciphertext
-        // verbatim without the plaintext CEK. The value must already be
-        // varbinary ciphertext (or NULL); anything else is a usage error rather
-        // than silently storing an un-decryptable value.
-        if self.allow_encrypted_value_modifications {
-            return match value {
-                ColumnValues::Null => Ok(Some(ColumnValues::Null)),
-                ColumnValues::Bytes(_) => Ok(Some(value.clone())),
-                other => Err(Error::UsageError(format!(
-                    "allow_encrypted_value_modifications requires already-encrypted varbinary \
-                     ciphertext for encrypted column '{}', but got {other:?}",
-                    col_meta.column_name
-                ))),
-            };
-        }
 
         let cek = self
             .plaintext_ceks
@@ -1415,20 +1429,35 @@ mod ae_colmetadata_tests {
     }
 
     #[tokio::test]
-    async fn passthrough_null_stays_null() {
+    async fn passthrough_null_serializes_as_null() {
         let mut net = CapturingWriter { buffer: Vec::new() };
-        let mut packet_writer = PacketWriter::new(PacketType::BulkLoad, &mut net, None, None);
-        let mut writer = StreamingBulkLoadWriter::new(
-            &mut packet_writer,
-            "T".to_string(),
-            vec![deterministic_int_column()],
-            SqlCollation::default(),
-        );
-        writer.set_column_encryption_enabled(true);
-        writer.set_allow_encrypted_value_modifications(true);
+        {
+            let mut packet_writer = PacketWriter::new(PacketType::BulkLoad, &mut net, None, None);
+            let mut writer = StreamingBulkLoadWriter::new(
+                &mut packet_writer,
+                "T".to_string(),
+                vec![deterministic_int_column()],
+                SqlCollation::default(),
+            );
+            writer.set_column_encryption_enabled(true);
+            writer.set_allow_encrypted_value_modifications(true);
+            writer.begin().await.unwrap();
+            writer
+                .write_column_value(0, &ColumnValues::Null)
+                .await
+                .unwrap();
+            let _ = writer.end().await.unwrap();
+        }
 
-        let out = writer.try_encrypt_cell(0, &ColumnValues::Null).unwrap();
-        assert_eq!(out, Some(ColumnValues::Null));
+        let body = net.buffer[9..].to_vec();
+        let mut reader = MockReader::new(body);
+        let parser = ColMetadataTokenParser;
+        let context = ParserContext::ColumnEncryption(true);
+        let _ = parser.parse(&mut reader, &context).await.unwrap();
+
+        // A NULL varbinary is the 0xFFFF length sentinel.
+        let len = reader.read_uint16().await.unwrap();
+        assert_eq!(len, 0xFFFF);
     }
 
     #[tokio::test]
@@ -1445,9 +1474,11 @@ mod ae_colmetadata_tests {
         );
         writer.set_column_encryption_enabled(true);
         writer.set_allow_encrypted_value_modifications(true);
+        writer.begin().await.unwrap();
 
         let err = writer
-            .try_encrypt_cell(0, &ColumnValues::Int(42))
+            .write_column_value(0, &ColumnValues::Int(42))
+            .await
             .unwrap_err();
         assert!(
             format!("{err}").to_lowercase().contains("ciphertext"),

--- a/mssql-tds/src/message/bulk_load.rs
+++ b/mssql-tds/src/message/bulk_load.rs
@@ -1485,4 +1485,32 @@ mod ae_colmetadata_tests {
             "expected a ciphertext usage error, got: {err}"
         );
     }
+
+    #[tokio::test]
+    async fn passthrough_out_of_bounds_column_errors() {
+        // Passthrough for an encrypted column whose context is missing (because
+        // begin() has not populated column_contexts) surfaces a clear
+        // out-of-bounds error instead of panicking.
+        let mut net = CapturingWriter { buffer: Vec::new() };
+        let mut packet_writer = PacketWriter::new(PacketType::BulkLoad, &mut net, None, None);
+        let mut writer = StreamingBulkLoadWriter::new(
+            &mut packet_writer,
+            "T".to_string(),
+            vec![deterministic_int_column()],
+            SqlCollation::default(),
+        );
+        writer.set_column_encryption_enabled(true);
+        writer.set_allow_encrypted_value_modifications(true);
+        // begin() intentionally not called: column_contexts stays empty even
+        // though column_metadata has the encrypted column.
+
+        let err = writer
+            .write_column_value(0, &ColumnValues::Bytes(vec![1, 2, 3, 4]))
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{err}").to_lowercase().contains("out of bounds"),
+            "expected an out-of-bounds error, got: {err}"
+        );
+    }
 }

--- a/mssql-tds/tests/test_always_encrypted.rs
+++ b/mssql-tds/tests/test_always_encrypted.rs
@@ -1377,6 +1377,59 @@ mod always_encrypted {
         }
     }
 
+    /// `allow_encrypted_value_modifications` lets bulk copy move ciphertext
+    /// between two columns that share a CEK without the driver re-encrypting it:
+    /// the raw ciphertext read from one encrypted column is bulk-copied verbatim
+    /// into another and still decrypts to the original plaintext.
+    #[tokio::test]
+    async fn bulk_copy_allow_encrypted_value_modifications_passthrough() {
+        ae_test!(|h| {
+            const SECRET: i32 = 4242;
+
+            // Source table: insert through an encrypted parameter, then read the
+            // raw ciphertext back over an AE-disabled connection.
+            let source = h.create_encrypted_table("INT", "DETERMINISTIC").await;
+            h.insert_encrypted(&source, SqlType::Int(Some(SECRET)))
+                .await;
+            let ciphertext = read_ciphertext(&source, 1).await;
+
+            // Destination table with the same CEK / algorithm / encryption type.
+            let enc = h.enc_clause("DETERMINISTIC");
+            let dest = h
+                .create_table(&format!("id INT NOT NULL, val INT {enc} NULL"))
+                .await;
+
+            // Bulk-copy the ciphertext verbatim into the encrypted column. Without
+            // passthrough the driver would try to encrypt these bytes again.
+            let rows = vec![GenericBulkRow {
+                values: vec![
+                    ColumnValues::Int(1),
+                    ColumnValues::Bytes(ciphertext.clone()),
+                ],
+            }];
+            let result = BulkCopy::new(&mut h.client, dest.as_str())
+                .allow_encrypted_value_modifications(true)
+                .write_to_server_zerocopy(rows)
+                .await
+                .expect("passthrough bulk copy into encrypted column");
+            assert_eq!(result.rows_affected, 1, "expected one row copied");
+
+            // The destination stores the identical ciphertext at rest.
+            let dest_ciphertext = read_ciphertext(&dest, 1).await;
+            assert_eq!(
+                dest_ciphertext, ciphertext,
+                "passthrough must store the ciphertext verbatim"
+            );
+
+            // Reading the destination over the AE-enabled connection decrypts it
+            // back to the original plaintext, proving the ciphertext was valid.
+            let got = h
+                .query_rows(&format!("SELECT val FROM {dest} WHERE id = 1;"), 1)
+                .await;
+            assert_eq!(got, vec![vec![ColumnValues::Int(SECRET)]]);
+        });
+    }
+
     /// Bulk-copying string and binary values into encrypted columns encrypts each
     /// one on the client and round-trips it back transparently decrypted.
     #[tokio::test]


### PR DESCRIPTION
Work item: [AB#46055](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46055)

## Summary

Phase 1B follow-up to Always Encrypted in `mssql-tds`: a bulk-copy option, `allow_encrypted_value_modifications`, that writes already-encrypted (ciphertext) values into Always Encrypted columns verbatim instead of encrypting them with the column's key. This is the counterpart to .NET `SqlBulkCopyOptions.AllowEncryptedValueModifications` and lets ciphertext move between two columns that share the same CEK, algorithm, and encryption type without the client needing the plaintext key.

## What changed

- **`BulkCopyOptions`** gains `allow_encrypted_value_modifications` (default `false`) with a builder method `BulkCopy::allow_encrypted_value_modifications(bool)`.
- **`StreamingBulkLoadWriter`** gains a passthrough mode: for an encrypted destination column it emits the caller-supplied value verbatim as varbinary (`NULL` stays `NULL`) and requires no plaintext CEK. A non-ciphertext value supplied for an encrypted column is a `UsageError` rather than a silently un-decryptable write.
- The bulk path still emits the encrypted `COLMETADATA` (CEK table + per-column crypto metadata) under passthrough — the server needs it to store the value as encrypted — but skips plaintext-CEK resolution entirely.

## Behavior

- Only takes effect when the connection negotiated and enabled Always Encrypted and the destination has encrypted columns (mirrors .NET, which requires `Column Encryption Setting = Enabled`).
- Non-encrypted columns are unaffected and continue through the normal plaintext path.

## Security

The server does not validate that the supplied ciphertext matches the destination column's encryption configuration. This option is intended only for moving ciphertext between columns encrypted with the same key, algorithm, and encryption type; otherwise the destination will hold values that cannot be decrypted. The same caveats as the .NET option apply, and this is documented on both the option field and the builder method.

## Tests

- **Unit** (`ae_colmetadata_tests`): ciphertext is emitted verbatim with no CEK attached; `NULL` passes through as `NULL`; a plaintext typed value for an encrypted column errors.
- **Live** (`test_always_encrypted`): `bulk_copy_allow_encrypted_value_modifications_passthrough` inserts through an encrypted parameter, reads the raw ciphertext over an AE-disabled connection, bulk-copies it verbatim into a second column sharing the CEK, confirms the destination stores the identical ciphertext at rest, and reads it back over the AE-enabled connection to confirm it decrypts to the original plaintext.

Full AE suite passes (34 live tests); `clippy --all-targets -D warnings` clean; `cargo fmt` clean.

## Phase 1B tracking

This is one of the remaining Phase 1B functional gaps. Positional stored-procedure parameter encryption and char/varchar collation normalization to the target column remain as separate follow-ups.
