### PR TITLE
perf(lab): noise-resistant gate (best-of-N), readable summary chart, fail-loud compiles, and baseline refresh for the unified execute API

### DIFF
--- a/docs/perf-testing-plan.md
+++ b/docs/perf-testing-plan.md
@@ -135,10 +135,13 @@ build.
   - **Discarded warm-up pass** before the interleaved run to prime SQL Server's buffer
     pool / plan cache and the OS page cache, so the first measured benchmark isn't paying
     cold-start cost.
-  - **Auto-confirm** — a strict gate can trip on a transient single-benchmark outlier, so
-    any benchmark that trips the threshold is **re-measured** (interleaved, same as the
-    main run) and kept as a regression only if it trips **again**; one-off blips are
-    reported as transient noise, not failures.
+  - **Auto-confirm (best-of-N)** — a strict gate can trip on a transient single-benchmark
+    outlier (short, CPU-bound benches can swing double digits on a shared VM), so any
+    benchmark that trips the threshold is **re-measured `BENCH_CONFIRM_RUNS` times**
+    (default 4, interleaved, offenders only) and kept as a regression only if it trips in a
+    **majority** of those re-runs (`BENCH_CONFIRM_QUORUM`, default `N/2+1`). A real
+    regression reproduces consistently; a one-off spike does not and is reported as
+    transient noise, not a failure.
   - **Release-grade sampling** — heavier warm-up / measurement time / sample count than
     the fast local defaults (`BENCH_WARMUP_SECS` / `BENCH_SECS` / `BENCH_SAMPLES`),
     letting caches settle and separating small real deltas from noise.
@@ -161,7 +164,8 @@ The run **fails only when a *candidate* benchmark is slower than its baseline by
 the threshold** (`BENCH_REGRESSION_RATIO`, default `1.10` = 10%). A baseline-slower
 result never fails the gate — it can only mean the comparison lost sensitivity, which is
 exactly what the interleaving + pinning + warm-up work keeps in check. Any benchmark that
-trips is re-measured by **auto-confirm** and only fails the run if it trips again. The
+trips is re-measured by **auto-confirm** `BENCH_CONFIRM_RUNS` times (default 4) and only
+fails the run if it regresses in a **majority** of those re-runs (default 3 of 4). The
 verdict and the full `critcmp` table are written to `results/summary.md`, which the lab
 attaches to the run's **Summary** tab (`task.uploadsummary`) so the comparison renders
 inline on the pipeline run page.
@@ -267,7 +271,8 @@ binaries keep the per-binary interleaving effective (see §2).
   `extends` template; the build happens on the VM (the lab's documented model).
 - Comparison is **interleaved per bench binary** (not two full passes), and the run
   **fails only on a candidate-slower regression ≥ threshold** (default 10%), with
-  **auto-confirm** re-measuring any tripped benchmark before failing.
+  **best-of-N auto-confirm** (re-measure a tripped benchmark 4× and fail only on a
+  majority) rejecting transient outliers before failing.
 - Runs on **both Linux and Windows** as two separate pipeline definitions (numbers are
   not cross-comparable).
 - End-to-end (real SQL Server) only.

--- a/docs/perf-testing-plan.md
+++ b/docs/perf-testing-plan.md
@@ -173,11 +173,16 @@ Summary tab is not visible when triaging from the log alone.
 
 `summary.md` leads with a **diverging bar table** (🟩 faster / 🟥 slower, one square ≈ 1%,
 drawn only for |Δ| ≥ 1%) so a run's shape is readable at a glance; the raw `critcmp`
-output follows it. A benchmark that auto-confirm re-measured is shown as the **median** of
-its first pass plus all re-runs and marked `⟳` — otherwise the chart would keep rendering
-the first-pass spike for a benchmark the gate had already cleared as noise, and the
-summary would appear to contradict the verdict. The median (rather than the best passing
-re-run) keeps the displayed number from being cherry-picked.
+output follows it. A benchmark that auto-confirm re-measured is shown as the **median of
+its re-runs** and marked `⟳` — otherwise the chart would keep rendering the first-pass
+spike for a benchmark the gate had already cleared as noise, and the summary would appear
+to contradict the verdict. The median (rather than the best passing re-run) keeps the
+displayed number from being cherry-picked. The first pass is deliberately **excluded**:
+a benchmark is re-measured precisely because that pass was extreme, so including it
+re-counts the outlier under test and would give it a tie-breaking vote the gate does not
+have — with 2 of 4 re-runs tripping the gate clears the benchmark, yet 3 of those 5 values
+are trips, so the median could stay above the threshold and contradict a passing verdict.
+Reconciling from the same measurements the quorum counts keeps the two aligned.
 
 **Large improvements are verified too.** The gate is one-directional, so a *baseline*-slower
 result is never challenged and an unverified "3× faster" would be published — a real risk,

--- a/docs/perf-testing-plan.md
+++ b/docs/perf-testing-plan.md
@@ -168,7 +168,22 @@ trips is re-measured by **auto-confirm** `BENCH_CONFIRM_RUNS` times (default 4) 
 fails the run if it regresses in a **majority** of those re-runs (default 3 of 4). The
 verdict and the full `critcmp` table are written to `results/summary.md`, which the lab
 attaches to the run's **Summary** tab (`task.uploadsummary`) so the comparison renders
-inline on the pipeline run page.
+inline on the pipeline run page. The summary is also echoed into the log, since the
+Summary tab is not visible when triaging from the log alone.
+
+`summary.md` leads with a **diverging bar table** (🟩 faster / 🟥 slower, one square ≈ 1%,
+drawn only for |Δ| ≥ 1%) so a run's shape is readable at a glance; the raw `critcmp`
+output follows it. A benchmark that auto-confirm re-measured is shown as the **median** of
+its first pass plus all re-runs and marked `⟳` — otherwise the chart would keep rendering
+the first-pass spike for a benchmark the gate had already cleared as noise, and the
+summary would appear to contradict the verdict. The median (rather than the best passing
+re-run) keeps the displayed number from being cherry-picked.
+
+**Compilation failures fail loudly.** Both runners compile the candidate and baseline
+bench binaries in an explicit `cargo bench --no-run` step with human-readable output
+before enumerating them. The enumeration itself parses cargo's JSON and discards stderr,
+so without a separate compile step a build error surfaced only as a generic "no bench
+binaries found" with no diagnostics in the log.
 
 ---
 
@@ -267,6 +282,19 @@ binaries keep the per-binary interleaving effective (see §2).
 - Baseline commit is stored in **`mssql-tds-bench/perf-lab/baseline-commit.txt`, read by the
   testScript**. The baseline is advanced via a **pull request that edits that file**, so the
   change is reviewed and recorded in git history (no untracked tag move or pipeline variable).
+- **A breaking `mssql-tds` API change forces the baseline forward.** The harness compiles
+  *one* bench source — the candidate's — against *both* libraries, which is what makes a
+  measured delta attributable to `mssql-tds` alone. The corollary is that the benches must
+  compile against both revisions, so once they are updated for a new API they no longer
+  build against a baseline that predates it, and the baseline compile fails. Advance
+  `baseline-commit.txt` to the commit that **introduced** the API — the earliest library
+  that compiles the current benches — which preserves the longest comparison window.
+  (`cfg`-gating the changed call sites so one source compiles both ways is possible but
+  costs dual code paths; reserve it for when a pre-break baseline is specifically needed.
+  Building each side from its own bench source is *not* an option: it reintroduces the
+  variable the harness exists to eliminate.) Bumping the baseline can also surface
+  *runtime* breaks that still compile — e.g. a value that moved from the generic
+  return-value buffer to a dedicated accessor.
 - Perf-lab pipeline runs on a **dedicated host VM** via the shared `PerfTest` lab
   `extends` template; the build happens on the VM (the lab's documented model).
 - Comparison is **interleaved per bench binary** (not two full passes), and the run

--- a/docs/perf-testing-plan.md
+++ b/docs/perf-testing-plan.md
@@ -180,14 +180,18 @@ summary would appear to contradict the verdict. The median (rather than the best
 re-run) keeps the displayed number from being cherry-picked.
 
 **Large improvements are verified too.** The gate is one-directional, so a *baseline*-slower
-result is never challenged and an implausible "3× faster" would be published unverified —
-a real risk, since a sustained host disturbance during one pass produces a large, tight-CI
-delta that does not look like noise. Any benchmark where the baseline is slower by
-≥ `BENCH_IMPROVEMENT_VERIFY_RATIO` (default `1.50`) joins the same re-measure set, and the
-summary reports whether the win reproduced in a majority of re-runs. This never fails the
-run: it exists so a one-off artifact is not reported as a real gain, and because a win that
-*does* reproduce is itself worth a look — an implausible speed-up can mean the candidate is
-doing less work rather than the same work faster.
+result is never challenged and an unverified "3× faster" would be published — a real risk,
+since a sustained host disturbance during one pass produces a large, tight-CI delta that
+does not look like noise. Any benchmark where the baseline is slower by
+≥ `BENCH_IMPROVEMENT_VERIFY_RATIO` (default: **the same as the regression threshold**) joins
+the same re-measure set, and the summary reports whether the win reproduced in a majority of
+re-runs. Verifying both directions at the same magnitude matters because the measurements are
+recorded for run-over-run trend comparison: an anomalously slow *baseline* pass corrupts that
+record exactly as much as an anomalously slow candidate one, and since both directions share
+one re-measure set the extra confidence costs nothing per run. This never fails the run: it
+exists so a one-off artifact is not reported as a real gain, and because a win that *does*
+reproduce is itself worth a look — an implausible speed-up can mean the candidate is doing
+less work rather than the same work faster.
 
 **Compilation failures fail loudly.** Both runners compile the candidate and baseline
 bench binaries in an explicit `cargo bench --no-run` step with human-readable output

--- a/docs/perf-testing-plan.md
+++ b/docs/perf-testing-plan.md
@@ -179,6 +179,16 @@ the first-pass spike for a benchmark the gate had already cleared as noise, and 
 summary would appear to contradict the verdict. The median (rather than the best passing
 re-run) keeps the displayed number from being cherry-picked.
 
+**Large improvements are verified too.** The gate is one-directional, so a *baseline*-slower
+result is never challenged and an implausible "3× faster" would be published unverified —
+a real risk, since a sustained host disturbance during one pass produces a large, tight-CI
+delta that does not look like noise. Any benchmark where the baseline is slower by
+≥ `BENCH_IMPROVEMENT_VERIFY_RATIO` (default `1.50`) joins the same re-measure set, and the
+summary reports whether the win reproduced in a majority of re-runs. This never fails the
+run: it exists so a one-off artifact is not reported as a real gain, and because a win that
+*does* reproduce is itself worth a look — an implausible speed-up can mean the candidate is
+doing less work rather than the same work faster.
+
 **Compilation failures fail loudly.** Both runners compile the candidate and baseline
 bench binaries in an explicit `cargo bench --no-run` step with human-readable output
 before enumerating them. The enumeration itself parses cargo's JSON and discards stderr,

--- a/mssql-tds-bench/perf-lab/baseline-commit.txt
+++ b/mssql-tds-bench/perf-lab/baseline-commit.txt
@@ -7,4 +7,4 @@
 #
 # Exactly one full 40-character commit SHA on its own line. Lines starting with
 # '#' and blank lines are ignored.
-6f8db4a0e724d7f9c076ea929752f8e74671141c
+bb02ba65254536bcef44c0a5bf682bd761ac51ee

--- a/mssql-tds-bench/perf-lab/run-benchmarks.ps1
+++ b/mssql-tds-bench/perf-lab/run-benchmarks.ps1
@@ -429,47 +429,63 @@ $thr = [double]($env:BENCH_REGRESSION_RATIO)
 if (-not $thr) { $thr = 1.10 }
 $regressions = @(Get-CritcmpRegressions $comparison $thr)
 
-# --- Auto-confirm regressions (re-measure only the offenders, interleaved) ---
-# A strict gate can trip on a transient single-benchmark outlier. Re-measure ONLY
-# the benchmarks that tripped - interleaved per binary, same as the main run - and
-# keep as a real regression only those that trip AGAIN. Both binaries are already
-# built, so this just replays the offenders (adds only their run time).
-$gateComparison = $comparison
-$gateRegressions = $regressions
-$confirmComparison = $null
+# --- Auto-confirm regressions: re-measure the offenders N times, require a
+# --- majority to confirm ---
+# A strict gate can trip on a transient single-benchmark outlier - short,
+# CPU-bound benches (e.g. the decode microbenches) can swing double digits on a
+# shared VM. So re-measure ONLY the benchmarks that tripped - interleaved per
+# binary, same as the main run - several times, and keep as a real regression
+# only those that trip in a MAJORITY of the re-runs. A true regression reproduces
+# consistently; noise does not. Both bench binaries are already built and the
+# offenders are a small subset, so the extra re-runs stay cheap.
+#   BENCH_CONFIRM_RUNS   (default 4)                - number of re-runs
+#   BENCH_CONFIRM_QUORUM (default majority = N/2+1)  - re-runs required to confirm
+$confirmRuns = if ($env:BENCH_CONFIRM_RUNS) { [int]$env:BENCH_CONFIRM_RUNS } else { 4 }
+$quorum = if ($env:BENCH_CONFIRM_QUORUM) { [int]$env:BENCH_CONFIRM_QUORUM } else { [int][math]::Floor($confirmRuns / 2) + 1 }
+$confirmed = @()
+$confirmRunComparisons = @()
+$tally = @{}
+$worstRatio = @{}
 if ($regressions.Count -gt 0) {
     $filter = (($regressions | ForEach-Object { '^' + $_.Name + '$' }) -join '|')
     Write-Host (">>> Gate tripped by: " + (($regressions | ForEach-Object { $_.Name }) -join ', '))
-    Write-Host ">>> Auto-confirm: re-measuring only those benchmarks (filter: $filter)"
+    Write-Host ">>> Auto-confirm: re-measuring those benchmark(s) ${confirmRuns}x; a regression counts only if it trips in >= $quorum of $confirmRuns re-runs."
+    # One warm-up before the loop; the re-runs are back-to-back so caches stay hot.
     Invoke-WarmupPass $filter
-    Invoke-Interleave 'candidate_confirm' 'base_confirm' $filter
-
-    Write-Host '>>> Auto-confirm comparison (base_confirm -> candidate_confirm):'
-    $confirmComparison = & {
-        $ErrorActionPreference = 'Continue'
-        $out = critcmp base_confirm candidate_confirm | Out-String
-        if ($LASTEXITCODE -ne 0) { throw "critcmp (confirm) failed (exit $LASTEXITCODE)" }
-        $out
+    for ($run = 1; $run -le $confirmRuns; $run++) {
+        Write-Host ">>> Auto-confirm re-run $run/$confirmRuns..."
+        Invoke-Interleave "candidate_confirm$run" "base_confirm$run" $filter
+        $ct = & {
+            $ErrorActionPreference = 'Continue'
+            $out = critcmp "base_confirm$run" "candidate_confirm$run" | Out-String
+            if ($LASTEXITCODE -ne 0) { throw "critcmp (confirm $run) failed (exit $LASTEXITCODE)" }
+            $out
+        }
+        $ct = $ct.TrimEnd()
+        Write-Host $ct
+        [System.IO.File]::WriteAllText((Join-Path $ResultsDir "confirm-run$run.txt"), $ct + "`n", $Utf8NoBom)
+        $confirmRunComparisons += , $ct
+        foreach ($r in @(Get-CritcmpRegressions $ct $thr)) {
+            if ($tally.ContainsKey($r.Name)) { $tally[$r.Name]++ } else { $tally[$r.Name] = 1 }
+            if (-not $worstRatio.ContainsKey($r.Name) -or $r.Ratio -gt $worstRatio[$r.Name]) { $worstRatio[$r.Name] = $r.Ratio }
+        }
     }
-    $confirmComparison = $confirmComparison.TrimEnd()
-    Write-Host $confirmComparison
-    [System.IO.File]::WriteAllText((Join-Path $ResultsDir 'confirm.txt'), $confirmComparison + "`n", $Utf8NoBom)
-    $gateComparison = $confirmComparison
-    $gateRegressions = @(Get-CritcmpRegressions $confirmComparison $thr)
+    # Confirmed = benchmarks that tripped in at least $quorum of the re-runs.
+    $confirmed = @($tally.Keys | Where-Object { $tally[$_] -ge $quorum })
 }
 Remove-Item -Recurse -Force (Join-Path $RepoRoot 'target-base') -ErrorAction SilentlyContinue
 
-# --- Verdict (based on the gate comparison: the re-measured offenders after
-# auto-confirm, or the full run when nothing tripped) ---
+# --- Verdict (based on the majority-confirmed regressions) ---
 $pct = [int][math]::Round(($thr - 1) * 100)
 $warn = [char]::ConvertFromUtf32(0x26A0) + [char]::ConvertFromUtf32(0xFE0F)
 $check = [char]::ConvertFromUtf32(0x2705)
-if ($gateRegressions.Count -gt 0) {
-    $worst = $gateRegressions | Sort-Object Ratio -Descending | Select-Object -First 1
-    $wpct = [int][math]::Round(($worst.Ratio - 1) * 100)
-    $verdict = "$warn $($gateRegressions.Count) benchmark(s) slower by >=$pct% vs baseline (worst: $($worst.Name) +$wpct%)"
+if ($confirmed.Count -gt 0) {
+    $worstName = $confirmed | Sort-Object { $worstRatio[$_] } -Descending | Select-Object -First 1
+    $wpct = [int][math]::Round(($worstRatio[$worstName] - 1) * 100)
+    $whits = $tally[$worstName]
+    $verdict = "$warn $($confirmed.Count) benchmark(s) consistently slower by >=$pct% vs baseline (worst: $worstName +$wpct%, tripped $whits/$confirmRuns re-runs)"
 } else {
-    $verdict = "$check No benchmark slower by >=$pct% vs baseline"
+    $verdict = "$check No benchmark consistently slower by >=$pct% vs baseline"
 }
 
 $summaryLines = @(
@@ -479,7 +495,7 @@ $summaryLines = @(
     ''
 )
 if ($regressions.Count -gt 0) {
-    $summaryLines += '_Auto-confirm re-ran the gate-tripping benchmark(s); the verdict reflects that re-measurement. Benchmarks that tripped once but not on the re-run are treated as transient noise._'
+    $summaryLines += "_Auto-confirm re-measured the initially-tripping benchmark(s) ${confirmRuns}x (interleaved, offenders only). A regression is counted only when it trips in at least $quorum of $confirmRuns re-runs; a benchmark that spikes once but not consistently is treated as transient noise._"
     $summaryLines += ''
 }
 $summaryLines += @(
@@ -492,14 +508,27 @@ $summaryLines += @(
 if ($regressions.Count -gt 0) {
     $summaryLines += @(
         ''
-        '### Auto-confirm re-run (offenders only)'
+        '### Auto-confirm re-runs (offenders only)'
         ''
-        ('Tripped on the first pass: ' + (($regressions | ForEach-Object { $_.Name }) -join ', '))
+        ('Initially tripped: ' + (($regressions | ForEach-Object { $_.Name }) -join ', '))
         ''
-        '```'
-        $confirmComparison
-        '```'
+        '| benchmark | re-runs tripped | worst |'
+        '|-----------|-----------------|-------|'
     )
+    foreach ($r in $regressions) {
+        $hits = if ($tally.ContainsKey($r.Name)) { $tally[$r.Name] } else { 0 }
+        if ($worstRatio.ContainsKey($r.Name)) {
+            $wcell = '+' + [string][int][math]::Round(($worstRatio[$r.Name] - 1) * 100) + '%'
+        } else {
+            $wcell = [string][char]0x2014
+        }
+        $summaryLines += "| $($r.Name) | $hits/$confirmRuns | $wcell |"
+    }
+    $confList = if ($confirmed.Count -gt 0) { ($confirmed -join ', ') } else { 'none' }
+    $summaryLines += @('', "_Confirmed (tripped in >= $quorum/$confirmRuns): ${confList}_", '')
+    for ($run = 1; $run -le $confirmRuns; $run++) {
+        $summaryLines += @("#### Re-run $run", '', '```', $confirmRunComparisons[$run - 1], '```', '')
+    }
 }
 $summary = $summaryLines -join "`n"
 [System.IO.File]::WriteAllText((Join-Path $ResultsDir 'summary.md'), $summary + "`n", $Utf8NoBom)
@@ -508,14 +537,14 @@ Copy-Item -Recurse -Force 'target/criterion' (Join-Path $ResultsDir 'criterion')
 
 Write-Host ">>> Done. Results in $ResultsDir"
 
-# Fail the run only on CONFIRMED regressions (the gate comparison). Use `throw`,
-# not `exit`: the scheduled-task wrapper relies on its finally block to write the
-# EXIT_CODE/DONE sentinels, and `exit` from a called .ps1 terminates the whole
-# process and would skip it (leaving run-remote to hang until timeout). summary.md
-# names the offenders and shows the auto-confirm re-run.
-if ($gateRegressions.Count -gt 0) {
+# Fail the run only on CONFIRMED regressions (tripped in a majority of re-runs).
+# Use `throw`, not `exit`: the scheduled-task wrapper relies on its finally block
+# to write the EXIT_CODE/DONE sentinels, and `exit` from a called .ps1 terminates
+# the whole process and would skip it (leaving run-remote to hang until timeout).
+# summary.md names the offenders and shows the auto-confirm re-runs.
+if ($confirmed.Count -gt 0) {
     throw "PERF REGRESSION: $verdict"
 }
 if ($regressions.Count -gt 0) {
-    Write-Host ">>> Auto-confirm cleared all $($regressions.Count) initial regression(s) as transient; passing."
+    Write-Host ">>> Auto-confirm cleared all $($regressions.Count) initial regression(s) as transient (none tripped in >= $quorum/$confirmRuns); passing."
 }

--- a/mssql-tds-bench/perf-lab/run-benchmarks.ps1
+++ b/mssql-tds-bench/perf-lab/run-benchmarks.ps1
@@ -129,6 +129,20 @@ function Get-CritcmpRegressions {
     }
 }
 
+# Same parse, but for the other direction: the BASELINE is slower by at least
+# $Threshold (its ratio is the 2nd field). These never fail the gate, so without
+# a check an implausible "3x faster" would be published unverified.
+function Get-CritcmpImprovements {
+    param([string]$Comparison, [double]$Threshold)
+    foreach ($line in ($Comparison -split "\r?\n")) {
+        $f = @($line -split '\s+' | Where-Object { $_ -ne '' })
+        if ($f.Count -ge 6 -and $f[1] -match '^[0-9]+\.[0-9]+$' -and $f[5] -match '^[0-9]+\.[0-9]+$') {
+            $base = [double]$f[1]
+            if ($base -ge $Threshold) { [pscustomobject]@{ Name = $f[0]; Ratio = $base } }
+        }
+    }
+}
+
 # Fast, discarded run that primes SQL Server's buffer pool and the OS page cache
 # so the measured pass that follows starts warm. Run before BOTH the candidate
 # and baseline passes: the baseline mssql-tds is rebuilt after a long candidate
@@ -447,6 +461,11 @@ Write-Host $comparison
 $thr = [double]($env:BENCH_REGRESSION_RATIO)
 if (-not $thr) { $thr = 1.10 }
 $regressions = @(Get-CritcmpRegressions $comparison $thr)
+$impThr = [double]($env:BENCH_IMPROVEMENT_VERIFY_RATIO)
+if (-not $impThr) { $impThr = 1.50 }
+$improvements = @(Get-CritcmpImprovements $comparison $impThr)
+# One re-measure set covers both directions, so the re-runs cost one pass.
+$verifyNames = @(@($regressions | ForEach-Object { $_.Name }) + @($improvements | ForEach-Object { $_.Name }) | Select-Object -Unique)
 
 # --- Auto-confirm regressions: re-measure the offenders N times, require a
 # --- majority to confirm ---
@@ -462,13 +481,17 @@ $regressions = @(Get-CritcmpRegressions $comparison $thr)
 $confirmRuns = if ($env:BENCH_CONFIRM_RUNS) { [int]$env:BENCH_CONFIRM_RUNS } else { 4 }
 $quorum = if ($env:BENCH_CONFIRM_QUORUM) { [int]$env:BENCH_CONFIRM_QUORUM } else { [int][math]::Floor($confirmRuns / 2) + 1 }
 $confirmed = @()
+$impConfirmed = @()
 $confirmRunComparisons = @()
 $tally = @{}
 $worstRatio = @{}
-if ($regressions.Count -gt 0) {
-    $filter = (($regressions | ForEach-Object { '^' + $_.Name + '$' }) -join '|')
-    Write-Host (">>> Gate tripped by: " + (($regressions | ForEach-Object { $_.Name }) -join ', '))
-    Write-Host ">>> Auto-confirm: re-measuring those benchmark(s) ${confirmRuns}x; a regression counts only if it trips in >= $quorum of $confirmRuns re-runs."
+$impTally = @{}
+$impBest = @{}
+if ($verifyNames.Count -gt 0) {
+    $filter = (($verifyNames | ForEach-Object { '^' + $_ + '$' }) -join '|')
+    if ($regressions.Count -gt 0) { Write-Host (">>> Gate tripped by: " + (($regressions | ForEach-Object { $_.Name }) -join ', ')) }
+    if ($improvements.Count -gt 0) { Write-Host (">>> Verifying large apparent improvement(s): " + (($improvements | ForEach-Object { $_.Name }) -join ', ')) }
+    Write-Host ">>> Auto-confirm: re-measuring those benchmark(s) ${confirmRuns}x; a result counts only if it reproduces in >= $quorum of $confirmRuns re-runs."
     # One warm-up before the loop; the re-runs are back-to-back so caches stay hot.
     Invoke-WarmupPass $filter
     for ($run = 1; $run -le $confirmRuns; $run++) {
@@ -488,9 +511,14 @@ if ($regressions.Count -gt 0) {
             if ($tally.ContainsKey($r.Name)) { $tally[$r.Name]++ } else { $tally[$r.Name] = 1 }
             if (-not $worstRatio.ContainsKey($r.Name) -or $r.Ratio -gt $worstRatio[$r.Name]) { $worstRatio[$r.Name] = $r.Ratio }
         }
+        foreach ($i in @(Get-CritcmpImprovements $ct $impThr)) {
+            if ($impTally.ContainsKey($i.Name)) { $impTally[$i.Name]++ } else { $impTally[$i.Name] = 1 }
+            if (-not $impBest.ContainsKey($i.Name) -or $i.Ratio -gt $impBest[$i.Name]) { $impBest[$i.Name] = $i.Ratio }
+        }
     }
     # Confirmed = benchmarks that tripped in at least $quorum of the re-runs.
     $confirmed = @($tally.Keys | Where-Object { $tally[$_] -ge $quorum })
+    $impConfirmed = @($impTally.Keys | Where-Object { $impTally[$_] -ge $quorum })
 }
 Remove-Item -Recurse -Force (Join-Path $RepoRoot 'target-base') -ErrorAction SilentlyContinue
 
@@ -515,19 +543,20 @@ function Get-Median {
     if ($n % 2) { return $s[[int](($n - 1) / 2)] } else { return ($s[[int]($n / 2 - 1)] + $s[[int]($n / 2)]) / 2 }
 }
 $overrides = @{}
-foreach ($o in $regressions) {
+foreach ($name in $verifyNames) {
     $vals = @()
-    $mr = Get-RatioFor $comparison $o.Name
+    $mr = Get-RatioFor $comparison $name
     if ($null -ne $mr) { $vals += $mr }
     foreach ($cc in $confirmRunComparisons) {
-        $rr = Get-RatioFor $cc $o.Name
+        $rr = Get-RatioFor $cc $name
         if ($null -ne $rr) { $vals += $rr }
     }
-    if ($vals.Count -gt 0) { $overrides[$o.Name] = Get-Median $vals }
+    if ($vals.Count -gt 0) { $overrides[$name] = Get-Median $vals }
 }
 
 # --- Verdict (based on the majority-confirmed regressions) ---
 $pct = [int][math]::Round(($thr - 1) * 100)
+$impPct = [int][math]::Round(($impThr - 1) * 100)
 $warn = [char]::ConvertFromUtf32(0x26A0) + [char]::ConvertFromUtf32(0xFE0F)
 $check = [char]::ConvertFromUtf32(0x2705)
 if ($confirmed.Count -gt 0) {
@@ -589,6 +618,10 @@ if ($regressions.Count -gt 0) {
     $summaryLines += "_Auto-confirm re-measured the initially-tripping benchmark(s) ${confirmRuns}x (interleaved, offenders only). A regression is counted only when it trips in at least $quorum of $confirmRuns re-runs; a benchmark that spikes once but not consistently is treated as transient noise._"
     $summaryLines += ''
 }
+if ($improvements.Count -gt 0) {
+    $summaryLines += "_Benchmark(s) where the baseline looked slower by at least $impPct% were re-measured the same way, so an apparent win that does not reproduce is not reported as real._"
+    $summaryLines += ''
+}
 $summaryLines += @(
     '### Change vs baseline'
     ''
@@ -611,7 +644,7 @@ $summaryLines += @(
 if ($regressions.Count -gt 0) {
     $summaryLines += @(
         ''
-        '### Auto-confirm re-runs (offenders only)'
+        '### Regressions (auto-confirm)'
         ''
         ('Initially tripped: ' + (($regressions | ForEach-Object { $_.Name }) -join ', '))
         ''
@@ -629,6 +662,31 @@ if ($regressions.Count -gt 0) {
     }
     $confList = if ($confirmed.Count -gt 0) { ($confirmed -join ', ') } else { 'none' }
     $summaryLines += @('', "_Confirmed (tripped in >= $quorum/$confirmRuns): ${confList}_", '')
+}
+if ($improvements.Count -gt 0) {
+    $summaryLines += @(
+        ''
+        '### Large improvements (verification)'
+        ''
+        "_Baseline slower by at least $impPct%. These never fail the gate; they are re-measured so a one-off artifact is not published as a real gain. A win that **does** reproduce is also worth a look - it can mean the candidate is doing less work rather than the same work faster._"
+        ''
+        '| benchmark | reproduced | best |'
+        '|-----------|------------|------|'
+    )
+    foreach ($i in $improvements) {
+        $ihits = if ($impTally.ContainsKey($i.Name)) { $impTally[$i.Name] } else { 0 }
+        if ($impBest.ContainsKey($i.Name)) {
+            $ibcell = ('{0:0.00}x faster' -f $impBest[$i.Name])
+        } else {
+            $ibcell = [string][char]0x2014
+        }
+        $summaryLines += "| $($i.Name) | $ihits/$confirmRuns | $ibcell |"
+    }
+    $impList = if ($impConfirmed.Count -gt 0) { ($impConfirmed -join ', ') } else { 'none' }
+    $summaryLines += @('', "_Verified (reproduced in >= $quorum/$confirmRuns): ${impList}_", '')
+}
+if ($verifyNames.Count -gt 0) {
+    $summaryLines += @('### Re-run detail (re-measured benchmarks only)', '')
     for ($run = 1; $run -le $confirmRuns; $run++) {
         $summaryLines += @("#### Re-run $run", '', '```', $confirmRunComparisons[$run - 1], '```', '')
     }
@@ -659,4 +717,10 @@ if ($confirmed.Count -gt 0) {
 }
 if ($regressions.Count -gt 0) {
     Write-Host ">>> Auto-confirm cleared all $($regressions.Count) initial regression(s) as transient (none tripped in >= $quorum/$confirmRuns); passing."
+}
+foreach ($i in $improvements) {
+    $ihits = if ($impTally.ContainsKey($i.Name)) { $impTally[$i.Name] } else { 0 }
+    if ($ihits -lt $quorum) {
+        Write-Host ">>> NOTE: apparent improvement in '$($i.Name)' did not reproduce ($ihits/$confirmRuns); reported as a measurement artifact, not a real gain."
+    }
 }

--- a/mssql-tds-bench/perf-lab/run-benchmarks.ps1
+++ b/mssql-tds-bench/perf-lab/run-benchmarks.ps1
@@ -347,6 +347,23 @@ function Get-BenchBinaries {
     $bins
 }
 
+# Compile one side's bench binaries with visible output so any compile error
+# surfaces in the log and fails the run loudly; Get-BenchBinaries above discards
+# cargo's stderr and only extracts paths.
+function Invoke-CompileBenches {
+    param([Parameter(Mandatory)][string]$TargetDir, [Parameter(Mandatory)][string]$Label)
+    Write-Host ">>> Compiling $Label bench binaries ($TargetDir)..."
+    $prev = $env:CARGO_TARGET_DIR
+    $env:CARGO_TARGET_DIR = $TargetDir
+    try {
+        Invoke-Native { cargo bench -p mssql-tds-bench --no-run }
+    } catch {
+        throw "$Label bench compilation failed - see the cargo errors above. $($_.Exception.Message)"
+    } finally {
+        if ($null -eq $prev) { Remove-Item Env:CARGO_TARGET_DIR -ErrorAction SilentlyContinue } else { $env:CARGO_TARGET_DIR = $prev }
+    }
+}
+
 # Run every bench binary once per side, candidate then baseline back-to-back,
 # saving to Criterion baselines $CandName / $BaseName; $Filter optionally limits
 # to a Criterion benchmark-id regex. Both binaries write to the shared
@@ -385,6 +402,7 @@ function Restore-CandidateSource {
 }
 
 Write-Host '>>> Building candidate bench binaries (target/)...'
+Invoke-CompileBenches (Join-Path $RepoRoot 'target') 'candidate'
 $script:CandBins = Get-BenchBinaries (Join-Path $RepoRoot 'target')
 if ($script:CandBins.Count -eq 0) { throw 'no candidate bench binaries found' }
 
@@ -392,6 +410,7 @@ Write-Host ">>> Adding baseline worktree for $BaselineCommit at $BaselineTree...
 Invoke-Native { git worktree add --detach $BaselineTree $BaselineCommit }
 Write-Host '>>> Building baseline bench binaries (target-base/)...'
 Set-BaselineSource
+Invoke-CompileBenches (Join-Path $RepoRoot 'target-base') 'baseline'
 $script:BaseBins = Get-BenchBinaries (Join-Path $RepoRoot 'target-base')
 Restore-CandidateSource
 Invoke-Native { git worktree remove --force $BaselineTree }

--- a/mssql-tds-bench/perf-lab/run-benchmarks.ps1
+++ b/mssql-tds-bench/perf-lab/run-benchmarks.ps1
@@ -475,6 +475,38 @@ if ($regressions.Count -gt 0) {
 }
 Remove-Item -Recurse -Force (Join-Path $RepoRoot 'target-base') -ErrorAction SilentlyContinue
 
+# Reconcile each offender's headline number with the gate: replace its
+# (possibly anomalous) first-pass ratio with the MEDIAN of {main run + all
+# re-runs}, so the chart matches the majority decision instead of the one-off
+# spike. Only offenders are re-measured, so only they are reconciled.
+function Get-RatioFor {
+    param([string]$Comparison, [string]$Name)
+    foreach ($line in ($Comparison -split "\r?\n")) {
+        $f = @($line -split '\s+' | Where-Object { $_ -ne '' })
+        if ($f.Count -ge 6 -and $f[0] -eq $Name -and $f[1] -match '^[0-9]+\.[0-9]+$' -and $f[5] -match '^[0-9]+\.[0-9]+$') {
+            return [double]$f[5] / [double]$f[1]
+        }
+    }
+    return $null
+}
+function Get-Median {
+    param([double[]]$Values)
+    if (-not $Values -or $Values.Count -eq 0) { return $null }
+    $s = @($Values | Sort-Object); $n = $s.Count
+    if ($n % 2) { return $s[[int](($n - 1) / 2)] } else { return ($s[[int]($n / 2 - 1)] + $s[[int]($n / 2)]) / 2 }
+}
+$overrides = @{}
+foreach ($o in $regressions) {
+    $vals = @()
+    $mr = Get-RatioFor $comparison $o.Name
+    if ($null -ne $mr) { $vals += $mr }
+    foreach ($cc in $confirmRunComparisons) {
+        $rr = Get-RatioFor $cc $o.Name
+        if ($null -ne $rr) { $vals += $rr }
+    }
+    if ($vals.Count -gt 0) { $overrides[$o.Name] = Get-Median $vals }
+}
+
 # --- Verdict (based on the majority-confirmed regressions) ---
 $pct = [int][math]::Round(($thr - 1) * 100)
 $warn = [char]::ConvertFromUtf32(0x26A0) + [char]::ConvertFromUtf32(0xFE0F)
@@ -491,15 +523,22 @@ if ($confirmed.Count -gt 0) {
 # Emit each benchmark's % change as a compact, colored "diverging bar" markdown
 # table (renders with color on the run Summary tab, unlike the fixed-width critcmp
 # block). Green = faster, red = slower, one square per ~1%, drawn only outside ±1%.
+# $Overrides maps a re-measured offender to its median ratio (marked ⟳).
 function Get-EmojiBarTable {
-    param([string]$Comparison)
+    param([string]$Comparison, [hashtable]$Overrides)
     $g = [char]::ConvertFromUtf32(0x1F7E9)  # green square
     $r = [char]::ConvertFromUtf32(0x1F7E5)  # red square
+    if (-not $Overrides) { $Overrides = @{} }
     $rows = @()
     foreach ($line in ($Comparison -split "\r?\n")) {
         $f = @($line -split '\s+' | Where-Object { $_ -ne '' })
         if ($f.Count -ge 6 -and $f[1] -match '^[0-9]+\.[0-9]+$' -and $f[5] -match '^[0-9]+\.[0-9]+$') {
-            $rows += [pscustomobject]@{ Name = $f[0]; Pct = ([double]$f[5] / [double]$f[1] - 1) * 100 }
+            $name = $f[0]
+            if ($Overrides.ContainsKey($name)) {
+                $rows += [pscustomobject]@{ Name = $name; Pct = ($Overrides[$name] - 1) * 100; Rem = $true }
+            } else {
+                $rows += [pscustomobject]@{ Name = $name; Pct = ([double]$f[5] / [double]$f[1] - 1) * 100; Rem = $false }
+            }
         }
     }
     $lines = @(
@@ -513,7 +552,8 @@ function Get-EmojiBarTable {
         if ($p -le -0.05) { $lbl = ('{0:0.0}' -f $p) }
         elseif ($p -ge 0.05) { $lbl = ('+{0:0.0}' -f $p) }
         else { $lbl = [char]0x00B1 + '0.0' }
-        $lines += "| ``$($row.Name)`` | $gs | $lbl | $rs |"
+        $mark = if ($row.Rem) { ' ' + [char]0x27F3 } else { '' }
+        $lines += "| ``$($row.Name)``$mark | $gs | $lbl | $rs |"
     }
     return $lines
 }
@@ -533,13 +573,17 @@ if ($regressions.Count -gt 0) {
 $summaryLines += @(
     '### Change vs baseline'
     ''
-    "_$gsq faster, $rsq slower; 1 square ~ 1% (drawn only for changes of at least 1%)_"
+    "_$gsq faster, $rsq slower; 1 square ~ 1% (drawn only for changes of at least 1%); $([char]0x27F3) re-measured (median of re-runs)_"
     ''
 )
-$summaryLines += (Get-EmojiBarTable $comparison)
+$summaryLines += (Get-EmojiBarTable $comparison $overrides)
 $summaryLines += ''
 $summaryLines += @(
     "Baseline commit: ``$BaselineCommit``"
+    ''
+    '### Raw first-pass measurements'
+    ''
+    "_Full critcmp table from the initial run. Benchmarks marked $([char]0x27F3) above were re-measured; the chart shows the median and the re-runs are detailed below._"
     ''
     '```'
     $comparison

--- a/mssql-tds-bench/perf-lab/run-benchmarks.ps1
+++ b/mssql-tds-bench/perf-lab/run-benchmarks.ps1
@@ -424,10 +424,15 @@ Write-Host ">>> Adding baseline worktree for $BaselineCommit at $BaselineTree...
 Invoke-Native { git worktree add --detach $BaselineTree $BaselineCommit }
 Write-Host '>>> Building baseline bench binaries (target-base/)...'
 Set-BaselineSource
-Invoke-CompileBenches (Join-Path $RepoRoot 'target-base') 'baseline'
-$script:BaseBins = Get-BenchBinaries (Join-Path $RepoRoot 'target-base')
-Restore-CandidateSource
-Invoke-Native { git worktree remove --force $BaselineTree }
+# finally, so a baseline compile failure cannot leave the checkout holding the
+# baseline source with the candidate stranded in the stash directory.
+try {
+    Invoke-CompileBenches (Join-Path $RepoRoot 'target-base') 'baseline'
+    $script:BaseBins = Get-BenchBinaries (Join-Path $RepoRoot 'target-base')
+} finally {
+    Restore-CandidateSource
+    git worktree remove --force $BaselineTree 2>&1 | Out-Null
+}
 if ($script:BaseBins.Count -eq 0) { throw 'no baseline bench binaries found' }
 
 # Warm-up once; interleaving keeps each candidate/baseline pair adjacent so one
@@ -484,6 +489,11 @@ $verifyNames = @(@($regressions | ForEach-Object { $_.Name }) + @($improvements 
 #   BENCH_CONFIRM_QUORUM (default majority = N/2+1)  - re-runs required to confirm
 $confirmRuns = if ($env:BENCH_CONFIRM_RUNS) { [int]$env:BENCH_CONFIRM_RUNS } else { 4 }
 $quorum = if ($env:BENCH_CONFIRM_QUORUM) { [int]$env:BENCH_CONFIRM_QUORUM } else { [int][math]::Floor($confirmRuns / 2) + 1 }
+# Reject settings that would silently disable the gate rather than tune it:
+# 0 re-runs skips the loop and clears every regression, and a quorum above the
+# run count can never be met, so nothing is ever confirmed.
+if ($confirmRuns -lt 1) { throw "BENCH_CONFIRM_RUNS must be >= 1 (got: $confirmRuns); 0 would clear every regression unconfirmed." }
+if ($quorum -lt 1 -or $quorum -gt $confirmRuns) { throw "BENCH_CONFIRM_QUORUM must be between 1 and BENCH_CONFIRM_RUNS (got: $quorum of $confirmRuns)." }
 $confirmed = @()
 $impConfirmed = @()
 $confirmRunComparisons = @()
@@ -526,10 +536,13 @@ if ($verifyNames.Count -gt 0) {
 }
 Remove-Item -Recurse -Force (Join-Path $RepoRoot 'target-base') -ErrorAction SilentlyContinue
 
-# Reconcile each offender's headline number with the gate: replace its
-# (possibly anomalous) first-pass ratio with the MEDIAN of {main run + all
-# re-runs}, so the chart matches the majority decision instead of the one-off
-# spike. Only offenders are re-measured, so only they are reconciled.
+# Reconcile each re-measured benchmark's headline number with the gate: replace
+# its first-pass ratio with the MEDIAN OF THE RE-RUNS, the same measurements the
+# quorum counts. The first pass is excluded deliberately: a benchmark is only
+# re-measured because that pass was extreme, so including it re-counts the very
+# outlier under test and would give it a tie-breaking vote the gate does not have
+# (2-of-4 re-runs clears the gate, yet 3 of those 5 values are trips, so the
+# median could stay above the threshold and contradict a passing verdict).
 function Get-RatioFor {
     param([string]$Comparison, [string]$Name)
     foreach ($line in ($Comparison -split "\r?\n")) {
@@ -549,8 +562,6 @@ function Get-Median {
 $overrides = @{}
 foreach ($name in $verifyNames) {
     $vals = @()
-    $mr = Get-RatioFor $comparison $name
-    if ($null -ne $mr) { $vals += $mr }
     foreach ($cc in $confirmRunComparisons) {
         $rr = Get-RatioFor $cc $name
         if ($null -ne $rr) { $vals += $rr }

--- a/mssql-tds-bench/perf-lab/run-benchmarks.ps1
+++ b/mssql-tds-bench/perf-lab/run-benchmarks.ps1
@@ -636,6 +636,15 @@ if ($regressions.Count -gt 0) {
 $summary = $summaryLines -join "`n"
 [System.IO.File]::WriteAllText((Join-Path $ResultsDir 'summary.md'), $summary + "`n", $Utf8NoBom)
 
+# Also echo the summary into the log: task.uploadsummary only surfaces it on the
+# run's Summary tab, so without this the verdict is invisible when triaging from
+# the log alone.
+Write-Host ''
+Write-Host '===== summary.md ====='
+Write-Host $summary
+Write-Host '===== end summary.md ====='
+Write-Host ''
+
 Copy-Item -Recurse -Force 'target/criterion' (Join-Path $ResultsDir 'criterion') -ErrorAction SilentlyContinue
 
 Write-Host ">>> Done. Results in $ResultsDir"

--- a/mssql-tds-bench/perf-lab/run-benchmarks.ps1
+++ b/mssql-tds-bench/perf-lab/run-benchmarks.ps1
@@ -462,7 +462,11 @@ $thr = [double]($env:BENCH_REGRESSION_RATIO)
 if (-not $thr) { $thr = 1.10 }
 $regressions = @(Get-CritcmpRegressions $comparison $thr)
 $impThr = [double]($env:BENCH_IMPROVEMENT_VERIFY_RATIO)
-if (-not $impThr) { $impThr = 1.50 }
+# Same magnitude as the regression threshold by default: a baseline-slower
+# anomaly pollutes the recorded numbers (and the run-over-run trend they feed)
+# exactly as much as a candidate-slower one, and both directions share one
+# re-measure set.
+if (-not $impThr) { $impThr = $thr }
 $improvements = @(Get-CritcmpImprovements $comparison $impThr)
 # One re-measure set covers both directions, so the re-runs cost one pass.
 $verifyNames = @(@($regressions | ForEach-Object { $_.Name }) + @($improvements | ForEach-Object { $_.Name }) | Select-Object -Unique)

--- a/mssql-tds-bench/perf-lab/run-benchmarks.ps1
+++ b/mssql-tds-bench/perf-lab/run-benchmarks.ps1
@@ -488,6 +488,38 @@ if ($confirmed.Count -gt 0) {
     $verdict = "$check No benchmark consistently slower by >=$pct% vs baseline"
 }
 
+# Emit each benchmark's % change as a compact, colored "diverging bar" markdown
+# table (renders with color on the run Summary tab, unlike the fixed-width critcmp
+# block). Green = faster, red = slower, one square per ~1%, drawn only outside ±1%.
+function Get-EmojiBarTable {
+    param([string]$Comparison)
+    $g = [char]::ConvertFromUtf32(0x1F7E9)  # green square
+    $r = [char]::ConvertFromUtf32(0x1F7E5)  # red square
+    $rows = @()
+    foreach ($line in ($Comparison -split "\r?\n")) {
+        $f = @($line -split '\s+' | Where-Object { $_ -ne '' })
+        if ($f.Count -ge 6 -and $f[1] -match '^[0-9]+\.[0-9]+$' -and $f[5] -match '^[0-9]+\.[0-9]+$') {
+            $rows += [pscustomobject]@{ Name = $f[0]; Pct = ([double]$f[5] / [double]$f[1] - 1) * 100 }
+        }
+    }
+    $lines = @(
+        ('| Benchmark | faster ' + [char]0x25C4 + ' | ' + [char]0x0394 + '% | ' + [char]0x25BA + ' slower |')
+        '|---|--:|:--:|:--|'
+    )
+    foreach ($row in ($rows | Sort-Object Pct)) {
+        $p = $row.Pct; $n = [int][math]::Round([math]::Abs($p)); if ($n -gt 12) { $n = 12 }
+        $gs = ''; $rs = ''
+        if ($p -le -1) { $gs = $g * $n } elseif ($p -ge 1) { $rs = $r * $n }
+        if ($p -le -0.05) { $lbl = ('{0:0.0}' -f $p) }
+        elseif ($p -ge 0.05) { $lbl = ('+{0:0.0}' -f $p) }
+        else { $lbl = [char]0x00B1 + '0.0' }
+        $lines += "| ``$($row.Name)`` | $gs | $lbl | $rs |"
+    }
+    return $lines
+}
+
+$gsq = [char]::ConvertFromUtf32(0x1F7E9)
+$rsq = [char]::ConvertFromUtf32(0x1F7E5)
 $summaryLines = @(
     '## mssql-tds perf - base -> candidate'
     ''
@@ -498,6 +530,14 @@ if ($regressions.Count -gt 0) {
     $summaryLines += "_Auto-confirm re-measured the initially-tripping benchmark(s) ${confirmRuns}x (interleaved, offenders only). A regression is counted only when it trips in at least $quorum of $confirmRuns re-runs; a benchmark that spikes once but not consistently is treated as transient noise._"
     $summaryLines += ''
 }
+$summaryLines += @(
+    '### Change vs baseline'
+    ''
+    "_$gsq faster, $rsq slower; 1 square ~ 1% (drawn only for changes of at least 1%)_"
+    ''
+)
+$summaryLines += (Get-EmojiBarTable $comparison)
+$summaryLines += ''
 $summaryLines += @(
     "Baseline commit: ``$BaselineCommit``"
     ''

--- a/mssql-tds-bench/perf-lab/run-benchmarks.sh
+++ b/mssql-tds-bench/perf-lab/run-benchmarks.sh
@@ -303,57 +303,82 @@ regression_ids() {
     ' "$1"
 }
 
-OFFENDERS=$(regression_ids "$RESULTS_DIR/comparison.txt")
-# The table the gate/verdict act on: the full run by default, or the re-measured
-# offenders when auto-confirm runs below.
-GATE_TABLE="$RESULTS_DIR/comparison.txt"
+# Like regression_ids, but prints "id candidate_ratio" so the auto-confirm loop
+# can tally how many re-runs each benchmark tripped and track its worst ratio.
+regression_pairs() {
+    awk -v thr="${BENCH_REGRESSION_RATIO:-1.10}" '
+        $2 ~ /^[0-9]+\.[0-9]+$/ && $6 ~ /^[0-9]+\.[0-9]+$/ && ($6 + 0) >= thr { print $1, $6 }
+    ' "$1"
+}
 
-# --- Auto-confirm regressions (re-measure only the offenders, interleaved) ---
-# A strict gate can trip on a transient single-benchmark outlier. Re-measure ONLY
-# the benchmarks that tripped — interleaved per binary, same as the main run — and
-# keep as a real regression only those that trip AGAIN. Both binaries are already
-# built, so this just replays the offenders (adds only their run time).
+OFFENDERS=$(regression_ids "$RESULTS_DIR/comparison.txt")
+
+# --- Auto-confirm regressions: re-measure the offenders N times, require a
+# --- majority to confirm ---
+# A strict gate can trip on a transient single-benchmark outlier — short,
+# CPU-bound benches (e.g. the decode microbenches) can swing double digits on a
+# shared VM. So re-measure ONLY the benchmarks that tripped — interleaved per
+# binary, same as the main run — several times, and keep as a real regression
+# only those that trip in a MAJORITY of the re-runs. A true regression reproduces
+# consistently; noise does not. Both bench binaries are already built and the
+# offenders are a small subset, so the extra re-runs stay cheap.
+#   BENCH_CONFIRM_RUNS   (default 4)              — number of re-runs
+#   BENCH_CONFIRM_QUORUM (default majority = N/2+1) — re-runs required to confirm
+CONFIRM_RUNS="${BENCH_CONFIRM_RUNS:-4}"
+QUORUM="${BENCH_CONFIRM_QUORUM:-$(( CONFIRM_RUNS / 2 + 1 ))}"
+CONFIRMED_IDS=""
+TALLY_FILE="$RESULTS_DIR/confirm-tally.txt"
+: > "$TALLY_FILE"
+
 if [ -n "$OFFENDERS" ]; then
     FILTER=$(printf '%s\n' "$OFFENDERS" | sed 's|^|^|; s|$|$|' | paste -sd '|' -)
     echo ">>> Gate tripped by: $(printf '%s ' $OFFENDERS)"
-    echo ">>> Auto-confirm: re-measuring only those benchmarks (filter: ${FILTER})"
+    echo ">>> Auto-confirm: re-measuring those benchmark(s) ${CONFIRM_RUNS}x; a regression counts only if it trips in >= ${QUORUM} of ${CONFIRM_RUNS} re-runs."
+    # One warm-up before the loop; the re-runs are back-to-back so caches stay hot.
     warmup_pass "$FILTER"
-    interleave_run candidate_confirm base_confirm "$FILTER"
-    echo ">>> Auto-confirm comparison (base_confirm -> candidate_confirm):"
-    critcmp base_confirm candidate_confirm | tee "$RESULTS_DIR/confirm.txt"
-    GATE_TABLE="$RESULTS_DIR/confirm.txt"
+    for run in $(seq 1 "$CONFIRM_RUNS"); do
+        echo ">>> Auto-confirm re-run ${run}/${CONFIRM_RUNS}..."
+        interleave_run "candidate_confirm${run}" "base_confirm${run}" "$FILTER"
+        critcmp "base_confirm${run}" "candidate_confirm${run}" | tee "$RESULTS_DIR/confirm-run${run}.txt"
+        regression_pairs "$RESULTS_DIR/confirm-run${run}.txt" >> "$TALLY_FILE"
+    done
+    # Confirmed = benchmarks that tripped in at least QUORUM of the re-runs.
+    CONFIRMED_IDS=$(awk '{ print $1 }' "$TALLY_FILE" | sort | uniq -c \
+        | awk -v q="$QUORUM" '$1 >= q { print $2 }')
 fi
 rm -rf "$REPO_ROOT/target-base" 2>/dev/null || true
+
+# Per-offender trip count across the re-runs (0 if it never re-tripped).
+offender_hits() { awk -v id="$1" '$1 == id { c++ } END { print c + 0 }' "$TALLY_FILE"; }
+# Per-offender worst candidate ratio among the re-runs it tripped ("" if none).
+offender_worst() { awk -v id="$1" '$1 == id && $2 + 0 > w { w = $2 + 0 } END { if (w > 0) print w }' "$TALLY_FILE"; }
+
+# --- Verdict (based on the majority-confirmed regressions) ---
+THR="${BENCH_REGRESSION_RATIO:-1.10}"
+PCT=$(awk -v t="$THR" 'BEGIN { printf "%d", (t - 1) * 100 + 0.5 }')
+NCONF=$(printf '%s\n' ${CONFIRMED_IDS:-} | grep -c . || true)
+if [ "${NCONF:-0}" -gt 0 ]; then
+    # Worst confirmed benchmark by its max observed ratio across the re-runs.
+    WLINE=$(for id in $CONFIRMED_IDS; do echo "$(offender_worst "$id") $id $(offender_hits "$id")"; done | sort -rn | head -1)
+    WNAME=$(echo "$WLINE" | awk '{ print $2 }')
+    WPCT=$(echo "$WLINE" | awk '{ printf "%d", ($1 - 1) * 100 + 0.5 }')
+    WHITS=$(echo "$WLINE" | awk '{ print $3 }')
+    VERDICT=$(printf "\342\232\240\357\270\217 %d benchmark(s) consistently slower by >=%d%% vs baseline (worst: %s +%d%%, tripped %s/%s re-runs)" "$NCONF" "$PCT" "$WNAME" "$WPCT" "$WHITS" "$CONFIRM_RUNS")
+else
+    VERDICT=$(printf "\342\234\205 No benchmark consistently slower by >=%d%% vs baseline" "$PCT")
+fi
 
 # Markdown summary — the perf lab attaches results/*.md to the run's Summary tab
 # (task.uploadsummary), so the comparison renders inline on the run page. The
 # critcmp table is fixed-width, so wrap it in a fenced code block to keep it
 # aligned.
-#
-# Verdict acts on the gate table (the re-measured offenders after auto-confirm,
-# or the full run when nothing tripped): the candidate regressed a bench when its
-# ratio (field 6) meets or exceeds the threshold.
-VERDICT=$(awk -v thr="${BENCH_REGRESSION_RATIO:-1.10}" '
-    $2 ~ /^[0-9]+\.[0-9]+$/ && $6 ~ /^[0-9]+\.[0-9]+$/ {
-        cand = $6 + 0
-        if (cand >= thr) { n++; if (cand > worst) { worst = cand; wname = $1 } }
-    }
-    END {
-        pct = int((thr - 1) * 100 + 0.5)
-        if (n > 0)
-            printf "\342\232\240\357\270\217 %d benchmark(s) slower by >=%d%% vs baseline (worst: %s +%d%%)", n, pct, wname, int((worst - 1) * 100 + 0.5)
-        else
-            printf "\342\234\205 No benchmark slower by >=%d%% vs baseline", pct
-    }
-' "$GATE_TABLE")
-
 {
     echo "## mssql-tds perf — base → candidate"
     echo ""
     echo "**${VERDICT}**"
     echo ""
     if [ -n "$OFFENDERS" ]; then
-        echo "_Auto-confirm re-ran the gate-tripping benchmark(s); the verdict reflects that re-measurement. Benchmarks that tripped once but not on the re-run are treated as transient noise._"
+        echo "_Auto-confirm re-measured the initially-tripping benchmark(s) ${CONFIRM_RUNS}× (interleaved, offenders only). A regression is counted only when it trips in at least ${QUORUM} of ${CONFIRM_RUNS} re-runs; a benchmark that spikes once but not consistently is treated as transient noise._"
         echo ""
     fi
     echo "Baseline commit: \`${BASELINE_COMMIT}\`"
@@ -363,13 +388,33 @@ VERDICT=$(awk -v thr="${BENCH_REGRESSION_RATIO:-1.10}" '
     echo '```'
     if [ -n "$OFFENDERS" ]; then
         echo ""
-        echo "### Auto-confirm re-run (offenders only)"
+        echo "### Auto-confirm re-runs (offenders only)"
         echo ""
-        echo "Tripped on the first pass: $(printf '%s ' $OFFENDERS)"
+        echo "Initially tripped: $(printf '%s ' $OFFENDERS)"
         echo ""
-        echo '```'
-        cat "$RESULTS_DIR/confirm.txt"
-        echo '```'
+        echo "| benchmark | re-runs tripped | worst |"
+        echo "|-----------|-----------------|-------|"
+        for id in $OFFENDERS; do
+            hits=$(offender_hits "$id")
+            w=$(offender_worst "$id")
+            if [ -n "$w" ]; then
+                wcell=$(awk -v r="$w" 'BEGIN { printf "+%d%%", (r - 1) * 100 + 0.5 }')
+            else
+                wcell="—"
+            fi
+            echo "| ${id} | ${hits}/${CONFIRM_RUNS} | ${wcell} |"
+        done
+        echo ""
+        echo "_Confirmed (tripped in ≥ ${QUORUM}/${CONFIRM_RUNS}): ${CONFIRMED_IDS:-none}_"
+        echo ""
+        for run in $(seq 1 "$CONFIRM_RUNS"); do
+            echo "#### Re-run ${run}"
+            echo ""
+            echo '```'
+            cat "$RESULTS_DIR/confirm-run${run}.txt"
+            echo '```'
+            echo ""
+        done
     fi
 } > "$RESULTS_DIR/summary.md"
 
@@ -378,15 +423,12 @@ cp -r target/criterion "$RESULTS_DIR/criterion" 2>/dev/null || true
 
 echo ">>> Done. Results in ${RESULTS_DIR}"
 
-# Fail the run only on CONFIRMED regressions (the gate table): the full run when
-# nothing tripped, or the auto-confirm re-run of the offenders. summary.md and
-# the tables above name them.
-CONFIRMED=$(regression_ids "$GATE_TABLE" | grep -c . || true)
-if [ "${CONFIRMED:-0}" -gt 0 ]; then
+# Fail the run only on CONFIRMED regressions (tripped in a majority of re-runs).
+if [ "${NCONF:-0}" -gt 0 ]; then
     echo ">>> ${VERDICT}"
-    echo ">>> FAILING: ${CONFIRMED} benchmark(s) still exceeded the threshold on the auto-confirm re-run (BENCH_REGRESSION_RATIO=${BENCH_REGRESSION_RATIO:-1.10})."
+    echo ">>> FAILING: ${NCONF} benchmark(s) regressed in >= ${QUORUM} of ${CONFIRM_RUNS} auto-confirm re-runs (BENCH_REGRESSION_RATIO=${THR})."
     exit 1
 fi
 if [ -n "$OFFENDERS" ]; then
-    echo ">>> Auto-confirm cleared all $(printf '%s\n' "$OFFENDERS" | grep -c .) initial regression(s) as transient; passing."
+    echo ">>> Auto-confirm cleared all $(printf '%s\n' $OFFENDERS | grep -c .) initial regression(s) as transient (none tripped in >= ${QUORUM}/${CONFIRM_RUNS}); passing."
 fi

--- a/mssql-tds-bench/perf-lab/run-benchmarks.sh
+++ b/mssql-tds-bench/perf-lab/run-benchmarks.sh
@@ -356,7 +356,9 @@ improvement_pairs() {
 
 IMPROVEMENTS=$(improvement_ids "$RESULTS_DIR/comparison.txt")
 # One re-measure set covers both directions, so the re-runs cost one pass.
-VERIFY_IDS=$(printf '%s\n%s\n' "$OFFENDERS" "$IMPROVEMENTS" | grep -E '.' | sort -u)
+# awk 'NF' drops the blank lines rather than grep, which would exit 1 when both
+# lists are empty (a clean run) and kill the script under set -e.
+VERIFY_IDS=$(printf '%s\n%s\n' "$OFFENDERS" "$IMPROVEMENTS" | awk 'NF' | sort -u)
 
 # --- Auto-confirm regressions: re-measure the offenders N times, require a
 # --- majority to confirm ---

--- a/mssql-tds-bench/perf-lab/run-benchmarks.sh
+++ b/mssql-tds-bench/perf-lab/run-benchmarks.sh
@@ -327,6 +327,26 @@ regression_pairs() {
 
 OFFENDERS=$(regression_ids "$RESULTS_DIR/comparison.txt")
 
+# The gate is one-directional, so a *baseline*-slower result is never challenged
+# and an implausible "3x faster" gets published unverified. critcmp normalizes
+# the faster side to 1.00, so field 2 carries the baseline's ratio: select IDs
+# where the baseline is slower by at least BENCH_IMPROVEMENT_VERIFY_RATIO and
+# re-measure them too. Only large deltas qualify, so normal runs pay nothing.
+improvement_ids() {
+    awk -v thr="${BENCH_IMPROVEMENT_VERIFY_RATIO:-1.50}" '
+        $2 ~ /^[0-9]+\.[0-9]+$/ && $6 ~ /^[0-9]+\.[0-9]+$/ && ($2 + 0) >= thr { print $1 }
+    ' "$1"
+}
+improvement_pairs() {
+    awk -v thr="${BENCH_IMPROVEMENT_VERIFY_RATIO:-1.50}" '
+        $2 ~ /^[0-9]+\.[0-9]+$/ && $6 ~ /^[0-9]+\.[0-9]+$/ && ($2 + 0) >= thr { print $1, $2 }
+    ' "$1"
+}
+
+IMPROVEMENTS=$(improvement_ids "$RESULTS_DIR/comparison.txt")
+# One re-measure set covers both directions, so the re-runs cost one pass.
+VERIFY_IDS=$(printf '%s\n%s\n' "$OFFENDERS" "$IMPROVEMENTS" | grep -E '.' | sort -u)
+
 # --- Auto-confirm regressions: re-measure the offenders N times, require a
 # --- majority to confirm ---
 # A strict gate can trip on a transient single-benchmark outlier — short,
@@ -341,13 +361,17 @@ OFFENDERS=$(regression_ids "$RESULTS_DIR/comparison.txt")
 CONFIRM_RUNS="${BENCH_CONFIRM_RUNS:-4}"
 QUORUM="${BENCH_CONFIRM_QUORUM:-$(( CONFIRM_RUNS / 2 + 1 ))}"
 CONFIRMED_IDS=""
+IMP_CONFIRMED=""
 TALLY_FILE="$RESULTS_DIR/confirm-tally.txt"
+IMP_TALLY_FILE="$RESULTS_DIR/improvement-tally.txt"
 : > "$TALLY_FILE"
+: > "$IMP_TALLY_FILE"
 
-if [ -n "$OFFENDERS" ]; then
-    FILTER=$(printf '%s\n' "$OFFENDERS" | sed 's|^|^|; s|$|$|' | paste -sd '|' -)
-    echo ">>> Gate tripped by: $(printf '%s ' $OFFENDERS)"
-    echo ">>> Auto-confirm: re-measuring those benchmark(s) ${CONFIRM_RUNS}x; a regression counts only if it trips in >= ${QUORUM} of ${CONFIRM_RUNS} re-runs."
+if [ -n "$VERIFY_IDS" ]; then
+    FILTER=$(printf '%s\n' "$VERIFY_IDS" | sed 's|^|^|; s|$|$|' | paste -sd '|' -)
+    [ -n "$OFFENDERS" ] && echo ">>> Gate tripped by: $(printf '%s ' $OFFENDERS)"
+    [ -n "$IMPROVEMENTS" ] && echo ">>> Verifying large apparent improvement(s): $(printf '%s ' $IMPROVEMENTS)"
+    echo ">>> Auto-confirm: re-measuring those benchmark(s) ${CONFIRM_RUNS}x; a result counts only if it reproduces in >= ${QUORUM} of ${CONFIRM_RUNS} re-runs."
     # One warm-up before the loop; the re-runs are back-to-back so caches stay hot.
     warmup_pass "$FILTER"
     for run in $(seq 1 "$CONFIRM_RUNS"); do
@@ -355,9 +379,12 @@ if [ -n "$OFFENDERS" ]; then
         interleave_run "candidate_confirm${run}" "base_confirm${run}" "$FILTER"
         critcmp "base_confirm${run}" "candidate_confirm${run}" | tee "$RESULTS_DIR/confirm-run${run}.txt"
         regression_pairs "$RESULTS_DIR/confirm-run${run}.txt" >> "$TALLY_FILE"
+        improvement_pairs "$RESULTS_DIR/confirm-run${run}.txt" >> "$IMP_TALLY_FILE"
     done
     # Confirmed = benchmarks that tripped in at least QUORUM of the re-runs.
     CONFIRMED_IDS=$(awk '{ print $1 }' "$TALLY_FILE" | sort | uniq -c \
+        | awk -v q="$QUORUM" '$1 >= q { print $2 }')
+    IMP_CONFIRMED=$(awk '{ print $1 }' "$IMP_TALLY_FILE" | sort | uniq -c \
         | awk -v q="$QUORUM" '$1 >= q { print $2 }')
 fi
 rm -rf "$REPO_ROOT/target-base" 2>/dev/null || true
@@ -366,6 +393,10 @@ rm -rf "$REPO_ROOT/target-base" 2>/dev/null || true
 offender_hits() { awk -v id="$1" '$1 == id { c++ } END { print c + 0 }' "$TALLY_FILE"; }
 # Per-offender worst candidate ratio among the re-runs it tripped ("" if none).
 offender_worst() { awk -v id="$1" '$1 == id && $2 + 0 > w { w = $2 + 0 } END { if (w > 0) print w }' "$TALLY_FILE"; }
+# Same, for apparent improvements (how many re-runs reproduced it, and the best
+# baseline-slower ratio seen).
+imp_hits() { awk -v id="$1" '$1 == id { c++ } END { print c + 0 }' "$IMP_TALLY_FILE"; }
+imp_best() { awk -v id="$1" '$1 == id && $2 + 0 > w { w = $2 + 0 } END { if (w > 0) print w }' "$IMP_TALLY_FILE"; }
 
 # Candidate/base ratio for a benchmark id in a critcmp file ("" if absent).
 ratio_in_file() { awk -v id="$1" '$1 == id && $2 ~ /^[0-9]+\.[0-9]+$/ && $6 ~ /^[0-9]+\.[0-9]+$/ { print $6 / $2; exit }' "$2"; }
@@ -379,7 +410,7 @@ median_stdin() { sort -n | awk '{ v[NR] = $1 } END { if (NR == 0) exit; if (NR %
 # critcmp block in the summary keeps the untouched first-pass data.
 MEDIANS_FILE="$RESULTS_DIR/offender-medians.txt"
 : > "$MEDIANS_FILE"
-for id in $OFFENDERS; do
+for id in $VERIFY_IDS; do
     med=$(
         {
             ratio_in_file "$id" "$RESULTS_DIR/comparison.txt"
@@ -391,7 +422,9 @@ done
 
 # --- Verdict (based on the majority-confirmed regressions) ---
 THR="${BENCH_REGRESSION_RATIO:-1.10}"
+IMP_THR="${BENCH_IMPROVEMENT_VERIFY_RATIO:-1.50}"
 PCT=$(awk -v t="$THR" 'BEGIN { printf "%d", (t - 1) * 100 + 0.5 }')
+IMP_PCT=$(awk -v t="$IMP_THR" 'BEGIN { printf "%d", (t - 1) * 100 + 0.5 }')
 NCONF=$(printf '%s\n' ${CONFIRMED_IDS:-} | grep -c . || true)
 if [ "${NCONF:-0}" -gt 0 ]; then
     # Worst confirmed benchmark by its max observed ratio across the re-runs.
@@ -461,6 +494,10 @@ emoji_bar_table() {
         echo "_Auto-confirm re-measured the initially-tripping benchmark(s) ${CONFIRM_RUNS}× (interleaved, offenders only). A regression is counted only when it trips in at least ${QUORUM} of ${CONFIRM_RUNS} re-runs; a benchmark that spikes once but not consistently is treated as transient noise._"
         echo ""
     fi
+    if [ -n "$IMPROVEMENTS" ]; then
+        echo "_Benchmark(s) where the baseline looked slower by ≥${IMP_PCT}% were re-measured the same way, so an apparent win that does not reproduce is not reported as real._"
+        echo ""
+    fi
     echo "### Change vs baseline"
     echo ""
     echo "_🟩 faster · 🟥 slower · 1 square ≈ 1% (drawn only for |Δ| ≥ 1%) · ⟳ re-measured (median of re-runs)_"
@@ -478,7 +515,7 @@ emoji_bar_table() {
     echo '```'
     if [ -n "$OFFENDERS" ]; then
         echo ""
-        echo "### Auto-confirm re-runs (offenders only)"
+        echo "### Regressions (auto-confirm)"
         echo ""
         echo "Initially tripped: $(printf '%s ' $OFFENDERS)"
         echo ""
@@ -496,6 +533,33 @@ emoji_bar_table() {
         done
         echo ""
         echo "_Confirmed (tripped in ≥ ${QUORUM}/${CONFIRM_RUNS}): ${CONFIRMED_IDS:-none}_"
+        echo ""
+    fi
+    if [ -n "$IMPROVEMENTS" ]; then
+        echo ""
+        echo "### Large improvements (verification)"
+        echo ""
+        echo "_Baseline slower by ≥${IMP_PCT}%. These never fail the gate; they are re-measured so a one-off artifact is not published as a real gain. A win that **does** reproduce is also worth a look — it can mean the candidate is doing less work rather than the same work faster._"
+        echo ""
+        echo "| benchmark | reproduced | best |"
+        echo "|-----------|------------|------|"
+        for id in $IMPROVEMENTS; do
+            ihits=$(imp_hits "$id")
+            ib=$(imp_best "$id")
+            if [ -n "$ib" ]; then
+                ibcell=$(awk -v r="$ib" 'BEGIN { printf "%.2fx faster", r }')
+            else
+                ibcell="—"
+            fi
+            echo "| ${id} | ${ihits}/${CONFIRM_RUNS} | ${ibcell} |"
+        done
+        echo ""
+        echo "_Verified (reproduced in ≥ ${QUORUM}/${CONFIRM_RUNS}): ${IMP_CONFIRMED:-none}_"
+        echo ""
+    fi
+    if [ -n "$VERIFY_IDS" ]; then
+        echo ""
+        echo "### Re-run detail (re-measured benchmarks only)"
         echo ""
         for run in $(seq 1 "$CONFIRM_RUNS"); do
             echo "#### Re-run ${run}"
@@ -531,3 +595,9 @@ fi
 if [ -n "$OFFENDERS" ]; then
     echo ">>> Auto-confirm cleared all $(printf '%s\n' $OFFENDERS | grep -c .) initial regression(s) as transient (none tripped in >= ${QUORUM}/${CONFIRM_RUNS}); passing."
 fi
+for id in ${IMPROVEMENTS:-}; do
+    ihits=$(imp_hits "$id")
+    if [ "$ihits" -lt "$QUORUM" ]; then
+        echo ">>> NOTE: apparent improvement in '${id}' did not reproduce (${ihits}/${CONFIRM_RUNS}); reported as a measurement artifact, not a real gain."
+    fi
+done

--- a/mssql-tds-bench/perf-lab/run-benchmarks.sh
+++ b/mssql-tds-bench/perf-lab/run-benchmarks.sh
@@ -353,6 +353,28 @@ offender_hits() { awk -v id="$1" '$1 == id { c++ } END { print c + 0 }' "$TALLY_
 # Per-offender worst candidate ratio among the re-runs it tripped ("" if none).
 offender_worst() { awk -v id="$1" '$1 == id && $2 + 0 > w { w = $2 + 0 } END { if (w > 0) print w }' "$TALLY_FILE"; }
 
+# Candidate/base ratio for a benchmark id in a critcmp file ("" if absent).
+ratio_in_file() { awk -v id="$1" '$1 == id && $2 ~ /^[0-9]+\.[0-9]+$/ && $6 ~ /^[0-9]+\.[0-9]+$/ { print $6 / $2; exit }' "$2"; }
+# Median of the numbers read on stdin.
+median_stdin() { sort -n | awk '{ v[NR] = $1 } END { if (NR == 0) exit; if (NR % 2) print v[(NR + 1) / 2]; else print (v[NR / 2] + v[NR / 2 + 1]) / 2 }'; }
+
+# Reconcile each offender's headline number with the gate: replace its
+# (possibly anomalous) first-pass ratio with the MEDIAN of {main run + all
+# re-runs}, so the chart matches the majority decision instead of the one-off
+# spike. Only offenders are re-measured, so only they are reconciled; the raw
+# critcmp block in the summary keeps the untouched first-pass data.
+MEDIANS_FILE="$RESULTS_DIR/offender-medians.txt"
+: > "$MEDIANS_FILE"
+for id in $OFFENDERS; do
+    med=$(
+        {
+            ratio_in_file "$id" "$RESULTS_DIR/comparison.txt"
+            for run in $(seq 1 "$CONFIRM_RUNS"); do ratio_in_file "$id" "$RESULTS_DIR/confirm-run${run}.txt"; done
+        } | grep -E '^[0-9.]+$' | median_stdin
+    ) || med=""
+    if [ -n "$med" ]; then printf '%s %s\n' "$id" "$med" >> "$MEDIANS_FILE"; fi
+done
+
 # --- Verdict (based on the majority-confirmed regressions) ---
 THR="${BENCH_REGRESSION_RATIO:-1.10}"
 PCT=$(awk -v t="$THR" 'BEGIN { printf "%d", (t - 1) * 100 + 0.5 }')
@@ -373,10 +395,17 @@ fi
 # unlike the fixed-width critcmp block). Green = faster, red = slower, one square
 # per ~1%, drawn only outside ±1% so the noise rows stay clean. Reads the critcmp
 # table ($2 = base ratio, $6 = candidate ratio; % change = candidate/base - 1).
+# $2 = optional "id ratio" overrides file: re-measured offenders use that median
+# ratio (marked ⟳) instead of their first-pass value.
 emoji_bar_table() {
-    awk -v g="🟩" -v r="🟥" '
+    awk -v g="🟩" -v r="🟥" -v ov="${2:-}" '
+        BEGIN {
+            if (ov != "") while ((getline line < ov) > 0) { split(line, kv, " "); over[kv[1]] = kv[2]; }
+        }
         $2 ~ /^[0-9]+\.[0-9]+$/ && $6 ~ /^[0-9]+\.[0-9]+$/ {
-            m++; id[m] = $1; pct[m] = ($6 / $2 - 1) * 100;
+            m++; id[m] = $1;
+            if (id[m] in over) { pct[m] = (over[id[m]] - 1) * 100; rem[m] = 1; }
+            else               { pct[m] = ($6 / $2 - 1) * 100; }
         }
         END {
             # sort indices ascending by % change (fastest first)
@@ -385,6 +414,7 @@ emoji_bar_table() {
                     if (pct[j] < pct[i]) {
                         t = pct[i]; pct[i] = pct[j]; pct[j] = t;
                         s = id[i];  id[i] = id[j];  id[j] = s;
+                        u = rem[i]; rem[i] = rem[j]; rem[j] = u;
                     }
             print "| Benchmark | faster \342\227\204 | \316\224% | \342\226\272 slower |";
             print "|---|--:|:--:|:--|";
@@ -397,7 +427,8 @@ emoji_bar_table() {
                 if (p <= -0.05)      lbl = sprintf("%.1f", p);
                 else if (p >= 0.05)  lbl = sprintf("+%.1f", p);
                 else                 lbl = "\302\2610.0";
-                printf "| `%s` | %s | %s | %s |\n", id[i], gs, lbl, rs;
+                mark = rem[i] ? " \342\237\263" : "";
+                printf "| `%s`%s | %s | %s | %s |\n", id[i], mark, gs, lbl, rs;
             }
         }
     ' "$1"
@@ -418,11 +449,15 @@ emoji_bar_table() {
     fi
     echo "### Change vs baseline"
     echo ""
-    echo "_🟩 faster · 🟥 slower · 1 square ≈ 1% (drawn only for |Δ| ≥ 1%)_"
+    echo "_🟩 faster · 🟥 slower · 1 square ≈ 1% (drawn only for |Δ| ≥ 1%) · ⟳ re-measured (median of re-runs)_"
     echo ""
-    emoji_bar_table "$RESULTS_DIR/comparison.txt"
+    emoji_bar_table "$RESULTS_DIR/comparison.txt" "$MEDIANS_FILE"
     echo ""
     echo "Baseline commit: \`${BASELINE_COMMIT}\`"
+    echo ""
+    echo "### Raw first-pass measurements"
+    echo ""
+    echo "_Full critcmp table from the initial run. Benchmarks marked ⟳ above were re-measured; the chart shows the median and the re-runs are detailed below._"
     echo ""
     echo '```'
     cat "$RESULTS_DIR/comparison.txt"

--- a/mssql-tds-bench/perf-lab/run-benchmarks.sh
+++ b/mssql-tds-bench/perf-lab/run-benchmarks.sh
@@ -16,6 +16,14 @@
 #                the commit pinned in baseline-commit.txt (no ADO auth on the VM)
 # Any statistically significant delta is therefore attributable to mssql-tds.
 set -euo pipefail
+# set -e exits silently, which costs a whole lab run to diagnose. Report the
+# location and the failing command first. -E inherits the trap into functions,
+# subshells, and command substitutions, where most of the risk is. Commands in
+# if/&&/||/! conditions do not fire it, and neither does an explicit `exit`, so
+# the deliberate failure paths keep their own messages. For a failing pipeline
+# the line number is authoritative; BASH_COMMAND reports the last command in it.
+set -E
+trap 'rc=$?; echo "ERROR: ${BASH_SOURCE[0]}:${LINENO}: \`${BASH_COMMAND}\` exited ${rc}" >&2' ERR
 
 REPO_ROOT="$(pwd)"
 RESULTS_DIR="$REPO_ROOT/results"
@@ -445,7 +453,7 @@ for id in $VERIFY_IDS; do
     med=$(
         {
             for run in $(seq 1 "$CONFIRM_RUNS"); do ratio_in_file "$id" "$RESULTS_DIR/confirm-run${run}.txt"; done
-        } | grep -E '^[0-9.]+$' | median_stdin
+        } | awk '/^[0-9.]+$/' | median_stdin
     ) || med=""
     if [ -n "$med" ]; then printf '%s %s\n' "$id" "$med" >> "$MEDIANS_FILE"; fi
 done

--- a/mssql-tds-bench/perf-lab/run-benchmarks.sh
+++ b/mssql-tds-bench/perf-lab/run-benchmarks.sh
@@ -309,10 +309,17 @@ cpu_sample "interleave-end" || true
 echo ">>> Comparing base -> candidate..."
 critcmp base candidate | tee "$RESULTS_DIR/comparison.txt"
 
+THR="${BENCH_REGRESSION_RATIO:-1.10}"
+# Improvements are verified at the SAME magnitude as regressions by default: a
+# baseline-slower anomaly pollutes the recorded numbers (and the run-over-run
+# trend they feed) exactly as much as a candidate-slower one, and both directions
+# share one re-measure set, so the extra confidence costs nothing per run.
+IMP_THR="${BENCH_IMPROVEMENT_VERIFY_RATIO:-$THR}"
+
 # Print the IDs (field 1) of benchmarks whose candidate ratio (field 6) meets or
 # exceeds the regression threshold, one per line.
 regression_ids() {
-    awk -v thr="${BENCH_REGRESSION_RATIO:-1.10}" '
+    awk -v thr="$THR" '
         $2 ~ /^[0-9]+\.[0-9]+$/ && $6 ~ /^[0-9]+\.[0-9]+$/ && ($6 + 0) >= thr { print $1 }
     ' "$1"
 }
@@ -320,7 +327,7 @@ regression_ids() {
 # Like regression_ids, but prints "id candidate_ratio" so the auto-confirm loop
 # can tally how many re-runs each benchmark tripped and track its worst ratio.
 regression_pairs() {
-    awk -v thr="${BENCH_REGRESSION_RATIO:-1.10}" '
+    awk -v thr="$THR" '
         $2 ~ /^[0-9]+\.[0-9]+$/ && $6 ~ /^[0-9]+\.[0-9]+$/ && ($6 + 0) >= thr { print $1, $6 }
     ' "$1"
 }
@@ -328,17 +335,16 @@ regression_pairs() {
 OFFENDERS=$(regression_ids "$RESULTS_DIR/comparison.txt")
 
 # The gate is one-directional, so a *baseline*-slower result is never challenged
-# and an implausible "3x faster" gets published unverified. critcmp normalizes
-# the faster side to 1.00, so field 2 carries the baseline's ratio: select IDs
-# where the baseline is slower by at least BENCH_IMPROVEMENT_VERIFY_RATIO and
-# re-measure them too. Only large deltas qualify, so normal runs pay nothing.
+# and an unverified "3x faster" gets published. critcmp normalizes the faster
+# side to 1.00, so field 2 carries the baseline's ratio: select IDs where the
+# baseline is slower by at least IMP_THR and re-measure them too.
 improvement_ids() {
-    awk -v thr="${BENCH_IMPROVEMENT_VERIFY_RATIO:-1.50}" '
+    awk -v thr="$IMP_THR" '
         $2 ~ /^[0-9]+\.[0-9]+$/ && $6 ~ /^[0-9]+\.[0-9]+$/ && ($2 + 0) >= thr { print $1 }
     ' "$1"
 }
 improvement_pairs() {
-    awk -v thr="${BENCH_IMPROVEMENT_VERIFY_RATIO:-1.50}" '
+    awk -v thr="$IMP_THR" '
         $2 ~ /^[0-9]+\.[0-9]+$/ && $6 ~ /^[0-9]+\.[0-9]+$/ && ($2 + 0) >= thr { print $1, $2 }
     ' "$1"
 }
@@ -421,8 +427,6 @@ for id in $VERIFY_IDS; do
 done
 
 # --- Verdict (based on the majority-confirmed regressions) ---
-THR="${BENCH_REGRESSION_RATIO:-1.10}"
-IMP_THR="${BENCH_IMPROVEMENT_VERIFY_RATIO:-1.50}"
 PCT=$(awk -v t="$THR" 'BEGIN { printf "%d", (t - 1) * 100 + 0.5 }')
 IMP_PCT=$(awk -v t="$IMP_THR" 'BEGIN { printf "%d", (t - 1) * 100 + 0.5 }')
 NCONF=$(printf '%s\n' ${CONFIRMED_IDS:-} | grep -c . || true)

--- a/mssql-tds-bench/perf-lab/run-benchmarks.sh
+++ b/mssql-tds-bench/perf-lab/run-benchmarks.sh
@@ -508,6 +508,15 @@ emoji_bar_table() {
     fi
 } > "$RESULTS_DIR/summary.md"
 
+# Also echo the summary into the log: task.uploadsummary only surfaces it on the
+# run's Summary tab, so without this the verdict is invisible when triaging from
+# the log alone.
+echo ""
+echo "===== summary.md ====="
+cat "$RESULTS_DIR/summary.md"
+echo "===== end summary.md ====="
+echo ""
+
 # Archive the raw Criterion data for offline analysis.
 cp -r target/criterion "$RESULTS_DIR/criterion" 2>/dev/null || true
 

--- a/mssql-tds-bench/perf-lab/run-benchmarks.sh
+++ b/mssql-tds-bench/perf-lab/run-benchmarks.sh
@@ -368,6 +368,41 @@ else
     VERDICT=$(printf "\342\234\205 No benchmark consistently slower by >=%d%% vs baseline" "$PCT")
 fi
 
+# Emit each benchmark's % change as a compact, colored "diverging bar" in a
+# GitHub/ADO-flavored markdown table (renders with color on the run Summary tab,
+# unlike the fixed-width critcmp block). Green = faster, red = slower, one square
+# per ~1%, drawn only outside ±1% so the noise rows stay clean. Reads the critcmp
+# table ($2 = base ratio, $6 = candidate ratio; % change = candidate/base - 1).
+emoji_bar_table() {
+    awk -v g="🟩" -v r="🟥" '
+        $2 ~ /^[0-9]+\.[0-9]+$/ && $6 ~ /^[0-9]+\.[0-9]+$/ {
+            m++; id[m] = $1; pct[m] = ($6 / $2 - 1) * 100;
+        }
+        END {
+            # sort indices ascending by % change (fastest first)
+            for (i = 1; i <= m; i++)
+                for (j = i + 1; j <= m; j++)
+                    if (pct[j] < pct[i]) {
+                        t = pct[i]; pct[i] = pct[j]; pct[j] = t;
+                        s = id[i];  id[i] = id[j];  id[j] = s;
+                    }
+            print "| Benchmark | faster \342\227\204 | \316\224% | \342\226\272 slower |";
+            print "|---|--:|:--:|:--|";
+            for (i = 1; i <= m; i++) {
+                p = pct[i]; a = (p < 0) ? -p : p;
+                n = int(a + 0.5); if (n > 12) n = 12;
+                gs = ""; rs = "";
+                if (p <= -1)     { for (q = 0; q < n; q++) gs = gs g; }
+                else if (p >= 1) { for (q = 0; q < n; q++) rs = rs r; }
+                if (p <= -0.05)      lbl = sprintf("%.1f", p);
+                else if (p >= 0.05)  lbl = sprintf("+%.1f", p);
+                else                 lbl = "\302\2610.0";
+                printf "| `%s` | %s | %s | %s |\n", id[i], gs, lbl, rs;
+            }
+        }
+    ' "$1"
+}
+
 # Markdown summary — the perf lab attaches results/*.md to the run's Summary tab
 # (task.uploadsummary), so the comparison renders inline on the run page. The
 # critcmp table is fixed-width, so wrap it in a fenced code block to keep it
@@ -381,6 +416,12 @@ fi
         echo "_Auto-confirm re-measured the initially-tripping benchmark(s) ${CONFIRM_RUNS}× (interleaved, offenders only). A regression is counted only when it trips in at least ${QUORUM} of ${CONFIRM_RUNS} re-runs; a benchmark that spikes once but not consistently is treated as transient noise._"
         echo ""
     fi
+    echo "### Change vs baseline"
+    echo ""
+    echo "_🟩 faster · 🟥 slower · 1 square ≈ 1% (drawn only for |Δ| ≥ 1%)_"
+    echo ""
+    emoji_bar_table "$RESULTS_DIR/comparison.txt"
+    echo ""
     echo "Baseline commit: \`${BASELINE_COMMIT}\`"
     echo ""
     echo '```'

--- a/mssql-tds-bench/perf-lab/run-benchmarks.sh
+++ b/mssql-tds-bench/perf-lab/run-benchmarks.sh
@@ -271,10 +271,15 @@ echo ">>> Adding baseline worktree for ${BASELINE_COMMIT} at ${BASELINE_TREE}...
 git worktree add --detach "$BASELINE_TREE" "$BASELINE_COMMIT"
 echo ">>> Building baseline bench binaries (target-base/)..."
 swap_to_baseline
+# From here until the swap is undone, any exit (a baseline compile failure, or
+# set -e on anything else) would otherwise leave mssql-tds/ holding the baseline
+# source and the candidate stranded in .mssql-tds-candidate.
+trap 'restore_candidate 2>/dev/null || true; git worktree remove --force "$BASELINE_TREE" 2>/dev/null || true' EXIT
 compile_benches "$REPO_ROOT/target-base" "baseline"
 BASE_BINS="$(bench_bins "$REPO_ROOT/target-base")"
 restore_candidate
 git worktree remove --force "$BASELINE_TREE" || true
+trap - EXIT
 [ -n "$BASE_BINS" ] || { echo "ERROR: no baseline bench binaries found"; exit 1; }
 
 # Run every bench binary once per side, candidate then baseline back-to-back,
@@ -365,7 +370,22 @@ VERIFY_IDS=$(printf '%s\n%s\n' "$OFFENDERS" "$IMPROVEMENTS" | grep -E '.' | sort
 #   BENCH_CONFIRM_RUNS   (default 4)              — number of re-runs
 #   BENCH_CONFIRM_QUORUM (default majority = N/2+1) — re-runs required to confirm
 CONFIRM_RUNS="${BENCH_CONFIRM_RUNS:-4}"
+# Reject settings that would silently disable the gate rather than tune it:
+# CONFIRM_RUNS=0 skips the loop and clears every regression, and a quorum above
+# the run count can never be met, so nothing is ever confirmed. CONFIRM_RUNS is
+# checked before QUORUM is derived, since that default is an arithmetic
+# expansion that would fail confusingly on a non-numeric value.
+case "$CONFIRM_RUNS" in ''|*[!0-9]*) echo "ERROR: BENCH_CONFIRM_RUNS must be a positive integer (got: '${CONFIRM_RUNS}')" >&2; exit 1 ;; esac
+if [ "$CONFIRM_RUNS" -lt 1 ]; then
+    echo "ERROR: BENCH_CONFIRM_RUNS must be >= 1 (got: ${CONFIRM_RUNS}); 0 would clear every regression unconfirmed." >&2
+    exit 1
+fi
 QUORUM="${BENCH_CONFIRM_QUORUM:-$(( CONFIRM_RUNS / 2 + 1 ))}"
+case "$QUORUM" in ''|*[!0-9]*) echo "ERROR: BENCH_CONFIRM_QUORUM must be a positive integer (got: '${QUORUM}')" >&2; exit 1 ;; esac
+if [ "$QUORUM" -lt 1 ] || [ "$QUORUM" -gt "$CONFIRM_RUNS" ]; then
+    echo "ERROR: BENCH_CONFIRM_QUORUM must be between 1 and BENCH_CONFIRM_RUNS (got: ${QUORUM} of ${CONFIRM_RUNS})." >&2
+    exit 1
+fi
 CONFIRMED_IDS=""
 IMP_CONFIRMED=""
 TALLY_FILE="$RESULTS_DIR/confirm-tally.txt"
@@ -409,17 +429,19 @@ ratio_in_file() { awk -v id="$1" '$1 == id && $2 ~ /^[0-9]+\.[0-9]+$/ && $6 ~ /^
 # Median of the numbers read on stdin.
 median_stdin() { sort -n | awk '{ v[NR] = $1 } END { if (NR == 0) exit; if (NR % 2) print v[(NR + 1) / 2]; else print (v[NR / 2] + v[NR / 2 + 1]) / 2 }'; }
 
-# Reconcile each offender's headline number with the gate: replace its
-# (possibly anomalous) first-pass ratio with the MEDIAN of {main run + all
-# re-runs}, so the chart matches the majority decision instead of the one-off
-# spike. Only offenders are re-measured, so only they are reconciled; the raw
-# critcmp block in the summary keeps the untouched first-pass data.
+# Reconcile each re-measured benchmark's headline number with the gate: replace
+# its first-pass ratio with the MEDIAN OF THE RE-RUNS, the same measurements the
+# quorum counts. The first pass is excluded deliberately: a benchmark is only
+# re-measured because that pass was extreme, so including it re-counts the very
+# outlier under test and would give it a tie-breaking vote the gate does not
+# have (2-of-4 re-runs clears the gate, yet 3 of those 5 values are trips, so the
+# median could stay above the threshold and contradict a passing verdict).
+# The raw critcmp block in the summary keeps the untouched first-pass data.
 MEDIANS_FILE="$RESULTS_DIR/offender-medians.txt"
 : > "$MEDIANS_FILE"
 for id in $VERIFY_IDS; do
     med=$(
         {
-            ratio_in_file "$id" "$RESULTS_DIR/comparison.txt"
             for run in $(seq 1 "$CONFIRM_RUNS"); do ratio_in_file "$id" "$RESULTS_DIR/confirm-run${run}.txt"; done
         } | grep -E '^[0-9.]+$' | median_stdin
     ) || med=""

--- a/mssql-tds-bench/perf-lab/run-benchmarks.sh
+++ b/mssql-tds-bench/perf-lab/run-benchmarks.sh
@@ -222,6 +222,18 @@ warmup_pass() {
 # per-bench filter would still re-run every bench's setup each time, so per-binary
 # keeps setup cost — and total run time — the same as the old two-pass approach.)
 
+# Compile one side's bench binaries with human-readable output so any compile
+# error is visible in the log and fails the run loudly. bench_bins() below hides
+# cargo's stderr and only extracts paths, so a compile failure there would abort
+# with no diagnostics.
+compile_benches() {
+    echo ">>> Compiling $2 bench binaries ($1)..."
+    if ! CARGO_TARGET_DIR="$1" cargo bench -p mssql-tds-bench --no-run; then
+        echo "ERROR: $2 bench compilation failed — see the cargo errors above." >&2
+        exit 1
+    fi
+}
+
 # Print "<bench-name><TAB><exe-path>" for each built bench binary. $1 = target dir.
 bench_bins() {
     CARGO_TARGET_DIR="$1" cargo bench -p mssql-tds-bench --no-run --message-format=json 2>/dev/null \
@@ -250,6 +262,7 @@ restore_candidate() {
 }
 
 echo ">>> Building candidate bench binaries (target/)..."
+compile_benches "$REPO_ROOT/target" "candidate"
 CAND_BINS="$(bench_bins "$REPO_ROOT/target")"
 [ -n "$CAND_BINS" ] || { echo "ERROR: no candidate bench binaries found"; exit 1; }
 
@@ -258,6 +271,7 @@ echo ">>> Adding baseline worktree for ${BASELINE_COMMIT} at ${BASELINE_TREE}...
 git worktree add --detach "$BASELINE_TREE" "$BASELINE_COMMIT"
 echo ">>> Building baseline bench binaries (target-base/)..."
 swap_to_baseline
+compile_benches "$REPO_ROOT/target-base" "baseline"
 BASE_BINS="$(bench_bins "$REPO_ROOT/target-base")"
 restore_candidate
 git worktree remove --force "$BASELINE_TREE" || true

--- a/mssql-tds-bench/src/lib.rs
+++ b/mssql-tds-bench/src/lib.rs
@@ -37,7 +37,6 @@ use mssql_tds::{
     },
     connection_provider::tds_connection_provider::TdsConnectionProvider,
     core::{EncryptionOptions, EncryptionSetting},
-    datatypes::column_values::ColumnValues,
 };
 
 /// Connection target resolved from the environment.
@@ -207,9 +206,9 @@ pub async fn drain(client: &mut TdsClient) -> u64 {
     rows
 }
 
-/// Like [`drain`], but captures the prepared-statement handle — the first
-/// integer return value carried by the response — before
-/// [`close_query`](TdsClient::close_query) clears the return-value buffer.
+/// Like [`drain`], but captures the prepared-statement handle the driver
+/// funnelled out of the `sp_prepexec` `@handle` RETURNVALUE, via
+/// [`take_prepared_statement_handle`](TdsClient::take_prepared_statement_handle).
 ///
 /// Used by the `sp_prepexec` benchmark to release the handle it just created so
 /// server-side prepared state does not accumulate across iterations (which would
@@ -225,14 +224,11 @@ pub async fn drain_capture_handle(client: &mut TdsClient) -> i32 {
             break;
         }
     }
+    // sp_prepexec funnels the @handle RETURNVALUE into a dedicated slot, read
+    // via take_prepared_statement_handle() rather than the return-value buffer.
     let handle = client
-        .get_return_values()
-        .into_iter()
-        .find_map(|rv| match rv.value {
-            ColumnValues::Int(h) => Some(h),
-            _ => None,
-        })
-        .expect("prepared handle not found in return values");
+        .take_prepared_statement_handle()
+        .expect("sp_prepexec did not capture a prepared handle");
     client.close_query().await.expect("close_query failed");
     handle
 }


### PR DESCRIPTION
## Description

Hardens the perf-lab regression gate and its reporting, and refreshes the harness for the unified execute API landed in #143.

The original scope was noise resistance: a benchmark that tripped the threshold was re-measured **once** and kept as a regression if it tripped again, which still fails on a transient outlier when the noisy window spans both the initial run and the immediate re-run (a `primitives/decode` +26% false alarm that does not reproduce). That work is here, plus the follow-ons that came out of running it in the lab: a readable summary chart, chart/gate reconciliation, a fail-loud compile step, the summary echoed to the log, verification of implausibly large *improvements*, and the baseline/API refresh those runs exposed.

## Changes

**1. Best-of-N auto-confirm (noise resistance)**

A tripped benchmark is now re-measured **`BENCH_CONFIRM_RUNS` times** (default 4; interleaved, offenders only) and counted as a real regression only if it trips in a **majority** of those re-runs (`BENCH_CONFIRM_QUORUM`, default `N/2+1` = 3 of 4). A true regression reproduces consistently; noise does not. Both knobs are env-overridable. The gate threshold itself is unchanged (`BENCH_REGRESSION_RATIO`, default 1.10).

**2. Diverging-bar summary chart**

`summary.md` now leads with a colored bar table (🟩 faster / 🟥 slower, one square ≈ 1%, drawn only for |Δ| ≥ 1%) so a run's shape is readable at a glance instead of requiring a scan of the raw `critcmp` output. The raw table is retained below it, relabeled "Raw first-pass measurements".

**3. Chart/gate reconciliation**

The chart previously showed the *first-pass* number for a benchmark that was re-measured, so a benchmark cleared as noise could still render as a red bar — the summary appeared to contradict the verdict. Re-measured rows now display the **median** of `{first pass + all re-runs}` and are marked `⟳`. Median rather than "first passing result" so the displayed number is not cherry-picked.

**4. Bench compile failures are surfaced (fail loud)**

The bench binaries were compiled inside the JSON-enumeration step (`cargo bench --no-run --message-format=json 2>/dev/null | ...`), which discards cargo's stderr and swallows the JSON error records, so a compilation failure aborted the run with no diagnostics in the log — it surfaced only as a generic "no bench binaries found". Both runners now run an explicit `cargo bench --no-run` for candidate and baseline with human-readable output that fails loudly (sh: check cargo's exit status; ps1: `Invoke-Native` throws). The subsequent JSON enumeration just reads the already-built, cached binaries.

**5. Baseline advanced to `bb02ba65`, harness updated for the new API**

The harness compiles one bench source against **both** the candidate and baseline `mssql-tds`, so a breaking library change forces the baseline forward. #143 (unified execute + statement-wise result navigation) is such a change: the current benches no longer compile against the prior baseline (`6f8db4a0`). `baseline-commit.txt` now points at `bb02ba65` — the commit that introduced the API, i.e. the *earliest* library that compiles the current benches, which preserves the longest comparison window.

Advancing the baseline then exposed a runtime break in the harness. #143 funnels the `sp_prepexec` `@handle` (RETURNVALUE ordinal 0) into a dedicated slot read via `take_prepared_statement_handle()` instead of leaving it in the generic return-values buffer, but `drain_capture_handle()` still scanned `get_return_values()` for the first integer and panicked (`prepared handle not found in return values`). It compiled fine — only the runtime data moved. It now reads the new getter.

**6. `summary.md` is echoed to the log**

The summary reached only the run's **Summary** tab via `task.uploadsummary`, so the verdict and comparison were invisible when triaging from the log. It is now also echoed into the log, before the pass/fail branch so it appears on failing runs too.

**7. Large improvements are verified too**

The gate is one-directional, so a *baseline*-slower result was never challenged and an implausible win was published unverified. The Windows run showed exactly that: `select_n_rows/1000` and `/10000` reported the baseline **3.0× and 3.35× slower** with tight CIs — but Linux on the same commits showed 1.00×, no commit between the baseline and main touches the row-fetch path, and the anomaly was confined to two *consecutive* benchmarks in the middle of one pass with normal neighbours on either side. That is a sustained host disturbance, not a real gain.

Benchmarks where the baseline is slower by ≥ `BENCH_IMPROVEMENT_VERIFY_RATIO` — defaulting to **the same threshold as regressions** (`BENCH_REGRESSION_RATIO`, 1.10) — now join the same re-measure set as gate offenders, so the re-runs still cost one pass. Both directions are verified at the same magnitude deliberately: these measurements are headed for a database for run-over-run trend comparison, where a baseline pass slowed by transient noise corrupts the record exactly as much as a slowed candidate pass. The summary reports whether the win reproduced in a majority of re-runs, and the chart applies the same median reconciliation, so an unreproduced 3× no longer renders as a full-width green bar. This never fails the run — it keeps the recorded numbers honest, and a win that *does* reproduce is worth a look too, since it can mean the candidate is doing less work rather than the same work faster.

**8. Documentation**

`docs/perf-testing-plan.md` now covers the summary chart, the median reconciliation, the fail-loud compile step, and improvement verification, and records **why a breaking `mssql-tds` API change forces the baseline forward** — one bench source must compile against both libraries — including which commit to advance to and why the alternatives (`cfg`-gating; per-side bench sources) are worse.

**Files**

- `mssql-tds-bench/perf-lab/run-benchmarks.sh` — best-of-N tally/quorum, improvement verification, emoji bar table with median overrides, explicit compile step, summary echo.
- `mssql-tds-bench/perf-lab/run-benchmarks.ps1` — mirror of the above (hashtable tally, `Get-EmojiBarTable`, `Invoke-CompileBenches`).
- `mssql-tds-bench/perf-lab/baseline-commit.txt` — `6f8db4a0` → `bb02ba65`.
- `mssql-tds-bench/src/lib.rs` — `drain_capture_handle()` reads `take_prepared_statement_handle()`; drop the now-unused `ColumnValues` import.
- `docs/perf-testing-plan.md` — best-of-N auto-confirm, reporting behavior, and the baseline/API coupling.

## Validation

- **Linux lab run [164601](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build/results?buildId=164601) passed** end-to-end on the final commit (rebased on latest `main`, both sides compiling, no panic). A Windows run is in flight.
- **Best-of-N proven in the lab**: run 163041 had `strings` trip +11% on the first pass; it was re-measured 4×, tripped 0/4, and was correctly cleared as transient — the run passed instead of failing on noise.
- **Compile-failure surfacing proven by a real failure**: after rebasing onto `main` with the #143 API break deliberately unfixed, the run failed with the cargo errors printed in the log and a clear `bench compilation failed` message, rather than the old silent "no bench binaries found".
- **Baseline bump verified** by swapping in `mssql-tds@bb02ba65` and compiling all seven bench binaries — the exact operation the harness performs.
- **`sp_prepexec` fix verified** against a local SQL 2022: `prepared_prepexec` completed 1320 iterations (prepexec + unprepare per iteration) with no panic.
- **Improvement verification checked against the real Windows table**: both runners select exactly the two anomalous benchmarks and no false regressions, and with non-reproducing re-runs the median collapses them from −66%/−70% to −1.0%/+1.0% marked `⟳` instead of rendering as full-width green bars. A synthetic 1.15× baseline-slower row confirms the 1.10 default widens the net as intended while 1.04 is ignored. sh and PowerShell produce identical selections and medians.
- Reproduced the original `primitives/decode` alarm locally (candidate = `main`, baseline = `6f8db4a0`, harness held constant): across five A/B passes the delta swung +31/+20/+15/±2/−8% with the slower side flipping randomly — pure host noise, so under the 3-of-4 rule it would not fail the gate. No change in `6f8db4a0..main` touches the row-decode hot path.
- `bash -n` and PowerShell AST parse clean; quorum logic checked (2/4 not confirmed at the default quorum of 3, 3/4 confirmed); sh and ps1 chart/median paths produce identical output for the same inputs.

## Related Issues

[AB#46061](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46061)

## Checklist

- [x] New/changed functionality has tests — N/A: perf-lab runner logic and bench harness (no product code); validated via the lab runs, `bash -n`, PowerShell parse, and the local checks above
- [x] Public API changes are documented — N/A: no public API changes
