### PR TITLE
Add msodbcsql diagnostic message prefix for parity

### DIFF
--- a/mssql-odbc/src/api/fetch.rs
+++ b/mssql-odbc/src/api/fetch.rs
@@ -245,7 +245,7 @@ mod tests {
         assert_eq!(stmt_state.diag_records[0].sql_state, SQLSTATE_HY000);
         assert_eq!(
             stmt_state.diag_records[0].message,
-            "Connection is busy with results for another command"
+            "[Microsoft][ODBC Driver 18 for SQL Server]Connection is busy with results for another command"
         );
         drop(stmt_state);
 

--- a/mssql-odbc/src/api/sqlstate.rs
+++ b/mssql-odbc/src/api/sqlstate.rs
@@ -89,6 +89,13 @@ pub(crate) fn post_diag(state: &mut impl HasDiagnostics, msg: DiagMsg) {
     post_sql_error(state, msg.state, 0, msg.text);
 }
 
+/// Sub-source tag msodbcsql inserts after the driver prefix for diagnostics
+/// that originate inside the SQL Server engine (errors and info/PRINT
+/// messages), yielding the full
+/// `[Microsoft][ODBC Driver 18 for SQL Server][SQL Server]<message>`. The
+/// driver prefix itself is added by [`post_sql_error`].
+const SERVER_DIAG_SUBSOURCE: &str = "[SQL Server]";
+
 /// SQL Server engine error number → ODBC 3.x SQLSTATE.
 ///
 /// We keep only the 3.x state (not 2.x) since that is the behavior
@@ -260,7 +267,12 @@ pub(crate) fn post_tds_error(state: &mut impl HasDiagnostics, err: &TdsError, de
             for e in &diagnostics.errors {
                 let sqlstate = sqlstate_for_sql_error(e.number).unwrap_or(default);
                 let native = i32::try_from(e.number).unwrap_or(i32::MAX);
-                post_sql_error(state, sqlstate, native, e.message.clone());
+                post_sql_error(
+                    state,
+                    sqlstate,
+                    native,
+                    format!("{SERVER_DIAG_SUBSOURCE}{}", e.message),
+                );
             }
         }
         // Informational/warning records follow the primary error record(s).
@@ -282,7 +294,12 @@ pub(crate) fn post_tds_info_messages(
     for message in messages {
         let sqlstate = sqlstate_for_sql_error(message.number).unwrap_or(SQLSTATE_01000);
         let native = i32::try_from(message.number).unwrap_or(i32::MAX);
-        post_sql_error(state, sqlstate, native, message.message.clone());
+        post_sql_error(
+            state,
+            sqlstate,
+            native,
+            format!("{SERVER_DIAG_SUBSOURCE}{}", message.message),
+        );
     }
 
     !messages.is_empty()
@@ -373,7 +390,13 @@ mod tests {
         assert_eq!(s.records.len(), 1);
         assert_eq!(s.records[0].sql_state, *b"28000");
         assert_eq!(s.records[0].native_error, 18456);
-        assert_eq!(s.records[0].message, "Login failed for user 'x'.");
+        assert_eq!(
+            s.records[0].message,
+            format!(
+                "{}{SERVER_DIAG_SUBSOURCE}Login failed for user 'x'.",
+                crate::error::diag::DRIVER_DIAG_PREFIX
+            )
+        );
     }
 
     #[test]
@@ -499,11 +522,20 @@ mod tests {
         assert_eq!(s.records[0].native_error, 5701);
         assert_eq!(
             s.records[0].message,
-            "Changed database context to 'master'."
+            format!(
+                "{}{SERVER_DIAG_SUBSOURCE}Changed database context to 'master'.",
+                crate::error::diag::DRIVER_DIAG_PREFIX
+            )
         );
         assert_eq!(s.records[1].sql_state, SQLSTATE_01000);
         assert_eq!(s.records[1].native_error, 0);
-        assert_eq!(s.records[1].message, "hello from PRINT");
+        assert_eq!(
+            s.records[1].message,
+            format!(
+                "{}{SERVER_DIAG_SUBSOURCE}hello from PRINT",
+                crate::error::diag::DRIVER_DIAG_PREFIX
+            )
+        );
     }
 
     #[test]
@@ -520,6 +552,33 @@ mod tests {
         assert_eq!(s.records.len(), 1);
         assert_eq!(s.records[0].sql_state, SQLSTATE_08003);
         assert_eq!(s.records[0].native_error, 0);
-        assert_eq!(s.records[0].message, "Connection does not exist");
+        assert_eq!(
+            s.records[0].message,
+            format!(
+                "{}Connection does not exist",
+                crate::error::diag::DRIVER_DIAG_PREFIX
+            )
+        );
+    }
+
+    #[test]
+    fn driver_raised_error_carries_only_driver_prefix() {
+        let mut s = FakeState::default();
+        post_sql_error(&mut s, SQLSTATE_HY000, 0, "Something broke");
+        assert_eq!(
+            s.records[0].message,
+            "[Microsoft][ODBC Driver 18 for SQL Server]Something broke"
+        );
+    }
+
+    #[test]
+    fn server_error_carries_driver_and_sql_server_prefix() {
+        let mut s = FakeState::default();
+        let err = TdsError::from_sql_errors(vec![sql_error(18456, "Login failed for user 'x'.")]);
+        post_tds_error(&mut s, &err, SQLSTATE_08001);
+        assert_eq!(
+            s.records[0].message,
+            "[Microsoft][ODBC Driver 18 for SQL Server][SQL Server]Login failed for user 'x'."
+        );
     }
 }

--- a/mssql-odbc/src/error/diag.rs
+++ b/mssql-odbc/src/error/diag.rs
@@ -12,6 +12,13 @@ use std::sync::MutexGuard;
 /// SQLSTATE stored as 5 ASCII bytes (no NUL).
 pub(crate) type SqlState = [u8; 5];
 
+/// Prefix every diagnostic message carries, matching msodbcsql's format:
+/// `[Microsoft][ODBC Driver 18 for SQL Server]`. Errors raised inside the
+/// SQL Server engine add a further `[SQL Server]` sub-source after this (see
+/// `post_tds_error`). Consumers such as mssql-python and pyodbc rely on this
+/// prefix being present to identify and reformat driver diagnostics.
+pub(crate) const DRIVER_DIAG_PREFIX: &str = "[Microsoft][ODBC Driver 18 for SQL Server]";
+
 /// Implemented by state structs that store ODBC diagnostic records.
 pub(crate) trait HasDiagnostics {
     fn diag_records(&self) -> &[DiagRecord];
@@ -48,12 +55,18 @@ impl DiagRecord {
 }
 
 /// Post an ODBC diagnostic record onto a handle-local diagnostic list.
+///
+/// The message is prefixed with [`DRIVER_DIAG_PREFIX`] so every record the
+/// driver surfaces via `SQLGetDiagRec` matches msodbcsql's format. Callers
+/// pass the bare message (server paths first prepend their `[SQL Server]`
+/// sub-source); they must not include the `[Microsoft]...` prefix themselves.
 pub(crate) fn post_sql_error(
     state: &mut impl HasDiagnostics,
     sql_state: SqlState,
     native_error: i32,
     message: impl Into<String>,
 ) {
+    let message = format!("{DRIVER_DIAG_PREFIX}{}", message.into());
     state
         .diag_records_mut()
         .push(DiagRecord::new(sql_state, native_error, message));


### PR DESCRIPTION
## Description

This pull request standardizes and improves the formatting of diagnostic messages returned by the driver, ensuring they consistently match the format used by Microsoft's official ODBC driver (`msodbcsql`). This is important for compatibility with client libraries like `mssql-python` and `pyodbc`, which rely on these prefixes to parse and handle errors correctly. The changes also add and update tests to verify the correct formatting of these messages.

**Diagnostic message formatting improvements:**

* Introduced a new constant, `DRIVER_DIAG_PREFIX`, to prefix all diagnostic messages with `[Microsoft][ODBC Driver 18 for SQL Server]` for consistency with `msodbcsql`.
* Updated `post_sql_error` to automatically add the driver prefix to all messages, ensuring callers do not manually add it.
* Added a `SERVER_DIAG_SUBSOURCE` constant for server-originated errors and info messages, so these are further prefixed with `[SQL Server]` after the driver prefix.
* Modified `post_tds_error` and `post_tds_info_messages` to prepend the `[SQL Server]` sub-source to server-generated messages. [[1]](diffhunk://#diff-5a016bf68bce0c6555bc48ec9b91f17d5585b24f1b13219348c19173e052412fL263-R275) [[2]](diffhunk://#diff-5a016bf68bce0c6555bc48ec9b91f17d5585b24f1b13219348c19173e052412fL285-R302)

**Testing and validation:**

* Updated and added tests to verify that both driver-raised and server-raised errors are correctly prefixed, including new test cases for each scenario. [[1]](diffhunk://#diff-5a016bf68bce0c6555bc48ec9b91f17d5585b24f1b13219348c19173e052412fL376-R399) [[2]](diffhunk://#diff-5a016bf68bce0c6555bc48ec9b91f17d5585b24f1b13219348c19173e052412fL502-R538) [[3]](diffhunk://#diff-5a016bf68bce0c6555bc48ec9b91f17d5585b24f1b13219348c19173e052412fL523-R582) [[4]](diffhunk://#diff-8b1ea5dcf3183980bf19bb418dde240eeeae7b5370c131ee1cde11e9b8abac3cL248-R248)

These changes ensure all diagnostic messages are consistently formatted, improving compatibility and clarity for downstream consumers.

## Related Issues

[AB#46416](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46416)

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [ ] `cargo btest` passes <!-- ran `cargo test -p mssql-odbc` locally (258 pass); nextest/llvm-cov not installed on dev box — CI runs the canonical path -->
- [x] New/changed functionality has tests
- [ ] Public API changes are documented <!-- N/A: internal `pub(crate)` only -->
