### PR TITLE
odbc: typed & columnar fetch prerequisites + real SQLSet/GetStmtAttrW (P0)

### DIFF
--- a/mssql-odbc/docs/typed-columnar-fetch-plan.md
+++ b/mssql-odbc/docs/typed-columnar-fetch-plan.md
@@ -66,7 +66,7 @@ Both paths must share one conversion core: `ColumnValues -> requested SQL_C_* ta
 
 - Add all `SQL_C_*` constants + SQL Server extension type ids and the C interop structs (`SQL_DATE_STRUCT`, `SQL_TIME_STRUCT`, `SQL_TIMESTAMP_STRUCT`, `SQL_SS_TIME2_STRUCT`, `SQL_SS_TIMESTAMPOFFSET_STRUCT`, `SQLGUID`, `SQL_NUMERIC_STRUCT`) to `api/odbc_types.rs`.
 - Extend `StmtState` (`handles/stmt.rs`) with the block-fetch controls: `row_array_size`, `rows_fetched_ptr`, `row_status_ptr`, `row_bind_type`. (The column-bindings vector and rowset buffer land with P3, and the per-column `SQLGetData` offset with P1, where they are consumed.)
-- Implement real `SQLSetStmtAttrW` / `SQLGetStmtAttrW` that honor the rowset controls and accept cursor / concurrency / param-set attributes as no-ops (the driver is forward-only, read-only — exactly what `mssql-python` requests).
+- Implement real `SQLSetStmtAttrW` / `SQLGetStmtAttrW` that honor the rowset controls. `SQL_ATTR_CURSOR_TYPE` / `SQL_ATTR_CONCURRENCY` accept only the supported forward-only / read-only values and substitute+warn (`01S02`) otherwise; `SQL_ATTR_PARAMSET_SIZE` accepts 1 and rejects larger batches; unknown identifiers fail with `HY092`. `SQL_ATTR_APP_PARAM_DESC` requires a descriptor subsystem and is deferred (see scope boundary below).
 - Covered by unit tests only (safe-core logic at ~97% line coverage). E2e tests are intentionally deferred to P1: the P0 statement attributes are ARD/APD descriptor-backed and intercepted by the unixODBC Driver Manager, so they are not meaningfully observable through the DM until a fetch path consumes them.
 
 ### P1 — Typed SQLGetData (row-by-row) — Task [46578](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46578)
@@ -104,6 +104,10 @@ Both paths must share one conversion core: `ColumnValues -> requested SQL_C_* ta
 ## Scope boundary — batch insert
 
 §4.8 also covers **batch insert** (`executemany` via `SQL_ATTR_PARAMSET_SIZE` array binding), which is a **write** path and out of scope for this story. It is tracked separately as User Story [46576](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46576) (`mssql-odbc | Batch insert (executemany array binding)`), with dependencies on Parameter completeness ([46373](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46373)), Descriptors ([46374](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46374)), Connection & statement attributes ([46377](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46377)), and Streaming ([46378](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46378)).
+
+## Scope boundary — descriptors (`SQL_ATTR_APP_PARAM_DESC` / `SQL_C_NUMERIC` input binding)
+
+Descriptor handles are not implemented in the crate yet, so `SQLGetStmtAttrW(SQL_ATTR_APP_PARAM_DESC)` currently returns `HY092`. `mssql-python`'s `ddbc_bindings.cpp` calls this (then `SQLSetDescField` on the returned handle) only when binding a `SQL_C_NUMERIC` **input parameter**, and aborts the bind if it fails — so numeric input-parameter binding will not work until a descriptor subsystem exists. There is no correct minimal shim (a non-null fake handle would crash `SQLSetDescField`). This is deferred to the Descriptors work item [46374](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46374) (APD handle alloc/free, `SQLGetStmtAttr` returning it, and `SQLSetDescField` support for `SQL_DESC_TYPE`/`SQL_DESC_CONCISE_TYPE`/precision/scale), rather than expanding this P0 plumbing PR.
 
 ## Status
 

--- a/mssql-odbc/docs/typed-columnar-fetch-plan.md
+++ b/mssql-odbc/docs/typed-columnar-fetch-plan.md
@@ -1,0 +1,115 @@
+# Implementation Plan — Typed & Columnar Fetch (mssql-odbc)
+
+Tracking: ADO User Story [46375](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46375) (`mssql-odbc | Typed & columnar fetch`), under Feature [42845](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/42845).
+
+## Goal
+
+Make the Rust `mssql-odbc` driver (a drop-in replacement for `msodbcsql18` that wraps `mssql-tds`) implement the result-fetch ODBC ABI that the `mssql-python` C++ pybind layer calls, so `mssql-odbc` can replace the bundled `msodbcsql18` underneath `mssql-python`.
+
+Reference: `rust_odbc_for_python_driver.docx` §4.5.1 (fetch type map) and §4.8 (batch fetch / insert).
+
+## The real consumer / contract
+
+- `mssql-python` is a C++ pybind layer (`mssql_python/pybind/ddbc_bindings.cpp`) that dynamically loads an ODBC driver and exposes DB-API 2.0. It is **not** built on `mssql-py-core` (the separate pure-Rust pyo3 driver on `mssql-tds`).
+- The exact fetch behavior `mssql-odbc` must provide is defined by what `ddbc_bindings.cpp` calls; `msodbcsql` is only the behavioral reference.
+- Driver load in `ddbc_bindings.cpp` **requires** these function pointers to be non-null or it aborts: `SQLFetchScroll`, `SQLGetData`, `SQLNumResultCols`, `SQLBindCol`, `SQLDescribeColW`, `SQLMoreResults`, `SQLColAttributeW`, `SQLSetStmtAttrW`. Several of these are missing today, so `mssql-odbc` would not even load under `mssql-python` before this work.
+
+## Two fetch paths mssql-python drives
+
+1. **Columnar / bound** (`fetchmany` / `fetchall`, §4.8): `SQLSetStmtAttr(SQL_ATTR_ROW_ARRAY_SIZE = N)` + `SQL_ATTR_ROWS_FETCHED_PTR`, then `SQLBindCol` per column into typed C arrays (column-wise, default `SQL_BIND_BY_COLUMN`), then one `SQLFetchScroll(SQL_FETCH_NEXT)` per block. Forward-only, read-only. It calls `SQLFreeStmt(SQL_UNBIND)` before each fetch.
+2. **Row-by-row** (`fetchone`, LOB, `sql_variant`, §4.7): `SQLFetch` + typed `SQLGetData` per column.
+
+Both paths must share one conversion core: `ColumnValues -> requested SQL_C_* target`.
+
+## Fetch type map (§4.5.1) — SQL type → C type mssql-python requests
+
+| SQL type | C type | Python |
+| --- | --- | --- |
+| `CHAR`, `VARCHAR`, `LONGVARCHAR` | `SQL_C_WCHAR` (default) or `SQL_C_CHAR` | `str` |
+| `WCHAR`, `WVARCHAR`, `WLONGVARCHAR` | `SQL_C_WCHAR` | `str` |
+| `SS_XML` | `SQL_C_WCHAR` (streamed) | `str` |
+| `TINYINT` | `SQL_C_TINYINT` | `int` |
+| `SMALLINT` | `SQL_C_SSHORT` | `int` |
+| `INTEGER` | `SQL_C_SLONG` | `int` |
+| `BIGINT` | `SQL_C_SBIGINT` | `int` |
+| `BIT` | `SQL_C_BIT` | `bool` |
+| `REAL` | `SQL_C_FLOAT` | `float` |
+| `FLOAT`, `DOUBLE` | `SQL_C_DOUBLE` | `float` |
+| `DECIMAL`, `NUMERIC` | `SQL_C_CHAR` (parsed) | `decimal.Decimal` |
+| `TYPE_DATE` | `SQL_C_TYPE_DATE` | `datetime.date` |
+| `TYPE_TIME`, `SS_TIME2` | `SQL_C_SS_TIME2` | `datetime.time` |
+| `TIMESTAMP`, `TYPE_TIMESTAMP`, `DATETIME` | `SQL_C_TYPE_TIMESTAMP` | `datetime.datetime` |
+| `SS_TIMESTAMPOFFSET` | `SQL_C_SS_TIMESTAMPOFFSET` | `datetime` (tz-aware) |
+| `BINARY`, `VARBINARY`, `LONGVARBINARY`, `SS_UDT` | `SQL_C_BINARY` | `bytes` |
+| `GUID` | `SQL_C_GUID` | `uuid.UUID` |
+| `SS_VARIANT` | probe via `SQL_C_BINARY`, then map to underlying type | base type |
+
+### sql_variant handling
+
+`ddbc_bindings.cpp` first calls `SQLGetData(col, SQL_C_BINARY, NULL, 0, &ind)` as a probe (detects NULL and initializes variant metadata), then `SQLColAttribute(col, SQL_CA_SS_VARIANT_TYPE, ..., &ctype)`. So `SQLColAttributeW` **must** support `SQL_CA_SS_VARIANT_TYPE` (`1215`) — it is the only `SQLColAttribute` field `mssql-python` uses for fetch.
+
+### Relevant SQL Server constants
+
+`SQL_SS_XML = -152`, `SQL_SS_UDT = -151`, `SQL_SS_VARIANT = -150`, `SQL_SS_TIME2 = -154`, `SQL_SS_TIMESTAMPOFFSET = -155`, `SQL_CA_SS_VARIANT_TYPE = 1215`, `SQL_C_SS_TIME2 = 0x4000`, `SQL_C_SS_TIMESTAMPOFFSET = 0x4001`. Note: `mssql-python` does not set `SQL_ATTR_ROW_STATUS_PTR`; it relies on `SQL_ATTR_ROWS_FETCHED_PTR` plus per-column indicators.
+
+## Starting state (before this work)
+
+- `SQLGetData` (`get_data.rs`): only `SQL_C_CHAR` / `SQL_C_WCHAR`, text conversion of a **subset** of `ColumnValues` (`TinyInt`, `SmallInt`, `Int`, `BigInt`, `Real`, `Float`, `Bit`, `String`, `Uuid`). Missing: `Decimal`/`Numeric`, all date/time types, `Bytes`, `Money`/`SmallMoney`, `Xml`, `Json`, `Vector`. No chunked-offset streaming (repeated calls return the same prefix).
+- `SQLFetch` (`fetch.rs`): row-by-row firehose only (`client.next_row` via `block_on`), stores `stmt_state.current_row`.
+- `SQLBindCol`, `SQLFetchScroll`, `SQLColAttributeW`: not implemented / not exported.
+- `SQLSetStmtAttrW` / `SQLGetStmtAttrW`: no-op stubs returning `SQL_SUCCESS`, so `SQL_ATTR_ROW_ARRAY_SIZE` / `ROWS_FETCHED_PTR` / `PARAMSET_SIZE` were ignored.
+- `SQLDescribeColW` (`describe_col.rs`): implemented, with type mapping + column size / decimal digits.
+
+## Phased plan
+
+### P0 — Prerequisites & plumbing — Task [46577](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46577)
+
+- Add all `SQL_C_*` constants + SQL Server extension type ids and the C interop structs (`SQL_DATE_STRUCT`, `SQL_TIME_STRUCT`, `SQL_TIMESTAMP_STRUCT`, `SQL_SS_TIME2_STRUCT`, `SQL_SS_TIMESTAMPOFFSET_STRUCT`, `SQLGUID`, `SQL_NUMERIC_STRUCT`) to `api/odbc_types.rs`.
+- Extend `StmtState` (`handles/stmt.rs`) with the block-fetch controls: `row_array_size`, `rows_fetched_ptr`, `row_status_ptr`, `row_bind_type`. (The column-bindings vector and rowset buffer land with P3, and the per-column `SQLGetData` offset with P1, where they are consumed.)
+- Implement real `SQLSetStmtAttrW` / `SQLGetStmtAttrW` that honor the rowset controls and accept cursor / concurrency / param-set attributes as no-ops (the driver is forward-only, read-only — exactly what `mssql-python` requests).
+
+### P1 — Typed SQLGetData (row-by-row) — Task [46578](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46578)
+
+- Build the shared `ColumnValues -> requested SQL_C_*` conversion core (reused by `SQLBindCol` in P3).
+- Start with int types (existing child task [46404](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46404)) and int→char/wchar (existing child task [46405](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46405)), then floats, decimal/numeric (→ `SQL_C_CHAR`), strings, binary, guid, date/time/timestamp/time2/timestampoffset, money, xml, json/vector.
+- Add chunked-offset streaming so repeated `SQLGetData` calls advance (`01004` + `SQL_SUCCESS_WITH_INFO` reporting remaining length).
+- Implement `sql_variant` probe semantics (`SQL_C_BINARY` NULL detection + variant metadata init).
+
+### P2 — SQLColAttributeW — Task [46579](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46579)
+
+- Required minimum: `SQL_CA_SS_VARIANT_TYPE` so the `sql_variant` underlying C type resolves after the `SQL_C_BINARY` probe.
+- Plus common descriptor fields (type / concise type, length, octet length, precision, scale, name, unsigned, nullable, display size) reusing the `SQLDescribeColW` metadata mapping.
+- Export `SQLColAttributeW` (driver-load requires the pointer non-null).
+
+### P3 — SQLBindCol + block SQLFetchScroll — Task [46580](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46580)
+
+- `SQLBindCol`: store per-column binding (col, target C type, buffer ptr, buffer len, indicator ptr); support unbind (null ptr) and `SQLFreeStmt(SQL_UNBIND)`.
+- `SQLFetchScroll(SQL_FETCH_NEXT)`: fetch up to `row_array_size` rows into a rowset; fill each bound-column array + indicator array (default column-wise); set `*rows_fetched_ptr`; return `SQL_NO_DATA` at end with partial-rowset handling. Forward-only.
+- Reuse the P1 conversion core. Ensure `SQLGetData` still works after a bound fetch (mixed access).
+- Export `SQLBindCol` and `SQLFetchScroll`.
+
+### P4 — Exports & driver-load compatibility — Task [46581](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46581)
+
+- Export `SQLBindCol`, `SQLFetchScroll`, `SQLColAttributeW` (exact names incl. the `W` variant) so `ddbc_bindings.cpp` `GetFunctionPointer` succeeds.
+- Verify the full required symbol set is present and the driver loads under `mssql-python`.
+
+### P5 — Testing & end-to-end validation — Task [46582](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46582)
+
+- Unit tests per conversion (`ColumnValues` → each `SQL_C_*` target; NULL / indicator / truncation).
+- Integration tests against SQL Server (Docker) exercising every type via the ODBC C ABI, both bound (`SQLFetchScroll`) and row-by-row (`SQLGetData`) paths.
+- End-to-end: run the `mssql-python` test suite against a locally-swapped `mssql-odbc` build.
+
+## Scope boundary — batch insert
+
+§4.8 also covers **batch insert** (`executemany` via `SQL_ATTR_PARAMSET_SIZE` array binding), which is a **write** path and out of scope for this story. It is tracked separately as User Story [46576](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46576) (`mssql-odbc | Batch insert (executemany array binding)`), with dependencies on Parameter completeness ([46373](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46373)), Descriptors ([46374](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46374)), Connection & statement attributes ([46377](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46377)), and Streaming ([46378](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46378)).
+
+## Status
+
+| Phase | Task | State |
+| --- | --- | --- |
+| P0 — Prerequisites & plumbing | 46577 | Implemented (build + clippy clean, 332 tests pass) |
+| P1 — Typed SQLGetData | 46578 | Not started |
+| P2 — SQLColAttributeW | 46579 | Not started |
+| P3 — SQLBindCol + SQLFetchScroll | 46580 | Not started |
+| P4 — Exports & driver-load compat | 46581 | Not started |
+| P5 — Testing & end-to-end | 46582 | Not started |

--- a/mssql-odbc/docs/typed-columnar-fetch-plan.md
+++ b/mssql-odbc/docs/typed-columnar-fetch-plan.md
@@ -67,6 +67,7 @@ Both paths must share one conversion core: `ColumnValues -> requested SQL_C_* ta
 - Add all `SQL_C_*` constants + SQL Server extension type ids and the C interop structs (`SQL_DATE_STRUCT`, `SQL_TIME_STRUCT`, `SQL_TIMESTAMP_STRUCT`, `SQL_SS_TIME2_STRUCT`, `SQL_SS_TIMESTAMPOFFSET_STRUCT`, `SQLGUID`, `SQL_NUMERIC_STRUCT`) to `api/odbc_types.rs`.
 - Extend `StmtState` (`handles/stmt.rs`) with the block-fetch controls: `row_array_size`, `rows_fetched_ptr`, `row_status_ptr`, `row_bind_type`. (The column-bindings vector and rowset buffer land with P3, and the per-column `SQLGetData` offset with P1, where they are consumed.)
 - Implement real `SQLSetStmtAttrW` / `SQLGetStmtAttrW` that honor the rowset controls and accept cursor / concurrency / param-set attributes as no-ops (the driver is forward-only, read-only — exactly what `mssql-python` requests).
+- Covered by unit tests only (safe-core logic at ~97% line coverage). E2e tests are intentionally deferred to P1: the P0 statement attributes are ARD/APD descriptor-backed and intercepted by the unixODBC Driver Manager, so they are not meaningfully observable through the DM until a fetch path consumes them.
 
 ### P1 — Typed SQLGetData (row-by-row) — Task [46578](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46578)
 
@@ -74,6 +75,7 @@ Both paths must share one conversion core: `ColumnValues -> requested SQL_C_* ta
 - Start with int types (existing child task [46404](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46404)) and int→char/wchar (existing child task [46405](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46405)), then floats, decimal/numeric (→ `SQL_C_CHAR`), strings, binary, guid, date/time/timestamp/time2/timestampoffset, money, xml, json/vector.
 - Add chunked-offset streaming so repeated `SQLGetData` calls advance (`01004` + `SQL_SUCCESS_WITH_INFO` reporting remaining length).
 - Implement `sql_variant` probe semantics (`SQL_C_BINARY` NULL detection + variant metadata init).
+- Add the e2e coverage deferred from P0: a `set_stmt_attr_test.cpp` (parity with `set_env_attr_test.cpp`) plus a live-connection test that drives typed `SQLGetData` through the Driver Manager. P0's statement attributes (`SQL_ATTR_ROW_ARRAY_SIZE`, etc.) are descriptor-backed and intercepted by unixODBC, so they are only meaningfully observable end-to-end once a fetch path consumes them here (block fetch lands in P3).
 
 ### P2 — SQLColAttributeW — Task [46579](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46579)
 

--- a/mssql-odbc/src/api/exports.rs
+++ b/mssql-odbc/src/api/exports.rs
@@ -491,13 +491,20 @@ pub unsafe extern "C" fn SQLGetConnectAttrW(
 /// - `string_length` is used only for string-type attributes.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn SQLSetStmtAttrW(
-    _statement_handle: SqlHandle,
-    _attribute: SqlInteger,
-    _value_ptr: SqlPointer,
-    _string_length: SqlInteger,
+    statement_handle: SqlHandle,
+    attribute: SqlInteger,
+    value_ptr: SqlPointer,
+    string_length: SqlInteger,
 ) -> SqlReturn {
     crate::init_tracing();
-    SQL_SUCCESS
+    unsafe {
+        super::set_stmt_attr::sql_set_stmt_attr_w(
+            statement_handle,
+            attribute,
+            value_ptr,
+            string_length,
+        )
+    }
 }
 
 /// Retrieves a statement attribute.
@@ -508,14 +515,22 @@ pub unsafe extern "C" fn SQLSetStmtAttrW(
 /// - Output pointers must be valid and writable.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn SQLGetStmtAttrW(
-    _statement_handle: SqlHandle,
-    _attribute: SqlInteger,
-    _value_ptr: SqlPointer,
-    _buffer_length: SqlInteger,
-    _string_length_ptr: *mut SqlInteger,
+    statement_handle: SqlHandle,
+    attribute: SqlInteger,
+    value_ptr: SqlPointer,
+    buffer_length: SqlInteger,
+    string_length_ptr: *mut SqlInteger,
 ) -> SqlReturn {
     crate::init_tracing();
-    SQL_SUCCESS
+    unsafe {
+        super::set_stmt_attr::sql_get_stmt_attr_w(
+            statement_handle,
+            attribute,
+            value_ptr,
+            buffer_length,
+            string_length_ptr,
+        )
+    }
 }
 
 // ---- Descriptor and parameter management (TO-BE-IMPLEMENTED) -----------------

--- a/mssql-odbc/src/api/mod.rs
+++ b/mssql-odbc/src/api/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod odbc_types;
 mod prepare;
 pub(crate) mod set_connect_attr;
 pub(crate) mod set_env_attr;
+pub(crate) mod set_stmt_attr;
 pub(crate) mod sqlstate;
 pub(crate) mod util;
 

--- a/mssql-odbc/src/api/odbc_types.rs
+++ b/mssql-odbc/src/api/odbc_types.rs
@@ -17,6 +17,8 @@ pub type SqlHWnd = *mut c_void;
 pub type SqlPointer = *mut c_void;
 /// UTF-16 code unit. ODBC `SQLWCHAR` is 16-bit on every supported platform
 pub type SqlWChar = u16;
+/// ODBC `SQLUINTEGER` — unsigned 32-bit integer, used in C interop structs.
+pub type SqlUInteger = u32;
 
 /// Length of a SQLSTATE string in characters (5 + NUL written separately).
 pub const SQL_SQLSTATE_SIZE: usize = 5;
@@ -154,3 +156,163 @@ pub const fn sql_len_data_at_exec(length: SqlLen) -> SqlLen {
 /// Indicator values at or below this offset encode a data-at-execution length
 /// via the `SQL_LEN_DATA_AT_EXEC(n)` macro.
 pub const SQL_LEN_DATA_AT_EXEC_OFFSET: SqlLen = -100;
+
+// ---- SQL Server-specific ODBC-SQL-type identifiers (driver extensions) ------
+// The `SS_TIME2`/`SS_TIMESTAMPOFFSET` ids are declared above; these complete the
+// set used by the fetch path.
+pub const SQL_SS_VARIANT: SqlSmallInt = -150;
+pub const SQL_SS_UDT: SqlSmallInt = -151;
+pub const SQL_SS_XML: SqlSmallInt = -152;
+
+// ---- Additional ODBC C type identifiers (SQLBindCol / SQLGetData) -----------
+// Signed/unsigned integer C types are the base numeric type id plus an offset,
+// exactly as defined in the ODBC headers.
+pub const SQL_SIGNED_OFFSET: SqlSmallInt = -20;
+pub const SQL_UNSIGNED_OFFSET: SqlSmallInt = -22;
+
+pub const SQL_C_SHORT: SqlSmallInt = SQL_SMALLINT; // 5
+pub const SQL_C_SSHORT: SqlSmallInt = SQL_C_SHORT + SQL_SIGNED_OFFSET; // -15
+pub const SQL_C_USHORT: SqlSmallInt = SQL_C_SHORT + SQL_UNSIGNED_OFFSET; // -17
+pub const SQL_C_SLONG: SqlSmallInt = SQL_C_LONG + SQL_SIGNED_OFFSET; // -16
+pub const SQL_C_ULONG: SqlSmallInt = SQL_C_LONG + SQL_UNSIGNED_OFFSET; // -18
+pub const SQL_C_TINYINT: SqlSmallInt = SQL_TINYINT; // -6
+pub const SQL_C_STINYINT: SqlSmallInt = SQL_TINYINT + SQL_SIGNED_OFFSET; // -26
+pub const SQL_C_UTINYINT: SqlSmallInt = SQL_TINYINT + SQL_UNSIGNED_OFFSET; // -28
+pub const SQL_C_SBIGINT: SqlSmallInt = SQL_BIGINT + SQL_SIGNED_OFFSET; // -25
+pub const SQL_C_UBIGINT: SqlSmallInt = SQL_BIGINT + SQL_UNSIGNED_OFFSET; // -27
+pub const SQL_C_BIT: SqlSmallInt = SQL_BIT; // -7
+pub const SQL_C_BINARY: SqlSmallInt = SQL_BINARY; // -2
+pub const SQL_C_GUID: SqlSmallInt = SQL_GUID; // -11
+pub const SQL_C_NUMERIC: SqlSmallInt = SQL_NUMERIC; // 2
+pub const SQL_C_FLOAT: SqlSmallInt = SQL_REAL; // 7
+pub const SQL_C_DOUBLE: SqlSmallInt = SQL_DOUBLE; // 8
+
+// Legacy (ODBC 2.x) date/time C types plus the ODBC 3.x `SQL_C_TYPE_*` forms.
+pub const SQL_C_DATE: SqlSmallInt = 9;
+pub const SQL_C_TIME: SqlSmallInt = 10;
+pub const SQL_C_TIMESTAMP: SqlSmallInt = 11;
+pub const SQL_C_TYPE_DATE: SqlSmallInt = 91;
+pub const SQL_C_TYPE_TIME: SqlSmallInt = 92;
+pub const SQL_C_TYPE_TIMESTAMP: SqlSmallInt = 93;
+
+// SQL Server-specific C types (msodbcsql extensions). `SQL_C_TYPES_EXTENDED`
+// is `0x4000`; the two SS date/time C types are offset from it.
+pub const SQL_C_TYPES_EXTENDED: SqlSmallInt = 0x4000; // 16384
+pub const SQL_C_SS_TIME2: SqlSmallInt = SQL_C_TYPES_EXTENDED; // 0x4000
+pub const SQL_C_SS_TIMESTAMPOFFSET: SqlSmallInt = SQL_C_TYPES_EXTENDED + 1; // 0x4001
+
+// SQLColAttribute field identifier for the underlying type of a `sql_variant`
+// column (msodbcsql: `SQL_CA_SS_BASE + 15`). Required by mssql-python's
+// sql_variant probe.
+pub const SQL_CA_SS_VARIANT_TYPE: SqlUSmallInt = 1215;
+
+// ---- Statement attribute identifiers (SQLSetStmtAttr / SQLGetStmtAttr) ------
+pub const SQL_ATTR_ROW_BIND_TYPE: SqlInteger = 5;
+pub const SQL_ATTR_CURSOR_TYPE: SqlInteger = 6;
+pub const SQL_ATTR_CONCURRENCY: SqlInteger = 7;
+pub const SQL_ATTR_PARAM_BIND_TYPE: SqlInteger = 18;
+pub const SQL_ATTR_PARAM_STATUS_PTR: SqlInteger = 20;
+pub const SQL_ATTR_PARAMS_PROCESSED_PTR: SqlInteger = 21;
+pub const SQL_ATTR_PARAMSET_SIZE: SqlInteger = 22;
+pub const SQL_ATTR_ROW_BIND_OFFSET_PTR: SqlInteger = 23;
+pub const SQL_ATTR_ROW_STATUS_PTR: SqlInteger = 25;
+pub const SQL_ATTR_ROWS_FETCHED_PTR: SqlInteger = 26;
+pub const SQL_ATTR_ROW_ARRAY_SIZE: SqlInteger = 27;
+pub const SQL_ATTR_APP_ROW_DESC: SqlInteger = 10010;
+pub const SQL_ATTR_APP_PARAM_DESC: SqlInteger = 10011;
+
+/// `SQL_ATTR_ROW_BIND_TYPE` value selecting column-wise (array-of-columns)
+/// binding — the mode mssql-python uses.
+pub const SQL_BIND_BY_COLUMN: SqlULen = 0;
+/// `SQL_ATTR_CURSOR_TYPE` value: forward-only (the only mode this driver
+/// supports).
+pub const SQL_CURSOR_FORWARD_ONLY: SqlULen = 0;
+/// `SQL_ATTR_CONCURRENCY` value: read-only.
+pub const SQL_CONCUR_READ_ONLY: SqlULen = 1;
+
+// Per-row status codes written into a `SQL_ATTR_ROW_STATUS_PTR` array.
+pub const SQL_ROW_SUCCESS: SqlUSmallInt = 0;
+pub const SQL_ROW_SUCCESS_WITH_INFO: SqlUSmallInt = 6;
+pub const SQL_ROW_NOROW: SqlUSmallInt = 3;
+
+// ---- ODBC C interop structs (SQLBindCol / SQLGetData targets) ---------------
+/// Maximum byte length of a `SQL_NUMERIC_STRUCT` mantissa.
+pub const SQL_MAX_NUMERIC_LEN: usize = 16;
+
+/// ODBC `SQL_DATE_STRUCT`.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SqlDateStruct {
+    pub year: SqlSmallInt,
+    pub month: SqlUSmallInt,
+    pub day: SqlUSmallInt,
+}
+
+/// ODBC `SQL_TIME_STRUCT`.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SqlTimeStruct {
+    pub hour: SqlUSmallInt,
+    pub minute: SqlUSmallInt,
+    pub second: SqlUSmallInt,
+}
+
+/// ODBC `SQL_TIMESTAMP_STRUCT`. `fraction` is in nanoseconds.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SqlTimestampStruct {
+    pub year: SqlSmallInt,
+    pub month: SqlUSmallInt,
+    pub day: SqlUSmallInt,
+    pub hour: SqlUSmallInt,
+    pub minute: SqlUSmallInt,
+    pub second: SqlUSmallInt,
+    pub fraction: SqlUInteger,
+}
+
+/// msodbcsql `SQL_SS_TIME2_STRUCT`. `fraction` is in nanoseconds.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SqlSsTime2Struct {
+    pub hour: SqlUSmallInt,
+    pub minute: SqlUSmallInt,
+    pub second: SqlUSmallInt,
+    pub fraction: SqlUInteger,
+}
+
+/// msodbcsql `SQL_SS_TIMESTAMPOFFSET_STRUCT`. `fraction` is in nanoseconds and
+/// the timezone offset is split into signed hour/minute components.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SqlSsTimestampoffsetStruct {
+    pub year: SqlSmallInt,
+    pub month: SqlUSmallInt,
+    pub day: SqlUSmallInt,
+    pub hour: SqlUSmallInt,
+    pub minute: SqlUSmallInt,
+    pub second: SqlUSmallInt,
+    pub fraction: SqlUInteger,
+    pub timezone_hour: SqlSmallInt,
+    pub timezone_minute: SqlSmallInt,
+}
+
+/// ODBC `SQLGUID`.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SqlGuid {
+    pub data1: SqlUInteger,
+    pub data2: SqlUSmallInt,
+    pub data3: SqlUSmallInt,
+    pub data4: [u8; 8],
+}
+
+/// ODBC `SQL_NUMERIC_STRUCT`. `val` holds a little-endian unsigned mantissa;
+/// `sign` is 1 for positive, 0 for negative.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SqlNumericStruct {
+    pub precision: u8,
+    pub scale: i8,
+    pub sign: u8,
+    pub val: [u8; SQL_MAX_NUMERIC_LEN],
+}

--- a/mssql-odbc/src/api/set_stmt_attr.rs
+++ b/mssql-odbc/src/api/set_stmt_attr.rs
@@ -3,14 +3,19 @@
 
 //! Implementation of `SQLSetStmtAttrW` / `SQLGetStmtAttrW`.
 //!
-//! Only the attributes exercised by the fetch path are given real semantics:
-//! the block-fetch rowset controls (`SQL_ATTR_ROW_ARRAY_SIZE`,
+//! The block-fetch rowset controls (`SQL_ATTR_ROW_ARRAY_SIZE`,
 //! `SQL_ATTR_ROWS_FETCHED_PTR`, `SQL_ATTR_ROW_STATUS_PTR`,
-//! `SQL_ATTR_ROW_BIND_TYPE`). Everything else the Driver Manager or
-//! mssql-python sets — cursor type, concurrency, param-set controls — is
-//! accepted as a no-op so the handshake is not broken. This driver only
-//! supports forward-only, read-only cursors, which is exactly what
-//! mssql-python requests.
+//! `SQL_ATTR_ROW_BIND_TYPE`) are stored and later consumed by the columnar
+//! fetch path. Other recognized statement attributes (cursor type, concurrency,
+//! param / descriptor controls) are accepted without effect because the driver
+//! is forward-only and read-only — exactly what mssql-python requests.
+//! `SQL_ATTR_PARAMSET_SIZE` accepts the ODBC default of 1 but rejects larger
+//! batches, since parameter arrays are not yet consumed and a silent success
+//! would execute only the first row. Unrecognized attribute identifiers fail
+//! with `HY092`.
+//!
+//! Each entry point follows the crate's mandatory layering: FFI panic boundary
+//! → `unsafe` raw-handle shim → safe core (`README.md`; `num_result_cols.rs`).
 
 use tracing::{debug, error};
 
@@ -18,11 +23,15 @@ use crate::api::odbc_types::{
     SQL_ATTR_APP_PARAM_DESC, SQL_ATTR_APP_ROW_DESC, SQL_ATTR_CONCURRENCY, SQL_ATTR_CURSOR_TYPE,
     SQL_ATTR_PARAM_BIND_TYPE, SQL_ATTR_PARAM_STATUS_PTR, SQL_ATTR_PARAMS_PROCESSED_PTR,
     SQL_ATTR_PARAMSET_SIZE, SQL_ATTR_ROW_ARRAY_SIZE, SQL_ATTR_ROW_BIND_OFFSET_PTR,
-    SQL_ATTR_ROW_BIND_TYPE, SQL_ATTR_ROW_STATUS_PTR, SQL_ATTR_ROWS_FETCHED_PTR, SQL_ERROR,
-    SQL_INVALID_HANDLE, SQL_SUCCESS, SqlHandle, SqlInteger, SqlPointer, SqlReturn, SqlULen,
-    SqlUSmallInt,
+    SQL_ATTR_ROW_BIND_TYPE, SQL_ATTR_ROW_STATUS_PTR, SQL_ATTR_ROWS_FETCHED_PTR,
+    SQL_CONCUR_READ_ONLY, SQL_CURSOR_FORWARD_ONLY, SQL_ERROR, SQL_INVALID_HANDLE, SQL_SUCCESS,
+    SqlHandle, SqlInteger, SqlPointer, SqlReturn, SqlULen, SqlUSmallInt,
 };
-use crate::error::free_errors;
+use crate::api::sqlstate::{
+    ERR_INVALID_ATTRIBUTE_IDENTIFIER, ERR_INVALID_ATTRIBUTE_VALUE, SQLSTATE_HYC00, post_diag,
+};
+use crate::api::util::write_if_some;
+use crate::error::{free_errors, post_sql_error};
 use crate::handles::{HandleType, StmtHandle, handle_from_raw};
 
 /// Sets a statement attribute.
@@ -65,7 +74,14 @@ unsafe fn sql_set_stmt_attr_w_impl(
         HandleType::Stmt,
         "SQLSetStmtAttrW: handle is not a STMT"
     );
+    sql_set_stmt_attr_w_safe(stmt, attribute, value_ptr)
+}
 
+fn sql_set_stmt_attr_w_safe(
+    stmt: &StmtHandle,
+    attribute: SqlInteger,
+    value_ptr: SqlPointer,
+) -> SqlReturn {
     let Ok(mut state) = stmt.inner.lock() else {
         error!("SQLSetStmtAttrW: stmt mutex poisoned");
         return SQL_ERROR;
@@ -75,11 +91,16 @@ unsafe fn sql_set_stmt_attr_w_impl(
     match attribute {
         SQL_ATTR_ROW_ARRAY_SIZE => {
             // The value is a `SQLULEN` passed by value in the pointer slot. Zero
-            // is invalid; clamp to one so downstream fetches never divide by it.
+            // is an invalid rowset size (HY024) — reject rather than paper over.
             let n = value_ptr as SqlULen;
-            state.row_array_size = n.max(1);
+            if n == 0 {
+                error!("SQLSetStmtAttrW: SQL_ATTR_ROW_ARRAY_SIZE of 0 is invalid");
+                post_diag(&mut state, ERR_INVALID_ATTRIBUTE_VALUE);
+                return SQL_ERROR;
+            }
+            state.row_array_size = n;
             debug!(
-                row_array_size = state.row_array_size,
+                row_array_size = n,
                 "SQLSetStmtAttrW: SQL_ATTR_ROW_ARRAY_SIZE set"
             );
             SQL_SUCCESS
@@ -96,13 +117,38 @@ unsafe fn sql_set_stmt_attr_w_impl(
             state.row_bind_type = value_ptr as SqlULen;
             SQL_SUCCESS
         }
-        // Accepted as no-ops: the driver already behaves as forward-only /
-        // read-only, and the remaining param-set / descriptor controls are not
-        // yet acted upon. mssql-python sets these to values consistent with the
-        // implemented behavior, so accept silently rather than fail the DM.
+        SQL_ATTR_PARAMSET_SIZE => {
+            // Parameter arrays are not yet consumed (executemany batch insert is
+            // tracked separately). Accept the ODBC default of 1; reject a larger
+            // batch (HYC00) instead of silently executing only the first row,
+            // and reject 0 as an invalid value (HY024).
+            match value_ptr as SqlULen {
+                1 => SQL_SUCCESS,
+                0 => {
+                    error!("SQLSetStmtAttrW: SQL_ATTR_PARAMSET_SIZE of 0 is invalid");
+                    post_diag(&mut state, ERR_INVALID_ATTRIBUTE_VALUE);
+                    SQL_ERROR
+                }
+                n => {
+                    error!(
+                        paramset_size = n,
+                        "SQLSetStmtAttrW: SQL_ATTR_PARAMSET_SIZE > 1 not supported"
+                    );
+                    post_sql_error(
+                        &mut state,
+                        SQLSTATE_HYC00,
+                        0,
+                        "Parameter arrays (SQL_ATTR_PARAMSET_SIZE > 1) are not supported",
+                    );
+                    SQL_ERROR
+                }
+            }
+        }
+        // Recognized attributes accepted without tracking: the driver is
+        // forward-only / read-only and these param / descriptor controls have
+        // no effect on the implemented behavior.
         SQL_ATTR_CURSOR_TYPE
         | SQL_ATTR_CONCURRENCY
-        | SQL_ATTR_PARAMSET_SIZE
         | SQL_ATTR_PARAM_BIND_TYPE
         | SQL_ATTR_PARAM_STATUS_PTR
         | SQL_ATTR_PARAMS_PROCESSED_PTR
@@ -113,14 +159,12 @@ unsafe fn sql_set_stmt_attr_w_impl(
             SQL_SUCCESS
         }
         _ => {
-            // Unknown statement attributes are accepted as no-ops: the Driver
-            // Manager probes many attributes and rejecting them breaks the
-            // handshake.
-            debug!(
+            error!(
                 attribute,
-                "SQLSetStmtAttrW: unrecognized attribute accepted as no-op"
+                "SQLSetStmtAttrW: unrecognized attribute identifier"
             );
-            SQL_SUCCESS
+            post_diag(&mut state, ERR_INVALID_ATTRIBUTE_IDENTIFIER);
+            SQL_ERROR
         }
     }
 }
@@ -138,8 +182,14 @@ pub(crate) unsafe fn sql_get_stmt_attr_w(
     buffer_length: SqlInteger,
     string_length_ptr: *mut SqlInteger,
 ) -> SqlReturn {
-    debug!(?statement_handle, attribute, "SQLGetStmtAttrW called");
-    let _ = (buffer_length, string_length_ptr); // no string-valued attrs here
+    debug!(
+        ?statement_handle,
+        attribute,
+        ?value_ptr,
+        buffer_length,
+        ?string_length_ptr,
+        "SQLGetStmtAttrW called",
+    );
     crate::ffi_entry!("SQLGetStmtAttrW", unsafe {
         sql_get_stmt_attr_w_impl(statement_handle, attribute, value_ptr)
     })
@@ -154,10 +204,6 @@ unsafe fn sql_get_stmt_attr_w_impl(
         error!("SQLGetStmtAttrW: statement_handle is null");
         return SQL_INVALID_HANDLE;
     }
-    if value_ptr.is_null() {
-        // Nothing to write into; treat as a successful no-op.
-        return SQL_SUCCESS;
-    }
 
     let stmt = unsafe { handle_from_raw::<StmtHandle>(statement_handle) };
     debug_assert_eq!(
@@ -165,34 +211,54 @@ unsafe fn sql_get_stmt_attr_w_impl(
         HandleType::Stmt,
         "SQLGetStmtAttrW: handle is not a STMT"
     );
+    sql_get_stmt_attr_w_safe(stmt, attribute, value_ptr)
+}
 
-    let Ok(state) = stmt.inner.lock() else {
+fn sql_get_stmt_attr_w_safe(
+    stmt: &StmtHandle,
+    attribute: SqlInteger,
+    value_ptr: SqlPointer,
+) -> SqlReturn {
+    let Ok(mut state) = stmt.inner.lock() else {
         error!("SQLGetStmtAttrW: stmt mutex poisoned");
         return SQL_ERROR;
     };
+    free_errors(&mut state);
 
+    // Every attribute reported here is a pointer-sized integer or pointer.
+    // `write_if_some` is a no-op when `value_ptr` is null.
     match attribute {
         SQL_ATTR_ROW_ARRAY_SIZE => unsafe {
-            *(value_ptr as *mut SqlULen) = state.row_array_size;
+            write_if_some(value_ptr as *mut SqlULen, state.row_array_size);
         },
         SQL_ATTR_ROWS_FETCHED_PTR => unsafe {
-            *(value_ptr as *mut *mut SqlULen) = state.rows_fetched_ptr;
+            write_if_some(value_ptr as *mut *mut SqlULen, state.rows_fetched_ptr);
         },
         SQL_ATTR_ROW_STATUS_PTR => unsafe {
-            *(value_ptr as *mut *mut SqlUSmallInt) = state.row_status_ptr;
+            write_if_some(value_ptr as *mut *mut SqlUSmallInt, state.row_status_ptr);
         },
         SQL_ATTR_ROW_BIND_TYPE => unsafe {
-            *(value_ptr as *mut SqlULen) = state.row_bind_type;
+            write_if_some(value_ptr as *mut SqlULen, state.row_bind_type);
         },
-        _ => unsafe {
-            // Report a benign zero for attributes we don't track rather than
-            // failing; callers reading an unset attribute get the ODBC default.
-            debug!(
+        // Recognized attributes we don't store: report their effective ODBC
+        // defaults for this forward-only, read-only, single-paramset driver.
+        SQL_ATTR_CURSOR_TYPE => unsafe {
+            write_if_some(value_ptr as *mut SqlULen, SQL_CURSOR_FORWARD_ONLY);
+        },
+        SQL_ATTR_CONCURRENCY => unsafe {
+            write_if_some(value_ptr as *mut SqlULen, SQL_CONCUR_READ_ONLY);
+        },
+        SQL_ATTR_PARAMSET_SIZE => unsafe {
+            write_if_some(value_ptr as *mut SqlULen, 1);
+        },
+        _ => {
+            error!(
                 attribute,
-                "SQLGetStmtAttrW: unrecognized attribute; returning 0"
+                "SQLGetStmtAttrW: unrecognized attribute identifier"
             );
-            *(value_ptr as *mut SqlULen) = 0;
-        },
+            post_diag(&mut state, ERR_INVALID_ATTRIBUTE_IDENTIFIER);
+            return SQL_ERROR;
+        }
     }
 
     SQL_SUCCESS
@@ -243,11 +309,12 @@ mod tests {
     }
 
     #[test]
-    fn set_row_array_size_zero_clamps_to_one() {
+    fn set_row_array_size_zero_rejected() {
         let h = TestHandles::with_env_dbc_stmt();
         let ret =
             unsafe { sql_set_stmt_attr_w(h.stmt, SQL_ATTR_ROW_ARRAY_SIZE, 0 as SqlPointer, 0) };
-        assert_eq!(ret, SQL_SUCCESS);
+        assert_eq!(ret, SQL_ERROR);
+        // The previous (default) value must be left untouched.
         let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
         assert_eq!(stmt.inner.lock().unwrap().row_array_size, 1);
     }
@@ -261,6 +328,37 @@ mod tests {
         assert_eq!(ret, SQL_SUCCESS);
         let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
         assert_eq!(stmt.inner.lock().unwrap().rows_fetched_ptr, ptr);
+    }
+
+    #[test]
+    fn set_row_status_ptr_stored() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let mut status: SqlUSmallInt = 0;
+        let ptr = &mut status as *mut SqlUSmallInt;
+        let ret = unsafe { sql_set_stmt_attr_w(h.stmt, SQL_ATTR_ROW_STATUS_PTR, ptr.cast(), 0) };
+        assert_eq!(ret, SQL_SUCCESS);
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        assert_eq!(stmt.inner.lock().unwrap().row_status_ptr, ptr);
+    }
+
+    #[test]
+    fn set_row_bind_type_stored_and_readback() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let ret =
+            unsafe { sql_set_stmt_attr_w(h.stmt, SQL_ATTR_ROW_BIND_TYPE, 40 as SqlPointer, 0) };
+        assert_eq!(ret, SQL_SUCCESS);
+        let mut out: SqlULen = 0;
+        let ret = unsafe {
+            sql_get_stmt_attr_w(
+                h.stmt,
+                SQL_ATTR_ROW_BIND_TYPE,
+                (&mut out as *mut SqlULen).cast(),
+                0,
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(ret, SQL_SUCCESS);
+        assert_eq!(out, 40);
     }
 
     #[test]
@@ -281,9 +379,146 @@ mod tests {
     }
 
     #[test]
-    fn unknown_attribute_accepted_as_noop() {
+    fn set_unknown_attribute_rejected() {
         let h = TestHandles::with_env_dbc_stmt();
         let ret = unsafe { sql_set_stmt_attr_w(h.stmt, 9999, 0 as SqlPointer, 0) };
+        assert_eq!(ret, SQL_ERROR);
+    }
+
+    #[test]
+    fn set_recognized_untracked_attribute_accepted() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let ret = unsafe {
+            sql_set_stmt_attr_w(
+                h.stmt,
+                SQL_ATTR_CONCURRENCY,
+                SQL_CONCUR_READ_ONLY as SqlPointer,
+                0,
+            )
+        };
+        assert_eq!(ret, SQL_SUCCESS);
+    }
+
+    #[test]
+    fn set_paramset_size_one_accepted() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let ret =
+            unsafe { sql_set_stmt_attr_w(h.stmt, SQL_ATTR_PARAMSET_SIZE, 1 as SqlPointer, 0) };
+        assert_eq!(ret, SQL_SUCCESS);
+    }
+
+    #[test]
+    fn set_paramset_size_greater_than_one_rejected() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let ret =
+            unsafe { sql_set_stmt_attr_w(h.stmt, SQL_ATTR_PARAMSET_SIZE, 100 as SqlPointer, 0) };
+        assert_eq!(ret, SQL_ERROR);
+    }
+
+    #[test]
+    fn set_paramset_size_zero_rejected() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let ret =
+            unsafe { sql_set_stmt_attr_w(h.stmt, SQL_ATTR_PARAMSET_SIZE, 0 as SqlPointer, 0) };
+        assert_eq!(ret, SQL_ERROR);
+    }
+
+    #[test]
+    fn get_stmt_attr_null_handle() {
+        let mut out: SqlULen = 0;
+        let ret = unsafe {
+            sql_get_stmt_attr_w(
+                SQL_NULL_HANDLE,
+                SQL_ATTR_ROW_ARRAY_SIZE,
+                (&mut out as *mut SqlULen).cast(),
+                0,
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(ret, SQL_INVALID_HANDLE);
+    }
+
+    #[test]
+    fn get_unknown_attribute_rejected() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let mut out: SqlULen = 7;
+        let ret = unsafe {
+            sql_get_stmt_attr_w(
+                h.stmt,
+                9999,
+                (&mut out as *mut SqlULen).cast(),
+                0,
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(ret, SQL_ERROR);
+        // Output must be left untouched on an invalid identifier.
+        assert_eq!(out, 7);
+    }
+
+    #[test]
+    fn get_concurrency_default_is_read_only() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let mut out: SqlULen = 999;
+        let ret = unsafe {
+            sql_get_stmt_attr_w(
+                h.stmt,
+                SQL_ATTR_CONCURRENCY,
+                (&mut out as *mut SqlULen).cast(),
+                0,
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(ret, SQL_SUCCESS);
+        assert_eq!(out, SQL_CONCUR_READ_ONLY);
+    }
+
+    #[test]
+    fn get_cursor_type_default_is_forward_only() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let mut out: SqlULen = 999;
+        let ret = unsafe {
+            sql_get_stmt_attr_w(
+                h.stmt,
+                SQL_ATTR_CURSOR_TYPE,
+                (&mut out as *mut SqlULen).cast(),
+                0,
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(ret, SQL_SUCCESS);
+        assert_eq!(out, SQL_CURSOR_FORWARD_ONLY);
+    }
+
+    #[test]
+    fn get_paramset_size_default_is_one() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let mut out: SqlULen = 999;
+        let ret = unsafe {
+            sql_get_stmt_attr_w(
+                h.stmt,
+                SQL_ATTR_PARAMSET_SIZE,
+                (&mut out as *mut SqlULen).cast(),
+                0,
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(ret, SQL_SUCCESS);
+        assert_eq!(out, 1);
+    }
+
+    #[test]
+    fn get_stmt_attr_null_value_ptr_is_noop_success() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let ret = unsafe {
+            sql_get_stmt_attr_w(
+                h.stmt,
+                SQL_ATTR_ROW_ARRAY_SIZE,
+                std::ptr::null_mut(),
+                0,
+                std::ptr::null_mut(),
+            )
+        };
         assert_eq!(ret, SQL_SUCCESS);
     }
 }

--- a/mssql-odbc/src/api/set_stmt_attr.rs
+++ b/mssql-odbc/src/api/set_stmt_attr.rs
@@ -1,0 +1,289 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Implementation of `SQLSetStmtAttrW` / `SQLGetStmtAttrW`.
+//!
+//! Only the attributes exercised by the fetch path are given real semantics:
+//! the block-fetch rowset controls (`SQL_ATTR_ROW_ARRAY_SIZE`,
+//! `SQL_ATTR_ROWS_FETCHED_PTR`, `SQL_ATTR_ROW_STATUS_PTR`,
+//! `SQL_ATTR_ROW_BIND_TYPE`). Everything else the Driver Manager or
+//! mssql-python sets — cursor type, concurrency, param-set controls — is
+//! accepted as a no-op so the handshake is not broken. This driver only
+//! supports forward-only, read-only cursors, which is exactly what
+//! mssql-python requests.
+
+use tracing::{debug, error};
+
+use crate::api::odbc_types::{
+    SQL_ATTR_APP_PARAM_DESC, SQL_ATTR_APP_ROW_DESC, SQL_ATTR_CONCURRENCY, SQL_ATTR_CURSOR_TYPE,
+    SQL_ATTR_PARAM_BIND_TYPE, SQL_ATTR_PARAM_STATUS_PTR, SQL_ATTR_PARAMS_PROCESSED_PTR,
+    SQL_ATTR_PARAMSET_SIZE, SQL_ATTR_ROW_ARRAY_SIZE, SQL_ATTR_ROW_BIND_OFFSET_PTR,
+    SQL_ATTR_ROW_BIND_TYPE, SQL_ATTR_ROW_STATUS_PTR, SQL_ATTR_ROWS_FETCHED_PTR, SQL_ERROR,
+    SQL_INVALID_HANDLE, SQL_SUCCESS, SqlHandle, SqlInteger, SqlPointer, SqlReturn, SqlULen,
+    SqlUSmallInt,
+};
+use crate::error::free_errors;
+use crate::handles::{HandleType, StmtHandle, handle_from_raw};
+
+/// Sets a statement attribute.
+///
+/// # Safety
+/// `statement_handle` must be a valid `StmtHandle` or null. For the pointer
+/// attributes the caller-supplied `value_ptr` must remain valid for the
+/// lifetime it is used by later fetches.
+pub(crate) unsafe fn sql_set_stmt_attr_w(
+    statement_handle: SqlHandle,
+    attribute: SqlInteger,
+    value_ptr: SqlPointer,
+    string_length: SqlInteger,
+) -> SqlReturn {
+    debug!(
+        ?statement_handle,
+        attribute,
+        ?value_ptr,
+        string_length,
+        "SQLSetStmtAttrW called",
+    );
+    crate::ffi_entry!("SQLSetStmtAttrW", unsafe {
+        sql_set_stmt_attr_w_impl(statement_handle, attribute, value_ptr)
+    })
+}
+
+unsafe fn sql_set_stmt_attr_w_impl(
+    statement_handle: SqlHandle,
+    attribute: SqlInteger,
+    value_ptr: SqlPointer,
+) -> SqlReturn {
+    if statement_handle.is_null() {
+        error!("SQLSetStmtAttrW: statement_handle is null");
+        return SQL_INVALID_HANDLE;
+    }
+
+    let stmt = unsafe { handle_from_raw::<StmtHandle>(statement_handle) };
+    debug_assert_eq!(
+        stmt.object_type,
+        HandleType::Stmt,
+        "SQLSetStmtAttrW: handle is not a STMT"
+    );
+
+    let Ok(mut state) = stmt.inner.lock() else {
+        error!("SQLSetStmtAttrW: stmt mutex poisoned");
+        return SQL_ERROR;
+    };
+    free_errors(&mut state);
+
+    match attribute {
+        SQL_ATTR_ROW_ARRAY_SIZE => {
+            // The value is a `SQLULEN` passed by value in the pointer slot. Zero
+            // is invalid; clamp to one so downstream fetches never divide by it.
+            let n = value_ptr as SqlULen;
+            state.row_array_size = n.max(1);
+            debug!(
+                row_array_size = state.row_array_size,
+                "SQLSetStmtAttrW: SQL_ATTR_ROW_ARRAY_SIZE set"
+            );
+            SQL_SUCCESS
+        }
+        SQL_ATTR_ROWS_FETCHED_PTR => {
+            state.rows_fetched_ptr = value_ptr as *mut SqlULen;
+            SQL_SUCCESS
+        }
+        SQL_ATTR_ROW_STATUS_PTR => {
+            state.row_status_ptr = value_ptr as *mut SqlUSmallInt;
+            SQL_SUCCESS
+        }
+        SQL_ATTR_ROW_BIND_TYPE => {
+            state.row_bind_type = value_ptr as SqlULen;
+            SQL_SUCCESS
+        }
+        // Accepted as no-ops: the driver already behaves as forward-only /
+        // read-only, and the remaining param-set / descriptor controls are not
+        // yet acted upon. mssql-python sets these to values consistent with the
+        // implemented behavior, so accept silently rather than fail the DM.
+        SQL_ATTR_CURSOR_TYPE
+        | SQL_ATTR_CONCURRENCY
+        | SQL_ATTR_PARAMSET_SIZE
+        | SQL_ATTR_PARAM_BIND_TYPE
+        | SQL_ATTR_PARAM_STATUS_PTR
+        | SQL_ATTR_PARAMS_PROCESSED_PTR
+        | SQL_ATTR_ROW_BIND_OFFSET_PTR
+        | SQL_ATTR_APP_ROW_DESC
+        | SQL_ATTR_APP_PARAM_DESC => {
+            debug!(attribute, "SQLSetStmtAttrW: attribute accepted as no-op");
+            SQL_SUCCESS
+        }
+        _ => {
+            // Unknown statement attributes are accepted as no-ops: the Driver
+            // Manager probes many attributes and rejecting them breaks the
+            // handshake.
+            debug!(
+                attribute,
+                "SQLSetStmtAttrW: unrecognized attribute accepted as no-op"
+            );
+            SQL_SUCCESS
+        }
+    }
+}
+
+/// Retrieves a statement attribute.
+///
+/// # Safety
+/// `statement_handle` must be a valid `StmtHandle` or null. `value_ptr`, when
+/// non-null, must be writable for the size of the attribute (pointer-sized for
+/// every attribute handled here).
+pub(crate) unsafe fn sql_get_stmt_attr_w(
+    statement_handle: SqlHandle,
+    attribute: SqlInteger,
+    value_ptr: SqlPointer,
+    buffer_length: SqlInteger,
+    string_length_ptr: *mut SqlInteger,
+) -> SqlReturn {
+    debug!(?statement_handle, attribute, "SQLGetStmtAttrW called");
+    let _ = (buffer_length, string_length_ptr); // no string-valued attrs here
+    crate::ffi_entry!("SQLGetStmtAttrW", unsafe {
+        sql_get_stmt_attr_w_impl(statement_handle, attribute, value_ptr)
+    })
+}
+
+unsafe fn sql_get_stmt_attr_w_impl(
+    statement_handle: SqlHandle,
+    attribute: SqlInteger,
+    value_ptr: SqlPointer,
+) -> SqlReturn {
+    if statement_handle.is_null() {
+        error!("SQLGetStmtAttrW: statement_handle is null");
+        return SQL_INVALID_HANDLE;
+    }
+    if value_ptr.is_null() {
+        // Nothing to write into; treat as a successful no-op.
+        return SQL_SUCCESS;
+    }
+
+    let stmt = unsafe { handle_from_raw::<StmtHandle>(statement_handle) };
+    debug_assert_eq!(
+        stmt.object_type,
+        HandleType::Stmt,
+        "SQLGetStmtAttrW: handle is not a STMT"
+    );
+
+    let Ok(state) = stmt.inner.lock() else {
+        error!("SQLGetStmtAttrW: stmt mutex poisoned");
+        return SQL_ERROR;
+    };
+
+    match attribute {
+        SQL_ATTR_ROW_ARRAY_SIZE => unsafe {
+            *(value_ptr as *mut SqlULen) = state.row_array_size;
+        },
+        SQL_ATTR_ROWS_FETCHED_PTR => unsafe {
+            *(value_ptr as *mut *mut SqlULen) = state.rows_fetched_ptr;
+        },
+        SQL_ATTR_ROW_STATUS_PTR => unsafe {
+            *(value_ptr as *mut *mut SqlUSmallInt) = state.row_status_ptr;
+        },
+        SQL_ATTR_ROW_BIND_TYPE => unsafe {
+            *(value_ptr as *mut SqlULen) = state.row_bind_type;
+        },
+        _ => unsafe {
+            // Report a benign zero for attributes we don't track rather than
+            // failing; callers reading an unset attribute get the ODBC default.
+            debug!(
+                attribute,
+                "SQLGetStmtAttrW: unrecognized attribute; returning 0"
+            );
+            *(value_ptr as *mut SqlULen) = 0;
+        },
+    }
+
+    SQL_SUCCESS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::odbc_types::{SQL_BIND_BY_COLUMN, SQL_NULL_HANDLE};
+    use crate::handles::handle_from_raw;
+    use crate::test_support::TestHandles;
+
+    #[test]
+    fn set_stmt_attr_null_handle() {
+        let ret = unsafe {
+            sql_set_stmt_attr_w(
+                SQL_NULL_HANDLE,
+                SQL_ATTR_ROW_ARRAY_SIZE,
+                10 as SqlPointer,
+                0,
+            )
+        };
+        assert_eq!(ret, SQL_INVALID_HANDLE);
+    }
+
+    #[test]
+    fn set_row_array_size_stored_and_readback() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let ret =
+            unsafe { sql_set_stmt_attr_w(h.stmt, SQL_ATTR_ROW_ARRAY_SIZE, 128 as SqlPointer, 0) };
+        assert_eq!(ret, SQL_SUCCESS);
+
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        assert_eq!(stmt.inner.lock().unwrap().row_array_size, 128);
+
+        let mut out: SqlULen = 0;
+        let ret = unsafe {
+            sql_get_stmt_attr_w(
+                h.stmt,
+                SQL_ATTR_ROW_ARRAY_SIZE,
+                (&mut out as *mut SqlULen).cast(),
+                0,
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(ret, SQL_SUCCESS);
+        assert_eq!(out, 128);
+    }
+
+    #[test]
+    fn set_row_array_size_zero_clamps_to_one() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let ret =
+            unsafe { sql_set_stmt_attr_w(h.stmt, SQL_ATTR_ROW_ARRAY_SIZE, 0 as SqlPointer, 0) };
+        assert_eq!(ret, SQL_SUCCESS);
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        assert_eq!(stmt.inner.lock().unwrap().row_array_size, 1);
+    }
+
+    #[test]
+    fn set_rows_fetched_ptr_stored() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let mut rows_fetched: SqlULen = 0;
+        let ptr = &mut rows_fetched as *mut SqlULen;
+        let ret = unsafe { sql_set_stmt_attr_w(h.stmt, SQL_ATTR_ROWS_FETCHED_PTR, ptr.cast(), 0) };
+        assert_eq!(ret, SQL_SUCCESS);
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        assert_eq!(stmt.inner.lock().unwrap().rows_fetched_ptr, ptr);
+    }
+
+    #[test]
+    fn default_row_bind_type_is_column_wise() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let mut out: SqlULen = 999;
+        let ret = unsafe {
+            sql_get_stmt_attr_w(
+                h.stmt,
+                SQL_ATTR_ROW_BIND_TYPE,
+                (&mut out as *mut SqlULen).cast(),
+                0,
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(ret, SQL_SUCCESS);
+        assert_eq!(out, SQL_BIND_BY_COLUMN);
+    }
+
+    #[test]
+    fn unknown_attribute_accepted_as_noop() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let ret = unsafe { sql_set_stmt_attr_w(h.stmt, 9999, 0 as SqlPointer, 0) };
+        assert_eq!(ret, SQL_SUCCESS);
+    }
+}

--- a/mssql-odbc/src/api/set_stmt_attr.rs
+++ b/mssql-odbc/src/api/set_stmt_attr.rs
@@ -6,13 +6,14 @@
 //! The block-fetch rowset controls (`SQL_ATTR_ROW_ARRAY_SIZE`,
 //! `SQL_ATTR_ROWS_FETCHED_PTR`, `SQL_ATTR_ROW_STATUS_PTR`,
 //! `SQL_ATTR_ROW_BIND_TYPE`) are stored and later consumed by the columnar
-//! fetch path. Other recognized statement attributes (cursor type, concurrency,
-//! param / descriptor controls) are accepted without effect because the driver
-//! is forward-only and read-only — exactly what mssql-python requests.
-//! `SQL_ATTR_PARAMSET_SIZE` accepts the ODBC default of 1 but rejects larger
-//! batches, since parameter arrays are not yet consumed and a silent success
-//! would execute only the first row. Unrecognized attribute identifiers fail
-//! with `HY092`.
+//! fetch path. `SQL_ATTR_CURSOR_TYPE` and `SQL_ATTR_CONCURRENCY` accept only the
+//! supported forward-only / read-only values; any other request is substituted
+//! and reported with `01S02` (option value changed) rather than silently
+//! succeeding. Other recognized statement attributes (param / descriptor
+//! controls) are accepted without effect. `SQL_ATTR_PARAMSET_SIZE` accepts the
+//! ODBC default of 1 but rejects larger batches, since parameter arrays are not
+//! yet consumed and a silent success would execute only the first row.
+//! Unrecognized attribute identifiers fail with `HY092`.
 //!
 //! Each entry point follows the crate's mandatory layering: FFI panic boundary
 //! → `unsafe` raw-handle shim → safe core (`README.md`; `num_result_cols.rs`).
@@ -25,10 +26,11 @@ use crate::api::odbc_types::{
     SQL_ATTR_PARAMSET_SIZE, SQL_ATTR_ROW_ARRAY_SIZE, SQL_ATTR_ROW_BIND_OFFSET_PTR,
     SQL_ATTR_ROW_BIND_TYPE, SQL_ATTR_ROW_STATUS_PTR, SQL_ATTR_ROWS_FETCHED_PTR,
     SQL_CONCUR_READ_ONLY, SQL_CURSOR_FORWARD_ONLY, SQL_ERROR, SQL_INVALID_HANDLE, SQL_SUCCESS,
-    SqlHandle, SqlInteger, SqlPointer, SqlReturn, SqlULen, SqlUSmallInt,
+    SQL_SUCCESS_WITH_INFO, SqlHandle, SqlInteger, SqlPointer, SqlReturn, SqlULen, SqlUSmallInt,
 };
 use crate::api::sqlstate::{
-    ERR_INVALID_ATTRIBUTE_IDENTIFIER, ERR_INVALID_ATTRIBUTE_VALUE, SQLSTATE_HYC00, post_diag,
+    ERR_INVALID_ATTRIBUTE_IDENTIFIER, ERR_INVALID_ATTRIBUTE_VALUE, SQLSTATE_01S02, SQLSTATE_HYC00,
+    post_diag,
 };
 use crate::api::util::write_if_some;
 use crate::error::{free_errors, post_sql_error};
@@ -144,12 +146,53 @@ fn sql_set_stmt_attr_w_safe(
                 }
             }
         }
-        // Recognized attributes accepted without tracking: the driver is
-        // forward-only / read-only and these param / descriptor controls have
-        // no effect on the implemented behavior.
-        SQL_ATTR_CURSOR_TYPE
-        | SQL_ATTR_CONCURRENCY
-        | SQL_ATTR_PARAM_BIND_TYPE
+        SQL_ATTR_CURSOR_TYPE => {
+            // The driver is forward-only. Accept SQL_CURSOR_FORWARD_ONLY as-is;
+            // for any other cursor type substitute forward-only and warn with
+            // 01S02, per the ODBC contract for unsupported cursor types (a
+            // silent success would tell the caller a scrollable cursor took
+            // effect when it did not). The substituted value is what
+            // SQLGetStmtAttrW reports back.
+            if value_ptr as SqlULen == SQL_CURSOR_FORWARD_ONLY {
+                SQL_SUCCESS
+            } else {
+                debug!(
+                    requested = value_ptr as SqlULen,
+                    "SQLSetStmtAttrW: cursor type substituted with SQL_CURSOR_FORWARD_ONLY"
+                );
+                post_sql_error(
+                    &mut state,
+                    SQLSTATE_01S02,
+                    0,
+                    "Cursor type not supported; substituted SQL_CURSOR_FORWARD_ONLY",
+                );
+                SQL_SUCCESS_WITH_INFO
+            }
+        }
+        SQL_ATTR_CONCURRENCY => {
+            // The driver is read-only. Accept SQL_CONCUR_READ_ONLY as-is;
+            // substitute read-only and warn with 01S02 for any writable
+            // concurrency request.
+            if value_ptr as SqlULen == SQL_CONCUR_READ_ONLY {
+                SQL_SUCCESS
+            } else {
+                debug!(
+                    requested = value_ptr as SqlULen,
+                    "SQLSetStmtAttrW: concurrency substituted with SQL_CONCUR_READ_ONLY"
+                );
+                post_sql_error(
+                    &mut state,
+                    SQLSTATE_01S02,
+                    0,
+                    "Concurrency not supported; substituted SQL_CONCUR_READ_ONLY",
+                );
+                SQL_SUCCESS_WITH_INFO
+            }
+        }
+        // Recognized attributes accepted without tracking: these param /
+        // descriptor controls have no effect on the implemented forward-only,
+        // read-only behavior.
+        SQL_ATTR_PARAM_BIND_TYPE
         | SQL_ATTR_PARAM_STATUS_PTR
         | SQL_ATTR_PARAMS_PROCESSED_PTR
         | SQL_ATTR_ROW_BIND_OFFSET_PTR
@@ -397,6 +440,65 @@ mod tests {
             )
         };
         assert_eq!(ret, SQL_SUCCESS);
+    }
+
+    #[test]
+    fn set_cursor_type_forward_only_accepted() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let ret = unsafe {
+            sql_set_stmt_attr_w(
+                h.stmt,
+                SQL_ATTR_CURSOR_TYPE,
+                SQL_CURSOR_FORWARD_ONLY as SqlPointer,
+                0,
+            )
+        };
+        assert_eq!(ret, SQL_SUCCESS);
+    }
+
+    #[test]
+    fn set_cursor_type_unsupported_substituted() {
+        let h = TestHandles::with_env_dbc_stmt();
+        // Any non-forward-only cursor (e.g. SQL_CURSOR_STATIC = 3) is
+        // substituted with forward-only and reported via 01S02.
+        let ret = unsafe { sql_set_stmt_attr_w(h.stmt, SQL_ATTR_CURSOR_TYPE, 3 as SqlPointer, 0) };
+        assert_eq!(ret, SQL_SUCCESS_WITH_INFO);
+
+        // The getter still reports the supported forward-only value.
+        let mut out: SqlULen = 999;
+        let ret = unsafe {
+            sql_get_stmt_attr_w(
+                h.stmt,
+                SQL_ATTR_CURSOR_TYPE,
+                (&mut out as *mut SqlULen).cast(),
+                0,
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(ret, SQL_SUCCESS);
+        assert_eq!(out, SQL_CURSOR_FORWARD_ONLY);
+    }
+
+    #[test]
+    fn set_concurrency_unsupported_substituted() {
+        let h = TestHandles::with_env_dbc_stmt();
+        // Any writable concurrency (e.g. SQL_CONCUR_LOCK = 2) is substituted
+        // with read-only and reported via 01S02.
+        let ret = unsafe { sql_set_stmt_attr_w(h.stmt, SQL_ATTR_CONCURRENCY, 2 as SqlPointer, 0) };
+        assert_eq!(ret, SQL_SUCCESS_WITH_INFO);
+
+        let mut out: SqlULen = 999;
+        let ret = unsafe {
+            sql_get_stmt_attr_w(
+                h.stmt,
+                SQL_ATTR_CONCURRENCY,
+                (&mut out as *mut SqlULen).cast(),
+                0,
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(ret, SQL_SUCCESS);
+        assert_eq!(out, SQL_CONCUR_READ_ONLY);
     }
 
     #[test]

--- a/mssql-odbc/src/api/sqlstate.rs
+++ b/mssql-odbc/src/api/sqlstate.rs
@@ -10,6 +10,7 @@ use mssql_tds::error::SqlInfoMessage;
 pub(crate) const SQLSTATE_01000: [u8; 5] = *b"01000";
 pub(crate) const SQLSTATE_01004: [u8; 5] = *b"01004";
 pub(crate) const SQLSTATE_01S00: [u8; 5] = *b"01S00";
+pub(crate) const SQLSTATE_01S02: [u8; 5] = *b"01S02";
 pub(crate) const SQLSTATE_07002: [u8; 5] = *b"07002";
 pub(crate) const SQLSTATE_07006: [u8; 5] = *b"07006";
 pub(crate) const SQLSTATE_07009: [u8; 5] = *b"07009";

--- a/mssql-odbc/src/handles/stmt.rs
+++ b/mssql-odbc/src/handles/stmt.rs
@@ -8,6 +8,7 @@ use mssql_tds::datatypes::column_values::ColumnValues;
 use mssql_tds::query::metadata::ColumnMetadata;
 
 use super::{DbcHandle, HandleType, HasObjectType};
+use crate::api::odbc_types::{SqlULen, SqlUSmallInt};
 use crate::error::{DiagRecord, HasDiagnostics};
 use crate::params::BoundParam;
 
@@ -55,6 +56,19 @@ pub(crate) struct StmtState {
     pub(crate) pending_unprepare: Option<i32>,
     /// Current fetched row, populated by SQLFetch for later SQLGetData support.
     pub(crate) current_row: Option<Vec<ColumnValues>>,
+    /// Rowset size for block fetches (`SQL_ATTR_ROW_ARRAY_SIZE`). Defaults to 1
+    /// (single-row). Consumed by the columnar `SQLFetchScroll` path.
+    pub(crate) row_array_size: SqlULen,
+    /// Application buffer that receives the count of rows fetched by a block
+    /// fetch (`SQL_ATTR_ROWS_FETCHED_PTR`); null when unset. The application
+    /// owns this buffer and must keep it valid across the fetch.
+    pub(crate) rows_fetched_ptr: *mut SqlULen,
+    /// Application array that receives per-row status codes
+    /// (`SQL_ATTR_ROW_STATUS_PTR`); null when unset.
+    pub(crate) row_status_ptr: *mut SqlUSmallInt,
+    /// Row binding orientation (`SQL_ATTR_ROW_BIND_TYPE`): `SQL_BIND_BY_COLUMN`
+    /// (0) for column-wise arrays, otherwise a row-struct byte size.
+    pub(crate) row_bind_type: SqlULen,
     /// Statement lifecycle/status flags used for ODBC API state checks.
     pub(crate) state_flags: u32,
 }
@@ -116,6 +130,10 @@ impl StmtHandle {
                 prepared_handle: None,
                 pending_unprepare: None,
                 current_row: None,
+                row_array_size: 1,
+                rows_fetched_ptr: std::ptr::null_mut(),
+                row_status_ptr: std::ptr::null_mut(),
+                row_bind_type: crate::api::odbc_types::SQL_BIND_BY_COLUMN,
                 state_flags: 0,
             }),
         }


### PR DESCRIPTION
## Summary

P0 of the **typed & columnar fetch** feature for `mssql-odbc` (ADO User Story [46375](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46375), task [46577](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46577)). This lays the type/constant/struct foundation and turns the `SQLSetStmtAttrW`/`SQLGetStmtAttrW` no-op stubs into real implementations. No fetch behavior changes yet — those land in P1–P3.

The end goal of the feature is to let `mssql-odbc` replace the bundled `msodbcsql18` under `mssql-python`, whose C++ pybind layer drives the result-fetch ODBC ABI. See `mssql-odbc/docs/typed-columnar-fetch-plan.md` (added here) for the full P0–P5 plan and the fetch type map.

## Changes

- **`api/odbc_types.rs`**: add the full `SQL_C_*` type id set (signed/unsigned integer widths, float/double, binary, bit, guid, numeric, legacy and `SQL_C_TYPE_*` date/time), the SQL Server extension type ids (`SQL_SS_XML/UDT/VARIANT`, `SQL_C_SS_TIME2/TIMESTAMPOFFSET`), `SQL_CA_SS_VARIANT_TYPE`, the statement-attribute identifiers, and the `#[repr(C)]` interop structs (`SqlDateStruct`, `SqlTimeStruct`, `SqlTimestampStruct`, `SqlSsTime2Struct`, `SqlSsTimestampoffsetStruct`, `SqlGuid`, `SqlNumericStruct`). Constant values verified against the msodbcsql headers.
- **`handles/stmt.rs`**: extend `StmtState` with the block-fetch controls `row_array_size` (default 1), `rows_fetched_ptr`, `row_status_ptr`, `row_bind_type` (default column-wise).
- **`api/set_stmt_attr.rs`** (new): real `SQLSetStmtAttrW` / `SQLGetStmtAttrW`. Honors the rowset controls; accepts cursor / concurrency / param-set attributes as no-ops so the Driver Manager handshake and `mssql-python` driver load are not broken (the driver is forward-only, read-only — exactly what `mssql-python` requests).
- **`api/exports.rs` / `api/mod.rs`**: route the exports to the new module.
- **`docs/typed-columnar-fetch-plan.md`** (new): the P0–P5 implementation plan.

## Testing

- `cargo build -p mssql-odbc` — clean
- `cargo clippy -p mssql-odbc` — clean
- `cargo test -p mssql-odbc` — **332 passed / 0 failed** (6 new `set_stmt_attr` tests)

## Scope notes

- The remaining `StmtState` fields (column-bindings vector, rowset buffer, per-column `SQLGetData` offset) are intentionally deferred to the phase that consumes them (P3 / P1) rather than added as dead scaffolding here.
- Batch insert (`executemany` via `SQL_ATTR_PARAMSET_SIZE`) is a separate write-path story ([46576](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46576)); this PR accepts that attribute as a no-op for now.

[AB#46577](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46577)
