### PR TITLE
Add mssql-python connection-string parity attributes to ODBC parser

### DIFF
--- a/mssql-odbc/docs/connection_string_parser.md
+++ b/mssql-odbc/docs/connection_string_parser.md
@@ -58,7 +58,7 @@ For each key/value pair, repeated until end of input:
    - *Mapped* — a key we act on. First occurrence stores the value; duplicates are
      discarded (**first-wins**).
    - *Ignored* — recognized by msodbcsql but not acted on here (e.g. `Driver`,
-     `DSN`, `ApplicationIntent`, `OEMToANSI`). No warning.
+     `DSN`, `QuotedId`, `OEMToANSI`). No warning.
    - *Unknown* — not in the table. Raises an `01S00` warning, but **parsing
      continues** to the next pair; the value is parsed and discarded. Never fails
      and never halts the scan.
@@ -131,15 +131,61 @@ Only an invalid **value** on a recognized, validated key is a hard error: msodbc
 returns `E_FAIL` (→ `Err(InvalidAttrValue)`) and the connect fails. Unknown or
 invalid *keywords* never fail.
 
+## Mapped connection attributes
+
+`MAPPED_KEYS` is the single source of truth for the keywords the parser acts on.
+Each maps (case-insensitively) to a `ConnectionParams` field, which
+`driver_connect` then wires into the mssql-tds `ClientContext` / `EncryptionOptions`.
+Several spellings can share one slot, giving first-wins semantics across the whole
+synonym group (e.g. `Server` / `Addr` / `Address`).
+
+| Connection-string key(s) | mssql-tds landing spot | Value handling |
+|--------------------------|------------------------|----------------|
+| `Server` / `Addr` / `Address` | `create_client(server)` | verbatim (`server,port`) |
+| `Database` | `ClientContext::database` | verbatim |
+| `UID` | `ClientContext::user_name` | verbatim |
+| `PWD` | `ClientContext::password` | verbatim, redacted in logs |
+| `Authentication` | auth resolution | recognized-keyword set |
+| `Trusted_Connection` | integrated auth | `Yes` / `No` |
+| `Encrypt` | `EncryptionOptions::mode` | `Yes` / `Mandatory` / `No` / `Optional` / `Strict` |
+| `TrustServerCertificate` | `EncryptionOptions::trust_server_certificate` | `Yes` / `No` |
+| `HostnameInCertificate` | `EncryptionOptions::host_name_in_cert` | verbatim |
+| `ServerCertificate` | `EncryptionOptions::server_certificate` (path) | verbatim path |
+| `ServerSPN` | `ClientContext::server_spn` | verbatim |
+| `ApplicationIntent` | `ClientContext::application_intent` | `ReadOnly` / `ReadWrite` |
+| `MultiSubnetFailover` | `ClientContext::multi_subnet_failover` | `Yes` / `No` |
+| `IpAddressPreference` | `ClientContext::ipaddress_preference` | `IPv4First` / `IPv6First` / `UsePlatformDefault` |
+| `ConnectRetryCount` | `ClientContext::connect_retry_count` | integer |
+| `ConnectRetryInterval` | `ClientContext::connect_retry_interval` | integer |
+| `KeepAlive` | `ClientContext::keep_alive_in_ms` (×1000) | integer, seconds |
+| `KeepAliveInterval` | `ClientContext::keep_alive_interval_in_ms` (×1000) | integer, seconds |
+| `PacketSize` | `ClientContext::packet_size` (u16) | integer, bytes |
+
+This mirrors the canonical keyword set that mssql-python normalizes to before it
+hands the string to the driver, so a mssql-python application can target mssql-odbc
+without changing its connection strings.
+
 ## Value validation
 
 Whole-value, case-insensitive, exact match (not prefix, not `y`/`1`):
 
-- **Yes/No** keys (`TrustServerCertificate`, `Trusted_Connection`): `Yes` | `No`.
+- **Yes/No** keys (`TrustServerCertificate`, `Trusted_Connection`,
+  `MultiSubnetFailover`): `Yes` | `No`.
 - **`Encrypt`**: `Yes` | `Mandatory` | `No` | `Optional` | `Strict`.
+- **`ApplicationIntent`**: `ReadOnly` | `ReadWrite`.
+- **`IpAddressPreference`**: `IPv4First` | `IPv6First` | `UsePlatformDefault`.
+- **Integer** keys (`ConnectRetryCount`, `ConnectRetryInterval`, `KeepAlive`,
+  `KeepAliveInterval`, `PacketSize`): a non-negative integer. Documented ranges are
+  **not** enforced at parse time — out-of-range clamping is left to mssql-tds so the
+  parser cannot diverge from the native driver. A non-numeric or negative value is a
+  hard error (`E_FAIL`).
 - **`Authentication`**: delegated to `is_recognized_keyword`
   (`odbc_supported_auth_keywords.rs`) so the accept/reject set never drifts from
   mssql-tds. An empty value is a recognized reset.
+
+Pass-through string keys (`Server`/`Addr`/`Address`, `Database`, `UID`, `PWD`,
+`ServerSPN`, `HostnameInCertificate`, `ServerCertificate`) are stored verbatim with
+no value validation, exactly as msodbcsql does.
 
 ## Keys we recognize but do not act on
 

--- a/mssql-odbc/docs/connection_string_parser.md
+++ b/mssql-odbc/docs/connection_string_parser.md
@@ -155,11 +155,11 @@ synonym group (e.g. `Server` / `Addr` / `Address`).
 | `ApplicationIntent` | `ClientContext::application_intent` | `ReadOnly` / `ReadWrite` |
 | `MultiSubnetFailover` | `ClientContext::multi_subnet_failover` | `Yes` / `No` |
 | `IpAddressPreference` | `ClientContext::ipaddress_preference` | `IPv4First` / `IPv6First` / `UsePlatformDefault` |
-| `ConnectRetryCount` | `ClientContext::connect_retry_count` | integer |
-| `ConnectRetryInterval` | `ClientContext::connect_retry_interval` | integer |
-| `KeepAlive` | `ClientContext::keep_alive_in_ms` (×1000) | integer, seconds |
-| `KeepAliveInterval` | `ClientContext::keep_alive_interval_in_ms` (×1000) | integer, seconds |
-| `PacketSize` | `ClientContext::packet_size` (u16) | integer, bytes |
+| `ConnectRetryCount` | `ClientContext::connect_retry_count` | integer, clamped to 0–255 |
+| `ConnectRetryInterval` | `ClientContext::connect_retry_interval` | integer, clamped to 1–60 (seconds) |
+| `KeepAlive` | `ClientContext::keep_alive_in_ms` (×1000) | integer, seconds (saturating) |
+| `KeepAliveInterval` | `ClientContext::keep_alive_interval_in_ms` (×1000) | integer, seconds (saturating) |
+| `PacketSize` | `ClientContext::packet_size` (u16) | integer bytes, clamped to 512–32768 |
 
 This mirrors the canonical keyword set that mssql-python normalizes to before it
 hands the string to the driver, so a mssql-python application can target mssql-odbc
@@ -175,10 +175,14 @@ Whole-value, case-insensitive, exact match (not prefix, not `y`/`1`):
 - **`ApplicationIntent`**: `ReadOnly` | `ReadWrite`.
 - **`IpAddressPreference`**: `IPv4First` | `IPv6First` | `UsePlatformDefault`.
 - **Integer** keys (`ConnectRetryCount`, `ConnectRetryInterval`, `KeepAlive`,
-  `KeepAliveInterval`, `PacketSize`): a non-negative integer. Documented ranges are
-  **not** enforced at parse time — out-of-range clamping is left to mssql-tds so the
-  parser cannot diverge from the native driver. A non-numeric or negative value is a
-  hard error (`E_FAIL`).
+  `KeepAliveInterval`, `PacketSize`): a non-negative integer. The parser accepts any
+  `u32` and does **not** range-check; a non-numeric or negative value is a hard error
+  (`E_FAIL`). Out-of-range values are clamped when mapped onto the `ClientContext`
+  (`apply_connection_params` in `driver_connect.rs`) — `ConnectRetryCount` to 0–255,
+  `ConnectRetryInterval` to 1–60, `PacketSize` to 512–32768 (the range mssql-tds
+  accepts), and `KeepAlive`/`KeepAliveInterval` saturate on the ×1000 conversion.
+  Clamping mirrors msodbcsql, which silently clamps rather than rejecting, and keeps
+  the downstream `connect_retry_count + 1` in mssql-tds from overflowing.
 - **`Authentication`**: delegated to `is_recognized_keyword`
   (`odbc_supported_auth_keywords.rs`) so the accept/reject set never drifts from
   mssql-tds. An empty value is a recognized reset.

--- a/mssql-odbc/docs/connection_string_parser.md
+++ b/mssql-odbc/docs/connection_string_parser.md
@@ -137,11 +137,16 @@ invalid *keywords* never fail.
 Each maps (case-insensitively) to a `ConnectionParams` field, which
 `driver_connect` then wires into the mssql-tds `ClientContext` / `EncryptionOptions`.
 Several spellings can share one slot, giving first-wins semantics across the whole
-synonym group (e.g. `Server` / `Addr` / `Address`).
+synonym group (e.g. `Server` / `Addr` / `Address`). The `Server` group is the one
+exception to plain first-wins: a non-empty `Address` / `Addr` takes precedence over
+`Server` regardless of position, and an empty `Address` falls back to `Server`,
+matching the SQL Server Native Client ODBC spec. (This only affects callers that
+pass both keys directly; mssql-python collapses the group to a single canonical
+`Server` before it reaches the driver.)
 
 | Connection-string key(s) | mssql-tds landing spot | Value handling |
 |--------------------------|------------------------|----------------|
-| `Server` / `Addr` / `Address` | `create_client(server)` | verbatim (`server,port`) |
+| `Server` / `Addr` / `Address` | `create_client(server)` | verbatim (`server,port`); `Address`/`Addr` wins over `Server` |
 | `Database` | `ClientContext::database` | verbatim |
 | `UID` | `ClientContext::user_name` | verbatim |
 | `PWD` | `ClientContext::password` | verbatim, redacted in logs |

--- a/mssql-odbc/docs/connection_string_parser.md
+++ b/mssql-odbc/docs/connection_string_parser.md
@@ -154,9 +154,9 @@ synonym group (e.g. `Server` / `Addr` / `Address`).
 | `ServerSPN` | `ClientContext::server_spn` | verbatim |
 | `ApplicationIntent` | `ClientContext::application_intent` | `ReadOnly` / `ReadWrite` |
 | `MultiSubnetFailover` | `ClientContext::multi_subnet_failover` | `Yes` / `No` |
-| `IpAddressPreference` | `ClientContext::ipaddress_preference` | `IPv4First` / `IPv6First` / `UsePlatformDefault` |
-| `ConnectRetryCount` | `ClientContext::connect_retry_count` | integer, clamped to 0–255 |
-| `ConnectRetryInterval` | `ClientContext::connect_retry_interval` | integer, clamped to 1–60 (seconds) |
+| `IpAddressPreference` | `ClientContext::ipaddress_preference` | `IPv4First` / `IPv6First` / `UsePlatformDefault`; unknown → `IPv4First` |
+| `ConnectRetryCount` | `ClientContext::connect_retry_count` | integer 0–255 (rejected if out of range) |
+| `ConnectRetryInterval` | `ClientContext::connect_retry_interval` | integer 1–60 seconds (rejected if out of range) |
 | `KeepAlive` | `ClientContext::keep_alive_in_ms` (×1000) | integer, seconds (saturating) |
 | `KeepAliveInterval` | `ClientContext::keep_alive_interval_in_ms` (×1000) | integer, seconds (saturating) |
 | `PacketSize` | `ClientContext::packet_size` (u16) | integer bytes, clamped to 512–32768 |
@@ -173,16 +173,17 @@ Whole-value, case-insensitive, exact match (not prefix, not `y`/`1`):
   `MultiSubnetFailover`): `Yes` | `No`.
 - **`Encrypt`**: `Yes` | `Mandatory` | `No` | `Optional` | `Strict`.
 - **`ApplicationIntent`**: `ReadOnly` | `ReadWrite`.
-- **`IpAddressPreference`**: `IPv4First` | `IPv6First` | `UsePlatformDefault`.
+- **`IpAddressPreference`**: `IPv4First` | `IPv6First` | `UsePlatformDefault`. Unknown
+  values are **not** rejected — they are accepted and fall back to `IPv4First` when
+  mapped onto the `ClientContext`, matching msodbcsql.
 - **Integer** keys (`ConnectRetryCount`, `ConnectRetryInterval`, `KeepAlive`,
-  `KeepAliveInterval`, `PacketSize`): a non-negative integer. The parser accepts any
-  `u32` and does **not** range-check; a non-numeric or negative value is a hard error
-  (`E_FAIL`). Out-of-range values are clamped when mapped onto the `ClientContext`
-  (`apply_connection_params` in `driver_connect.rs`) — `ConnectRetryCount` to 0–255,
-  `ConnectRetryInterval` to 1–60, `PacketSize` to 512–32768 (the range mssql-tds
-  accepts), and `KeepAlive`/`KeepAliveInterval` saturate on the ×1000 conversion.
-  Clamping mirrors msodbcsql, which silently clamps rather than rejecting, and keeps
-  the downstream `connect_retry_count + 1` in mssql-tds from overflowing.
+  `KeepAliveInterval`, `PacketSize`): a non-negative integer; a non-numeric or negative
+  value is a hard error (`E_FAIL`). Range handling then differs per key, matching
+  msodbcsql: `ConnectRetryCount` (0–255) and `ConnectRetryInterval` (1–60) are
+  **range-validated at parse time and rejected** when out of range, while `PacketSize`
+  is **clamped** to 512–32768 (the range mssql-tds accepts) when mapped onto the
+  `ClientContext` (`apply_connection_params` in `driver_connect.rs`).
+  `KeepAlive`/`KeepAliveInterval` saturate on the ×1000 seconds→ms conversion.
 - **`Authentication`**: delegated to `is_recognized_keyword`
   (`odbc_supported_auth_keywords.rs`) so the accept/reject set never drifts from
   mssql-tds. An empty value is a recognized reset.

--- a/mssql-odbc/docs/connection_string_parser.md
+++ b/mssql-odbc/docs/connection_string_parser.md
@@ -140,7 +140,8 @@ Several spellings can share one slot, giving first-wins semantics across the who
 synonym group (e.g. `Server` / `Addr` / `Address`). The `Server` group is the one
 exception to plain first-wins: a non-empty `Address` / `Addr` takes precedence over
 `Server` regardless of position, and an empty `Address` falls back to `Server`,
-matching the SQL Server Native Client ODBC spec. (This only affects callers that
+matching the msodbcsql driver (`sqlcconn.cpp` builds its login target from `KEY_ADDR`
+when Address has a value, otherwise `KEY_SERVER`). (This only affects callers that
 pass both keys directly; mssql-python collapses the group to a single canonical
 `Server` before it reaches the driver.)
 

--- a/mssql-odbc/src/api/driver_connect.rs
+++ b/mssql-odbc/src/api/driver_connect.rs
@@ -20,9 +20,11 @@ use crate::handles::DbcHandle;
 use crate::handles::dbc::{ConnectionState, DbcState};
 use crate::handles::{HandleType, handle_from_raw};
 
-use mssql_tds::connection::client_context::ClientContext;
+use mssql_tds::connection::client_context::{ClientContext, IPAddressPreference};
 use mssql_tds::connection_provider::tds_connection_provider::TdsConnectionProvider;
 use mssql_tds::core::{EncryptionOptions, EncryptionSetting};
+use mssql_tds::message::login_options::ApplicationIntent;
+use std::path::PathBuf;
 
 use super::util::read_utf16;
 use crate::auth::configure_auth;
@@ -278,9 +280,52 @@ fn do_connect(
             Some(e) if e.eq_ignore_ascii_case("strict") => EncryptionSetting::Strict,
             _ => EncryptionSetting::On, // ODBC default
         },
-        host_name_in_cert: None,
-        server_certificate: None,
+        host_name_in_cert: params.host_name_in_certificate.clone(),
+        server_certificate: params.server_certificate.as_deref().map(PathBuf::from),
     };
+
+    // Transport, routing, and TLS-identity options. Values were validated during
+    // parsing, so the enum mappings below fall through to their default variant.
+    if let Some(server_spn) = &params.server_spn {
+        context.server_spn = Some(server_spn.clone());
+    }
+    if let Some(intent) = &params.application_intent {
+        context.application_intent = if intent.eq_ignore_ascii_case("readonly") {
+            ApplicationIntent::ReadOnly
+        } else {
+            ApplicationIntent::ReadWrite
+        };
+    }
+    if let Some(multi_subnet_failover) = params.multi_subnet_failover {
+        context.multi_subnet_failover = multi_subnet_failover;
+    }
+    if let Some(count) = params.connect_retry_count {
+        context.connect_retry_count = count;
+    }
+    if let Some(interval) = params.connect_retry_interval {
+        context.connect_retry_interval = interval;
+    }
+    // ODBC expresses KeepAlive/KeepAliveInterval in seconds; mssql-tds stores
+    // milliseconds. Saturate so an out-of-range value can't overflow.
+    if let Some(secs) = params.keep_alive {
+        context.keep_alive_in_ms = secs.saturating_mul(1000);
+    }
+    if let Some(secs) = params.keep_alive_interval {
+        context.keep_alive_interval_in_ms = secs.saturating_mul(1000);
+    }
+    if let Some(pref) = &params.ip_address_preference {
+        context.ipaddress_preference = if pref.eq_ignore_ascii_case("ipv6first") {
+            IPAddressPreference::IPv6First
+        } else if pref.eq_ignore_ascii_case("useplatformdefault") {
+            IPAddressPreference::UsePlatformDefault
+        } else {
+            IPAddressPreference::IPv4First
+        };
+    }
+    // Parsed leniently as u32; mssql-tds owns range clamping (valid 512–32768).
+    if let Some(size) = params.packet_size {
+        context.packet_size = u16::try_from(size).unwrap_or(u16::MAX);
+    }
 
     // Connect via mssql-tds (lock is NOT held - the 'Connecting' state prevents races)
     let provider = TdsConnectionProvider::new();

--- a/mssql-odbc/src/api/driver_connect.rs
+++ b/mssql-odbc/src/api/driver_connect.rs
@@ -30,7 +30,7 @@ use super::util::read_utf16;
 use crate::auth::configure_auth;
 use crate::connection::odbc_authentication_transformer::transform_auth;
 use crate::connection::odbc_authentication_validator::validate_auth;
-use crate::connection::parse_connection_string;
+use crate::connection::{ConnectionParams, parse_connection_string};
 
 /// Implementation of `SQLDriverConnectW`.
 ///
@@ -280,52 +280,11 @@ fn do_connect(
             Some(e) if e.eq_ignore_ascii_case("strict") => EncryptionSetting::Strict,
             _ => EncryptionSetting::On, // ODBC default
         },
-        host_name_in_cert: params.host_name_in_certificate.clone(),
-        server_certificate: params.server_certificate.as_deref().map(PathBuf::from),
+        host_name_in_cert: None,
+        server_certificate: None,
     };
 
-    // Transport, routing, and TLS-identity options. Values were validated during
-    // parsing, so the enum mappings below fall through to their default variant.
-    if let Some(server_spn) = &params.server_spn {
-        context.server_spn = Some(server_spn.clone());
-    }
-    if let Some(intent) = &params.application_intent {
-        context.application_intent = if intent.eq_ignore_ascii_case("readonly") {
-            ApplicationIntent::ReadOnly
-        } else {
-            ApplicationIntent::ReadWrite
-        };
-    }
-    if let Some(multi_subnet_failover) = params.multi_subnet_failover {
-        context.multi_subnet_failover = multi_subnet_failover;
-    }
-    if let Some(count) = params.connect_retry_count {
-        context.connect_retry_count = count;
-    }
-    if let Some(interval) = params.connect_retry_interval {
-        context.connect_retry_interval = interval;
-    }
-    // ODBC expresses KeepAlive/KeepAliveInterval in seconds; mssql-tds stores
-    // milliseconds. Saturate so an out-of-range value can't overflow.
-    if let Some(secs) = params.keep_alive {
-        context.keep_alive_in_ms = secs.saturating_mul(1000);
-    }
-    if let Some(secs) = params.keep_alive_interval {
-        context.keep_alive_interval_in_ms = secs.saturating_mul(1000);
-    }
-    if let Some(pref) = &params.ip_address_preference {
-        context.ipaddress_preference = if pref.eq_ignore_ascii_case("ipv6first") {
-            IPAddressPreference::IPv6First
-        } else if pref.eq_ignore_ascii_case("useplatformdefault") {
-            IPAddressPreference::UsePlatformDefault
-        } else {
-            IPAddressPreference::IPv4First
-        };
-    }
-    // Parsed leniently as u32; mssql-tds owns range clamping (valid 512–32768).
-    if let Some(size) = params.packet_size {
-        context.packet_size = u16::try_from(size).unwrap_or(u16::MAX);
-    }
+    apply_connection_params(&mut context, &params);
 
     // Connect via mssql-tds (lock is NOT held - the 'Connecting' state prevents races)
     let provider = TdsConnectionProvider::new();
@@ -373,6 +332,69 @@ fn do_connect(
         SQL_SUCCESS_WITH_INFO
     } else {
         SQL_SUCCESS
+    }
+}
+
+/// `ConnectRetryCount` is valid over 0–255; clamping keeps the downstream
+/// `connect_retry_count + 1` in `mssql-tds` from overflowing.
+const MAX_CONNECT_RETRY_COUNT: u32 = 255;
+/// `ConnectRetryInterval` is valid over 1–60 seconds.
+const MIN_CONNECT_RETRY_INTERVAL: u32 = 1;
+const MAX_CONNECT_RETRY_INTERVAL: u32 = 60;
+/// TDS packet-size range accepted by `mssql-tds` (`DefaultClientContextValidator`).
+const MIN_PACKET_SIZE: u32 = 512;
+const MAX_PACKET_SIZE: u32 = 32768;
+
+/// Maps parsed [`ConnectionParams`] onto a [`ClientContext`]. Integer values are
+/// clamped to the ranges `mssql-tds` accepts — mirroring msodbcsql, which clamps
+/// out-of-range values rather than rejecting them — and enum strings (already
+/// validated during parsing) fall through to their default variant. Kept separate
+/// from `do_connect` so the mapping is unit-testable without a live server.
+fn apply_connection_params(context: &mut ClientContext, params: &ConnectionParams) {
+    context.encryption_options.host_name_in_cert = params.host_name_in_certificate.clone();
+    context.encryption_options.server_certificate =
+        params.server_certificate.as_deref().map(PathBuf::from);
+
+    if let Some(server_spn) = &params.server_spn {
+        context.server_spn = Some(server_spn.clone());
+    }
+    if let Some(intent) = &params.application_intent {
+        context.application_intent = if intent.eq_ignore_ascii_case("readonly") {
+            ApplicationIntent::ReadOnly
+        } else {
+            ApplicationIntent::ReadWrite
+        };
+    }
+    if let Some(multi_subnet_failover) = params.multi_subnet_failover {
+        context.multi_subnet_failover = multi_subnet_failover;
+    }
+    if let Some(count) = params.connect_retry_count {
+        context.connect_retry_count = count.min(MAX_CONNECT_RETRY_COUNT);
+    }
+    if let Some(interval) = params.connect_retry_interval {
+        context.connect_retry_interval =
+            interval.clamp(MIN_CONNECT_RETRY_INTERVAL, MAX_CONNECT_RETRY_INTERVAL);
+    }
+    // ODBC expresses KeepAlive/KeepAliveInterval in seconds; mssql-tds stores
+    // milliseconds. Saturate so a large value can't overflow.
+    if let Some(secs) = params.keep_alive {
+        context.keep_alive_in_ms = secs.saturating_mul(1000);
+    }
+    if let Some(secs) = params.keep_alive_interval {
+        context.keep_alive_interval_in_ms = secs.saturating_mul(1000);
+    }
+    if let Some(pref) = &params.ip_address_preference {
+        context.ipaddress_preference = if pref.eq_ignore_ascii_case("ipv6first") {
+            IPAddressPreference::IPv6First
+        } else if pref.eq_ignore_ascii_case("useplatformdefault") {
+            IPAddressPreference::UsePlatformDefault
+        } else {
+            IPAddressPreference::IPv4First
+        };
+    }
+    if let Some(size) = params.packet_size {
+        context.packet_size =
+            u16::try_from(size.clamp(MIN_PACKET_SIZE, MAX_PACKET_SIZE)).unwrap_or(u16::MAX);
     }
 }
 
@@ -620,5 +642,133 @@ mod tests {
                 "mode {mode} should post HY110"
             );
         }
+    }
+
+    #[test]
+    fn apply_params_maps_tls_identity_fields() {
+        let mut ctx = ClientContext::default();
+        let params = ConnectionParams {
+            host_name_in_certificate: Some("cn.contoso.com".to_string()),
+            server_certificate: Some("/etc/ssl/server.pem".to_string()),
+            ..Default::default()
+        };
+        apply_connection_params(&mut ctx, &params);
+        assert_eq!(
+            ctx.encryption_options.host_name_in_cert.as_deref(),
+            Some("cn.contoso.com")
+        );
+        assert_eq!(
+            ctx.encryption_options.server_certificate,
+            Some(PathBuf::from("/etc/ssl/server.pem"))
+        );
+    }
+
+    #[test]
+    fn apply_params_clamps_connect_retry_count() {
+        let mut ctx = ClientContext::default();
+        apply_connection_params(
+            &mut ctx,
+            &ConnectionParams {
+                connect_retry_count: Some(u32::MAX),
+                ..Default::default()
+            },
+        );
+        assert_eq!(ctx.connect_retry_count, MAX_CONNECT_RETRY_COUNT);
+        // The downstream `connect_retry_count + 1` in mssql-tds must not overflow.
+        assert!(ctx.connect_retry_count.checked_add(1).is_some());
+    }
+
+    #[test]
+    fn apply_params_clamps_connect_retry_interval() {
+        let mut ctx = ClientContext::default();
+        apply_connection_params(
+            &mut ctx,
+            &ConnectionParams {
+                connect_retry_interval: Some(0),
+                ..Default::default()
+            },
+        );
+        assert_eq!(ctx.connect_retry_interval, MIN_CONNECT_RETRY_INTERVAL);
+        apply_connection_params(
+            &mut ctx,
+            &ConnectionParams {
+                connect_retry_interval: Some(9_999),
+                ..Default::default()
+            },
+        );
+        assert_eq!(ctx.connect_retry_interval, MAX_CONNECT_RETRY_INTERVAL);
+    }
+
+    #[test]
+    fn apply_params_clamps_packet_size_to_tds_range() {
+        let mut ctx = ClientContext::default();
+        apply_connection_params(
+            &mut ctx,
+            &ConnectionParams {
+                packet_size: Some(100),
+                ..Default::default()
+            },
+        );
+        assert_eq!(ctx.packet_size, 512);
+        apply_connection_params(
+            &mut ctx,
+            &ConnectionParams {
+                packet_size: Some(70_000),
+                ..Default::default()
+            },
+        );
+        assert_eq!(ctx.packet_size, 32768);
+    }
+
+    #[test]
+    fn apply_params_maps_keepalive_seconds_to_millis() {
+        let mut ctx = ClientContext::default();
+        apply_connection_params(
+            &mut ctx,
+            &ConnectionParams {
+                keep_alive: Some(30),
+                keep_alive_interval: Some(5),
+                ..Default::default()
+            },
+        );
+        assert_eq!(ctx.keep_alive_in_ms, 30_000);
+        assert_eq!(ctx.keep_alive_interval_in_ms, 5_000);
+    }
+
+    #[test]
+    fn apply_params_maps_validated_enums() {
+        let mut ctx = ClientContext::default();
+        apply_connection_params(
+            &mut ctx,
+            &ConnectionParams {
+                application_intent: Some("ReadOnly".to_string()),
+                ip_address_preference: Some("IPv6First".to_string()),
+                multi_subnet_failover: Some(true),
+                server_spn: Some("MSSQLSvc/host:1433".to_string()),
+                ..Default::default()
+            },
+        );
+        assert!(matches!(
+            ctx.application_intent,
+            ApplicationIntent::ReadOnly
+        ));
+        assert!(matches!(
+            ctx.ipaddress_preference,
+            IPAddressPreference::IPv6First
+        ));
+        assert!(ctx.multi_subnet_failover);
+        assert_eq!(ctx.server_spn.as_deref(), Some("MSSQLSvc/host:1433"));
+    }
+
+    #[test]
+    fn apply_params_leaves_unset_fields_at_defaults() {
+        let mut ctx = ClientContext::default();
+        let before_packet = ctx.packet_size;
+        let before_retry = ctx.connect_retry_count;
+        apply_connection_params(&mut ctx, &ConnectionParams::default());
+        assert_eq!(ctx.packet_size, before_packet);
+        assert_eq!(ctx.connect_retry_count, before_retry);
+        assert_eq!(ctx.encryption_options.host_name_in_cert, None);
+        assert_eq!(ctx.encryption_options.server_certificate, None);
     }
 }

--- a/mssql-odbc/src/api/driver_connect.rs
+++ b/mssql-odbc/src/api/driver_connect.rs
@@ -335,21 +335,19 @@ fn do_connect(
     }
 }
 
-/// `ConnectRetryCount` is valid over 0–255; clamping keeps the downstream
-/// `connect_retry_count + 1` in `mssql-tds` from overflowing.
-const MAX_CONNECT_RETRY_COUNT: u32 = 255;
-/// `ConnectRetryInterval` is valid over 1–60 seconds.
-const MIN_CONNECT_RETRY_INTERVAL: u32 = 1;
-const MAX_CONNECT_RETRY_INTERVAL: u32 = 60;
 /// TDS packet-size range accepted by `mssql-tds` (`DefaultClientContextValidator`).
+/// Unlike `ConnectRetryCount` / `ConnectRetryInterval` (which the parser rejects
+/// out-of-range to match msodbcsql), `PacketSize` is clamped to this range.
 const MIN_PACKET_SIZE: u32 = 512;
 const MAX_PACKET_SIZE: u32 = 32768;
 
-/// Maps parsed [`ConnectionParams`] onto a [`ClientContext`]. Integer values are
-/// clamped to the ranges `mssql-tds` accepts — mirroring msodbcsql, which clamps
-/// out-of-range values rather than rejecting them — and enum strings (already
-/// validated during parsing) fall through to their default variant. Kept separate
-/// from `do_connect` so the mapping is unit-testable without a live server.
+/// Maps parsed [`ConnectionParams`] onto a [`ClientContext`]. `ConnectRetryCount`
+/// and `ConnectRetryInterval` are already range-validated during parsing;
+/// `PacketSize` is clamped here to the range `mssql-tds` accepts. Enum strings are
+/// mapped to their variant with a default fallback — validated during parsing,
+/// except `IpAddressPreference`, whose unknown values fall back to `IPv4First`
+/// (matching msodbcsql). Kept separate from `do_connect` so the mapping is
+/// unit-testable without a live server.
 fn apply_connection_params(context: &mut ClientContext, params: &ConnectionParams) {
     context.encryption_options.host_name_in_cert = params.host_name_in_certificate.clone();
     context.encryption_options.server_certificate =
@@ -369,11 +367,10 @@ fn apply_connection_params(context: &mut ClientContext, params: &ConnectionParam
         context.multi_subnet_failover = multi_subnet_failover;
     }
     if let Some(count) = params.connect_retry_count {
-        context.connect_retry_count = count.min(MAX_CONNECT_RETRY_COUNT);
+        context.connect_retry_count = count;
     }
     if let Some(interval) = params.connect_retry_interval {
-        context.connect_retry_interval =
-            interval.clamp(MIN_CONNECT_RETRY_INTERVAL, MAX_CONNECT_RETRY_INTERVAL);
+        context.connect_retry_interval = interval;
     }
     // ODBC expresses KeepAlive/KeepAliveInterval in seconds; mssql-tds stores
     // milliseconds. Saturate so a large value can't overflow.
@@ -664,39 +661,35 @@ mod tests {
     }
 
     #[test]
-    fn apply_params_clamps_connect_retry_count() {
+    fn apply_params_passes_through_connect_retry_values() {
+        // The parser range-validates these, so the mapping stores them verbatim.
         let mut ctx = ClientContext::default();
         apply_connection_params(
             &mut ctx,
             &ConnectionParams {
-                connect_retry_count: Some(u32::MAX),
+                connect_retry_count: Some(255),
+                connect_retry_interval: Some(60),
                 ..Default::default()
             },
         );
-        assert_eq!(ctx.connect_retry_count, MAX_CONNECT_RETRY_COUNT);
-        // The downstream `connect_retry_count + 1` in mssql-tds must not overflow.
-        assert!(ctx.connect_retry_count.checked_add(1).is_some());
+        assert_eq!(ctx.connect_retry_count, 255);
+        assert_eq!(ctx.connect_retry_interval, 60);
     }
 
     #[test]
-    fn apply_params_clamps_connect_retry_interval() {
+    fn apply_params_falls_back_unknown_ip_preference_to_ipv4first() {
         let mut ctx = ClientContext::default();
         apply_connection_params(
             &mut ctx,
             &ConnectionParams {
-                connect_retry_interval: Some(0),
+                ip_address_preference: Some("IPv7".to_string()),
                 ..Default::default()
             },
         );
-        assert_eq!(ctx.connect_retry_interval, MIN_CONNECT_RETRY_INTERVAL);
-        apply_connection_params(
-            &mut ctx,
-            &ConnectionParams {
-                connect_retry_interval: Some(9_999),
-                ..Default::default()
-            },
-        );
-        assert_eq!(ctx.connect_retry_interval, MAX_CONNECT_RETRY_INTERVAL);
+        assert!(matches!(
+            ctx.ipaddress_preference,
+            IPAddressPreference::IPv4First
+        ));
     }
 
     #[test]

--- a/mssql-odbc/src/connection/connection_string_parser.rs
+++ b/mssql-odbc/src/connection/connection_string_parser.rs
@@ -212,13 +212,13 @@ impl ConnectionParams {
         let mut parts = Vec::new();
 
         if !self.server.is_empty() {
-            parts.push(format!("Server={}", self.server));
+            parts.push(format!("Server={}", quote_odbc_value(&self.server)));
         }
         if !self.database.is_empty() {
-            parts.push(format!("Database={}", self.database));
+            parts.push(format!("Database={}", quote_odbc_value(&self.database)));
         }
         if !self.uid.is_empty() {
-            parts.push(format!("UID={}", self.uid));
+            parts.push(format!("UID={}", quote_odbc_value(&self.uid)));
         }
         if !self.pwd.is_empty() {
             parts.push("PWD=******".to_string());
@@ -239,7 +239,7 @@ impl ConnectionParams {
             ));
         }
         if let Some(server_spn) = &self.server_spn {
-            parts.push(format!("ServerSPN={server_spn}"));
+            parts.push(format!("ServerSPN={}", quote_odbc_value(server_spn)));
         }
         if let Some(application_intent) = &self.application_intent {
             parts.push(format!("ApplicationIntent={application_intent}"));
@@ -269,13 +269,32 @@ impl ConnectionParams {
             parts.push(format!("PacketSize={packet_size}"));
         }
         if let Some(host_name_in_certificate) = &self.host_name_in_certificate {
-            parts.push(format!("HostnameInCertificate={host_name_in_certificate}"));
+            parts.push(format!(
+                "HostnameInCertificate={}",
+                quote_odbc_value(host_name_in_certificate)
+            ));
         }
         if let Some(server_certificate) = &self.server_certificate {
-            parts.push(format!("ServerCertificate={server_certificate}"));
+            parts.push(format!(
+                "ServerCertificate={}",
+                quote_odbc_value(server_certificate)
+            ));
         }
 
         parts.join(";")
+    }
+}
+
+/// Quote a free-form value for the redacted ODBC connection-string rendering used
+/// in diagnostic logs. Values containing a delimiter (`;`), brace, or `=` are
+/// wrapped in braces with any inner `}` doubled — matching the parser's
+/// brace-quoting rules — so the logged string stays unambiguous. Ordinary values
+/// are returned unchanged.
+fn quote_odbc_value(value: &str) -> String {
+    if value.contains([';', '{', '}', '=']) {
+        format!("{{{}}}", value.replace('}', "}}"))
+    } else {
+        value.to_string()
     }
 }
 
@@ -653,9 +672,10 @@ fn is_yes(value: &str) -> bool {
 }
 
 /// Parse a non-negative integer attribute value. Rejects non-numeric or negative
-/// input with `InvalidAttrValue` (msodbcsql `E_FAIL`). Documented per-key ranges
-/// (e.g. PacketSize 512–32767) are intentionally not enforced here; range handling
-/// is left to mssql-tds so the parser does not diverge from the native driver.
+/// input with `InvalidAttrValue` (msodbcsql `E_FAIL`). Per-key ranges (e.g.
+/// PacketSize 512–32768) are not enforced here — the driver clamps out-of-range
+/// values to the range mssql-tds accepts when mapping onto the client context
+/// (see `apply_connection_params`), matching msodbcsql's clamping behavior.
 fn parse_uint(key: &str, value: &str) -> Result<u32, InvalidAttrValue> {
     value.parse::<u32>().map_err(|_| InvalidAttrValue {
         key: key.to_string(),
@@ -1350,6 +1370,26 @@ mod tests {
         ] {
             assert!(out.contains(expected), "missing {expected} in {out}");
         }
+    }
+
+    #[test]
+    fn fmt_as_odbc_conn_str_quotes_values_with_delimiters() {
+        let (p, _) = parse_connection_string("Server=h;Database={my;db};UID=u").unwrap();
+        assert_eq!(p.database, "my;db");
+        let out = p.fmt_as_odbc_conn_str();
+        // The `;` in the value would otherwise split the logged pair into two.
+        assert!(
+            out.contains("Database={my;db}"),
+            "delimiter value not brace-quoted in {out}"
+        );
+    }
+
+    #[test]
+    fn quote_odbc_value_wraps_and_escapes() {
+        assert_eq!(quote_odbc_value("plain"), "plain");
+        assert_eq!(quote_odbc_value("a;b"), "{a;b}");
+        assert_eq!(quote_odbc_value("a}b"), "{a}}b}");
+        assert_eq!(quote_odbc_value("k=v"), "{k=v}");
     }
 
     #[test]

--- a/mssql-odbc/src/connection/connection_string_parser.rs
+++ b/mssql-odbc/src/connection/connection_string_parser.rs
@@ -33,16 +33,6 @@ use std::fmt;
 use crate::connection::odbc_supported_auth_keywords::is_recognized_keyword;
 use tracing::warn;
 
-// Connection string keys (lowercase for matching)
-const KEY_SERVER: &str = "server";
-const KEY_DATABASE: &str = "database";
-const KEY_UID: &str = "uid";
-const KEY_PWD: &str = "pwd";
-const KEY_TRUST_SRV_CERT: &str = "trustservercertificate";
-const KEY_ENCRYPT: &str = "encrypt";
-const KEY_AUTHENTICATION: &str = "authentication";
-const KEY_TRUSTED_CONNECTION: &str = "trusted_connection";
-
 // Recognized msodbcsql keywords we accept but do not act on. Mirrors the
 // non-acted-on entries of msodbcsql's `x_rgLookup` table (including synonyms and
 // deprecated keys). Recognized keys never raise the 01S00 "invalid attribute"
@@ -63,8 +53,6 @@ const KNOWN_IGNORED_KEYS: &[&str] = &[
     "language",
     "network",
     "net",
-    "address",
-    "addr",
     "mars_connection",
     "failover_partner",
     "failoverpartnerspn",
@@ -78,11 +66,6 @@ const KNOWN_IGNORED_KEYS: &[&str] = &[
     "quotedid",
     "ansinpw",
     "attachdbfilename",
-    "serverspn",
-    "applicationintent",
-    "multisubnetfailover",
-    "connectretrycount",
-    "connectretryinterval",
     "clientcertificate",
     "columnencryption",
     "transparentnetworkipresolution",
@@ -92,17 +75,11 @@ const KNOWN_IGNORED_KEYS: &[&str] = &[
     "keystorelocation",
     "usefmtonly",
     "clientkey",
-    "keepalive",
-    "keepaliveinterval",
     "replication",
     "longasmax",
-    "hostnameincertificate",
     "getdataextensions",
-    "ipaddresspreference",
-    "servercertificate",
     "retryexec",
     "concatnullyieldsnull",
-    "packetsize",
     "vectortypesupport",
     // Deprecated keys kept for back-compat (msodbcsql KEY_UNUSED entries).
     "oemtoansi",
@@ -117,6 +94,11 @@ const KNOWN_IGNORED_KEYS: &[&str] = &[
 // Valid attribute values
 const YES_NO: &[&str] = &["yes", "no"];
 const ENCRYPT_VALUES: &[&str] = &["yes", "mandatory", "no", "optional", "strict"];
+const APPLICATION_INTENT_VALUES: &[&str] = &["ReadOnly", "ReadWrite"];
+const IP_ADDRESS_PREFERENCE_VALUES: &[&str] = &["IPv4First", "IPv6First", "UsePlatformDefault"];
+// Shown in the diagnostic when a numeric attribute (PacketSize, ConnectRetryCount,
+// …) is given a non-numeric or negative value.
+const INTEGER_EXPECTED: &[&str] = &["a non-negative integer"];
 
 // Recognized `Authentication=` keywords (mirrors `auth_method_from_keyword`).
 // Used only for the diagnostic hint; the accept/reject decision is delegated to
@@ -144,6 +126,17 @@ enum ConnAttrKey {
     Encrypt,
     Authentication,
     TrustedConnection,
+    ServerSpn,
+    ApplicationIntent,
+    MultiSubnetFailover,
+    ConnectRetryCount,
+    ConnectRetryInterval,
+    KeepAlive,
+    KeepAliveInterval,
+    IpAddressPreference,
+    PacketSize,
+    HostNameInCert,
+    ServerCertificate,
     Count,
 }
 
@@ -201,6 +194,17 @@ pub(crate) struct ConnectionParams {
     pub(crate) encrypt: Option<String>,
     pub(crate) authentication: Option<String>,
     pub(crate) trusted_connection: Option<bool>,
+    pub(crate) server_spn: Option<String>,
+    pub(crate) application_intent: Option<String>,
+    pub(crate) multi_subnet_failover: Option<bool>,
+    pub(crate) connect_retry_count: Option<u32>,
+    pub(crate) connect_retry_interval: Option<u32>,
+    pub(crate) keep_alive: Option<u32>,
+    pub(crate) keep_alive_interval: Option<u32>,
+    pub(crate) ip_address_preference: Option<String>,
+    pub(crate) packet_size: Option<u32>,
+    pub(crate) host_name_in_certificate: Option<String>,
+    pub(crate) server_certificate: Option<String>,
 }
 
 impl ConnectionParams {
@@ -234,6 +238,42 @@ impl ConnectionParams {
                 if trusted_connection { "yes" } else { "no" }
             ));
         }
+        if let Some(server_spn) = &self.server_spn {
+            parts.push(format!("ServerSPN={server_spn}"));
+        }
+        if let Some(application_intent) = &self.application_intent {
+            parts.push(format!("ApplicationIntent={application_intent}"));
+        }
+        if let Some(multi_subnet_failover) = self.multi_subnet_failover {
+            parts.push(format!(
+                "MultiSubnetFailover={}",
+                if multi_subnet_failover { "yes" } else { "no" }
+            ));
+        }
+        if let Some(connect_retry_count) = self.connect_retry_count {
+            parts.push(format!("ConnectRetryCount={connect_retry_count}"));
+        }
+        if let Some(connect_retry_interval) = self.connect_retry_interval {
+            parts.push(format!("ConnectRetryInterval={connect_retry_interval}"));
+        }
+        if let Some(keep_alive) = self.keep_alive {
+            parts.push(format!("KeepAlive={keep_alive}"));
+        }
+        if let Some(keep_alive_interval) = self.keep_alive_interval {
+            parts.push(format!("KeepAliveInterval={keep_alive_interval}"));
+        }
+        if let Some(ip_address_preference) = &self.ip_address_preference {
+            parts.push(format!("IpAddressPreference={ip_address_preference}"));
+        }
+        if let Some(packet_size) = self.packet_size {
+            parts.push(format!("PacketSize={packet_size}"));
+        }
+        if let Some(host_name_in_certificate) = &self.host_name_in_certificate {
+            parts.push(format!("HostnameInCertificate={host_name_in_certificate}"));
+        }
+        if let Some(server_certificate) = &self.server_certificate {
+            parts.push(format!("ServerCertificate={server_certificate}"));
+        }
 
         parts.join(";")
     }
@@ -250,6 +290,17 @@ impl fmt::Debug for ConnectionParams {
             .field("encrypt", &self.encrypt)
             .field("authentication", &self.authentication)
             .field("trusted_connection", &self.trusted_connection)
+            .field("server_spn", &self.server_spn)
+            .field("application_intent", &self.application_intent)
+            .field("multi_subnet_failover", &self.multi_subnet_failover)
+            .field("connect_retry_count", &self.connect_retry_count)
+            .field("connect_retry_interval", &self.connect_retry_interval)
+            .field("keep_alive", &self.keep_alive)
+            .field("keep_alive_interval", &self.keep_alive_interval)
+            .field("ip_address_preference", &self.ip_address_preference)
+            .field("packet_size", &self.packet_size)
+            .field("host_name_in_certificate", &self.host_name_in_certificate)
+            .field("server_certificate", &self.server_certificate)
             .finish()
     }
 }
@@ -271,24 +322,45 @@ fn is_odbc_space(c: char) -> bool {
     matches!(c, ' ' | '\u{0c}' | '\n' | '\r' | '\t' | '\u{0b}')
 }
 
-// TODO: If the acted-on key set grows past ~15, collapse the `KEY_*` consts and
-// the match below into a single descriptor table (`&[{ lower, ConnAttrKey }]`)
-// that `classify_key` iterates, making it the one source of truth. Adding a
-// mapped key currently fans out across ~6 sites; only `assign_value` is
-// compiler-enforced to stay in sync — `classify_key`, the `ConnectionParams`
-// field, `fmt_as_odbc_conn_str`, and the `Debug` impl can silently drift.
+/// Connection-string keys we act on, paired with their target [`ConnectionParams`]
+/// slot. Keys are lowercase for case-insensitive matching. Several spellings may
+/// share one slot (e.g. `server`/`addr`/`address`); a shared slot yields first-wins
+/// semantics across the whole synonym group, matching msodbcsql.
+///
+/// This table is the single source of truth for *which* keys are acted on. Adding
+/// a key still requires a matching `ConnectionParams` field plus arms in
+/// `assign_value` (compiler-enforced), `fmt_as_odbc_conn_str`, and the `Debug` impl.
+const MAPPED_KEYS: &[(&str, ConnAttrKey)] = &[
+    ("server", ConnAttrKey::Server),
+    ("addr", ConnAttrKey::Server),
+    ("address", ConnAttrKey::Server),
+    ("database", ConnAttrKey::Database),
+    ("uid", ConnAttrKey::Uid),
+    ("pwd", ConnAttrKey::Pwd),
+    ("trustservercertificate", ConnAttrKey::TrustServerCert),
+    ("encrypt", ConnAttrKey::Encrypt),
+    ("authentication", ConnAttrKey::Authentication),
+    ("trusted_connection", ConnAttrKey::TrustedConnection),
+    ("serverspn", ConnAttrKey::ServerSpn),
+    ("applicationintent", ConnAttrKey::ApplicationIntent),
+    ("multisubnetfailover", ConnAttrKey::MultiSubnetFailover),
+    ("connectretrycount", ConnAttrKey::ConnectRetryCount),
+    ("connectretryinterval", ConnAttrKey::ConnectRetryInterval),
+    ("keepalive", ConnAttrKey::KeepAlive),
+    ("keepaliveinterval", ConnAttrKey::KeepAliveInterval),
+    ("ipaddresspreference", ConnAttrKey::IpAddressPreference),
+    ("packetsize", ConnAttrKey::PacketSize),
+    ("hostnameincertificate", ConnAttrKey::HostNameInCert),
+    ("servercertificate", ConnAttrKey::ServerCertificate),
+];
+
 fn classify_key(lower: &str) -> KeyClass {
-    match lower {
-        KEY_SERVER => KeyClass::Mapped(ConnAttrKey::Server),
-        KEY_DATABASE => KeyClass::Mapped(ConnAttrKey::Database),
-        KEY_UID => KeyClass::Mapped(ConnAttrKey::Uid),
-        KEY_PWD => KeyClass::Mapped(ConnAttrKey::Pwd),
-        KEY_TRUST_SRV_CERT => KeyClass::Mapped(ConnAttrKey::TrustServerCert),
-        KEY_ENCRYPT => KeyClass::Mapped(ConnAttrKey::Encrypt),
-        KEY_AUTHENTICATION => KeyClass::Mapped(ConnAttrKey::Authentication),
-        KEY_TRUSTED_CONNECTION => KeyClass::Mapped(ConnAttrKey::TrustedConnection),
-        _ if KNOWN_IGNORED_KEYS.contains(&lower) => KeyClass::Ignored,
-        _ => KeyClass::Unknown,
+    if let Some((_, slot)) = MAPPED_KEYS.iter().find(|(name, _)| *name == lower) {
+        KeyClass::Mapped(*slot)
+    } else if KNOWN_IGNORED_KEYS.contains(&lower) {
+        KeyClass::Ignored
+    } else {
+        KeyClass::Unknown
     }
 }
 
@@ -332,6 +404,40 @@ fn assign_value(
             validate_attr(lower, value, YES_NO)?;
             params.trusted_connection = Some(is_yes(value));
         }
+        ConnAttrKey::ServerSpn => params.server_spn = Some(value.to_string()),
+        ConnAttrKey::ApplicationIntent => {
+            validate_attr(lower, value, APPLICATION_INTENT_VALUES)?;
+            params.application_intent = Some(value.to_string());
+        }
+        ConnAttrKey::MultiSubnetFailover => {
+            validate_attr(lower, value, YES_NO)?;
+            params.multi_subnet_failover = Some(is_yes(value));
+        }
+        ConnAttrKey::ConnectRetryCount => {
+            params.connect_retry_count = Some(parse_uint(lower, value)?);
+        }
+        ConnAttrKey::ConnectRetryInterval => {
+            params.connect_retry_interval = Some(parse_uint(lower, value)?);
+        }
+        ConnAttrKey::KeepAlive => {
+            params.keep_alive = Some(parse_uint(lower, value)?);
+        }
+        ConnAttrKey::KeepAliveInterval => {
+            params.keep_alive_interval = Some(parse_uint(lower, value)?);
+        }
+        ConnAttrKey::IpAddressPreference => {
+            validate_attr(lower, value, IP_ADDRESS_PREFERENCE_VALUES)?;
+            params.ip_address_preference = Some(value.to_string());
+        }
+        ConnAttrKey::PacketSize => {
+            params.packet_size = Some(parse_uint(lower, value)?);
+        }
+        ConnAttrKey::HostNameInCert => {
+            params.host_name_in_certificate = Some(value.to_string());
+        }
+        ConnAttrKey::ServerCertificate => {
+            params.server_certificate = Some(value.to_string());
+        }
         ConnAttrKey::Count => {}
     }
     Ok(())
@@ -353,7 +459,7 @@ fn assign_value(
 /// ```text
 /// "Server=host;UID=sa;PWD=p"      -> server="host", uid="sa", pwd="p", no warnings
 /// "Server=host;Foo=1;UID=sa"      -> Foo is unknown: warns, discarded; UID still set
-/// "Server=host;ApplicationIntent=ReadOnly" -> recognized-but-ignored: no warning
+/// "Server=host;QuotedId=yes"       -> recognized-but-ignored: no warning
 /// "Server=host;PWD={p;w=d}"       -> braces quote ';' and '=': pwd="p;w=d"
 /// "Server=host;PWD={a}}b}"        -> "}}" escapes one '}': pwd="a}b"
 /// "Server=host;Encrypt=banana"    -> Err(InvalidAttrValue): validated key, bad value
@@ -544,6 +650,18 @@ pub(crate) fn parse_connection_string(
 
 fn is_yes(value: &str) -> bool {
     value.eq_ignore_ascii_case("yes")
+}
+
+/// Parse a non-negative integer attribute value. Rejects non-numeric or negative
+/// input with `InvalidAttrValue` (msodbcsql `E_FAIL`). Documented per-key ranges
+/// (e.g. PacketSize 512–32767) are intentionally not enforced here; range handling
+/// is left to mssql-tds so the parser does not diverge from the native driver.
+fn parse_uint(key: &str, value: &str) -> Result<u32, InvalidAttrValue> {
+    value.parse::<u32>().map_err(|_| InvalidAttrValue {
+        key: key.to_string(),
+        value: value.to_string(),
+        expected: INTEGER_EXPECTED,
+    })
 }
 
 #[cfg(test)]
@@ -1072,14 +1190,9 @@ mod tests {
             "WSID",
             "Language",
             "Network",
-            "Address",
             "MARS_Connection",
             "AutoTranslate",
             "QuotedId",
-            "ApplicationIntent",
-            "MultiSubnetFailover",
-            "ConnectRetryCount",
-            "PacketSize",
             "ColumnEncryption",
             "TransparentNetworkIPResolution",
             "OEMToANSI",
@@ -1089,6 +1202,153 @@ mod tests {
             assert!(!warn, "recognized-but-ignored key should not warn: {key}");
             assert_eq!(p.server, "h", "key {key}");
             assert_eq!(p.uid, "u", "key {key}");
+        }
+    }
+
+    #[test]
+    fn addr_and_address_map_to_server() {
+        for key in ["Addr", "Address", "ADDR", "address"] {
+            let s = format!("{key}=host1;UID=u;<PW>=p");
+            let (p, warn) = parse_connection_string(&cs(&s)).unwrap();
+            assert!(!warn, "{key} should map cleanly to Server");
+            assert_eq!(p.server, "host1", "key {key}");
+        }
+    }
+
+    #[test]
+    fn server_and_address_share_one_slot_first_wins() {
+        let (p, warn) = parse_connection_string("Server=first;Address=second;UID=u").unwrap();
+        assert!(!warn);
+        assert_eq!(p.server, "first");
+
+        let (p, warn) = parse_connection_string("Address=first;Server=second;UID=u").unwrap();
+        assert!(!warn);
+        assert_eq!(p.server, "first");
+    }
+
+    #[test]
+    fn string_pass_through_keys_are_stored_verbatim() {
+        let (p, warn) = parse_connection_string(
+            "Server=h;ServerSPN=MSSQLSvc/host:1433;HostnameInCertificate=cn.example.com;ServerCertificate=C:\\certs\\srv.pem;UID=u",
+        )
+        .unwrap();
+        assert!(!warn);
+        assert_eq!(p.server_spn.as_deref(), Some("MSSQLSvc/host:1433"));
+        assert_eq!(
+            p.host_name_in_certificate.as_deref(),
+            Some("cn.example.com")
+        );
+        assert_eq!(p.server_certificate.as_deref(), Some("C:\\certs\\srv.pem"));
+    }
+
+    #[test]
+    fn application_intent_is_validated() {
+        for (val, expected) in [("ReadOnly", "ReadOnly"), ("readwrite", "readwrite")] {
+            let s = format!("Server=h;ApplicationIntent={val};UID=u");
+            let (p, warn) = parse_connection_string(&s).unwrap();
+            assert!(!warn);
+            assert_eq!(p.application_intent.as_deref(), Some(expected));
+        }
+        let err = parse_connection_string("Server=h;ApplicationIntent=sideways;UID=u").unwrap_err();
+        assert_eq!(err.key, "applicationintent");
+        assert_eq!(err.value, "sideways");
+    }
+
+    #[test]
+    fn multi_subnet_failover_is_yes_no() {
+        let (p, _) = parse_connection_string("Server=h;MultiSubnetFailover=Yes;UID=u").unwrap();
+        assert_eq!(p.multi_subnet_failover, Some(true));
+        let (p, _) = parse_connection_string("Server=h;MultiSubnetFailover=no;UID=u").unwrap();
+        assert_eq!(p.multi_subnet_failover, Some(false));
+        let err = parse_connection_string("Server=h;MultiSubnetFailover=maybe;UID=u").unwrap_err();
+        assert_eq!(err.key, "multisubnetfailover");
+    }
+
+    #[test]
+    fn ip_address_preference_is_validated() {
+        for val in ["IPv4First", "ipv6first", "UsePlatformDefault"] {
+            let s = format!("Server=h;IpAddressPreference={val};UID=u");
+            let (p, warn) = parse_connection_string(&s).unwrap();
+            assert!(!warn);
+            assert_eq!(p.ip_address_preference.as_deref(), Some(val));
+        }
+        let err = parse_connection_string("Server=h;IpAddressPreference=IPv7;UID=u").unwrap_err();
+        assert_eq!(err.key, "ipaddresspreference");
+    }
+
+    #[test]
+    fn integer_keys_parse_and_reject_non_numeric() {
+        let (p, warn) = parse_connection_string(
+            "Server=h;ConnectRetryCount=3;ConnectRetryInterval=20;KeepAlive=45;KeepAliveInterval=7;PacketSize=8192;UID=u",
+        )
+        .unwrap();
+        assert!(!warn);
+        assert_eq!(p.connect_retry_count, Some(3));
+        assert_eq!(p.connect_retry_interval, Some(20));
+        assert_eq!(p.keep_alive, Some(45));
+        assert_eq!(p.keep_alive_interval, Some(7));
+        assert_eq!(p.packet_size, Some(8192));
+
+        for key in [
+            "ConnectRetryCount",
+            "ConnectRetryInterval",
+            "KeepAlive",
+            "KeepAliveInterval",
+            "PacketSize",
+        ] {
+            let s = format!("Server=h;{key}=lots;UID=u");
+            let err = parse_connection_string(&s).unwrap_err();
+            assert_eq!(err.key, key.to_ascii_lowercase(), "key {key}");
+            assert_eq!(err.value, "lots");
+        }
+    }
+
+    #[test]
+    fn integer_keys_reject_negative_values() {
+        let err = parse_connection_string("Server=h;ConnectRetryCount=-1;UID=u").unwrap_err();
+        assert_eq!(err.key, "connectretrycount");
+        assert_eq!(err.value, "-1");
+    }
+
+    #[test]
+    fn new_keys_are_case_insensitive() {
+        let (p, warn) =
+            parse_connection_string("server=h;APPLICATIONINTENT=ReadOnly;packetsize=512;UID=u")
+                .unwrap();
+        assert!(!warn);
+        assert_eq!(p.application_intent.as_deref(), Some("ReadOnly"));
+        assert_eq!(p.packet_size, Some(512));
+    }
+
+    #[test]
+    fn new_key_first_occurrence_wins() {
+        let (p, warn) =
+            parse_connection_string("Server=h;PacketSize=512;PacketSize=1024;UID=u").unwrap();
+        assert!(!warn);
+        assert_eq!(p.packet_size, Some(512));
+    }
+
+    #[test]
+    fn fmt_as_odbc_conn_str_includes_new_keys() {
+        let (p, _) = parse_connection_string(
+            "Server=h;ApplicationIntent=ReadOnly;MultiSubnetFailover=yes;ConnectRetryCount=2;ConnectRetryInterval=10;KeepAlive=30;KeepAliveInterval=1;PacketSize=4096;IpAddressPreference=IPv4First;ServerSPN=svc;HostnameInCertificate=cn;ServerCertificate=/tmp/c.pem;UID=u",
+        )
+        .unwrap();
+        let out = p.fmt_as_odbc_conn_str();
+        for expected in [
+            "ApplicationIntent=ReadOnly",
+            "MultiSubnetFailover=yes",
+            "ConnectRetryCount=2",
+            "ConnectRetryInterval=10",
+            "KeepAlive=30",
+            "KeepAliveInterval=1",
+            "PacketSize=4096",
+            "IpAddressPreference=IPv4First",
+            "ServerSPN=svc",
+            "HostnameInCertificate=cn",
+            "ServerCertificate=/tmp/c.pem",
+        ] {
+            assert!(out.contains(expected), "missing {expected} in {out}");
         }
     }
 

--- a/mssql-odbc/src/connection/connection_string_parser.rs
+++ b/mssql-odbc/src/connection/connection_string_parser.rs
@@ -354,7 +354,8 @@ fn is_odbc_space(c: char) -> bool {
 /// share one slot; a shared slot yields first-wins semantics across the synonym
 /// group, matching msodbcsql. The `server`/`addr`/`address` group is the one
 /// exception — a non-empty `Address`/`Addr` takes precedence over `Server`
-/// regardless of position (SNAC ODBC spec), so it is resolved in
+/// regardless of position (msodbcsql `sqlcconn.cpp` builds its login target from
+/// `KEY_ADDR` when Address has a value, else `KEY_SERVER`), so it is resolved in
 /// `parse_connection_string` rather than through this table's first-wins path.
 ///
 /// This table is the single source of truth for *which* keys are acted on. Adding
@@ -532,7 +533,7 @@ pub(crate) fn parse_connection_string(
     // recognized key wins and later duplicates are ignored (e.g. in
     // "Database=a;Database=b" the stored database is "a"). The `server`/`addr`/
     // `address` group is the exception: it is resolved out-of-band below so a
-    // non-empty Address/Addr can take precedence over Server (SNAC ODBC spec),
+    // non-empty Address/Addr can take precedence over Server (msodbcsql parity),
     // while still applying first-wins within each spelling.
     let mut seen_slots = [false; ConnAttrKey::COUNT];
     let mut server_kw: Option<String> = None;
@@ -715,9 +716,10 @@ pub(crate) fn parse_connection_string(
         }
     }
 
-    // Resolve the `server`/`addr`/`address` group: a non-empty Address/Addr wins
-    // over Server regardless of position (SNAC ODBC spec); an empty or absent
-    // Address falls back to Server.
+    // Resolve the `server`/`addr`/`address` group to match msodbcsql `sqlcconn.cpp`
+    // (login target = KEY_ADDR when Address has a value, else KEY_SERVER): a
+    // non-empty Address/Addr wins over Server regardless of position; an empty or
+    // absent Address falls back to Server.
     params.server = match address_kw {
         Some(addr) if !addr.is_empty() => addr,
         _ => server_kw.unwrap_or_default(),
@@ -1319,9 +1321,9 @@ mod tests {
 
     #[test]
     fn address_takes_precedence_over_server() {
-        // SNAC ODBC spec: a non-empty Address/Addr wins over Server regardless of
-        // position. (mssql-python never sends both — it collapses the synonym group
-        // first — so this only affects direct ODBC callers.)
+        // msodbcsql parity (sqlcconn.cpp): a non-empty Address/Addr wins over Server
+        // regardless of position. (mssql-python never sends both — it collapses the
+        // synonym group first — so this only affects direct ODBC callers.)
         for s in [
             "Server=srv;Address=addr;UID=u",
             "Address=addr;Server=srv;UID=u",

--- a/mssql-odbc/src/connection/connection_string_parser.rs
+++ b/mssql-odbc/src/connection/connection_string_parser.rs
@@ -95,10 +95,18 @@ const KNOWN_IGNORED_KEYS: &[&str] = &[
 const YES_NO: &[&str] = &["yes", "no"];
 const ENCRYPT_VALUES: &[&str] = &["yes", "mandatory", "no", "optional", "strict"];
 const APPLICATION_INTENT_VALUES: &[&str] = &["ReadOnly", "ReadWrite"];
-const IP_ADDRESS_PREFERENCE_VALUES: &[&str] = &["IPv4First", "IPv6First", "UsePlatformDefault"];
 // Shown in the diagnostic when a numeric attribute (PacketSize, ConnectRetryCount,
 // …) is given a non-numeric or negative value.
 const INTEGER_EXPECTED: &[&str] = &["a non-negative integer"];
+
+// msodbcsql range-validates ConnectRetryCount / ConnectRetryInterval at parse time
+// and rejects out-of-range values (E_FAIL) — see sqlcconn.cpp — so we mirror that
+// here rather than clamping downstream.
+const CONNECT_RETRY_COUNT_MAX: u32 = 255;
+const CONNECT_RETRY_INTERVAL_MIN: u32 = 1;
+const CONNECT_RETRY_INTERVAL_MAX: u32 = 60;
+const CONNECT_RETRY_COUNT_EXPECTED: &[&str] = &["an integer in the range 0 to 255"];
+const CONNECT_RETRY_INTERVAL_EXPECTED: &[&str] = &["an integer in the range 1 to 60"];
 
 // Recognized `Authentication=` keywords (mirrors `auth_method_from_keyword`).
 // Used only for the diagnostic hint; the accept/reject decision is delegated to
@@ -433,10 +441,22 @@ fn assign_value(
             params.multi_subnet_failover = Some(is_yes(value));
         }
         ConnAttrKey::ConnectRetryCount => {
-            params.connect_retry_count = Some(parse_uint(lower, value)?);
+            params.connect_retry_count = Some(parse_uint_in_range(
+                lower,
+                value,
+                0,
+                CONNECT_RETRY_COUNT_MAX,
+                CONNECT_RETRY_COUNT_EXPECTED,
+            )?);
         }
         ConnAttrKey::ConnectRetryInterval => {
-            params.connect_retry_interval = Some(parse_uint(lower, value)?);
+            params.connect_retry_interval = Some(parse_uint_in_range(
+                lower,
+                value,
+                CONNECT_RETRY_INTERVAL_MIN,
+                CONNECT_RETRY_INTERVAL_MAX,
+                CONNECT_RETRY_INTERVAL_EXPECTED,
+            )?);
         }
         ConnAttrKey::KeepAlive => {
             params.keep_alive = Some(parse_uint(lower, value)?);
@@ -445,7 +465,8 @@ fn assign_value(
             params.keep_alive_interval = Some(parse_uint(lower, value)?);
         }
         ConnAttrKey::IpAddressPreference => {
-            validate_attr(lower, value, IP_ADDRESS_PREFERENCE_VALUES)?;
+            // msodbcsql accepts any value and falls back unknown ones to IPv4First
+            // at connect time (see `apply_connection_params`); no parse-time reject.
             params.ip_address_preference = Some(value.to_string());
         }
         ConnAttrKey::PacketSize => {
@@ -672,16 +693,39 @@ fn is_yes(value: &str) -> bool {
 }
 
 /// Parse a non-negative integer attribute value. Rejects non-numeric or negative
-/// input with `InvalidAttrValue` (msodbcsql `E_FAIL`). Per-key ranges (e.g.
-/// PacketSize 512–32768) are not enforced here — the driver clamps out-of-range
-/// values to the range mssql-tds accepts when mapping onto the client context
-/// (see `apply_connection_params`), matching msodbcsql's clamping behavior.
+/// input with `InvalidAttrValue` (msodbcsql `E_FAIL`). Range handling is per-key:
+/// `ConnectRetryCount` / `ConnectRetryInterval` are range-validated at parse time
+/// via [`parse_uint_in_range`] (msodbcsql rejects out-of-range values here);
+/// `PacketSize` is instead clamped to the range mssql-tds accepts when mapping onto
+/// the client context (see `apply_connection_params`).
 fn parse_uint(key: &str, value: &str) -> Result<u32, InvalidAttrValue> {
     value.parse::<u32>().map_err(|_| InvalidAttrValue {
         key: key.to_string(),
         value: value.to_string(),
         expected: INTEGER_EXPECTED,
     })
+}
+
+/// Like [`parse_uint`], but also rejects values outside the inclusive `[min, max]`
+/// range with `InvalidAttrValue` (E_FAIL), mirroring msodbcsql's parse-time range
+/// validation for `ConnectRetryCount` / `ConnectRetryInterval`.
+fn parse_uint_in_range(
+    key: &str,
+    value: &str,
+    min: u32,
+    max: u32,
+    expected: &'static [&'static str],
+) -> Result<u32, InvalidAttrValue> {
+    let parsed = parse_uint(key, value)?;
+    if (min..=max).contains(&parsed) {
+        Ok(parsed)
+    } else {
+        Err(InvalidAttrValue {
+            key: key.to_string(),
+            value: value.to_string(),
+            expected,
+        })
+    }
 }
 
 #[cfg(test)]
@@ -1285,15 +1329,43 @@ mod tests {
     }
 
     #[test]
-    fn ip_address_preference_is_validated() {
+    fn ip_address_preference_accepts_any_value() {
         for val in ["IPv4First", "ipv6first", "UsePlatformDefault"] {
             let s = format!("Server=h;IpAddressPreference={val};UID=u");
             let (p, warn) = parse_connection_string(&s).unwrap();
             assert!(!warn);
             assert_eq!(p.ip_address_preference.as_deref(), Some(val));
         }
-        let err = parse_connection_string("Server=h;IpAddressPreference=IPv7;UID=u").unwrap_err();
-        assert_eq!(err.key, "ipaddresspreference");
+        // msodbcsql falls back unknown values to IPv4First at connect time rather
+        // than rejecting them at parse; the raw value is stored verbatim here.
+        let (p, warn) = parse_connection_string("Server=h;IpAddressPreference=IPv7;UID=u").unwrap();
+        assert!(!warn);
+        assert_eq!(p.ip_address_preference.as_deref(), Some("IPv7"));
+    }
+
+    #[test]
+    fn connect_retry_values_reject_out_of_range() {
+        let err = parse_connection_string("Server=h;ConnectRetryCount=256;UID=u").unwrap_err();
+        assert_eq!(err.key, "connectretrycount");
+        assert_eq!(err.value, "256");
+
+        for bad in ["0", "61"] {
+            let s = format!("Server=h;ConnectRetryInterval={bad};UID=u");
+            let err = parse_connection_string(&s).unwrap_err();
+            assert_eq!(err.key, "connectretryinterval", "interval {bad}");
+        }
+
+        // Boundary values are accepted (count 0..=255, interval 1..=60).
+        let (p, _) =
+            parse_connection_string("Server=h;ConnectRetryCount=0;ConnectRetryInterval=1;UID=u")
+                .unwrap();
+        assert_eq!(p.connect_retry_count, Some(0));
+        assert_eq!(p.connect_retry_interval, Some(1));
+        let (p, _) =
+            parse_connection_string("Server=h;ConnectRetryCount=255;ConnectRetryInterval=60;UID=u")
+                .unwrap();
+        assert_eq!(p.connect_retry_count, Some(255));
+        assert_eq!(p.connect_retry_interval, Some(60));
     }
 
     #[test]

--- a/mssql-odbc/src/connection/connection_string_parser.rs
+++ b/mssql-odbc/src/connection/connection_string_parser.rs
@@ -351,8 +351,11 @@ fn is_odbc_space(c: char) -> bool {
 
 /// Connection-string keys we act on, paired with their target [`ConnectionParams`]
 /// slot. Keys are lowercase for case-insensitive matching. Several spellings may
-/// share one slot (e.g. `server`/`addr`/`address`); a shared slot yields first-wins
-/// semantics across the whole synonym group, matching msodbcsql.
+/// share one slot; a shared slot yields first-wins semantics across the synonym
+/// group, matching msodbcsql. The `server`/`addr`/`address` group is the one
+/// exception — a non-empty `Address`/`Addr` takes precedence over `Server`
+/// regardless of position (SNAC ODBC spec), so it is resolved in
+/// `parse_connection_string` rather than through this table's first-wins path.
 ///
 /// This table is the single source of truth for *which* keys are acted on. Adding
 /// a key still requires a matching `ConnectionParams` field plus arms in
@@ -402,6 +405,9 @@ fn assign_value(
     value: &str,
 ) -> Result<(), InvalidAttrValue> {
     match slot {
+        // The server/addr/address group is resolved in `parse_connection_string`
+        // (Address takes precedence over Server), so this arm is never reached; it
+        // only keeps the match exhaustive.
         ConnAttrKey::Server => params.server = value.to_string(),
         ConnAttrKey::Database => params.database = value.to_string(),
         ConnAttrKey::Uid => params.uid = value.to_string(),
@@ -524,8 +530,13 @@ pub(crate) fn parse_connection_string(
     let mut params = ConnectionParams::default();
     // One "already seen" flag per acted-on key so the *first* occurrence of a
     // recognized key wins and later duplicates are ignored (e.g. in
-    // "Server=a;Server=b" the stored server is "a").
+    // "Database=a;Database=b" the stored database is "a"). The `server`/`addr`/
+    // `address` group is the exception: it is resolved out-of-band below so a
+    // non-empty Address/Addr can take precedence over Server (SNAC ODBC spec),
+    // while still applying first-wins within each spelling.
     let mut seen_slots = [false; ConnAttrKey::COUNT];
+    let mut server_kw: Option<String> = None;
+    let mut address_kw: Option<String> = None;
     let mut has_warnings = false;
 
     loop {
@@ -580,7 +591,15 @@ pub(crate) fn parse_connection_string(
         // gets a slot to receive the value; everything else parses the value but
         // discards it (mirrors msodbcsql leaving `lpszValue` unstored). `target`
         // is `Some(slot)` only when we will actually store the value.
+        // Set when this iteration's key is in the `server`/`addr`/`address` group;
+        // the value is captured after Phase 4 so Address can take precedence over
+        // Server once both values are known.
+        let mut server_group_is_addr: Option<bool> = None;
         let target = match classify_key(&lower) {
+            KeyClass::Mapped(ConnAttrKey::Server) => {
+                server_group_is_addr = Some(lower == "addr" || lower == "address");
+                None
+            }
             KeyClass::Mapped(slot) => {
                 let idx = slot.idx();
                 if seen_slots[idx] {
@@ -666,7 +685,18 @@ pub(crate) fn parse_connection_string(
         // brace-close checks, so a value with trailing junk is still stored before
         // we stop. An invalid value on a validated key fails immediately (E_FAIL)
         // and aborts the whole parse via the `?`.
-        if let Some(slot) = target {
+        if let Some(is_addr) = server_group_is_addr {
+            // First-wins within each spelling; the Address-vs-Server precedence is
+            // resolved after the loop from `server_kw`/`address_kw`.
+            let captured = if is_addr {
+                &mut address_kw
+            } else {
+                &mut server_kw
+            };
+            if captured.is_none() {
+                *captured = Some(value.clone());
+            }
+        } else if let Some(slot) = target {
             assign_value(&mut params, slot, &lower, &value)?;
         }
 
@@ -684,6 +714,14 @@ pub(crate) fn parse_connection_string(
             i += 1;
         }
     }
+
+    // Resolve the `server`/`addr`/`address` group: a non-empty Address/Addr wins
+    // over Server regardless of position (SNAC ODBC spec); an empty or absent
+    // Address falls back to Server.
+    params.server = match address_kw {
+        Some(addr) if !addr.is_empty() => addr,
+        _ => server_kw.unwrap_or_default(),
+    };
 
     Ok((params, has_warnings))
 }
@@ -1280,13 +1318,35 @@ mod tests {
     }
 
     #[test]
-    fn server_and_address_share_one_slot_first_wins() {
-        let (p, warn) = parse_connection_string("Server=first;Address=second;UID=u").unwrap();
+    fn address_takes_precedence_over_server() {
+        // SNAC ODBC spec: a non-empty Address/Addr wins over Server regardless of
+        // position. (mssql-python never sends both — it collapses the synonym group
+        // first — so this only affects direct ODBC callers.)
+        for s in [
+            "Server=srv;Address=addr;UID=u",
+            "Address=addr;Server=srv;UID=u",
+            "Server=srv;Addr=addr;UID=u",
+            "Addr=addr;Server=srv;UID=u",
+        ] {
+            let (p, warn) = parse_connection_string(s).unwrap();
+            assert!(!warn, "input: {s}");
+            assert_eq!(p.server, "addr", "input: {s}");
+        }
+    }
+
+    #[test]
+    fn empty_address_falls_back_to_server() {
+        let (p, warn) = parse_connection_string("Server=srv;Address=;UID=u").unwrap();
         assert!(!warn);
+        assert_eq!(p.server, "srv");
+    }
+
+    #[test]
+    fn server_group_is_first_wins_within_each_spelling() {
+        let (p, _) = parse_connection_string("Server=first;Server=second;UID=u").unwrap();
         assert_eq!(p.server, "first");
 
-        let (p, warn) = parse_connection_string("Address=first;Server=second;UID=u").unwrap();
-        assert!(!warn);
+        let (p, _) = parse_connection_string("Address=first;Address=second;UID=u").unwrap();
         assert_eq!(p.server, "first");
     }
 

--- a/mssql-odbc/src/connection/mod.rs
+++ b/mssql-odbc/src/connection/mod.rs
@@ -14,4 +14,4 @@ pub(crate) mod odbc_authentication_transformer;
 pub(crate) mod odbc_authentication_validator;
 mod odbc_supported_auth_keywords;
 
-pub(crate) use connection_string_parser::parse_connection_string;
+pub(crate) use connection_string_parser::{ConnectionParams, parse_connection_string};

--- a/mssql-odbc/tests/e2e/tests/driver_connect_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/driver_connect_test.cpp
@@ -457,3 +457,97 @@ TEST_F(DriverConnectLiveTest, ConnectionStringParserParityBehaviors) {
         EXPECT_TRUE(r.has28000);
     }
 }
+
+// End-to-end coverage of the connection-string keywords added for mssql-python
+// parity (AB#46418): ServerSPN, ApplicationIntent, MultiSubnetFailover,
+// ConnectRetry*, KeepAlive*, IpAddressPreference, PacketSize, HostnameInCertificate,
+// and ServerCertificate. Recognized canonical values connect with no parse warning;
+// an invalid value on a validated key is a hard HY024 failure. Fine-grained value
+// handling is unit-tested in connection_string_parser.rs; here we assert the
+// behavior visible through a real SQLDriverConnect.
+TEST_F(DriverConnectLiveTest, NewConnectionAttributesParity) {
+    auto& cfg = ODBCTestConfig::Instance();
+    if (!cfg.HasSqlAuth()) {
+        GTEST_SKIP() << "Requires SQL auth (ODBC_TEST_SERVER + ODBC_TEST_UID + "
+                        "ODBC_TEST_PWD); see follow-up issue for capability gating";
+    }
+
+    struct ConnResult {
+        SQLRETURN rc;
+        bool has01S00;
+        bool hasHY024;
+    };
+
+    auto tryConnect = [&](const std::string& cs) -> ConnResult {
+        SQLHDBC hdbc = SQL_NULL_HDBC;
+        SQLRETURN rc = SQLAllocHandle(SQL_HANDLE_DBC, env_, &hdbc);
+        EXPECT_EQ(SQL_SUCCESS, rc);
+        if (rc != SQL_SUCCESS) return {rc, false, false};
+
+        SqlTString connstr = ODBCTestUtils::ToSqlTStr(cs);
+        SQLTCHAR outStr[1024] = {};
+        SQLSMALLINT outLen = 0;
+
+        rc = SQLDriverConnect(hdbc, nullptr,
+                              const_cast<SQLTCHAR*>(connstr.c_str()),
+                              static_cast<SQLSMALLINT>(connstr.size()),
+                              outStr, 1024, &outLen,
+                              SQL_DRIVER_NOPROMPT);
+
+        bool has01S00 = false;
+        bool hasHY024 = false;
+        if (rc == SQL_SUCCESS_WITH_INFO || rc == SQL_ERROR) {
+            has01S00 = ODBCTestUtils::HasDiagState(SQL_HANDLE_DBC, hdbc, "01S00");
+            hasHY024 = ODBCTestUtils::HasDiagState(SQL_HANDLE_DBC, hdbc, "HY024");
+        }
+
+        if (SQL_SUCCEEDED(rc)) SQLDisconnect(hdbc);
+        SQLFreeHandle(SQL_HANDLE_DBC, hdbc);
+        return {rc, has01S00, hasHY024};
+    };
+
+    const std::string base =
+        "Driver={" + cfg.Driver() + "}"
+        ";Server=" + cfg.Server() +
+        ";UID=" + cfg.Uid() +
+        ";PWD=" + cfg.Pwd() +
+        ";TrustServerCertificate=" + cfg.TrustCert();
+
+    // Recognized canonical attributes with valid values: login succeeds and the
+    // parser raises no 01S00 (they are acted-on keys, not unknown ones).
+    {
+        auto r = tryConnect(base +
+            ";ApplicationIntent=ReadOnly"
+            ";MultiSubnetFailover=no"
+            ";ConnectRetryCount=1"
+            ";ConnectRetryInterval=10"
+            ";KeepAlive=30"
+            ";KeepAliveInterval=1"
+            ";PacketSize=4096"
+            ";IpAddressPreference=IPv4First"
+            ";ServerSPN=MSSQLSvc/testhost:1433");
+        EXPECT_TRUE(SQL_SUCCEEDED(r.rc)) << "rc=" << r.rc;
+        EXPECT_FALSE(r.has01S00);
+    }
+
+    // Invalid enum value on a validated key -> E_FAIL -> HY024, connect fails.
+    {
+        auto r = tryConnect(base + ";ApplicationIntent=sideways");
+        EXPECT_EQ(SQL_ERROR, r.rc);
+        EXPECT_TRUE(r.hasHY024);
+    }
+
+    // Non-numeric integer value -> HY024, connect fails.
+    {
+        auto r = tryConnect(base + ";PacketSize=notanumber");
+        EXPECT_EQ(SQL_ERROR, r.rc);
+        EXPECT_TRUE(r.hasHY024);
+    }
+
+    // Out-of-domain IpAddressPreference -> HY024, connect fails.
+    {
+        auto r = tryConnect(base + ";IpAddressPreference=IPv7");
+        EXPECT_EQ(SQL_ERROR, r.rc);
+        EXPECT_TRUE(r.hasHY024);
+    }
+}

--- a/mssql-odbc/tests/e2e/tests/driver_connect_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/driver_connect_test.cpp
@@ -544,10 +544,12 @@ TEST_F(DriverConnectLiveTest, NewConnectionAttributesParity) {
         EXPECT_TRUE(r.hasHY024);
     }
 
-    // Out-of-domain IpAddressPreference -> HY024, connect fails.
+    // Out-of-domain IpAddressPreference is accepted and falls back to IPv4First
+    // at connect time (msodbcsql parity), so the parser raises no error and the
+    // connection succeeds without an 01S00 warning.
     {
         auto r = tryConnect(base + ";IpAddressPreference=IPv7");
-        EXPECT_EQ(SQL_ERROR, r.rc);
-        EXPECT_TRUE(r.hasHY024);
+        EXPECT_TRUE(SQL_SUCCEEDED(r.rc)) << "rc=" << r.rc;
+        EXPECT_FALSE(r.has01S00);
     }
 }


### PR DESCRIPTION
## Description

Finishes connection-string compatibility parity with mssql-python (feature [AB#46372](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46372)) by extending the `SQLDriverConnect` parser to recognize and act on the full canonical ODBC Driver 18 keyword set that mssql-python normalizes to before handing the string to the driver.

Newly acted-on keywords, each wired into the mssql-tds `ClientContext` / `EncryptionOptions`:

| Keyword(s) | Landing spot | Value handling |
|---|---|---|
| `ServerSPN` | `server_spn` | verbatim |
| `ApplicationIntent` | `application_intent` | `ReadOnly` / `ReadWrite` (validated) |
| `MultiSubnetFailover` | `multi_subnet_failover` | `Yes` / `No` (validated) |
| `ConnectRetryCount` / `ConnectRetryInterval` | matching fields | integer |
| `KeepAlive` / `KeepAliveInterval` | `keep_alive_in_ms` / `keep_alive_interval_in_ms` | integer seconds → ms (×1000) |
| `IpAddressPreference` | `ipaddress_preference` | `IPv4First` / `IPv6First` / `UsePlatformDefault` (validated) |
| `PacketSize` | `packet_size` | integer bytes (→ u16, saturating) |
| `HostnameInCertificate` | `EncryptionOptions::host_name_in_cert` | verbatim |
| `ServerCertificate` | `EncryptionOptions::server_certificate` | verbatim path → `PathBuf` |

Also:
- Map the msodbcsql-native `Addr` / `Address` synonyms to `Server` (they were previously in the ignored set and silently dropped).
- Enumerated keys hard-reject invalid values (`E_FAIL` → `HY024`), matching how `Encrypt`/`Yes-No` already behave. Integer keys parse leniently — rejecting only non-numeric/negative input and leaving documented range clamping to mssql-tds so the parser can't diverge from the native driver.
- Collapse the `KEY_*` consts and the `classify_key` match into a single `MAPPED_KEYS` descriptor table (the code's own TODO sanctioned this once the mapped set grew).

Value validation ownership note: mssql-python value-validates nothing itself (it only *maps* `Authentication` for client-side token acquisition and passes everything else through), so mssql-odbc owns all connection-string value validation — which this PR implements.

## Related Issues

Closes [AB#46418](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46418)
Feature: [AB#46372](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46372)
Work item: https://dev.azure.com/SqlClientDrivers/mssql-rs/_workitems/edit/46418

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes — mssql-odbc suite is green (337/337 via nextest). The remaining workspace failures are mssql-tds live-DB integration tests that require a `.env`/SQL Server (untouched crate, environmental).
- [x] New/changed functionality has tests — 14 new parser unit tests + a gated end-to-end `NewConnectionAttributesParity` test
- [x] Public API changes are documented — `docs/connection_string_parser.md` updated (mapped-attributes table + value validation)