### PR TITLE
Add glibc-2.28 rust build images + UBI8 sync for ODBC CI

### DIFF
--- a/.pipeline/sync-container-images.yml
+++ b/.pipeline/sync-container-images.yml
@@ -570,6 +570,15 @@ stages:
               .
           echo "✅ musllinux x64 image built successfully"
 
+          # Build manylinux_2_28 x64 image (glibc 2.28 / OpenSSL 1.1 for the
+          # mssql-odbc RHEL 8 track; includes cmake + unixODBC-devel + rust)
+          echo "==> Building manylinux_2_28 x64 image..."
+          docker build \
+              -f Dockerfile.PythonBuild.manylinux.2_28.x64 \
+              -t tdslibrs.azurecr.io/python-build/manylinux_2_28_x86_64_rust:latest \
+              .
+          echo "✅ manylinux_2_28 x64 image built successfully"
+
     - task: AzureCLI@2
       displayName: 'Build Ubuntu x64 build image with Rust and tooling'
       condition: eq('${{ parameters.buildUbuntuImages }}', 'true')
@@ -628,6 +637,7 @@ stages:
           if [ "${{ parameters.buildPythonImages }}" == "True" ]; then
             docker push tdslibrs.azurecr.io/python-build/manylinux_2_34_x86_64_rust:latest
             docker push tdslibrs.azurecr.io/python-build/musllinux_1_2_x86_64_rust:latest
+            docker push tdslibrs.azurecr.io/python-build/manylinux_2_28_x86_64_rust:latest
           fi
           
           # Push Ubuntu images if enabled
@@ -688,6 +698,15 @@ stages:
               .
           echo "✅ musllinux ARM64 image built successfully"
 
+          # Build manylinux_2_28 ARM64 image (glibc 2.28 / OpenSSL 1.1 for the
+          # mssql-odbc RHEL 8 track; includes cmake + unixODBC-devel + rust)
+          echo "==> Building manylinux_2_28 ARM64 image..."
+          docker build \
+              -f Dockerfile.PythonBuild.manylinux.2_28.arm64 \
+              -t tdslibrs.azurecr.io/python-build/manylinux_2_28_aarch64_rust:latest \
+              .
+          echo "✅ manylinux_2_28 ARM64 image built successfully"
+
     - task: AzureCLI@2
       displayName: 'Build Ubuntu ARM64 build image with Rust and tooling'
       condition: eq('${{ parameters.buildUbuntuImages }}', 'true')
@@ -746,6 +765,7 @@ stages:
           if [ "${{ parameters.buildPythonImages }}" == "True" ]; then
             docker push tdslibrs.azurecr.io/python-build/manylinux_2_34_aarch64_rust:latest
             docker push tdslibrs.azurecr.io/python-build/musllinux_1_2_aarch64_rust:latest
+            docker push tdslibrs.azurecr.io/python-build/manylinux_2_28_aarch64_rust:latest
           fi
           
           # Push Ubuntu images if enabled
@@ -904,6 +924,8 @@ stages:
         echo "    - $(ACR_REGISTRY)/python-build/manylinux_2_34_aarch64_rust:latest"
         echo "    - $(ACR_REGISTRY)/python-build/musllinux_1_2_x86_64_rust:latest"
         echo "    - $(ACR_REGISTRY)/python-build/musllinux_1_2_aarch64_rust:latest"
+        echo "    - $(ACR_REGISTRY)/python-build/manylinux_2_28_x86_64_rust:latest"
+        echo "    - $(ACR_REGISTRY)/python-build/manylinux_2_28_aarch64_rust:latest"
         echo ""
         echo "  Ubuntu build images (RECOMMENDED FOR GENERAL BUILDS):"
         echo "    - $(ACR_REGISTRY)/build/ubuntu:22.04 (multi-arch: amd64, arm64)"
@@ -999,9 +1021,10 @@ stages:
         python-build/manylinux_2_34_aarch64_rust:latest
         python-build/musllinux_1_2_x86_64_rust:latest
         python-build/musllinux_1_2_aarch64_rust:latest
+        python-build/manylinux_2_28_x86_64_rust:latest
+        python-build/manylinux_2_28_aarch64_rust:latest
         build/ubuntu:22.04
         build/alpine:3.18
-        import/python-build/manylinux_2_28_x86_64:latest
         import/debian:bookworm
         import/alpine:3.18
         import/alpine:3.19

--- a/.pipeline/sync-container-images.yml
+++ b/.pipeline/sync-container-images.yml
@@ -457,6 +457,30 @@ stages:
         DOCKER_USER: $(DOCKERHUB_USERNAME)
         DOCKER_PAT: $(DOCKERHUB_PAT)
       retryCountOnTaskFailure: 3
+    - task: AzureCLI@2
+      displayName: 'Import Red Hat UBI8'
+      inputs:
+        azureSubscription: 'Magnitude Test'
+        scriptType: 'bash'
+        scriptLocation: 'inlineScript'
+        inlineScript: |
+          AUTH_ARGS=""
+          if [[ -n "$DOCKER_USER" && -n "$DOCKER_PAT" ]]; then
+            echo "Using authenticated Docker Hub access"
+            AUTH_ARGS="--username $DOCKER_USER --password $DOCKER_PAT"
+          else
+            echo "Using anonymous Docker Hub access"
+          fi
+          az acr import \
+            --name $(ACR_NAME) \
+            --source docker.io/redhat/ubi8:latest \
+            --image import/redhat/ubi8:latest \
+            $AUTH_ARGS \
+            --force
+      env:
+        DOCKER_USER: $(DOCKERHUB_USERNAME)
+        DOCKER_PAT: $(DOCKERHUB_PAT)
+      retryCountOnTaskFailure: 3
 
   # Oracle Linux (Docker Hub - rate limited)
   - job: Oracle
@@ -854,7 +878,7 @@ stages:
           echo "======================================================"
           echo "Imported Base Images:"
           echo "======================================================"
-          for repo in import/ubuntu import/alpine import/debian import/redhat/ubi9 import/oraclelinux; do
+          for repo in import/ubuntu import/alpine import/debian import/redhat/ubi9 import/redhat/ubi8 import/oraclelinux; do
             echo ""
             echo "==> $repo"
             az acr repository show-tags --name $(ACR_NAME) --repository $repo --output table --orderby time_desc --top 5 2>/dev/null || echo "  (not found)"
@@ -896,6 +920,7 @@ stages:
         echo "    - $(ACR_REGISTRY)/import/alpine:3.18, 3.19, 3.20, 3.21"
         echo "    - $(ACR_REGISTRY)/import/debian:bookworm"
         echo "    - $(ACR_REGISTRY)/import/redhat/ubi9:latest"
+        echo "    - $(ACR_REGISTRY)/import/redhat/ubi8:latest"
         echo "    - $(ACR_REGISTRY)/import/oraclelinux:9"
         echo ""
         echo "Next scheduled build: Next Monday at 3:00 AM UTC"
@@ -976,6 +1001,7 @@ stages:
         python-build/musllinux_1_2_aarch64_rust:latest
         build/ubuntu:22.04
         build/alpine:3.18
+        import/python-build/manylinux_2_28_x86_64:latest
         import/debian:bookworm
         import/alpine:3.18
         import/alpine:3.19
@@ -984,6 +1010,7 @@ stages:
         import/ubuntu:22.04
         import/ubuntu:24.04
         import/redhat/ubi9:latest
+        import/redhat/ubi8:latest
         import/oraclelinux:9
         EOF
         echo "Images to mirror to GHCR:"

--- a/containers/Dockerfile.PythonBuild.manylinux.2_28.arm64
+++ b/containers/Dockerfile.PythonBuild.manylinux.2_28.arm64
@@ -1,0 +1,33 @@
+# Pre-built glibc-2.28 build image for the mssql-odbc driver (ARM64).
+# Extends the PyPA manylinux_2_28 base with Rust and the C/C++ toolchain the
+# ODBC e2e build needs (cmake, unixODBC-devel, OpenSSL 1.1 dev, git), so CI does
+# not install them at runtime.
+#
+# manylinux_2_28 is based on AlmaLinux 8 (glibc 2.28, OpenSSL 1.1.x). Building
+# here links the driver against libssl.so.1.1, so it loads on RHEL 8 / UBI 8 -
+# where the modern glibc 2.35 / OpenSSL 3 build images would not.
+#
+# Base image is synced from quay.io/pypa to ACR via sync-container-images.yml.
+
+FROM tdslibrs.azurecr.io/import/python-build/manylinux_2_28_aarch64:latest
+
+# unixODBC-devel + cmake + OpenSSL 1.1 headers for the driver and gtest e2e;
+# git for the e2e CMake FetchContent(googletest) clone. gcc/g++/make ship in the
+# manylinux base.
+RUN dnf install -y --allowerasing \
+        cmake \
+        unixODBC-devel \
+        openssl-devel \
+        pkgconfig \
+        git \
+    && dnf clean all
+
+# Install Rust toolchain (stable), system-wide so the build script needs no setup.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+ENV PATH="/root/.cargo/bin:$PATH"
+
+RUN rustc --version && cargo --version
+
+WORKDIR /workspace
+
+CMD ["bash"]

--- a/containers/Dockerfile.PythonBuild.manylinux.2_28.arm64
+++ b/containers/Dockerfile.PythonBuild.manylinux.2_28.arm64
@@ -5,7 +5,7 @@
 #
 # manylinux_2_28 is based on AlmaLinux 8 (glibc 2.28, OpenSSL 1.1.x). Building
 # here links the driver against libssl.so.1.1, so it loads on RHEL 8 / UBI 8 -
-# where the modern glibc 2.35 / OpenSSL 3 build images would not.
+# where the modern glibc 2.34 / OpenSSL 3 build images would not.
 #
 # Base image is synced from quay.io/pypa to ACR via sync-container-images.yml.
 

--- a/containers/Dockerfile.PythonBuild.manylinux.2_28.x64
+++ b/containers/Dockerfile.PythonBuild.manylinux.2_28.x64
@@ -1,0 +1,33 @@
+# Pre-built glibc-2.28 build image for the mssql-odbc driver (x64).
+# Extends the PyPA manylinux_2_28 base with Rust and the C/C++ toolchain the
+# ODBC e2e build needs (cmake, unixODBC-devel, OpenSSL 1.1 dev, git), so CI does
+# not install them at runtime.
+#
+# manylinux_2_28 is based on AlmaLinux 8 (glibc 2.28, OpenSSL 1.1.x). Building
+# here links the driver against libssl.so.1.1, so it loads on RHEL 8 / UBI 8 -
+# where the modern glibc 2.35 / OpenSSL 3 build images would not.
+#
+# Base image is synced from quay.io/pypa to ACR via sync-container-images.yml.
+
+FROM tdslibrs.azurecr.io/import/python-build/manylinux_2_28_x86_64:latest
+
+# unixODBC-devel + cmake + OpenSSL 1.1 headers for the driver and gtest e2e;
+# git for the e2e CMake FetchContent(googletest) clone. gcc/g++/make ship in the
+# manylinux base.
+RUN dnf install -y --allowerasing \
+        cmake \
+        unixODBC-devel \
+        openssl-devel \
+        pkgconfig \
+        git \
+    && dnf clean all
+
+# Install Rust toolchain (stable), system-wide so the build script needs no setup.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+ENV PATH="/root/.cargo/bin:$PATH"
+
+RUN rustc --version && cargo --version
+
+WORKDIR /workspace
+
+CMD ["bash"]

--- a/containers/Dockerfile.PythonBuild.manylinux.2_28.x64
+++ b/containers/Dockerfile.PythonBuild.manylinux.2_28.x64
@@ -5,7 +5,7 @@
 #
 # manylinux_2_28 is based on AlmaLinux 8 (glibc 2.28, OpenSSL 1.1.x). Building
 # here links the driver against libssl.so.1.1, so it loads on RHEL 8 / UBI 8 -
-# where the modern glibc 2.35 / OpenSSL 3 build images would not.
+# where the modern glibc 2.34 / OpenSSL 3 build images would not.
 #
 # Base image is synced from quay.io/pypa to ACR via sync-container-images.yml.
 


### PR DESCRIPTION
Extracted from #127 to keep the container-image sync separate from the ODBC CI build/test work.

## What
Provides the base + build images the ODBC glibc-2.28 track depends on, in the container sync pipeline (`.pipeline/sync-container-images.yml`) plus two new Dockerfiles:

- **New** `containers/Dockerfile.PythonBuild.manylinux.2_28.x64` / `.arm64` — extend the PyPA `manylinux_2_28_{x86_64,aarch64}` base (AlmaLinux 8, glibc 2.28, OpenSSL 1.1) with rust + cmake + unixODBC-devel + OpenSSL 1.1 dev + git.
- Build and push `python-build/manylinux_2_28_{x86_64,aarch64}_rust:latest` to ACR (x64 and arm64 build jobs).
- Import `docker.io/redhat/ubi8:latest` into ACR as `import/redhat/ubi8:latest` (multi-arch manifest, so x64 + arm64 in one import).
- Mirror `python-build/manylinux_2_28_{x86_64,aarch64}_rust:latest` and `import/redhat/ubi8:latest` to GHCR (the plain `import/python-build/manylinux_2_28_x86_64` mirror entry is replaced by the two `_rust` tags).

## Why
The ODBC CI in #127 builds a glibc-2.28 driver in the `manylinux_2_28_*_rust` images (so it links `libssl.so.1.1`) and tests it in RHEL 8 / UBI 8 containers, on both x64 and arm64. Baking rust + the C/C++ toolchain into the build image avoids installing it at build time. The modern `manylinux_2_34` (glibc 2.34, OpenSSL 3) images can't serve this track — a 2_34 binary won't load on RHEL 8.

These images must be synced to ACR/GHCR **before** #127 can pass. Splitting this out lets the sync land independently of the ODBC pipeline changes.

Kept as **draft** pending review.

## Work item

[AB#46492](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46492)
