### PR TITLE
Bump mssql-py-core to 0.1.8

### DIFF
--- a/mssql-py-core/Cargo.toml
+++ b/mssql-py-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mssql-py-core"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 publish = false
 


### PR DESCRIPTION
Bumps `mssql-py-core` from 0.1.7 to 0.1.8.

**Why:** The Arrow bulk copy feature (#95) merged into `main` without a version bump — `0.1.7` was already claimed by the CLR UDT fix (#111). Publishing the Arrow-enabled wheel needs a fresh version so the published native artifact stays immutable/traceable and `mssql-python` can pin the Arrow build explicitly.

**Scope:** version string only. `mssql-py-core/Cargo.lock` is gitignored and the crate is workspace-excluded, so no lockfile changes. Follow-up: bump the py-core pin in `mssql-python` to 0.1.8 once the 0.1.8 wheel is published.