### PR TITLE
Flow Linux ODBC C++ e2e coverage into PR diff coverage

### DIFF
--- a/.pipeline/scripts/containerized-odbc-e2e.sh
+++ b/.pipeline/scripts/containerized-odbc-e2e.sh
@@ -11,6 +11,8 @@
 #
 # Connection details are passed via ODBC_TEST_* env vars by the caller.
 # ODBC_E2E_RETRIES controls the ctest until-pass retry count (default 3).
+# ODBC_E2E_COVERAGE=1 builds the driver instrumented and emits a Cobertura
+# report (x64 Linux PR builds only).
 
 set -euo pipefail
 
@@ -21,4 +23,15 @@ apt-get update
 apt-get install -y --no-install-recommends cmake unixodbc-dev
 rm -rf /var/lib/apt/lists/*
 
-exec /workspace/mssql-odbc/tests/e2e/run_e2e.sh --retries="${ODBC_E2E_RETRIES:-3}"
+# When ODBC_E2E_COVERAGE=1 (x64 Linux PR builds), build the driver with LLVM
+# instrumentation and emit a Cobertura report to the mounted workspace target/
+# dir so the host agent can publish it as CoberturaCoverageOdbcE2E_Linux. The
+# cargo-llvm-cov + llvm-tools this needs already ship in the build image.
+coverage_args=()
+case "$(printf '%s' "${ODBC_E2E_COVERAGE:-0}" | tr '[:upper:]' '[:lower:]')" in
+    1|true|yes)
+        coverage_args+=(--coverage=/workspace/target/cobertura-odbc-e2e.xml)
+        ;;
+esac
+
+exec /workspace/mssql-odbc/tests/e2e/run_e2e.sh --retries="${ODBC_E2E_RETRIES:-3}" "${coverage_args[@]}"

--- a/.pipeline/templates/build-template-container.yml
+++ b/.pipeline/templates/build-template-container.yml
@@ -279,6 +279,7 @@ steps:
         -e ODBC_TEST_PWD="$(SQL_PASSWORD)" \
         -e ODBC_TEST_TRUST_CERT="Yes" \
         -e ODBC_E2E_RETRIES="3" \
+        -e ODBC_E2E_COVERAGE="${{ lower(parameters.collectRustCoverage) }}" \
         -e RUST_BACKTRACE=full \
         -w /workspace \
         $BUILD_IMAGE \
@@ -391,6 +392,20 @@ steps:
     inputs:
       targetPath: $(Build.SourcesDirectory)/target/cobertura.xml
       artifactName: CoberturaCoverageRust_Linux
+
+# ODBC C++ e2e coverage: the instrumented driver is exercised through the
+# unixODBC Driver Manager as a separate process, so this report adds coverage
+# for mssql-odbc (and statically-linked mssql-tds) lines reachable only via the
+# ODBC surface. Best-effort (continueOnError) so a coverage hiccup never fails
+# the build; the Merge Coverage stage skips it if absent.
+- ${{ if eq(parameters.collectRustCoverage, true) }}:
+  - task: PublishPipelineArtifact@1
+    condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
+    displayName: Publish ODBC e2e Linux Cobertura coverage artifact
+    continueOnError: true
+    inputs:
+      targetPath: $(Build.SourcesDirectory)/target/cobertura-odbc-e2e.xml
+      artifactName: CoberturaCoverageOdbcE2E_Linux
 
 - task: CopyFiles@2
   displayName: Copy Rust Debug Build

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -605,11 +605,11 @@ stages:
             entry: deb-bookworm.sh
 
 # Merge the mssql-tds Rust coverage from every OS that runs the tests
-# (Build_Windows, Build_Linux, Test_MacOS) and the mssql-py-core coverage from
-# the Python tests (Build_Linux) into one Cobertura report. ADO does not merge
-# coverage across stages/jobs, so it is combined here and published as
-# CoberturaCoverage (the artifact the GitHub diff-cover workflow consumes) and
-# to the ADO coverage tab.
+# (Build_Windows, Build_Linux, Test_MacOS), the ODBC C++ e2e coverage
+# (Build_Linux x64), and the mssql-py-core coverage from the Python tests
+# (Build_Linux) into one Cobertura report. ADO does not merge coverage across
+# stages/jobs, so it is combined here and published as CoberturaCoverage (the
+# artifact the GitHub diff-cover workflow consumes) and to the ADO coverage tab.
 - stage: Coverage
   displayName: Merge Coverage
   dependsOn:
@@ -639,6 +639,13 @@ stages:
           artifactName: 'CoberturaCoverageRust_Linux'
           targetPath: '$(Pipeline.Workspace)/cov-rust-linux'
       - task: DownloadPipelineArtifact@2
+        displayName: Download ODBC e2e Linux coverage
+        continueOnError: true
+        inputs:
+          buildType: 'current'
+          artifactName: 'CoberturaCoverageOdbcE2E_Linux'
+          targetPath: '$(Pipeline.Workspace)/cov-odbc-e2e-linux'
+      - task: DownloadPipelineArtifact@2
         displayName: Download Rust (mssql-tds) macOS coverage
         continueOnError: true
         inputs:
@@ -666,10 +673,13 @@ stages:
           # Each OS emits its mssql-tds + mssql-odbc report with repo-root-relative
           # paths, so the same source file lines up across reports and coverage is
           # unioned: a line covered on any OS counts as covered in the merged result.
+          # The ODBC e2e report (Linux x64) is also repo-root-relative and adds
+          # coverage for lines reachable only through the ODBC Driver Manager.
           for report in \
             "$(Pipeline.Workspace)/cov-rust-windows/cobertura.xml" \
             "$(Pipeline.Workspace)/cov-rust-linux/cobertura.xml" \
-            "$(Pipeline.Workspace)/cov-rust-macos/cobertura.xml"; do
+            "$(Pipeline.Workspace)/cov-rust-macos/cobertura.xml" \
+            "$(Pipeline.Workspace)/cov-odbc-e2e-linux/cobertura-odbc-e2e.xml"; do
             [ -f "$report" ] && inputs+=("$report")
           done
           # mssql-py-core coverage is measured from within its own crate

--- a/mssql-odbc/tests/e2e/README.md
+++ b/mssql-odbc/tests/e2e/README.md
@@ -76,6 +76,29 @@ the two drivers.
 ./run_e2e.sh --compare-with-msodbcsql --msodbcsql-ini=/opt/msodbcsql/odbcinst.ini
 ```
 
+### Collecting coverage
+
+`run_e2e.sh --coverage` builds the Rust driver with LLVM source-based
+instrumentation so the driver code exercised by the C++ tests — which load the
+`.so` through the unixODBC Driver Manager as separate processes — is measured.
+It writes a Cobertura report for `mssql-tds` + `mssql-odbc` (the cdylib
+statically links `mssql-tds`, so both are covered).
+
+```bash
+# Report to the default path: <repo>/target/cobertura-odbc-e2e.xml
+./run_e2e.sh --coverage
+
+# Custom output path
+./run_e2e.sh --coverage=/tmp/odbc-e2e.xml
+```
+
+This uses the same mechanism as `dev/test-python.sh --coverage`: everything runs
+through `cargo llvm-cov` (`show-env` to instrument the build, `report` to emit
+the report), so the LLVM version that reads the `.profraw` always matches the
+rustc that produced the instrumented `.so`. In CI, the Linux x64 PR build sets
+`ODBC_E2E_COVERAGE=1`, publishes the report as `CoberturaCoverageOdbcE2E_Linux`,
+and the Merge Coverage stage unions it into the diff-coverage report.
+
 Both INIs must register the driver under the same section name
 (`[ODBC Driver 18 for SQL Server]`). The script exits `0` only if **both**
 runs pass.

--- a/mssql-odbc/tests/e2e/README.md
+++ b/mssql-odbc/tests/e2e/README.md
@@ -76,6 +76,10 @@ the two drivers.
 ./run_e2e.sh --compare-with-msodbcsql --msodbcsql-ini=/opt/msodbcsql/odbcinst.ini
 ```
 
+Both INIs must register the driver under the same section name
+(`[ODBC Driver 18 for SQL Server]`). The script exits `0` only if **both**
+runs pass.
+
 ### Collecting coverage
 
 `run_e2e.sh --coverage` builds the Rust driver with LLVM source-based
@@ -98,10 +102,6 @@ the report), so the LLVM version that reads the `.profraw` always matches the
 rustc that produced the instrumented `.so`. In CI, the Linux x64 PR build sets
 `ODBC_E2E_COVERAGE=1`, publishes the report as `CoberturaCoverageOdbcE2E_Linux`,
 and the Merge Coverage stage unions it into the diff-coverage report.
-
-Both INIs must register the driver under the same section name
-(`[ODBC Driver 18 for SQL Server]`). The script exits `0` only if **both**
-runs pass.
 
 ### Windows (requires Administrator)
 

--- a/mssql-odbc/tests/e2e/run_e2e.sh
+++ b/mssql-odbc/tests/e2e/run_e2e.sh
@@ -367,7 +367,10 @@ generate_coverage_report() {
             echo "WARNING: no .profraw produced; the driver ctest loaded may not be instrumented" >&2
         fi
     fi
-    mkdir -p "$(dirname "$COVERAGE_OUTPUT")"
+    if ! mkdir -p "$(dirname "$COVERAGE_OUTPUT")"; then
+        echo "WARNING: failed to create ODBC e2e coverage output directory" >&2
+        return 0
+    fi
     if cargo llvm-cov report --package mssql-tds --package mssql-odbc \
         --cobertura --output-path "$COVERAGE_OUTPUT"; then
         echo "Coverage report written to $COVERAGE_OUTPUT"

--- a/mssql-odbc/tests/e2e/run_e2e.sh
+++ b/mssql-odbc/tests/e2e/run_e2e.sh
@@ -9,7 +9,7 @@
 # For Windows, see run_e2e.ps1 (uses the Windows registry instead).
 #
 # Usage:
-#   ./run_e2e.sh [--release] [--verbose] [--retries=N]
+#   ./run_e2e.sh [--release] [--verbose] [--retries=N] [--coverage[=OUTPUT]]
 #                [--compare-with-msodbcsql] [--msodbcsql-ini=PATH]
 #
 # Default: runs the e2e suite against mssql-odbc only.
@@ -17,6 +17,14 @@
 # --retries=N reruns each failing test up to N extra times (ctest
 # --repeat until-pass:N+1). A test that passes on any attempt counts as a
 # pass; the suite only fails if a test still fails after all retries.
+#
+# --coverage[=OUTPUT] builds the Rust driver with LLVM source-based coverage
+# instrumentation so the driver code exercised by the C++ tests (which load the
+# .so through the Driver Manager as separate processes) is measured. A Cobertura
+# report for mssql-tds + mssql-odbc is written to OUTPUT (default
+# <repo>/target/cobertura-odbc-e2e.xml). Same mechanism as dev/test-python.sh
+# --coverage; everything runs through cargo-llvm-cov so the LLVM version that
+# reads the .profraw matches the rustc that produced the instrumented .so.
 #
 # With --compare-with-msodbcsql, the script reruns the same suite against
 # the Microsoft C++ driver registered in --msodbcsql-ini (default
@@ -51,6 +59,10 @@ BUILD_TYPE="debug"
 VERBOSE=0
 COMPARE=0
 RETRIES=0
+COVERAGE=0
+# Default Cobertura output lives in the workspace target/ dir so the CI mount
+# (-v $PWD:/workspace) exposes it to the host agent for artifact publishing.
+COVERAGE_OUTPUT="${COVERAGE_OUTPUT:-$ODBC_CRATE_DIR/../target/cobertura-odbc-e2e.xml}"
 MSODBCSQL_INI="/etc/odbcinst.ini"
 
 CTEST_ARGS=(--output-on-failure)
@@ -61,7 +73,7 @@ RUST_DRIVER_PATH=""
 # CLI parsing / help
 # ----------------------------------------------------------------------------
 usage() {
-    sed -n '2,32p' "$0" | sed 's/^# \{0,1\}//'
+    sed -n '2,46p' "$0" | sed 's/^# \{0,1\}//'
 }
 
 parse_args() {
@@ -74,6 +86,8 @@ parse_args() {
                 ;;
             --compare-with-msodbcsql) COMPARE=1 ;;
             --retries=*) RETRIES="${arg#--retries=}" ;;
+            --coverage) COVERAGE=1 ;;
+            --coverage=*) COVERAGE=1; COVERAGE_OUTPUT="${arg#--coverage=}" ;;
             --msodbcsql-ini=*) MSODBCSQL_INI="${arg#--msodbcsql-ini=}" ;;
             -h|--help) usage; exit 0 ;;
             *) echo "Unknown argument: $arg" >&2; usage >&2; exit 2 ;;
@@ -90,6 +104,25 @@ cleanup() {
     fi
 }
 trap cleanup EXIT
+
+# ----------------------------------------------------------------------------
+# Coverage: enable LLVM source-based instrumentation for the driver build
+# ----------------------------------------------------------------------------
+# `cargo llvm-cov show-env` exports RUSTFLAGS (-C instrument-coverage), the
+# llvm-cov target dir and an LLVM_PROFILE_FILE pattern (with %p/%m so distinct
+# gtest processes and ctest retries never clobber each other's .profraw). The
+# subsequent `cargo build` then produces an instrumented libmsodbcsql18.so, and
+# every ctest child process inherits LLVM_PROFILE_FILE from this environment.
+setup_coverage_env() {
+    echo "=== Enabling coverage instrumentation for the Rust driver ==="
+    cargo llvm-cov clean --workspace
+    # Warm the tooling first so any one-time rustup component install output
+    # (e.g. downloading llvm-tools) is not sourced into the shell below.
+    cargo llvm-cov show-env --export-prefix >/dev/null 2>&1 || true
+    # Source only the export statements; discard rustup/info chatter.
+    eval "$(cargo llvm-cov show-env --export-prefix 2>/dev/null | grep '^export ')"
+    echo "LLVM_PROFILE_FILE=${LLVM_PROFILE_FILE:-<unset>}"
+}
 
 # ----------------------------------------------------------------------------
 # Step 1: Configure tracing for verbose mode
@@ -117,7 +150,10 @@ build_rust_driver() {
     )
 
     # Cargo builds into the workspace root's target/ directory, which may
-    # differ from the crate-local directory. Use `cargo metadata` to resolve.
+    # differ from the crate-local directory. Use `cargo metadata` to resolve it.
+    # Under coverage, `cargo llvm-cov show-env` may redirect the build via
+    # CARGO_TARGET_DIR; `cargo metadata` honors that env var, so target_directory
+    # always points at wherever the instrumented .so actually lands.
     local target_dir
     target_dir="$(cd "$ODBC_CRATE_DIR" && cargo metadata --format-version 1 --no-deps 2>/dev/null \
         | python3 -c 'import sys,json; print(json.load(sys.stdin)["target_directory"])' 2>/dev/null \
@@ -134,6 +170,15 @@ build_rust_driver() {
         exit 1
     fi
     echo "Rust driver: $RUST_DRIVER_PATH"
+
+    # Under coverage, surface the resolved paths so a broken instrumentation
+    # setup is obvious in the log. RUSTFLAGS=-C instrument-coverage was exported
+    # before this build, so this .so is the instrumented one ctest will load;
+    # the post-run .profraw check in generate_coverage_report proves it fired.
+    if [ "$COVERAGE" -eq 1 ]; then
+        echo "Coverage: LLVM_PROFILE_FILE=${LLVM_PROFILE_FILE:-<unset>}"
+        echo "Coverage: instrumented driver=$RUST_DRIVER_PATH"
+    fi
 }
 
 # ----------------------------------------------------------------------------
@@ -296,6 +341,42 @@ PY
 }
 
 # ----------------------------------------------------------------------------
+# Coverage: turn the .profraw written by the ctest processes into Cobertura.
+# `cargo llvm-cov report` wraps llvm-profdata merge + llvm-cov export, so the
+# LLVM tooling matches the rustc that produced the instrumented .so. Includes
+# both mssql-tds and mssql-odbc because the cdylib statically links mssql-tds,
+# so driver execution also covers mssql-tds source. Best-effort: the suite has
+# already run, so a coverage tooling hiccup must not change the pass/fail result.
+# Run from the workspace root (the script's cwd) so Cobertura filenames are
+# repo-root-relative and union with the other per-OS reports in the merge.
+# ----------------------------------------------------------------------------
+generate_coverage_report() {
+    echo ""
+    echo "=== Generating ODBC e2e coverage report ==="
+    # Prove the instrumented driver actually ran under the Driver Manager: each
+    # gtest process writes a .profraw keyed by LLVM_PROFILE_FILE. Zero .profraw
+    # means coverage silently captured nothing (e.g. an uninstrumented .so was
+    # loaded), so warn loudly. Non-fatal: the functional result already stands.
+    local profraw_dir
+    profraw_dir="$(dirname "${LLVM_PROFILE_FILE:-}")"
+    if [ -n "$profraw_dir" ] && [ -d "$profraw_dir" ]; then
+        local n
+        n="$(find "$profraw_dir" -name '*.profraw' 2>/dev/null | wc -l | tr -d ' ')"
+        echo "Coverage: found $n .profraw file(s) under $profraw_dir"
+        if [ "$n" -eq 0 ]; then
+            echo "WARNING: no .profraw produced; the driver ctest loaded may not be instrumented" >&2
+        fi
+    fi
+    mkdir -p "$(dirname "$COVERAGE_OUTPUT")"
+    if cargo llvm-cov report --package mssql-tds --package mssql-odbc \
+        --cobertura --output-path "$COVERAGE_OUTPUT"; then
+        echo "Coverage report written to $COVERAGE_OUTPUT"
+    else
+        echo "WARNING: failed to generate ODBC e2e coverage report" >&2
+    fi
+}
+
+# ----------------------------------------------------------------------------
 # Main
 # ----------------------------------------------------------------------------
 main() {
@@ -306,6 +387,9 @@ main() {
         echo "Retries enabled: each failing test reruns up to $RETRIES time(s)."
     fi
     setup_tracing
+    if [ "$COVERAGE" -eq 1 ]; then
+        setup_coverage_env
+    fi
     setup_dev_sql_env
     build_rust_driver
     register_rust_driver
@@ -319,6 +403,12 @@ main() {
     local rust_rc=0 ms_rc=0
 
     run_tests "mssql-odbc" "$RUST_INI_DIR" "$rust_junit" || rust_rc=$?
+
+    # Report on the instrumented mssql-odbc leg before the (uninstrumented)
+    # msodbcsql reference leg runs, so the profraw reflects our driver only.
+    if [ "$COVERAGE" -eq 1 ]; then
+        generate_coverage_report
+    fi
 
     if [ "$COMPARE" -eq 0 ]; then
         if [ "$rust_rc" -ne 0 ]; then


### PR DESCRIPTION
## Summary

The C++ gtest ODBC e2e suite loads the compiled Rust driver (`libmsodbcsql18.so`) through the unixODBC Driver Manager as **separate processes**. Because that build was uninstrumented and ran in a later `docker run` (after the Rust cobertura report was already finalized), the e2e execution contributed **zero** coverage. This PR makes it count.

**Scope: Linux e2e coverage only (x64).** Out of scope: Windows e2e, macOS, and Rust unit-test coverage (already works).

## Mechanism

Reuses the exact cross-FFI coverage pattern already in the tree at `dev/test-python.sh --coverage`:

- `run_e2e.sh --coverage[=OUTPUT]` runs `cargo llvm-cov show-env` to export `RUSTFLAGS=-C instrument-coverage`, the llvm-cov target dir, and an `LLVM_PROFILE_FILE` pattern.
- The subsequent `cargo build` produces an **instrumented** `.so`; each gtest child process inherits `LLVM_PROFILE_FILE` and emits `%p`/`%m`-keyed `.profraw` (safe across parallel tests + ctest retries).
- After the suite runs, `cargo llvm-cov report --package mssql-tds --package mssql-odbc --cobertura` emits a **repo-root-relative** report. Driving everything through `cargo llvm-cov` guarantees the LLVM version reading the `.profraw` matches the rustc that produced the `.so` (no profraw-version mismatch). The cdylib statically links `mssql-tds`, so both crates gain coverage.

All three phases (instrument build → ctest → report) run **inside the single e2e container**; only the final `target/cobertura-odbc-e2e.xml` crosses the boundary via the mounted `/workspace` volume, then a host-side `PublishPipelineArtifact` publishes `CoberturaCoverageOdbcE2E_Linux`. The Merge Coverage stage unions it with the existing per-OS reports (a line covered on any input counts as covered).

## Changes

| File | Change |
|---|---|
| `mssql-odbc/tests/e2e/run_e2e.sh` | Add `--coverage[=OUTPUT]`: `show-env` instrument, inherit `LLVM_PROFILE_FILE`, post-run `.profraw` sanity check, `cargo llvm-cov report --cobertura`. |
| `.pipeline/scripts/containerized-odbc-e2e.sh` | Pass `--coverage=/workspace/target/cobertura-odbc-e2e.xml` when `ODBC_E2E_COVERAGE` is truthy. |
| `.pipeline/templates/build-template-container.yml` | x64 e2e step: `-e ODBC_E2E_COVERAGE="${{ lower(parameters.collectRustCoverage) }}"`; publish `CoberturaCoverageOdbcE2E_Linux` (gated on `collectRustCoverage` + PR). |
| `.pipeline/templates/validation-stages.yml` | Merge_Coverage: download + union the new artifact (no prefix; already repo-root-relative). |
| `mssql-odbc/tests/e2e/README.md` | Document `--coverage`. |

## Safety / rollback

All additions are additive and best-effort: `continueOnError` + `succeededOrFailed` on the publish, the download `[ -f ]`-guarded in the merge, and a report failure is only a warning. The e2e functional pass/fail contract is unchanged. To hot-disable, drop `-e ODBC_E2E_COVERAGE` from the x64 step — coverage reverts to today's unit-only behavior. ARM e2e stays an uninstrumented functional test.

## Validation

- `bash -n` clean on both scripts; both pipeline YAMLs parse.
- The post-run `.profraw` count in the log proves a Driver-Manager-only line becomes covered (zero `.profraw` warns loudly).
- CI proof: confirm `CoberturaCoverageOdbcE2E_Linux` is published and the Merge Coverage log lists `cobertura-odbc-e2e.xml` among the merge inputs.

[AB#46451](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46451)