### PR TITLE
Fix fuzz crash in SQL_VARIANT 7-prop-byte decoder

### DIFF
--- a/mssql-tds/src/datatypes/decoder.rs
+++ b/mssql-tds/src/datatypes/decoder.rs
@@ -2129,10 +2129,14 @@ async fn decode_seven_propbyte_variant<T>(
 where
     T: TdsPacketReader + Send + Sync,
 {
-    assert!(matches!(
+    if !matches!(
         tds_type,
         TdsDataType::BigVarChar | TdsDataType::BigChar | TdsDataType::NVarChar | TdsDataType::NChar
-    ));
+    ) {
+        return Err(crate::error::Error::ProtocolError(format!(
+            "Unexpected SQL variant base type for len(7) prop bytes: {tds_type:?}. Expected a character type."
+        )));
+    }
     let mut collation_bytes = vec![0u8; 5];
     reader.read_bytes(&mut collation_bytes).await?;
     let _max_length = reader.read_uint16().await? as usize;
@@ -4181,6 +4185,21 @@ mod test {
             buf.push(TdsDataType::IntN as u8); // not binary/decimal → error
             buf.push(2); // prop_bytes=2
             buf.extend_from_slice(&[0; 4]); // prop data + value data
+            assert_decode_err(buf, &md).await;
+        }
+
+        #[tokio::test]
+        async fn ssvariant_seven_prop_unexpected_type() {
+            // Regression for fuzz crash-80c55599: a SQL_VARIANT advertising 7
+            // property bytes with a non-character base type used to trip a
+            // debug assertion in decode_seven_propbyte_variant. It must now
+            // return a ProtocolError instead of panicking.
+            let md = ssvariant_metadata();
+            let mut buf = Vec::new();
+            buf.extend_from_slice(&20u32.to_le_bytes()); // length
+            buf.push(TdsDataType::IntN as u8); // not a character type → error
+            buf.push(7); // prop_bytes=7 selects the character-type decoder
+            buf.extend_from_slice(&[0; 11]); // padding, never read
             assert_decode_err(buf, &md).await;
         }
 


### PR DESCRIPTION
## Summary

The `GH-Rust Fuzz Test` pipeline (definitionId 2207, [build 164079](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build/results?buildId=164079&view=results)) detected a crash in the `fuzz_token_stream` target (`crash-80c55599ebe9adee81668324e4c6151894a33fbe`).

## Root cause

In `read_sql_variant`, a `SQL_VARIANT` value advertising **7 property bytes** is dispatched to `decode_seven_propbyte_variant` based solely on the property-byte count, regardless of the variant base type. That function held a debug `assert!` requiring the base type to be a character type (`BigVarChar` / `BigChar` / `NVarChar` / `NChar`). A malformed/fuzzed stream carrying 7 property bytes with a non-character base type (e.g. `IntN`) trips the assertion and aborts the process.

```
assertion failed: matches!(tds_type, TdsDataType::BigVarChar | TdsDataType::BigChar
    | TdsDataType::NVarChar | TdsDataType::NChar)
  at mssql-tds/src/datatypes/decoder.rs:2132
```

Reached via token `0xAC` (RETURNVALUE) → base type `0x62` (SQL_VARIANT) → `read_sql_variant` → `decode_seven_propbyte_variant`.

## Fix

Replace the assertion with a graceful `ProtocolError` return, consistent with the other property-byte SQL_VARIANT decoders (`decode_two_propbyte_variant`, the `_ =>` arms, etc.). Untrusted wire data must never abort the process.

Added regression test `ssvariant_seven_prop_unexpected_type` in the decoder test module, which reproduces the crash input shape and asserts a graceful error.

## Validation

- Reproduced the original crash locally against the downloaded artifact, confirmed the fix returns `Err` instead of panicking.
- `cargo bfmt` ✅
- `cargo bclippy` ✅ (no warnings)
- Decoder SQL_VARIANT tests pass ✅

## Work item

[AB#46937](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46937)