### PR TITLE
Fix u32 overflow panic in FedAuthInfo token parser

### DIFF
--- a/mssql-tds/src/token/parsers/fedauth_parser.rs
+++ b/mssql-tds/src/token/parsers/fedauth_parser.rs
@@ -694,9 +694,17 @@ mod tests {
         let context = ParserContext::default();
 
         let result = parser.parse(&mut reader, &context).await;
-        assert!(
-            result.is_err(),
-            "Overflowing option offset/length must produce an error, not a panic"
-        );
+        let err = result
+            .expect_err("Overflowing option offset/length must produce an error, not a panic");
+        match err {
+            crate::error::Error::Io(io_err) => {
+                assert_eq!(io_err.kind(), std::io::ErrorKind::InvalidData);
+                assert!(
+                    io_err.to_string().contains("out of bounds"),
+                    "unexpected error message: {io_err}"
+                );
+            }
+            other => panic!("expected Error::Io with InvalidData, got: {other:?}"),
+        }
     }
 }

--- a/mssql-tds/src/token/parsers/fedauth_parser.rs
+++ b/mssql-tds/src/token/parsers/fedauth_parser.rs
@@ -127,10 +127,17 @@ where
                     )
                 })?;
 
+            // Compute the end offset in usize to avoid u32 overflow on malformed input.
+            let string_end = (option_data_offset as usize)
+                .checked_add(option_data_length as usize)
+                .ok_or_else(|| {
+                    Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "FedAuth string data length overflow",
+                    )
+                })?;
             let string_bytes: &[u8] = token_data
-                .get(
-                    option_data_offset as usize..(option_data_offset + option_data_length) as usize,
-                )
+                .get(option_data_offset as usize..string_end)
                 .ok_or_else(|| {
                     Error::new(
                         std::io::ErrorKind::InvalidData,
@@ -663,6 +670,33 @@ mod tests {
         assert!(
             result.is_err(),
             "Should error when options_count requires more data than available"
+        );
+    }
+
+    /// Regression test for a fuzzer-discovered crash (crash-1a0718529807d9d6b4ae25c65ac23c42c1b742aa).
+    /// A malformed option header whose data offset and length are both large u32 values caused
+    /// `offset + length` to overflow when computing the string slice bounds, aborting the process.
+    /// The parser must return an error instead of panicking.
+    #[tokio::test]
+    async fn test_parse_fedauth_option_offset_length_overflow() {
+        // Crash input without the leading token-type byte (consumed by the token stream reader).
+        let data = vec![
+            0x0e, 0x00, 0x00, 0x00, // length = 14
+            0x01, 0x00, 0x00, 0x00, // options_count = 1
+            0x00, // option_id
+            0x00, 0x04, 0x27, 0x81, // option_data_length = 0x81270400
+            0xb9, 0xdf, 0x0b, 0xfe, // option_data_offset = 0xfe0bdfb9
+            0x3b, // filler
+        ];
+
+        let mut reader = MockReader::new(data);
+        let parser = FedAuthInfoTokenParser::default();
+        let context = ParserContext::default();
+
+        let result = parser.parse(&mut reader, &context).await;
+        assert!(
+            result.is_err(),
+            "Overflowing option offset/length must produce an error, not a panic"
         );
     }
 }


### PR DESCRIPTION
## Description

The `fuzz_token_stream` fuzzer (ADO build [161573](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build/results?buildId=161573)) found a crash in the FedAuthInfo token parser (`crash-1a0718529807d9d6b4ae25c65ac23c42c1b742aa`).

A malformed `FedAuthInfo` (`0xEE`) token whose option header has a large data offset and length caused `option_data_offset + option_data_length` (both `u32`) to overflow when computing the string slice bounds. Under the fuzzer's overflow checks this aborts the process (`panic_const_add_overflow` at `fedauth_parser.rs:132`).

The fix computes the slice end in `usize` via `checked_add`, so out-of-bounds/overflowing input returns a `ProtocolError`/`InvalidData` error instead of panicking. `.get()` already handled genuinely out-of-bounds ranges once the addition no longer overflows.

Reproduced in WSL with `cargo +nightly fuzz run fuzz_token_stream <crash>`:
- Before: `SUMMARY: libFuzzer: deadly signal` (abort)
- After: input runs cleanly, no crash

Added a regression unit test (`test_parse_fedauth_option_offset_length_overflow`) built from the exact crash bytes.

## Related Issues

Fixes #136

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes (`cargo clippy -p mssql-tds --all-targets -- -D warnings`)
- [x] `cargo btest` passes (34 fedauth tests, incl. new regression)
- [x] New/changed functionality has tests
- [ ] Public API changes are documented (n/a — internal parser)