### PR TITLE
Retarget x64 CI to the NVMe 1ES pool and images

### DIFF
--- a/.pipeline/OneBranch/PublishFeeds-Sandbox.yml
+++ b/.pipeline/OneBranch/PublishFeeds-Sandbox.yml
@@ -110,9 +110,9 @@ extends:
         pool:
           type: windows
           isCustom: true
-          name: RUST-1ES-POOL-WUS3
+          name: RUST-1ES-POOL-WUS3-NVME
           demands:
-            - imageOverride -equals RUST-Win22-Sql25-1P
+            - imageOverride -equals RUST-Win22-Sql25-1P-NVME
         variables:
           ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
         steps:
@@ -144,9 +144,9 @@ extends:
         pool:
           type: linux
           isCustom: true
-          name: RUST-1ES-POOL-WUS3
+          name: RUST-1ES-POOL-WUS3-NVME
           demands:
-            - imageOverride -equals RUST-1ES-UBUSLIM
+            - imageOverride -equals RUST-1ES-UBUSLIM-NVME
         variables:
           ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
           ob_artifactSuffix: '_mock_linux_x64'
@@ -248,9 +248,9 @@ extends:
         pool:
           type: linux
           isCustom: true
-          name: RUST-1ES-POOL-WUS3
+          name: RUST-1ES-POOL-WUS3-NVME
           demands:
-            - imageOverride -equals RUST-1ES-UBUSLIM
+            - imageOverride -equals RUST-1ES-UBUSLIM-NVME
         variables:
           ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
           ob_artifactSuffix: '_mock_linux_musl_x64'
@@ -353,9 +353,9 @@ extends:
         pool:
           type: windows
           isCustom: true
-          name: RUST-1ES-POOL-WUS3
+          name: RUST-1ES-POOL-WUS3-NVME
           demands:
-            - imageOverride -equals RUST-Win22-Sql25-1P
+            - imageOverride -equals RUST-Win22-Sql25-1P-NVME
         variables:
           ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
           ob_artifactSuffix: '_mock_windows_x64'
@@ -522,9 +522,9 @@ extends:
         pool:
           type: windows
           isCustom: true
-          name: RUST-1ES-POOL-WUS3
+          name: RUST-1ES-POOL-WUS3-NVME
           demands:
-            - imageOverride -equals RUST-Win22-Sql25-1P
+            - imageOverride -equals RUST-Win22-Sql25-1P-NVME
         variables:
           ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
         steps:
@@ -576,9 +576,9 @@ extends:
         pool:
           type: windows
           isCustom: true
-          name: RUST-1ES-POOL-WUS3
+          name: RUST-1ES-POOL-WUS3-NVME
           demands:
-            - imageOverride -equals RUST-Win22-Sql25-1P
+            - imageOverride -equals RUST-Win22-Sql25-1P-NVME
         variables:
           ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
           CARGO_TARGET_DIR: C:\cargo_target_dir

--- a/.pipeline/OneBranch/stages.yml
+++ b/.pipeline/OneBranch/stages.yml
@@ -48,9 +48,9 @@ stages:
     pool:
       type: windows
       isCustom: true
-      name: RUST-1ES-POOL-WUS3
+      name: RUST-1ES-POOL-WUS3-NVME
       demands:
-        - imageOverride -equals RUST-Win22-Sql25-1P
+        - imageOverride -equals RUST-Win22-Sql25-1P-NVME
     variables:
     - ${{ if eq(parameters.isOfficial, true) }}:
       - group: 'ESRP Federated Creds (AME)'
@@ -148,9 +148,9 @@ stages:
     pool:
       type: linux
       isCustom: true
-      name: RUST-1ES-POOL-WUS3
+      name: RUST-1ES-POOL-WUS3-NVME
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-1ES-UBUSLIM-NVME
     variables:
       ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
       ob_artifactSuffix: '_linux_x64'

--- a/.pipeline/benchmark-pipeline.yml
+++ b/.pipeline/benchmark-pipeline.yml
@@ -25,9 +25,9 @@ stages:
         displayName: 'Criterion Benchmark'
         timeoutInMinutes: 30
         pool:
-          name: RUST-1ES-POOL-WUS3
+          name: RUST-1ES-POOL-WUS3-NVME
           demands:
-            - imageOverride -equals RUST-1ES-UBUSLIM
+            - imageOverride -equals RUST-1ES-UBUSLIM-NVME
         variables:
           ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
 

--- a/.pipeline/docs/arm-sql-host-design.md
+++ b/.pipeline/docs/arm-sql-host-design.md
@@ -341,7 +341,7 @@ unchanged.
 
 ## Open assumptions
 
-- Cross-pool reachability between `RUST-1ES-POOL-WUS3` (x64) and
+- Cross-pool reachability between `RUST-1ES-POOL-WUS3-NVME` (x64) and
   `RUST-1ES-POOL-ARM-WUS3` (ARM) on the SQL host's private IPv4 and the
   published port. Confirmed at design time; a connectivity regression here
   would surface as `poll-for-endpoint.sh` succeeds (the test job sees the
@@ -349,7 +349,7 @@ unchanged.
 - `mcr.microsoft.com/mssql/server:<sqlImageTag>` ships
   `/opt/mssql-tools18/bin/sqlcmd`, which `start.sh` uses for the readiness
   probe. The current default tag (`2025-latest`) does.
-- The ubuntu image used by the x64 SQL host (`RUST-1ES-UBUSLIM`) provides
+- The ubuntu image used by the x64 SQL host (`RUST-1ES-UBUSLIM-NVME`) provides
   `curl` and `docker`. The latter is enforced by `DockerInstaller@0` and
   `install-ubuntu-dependency.yaml`; the former is standard in the image.
 - Both ARM and x64 1ES pool agents have `python3` available (used by

--- a/.pipeline/scripts/Generate-SqlCertificates.ps1
+++ b/.pipeline/scripts/Generate-SqlCertificates.ps1
@@ -23,6 +23,39 @@ function Copy-To-Root-Store($cert) {
     }
 }
 
+function Restart-SqlServiceSafely($serviceName) {
+    # Freshly-provisioned images can leave SQL Server briefly in a start-pending /
+    # not-yet-stoppable state (startup database recovery), which makes a plain
+    # Restart-Service fail intermittently with "cannot be stopped"
+    # (CouldNotStopService). Wait for a steady state, then stop/start with retries.
+    $svc = Get-Service -Name $serviceName -ErrorAction Stop
+
+    for ($i = 1; $i -le 30; $i++) {
+        $svc.Refresh()
+        if ($svc.Status -eq 'Running' -or $svc.Status -eq 'Stopped') { break }
+        Write-Host "Waiting for $serviceName to reach a steady state (current: $($svc.Status))..."
+        Start-Sleep -Seconds 5
+    }
+
+    for ($attempt = 1; $attempt -le 5; $attempt++) {
+        try {
+            $svc.Refresh()
+            if ($svc.Status -ne 'Stopped') {
+                Stop-Service -Name $serviceName -Force -ErrorAction Stop
+                $svc.WaitForStatus('Stopped', [TimeSpan]::FromSeconds(120))
+            }
+            Start-Service -Name $serviceName -ErrorAction Stop
+            $svc.WaitForStatus('Running', [TimeSpan]::FromSeconds(120))
+            Write-Host "SQL service '$serviceName' restarted (attempt $attempt)."
+            return
+        } catch {
+            Write-Host "Restart attempt $attempt for '$serviceName' failed: $($_.Exception.Message)"
+            Start-Sleep -Seconds 10
+        }
+    }
+    throw "Failed to restart SQL service '$serviceName' after multiple attempts."
+}
+
 function New-And-Install-Certificates($instanceName) {
     Write-Output "Instance name received is " + $instanceName
     $certStorePath  = "Cert:\LocalMachine\My"
@@ -70,7 +103,7 @@ function New-And-Install-Certificates($instanceName) {
 
     Set-ItemProperty -Path $registryPath -Name "Certificate" -Value $thumbprint
 
-    Restart-Service -Name "MSSQLSERVER"
+    Restart-SqlServiceSafely -serviceName $instanceName
     Copy-To-Root-Store -cert $cert
 }
 

--- a/.pipeline/scripts/PrintAgentDebugInfo.ps1
+++ b/.pipeline/scripts/PrintAgentDebugInfo.ps1
@@ -17,3 +17,26 @@ if (Test-Path $pythonDir) {
 } else {
     Write-Host "Directory $pythonDir does NOT exist"
 }
+
+Write-Host ""
+Write-Host "=== Physical Disks (BusType shows NVMe / SATA / SAS) ==="
+try {
+    Get-PhysicalDisk | Select-Object DeviceId, FriendlyName, MediaType, BusType,
+        @{N='SizeGB';E={[math]::Round($_.Size/1GB,1)}} |
+        Format-Table -AutoSize | Out-String | Write-Host
+} catch { Write-Host "Get-PhysicalDisk failed: $_" }
+
+Write-Host "=== Disks ==="
+try {
+    Get-Disk | Select-Object Number, FriendlyName, BusType,
+        @{N='SizeGB';E={[math]::Round($_.Size/1GB,1)}}, PartitionStyle, OperationalStatus |
+        Format-Table -AutoSize | Out-String | Write-Host
+} catch { Write-Host "Get-Disk failed: $_" }
+
+Write-Host "=== Volumes (drive letters + free space) ==="
+try {
+    Get-Volume | Where-Object DriveLetter | Select-Object DriveLetter, FileSystemLabel, FileSystem,
+        @{N='SizeGB';E={[math]::Round($_.Size/1GB,1)}},
+        @{N='FreeGB';E={[math]::Round($_.SizeRemaining/1GB,1)}} |
+        Format-Table -AutoSize | Out-String | Write-Host
+} catch { Write-Host "Get-Volume failed: $_" }

--- a/.pipeline/scripts/print-disk-info.sh
+++ b/.pipeline/scripts/print-disk-info.sh
@@ -5,6 +5,34 @@ echo "=== Disk Space - All Mount Points ==="
 df -h
 
 echo ""
+echo "=== Block Devices (TYPE / TRAN=transport / ROTA=1 spinning,0 SSD) ==="
+# TRAN column shows 'nvme' for NVMe-attached devices; ROTA=0 confirms SSD/NVMe.
+lsblk -o NAME,SIZE,TYPE,TRAN,ROTA,FSTYPE,MOUNTPOINT,MODEL 2>/dev/null || lsblk
+
+echo ""
+echo "=== NVMe devices present ==="
+if ls /dev/nvme* >/dev/null 2>&1; then
+  ls -l /dev/nvme*
+  command -v nvme >/dev/null 2>&1 && nvme list 2>/dev/null || true
+else
+  echo "No /dev/nvme* devices found (agent is NOT on NVMe)."
+fi
+
+echo ""
+echo "=== Backing device + transport for key mount points ==="
+for m in / /mnt /mnt/vss /mnt/azure_nvme_temp "${AGENT_WORKFOLDER:-/mnt/vss/_work}"; do
+  [ -e "$m" ] || continue
+  src=$(findmnt -no SOURCE --target "$m" 2>/dev/null)
+  fstype=$(findmnt -no FSTYPE --target "$m" 2>/dev/null)
+  # Resolve the parent block device and read its transport from sysfs.
+  dev=$(lsblk -no PKNAME "$src" 2>/dev/null | head -1)
+  [ -z "$dev" ] && dev=$(basename "$src" 2>/dev/null)
+  tran=$(cat "/sys/class/block/$dev/device/../transport" 2>/dev/null)
+  case "$src" in *nvme*) tran="${tran:-nvme}";; esac
+  echo "$m -> ${src:-?} (${fstype:-?}) transport=${tran:-unknown}"
+done
+
+echo ""
 echo "=== Agent Work Folder Disk Space ==="
 WORK_DIR="${AGENT_WORKFOLDER:-/mnt/vss/_work}"
 df -h "$WORK_DIR" 2>/dev/null || echo "Work folder $WORK_DIR not found"

--- a/.pipeline/sync-container-images.yml
+++ b/.pipeline/sync-container-images.yml
@@ -428,9 +428,9 @@ stages:
     displayName: 'Import Alpine 3.22 & 3.23'
     condition: eq('${{ parameters.syncAlpine3 }}', 'true')
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ variables.poolName }}
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals ${{ variables.imageName }}
     steps:
     - checkout: none
     - task: AzureCLI@2
@@ -668,9 +668,9 @@ stages:
     displayName: 'Import CentOS Stream 9'
     condition: eq('${{ parameters.syncCentOS }}', 'true')
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ variables.poolName }}
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals ${{ variables.imageName }}
     steps:
     - checkout: none
     - task: AzureCLI@2
@@ -692,9 +692,9 @@ stages:
     displayName: 'Import openSUSE Leap 15.6'
     condition: eq('${{ parameters.syncSUSE }}', 'true')
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ variables.poolName }}
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals ${{ variables.imageName }}
     steps:
     - checkout: none
     - task: AzureCLI@2
@@ -862,9 +862,9 @@ stages:
     timeoutInMinutes: 120
     condition: eq('${{ parameters.buildKerberosImages }}', 'true')
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ variables.poolName }}
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals ${{ variables.imageName }}
     steps:
     - checkout: self
       displayName: Checkout repository

--- a/.pipeline/sync-container-images.yml
+++ b/.pipeline/sync-container-images.yml
@@ -126,6 +126,10 @@ variables:
   ACR_REGISTRY: 'tdslibrs.azurecr.io'
   GHCR_REGISTRY: 'ghcr.io'
   GHCR_NAMESPACE: 'ghcr.io/${{ parameters.ghcrOrg }}'
+  # 1ES pool + Linux image used by every job in this pipeline. Single source of
+  # truth: change these two lines to retarget the whole pipeline.
+  poolName: 'RUST-1ES-POOL-WUS3-NVME'
+  imageName: 'RUST-1ES-UBUSLIM-NVME'
 
 # =============================================================================
 # STAGE 1 (Import): Sync base images from public registries (incl. Docker Hub) to ACR
@@ -147,9 +151,9 @@ stages:
     displayName: 'Import manylinux x64 & arm64'
     condition: eq('${{ parameters.syncManylinux }}', 'true')
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ variables.poolName }}
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals ${{ variables.imageName }}
     steps:
     - checkout: none
     - task: AzureCLI@2
@@ -210,9 +214,9 @@ stages:
     displayName: 'Import musllinux x64 & arm64'
     condition: eq('${{ parameters.syncMusllinux }}', 'true')
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ variables.poolName }}
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals ${{ variables.imageName }}
     steps:
     - checkout: none
     - task: AzureCLI@2
@@ -247,9 +251,9 @@ stages:
     displayName: 'Import Ubuntu 22.04 & 24.04'
     condition: eq('${{ parameters.syncUbuntu }}', 'true')
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ variables.poolName }}
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals ${{ variables.imageName }}
     steps:
     - checkout: none
     - task: AzureCLI@2
@@ -306,9 +310,9 @@ stages:
     displayName: 'Import Alpine 3.18 & 3.19'
     condition: eq('${{ parameters.syncAlpine1 }}', 'true')
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ variables.poolName }}
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals ${{ variables.imageName }}
     steps:
     - checkout: none
     - task: AzureCLI@2
@@ -365,9 +369,9 @@ stages:
     displayName: 'Import Alpine 3.20 & 3.21'
     condition: eq('${{ parameters.syncAlpine2 }}', 'true')
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ variables.poolName }}
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals ${{ variables.imageName }}
     steps:
     - checkout: none
     - task: AzureCLI@2
@@ -483,9 +487,9 @@ stages:
     displayName: 'Import Debian & RHEL UBI'
     condition: eq('${{ parameters.syncDebianRHEL }}', 'true')
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ variables.poolName }}
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals ${{ variables.imageName }}
     steps:
     - checkout: none
     - task: AzureCLI@2
@@ -629,9 +633,9 @@ stages:
     displayName: 'Import Oracle Linux 9'
     condition: eq('${{ parameters.syncOracle }}', 'true')
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ variables.poolName }}
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals ${{ variables.imageName }}
     steps:
     - checkout: none
     - task: AzureCLI@2
@@ -735,9 +739,9 @@ stages:
     displayName: Build x64 Images
     condition: or(eq('${{ parameters.buildPythonImages }}', 'true'), eq('${{ parameters.buildUbuntuImages }}', 'true'))
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ variables.poolName }}
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals ${{ variables.imageName }}
     steps:
     - checkout: self
       displayName: Checkout repository
@@ -1071,9 +1075,9 @@ stages:
     - BuildARM64Images
     condition: eq('${{ parameters.buildUbuntuImages }}', 'true')
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ variables.poolName }}
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals ${{ variables.imageName }}
     steps:
     - checkout: none
 
@@ -1132,9 +1136,9 @@ stages:
     - CreateMultiArchManifests
     condition: always()
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ variables.poolName }}
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals ${{ variables.imageName }}
     steps:
     - checkout: none
 
@@ -1268,9 +1272,9 @@ stages:
     displayName: 'Mirror ACR -> GHCR'
     timeoutInMinutes: 60
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ variables.poolName }}
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals ${{ variables.imageName }}
     steps:
     - checkout: none
 

--- a/.pipeline/sync-github-main-to-stable.yml
+++ b/.pipeline/sync-github-main-to-stable.yml
@@ -35,9 +35,9 @@ resources:
     ref: refs/heads/stable
 
 pool:
-  name: RUST-1ES-POOL-WUS3
+  name: RUST-1ES-POOL-WUS3-NVME
   demands:
-    - imageOverride -equals RUST-1ES-UBUSLIM
+    - imageOverride -equals RUST-1ES-UBUSLIM-NVME
 
 steps:
 # GitHub main (self): the source we are syncing from.

--- a/.pipeline/templates/kerberos-test-template.yml
+++ b/.pipeline/templates/kerberos-test-template.yml
@@ -33,10 +33,10 @@ parameters:
       - alpine318
   - name: poolName
     type: string
-    default: 'RUST-1ES-POOL-WUS3'
+    default: 'RUST-1ES-POOL-WUS3-NVME'
   - name: poolImageOverride
     type: string
-    default: 'imageOverride -equals RUST-1ES-UBUSLIM'
+    default: 'imageOverride -equals RUST-1ES-UBUSLIM-NVME'
   - name: testTimeout
     type: number
     default: 60

--- a/.pipeline/templates/odbc-e2e-windows-remote-sql-template.yml
+++ b/.pipeline/templates/odbc-e2e-windows-remote-sql-template.yml
@@ -3,7 +3,7 @@
 # Runs the mssql-odbc C++ gtest e2e suite on a Windows agent that has no local
 # SQL Server, against the cross-pool x64 SQL host booted by sql-host-template.yml.
 #
-# The Windows ARM agent image ships no SQL Server (unlike RUST-Win22-Sql25-1P used
+# The Windows ARM agent image ships no SQL Server (unlike RUST-Win22-Sql25-1P-NVME used
 # by Build_Windows), so the ARM job joins the same artifact-sentinel rendezvous the
 # Linux ARM jobs use: derive the shared SA password, poll for the sql-ready
 # endpoint sentinel, run the suite, then publish a teardown sentinel to release

--- a/.pipeline/templates/private-link-smoke-template.yml
+++ b/.pipeline/templates/private-link-smoke-template.yml
@@ -70,9 +70,9 @@ jobs:
 - job: PrivateLink_Smoke
   displayName: Private Link Smoke Test (ACI)
   pool:
-    name: RUST-1ES-POOL-WUS3
+    name: RUST-1ES-POOL-WUS3-NVME
     demands:
-      - imageOverride -equals RUST-1ES-UBUSLIM
+      - imageOverride -equals RUST-1ES-UBUSLIM-NVME
   timeoutInMinutes: 30
   steps:
   # --- Login ---

--- a/.pipeline/templates/sql-host-template.yml
+++ b/.pipeline/templates/sql-host-template.yml
@@ -51,10 +51,10 @@ parameters:
     default: 120
   - name: poolName
     type: string
-    default: 'RUST-1ES-POOL-WUS3'
+    default: 'RUST-1ES-POOL-WUS3-NVME'
   - name: poolImageOverride
     type: string
-    default: 'imageOverride -equals RUST-1ES-UBUSLIM'
+    default: 'imageOverride -equals RUST-1ES-UBUSLIM-NVME'
   - name: jobCondition
     # Job-level condition. Defaults to succeeded(); callers that only need the
     # SQL host on PRs (e.g. the Build stage) pass a Build.Reason check.

--- a/.pipeline/templates/sql-setup-template.yml
+++ b/.pipeline/templates/sql-setup-template.yml
@@ -36,8 +36,23 @@ steps:
         sqlcmd -Q "ALTER SERVER ROLE sysadmin ADD MEMBER testuser;"
         sqlcmd -S localhost,1433 -U sa -P $(SQL_PASSWORD) -Q "SELECT @@VERSION"
 
-        # Setup the same logins on the SQLDEV named instance (used by SSRP tests)
+        # Setup the same logins on the SQLDEV named instance (used by SSRP tests).
+        # Freshly-built images can leave the SQLDEV service stopped / manual-start,
+        # so ensure it is set to start automatically and is actually running before
+        # we configure its sa login. Previously this block was skipped whenever the
+        # service wasn't already running, which left sa unconfigured and broke the
+        # SSRP named-instance test (login failed for user 'sa' on HOST\SQLDEV).
         $svc = Get-Service -Name 'MSSQL$SQLDEV' -ErrorAction SilentlyContinue
+        if ($svc) {
+          echo "Ensuring SQLDEV instance is running..."
+          Set-Service -Name 'MSSQL$SQLDEV' -StartupType Automatic -ErrorAction SilentlyContinue
+          Start-Service -Name 'MSSQL$SQLDEV' -ErrorAction SilentlyContinue
+          for ($i = 1; $i -le 12; $i++) {
+            $svc.Refresh()
+            if ($svc.Status -eq 'Running') { break }
+            Start-Sleep -Seconds 5
+          }
+        }
         if ($svc -and $svc.Status -eq 'Running') {
           echo "Configuring logins on SQLDEV instance..."
           sqlcmd -S "localhost\SQLDEV" -C -Q "EXEC xp_instance_regwrite N'HKEY_LOCAL_MACHINE', N'Software\Microsoft\MSSQLServer\MSSQLServer', N'LoginMode', REG_DWORD, 2"

--- a/.pipeline/templates/test-matrix-odbc-template.yml
+++ b/.pipeline/templates/test-matrix-odbc-template.yml
@@ -17,9 +17,9 @@ jobs:
     strategy:
       matrix: ${{ parameters.matrix }}
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: RUST-1ES-POOL-WUS3-NVME
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-1ES-UBUSLIM-NVME
     steps:
       - template: generate-sql-password-template.yml
         parameters:

--- a/.pipeline/templates/test-matrix-template-alpine.yml
+++ b/.pipeline/templates/test-matrix-template-alpine.yml
@@ -2,8 +2,8 @@
 parameters:
   matrix: {}
   artifactName: 'Build_Linux'
-  poolName: 'RUST-1ES-POOL-WUS3'
-  poolImageOverride: 'imageOverride -equals RUST-1ES-UBUSLIM'
+  poolName: 'RUST-1ES-POOL-WUS3-NVME'
+  poolImageOverride: 'imageOverride -equals RUST-1ES-UBUSLIM-NVME'
 
 jobs:
   - job: Test_Matrix

--- a/.pipeline/templates/test-matrix-template.yml
+++ b/.pipeline/templates/test-matrix-template.yml
@@ -8,9 +8,9 @@ jobs:
     strategy:
       matrix: ${{ parameters.matrix }}
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: RUST-1ES-POOL-WUS3-NVME
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-1ES-UBUSLIM-NVME
     steps:
       - template: generate-sql-password-template.yml
         parameters:

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -1052,9 +1052,9 @@ stages:
     - job: LongHaul_BCP_Arrow_Test
       displayName: Long-Haul BCP Arrow Test Ubuntu
       pool:
-        name: RUST-1ES-POOL-WUS3
+        name: ${{ parameters.poolName }}
         demands:
-          - imageOverride -equals RUST-1ES-UBUSLIM
+          - imageOverride -equals ${{ parameters.linuxImage }}
       variables:
         CARGO_TARGET_DIR: $(Build.SourcesDirectory)
       steps:

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -39,6 +39,20 @@ parameters:
   type: string
   default: '2025-latest'
 
+# 1ES pool + image overrides for the x64 Windows/Linux jobs. Single source of
+# truth: change these defaults to retarget every x64 job in this pipeline.
+- name: poolName
+  type: string
+  default: RUST-1ES-POOL-WUS3-NVME
+
+- name: linuxImage
+  type: string
+  default: RUST-1ES-UBUSLIM-NVME
+
+- name: windowsImage
+  type: string
+  default: RUST-Win22-Sql25-1P-NVME
+
 stages:
 - stage: EvaluateDuplicate
   displayName: Evaluate PR duplicate
@@ -47,9 +61,9 @@ stages:
   - job: Evaluate
     displayName: Check prior successful PR validation
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ parameters.poolName }}
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals ${{ parameters.linuxImage }}
     steps:
     - bash: |
         set -euo pipefail
@@ -88,9 +102,9 @@ stages:
   - job: Build_Windows
     displayName: Build Windows
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ parameters.poolName }}
       demands:
-        - imageOverride -equals RUST-Win22-Sql25-1P
+        - imageOverride -equals ${{ parameters.windowsImage }}
     variables:
       # For details on this CARGO_TARGET_DIR setting, see https://eng.ms/docs/more/rust/topics/onebranch-workaround
       CARGO_TARGET_DIR: C:\cargo_target_dir
@@ -215,9 +229,9 @@ stages:
   - job: Build_Linux
     displayName: Build Linux
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ parameters.poolName }}
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals ${{ parameters.linuxImage }}
     variables:
       CARGO_TARGET_DIR: $(Build.SourcesDirectory)
       ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
@@ -413,9 +427,9 @@ stages:
   - job: Fuzz_TokenStream_Linux
     displayName: Fuzz Test Token Stream Linux (30 min)
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ parameters.poolName }}
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals ${{ parameters.linuxImage }}
     variables:
       CARGO_TARGET_DIR: $(Build.SourcesDirectory)
     steps:
@@ -434,9 +448,9 @@ stages:
   - job: Fuzz_TdsClient_Linux
     displayName: Fuzz Test TdsClient Linux (30 min)
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ parameters.poolName }}
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals ${{ parameters.linuxImage }}
     variables:
       CARGO_TARGET_DIR: $(Build.SourcesDirectory)
     steps:
@@ -455,9 +469,9 @@ stages:
   - job: Fuzz_Additional_Targets_Linux
     displayName: Fuzz Additional Targets Linux (Serial - 5 min each)
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ parameters.poolName }}
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals ${{ parameters.linuxImage }}
     variables:
       CARGO_TARGET_DIR: $(Build.SourcesDirectory)
     steps:
@@ -507,9 +521,9 @@ stages:
   - job: Build_mssql_python_Linux
     displayName: Build mssql-python (cross-repo)
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ parameters.poolName }}
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals ${{ parameters.linuxImage }}
     variables:
       CARGO_TARGET_DIR: $(Build.SourcesDirectory)
     steps:
@@ -895,9 +909,9 @@ stages:
   - job: Merge_Coverage
     displayName: Merge Rust and Python coverage
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ parameters.poolName }}
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals ${{ parameters.linuxImage }}
     steps:
       - checkout: self
       - task: DownloadPipelineArtifact@2
@@ -1016,9 +1030,9 @@ stages:
     - job: LongHaul_BCP_Test
       displayName: Long-Haul BCP Test Ubuntu
       pool:
-        name: RUST-1ES-POOL-WUS3
+        name: ${{ parameters.poolName }}
         demands:
-          - imageOverride -equals RUST-1ES-UBUSLIM
+          - imageOverride -equals ${{ parameters.linuxImage }}
       variables:
         CARGO_TARGET_DIR: $(Build.SourcesDirectory)
       steps:

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -236,6 +236,9 @@ stages:
       CARGO_TARGET_DIR: $(Build.SourcesDirectory)
       ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
     steps:
+      - script: |
+          .pipeline/scripts/print-disk-info.sh
+        displayName: 'Print agent disk info'
       - template: cargo-authenticate-template.yml
         parameters:
           osType: Linux

--- a/.pipeline/validation-pipeline.yml
+++ b/.pipeline/validation-pipeline.yml
@@ -36,70 +36,14 @@ parameters:
   type: string
   default: '2025-latest'
 
-# ============================================================================
-# TEMPORARY HIJACK: PR validation is reduced to ONLY printing agent disk info
-# (Windows + Linux) and exiting, to confirm the NVMe disk layout without burning
-# compute on the full build/test matrix.
-# TO REVERT: delete the DiskInfo stage below and un-comment the original
-# `- template: templates/validation-stages.yml` block at the bottom of this file.
-# ============================================================================
 stages:
-- stage: DiskInfo
-  displayName: Agent disk info (validation temporarily hijacked)
-  jobs:
-  - job: DiskInfo_Linux
-    displayName: Disk info (Linux)
-    pool:
-      name: RUST-1ES-POOL-WUS3-NVME
-      demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM-NVME
-    steps:
-    - checkout: none
-    - bash: |
-        set -x
-        echo "===== LINUX AGENT DISK INFO ====="
-        uname -a
-        df -h
-        echo "--- Block devices (TRAN=nvme + ROTA=0 => NVMe SSD) ---"
-        lsblk -o NAME,SIZE,TYPE,TRAN,ROTA,FSTYPE,MOUNTPOINT,MODEL || lsblk
-        echo "--- NVMe devices ---"
-        ls -l /dev/nvme* 2>/dev/null || echo "no /dev/nvme* devices"
-        command -v nvme >/dev/null 2>&1 && nvme list 2>/dev/null || true
-        echo "--- Backing device + transport for key mounts ---"
-        for m in / /mnt /mnt/vss /mnt/azure_nvme_temp "${AGENT_WORKFOLDER:-/mnt/vss/_work}"; do
-          [ -e "$m" ] || continue
-          echo "$m -> $(findmnt -no SOURCE,FSTYPE --target "$m" 2>/dev/null)"
-        done
-      displayName: Print Linux disk info
-  - job: DiskInfo_Windows
-    displayName: Disk info (Windows)
-    pool:
-      name: RUST-1ES-POOL-WUS3-NVME
-      demands:
-        - imageOverride -equals RUST-Win22-Sql25-1P-NVME
-    steps:
-    - checkout: none
-    - powershell: |
-        Write-Host "===== WINDOWS AGENT DISK INFO ====="
-        Get-CimInstance Win32_OperatingSystem | Select-Object Caption, Version | Format-List | Out-String | Write-Host
-        Write-Host "--- Physical disks (BusType = NVMe / SATA / SAS) ---"
-        Get-PhysicalDisk | Select-Object DeviceId, FriendlyName, MediaType, BusType, @{N='SizeGB';E={[math]::Round($_.Size/1GB,1)}} | Format-Table -AutoSize | Out-String | Write-Host
-        Write-Host "--- Disks ---"
-        Get-Disk | Select-Object Number, FriendlyName, BusType, @{N='SizeGB';E={[math]::Round($_.Size/1GB,1)}}, PartitionStyle | Format-Table -AutoSize | Out-String | Write-Host
-        Write-Host "--- Volumes (drive letters + free space) ---"
-        Get-Volume | Where-Object DriveLetter | Select-Object DriveLetter, FileSystem, @{N='SizeGB';E={[math]::Round($_.Size/1GB,1)}}, @{N='FreeGB';E={[math]::Round($_.SizeRemaining/1GB,1)}} | Format-Table -AutoSize | Out-String | Write-Host
-        Write-Host "--- Agent work folder ---"
-        Write-Host "AGENT_WORKFOLDER=$env:AGENT_WORKFOLDER  BUILD_SOURCESDIRECTORY=$env:BUILD_SOURCESDIRECTORY"
-      displayName: Print Windows disk info
-
-# ORIGINAL PR validation (restore this and delete the DiskInfo stage above to re-enable):
-# - template: templates/validation-stages.yml
-#   parameters:
-#     buildType: ${{ parameters.buildType }}
-#     RunFuzz: ${{ parameters.RunFuzz }}
-#     RunLongHaul: ${{ parameters.RunLongHaul }}
-#     sqlInstanceMode: ${{ parameters.sqlInstanceMode }}
-#     sqlImageTag: ${{ parameters.sqlImageTag }}
-#     # PR validation for internal ADO and GitHub PRs. GitHub PRs run in the public
-#     # project, which lacks 'Magnitude Test', so exclude the infra stages here.
-#     includeInfraStages: false
+- template: templates/validation-stages.yml
+  parameters:
+    buildType: ${{ parameters.buildType }}
+    RunFuzz: ${{ parameters.RunFuzz }}
+    RunLongHaul: ${{ parameters.RunLongHaul }}
+    sqlInstanceMode: ${{ parameters.sqlInstanceMode }}
+    sqlImageTag: ${{ parameters.sqlImageTag }}
+    # PR validation for internal ADO and GitHub PRs. GitHub PRs run in the public
+    # project, which lacks 'Magnitude Test', so exclude the infra stages here.
+    includeInfraStages: false

--- a/.pipeline/validation-pipeline.yml
+++ b/.pipeline/validation-pipeline.yml
@@ -36,14 +36,70 @@ parameters:
   type: string
   default: '2025-latest'
 
+# ============================================================================
+# TEMPORARY HIJACK: PR validation is reduced to ONLY printing agent disk info
+# (Windows + Linux) and exiting, to confirm the NVMe disk layout without burning
+# compute on the full build/test matrix.
+# TO REVERT: delete the DiskInfo stage below and un-comment the original
+# `- template: templates/validation-stages.yml` block at the bottom of this file.
+# ============================================================================
 stages:
-- template: templates/validation-stages.yml
-  parameters:
-    buildType: ${{ parameters.buildType }}
-    RunFuzz: ${{ parameters.RunFuzz }}
-    RunLongHaul: ${{ parameters.RunLongHaul }}
-    sqlInstanceMode: ${{ parameters.sqlInstanceMode }}
-    sqlImageTag: ${{ parameters.sqlImageTag }}
-    # PR validation for internal ADO and GitHub PRs. GitHub PRs run in the public
-    # project, which lacks 'Magnitude Test', so exclude the infra stages here.
-    includeInfraStages: false
+- stage: DiskInfo
+  displayName: Agent disk info (validation temporarily hijacked)
+  jobs:
+  - job: DiskInfo_Linux
+    displayName: Disk info (Linux)
+    pool:
+      name: RUST-1ES-POOL-WUS3-NVME
+      demands:
+        - imageOverride -equals RUST-1ES-UBUSLIM-NVME
+    steps:
+    - checkout: none
+    - bash: |
+        set -x
+        echo "===== LINUX AGENT DISK INFO ====="
+        uname -a
+        df -h
+        echo "--- Block devices (TRAN=nvme + ROTA=0 => NVMe SSD) ---"
+        lsblk -o NAME,SIZE,TYPE,TRAN,ROTA,FSTYPE,MOUNTPOINT,MODEL || lsblk
+        echo "--- NVMe devices ---"
+        ls -l /dev/nvme* 2>/dev/null || echo "no /dev/nvme* devices"
+        command -v nvme >/dev/null 2>&1 && nvme list 2>/dev/null || true
+        echo "--- Backing device + transport for key mounts ---"
+        for m in / /mnt /mnt/vss /mnt/azure_nvme_temp "${AGENT_WORKFOLDER:-/mnt/vss/_work}"; do
+          [ -e "$m" ] || continue
+          echo "$m -> $(findmnt -no SOURCE,FSTYPE --target "$m" 2>/dev/null)"
+        done
+      displayName: Print Linux disk info
+  - job: DiskInfo_Windows
+    displayName: Disk info (Windows)
+    pool:
+      name: RUST-1ES-POOL-WUS3-NVME
+      demands:
+        - imageOverride -equals RUST-Win22-Sql25-1P-NVME
+    steps:
+    - checkout: none
+    - powershell: |
+        Write-Host "===== WINDOWS AGENT DISK INFO ====="
+        Get-CimInstance Win32_OperatingSystem | Select-Object Caption, Version | Format-List | Out-String | Write-Host
+        Write-Host "--- Physical disks (BusType = NVMe / SATA / SAS) ---"
+        Get-PhysicalDisk | Select-Object DeviceId, FriendlyName, MediaType, BusType, @{N='SizeGB';E={[math]::Round($_.Size/1GB,1)}} | Format-Table -AutoSize | Out-String | Write-Host
+        Write-Host "--- Disks ---"
+        Get-Disk | Select-Object Number, FriendlyName, BusType, @{N='SizeGB';E={[math]::Round($_.Size/1GB,1)}}, PartitionStyle | Format-Table -AutoSize | Out-String | Write-Host
+        Write-Host "--- Volumes (drive letters + free space) ---"
+        Get-Volume | Where-Object DriveLetter | Select-Object DriveLetter, FileSystem, @{N='SizeGB';E={[math]::Round($_.Size/1GB,1)}}, @{N='FreeGB';E={[math]::Round($_.SizeRemaining/1GB,1)}} | Format-Table -AutoSize | Out-String | Write-Host
+        Write-Host "--- Agent work folder ---"
+        Write-Host "AGENT_WORKFOLDER=$env:AGENT_WORKFOLDER  BUILD_SOURCESDIRECTORY=$env:BUILD_SOURCESDIRECTORY"
+      displayName: Print Windows disk info
+
+# ORIGINAL PR validation (restore this and delete the DiskInfo stage above to re-enable):
+# - template: templates/validation-stages.yml
+#   parameters:
+#     buildType: ${{ parameters.buildType }}
+#     RunFuzz: ${{ parameters.RunFuzz }}
+#     RunLongHaul: ${{ parameters.RunLongHaul }}
+#     sqlInstanceMode: ${{ parameters.sqlInstanceMode }}
+#     sqlImageTag: ${{ parameters.sqlImageTag }}
+#     # PR validation for internal ADO and GitHub PRs. GitHub PRs run in the public
+#     # project, which lacks 'Magnitude Test', so exclude the infra stages here.
+#     includeInfraStages: false

--- a/mssql-tds-bench/perf-lab/run-benchmarks.ps1
+++ b/mssql-tds-bench/perf-lab/run-benchmarks.ps1
@@ -235,7 +235,7 @@ if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) {
 }
 
 # --- git (needed for the baseline worktree) ---
-# The Windows Server perf image (RUST-Win22-Sql25-1P) normally ships git, but
+# The Windows Server perf image (RUST-Win22-Sql25-1P-NVME) normally ships git, but
 # install it if absent: winget first, then Chocolatey as a fallback.
 if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
     Write-Host '>>> git not found; installing...'


### PR DESCRIPTION
## Summary

Switches every x64 Windows/Linux job in the Rust CI pipelines from the `RUST-1ES-POOL-WUS3` pool (`RUST-1ES-UBUSLIM` / `RUST-Win22-Sql25-1P` images) to the NVMe-capable `RUST-1ES-POOL-WUS3-NVME` pool and the `RUST-1ES-UBUSLIM-NVME` / `RUST-Win22-Sql25-1P-NVME` images. The NVMe images/pool were newly provisioned (v6 `D4ads_v6` SKU with a local NVMe temp disk); the old pool and images are being retired, so NVMe becomes the default everywhere rather than an opt-in override.

### DRY refactor (single source of truth per file)
- `validation-stages.yml` — adds `poolName` / `linuxImage` / `windowsImage` parameters (NVMe defaults); every inline x64 pool block now references them, so a future retarget is a 1–3 line change.
- `sync-container-images.yml` — adds `poolName` / `imageName` pipeline variables; all 11 job pool blocks now reference them.

### Straight rename
- `OneBranch/stages.yml`, `benchmark-pipeline.yml`, `sync-github-main-to-stable.yml`
- Shared templates: `sql-host-template.yml`, `kerberos-test-template.yml`, `test-matrix-template.yml`, `test-matrix-template-alpine.yml`, `private-link-smoke-template.yml`
- `run-benchmarks.ps1` comment and `arm-sql-host-design.md`

### Unchanged (intentional)
ARM jobs (`RUST-1ES-POOL-ARM-WUS3`, `RUST-UBUNTU-ARM64`, `RUST-WINSRV-ARM`) — no NVMe ARM images exist.

## Linked work item

[AB#46593](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46593)

## Testing

- All 10 changed YAML files parse with `yaml.safe_load`.
- Verified the 19 ARM references are untouched and no non-NVMe x64 pool/image names remain (outside intentional references).
- Not yet exercised on an actual pipeline run — needs a validation-pipeline run from this branch to confirm the NVMe pool schedules and builds green.

## Breaking changes / migration notes

The NVMe pool uses a 4-vCPU `D4ads_v6` SKU vs. the previous 8-vCPU pool. Functionally equivalent, but absolute perf/benchmark numbers will shift; PR-vs-target benchmark comparisons stay valid since both sides run on the same pool. The 1ES images/pool/subnet themselves are provisioned via Bicep that is intentionally kept out of this public repo (contains internal subscription/tenant IDs).