### PR TITLE
Report mssql-py-core and mssql-odbc Rust unit tests in CI

### DIFF
--- a/.github/actions/post-coverage-comment/action.yml
+++ b/.github/actions/post-coverage-comment/action.yml
@@ -45,7 +45,7 @@ runs:
           </td>
           <td>
 
-          **📦 Project:** `mssql-tds + mssql-py-core`
+          **📦 Project:** `mssql-tds + mssql-odbc + mssql-py-core`
           **ℹ️ Note:** diff coverage is reported, not enforced.
 
           </td>

--- a/.pipeline/scripts/containerized-pycore-rust-test.sh
+++ b/.pipeline/scripts/containerized-pycore-rust-test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+source ~/.cargo/env
+
+# mssql-py-core is outside the workspace, so its Rust unit tests are not covered
+# by the mssql-tds nextest run. Run them here with the crate-local `ci` profile
+# so JUnit is written to mssql-py-core/target/nextest/ci/junit.xml for the ADO
+# test-results tab.
+echo '==> Running mssql-py-core Rust unit tests...'
+cd /workspace/mssql-py-core
+cargo nextest run --frozen --profile ci --no-fail-fast

--- a/.pipeline/scripts/containerized-pycore-rust-test.sh
+++ b/.pipeline/scripts/containerized-pycore-rust-test.sh
@@ -2,10 +2,8 @@
 set -e
 source ~/.cargo/env
 
-# mssql-py-core is outside the workspace, so its Rust unit tests are not covered
-# by the mssql-tds nextest run. Run them here under llvm-cov with the crate-local
-# `ci` profile so JUnit is written to mssql-py-core/target/nextest/ci/junit.xml
-# for the ADO test-results tab and a Cobertura report is produced for coverage.
+# mssql-py-core is excluded from the Cargo workspace, so its Rust unit tests
+# need a dedicated run here.
 echo '==> Running mssql-py-core Rust unit tests with coverage...'
 cd /workspace/mssql-py-core
 cargo llvm-cov clean --workspace

--- a/.pipeline/scripts/containerized-pycore-rust-test.sh
+++ b/.pipeline/scripts/containerized-pycore-rust-test.sh
@@ -3,9 +3,17 @@ set -e
 source ~/.cargo/env
 
 # mssql-py-core is outside the workspace, so its Rust unit tests are not covered
-# by the mssql-tds nextest run. Run them here with the crate-local `ci` profile
-# so JUnit is written to mssql-py-core/target/nextest/ci/junit.xml for the ADO
-# test-results tab.
-echo '==> Running mssql-py-core Rust unit tests...'
+# by the mssql-tds nextest run. Run them here under llvm-cov with the crate-local
+# `ci` profile so JUnit is written to mssql-py-core/target/nextest/ci/junit.xml
+# for the ADO test-results tab and a Cobertura report is produced for coverage.
+echo '==> Running mssql-py-core Rust unit tests with coverage...'
 cd /workspace/mssql-py-core
-cargo nextest run --frozen --profile ci --no-fail-fast
+cargo llvm-cov clean --workspace
+cargo llvm-cov nextest --frozen --profile ci --no-fail-fast --no-report
+
+echo '==> Generating mssql-py-core Rust coverage report...'
+# Scope to mssql-py-core's own sources: the mssql-tds path dependency is covered
+# comprehensively by the mssql-tds suite and would otherwise leak into this report.
+mkdir -p /workspace/target
+cargo llvm-cov report --ignore-filename-regex '(^|/)mssql-tds/' \
+  --cobertura --output-path /workspace/target/pycore-rust-cobertura.xml

--- a/.pipeline/scripts/containerized-test.sh
+++ b/.pipeline/scripts/containerized-test.sh
@@ -10,7 +10,10 @@ echo '==> Generating test certificates for mock TDS server...'
 
 echo '==> Running tests...'
 mkdir -p /workspace/target/nextest/ci
-cargo llvm-cov nextest "$@" --frozen --no-report --all-targets --package mssql-tds --no-fail-fast --profile ci --success-output immediate
+# mssql-odbc is a workspace member but was excluded by the mssql-tds-only filter.
+# Include it so its Rust unit tests run and land in the shared JUnit report. Its
+# pure-Rust unit tests need no SQL Server; the C++ e2e suite runs separately.
+cargo llvm-cov nextest "$@" --frozen --no-report --all-targets --package mssql-tds --package mssql-odbc --no-fail-fast --profile ci --success-output immediate
 
 echo '==> Generating coverage report...'
 cargo llvm-cov report --package mssql-tds --lcov --output-path /workspace/target/lcov.info

--- a/.pipeline/scripts/containerized-test.sh
+++ b/.pipeline/scripts/containerized-test.sh
@@ -16,5 +16,5 @@ mkdir -p /workspace/target/nextest/ci
 cargo llvm-cov nextest "$@" --frozen --no-report --all-targets --package mssql-tds --package mssql-odbc --no-fail-fast --profile ci --success-output immediate
 
 echo '==> Generating coverage report...'
-cargo llvm-cov report --package mssql-tds --lcov --output-path /workspace/target/lcov.info
-cargo llvm-cov report --package mssql-tds --cobertura --output-path /workspace/target/cobertura.xml
+cargo llvm-cov report --package mssql-tds --package mssql-odbc --lcov --output-path /workspace/target/lcov.info
+cargo llvm-cov report --package mssql-tds --package mssql-odbc --cobertura --output-path /workspace/target/cobertura.xml

--- a/.pipeline/templates/build-template-container.yml
+++ b/.pipeline/templates/build-template-container.yml
@@ -495,6 +495,19 @@ steps:
     failTaskOnFailedTests: false
     publishRunAttachments: true
 
+# Cobertura from the mssql-py-core Rust unit tests (produced by the step above).
+# Merged with the mssql-py-core Python coverage under the same crate prefix in
+# the Coverage stage, since ADO does not merge coverage across stages/jobs.
+- ${{ if eq(parameters.collectPythonCoverage, true) }}:
+  - task: PublishPipelineArtifact@1
+    condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
+    displayName: Publish mssql-py-core Rust Cobertura coverage artifact
+    continueOnError: true
+    inputs:
+      targetPath: $(Build.SourcesDirectory)/target/pycore-rust-cobertura.xml
+      artifactName: CoberturaCoveragePyCoreRust
+
+
 - script: |
     BUILD_IMAGE="ghcr.io/microsoft/mssql-rs/build/ubuntu:22.04"
     

--- a/.pipeline/templates/build-template-container.yml
+++ b/.pipeline/templates/build-template-container.yml
@@ -480,13 +480,13 @@ steps:
       $BUILD_IMAGE \
       /workspace/.pipeline/scripts/containerized-pycore-rust-test.sh
   displayName: Run Rust unit tests (mssql-py-core)
-  condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+  condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'), ne('${{ parameters.architecture }}', 'ARM64'))
   env:
     CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN)
     CARGO_REGISTRIES_MSSQL_RS_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_TOKEN)
 
 - task: PublishTestResults@2
-  condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
+  condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'), ne('${{ parameters.architecture }}', 'ARM64'))
   displayName: Publish mssql-py-core Rust test results
   inputs:
     testResultsFormat: JUnit
@@ -506,7 +506,6 @@ steps:
     inputs:
       targetPath: $(Build.SourcesDirectory)/target/pycore-rust-cobertura.xml
       artifactName: CoberturaCoveragePyCoreRust
-
 
 - script: |
     BUILD_IMAGE="ghcr.io/microsoft/mssql-rs/build/ubuntu:22.04"

--- a/.pipeline/templates/build-template-container.yml
+++ b/.pipeline/templates/build-template-container.yml
@@ -466,6 +466,35 @@ steps:
       testResultsFiles: $(Build.SourcesDirectory)/mssql-js/junit.xml
       testRunTitle: $(System.PhaseName)-Js
 
+# mssql-py-core is outside the workspace, so its Rust unit tests are not part of
+# the mssql-tds nextest run above. Run them in the build container and publish
+# the JUnit results to the ADO test tab. Pure unit tests, so no SQL Server needed.
+- script: |
+    BUILD_IMAGE="ghcr.io/microsoft/mssql-rs/build/ubuntu:22.04"
+
+    bash .pipeline/scripts/docker-cargo-run.sh --rm \
+      -v $PWD:/workspace \
+      -v $HOME/.cargo/registry:/root/.cargo/registry \
+      -v $HOME/.cargo/git:/root/.cargo/git \
+      -w /workspace \
+      $BUILD_IMAGE \
+      /workspace/.pipeline/scripts/containerized-pycore-rust-test.sh
+  displayName: Run Rust unit tests (mssql-py-core)
+  condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+  env:
+    CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN)
+    CARGO_REGISTRIES_MSSQL_RS_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_TOKEN)
+
+- task: PublishTestResults@2
+  condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
+  displayName: Publish mssql-py-core Rust test results
+  inputs:
+    testResultsFormat: JUnit
+    testResultsFiles: $(Build.SourcesDirectory)/mssql-py-core/target/nextest/ci/junit.xml
+    testRunTitle: $(System.PhaseName)-PyCore-Rust
+    failTaskOnFailedTests: false
+    publishRunAttachments: true
+
 - script: |
     BUILD_IMAGE="ghcr.io/microsoft/mssql-rs/build/ubuntu:22.04"
     

--- a/.pipeline/templates/build-template.yml
+++ b/.pipeline/templates/build-template.yml
@@ -146,10 +146,10 @@ steps:
       testResultsFiles: $(Build.SourcesDirectory)/target/nextest/ci/junit.xml
       testRunTitle: $(System.PhaseName)
 
-  - script: cargo llvm-cov report --package mssql-tds --lcov --output-path "$(Build.SourcesDirectory)/target/lcov.info"
+  - script: cargo llvm-cov report --package mssql-tds --package mssql-odbc --lcov --output-path "$(Build.SourcesDirectory)/target/lcov.info"
     condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
     workingDirectory: "$(Build.SourcesDirectory)"
-    displayName: Save code coverage in lcov format (mssql-tds package only)
+    displayName: Save code coverage in lcov format (mssql-tds and mssql-odbc)
 
   - ${{ if eq(parameters.osType, 'Linux') }}:
     - bash: |
@@ -166,10 +166,10 @@ steps:
   # with the mssql-py-core Python report and publishes the single combined
   # report to the ADO coverage tab, because ADO does not merge coverage across
   # stages/jobs. The merged report is what the GitHub diff-cover workflow uses.
-  - script: cargo llvm-cov report --package mssql-tds --cobertura --output-path "$(Build.SourcesDirectory)/target/cobertura.xml"
+  - script: cargo llvm-cov report --package mssql-tds --package mssql-odbc --cobertura --output-path "$(Build.SourcesDirectory)/target/cobertura.xml"
     condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
     workingDirectory: "$(Build.SourcesDirectory)"
-    displayName: Save code coverage in Cobertura format (mssql-tds package only)
+    displayName: Save code coverage in Cobertura format (mssql-tds and mssql-odbc)
 
   - task: PublishPipelineArtifact@1
     condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))

--- a/.pipeline/templates/build-template.yml
+++ b/.pipeline/templates/build-template.yml
@@ -130,8 +130,8 @@ steps:
 
   - script: |
         export CERT_HOST_NAME="sql1"
-        cargo llvm-cov nextest ${{ parameters.testFilter }} --frozen --no-report --all-targets --package mssql-tds --no-fail-fast --profile ci --success-output immediate
-    displayName: Run tests (mssql-tds package only)
+        cargo llvm-cov nextest ${{ parameters.testFilter }} --frozen --no-report --all-targets --package mssql-tds --package mssql-odbc --no-fail-fast --profile ci --success-output immediate
+    displayName: Run tests (mssql-tds and mssql-odbc packages)
     condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
     env:
       SQL_PASSWORD: $(SQL_PASSWORD)
@@ -150,13 +150,6 @@ steps:
     condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
     workingDirectory: "$(Build.SourcesDirectory)"
     displayName: Save code coverage in lcov format (mssql-tds package only)
-
-  - ${{ if eq(parameters.osType, 'Linux') }}:
-    - bash: |
-        echo "Running mssql-py-core Rust unit tests..."
-        cd mssql-py-core && cargo test --frozen -- --show-output
-      displayName: Run Rust unit tests (mssql-py-core)
-      condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
 
   - ${{ if eq(parameters.osType, 'Linux') }}:
     - bash: |

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -652,13 +652,20 @@ stages:
           buildType: 'current'
           artifactName: 'CoberturaCoveragePython'
           targetPath: '$(Pipeline.Workspace)/cov-python'
+      - task: DownloadPipelineArtifact@2
+        displayName: Download Rust (mssql-py-core) coverage
+        continueOnError: true
+        inputs:
+          buildType: 'current'
+          artifactName: 'CoberturaCoveragePyCoreRust'
+          targetPath: '$(Pipeline.Workspace)/cov-pycore-rust'
       - bash: |
           set -euo pipefail
           mkdir -p "$(Build.SourcesDirectory)/target"
           inputs=()
-          # Each OS emits its mssql-tds report with repo-root-relative paths, so
-          # the same source file lines up across reports and coverage is unioned:
-          # a line covered on any OS counts as covered in the merged result.
+          # Each OS emits its mssql-tds + mssql-odbc report with repo-root-relative
+          # paths, so the same source file lines up across reports and coverage is
+          # unioned: a line covered on any OS counts as covered in the merged result.
           for report in \
             "$(Pipeline.Workspace)/cov-rust-windows/cobertura.xml" \
             "$(Pipeline.Workspace)/cov-rust-linux/cobertura.xml" \
@@ -667,9 +674,12 @@ stages:
           done
           # mssql-py-core coverage is measured from within its own crate
           # directory, so prefix its relative filenames to make them repo-root
-          # relative in the merged report.
+          # relative in the merged report. Both the Python bindings coverage and
+          # the Rust unit test coverage use the same crate prefix so they union.
           py="$(Pipeline.Workspace)/cov-python/pycore-cobertura.xml"
           [ -f "$py" ] && inputs+=("$py::mssql-py-core")
+          pyrust="$(Pipeline.Workspace)/cov-pycore-rust/pycore-rust-cobertura.xml"
+          [ -f "$pyrust" ] && inputs+=("$pyrust::mssql-py-core")
           if [ ${#inputs[@]} -eq 0 ]; then
             echo "##vso[task.logissue type=warning]No coverage inputs found to merge"
             exit 0

--- a/mssql-py-core/.config/nextest.toml
+++ b/mssql-py-core/.config/nextest.toml
@@ -1,0 +1,5 @@
+# mssql-py-core is excluded from the root Cargo workspace, so it does not pick
+# up the workspace-level .config/nextest.toml. This standalone config gives the
+# crate a `ci` profile that emits JUnit for the CI test-results tab.
+[profile.ci.junit]
+path = "junit.xml"


### PR DESCRIPTION
## Description

Two workspace crates had Rust `#[cfg(test)]` unit tests that never ran in CI and were never reported to the test tab. This PR runs them **and** reports their code coverage.

- **mssql-py-core** is excluded from the Cargo workspace, so the `mssql-tds`-scoped nextest run never touched it. The only `cargo test` step for it was Linux-gated inside a template that only runs on Windows/macOS — dead code with no JUnit publishing. This adds a Linux container step that runs its 91 Rust unit tests under `cargo llvm-cov nextest` (crate-local `ci` profile), publishes the JUnit results, and emits a crate-scoped Cobertura report. Pure unit tests, so no SQL Server is needed.
- **mssql-odbc** is a workspace member but was excluded by the `--package mssql-tds`-only nextest filter, so its Rust unit tests never ran in CI (only the C++ gtest e2e suite did). This adds `--package mssql-odbc` to the Linux and Windows/macOS nextest invocations so its unit tests run and land in the already-published shared `junit.xml`.

Also removes the dead Linux-gated `cargo test` step from the Windows/macOS-only `build-template.yml`.

### Coverage

Both crates' Rust unit tests now feed the merged coverage report:

- The workspace `cargo llvm-cov report` calls (Linux container + Windows/macOS templates) are scoped `--package mssql-tds --package mssql-odbc`, so **mssql-odbc**'s own lines are measured and unioned across all three OSes into the existing per-OS Cobertura artifacts.
- **mssql-py-core**'s Rust unit tests produce a crate-scoped `pycore-rust-cobertura.xml` (ignoring the `mssql-tds` path dependency so it does not leak in). A new `CoberturaCoveragePyCoreRust` artifact is downloaded in the Coverage stage and merged under the `mssql-py-core` prefix, so it unions with the existing py-core Python coverage on the same source files.

Because these lines now count toward the merged report, new code in `mssql-odbc` / `mssql-py-core` will need coverage to satisfy the diff-cover gate.

### Validation

Validated inside the real build image `ghcr.io/microsoft/mssql-rs/build/ubuntu:22.04`:
- mssql-py-core: 91 tests run, 91 passed; JUnit at `mssql-py-core/target/nextest/ci/junit.xml`; Cobertura report contains only the crate's own `src/**` files.
- mssql-odbc: unit tests run and pass; the tds+odbc report contains 29 `mssql-odbc/**` files alongside the tds sources with repo-root-relative paths.
- `merge-cobertura.py`: py-core Rust report paths rebase to `mssql-py-core/src/...` and union with the Python coverage; merged report contains `mssql-odbc`, `mssql-py-core`, and `mssql-tds` sources.

## Related Issues

[AB#46492](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46492)

## Checklist

- [ ] `cargo bfmt` passes
- [ ] `cargo bclippy` passes
- [ ] `cargo btest` passes
- [x] New/changed functionality has tests
- [x] Public API changes are documented

<sub>No Rust source changed; changes are limited to CI YAML, a nextest config, and shell scripts.</sub>
