### PR TITLE
Always Encrypted (Phase 1B): ForceColumnEncryption and trusted master key paths

### DIFF
--- a/mssql-tds/src/connection/client_context.rs
+++ b/mssql-tds/src/connection/client_context.rs
@@ -307,8 +307,23 @@ pub struct ClientContext {
     /// is configured for the connected server, the driver only unwraps a column
     /// encryption key whose CMK path is in the list, defending against a
     /// malicious server that points the client at an attacker-controlled CMK. A
-    /// server with no entry (or an empty list) is unrestricted. Empty by default.
-    pub(crate) trusted_master_key_paths: HashMap<String, Vec<String>>,
+    /// server with no entry (or an empty list) is unrestricted.
+    ///
+    /// `None` (unrestricted) by default. Boxed behind an `Option` so the common
+    /// case — connections that never opt into trusted paths — costs a single
+    /// pointer (8 bytes) instead of an inline 48-byte `HashMap`. (An
+    /// `Option<HashMap>` alone would not shrink: the map's internal non-null
+    /// pointer gives `Option` a free niche, so it stays 48 bytes — the `Box` is
+    /// what buys the reduction.) Keeping this by-value field small keeps the
+    /// `ClientContext`-carrying connect future off the `clippy::large_futures`
+    /// budget.
+    //
+    // The `#[allow]` is deliberate: `clippy::box_collection` flags `Box<HashMap>`
+    // as redundant heap-on-heap, but here the boxing is the whole point — it
+    // moves the map's 48-byte inline control block off the by-value
+    // `ClientContext` so the connect future stays small.
+    #[allow(clippy::box_collection)]
+    pub(crate) trusted_master_key_paths: Option<Box<HashMap<String, Vec<String>>>>,
     /// UserAgent telemetry payload components.
     pub user_agent: UserAgent,
 }
@@ -407,6 +422,7 @@ impl ClientContext {
         key_paths: Vec<String>,
     ) {
         self.trusted_master_key_paths
+            .get_or_insert_with(|| Box::new(HashMap::new()))
             .insert(server_name.as_ref().to_ascii_uppercase(), key_paths);
     }
 
@@ -415,17 +431,18 @@ impl ClientContext {
     /// unrestricted (no list registered, or none registered at all). An empty
     /// slice means "no restriction".
     pub(crate) fn trusted_key_paths_for_current_server(&self) -> &[String] {
-        if self.trusted_master_key_paths.is_empty() {
+        let Some(paths) = self
+            .trusted_master_key_paths
+            .as_ref()
+            .filter(|paths| !paths.is_empty())
+        else {
             return &[];
-        }
+        };
         let server = self
             .transport_context
             .get_server_name()
             .to_ascii_uppercase();
-        self.trusted_master_key_paths
-            .get(&server)
-            .map(Vec::as_slice)
-            .unwrap_or(&[])
+        paths.get(&server).map(Vec::as_slice).unwrap_or(&[])
     }
 
     /// Creates a new ClientContext with the specified data source.
@@ -486,7 +503,7 @@ impl ClientContext {
                 crate::security::keystore::ColumnEncryptionKeyStoreProviderRegistry::new(),
             ),
             cek_cache: std::sync::Arc::new(crate::security::keystore::CekCache::new()),
-            trusted_master_key_paths: HashMap::new(),
+            trusted_master_key_paths: None,
             user_agent: UserAgent::default(),
         }
     }
@@ -548,7 +565,7 @@ impl ClientContext {
                 crate::security::keystore::ColumnEncryptionKeyStoreProviderRegistry::new(),
             ),
             cek_cache: std::sync::Arc::new(crate::security::keystore::CekCache::new()),
-            trusted_master_key_paths: HashMap::new(),
+            trusted_master_key_paths: None,
             user_agent: UserAgent::default(),
         }
     }

--- a/mssql-tds/src/connection/client_context.rs
+++ b/mssql-tds/src/connection/client_context.rs
@@ -302,6 +302,13 @@ pub struct ClientContext {
     /// Cache of decrypted column encryption keys, shared across the connection
     /// (and its session-recovery clones) so a CMK only unwraps a CEK once.
     pub(crate) cek_cache: std::sync::Arc<crate::security::keystore::CekCache>,
+    /// Per-server allow-list of trusted column master key (CMK) paths for Always
+    /// Encrypted, keyed by server name (case-insensitive). When a non-empty list
+    /// is configured for the connected server, the driver only unwraps a column
+    /// encryption key whose CMK path is in the list, defending against a
+    /// malicious server that points the client at an attacker-controlled CMK. A
+    /// server with no entry (or an empty list) is unrestricted. Empty by default.
+    pub(crate) trusted_master_key_paths: HashMap<String, Vec<String>>,
     /// UserAgent telemetry payload components.
     pub user_agent: UserAgent,
 }
@@ -379,6 +386,48 @@ impl ClientContext {
             .register(name, provider);
     }
 
+    /// Registers the allow-list of trusted column master key (CMK) paths for
+    /// `server_name`, enabling the Always Encrypted trusted-master-key-path
+    /// check for that server.
+    ///
+    /// When a non-empty list is registered for the connected server, the driver
+    /// only unwraps a column encryption key whose CMK path matches one of the
+    /// listed paths (compared case-insensitively); any other path is rejected.
+    /// This defends against a compromised or malicious server that points the
+    /// client at an attacker-controlled column master key. A server with no
+    /// registered list (or an empty list) is unrestricted, so this is a
+    /// per-server opt-in, matching .NET
+    /// `SqlConnection.ColumnEncryptionTrustedMasterKeyPaths`.
+    ///
+    /// `server_name` is matched case-insensitively against the connected
+    /// server's name (the host portion of the data source).
+    pub fn register_trusted_master_key_paths(
+        &mut self,
+        server_name: impl AsRef<str>,
+        key_paths: Vec<String>,
+    ) {
+        self.trusted_master_key_paths
+            .insert(server_name.as_ref().to_ascii_uppercase(), key_paths);
+    }
+
+    /// Returns the trusted column master key path allow-list configured for the
+    /// currently connected server, or an empty slice when the server is
+    /// unrestricted (no list registered, or none registered at all). An empty
+    /// slice means "no restriction".
+    pub(crate) fn trusted_key_paths_for_current_server(&self) -> &[String] {
+        if self.trusted_master_key_paths.is_empty() {
+            return &[];
+        }
+        let server = self
+            .transport_context
+            .get_server_name()
+            .to_ascii_uppercase();
+        self.trusted_master_key_paths
+            .get(&server)
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
+    }
+
     /// Creates a new ClientContext with the specified data source.
     /// The data source is mandatory for establishing a connection.
     ///
@@ -437,6 +486,7 @@ impl ClientContext {
                 crate::security::keystore::ColumnEncryptionKeyStoreProviderRegistry::new(),
             ),
             cek_cache: std::sync::Arc::new(crate::security::keystore::CekCache::new()),
+            trusted_master_key_paths: HashMap::new(),
             user_agent: UserAgent::default(),
         }
     }
@@ -498,6 +548,7 @@ impl ClientContext {
                 crate::security::keystore::ColumnEncryptionKeyStoreProviderRegistry::new(),
             ),
             cek_cache: std::sync::Arc::new(crate::security::keystore::CekCache::new()),
+            trusted_master_key_paths: HashMap::new(),
             user_agent: UserAgent::default(),
         }
     }
@@ -737,6 +788,7 @@ impl Clone for ClientContext {
                 .column_encryption_key_store_providers
                 .clone(),
             cek_cache: self.cek_cache.clone(),
+            trusted_master_key_paths: self.trusted_master_key_paths.clone(),
             user_agent: self.user_agent.clone(),
         }
     }
@@ -1069,6 +1121,32 @@ mod tests {
         let ctx = ClientContext::with_data_source("tcp:myserver,1433");
         let cloned = ctx.clone();
         assert_eq!(cloned.data_source, "tcp:myserver,1433");
+    }
+
+    #[test]
+    fn trusted_master_key_paths_are_per_server_and_case_insensitive() {
+        let mut ctx = ClientContext::with_data_source("tcp:myserver,1433");
+        let _ = ctx.parse_datasource("tcp:myserver,1433");
+
+        // No configuration at all: the current server is unrestricted.
+        assert!(ctx.trusted_key_paths_for_current_server().is_empty());
+
+        // A list configured for a different server leaves this one unrestricted.
+        ctx.register_trusted_master_key_paths("otherserver", vec!["p".to_string()]);
+        assert!(ctx.trusted_key_paths_for_current_server().is_empty());
+
+        // A list for this server (registered with different casing) applies.
+        ctx.register_trusted_master_key_paths("MYSERVER", vec!["path/a".to_string()]);
+        assert_eq!(
+            ctx.trusted_key_paths_for_current_server(),
+            &["path/a".to_string()]
+        );
+
+        // Cloning preserves the configuration.
+        assert_eq!(
+            ctx.clone().trusted_key_paths_for_current_server(),
+            &["path/a".to_string()]
+        );
     }
 
     #[test]

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -700,6 +700,7 @@ impl TdsClient {
         // Always Encrypted: when the connection enabled column encryption and the
         // server acknowledged the feature, ask the server which parameters need
         // encryption and encrypt them in place before sending the real RPC.
+        self.ensure_force_column_encryption_supported(named_params.iter())?;
         if self.should_encrypt_parameters() && !named_params.is_empty() {
             self.encrypt_parameters(
                 &sql,
@@ -851,7 +852,7 @@ impl TdsClient {
             if encrypt_bulk_copy && !passthrough_ciphertext {
                 use crate::security::keystore::decrypt_cek;
 
-                let (providers, cek_cache) = {
+                let (providers, cek_cache, trusted_key_paths) = {
                     let client_context =
                         self.recovery_context
                             .client_context
@@ -865,6 +866,9 @@ impl TdsClient {
                     (
                         client_context.column_encryption_key_store_providers.clone(),
                         client_context.cek_cache.clone(),
+                        client_context
+                            .trusted_key_paths_for_current_server()
+                            .to_vec(),
                     )
                 };
 
@@ -872,7 +876,13 @@ impl TdsClient {
                 for col in &mapped_column_metadata {
                     match &col.encryption {
                         Some(enc) => {
-                            let cek = decrypt_cek(&providers, &cek_cache, &enc.cek_entry).await?;
+                            let cek = decrypt_cek(
+                                &providers,
+                                &cek_cache,
+                                &enc.cek_entry,
+                                &trusted_key_paths,
+                            )
+                            .await?;
                             ceks.push(Some(cek));
                         }
                         None => ceks.push(None),
@@ -1104,6 +1114,12 @@ impl TdsClient {
         // form of the call) and encrypt them in place before sending the real
         // stored-procedure RPC. Positional parameters are described under
         // synthetic names bound by position; named parameters bind by name.
+        self.ensure_force_column_encryption_supported(
+            positional_parameters
+                .iter()
+                .flatten()
+                .chain(named_parameters.iter().flatten()),
+        )?;
         let has_positional = positional_parameters
             .as_ref()
             .is_some_and(|p| !p.is_empty());
@@ -1457,6 +1473,7 @@ impl TdsClient {
         // sending the real RPC. The `@params` declaration keeps each parameter's
         // original type; only the value is replaced with ciphertext plus cipher
         // metadata.
+        self.ensure_force_column_encryption_supported(named_params.iter())?;
         if self.should_encrypt_parameters() && !named_params.is_empty() {
             self.encrypt_parameters(
                 &sql,
@@ -1553,13 +1570,19 @@ impl TdsClient {
         // the metadata captured when the statement was prepared, then send the
         // real RPC. sp_execute never describes — the metadata must already have
         // been cached by execute_sp_prepare on this connection.
+        self.ensure_force_column_encryption_supported(
+            positional_parameters
+                .iter()
+                .flatten()
+                .chain(named_parameters.iter().flatten()),
+        )?;
         if self.should_encrypt_parameters()
             && (positional_parameters
                 .as_ref()
                 .is_some_and(|p| !p.is_empty())
                 || named_parameters.as_ref().is_some_and(|p| !p.is_empty()))
         {
-            let (providers, cek_cache) = self.cloned_ce_key_material()?;
+            let (providers, cek_cache, trusted_key_paths) = self.cloned_ce_key_material()?;
             let describe = self
                 .prepared_param_encryption
                 .get(&handle)
@@ -1587,6 +1610,7 @@ impl TdsClient {
                 &cek_cache,
                 &mut param_refs,
                 &mut self.output_param_ceks,
+                &trusted_key_paths,
             )
             .await?;
         }
@@ -1861,6 +1885,27 @@ impl TdsClient {
             && self.effective_command_ce_setting() == ExecutionColumnEncryptionSetting::Enabled
     }
 
+    /// Enforces the ForceColumnEncryption precondition: if any supplied parameter
+    /// requires encryption but Always Encrypted is not enabled for this command,
+    /// fail rather than sending it as plaintext. The per-parameter downgrade
+    /// check (server reports the column plaintext) is enforced separately in
+    /// [`apply_parameter_encryption`](Self::apply_parameter_encryption).
+    fn ensure_force_column_encryption_supported<'p>(
+        &self,
+        params: impl IntoIterator<Item = &'p RpcParameter>,
+    ) -> TdsResult<()> {
+        if !self.should_encrypt_parameters()
+            && params.into_iter().any(|p| p.force_column_encryption())
+        {
+            return Err(crate::error::Error::UsageError(
+                "A parameter has ForceColumnEncryption set, but Always Encrypted is not enabled \
+                 for this command; enable column encryption on the connection, or clear the flag."
+                    .to_string(),
+            ));
+        }
+        Ok(())
+    }
+
     /// Returns `true` when the connection negotiated Always Encrypted and
     /// enabled column encryption, ignoring any per-command override. Used by
     /// paths that have no per-command setting (bulk copy, prepared statements).
@@ -2115,13 +2160,14 @@ impl TdsClient {
             .describe_parameters_cached(sql, params_decl, has_output, timeout_sec, cancel_handle)
             .await?;
 
-        let (providers, cek_cache) = self.cloned_ce_key_material()?;
+        let (providers, cek_cache, trusted_key_paths) = self.cloned_ce_key_material()?;
         Self::apply_parameter_encryption(
             &describe,
             &providers,
             &cek_cache,
             params,
             &mut self.output_param_ceks,
+            &trusted_key_paths,
         )
         .await
     }
@@ -2170,13 +2216,15 @@ impl TdsClient {
     }
 
     /// Clones the `Arc` handles to the column-master-key provider registry and
-    /// the CEK cache from the client context, so the parameter-encryption paths
+    /// the CEK cache from the client context, plus the trusted master key path
+    /// allow-list for the connected server, so the parameter-encryption paths
     /// can pass them around without holding a borrow on `self`.
     fn cloned_ce_key_material(
         &self,
     ) -> TdsResult<(
         std::sync::Arc<crate::security::keystore::ColumnEncryptionKeyStoreProviderRegistry>,
         std::sync::Arc<crate::security::keystore::CekCache>,
+        Vec<String>,
     )> {
         let client_context = self
             .recovery_context
@@ -2190,7 +2238,34 @@ impl TdsClient {
         Ok((
             client_context.column_encryption_key_store_providers.clone(),
             client_context.cek_cache.clone(),
+            client_context
+                .trusted_key_paths_for_current_server()
+                .to_vec(),
         ))
+    }
+
+    /// Matches a `sp_describe_parameter_encryption` result entry to a supplied
+    /// parameter: by name first (case-insensitively, like a T-SQL identifier),
+    /// otherwise falling back to the *unnamed* parameter at the describe's
+    /// 1-based ordinal (the positional case). Requiring the ordinal slot to be
+    /// unnamed keeps a named parameter from being matched by position.
+    fn match_describe_param_index(
+        params: &[&mut RpcParameter],
+        info: &crate::security::describe_parameter_encryption::ParameterEncryptionInfo,
+    ) -> Option<usize> {
+        params
+            .iter()
+            .position(|p| {
+                p.name
+                    .as_deref()
+                    .map(|n| n.eq_ignore_ascii_case(&info.parameter_name))
+                    .unwrap_or(false)
+            })
+            .or_else(|| {
+                (info.parameter_ordinal as usize)
+                    .checked_sub(1)
+                    .filter(|&i| i < params.len() && params[i].name.is_none())
+            })
     }
 
     /// Encrypts, in place, the parameters that a prior
@@ -2211,6 +2286,7 @@ impl TdsClient {
         cek_cache: &crate::security::keystore::CekCache,
         params: &mut [&mut RpcParameter],
         output_param_ceks: &mut HashMap<String, Arc<zeroize::Zeroizing<Vec<u8>>>>,
+        trusted_key_paths: &[String],
     ) -> TdsResult<()> {
         use crate::message::parameters::rpc_parameters::RpcEncryptionMetadata;
         use crate::security::encryption::encrypt_parameter;
@@ -2220,6 +2296,26 @@ impl TdsClient {
         // command's parameters, so a previous command's keys cannot leak into
         // this one's output-parameter decryption.
         output_param_ceks.clear();
+
+        // ForceColumnEncryption: every parameter that demands encryption must be
+        // reported as encrypted by the server. Validate before any work — and
+        // before the "nothing encrypted" early return below — so a server that
+        // downgrades a parameter (reporting it plaintext) is caught rather than
+        // silently sending the value as plaintext.
+        for info in &describe.parameters {
+            if info.is_encrypted() {
+                continue;
+            }
+            if let Some(index) = Self::match_describe_param_index(params, info)
+                && params[index].force_column_encryption()
+            {
+                return Err(crate::error::Error::UsageError(format!(
+                    "Parameter {} has ForceColumnEncryption set, but the server reported its \
+                     target column as not encrypted; refusing to send it as plaintext.",
+                    info.parameter_name
+                )));
+            }
+        }
 
         // Nothing to do when the server reports no encrypted parameters.
         if !describe.parameters.iter().any(|p| p.is_encrypted()) {
@@ -2238,25 +2334,7 @@ impl TdsClient {
                 ))
             })?;
 
-            // Match by name first; otherwise fall back to the unnamed parameter at
-            // this describe ordinal (the positional case). Requiring the ordinal
-            // slot to be unnamed keeps a named parameter from being matched by
-            // position.
-            let index = params
-                .iter()
-                .position(|p| {
-                    p.name
-                        .as_deref()
-                        .map(|n| n.eq_ignore_ascii_case(&info.parameter_name))
-                        .unwrap_or(false)
-                })
-                .or_else(|| {
-                    (info.parameter_ordinal as usize)
-                        .checked_sub(1)
-                        .filter(|&i| i < params.len() && params[i].name.is_none())
-                });
-
-            let Some(index) = index else {
+            let Some(index) = Self::match_describe_param_index(params, info) else {
                 return Err(crate::error::Error::ColumnEncryptionError(format!(
                     "sp_describe_parameter_encryption returned encryption info for parameter {} \
                      that was not supplied to the call",
@@ -2281,7 +2359,8 @@ impl TdsClient {
                 ));
             }
 
-            let plaintext_cek = decrypt_cek(providers, cek_cache, cek_entry).await?;
+            let plaintext_cek =
+                decrypt_cek(providers, cek_cache, cek_entry, trusted_key_paths).await?;
 
             // An encrypted RETURNVALUE output parameter carries no CEK table and
             // reuses the CEK that encrypted the matching input parameter. Retain
@@ -2462,6 +2541,7 @@ impl TdsClient {
             &client_context.column_encryption_key_store_providers,
             &client_context.cek_cache,
             &metadata.cek_table,
+            client_context.trusted_key_paths_for_current_server(),
         )
         .await;
         let decryptor: Arc<dyn CellDecryptor> = Arc::new(resolved);

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -2306,6 +2306,14 @@ impl TdsClient {
         // plaintext, or it omits a row for the parameter entirely (which would
         // otherwise slip past a describe-driven check and be serialized in the
         // clear).
+        //
+        // This is a server-trust failure — the "compromised server downgrades to
+        // harvest plaintext" threat this flag defends against — so it is a
+        // `ColumnEncryptionError`, matching the "parameter not supplied" mismatch
+        // below and the trusted-master-key-path rejection in `decrypt_cek`. It is
+        // deliberately distinct from the caller-misconfiguration case (the flag
+        // set while Always Encrypted is off) that
+        // `ensure_force_column_encryption_supported` reports as a `UsageError`.
         for index in 0..params.len() {
             if !params[index].force_column_encryption() {
                 continue;
@@ -2319,7 +2327,7 @@ impl TdsClient {
                     .as_deref()
                     .unwrap_or("<positional>")
                     .to_string();
-                return Err(crate::error::Error::UsageError(format!(
+                return Err(crate::error::Error::ColumnEncryptionError(format!(
                     "Parameter {name} has ForceColumnEncryption set, but the server did not \
                      report it as encrypted; refusing to send it as plaintext.",
                 )));
@@ -4169,8 +4177,8 @@ mod tests {
         .expect_err("a forced parameter omitted from the describe result must be rejected");
 
         assert!(
-            matches!(&err, UsageError(message) if message.contains("ForceColumnEncryption")),
-            "expected a ForceColumnEncryption usage error, got: {err}"
+            matches!(&err, crate::error::Error::ColumnEncryptionError(message) if message.contains("ForceColumnEncryption")),
+            "expected a ForceColumnEncryption column-encryption error, got: {err}"
         );
     }
 }

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -2297,22 +2297,31 @@ impl TdsClient {
         // this one's output-parameter decryption.
         output_param_ceks.clear();
 
-        // ForceColumnEncryption: every parameter that demands encryption must be
-        // reported as encrypted by the server. Validate before any work — and
-        // before the "nothing encrypted" early return below — so a server that
-        // downgrades a parameter (reporting it plaintext) is caught rather than
-        // silently sending the value as plaintext.
-        for info in &describe.parameters {
-            if info.is_encrypted() {
+        // ForceColumnEncryption: every supplied parameter that demands
+        // encryption must be reported as encrypted by the server. Validate before
+        // any work — and before the "nothing encrypted" early return below — so a
+        // server that downgrades a forced parameter is caught rather than
+        // silently sending its value as plaintext. A downgrade takes two forms,
+        // both rejected here: the server reports the parameter's target column as
+        // plaintext, or it omits a row for the parameter entirely (which would
+        // otherwise slip past a describe-driven check and be serialized in the
+        // clear).
+        for index in 0..params.len() {
+            if !params[index].force_column_encryption() {
                 continue;
             }
-            if let Some(index) = Self::match_describe_param_index(params, info)
-                && params[index].force_column_encryption()
-            {
+            let reported_encrypted = describe.parameters.iter().any(|info| {
+                info.is_encrypted() && Self::match_describe_param_index(params, info) == Some(index)
+            });
+            if !reported_encrypted {
+                let name = params[index]
+                    .name
+                    .as_deref()
+                    .unwrap_or("<positional>")
+                    .to_string();
                 return Err(crate::error::Error::UsageError(format!(
-                    "Parameter {} has ForceColumnEncryption set, but the server reported its \
-                     target column as not encrypted; refusing to send it as plaintext.",
-                    info.parameter_name
+                    "Parameter {name} has ForceColumnEncryption set, but the server did not \
+                     report it as encrypted; refusing to send it as plaintext.",
                 )));
             }
         }
@@ -4122,5 +4131,46 @@ mod tests {
             .expect_err("synthetic positional name collision should be rejected");
 
         assert!(matches!(err, UsageError(message) if message.contains("@CE_POS_0")));
+    }
+
+    /// A forced parameter whose row the server omits entirely from the describe
+    /// result must be rejected — not silently sent as plaintext. This is the
+    /// downgrade a describe-driven check (iterating only the server's rows) would
+    /// miss, so the validation iterates the supplied forced parameters instead.
+    #[tokio::test]
+    async fn apply_parameter_encryption_rejects_forced_param_omitted_from_describe() {
+        use crate::datatypes::sqltypes::SqlType;
+        use crate::security::describe_parameter_encryption::DescribeParameterEncryptionResult;
+        use crate::security::keystore::{CekCache, ColumnEncryptionKeyStoreProviderRegistry};
+
+        // Server returns an empty describe result: no row for the forced param.
+        let describe = DescribeParameterEncryptionResult::new();
+        let providers = ColumnEncryptionKeyStoreProviderRegistry::new();
+        let cek_cache = CekCache::new();
+        let mut output_param_ceks = HashMap::new();
+
+        let mut forced = RpcParameter::new(
+            Some("@p1".to_string()),
+            StatusFlags::NONE,
+            SqlType::Int(Some(42)),
+        )
+        .with_force_column_encryption(true);
+        let mut params: Vec<&mut RpcParameter> = vec![&mut forced];
+
+        let err = TdsClient::apply_parameter_encryption(
+            &describe,
+            &providers,
+            &cek_cache,
+            &mut params,
+            &mut output_param_ceks,
+            &[],
+        )
+        .await
+        .expect_err("a forced parameter omitted from the describe result must be rejected");
+
+        assert!(
+            matches!(&err, UsageError(message) if message.contains("ForceColumnEncryption")),
+            "expected a ForceColumnEncryption usage error, got: {err}"
+        );
     }
 }

--- a/mssql-tds/src/message/parameters/rpc_parameters.rs
+++ b/mssql-tds/src/message/parameters/rpc_parameters.rs
@@ -105,6 +105,14 @@ pub struct RpcParameter {
     /// ciphertext is serialized as a BIGVARBINARY with the ENCRYPTED status flag
     /// and a trailing CryptoMetaData block, bypassing the plaintext `value`.
     encrypted: Option<EncryptedRpcValue>,
+
+    /// When `true`, the caller requires this parameter to be encrypted: if
+    /// `sp_describe_parameter_encryption` reports the target column as not
+    /// encrypted (or Always Encrypted is not enabled for the command), the
+    /// driver fails rather than sending the value as plaintext. Mirrors .NET
+    /// `SqlParameter.ForceColumnEncryption`; a client-side directive that is
+    /// never sent on the wire.
+    force_column_encryption: bool,
 }
 
 impl RpcParameter {
@@ -115,7 +123,26 @@ impl RpcParameter {
             options,
             value,
             encrypted: None,
+            force_column_encryption: false,
         }
+    }
+
+    /// Requires this parameter to be encrypted under Always Encrypted.
+    ///
+    /// When set, the driver fails with a usage error if the server reports the
+    /// target column as not encrypted, or if Always Encrypted is not enabled for
+    /// the command — instead of silently sending the value as plaintext. This
+    /// defends against a compromised or misconfigured server downgrading a
+    /// parameter to harvest its plaintext. Mirrors .NET
+    /// `SqlParameter.ForceColumnEncryption`.
+    pub fn with_force_column_encryption(mut self, force: bool) -> Self {
+        self.force_column_encryption = force;
+        self
+    }
+
+    /// Returns `true` if the caller required this parameter to be encrypted.
+    pub(crate) fn force_column_encryption(&self) -> bool {
+        self.force_column_encryption
     }
 
     /// Get the SQL type name from a SqlType value for use in parameter declarations.

--- a/mssql-tds/src/security/keystore/certificate.rs
+++ b/mssql-tds/src/security/keystore/certificate.rs
@@ -439,7 +439,7 @@ mod tests {
             }],
         };
 
-        let plaintext = decrypt_cek(&registry, &cache, &entry).await.unwrap();
+        let plaintext = decrypt_cek(&registry, &cache, &entry, &[]).await.unwrap();
         assert_eq!(plaintext.as_ref().as_slice(), &CEK);
     }
 }

--- a/mssql-tds/src/security/keystore/mod.rs
+++ b/mssql-tds/src/security/keystore/mod.rs
@@ -184,20 +184,26 @@ pub(crate) async fn decrypt_cek(
 
     for value in &entry.encrypted_cek_values {
         // Trusted master key paths: when an allow-list is configured for this
-        // server, reject any CMK path that is not on it before attempting to use
+        // server, skip any CMK path that is not on it before attempting to use
         // it (even a cached one), so a malicious server cannot point the client
         // at an attacker-controlled column master key. An empty list means the
         // server is unrestricted. Compared case-insensitively.
+        //
+        // Skip (record the error and continue) rather than return: a CEK entry
+        // may carry several CMK-wrapped values for key rotation, so a later value
+        // at a trusted path can still resolve the key. No untrusted path is ever
+        // used; if every value is untrusted this error is surfaced below.
         if !trusted_key_paths.is_empty()
             && !trusted_key_paths
                 .iter()
                 .any(|trusted| trusted.eq_ignore_ascii_case(&value.key_path))
         {
-            return Err(Error::ColumnEncryptionError(format!(
+            last_error = Some(Error::ColumnEncryptionError(format!(
                 "The column master key path '{}' is not in the trusted master key paths list \
                  configured for this server; refusing to use it to unwrap a column encryption key.",
                 value.key_path
             )));
+            continue;
         }
 
         let cache_key = CekCacheKey {
@@ -509,6 +515,30 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(key.as_slice(), vec![7u8; 32].as_slice());
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn decrypt_cek_falls_back_from_untrusted_to_trusted_key_path() {
+        let provider = Arc::new(MockProvider::new(vec![7u8; 32]));
+        let mut registry = ColumnEncryptionKeyStoreProviderRegistry::new();
+        registry.register("PROVIDER", provider.clone());
+        let cache = CekCache::new();
+
+        // Key rotation: the entry wraps the CEK under two CMKs. The first path is
+        // untrusted and must be skipped; the second is trusted and must resolve.
+        let entry = entry(vec![
+            cek_value("PROVIDER", "https://vault/keys/attacker", &[0xAB]),
+            cek_value("PROVIDER", "https://vault/keys/trusted", &[0xCD]),
+        ]);
+
+        let trusted = vec!["https://vault/keys/trusted".to_string()];
+        let key = decrypt_cek(&registry, &cache, &entry, &trusted)
+            .await
+            .unwrap();
+        assert_eq!(key.as_slice(), vec![7u8; 32].as_slice());
+        // The provider is asked to unwrap exactly once — only for the trusted
+        // value; the untrusted path is skipped before the provider is reached.
         assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
     }
 

--- a/mssql-tds/src/security/keystore/mod.rs
+++ b/mssql-tds/src/security/keystore/mod.rs
@@ -172,6 +172,7 @@ pub(crate) async fn decrypt_cek(
     registry: &ColumnEncryptionKeyStoreProviderRegistry,
     cache: &CekCache,
     entry: &CekTableEntry,
+    trusted_key_paths: &[String],
 ) -> TdsResult<Arc<Zeroizing<Vec<u8>>>> {
     if entry.encrypted_cek_values.is_empty() {
         return Err(Error::ColumnEncryptionError(
@@ -182,6 +183,23 @@ pub(crate) async fn decrypt_cek(
     let mut last_error: Option<Error> = None;
 
     for value in &entry.encrypted_cek_values {
+        // Trusted master key paths: when an allow-list is configured for this
+        // server, reject any CMK path that is not on it before attempting to use
+        // it (even a cached one), so a malicious server cannot point the client
+        // at an attacker-controlled column master key. An empty list means the
+        // server is unrestricted. Compared case-insensitively.
+        if !trusted_key_paths.is_empty()
+            && !trusted_key_paths
+                .iter()
+                .any(|trusted| trusted.eq_ignore_ascii_case(&value.key_path))
+        {
+            return Err(Error::ColumnEncryptionError(format!(
+                "The column master key path '{}' is not in the trusted master key paths list \
+                 configured for this server; refusing to use it to unwrap a column encryption key.",
+                value.key_path
+            )));
+        }
+
         let cache_key = CekCacheKey {
             provider_name: value.key_store_name.to_ascii_uppercase(),
             master_key_path: value.key_path.clone(),
@@ -272,11 +290,12 @@ impl ResolvedCekDecryptor {
         registry: &ColumnEncryptionKeyStoreProviderRegistry,
         cache: &CekCache,
         cek_table: &[CekTableEntry],
+        trusted_key_paths: &[String],
     ) -> Self {
         let mut ceks = Vec::with_capacity(cek_table.len());
         for entry in cek_table {
             ceks.push(
-                decrypt_cek(registry, cache, entry)
+                decrypt_cek(registry, cache, entry, trusted_key_paths)
                     .await
                     .map_err(|error| error.to_string()),
             );
@@ -400,11 +419,11 @@ mod tests {
 
         let entry = entry(vec![cek_value("PROVIDER", "path", &[0xAB, 0xCD])]);
 
-        let first = decrypt_cek(&registry, &cache, &entry).await.unwrap();
+        let first = decrypt_cek(&registry, &cache, &entry, &[]).await.unwrap();
         assert_eq!(first.as_slice(), vec![7u8; 32].as_slice());
 
         // Second resolution must come from the cache (provider not called again).
-        let second = decrypt_cek(&registry, &cache, &entry).await.unwrap();
+        let second = decrypt_cek(&registry, &cache, &entry, &[]).await.unwrap();
         assert_eq!(second.as_slice(), vec![7u8; 32].as_slice());
         assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
     }
@@ -422,7 +441,7 @@ mod tests {
             cek_value("GOOD", "p2", &[2]),
         ]);
 
-        let key = decrypt_cek(&registry, &cache, &entry).await.unwrap();
+        let key = decrypt_cek(&registry, &cache, &entry, &[]).await.unwrap();
         assert_eq!(key.as_slice(), vec![9u8; 32].as_slice());
     }
 
@@ -432,7 +451,9 @@ mod tests {
         let cache = CekCache::new();
         let entry = entry(vec![cek_value("MISSING", "p", &[1])]);
 
-        let error = decrypt_cek(&registry, &cache, &entry).await.unwrap_err();
+        let error = decrypt_cek(&registry, &cache, &entry, &[])
+            .await
+            .unwrap_err();
         assert!(matches!(error, Error::ColumnEncryptionError(_)));
     }
 
@@ -442,8 +463,53 @@ mod tests {
         let cache = CekCache::new();
         let entry = entry(vec![]);
 
-        let error = decrypt_cek(&registry, &cache, &entry).await.unwrap_err();
+        let error = decrypt_cek(&registry, &cache, &entry, &[])
+            .await
+            .unwrap_err();
         assert!(matches!(error, Error::ColumnEncryptionError(_)));
+    }
+
+    #[tokio::test]
+    async fn decrypt_cek_rejects_untrusted_key_path() {
+        let provider = Arc::new(MockProvider::new(vec![7u8; 32]));
+        let mut registry = ColumnEncryptionKeyStoreProviderRegistry::new();
+        registry.register("PROVIDER", provider.clone());
+        let cache = CekCache::new();
+        let entry = entry(vec![cek_value(
+            "PROVIDER",
+            "https://vault/keys/attacker",
+            &[0xAB],
+        )]);
+
+        // A trusted list is configured but does not include the entry's key path.
+        let trusted = vec!["https://vault/keys/trusted".to_string()];
+        let error = decrypt_cek(&registry, &cache, &entry, &trusted)
+            .await
+            .unwrap_err();
+        assert!(matches!(error, Error::ColumnEncryptionError(_)));
+        // The provider must never be asked to unwrap a key at an untrusted path.
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn decrypt_cek_allows_trusted_key_path_case_insensitively() {
+        let provider = Arc::new(MockProvider::new(vec![7u8; 32]));
+        let mut registry = ColumnEncryptionKeyStoreProviderRegistry::new();
+        registry.register("PROVIDER", provider.clone());
+        let cache = CekCache::new();
+        let entry = entry(vec![cek_value(
+            "PROVIDER",
+            "https://Vault/Keys/Trusted",
+            &[0xAB],
+        )]);
+
+        // Same path, different case — trust comparison is case-insensitive.
+        let trusted = vec!["https://vault/keys/trusted".to_string()];
+        let key = decrypt_cek(&registry, &cache, &entry, &trusted)
+            .await
+            .unwrap();
+        assert_eq!(key.as_slice(), vec![7u8; 32].as_slice());
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
     }
 
     use crate::datatypes::column_values::ColumnValues;
@@ -487,7 +553,7 @@ mod tests {
         let cache = CekCache::new();
         let cek_table = vec![entry(vec![cek_value("PROVIDER", "path", &[0xAB])])];
 
-        let decryptor = ResolvedCekDecryptor::resolve(&registry, &cache, &cek_table).await;
+        let decryptor = ResolvedCekDecryptor::resolve(&registry, &cache, &cek_table, &[]).await;
 
         let crypto = int_crypto_metadata(0);
         let decrypted = decryptor.decrypt(&crypto, &cipher).unwrap();
@@ -501,7 +567,7 @@ mod tests {
         let cache = CekCache::new();
         let cek_table = vec![entry(vec![cek_value("FAILING", "p", &[1])])];
 
-        let decryptor = ResolvedCekDecryptor::resolve(&registry, &cache, &cek_table).await;
+        let decryptor = ResolvedCekDecryptor::resolve(&registry, &cache, &cek_table, &[]).await;
 
         // Resolution failed, but the error only surfaces when the ordinal is used.
         let error = decryptor
@@ -515,7 +581,7 @@ mod tests {
         let registry = ColumnEncryptionKeyStoreProviderRegistry::new();
         let cache = CekCache::new();
 
-        let decryptor = ResolvedCekDecryptor::resolve(&registry, &cache, &[]).await;
+        let decryptor = ResolvedCekDecryptor::resolve(&registry, &cache, &[], &[]).await;
 
         let error = decryptor.decrypt(&int_crypto_metadata(5), &[]).unwrap_err();
         assert!(matches!(error, Error::ColumnEncryptionError(_)));

--- a/mssql-tds/tests/test_always_encrypted.rs
+++ b/mssql-tds/tests/test_always_encrypted.rs
@@ -893,8 +893,8 @@ mod always_encrypted {
                 .await
                 .expect_err("ForceColumnEncryption on a plaintext column must be rejected");
             assert!(
-                matches!(&err, mssql_tds::error::Error::UsageError(m) if m.contains("ForceColumnEncryption")),
-                "expected a ForceColumnEncryption usage error, got {err:?}"
+                matches!(&err, mssql_tds::error::Error::ColumnEncryptionError(m) if m.contains("ForceColumnEncryption")),
+                "expected a ForceColumnEncryption column-encryption error, got {err:?}"
             );
         });
     }

--- a/mssql-tds/tests/test_always_encrypted.rs
+++ b/mssql-tds/tests/test_always_encrypted.rs
@@ -834,6 +834,93 @@ mod always_encrypted {
         });
     }
 
+    // ----- ForceColumnEncryption -----
+
+    /// A parameter with `ForceColumnEncryption` set that targets an encrypted
+    /// column is encrypted normally and round-trips — the flag only changes the
+    /// failure behavior, not the success path.
+    #[tokio::test]
+    async fn force_column_encryption_encrypts_encrypted_column() {
+        ae_test!(|h| {
+            let table = h.create_encrypted_table("INT", "DETERMINISTIC").await;
+            let param = RpcParameter::new(
+                Some("@val".to_string()),
+                StatusFlags::NONE,
+                SqlType::Int(Some(4242)),
+            )
+            .with_force_column_encryption(true);
+            h.client
+                .execute_sp_executesql(
+                    format!("INSERT INTO {table} (val) VALUES (@val);"),
+                    vec![param],
+                    None,
+                    None,
+                )
+                .await
+                .expect("force-encrypted insert into an encrypted column should succeed");
+            while h.client.move_to_next().await.unwrap() {}
+            h.client.close_query().await.unwrap();
+
+            let got = select_val(&mut h.client, &table)
+                .await
+                .expect("read back force-encrypted value");
+            assert!(matches!(got, ColumnValues::Int(4242)), "got {got:?}");
+        });
+    }
+
+    /// A parameter with `ForceColumnEncryption` set that targets a **plaintext**
+    /// column is rejected: the server reports the column as not encrypted, so the
+    /// driver refuses to send the value as plaintext (defending against a server
+    /// that downgrades an encrypted column to harvest plaintext).
+    #[tokio::test]
+    async fn force_column_encryption_rejects_plaintext_column() {
+        ae_test!(|h| {
+            let table = h.create_table("val INT NULL").await;
+            let param = RpcParameter::new(
+                Some("@val".to_string()),
+                StatusFlags::NONE,
+                SqlType::Int(Some(1)),
+            )
+            .with_force_column_encryption(true);
+            let err = h
+                .client
+                .execute_sp_executesql(
+                    format!("INSERT INTO {table} (val) VALUES (@val);"),
+                    vec![param],
+                    None,
+                    None,
+                )
+                .await
+                .expect_err("ForceColumnEncryption on a plaintext column must be rejected");
+            assert!(
+                matches!(&err, mssql_tds::error::Error::UsageError(m) if m.contains("ForceColumnEncryption")),
+                "expected a ForceColumnEncryption usage error, got {err:?}"
+            );
+        });
+    }
+
+    /// A parameter with `ForceColumnEncryption` set on a connection where Always
+    /// Encrypted is not enabled is rejected before the value is sent, rather than
+    /// silently transmitting it as plaintext.
+    #[tokio::test]
+    async fn force_column_encryption_without_ae_errors() {
+        let mut client = connect_disabled().await;
+        let param = RpcParameter::new(
+            Some("@val".to_string()),
+            StatusFlags::NONE,
+            SqlType::Int(Some(1)),
+        )
+        .with_force_column_encryption(true);
+        let err = client
+            .execute_sp_executesql("SELECT @val;".to_string(), vec![param], None, None)
+            .await
+            .expect_err("ForceColumnEncryption without Always Encrypted must be rejected");
+        assert!(
+            matches!(&err, mssql_tds::error::Error::UsageError(m) if m.contains("ForceColumnEncryption")),
+            "expected a ForceColumnEncryption usage error, got {err:?}"
+        );
+    }
+
     // ----- Stored-procedure parameter encryption -----
 
     /// A named parameter passed to [`TdsClient::execute_stored_procedure`] that

--- a/mssql-tds/tests/test_windows_sspi.rs
+++ b/mssql-tds/tests/test_windows_sspi.rs
@@ -308,7 +308,7 @@ async fn test_tcp_prefix_uses_tcp_transport() -> TdsResult<()> {
     let instance = env::var("DB_INSTANCE").unwrap_or_else(|_| r"localhost\SQLDEV".to_string());
     let datasource = format!("tcp:{instance}");
 
-    let transport = connect_and_get_transport(&datasource).await?;
+    let transport = Box::pin(connect_and_get_transport(&datasource)).await?;
     assert_eq!(
         transport, "TCP",
         "tcp: prefix should use TCP transport, got {transport}"
@@ -328,7 +328,7 @@ async fn test_np_prefix_uses_named_pipe_transport() -> TdsResult<()> {
     let instance = env::var("DB_INSTANCE").unwrap_or_else(|_| r"localhost\SQLDEV".to_string());
     let datasource = format!("np:{instance}");
 
-    let transport = connect_and_get_transport(&datasource).await?;
+    let transport = Box::pin(connect_and_get_transport(&datasource)).await?;
     assert_eq!(
         transport, "Named pipe",
         "np: prefix should use Named pipe transport, got {transport}"


### PR DESCRIPTION
Work item: [AB#46055](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46055)

## Summary

Two Phase 1B **server-trust hardening** features for Always Encrypted in `mssql-tds`. Both defend against a compromised or malicious server; neither changes behavior for existing code that doesn't opt in.

## 1. ForceColumnEncryption (per-parameter)

Mirrors .NET `SqlParameter.ForceColumnEncryption`. A caller can require a parameter to be encrypted:

```rust
let p = RpcParameter::new(Some("@ssn".into()), StatusFlags::NONE, value)
    .with_force_column_encryption(true);
```

When set, the driver **fails rather than sending the value as plaintext** if:
- the server's `sp_describe_parameter_encryption` reports the target column as **not encrypted** (enforced in `apply_parameter_encryption`), or
- **Always Encrypted is not enabled** for the command (enforced by `ensure_force_column_encryption_supported` on the `sp_executesql`, stored-procedure, `sp_prepexec`, and `sp_execute` paths).

This defends against a compromised server that downgrades an encrypted column to harvest plaintext.

## 2. Trusted master key paths (per-server)

Mirrors .NET `SqlConnection.ColumnEncryptionTrustedMasterKeyPaths`. A per-server allow-list of column master key (CMK) paths:

```rust
context.register_trusted_master_key_paths("myserver", vec![
    "https://myvault.vault.azure.net/keys/CMK/...".into(),
]);
```

When a non-empty list is configured for the connected server, `decrypt_cek` only unwraps a CEK whose CMK path is on the list (compared **case-insensitively**), and rejects any other path **before it is used — even a cached one**. A server with no list (or none configured at all) is unrestricted, so this is a per-server opt-in. Enforced across **every** CEK-resolution path: parameter encryption, bulk copy, and result-set column decryption.

This defends against a malicious server that points the client at an attacker-controlled column master key.

## Tests

- **Unit** (deterministic): `decrypt_cek` rejects an untrusted key path (and never calls the provider) and allows a trusted one case-insensitively; the per-server config lookup is case-insensitive, per-server, and survives cloning.
- **Live** (`test_always_encrypted`): `force_column_encryption_encrypts_encrypted_column` (success path), `force_column_encryption_rejects_plaintext_column` (downgrade rejected), `force_column_encryption_without_ae_errors` (rejected when AE is off).

Verified: lib **1539** unit tests, live AE suite **40**, `clippy --all-targets -D warnings` clean, `cargo fmt` clean, and the fuzz crate builds (`RUSTFLAGS="--cfg fuzzing" cargo +nightly fuzz build`).

## Phase 1B tracking

These are the two Always Encrypted security items. Remaining Phase 1B: char/varchar collation normalization to the target column, and mock-server AE tests.
