### PR TITLE
Fix CredScan false positive in ARM SQL host design

### DIFF
--- a/.pipeline/docs/arm-sql-host-design.md
+++ b/.pipeline/docs/arm-sql-host-design.md
@@ -100,18 +100,11 @@ must agree on the password without sharing a secret across jobs (artifacts
 are readable by anyone with build read access; we do not want to leak the
 SA password through the `sql-ready` artifact).
 
-`sql-host/derive-sql-password.sh` deterministically derives the SA password
-from build context:
-
-```
-SQL_PASSWORD = "Aa1!" || sha256(Build.BuildId "-" System.CollectionId "-" salt)[0:22]
-```
-
-Both the SQL host job and the test jobs invoke the same script, so they
-agree on the value without any cross-job transport. The `Aa1!` prefix
-guarantees all four character classes the SQL Server SA policy requires.
-The script uses the same `SQL_PASSWORD_GENERATED` marker as the random
-template so the two are interchangeable.
+Both the SQL host job and the test jobs invoke
+`sql-host/derive-sql-password.sh`, which deterministically produces the same
+policy-compliant value from build context without any cross-job transport.
+The script uses the same `SQL_PASSWORD_GENERATED` marker as the random template
+so the two are interchangeable.
 
 ### Shared TLS cert chain
 


### PR DESCRIPTION
## Description

Remove the credential-shaped password derivation example from the ARM SQL host design document. The document now points to the owning script and describes its contract without embedding a password-like literal that triggers CSCAN-GENERAL0060.

## Related Issues

Fixes #150

## Checklist

- [x] cargo bfmt passes (not applicable; documentation-only change)
- [x] cargo bclippy passes (not applicable; documentation-only change)
- [x] cargo btest passes (not applicable; documentation-only change)
- [x] New/changed functionality has tests (not applicable; no functional change)
- [x] Public API changes are documented (not applicable; no public API change)