### PR TITLE
test(odbc-e2e): skip INFO-surfacing tests on the msodbcsql comparison leg

### DIFF
--- a/mssql-odbc/tests/e2e/include/odbc_test_fixture.h
+++ b/mssql-odbc/tests/e2e/include/odbc_test_fixture.h
@@ -23,6 +23,7 @@
 #include <string>
 #include <vector>
 #include <chrono>
+#include <cstdlib>
 
 /// SQLTCHAR-based string type for ODBC API calls.
 using SqlTString = std::basic_string<SQLTCHAR>;
@@ -67,6 +68,21 @@ using SqlTString = std::basic_string<SQLTCHAR>;
 #define EXPECT_SQLSTATE(handle_type, handle, expected_state)                    \
     EXPECT_EQ(std::string(expected_state),                                     \
               ODBCTestUtils::GetDiagState(handle_type, handle))
+
+// Skip the current test on the msodbcsql leg of a --compare-with-msodbcsql run.
+// The same test binary runs against both drivers; use this at the top of a test
+// that asserts mssql-odbc-specific behavior the full msodbcsql driver does not
+// share (e.g. a Phase-1 "HYC00 not implemented" response). The runner
+// (run_e2e.sh) exports ODBC_TEST_TARGET with the driver under test; a skipped
+// gtest case does not fail the binary, so the parity run stays green.
+#define SKIP_IF_COMPARING_MSODBCSQL()                                          \
+    do {                                                                       \
+        const char* _target = std::getenv("ODBC_TEST_TARGET");                 \
+        if (_target && std::string(_target) == "msodbcsql") {                  \
+            GTEST_SKIP() << "mssql-odbc-specific test; skipped on msodbcsql "   \
+                            "comparison leg";                                  \
+        }                                                                      \
+    } while (0)
 
 // ---------------------------------------------------------------------------
 // Forward declarations

--- a/mssql-odbc/tests/e2e/run_e2e.sh
+++ b/mssql-odbc/tests/e2e/run_e2e.sh
@@ -234,7 +234,10 @@ run_tests() {
     local rc=0
     (
         cd "$BUILD_DIR"
-        ODBCSYSINI="$ini_dir" ctest "${CTEST_ARGS[@]}" --output-junit "$junit_out"
+        # ODBC_TEST_TARGET tells tests which driver implementation this leg runs
+        # against ("mssql-odbc" or "msodbcsql") so mssql-odbc-specific tests can
+        # SKIP_IF_COMPARING_MSODBCSQL() on the reference-driver leg.
+        ODBC_TEST_TARGET="$label" ODBCSYSINI="$ini_dir" ctest "${CTEST_ARGS[@]}" --output-junit "$junit_out"
     ) || rc=$?
     return $rc
 }

--- a/mssql-odbc/tests/e2e/tests/exec_direct_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/exec_direct_test.cpp
@@ -155,6 +155,11 @@ TEST_F(ExecDirectLiveTest, DmlDoesNotOpenCursor) {
 }
 
 TEST_F(ExecDirectLiveTest, InfoMessagesSurfaceAsDiagnostics) {
+    // mssql-odbc surfaces PRINT / low-severity RAISERROR output from a
+    // no-result-set batch as SQL_SUCCESS_WITH_INFO on SQLExecDirect. msodbcsql
+    // defers these differently, so skip this assertion in the parity comparison.
+    SKIP_IF_COMPARING_MSODBCSQL();
+
     SqlTString sql = ODBCTestUtils::ToSqlTStr(
         "PRINT N'odbc info one'; RAISERROR(N'odbc info two', 10, 1) WITH NOWAIT;");
 

--- a/mssql-odbc/tests/e2e/tests/more_results_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/more_results_test.cpp
@@ -88,6 +88,11 @@ TEST_F(MoreResultsLiveTest, MultipleSelectBatchAdvances) {
 // boundary-reporting call (SQLMoreResults advance, or SQLCloseCursor) rather than
 // posting them under SQL_NO_DATA where many applications never read them.
 TEST_F(MoreResultsLiveTest, TrailingInfoBetweenResultSetsSurfacesWithHint) {
+    // mssql-odbc surfaces an INFO message emitted between two result sets on the
+    // SQLMoreResults advance as SQL_SUCCESS_WITH_INFO. msodbcsql surfaces
+    // between-result INFO differently, so skip this assertion in the comparison.
+    SKIP_IF_COMPARING_MSODBCSQL();
+
     SqlTString sql = ODBCTestUtils::ToSqlTStr(
         "SELECT 1 AS a; PRINT N'between result sets info'; SELECT 2 AS b;");
     SQLRETURN rc = SQLExecDirect(stmt_, const_cast<SQLTCHAR*>(sql.c_str()), SQL_NTS);


### PR DESCRIPTION
## Description

`./run_e2e.sh --compare-with-msodbcsql` reruns the ODBC e2e suite against msodbcsql 18 and currently fails two INFO-token tests (added in #113) that assert **mssql-odbc-specific** INFO surfacing which msodbcsql does not replicate:

- `ExecDirectLiveTest.InfoMessagesSurfaceAsDiagnostics` — a no-result-set `PRINT` / low-severity `RAISERROR` batch returns `SQL_SUCCESS_WITH_INFO` on `SQLExecDirect`; msodbcsql defers these differently.
- `MoreResultsLiveTest.TrailingInfoBetweenResultSetsSurfacesWithHint` — an INFO message between two result sets surfaces on the `SQLMoreResults` advance as `SQL_SUCCESS_WITH_INFO`; msodbcsql surfaces between-result INFO differently (its leg hits SQLSTATE `24000` invalid cursor state).

Both are intended divergences, so they are gated with `SKIP_IF_COMPARING_MSODBCSQL()`.

To avoid conflicts, the `SKIP_IF_COMPARING_MSODBCSQL()` macro and its `run_e2e.sh` `ODBC_TEST_TARGET` wiring are taken **byte-for-byte from #119** (`dev/tkotian/SQLExecAndParams`), which introduces the same helper. Whichever PR merges first, the identical additions merge cleanly.

## Validation

Against a live SQL Server 2022 container:
- `./run_e2e.sh --compare-with-msodbcsql` → parity report shows both tests as `parity`, "Both runs passed".
- Direct binary run confirms each case reports `[ SKIPPED ]` on the msodbcsql leg (`ODBC_TEST_TARGET=msodbcsql`) and runs/passes on the mssql-odbc leg.

## Checklist

- [x] `run_e2e.sh` passes (mssql-odbc only) — 13/13
- [x] `run_e2e.sh --compare-with-msodbcsql` passes — both legs green
- [x] Shared helper matches #119 byte-for-byte
