### PR TITLE
Sync vanilla Python build images and additional Linux base images to GHCR

### DIFF
--- a/.pipeline/sync-container-images.yml
+++ b/.pipeline/sync-container-images.yml
@@ -733,6 +733,7 @@ stages:
   jobs:
   - job: BuildX64Images
     displayName: Build x64 Images
+    condition: or(eq('${{ parameters.buildPythonImages }}', 'true'), eq('${{ parameters.buildUbuntuImages }}', 'true'))
     pool:
       name: RUST-1ES-POOL-WUS3
       demands:
@@ -921,6 +922,10 @@ stages:
   - job: BuildARM64Images
     displayName: Build ARM64 Images
     dependsOn: BuildX64Images
+    # succeeded() must stay explicit: supplying a condition replaces the
+    # implicit succeeded(), which would otherwise let ARM64 start after an
+    # x64 failure.
+    condition: and(succeeded(), or(eq('${{ parameters.buildPythonImages }}', 'true'), eq('${{ parameters.buildUbuntuImages }}', 'true')))
     pool:
       name: RUST-1ES-POOL-ARM-WUS3
       demands:

--- a/.pipeline/sync-container-images.yml
+++ b/.pipeline/sync-container-images.yml
@@ -1035,6 +1035,12 @@ stages:
         import/redhat/ubi9:latest
         import/redhat/ubi8:latest
         import/oraclelinux:9
+        import/python-build/manylinux_2_34_x86_64:latest
+        import/python-build/manylinux_2_34_aarch64:latest
+        import/python-build/manylinux_2_28_x86_64:latest
+        import/python-build/manylinux_2_28_aarch64:latest
+        import/python-build/musllinux_1_2_x86_64:latest
+        import/python-build/musllinux_1_2_aarch64:latest
         EOF
         echo "Images to mirror to GHCR:"
         sed 's/^/  /' "$(Pipeline.Workspace)/ghcr/images.txt"

--- a/.pipeline/sync-container-images.yml
+++ b/.pipeline/sync-container-images.yml
@@ -41,8 +41,23 @@ parameters:
   type: boolean
   default: true
 
+- name: syncAlpine3
+  displayName: 'Import: Alpine 3.22-3.23 (docker.io)'
+  type: boolean
+  default: true
+
 - name: syncDebianRHEL
   displayName: 'Import: Debian & RHEL (docker.io)'
+  type: boolean
+  default: true
+
+- name: syncCentOS
+  displayName: 'Import: CentOS Stream (quay.io)'
+  type: boolean
+  default: true
+
+- name: syncSUSE
+  displayName: 'Import: openSUSE Leap (docker.io)'
   type: boolean
   default: true
 
@@ -399,9 +414,68 @@ stages:
         DOCKER_PAT: $(DOCKERHUB_PAT)
       retryCountOnTaskFailure: 3
 
+  # Alpine 3.22 & 3.23 (Docker Hub - rate limited)
+  - job: Alpine3
+    displayName: 'Import Alpine 3.22 & 3.23'
+    condition: eq('${{ parameters.syncAlpine3 }}', 'true')
+    pool:
+      name: RUST-1ES-POOL-WUS3
+      demands:
+        - imageOverride -equals RUST-1ES-UBUSLIM
+    steps:
+    - checkout: none
+    - task: AzureCLI@2
+      displayName: 'Import Alpine 3.22'
+      inputs:
+        azureSubscription: 'Magnitude Test'
+        scriptType: 'bash'
+        scriptLocation: 'inlineScript'
+        inlineScript: |
+          AUTH_ARGS=""
+          if [[ -n "$DOCKER_USER" && -n "$DOCKER_PAT" ]]; then
+            echo "Using authenticated Docker Hub access"
+            AUTH_ARGS="--username $DOCKER_USER --password $DOCKER_PAT"
+          else
+            echo "Using anonymous Docker Hub access"
+          fi
+          az acr import \
+            --name $(ACR_NAME) \
+            --source docker.io/library/alpine:3.22 \
+            --image import/alpine:3.22 \
+            $AUTH_ARGS \
+            --force
+      env:
+        DOCKER_USER: $(DOCKERHUB_USERNAME)
+        DOCKER_PAT: $(DOCKERHUB_PAT)
+      retryCountOnTaskFailure: 3
+    - task: AzureCLI@2
+      displayName: 'Import Alpine 3.23'
+      inputs:
+        azureSubscription: 'Magnitude Test'
+        scriptType: 'bash'
+        scriptLocation: 'inlineScript'
+        inlineScript: |
+          AUTH_ARGS=""
+          if [[ -n "$DOCKER_USER" && -n "$DOCKER_PAT" ]]; then
+            echo "Using authenticated Docker Hub access"
+            AUTH_ARGS="--username $DOCKER_USER --password $DOCKER_PAT"
+          else
+            echo "Using anonymous Docker Hub access"
+          fi
+          az acr import \
+            --name $(ACR_NAME) \
+            --source docker.io/library/alpine:3.23 \
+            --image import/alpine:3.23 \
+            $AUTH_ARGS \
+            --force
+      env:
+        DOCKER_USER: $(DOCKERHUB_USERNAME)
+        DOCKER_PAT: $(DOCKERHUB_PAT)
+      retryCountOnTaskFailure: 3
+
   # Debian & RHEL (Docker Hub - rate limited)
   - job: DebianRHEL
-    displayName: 'Import Debian & RHEL UBI9'
+    displayName: 'Import Debian & RHEL UBI'
     condition: eq('${{ parameters.syncDebianRHEL }}', 'true')
     pool:
       name: RUST-1ES-POOL-WUS3
@@ -427,6 +501,54 @@ stages:
             --name $(ACR_NAME) \
             --source docker.io/library/debian:bookworm \
             --image import/debian:bookworm \
+            $AUTH_ARGS \
+            --force
+      env:
+        DOCKER_USER: $(DOCKERHUB_USERNAME)
+        DOCKER_PAT: $(DOCKERHUB_PAT)
+      retryCountOnTaskFailure: 3
+    - task: AzureCLI@2
+      displayName: 'Import Debian Bullseye'
+      inputs:
+        azureSubscription: 'Magnitude Test'
+        scriptType: 'bash'
+        scriptLocation: 'inlineScript'
+        inlineScript: |
+          AUTH_ARGS=""
+          if [[ -n "$DOCKER_USER" && -n "$DOCKER_PAT" ]]; then
+            echo "Using authenticated Docker Hub access"
+            AUTH_ARGS="--username $DOCKER_USER --password $DOCKER_PAT"
+          else
+            echo "Using anonymous Docker Hub access"
+          fi
+          az acr import \
+            --name $(ACR_NAME) \
+            --source docker.io/library/debian:bullseye \
+            --image import/debian:bullseye \
+            $AUTH_ARGS \
+            --force
+      env:
+        DOCKER_USER: $(DOCKERHUB_USERNAME)
+        DOCKER_PAT: $(DOCKERHUB_PAT)
+      retryCountOnTaskFailure: 3
+    - task: AzureCLI@2
+      displayName: 'Import Debian Trixie'
+      inputs:
+        azureSubscription: 'Magnitude Test'
+        scriptType: 'bash'
+        scriptLocation: 'inlineScript'
+        inlineScript: |
+          AUTH_ARGS=""
+          if [[ -n "$DOCKER_USER" && -n "$DOCKER_PAT" ]]; then
+            echo "Using authenticated Docker Hub access"
+            AUTH_ARGS="--username $DOCKER_USER --password $DOCKER_PAT"
+          else
+            echo "Using anonymous Docker Hub access"
+          fi
+          az acr import \
+            --name $(ACR_NAME) \
+            --source docker.io/library/debian:trixie \
+            --image import/debian:trixie \
             $AUTH_ARGS \
             --force
       env:
@@ -481,6 +603,21 @@ stages:
         DOCKER_USER: $(DOCKERHUB_USERNAME)
         DOCKER_PAT: $(DOCKERHUB_PAT)
       retryCountOnTaskFailure: 3
+    # UBI10 is not published on Docker Hub, so it comes straight from the
+    # Red Hat public registry (anonymous, no Docker Hub credentials).
+    - task: AzureCLI@2
+      displayName: 'Import Red Hat UBI10'
+      inputs:
+        azureSubscription: 'Magnitude Test'
+        scriptType: 'bash'
+        scriptLocation: 'inlineScript'
+        inlineScript: |
+          az acr import \
+            --name $(ACR_NAME) \
+            --source registry.access.redhat.com/ubi10/ubi:latest \
+            --image import/redhat/ubi10:latest \
+            --force
+      retryCountOnTaskFailure: 3
 
   # Oracle Linux (Docker Hub - rate limited)
   - job: Oracle
@@ -510,6 +647,65 @@ stages:
             --name $(ACR_NAME) \
             --source docker.io/library/oraclelinux:9 \
             --image import/oraclelinux:9 \
+            $AUTH_ARGS \
+            --force
+      env:
+        DOCKER_USER: $(DOCKERHUB_USERNAME)
+        DOCKER_PAT: $(DOCKERHUB_PAT)
+      retryCountOnTaskFailure: 3
+
+  # CentOS Stream (quay.io - no Docker Hub rate limit)
+  - job: CentOS
+    displayName: 'Import CentOS Stream 9'
+    condition: eq('${{ parameters.syncCentOS }}', 'true')
+    pool:
+      name: RUST-1ES-POOL-WUS3
+      demands:
+        - imageOverride -equals RUST-1ES-UBUSLIM
+    steps:
+    - checkout: none
+    - task: AzureCLI@2
+      displayName: 'Import CentOS Stream 9'
+      inputs:
+        azureSubscription: 'Magnitude Test'
+        scriptType: 'bash'
+        scriptLocation: 'inlineScript'
+        inlineScript: |
+          az acr import \
+            --name $(ACR_NAME) \
+            --source quay.io/centos/centos:stream9 \
+            --image import/centos:stream9 \
+            --force
+      retryCountOnTaskFailure: 3
+
+  # openSUSE Leap (Docker Hub - rate limited)
+  - job: SUSE
+    displayName: 'Import openSUSE Leap 15.6'
+    condition: eq('${{ parameters.syncSUSE }}', 'true')
+    pool:
+      name: RUST-1ES-POOL-WUS3
+      demands:
+        - imageOverride -equals RUST-1ES-UBUSLIM
+    steps:
+    - checkout: none
+    - task: AzureCLI@2
+      displayName: 'Import openSUSE Leap 15.6'
+      inputs:
+        azureSubscription: 'Magnitude Test'
+        scriptType: 'bash'
+        scriptLocation: 'inlineScript'
+        inlineScript: |
+          AUTH_ARGS=""
+          if [[ -n "$DOCKER_USER" && -n "$DOCKER_PAT" ]]; then
+            echo "Using authenticated Docker Hub access"
+            AUTH_ARGS="--username $DOCKER_USER --password $DOCKER_PAT"
+          else
+            echo "Using anonymous Docker Hub access"
+          fi
+          az acr import \
+            --name $(ACR_NAME) \
+            --source docker.io/opensuse/leap:15.6 \
+            --image import/opensuse/leap:15.6 \
             $AUTH_ARGS \
             --force
       env:
@@ -1026,15 +1222,22 @@ stages:
         build/ubuntu:22.04
         build/alpine:3.18
         import/debian:bookworm
+        import/debian:bullseye
+        import/debian:trixie
         import/alpine:3.18
         import/alpine:3.19
         import/alpine:3.20
         import/alpine:3.21
+        import/alpine:3.22
+        import/alpine:3.23
         import/ubuntu:22.04
         import/ubuntu:24.04
         import/redhat/ubi9:latest
         import/redhat/ubi8:latest
+        import/redhat/ubi10:latest
         import/oraclelinux:9
+        import/centos:stream9
+        import/opensuse/leap:15.6
         import/python-build/manylinux_2_34_x86_64:latest
         import/python-build/manylinux_2_34_aarch64:latest
         import/python-build/manylinux_2_28_x86_64:latest

--- a/.pipeline/sync-container-images.yml
+++ b/.pipeline/sync-container-images.yml
@@ -259,10 +259,10 @@ stages:
         scriptType: 'bash'
         scriptLocation: 'inlineScript'
         inlineScript: |
-          AUTH_ARGS=""
+          AUTH_ARGS=()
           if [[ -n "$DOCKER_USER" && -n "$DOCKER_PAT" ]]; then
             echo "Using authenticated Docker Hub access"
-            AUTH_ARGS="--username $DOCKER_USER --password $DOCKER_PAT"
+            AUTH_ARGS=(--username "$DOCKER_USER" --password "$DOCKER_PAT")
           else
             echo "Using anonymous Docker Hub access"
           fi
@@ -270,7 +270,7 @@ stages:
             --name $(ACR_NAME) \
             --source docker.io/library/ubuntu:22.04 \
             --image import/ubuntu:22.04 \
-            $AUTH_ARGS \
+            "${AUTH_ARGS[@]}" \
             --force
       env:
         DOCKER_USER: $(DOCKERHUB_USERNAME)
@@ -283,10 +283,10 @@ stages:
         scriptType: 'bash'
         scriptLocation: 'inlineScript'
         inlineScript: |
-          AUTH_ARGS=""
+          AUTH_ARGS=()
           if [[ -n "$DOCKER_USER" && -n "$DOCKER_PAT" ]]; then
             echo "Using authenticated Docker Hub access"
-            AUTH_ARGS="--username $DOCKER_USER --password $DOCKER_PAT"
+            AUTH_ARGS=(--username "$DOCKER_USER" --password "$DOCKER_PAT")
           else
             echo "Using anonymous Docker Hub access"
           fi
@@ -294,7 +294,7 @@ stages:
             --name $(ACR_NAME) \
             --source docker.io/library/ubuntu:24.04 \
             --image import/ubuntu:24.04 \
-            $AUTH_ARGS \
+            "${AUTH_ARGS[@]}" \
             --force
       env:
         DOCKER_USER: $(DOCKERHUB_USERNAME)
@@ -318,10 +318,10 @@ stages:
         scriptType: 'bash'
         scriptLocation: 'inlineScript'
         inlineScript: |
-          AUTH_ARGS=""
+          AUTH_ARGS=()
           if [[ -n "$DOCKER_USER" && -n "$DOCKER_PAT" ]]; then
             echo "Using authenticated Docker Hub access"
-            AUTH_ARGS="--username $DOCKER_USER --password $DOCKER_PAT"
+            AUTH_ARGS=(--username "$DOCKER_USER" --password "$DOCKER_PAT")
           else
             echo "Using anonymous Docker Hub access"
           fi
@@ -329,7 +329,7 @@ stages:
             --name $(ACR_NAME) \
             --source docker.io/library/alpine:3.18 \
             --image import/alpine:3.18 \
-            $AUTH_ARGS \
+            "${AUTH_ARGS[@]}" \
             --force
       env:
         DOCKER_USER: $(DOCKERHUB_USERNAME)
@@ -342,10 +342,10 @@ stages:
         scriptType: 'bash'
         scriptLocation: 'inlineScript'
         inlineScript: |
-          AUTH_ARGS=""
+          AUTH_ARGS=()
           if [[ -n "$DOCKER_USER" && -n "$DOCKER_PAT" ]]; then
             echo "Using authenticated Docker Hub access"
-            AUTH_ARGS="--username $DOCKER_USER --password $DOCKER_PAT"
+            AUTH_ARGS=(--username "$DOCKER_USER" --password "$DOCKER_PAT")
           else
             echo "Using anonymous Docker Hub access"
           fi
@@ -353,7 +353,7 @@ stages:
             --name $(ACR_NAME) \
             --source docker.io/library/alpine:3.19 \
             --image import/alpine:3.19 \
-            $AUTH_ARGS \
+            "${AUTH_ARGS[@]}" \
             --force
       env:
         DOCKER_USER: $(DOCKERHUB_USERNAME)
@@ -377,10 +377,10 @@ stages:
         scriptType: 'bash'
         scriptLocation: 'inlineScript'
         inlineScript: |
-          AUTH_ARGS=""
+          AUTH_ARGS=()
           if [[ -n "$DOCKER_USER" && -n "$DOCKER_PAT" ]]; then
             echo "Using authenticated Docker Hub access"
-            AUTH_ARGS="--username $DOCKER_USER --password $DOCKER_PAT"
+            AUTH_ARGS=(--username "$DOCKER_USER" --password "$DOCKER_PAT")
           else
             echo "Using anonymous Docker Hub access"
           fi
@@ -388,7 +388,7 @@ stages:
             --name $(ACR_NAME) \
             --source docker.io/library/alpine:3.20 \
             --image import/alpine:3.20 \
-            $AUTH_ARGS \
+            "${AUTH_ARGS[@]}" \
             --force
       env:
         DOCKER_USER: $(DOCKERHUB_USERNAME)
@@ -401,10 +401,10 @@ stages:
         scriptType: 'bash'
         scriptLocation: 'inlineScript'
         inlineScript: |
-          AUTH_ARGS=""
+          AUTH_ARGS=()
           if [[ -n "$DOCKER_USER" && -n "$DOCKER_PAT" ]]; then
             echo "Using authenticated Docker Hub access"
-            AUTH_ARGS="--username $DOCKER_USER --password $DOCKER_PAT"
+            AUTH_ARGS=(--username "$DOCKER_USER" --password "$DOCKER_PAT")
           else
             echo "Using anonymous Docker Hub access"
           fi
@@ -412,7 +412,7 @@ stages:
             --name $(ACR_NAME) \
             --source docker.io/library/alpine:3.21 \
             --image import/alpine:3.21 \
-            $AUTH_ARGS \
+            "${AUTH_ARGS[@]}" \
             --force
       env:
         DOCKER_USER: $(DOCKERHUB_USERNAME)
@@ -436,10 +436,10 @@ stages:
         scriptType: 'bash'
         scriptLocation: 'inlineScript'
         inlineScript: |
-          AUTH_ARGS=""
+          AUTH_ARGS=()
           if [[ -n "$DOCKER_USER" && -n "$DOCKER_PAT" ]]; then
             echo "Using authenticated Docker Hub access"
-            AUTH_ARGS="--username $DOCKER_USER --password $DOCKER_PAT"
+            AUTH_ARGS=(--username "$DOCKER_USER" --password "$DOCKER_PAT")
           else
             echo "Using anonymous Docker Hub access"
           fi
@@ -447,7 +447,7 @@ stages:
             --name $(ACR_NAME) \
             --source docker.io/library/alpine:3.22 \
             --image import/alpine:3.22 \
-            $AUTH_ARGS \
+            "${AUTH_ARGS[@]}" \
             --force
       env:
         DOCKER_USER: $(DOCKERHUB_USERNAME)
@@ -460,10 +460,10 @@ stages:
         scriptType: 'bash'
         scriptLocation: 'inlineScript'
         inlineScript: |
-          AUTH_ARGS=""
+          AUTH_ARGS=()
           if [[ -n "$DOCKER_USER" && -n "$DOCKER_PAT" ]]; then
             echo "Using authenticated Docker Hub access"
-            AUTH_ARGS="--username $DOCKER_USER --password $DOCKER_PAT"
+            AUTH_ARGS=(--username "$DOCKER_USER" --password "$DOCKER_PAT")
           else
             echo "Using anonymous Docker Hub access"
           fi
@@ -471,7 +471,7 @@ stages:
             --name $(ACR_NAME) \
             --source docker.io/library/alpine:3.23 \
             --image import/alpine:3.23 \
-            $AUTH_ARGS \
+            "${AUTH_ARGS[@]}" \
             --force
       env:
         DOCKER_USER: $(DOCKERHUB_USERNAME)
@@ -495,10 +495,10 @@ stages:
         scriptType: 'bash'
         scriptLocation: 'inlineScript'
         inlineScript: |
-          AUTH_ARGS=""
+          AUTH_ARGS=()
           if [[ -n "$DOCKER_USER" && -n "$DOCKER_PAT" ]]; then
             echo "Using authenticated Docker Hub access"
-            AUTH_ARGS="--username $DOCKER_USER --password $DOCKER_PAT"
+            AUTH_ARGS=(--username "$DOCKER_USER" --password "$DOCKER_PAT")
           else
             echo "Using anonymous Docker Hub access"
           fi
@@ -506,7 +506,7 @@ stages:
             --name $(ACR_NAME) \
             --source docker.io/library/debian:bookworm \
             --image import/debian:bookworm \
-            $AUTH_ARGS \
+            "${AUTH_ARGS[@]}" \
             --force
       env:
         DOCKER_USER: $(DOCKERHUB_USERNAME)
@@ -519,10 +519,10 @@ stages:
         scriptType: 'bash'
         scriptLocation: 'inlineScript'
         inlineScript: |
-          AUTH_ARGS=""
+          AUTH_ARGS=()
           if [[ -n "$DOCKER_USER" && -n "$DOCKER_PAT" ]]; then
             echo "Using authenticated Docker Hub access"
-            AUTH_ARGS="--username $DOCKER_USER --password $DOCKER_PAT"
+            AUTH_ARGS=(--username "$DOCKER_USER" --password "$DOCKER_PAT")
           else
             echo "Using anonymous Docker Hub access"
           fi
@@ -530,7 +530,7 @@ stages:
             --name $(ACR_NAME) \
             --source docker.io/library/debian:bullseye \
             --image import/debian:bullseye \
-            $AUTH_ARGS \
+            "${AUTH_ARGS[@]}" \
             --force
       env:
         DOCKER_USER: $(DOCKERHUB_USERNAME)
@@ -543,10 +543,10 @@ stages:
         scriptType: 'bash'
         scriptLocation: 'inlineScript'
         inlineScript: |
-          AUTH_ARGS=""
+          AUTH_ARGS=()
           if [[ -n "$DOCKER_USER" && -n "$DOCKER_PAT" ]]; then
             echo "Using authenticated Docker Hub access"
-            AUTH_ARGS="--username $DOCKER_USER --password $DOCKER_PAT"
+            AUTH_ARGS=(--username "$DOCKER_USER" --password "$DOCKER_PAT")
           else
             echo "Using anonymous Docker Hub access"
           fi
@@ -554,7 +554,7 @@ stages:
             --name $(ACR_NAME) \
             --source docker.io/library/debian:trixie \
             --image import/debian:trixie \
-            $AUTH_ARGS \
+            "${AUTH_ARGS[@]}" \
             --force
       env:
         DOCKER_USER: $(DOCKERHUB_USERNAME)
@@ -567,10 +567,10 @@ stages:
         scriptType: 'bash'
         scriptLocation: 'inlineScript'
         inlineScript: |
-          AUTH_ARGS=""
+          AUTH_ARGS=()
           if [[ -n "$DOCKER_USER" && -n "$DOCKER_PAT" ]]; then
             echo "Using authenticated Docker Hub access"
-            AUTH_ARGS="--username $DOCKER_USER --password $DOCKER_PAT"
+            AUTH_ARGS=(--username "$DOCKER_USER" --password "$DOCKER_PAT")
           else
             echo "Using anonymous Docker Hub access"
           fi
@@ -578,7 +578,7 @@ stages:
             --name $(ACR_NAME) \
             --source docker.io/redhat/ubi9:latest \
             --image import/redhat/ubi9:latest \
-            $AUTH_ARGS \
+            "${AUTH_ARGS[@]}" \
             --force
       env:
         DOCKER_USER: $(DOCKERHUB_USERNAME)
@@ -591,10 +591,10 @@ stages:
         scriptType: 'bash'
         scriptLocation: 'inlineScript'
         inlineScript: |
-          AUTH_ARGS=""
+          AUTH_ARGS=()
           if [[ -n "$DOCKER_USER" && -n "$DOCKER_PAT" ]]; then
             echo "Using authenticated Docker Hub access"
-            AUTH_ARGS="--username $DOCKER_USER --password $DOCKER_PAT"
+            AUTH_ARGS=(--username "$DOCKER_USER" --password "$DOCKER_PAT")
           else
             echo "Using anonymous Docker Hub access"
           fi
@@ -602,7 +602,7 @@ stages:
             --name $(ACR_NAME) \
             --source docker.io/redhat/ubi8:latest \
             --image import/redhat/ubi8:latest \
-            $AUTH_ARGS \
+            "${AUTH_ARGS[@]}" \
             --force
       env:
         DOCKER_USER: $(DOCKERHUB_USERNAME)
@@ -641,10 +641,10 @@ stages:
         scriptType: 'bash'
         scriptLocation: 'inlineScript'
         inlineScript: |
-          AUTH_ARGS=""
+          AUTH_ARGS=()
           if [[ -n "$DOCKER_USER" && -n "$DOCKER_PAT" ]]; then
             echo "Using authenticated Docker Hub access"
-            AUTH_ARGS="--username $DOCKER_USER --password $DOCKER_PAT"
+            AUTH_ARGS=(--username "$DOCKER_USER" --password "$DOCKER_PAT")
           else
             echo "Using anonymous Docker Hub access"
           fi
@@ -652,7 +652,7 @@ stages:
             --name $(ACR_NAME) \
             --source docker.io/library/oraclelinux:9 \
             --image import/oraclelinux:9 \
-            $AUTH_ARGS \
+            "${AUTH_ARGS[@]}" \
             --force
       env:
         DOCKER_USER: $(DOCKERHUB_USERNAME)
@@ -700,10 +700,10 @@ stages:
         scriptType: 'bash'
         scriptLocation: 'inlineScript'
         inlineScript: |
-          AUTH_ARGS=""
+          AUTH_ARGS=()
           if [[ -n "$DOCKER_USER" && -n "$DOCKER_PAT" ]]; then
             echo "Using authenticated Docker Hub access"
-            AUTH_ARGS="--username $DOCKER_USER --password $DOCKER_PAT"
+            AUTH_ARGS=(--username "$DOCKER_USER" --password "$DOCKER_PAT")
           else
             echo "Using anonymous Docker Hub access"
           fi
@@ -711,7 +711,7 @@ stages:
             --name $(ACR_NAME) \
             --source docker.io/opensuse/leap:15.6 \
             --image import/opensuse/leap:15.6 \
-            $AUTH_ARGS \
+            "${AUTH_ARGS[@]}" \
             --force
       env:
         DOCKER_USER: $(DOCKERHUB_USERNAME)
@@ -780,6 +780,7 @@ stages:
               -t tdslibrs.azurecr.io/python-build/manylinux_2_28_x86_64_rust:latest \
               .
           echo "✅ manylinux_2_28 x64 image built successfully"
+      retryCountOnTaskFailure: 3
 
     - task: AzureCLI@2
       displayName: 'Build Ubuntu x64 build image with Rust and tooling'
@@ -803,6 +804,7 @@ stages:
               -t tdslibrs.azurecr.io/build/ubuntu:latest-x64 \
               .
           echo "✅ Ubuntu x64 build image built successfully"
+      retryCountOnTaskFailure: 3
 
     - task: AzureCLI@2
       displayName: 'Build Alpine x64 build image with Rust and tooling'
@@ -825,6 +827,7 @@ stages:
               -t tdslibrs.azurecr.io/build/alpine:3.18-amd64 \
               .
           echo "✅ Alpine x64 build image built successfully"
+      retryCountOnTaskFailure: 3
 
     - task: AzureCLI@2
       displayName: 'Push x64 images to ACR'
@@ -848,6 +851,7 @@ stages:
             docker push tdslibrs.azurecr.io/build/ubuntu:latest-x64
             docker push tdslibrs.azurecr.io/build/alpine:3.18-amd64
           fi
+      retryCountOnTaskFailure: 3
 
   - job: BuildKerberosImages
     displayName: Build Kerberos Test Images
@@ -881,6 +885,7 @@ stages:
           docker build -f Dockerfile.mssql-ad \
             -t $(ACR_REGISTRY)/kerberos/mssql-ad:latest .
           docker push $(ACR_REGISTRY)/kerberos/mssql-ad:latest
+      retryCountOnTaskFailure: 3
 
     - task: AzureCLI@2
       displayName: 'Build and push Kerberos client images (all distros)'
@@ -918,6 +923,7 @@ stages:
             docker push "$tag"
             echo "✅ $tag"
           done
+      retryCountOnTaskFailure: 3
 
   - job: BuildARM64Images
     displayName: Build ARM64 Images
@@ -982,6 +988,7 @@ stages:
               -t tdslibrs.azurecr.io/python-build/manylinux_2_28_aarch64_rust:latest \
               .
           echo "✅ manylinux_2_28 ARM64 image built successfully"
+      retryCountOnTaskFailure: 3
 
     - task: AzureCLI@2
       displayName: 'Build Ubuntu ARM64 build image with Rust and tooling'
@@ -1005,6 +1012,7 @@ stages:
               -t tdslibrs.azurecr.io/build/ubuntu:latest-arm64 \
               .
           echo "✅ Ubuntu ARM64 build image built successfully"
+      retryCountOnTaskFailure: 3
 
     - task: AzureCLI@2
       displayName: 'Build Alpine ARM64 build image with Rust and tooling'
@@ -1027,6 +1035,7 @@ stages:
               -t tdslibrs.azurecr.io/build/alpine:3.18-arm64 \
               .
           echo "✅ Alpine ARM64 build image built successfully"
+      retryCountOnTaskFailure: 3
 
     - task: AzureCLI@2
       displayName: 'Push ARM64 images to ACR'
@@ -1050,6 +1059,7 @@ stages:
             docker push tdslibrs.azurecr.io/build/ubuntu:latest-arm64
             docker push tdslibrs.azurecr.io/build/alpine:3.18-arm64
           fi
+      retryCountOnTaskFailure: 3
 
   - job: CreateMultiArchManifests
     displayName: Create Multi-Arch Manifests
@@ -1085,6 +1095,7 @@ stages:
           
           echo "==> Verifying manifest..."
           docker manifest inspect tdslibrs.azurecr.io/build/ubuntu:22.04
+      retryCountOnTaskFailure: 3
 
     - task: AzureCLI@2
       displayName: 'Create multi-arch manifest for Alpine build image'
@@ -1107,6 +1118,7 @@ stages:
           
           echo "==> Verifying manifest..."
           docker manifest inspect tdslibrs.azurecr.io/build/alpine:3.18
+      retryCountOnTaskFailure: 3
 
   - job: VerifyAllImages
     displayName: Verify All Images in ACR
@@ -1180,6 +1192,7 @@ stages:
             echo "==> $repo"
             az acr repository show-tags --name $(ACR_NAME) --repository $repo --output table --orderby time_desc --top 5 2>/dev/null || echo "  (not found)"
           done
+      retryCountOnTaskFailure: 3
 
     - script: |
         echo ""
@@ -1352,6 +1365,7 @@ stages:
         inlineScript: |
           set -euo pipefail
           az acr login --name $(ACR_NAME)
+      retryCountOnTaskFailure: 3
 
     - script: |
         set -euo pipefail

--- a/.pipeline/sync-container-images.yml
+++ b/.pipeline/sync-container-images.yml
@@ -921,6 +921,9 @@ stages:
               --build-arg ENTRY_SCRIPT="$entry" \
               -t "$tag" .
             docker push "$tag"
+            # Reclaim disk between builds: 9 client images at ~1.5-3 GB each
+            # would otherwise accumulate on the agent for the whole job.
+            docker rmi "$tag" || true
             echo "✅ $tag"
           done
       retryCountOnTaskFailure: 3

--- a/.pipeline/sync-container-images.yml
+++ b/.pipeline/sync-container-images.yml
@@ -94,6 +94,11 @@ parameters:
   type: boolean
   default: true
 
+- name: buildKerberosImages
+  displayName: 'Build Kerberos test images (DC, SQL+AD, per-distro clients)'
+  type: boolean
+  default: true
+
 # GitHub Container Registry (GHCR) mirror.
 # To also publish images to GHCR, define a SECRET pipeline variable named
 # GHCR_TOKEN (a GitHub PAT with write:packages), settable at queue time. If
@@ -724,7 +729,7 @@ stages:
 - stage: BuildAndPushImages
   displayName: Build and Push Custom Images
   dependsOn: []
-  condition: or(eq('${{ parameters.buildPythonImages }}', 'true'), eq('${{ parameters.buildUbuntuImages }}', 'true'))
+  condition: or(eq('${{ parameters.buildPythonImages }}', 'true'), eq('${{ parameters.buildUbuntuImages }}', 'true'), eq('${{ parameters.buildKerberosImages }}', 'true'))
   jobs:
   - job: BuildX64Images
     displayName: Build x64 Images
@@ -842,6 +847,76 @@ stages:
             docker push tdslibrs.azurecr.io/build/ubuntu:latest-x64
             docker push tdslibrs.azurecr.io/build/alpine:3.18-amd64
           fi
+
+  - job: BuildKerberosImages
+    displayName: Build Kerberos Test Images
+    timeoutInMinutes: 120
+    condition: eq('${{ parameters.buildKerberosImages }}', 'true')
+    pool:
+      name: RUST-1ES-POOL-WUS3
+      demands:
+        - imageOverride -equals RUST-1ES-UBUSLIM
+    steps:
+    - checkout: self
+      displayName: Checkout repository
+
+    - task: AzureCLI@2
+      displayName: 'Build and push Kerberos infrastructure images'
+      inputs:
+        azureSubscription: 'Magnitude Test'
+        scriptType: 'bash'
+        scriptLocation: 'inlineScript'
+        inlineScript: |
+          set -euo pipefail
+          cd $(Build.SourcesDirectory)/kerberos-test
+          az acr login --name $(ACR_NAME)
+
+          echo "==> Building Samba AD DC image..."
+          docker build -f Dockerfile.samba-dc \
+            -t $(ACR_REGISTRY)/kerberos/samba-dc:latest .
+          docker push $(ACR_REGISTRY)/kerberos/samba-dc:latest
+
+          echo "==> Building SQL Server + AD image..."
+          docker build -f Dockerfile.mssql-ad \
+            -t $(ACR_REGISTRY)/kerberos/mssql-ad:latest .
+          docker push $(ACR_REGISTRY)/kerberos/mssql-ad:latest
+
+    - task: AzureCLI@2
+      displayName: 'Build and push Kerberos client images (all distros)'
+      inputs:
+        azureSubscription: 'Magnitude Test'
+        scriptType: 'bash'
+        scriptLocation: 'inlineScript'
+        inlineScript: |
+          set -euo pipefail
+          cd $(Build.SourcesDirectory)/kerberos-test
+          az acr login --name $(ACR_NAME)
+
+          # profile|base image|entry script - must stay in sync with
+          # kerberos-test/docker-compose-matrix.yml
+          PROFILES="
+          alpine318|$(ACR_REGISTRY)/import/alpine:3.18|alpine.sh
+          alpine319|$(ACR_REGISTRY)/import/alpine:3.19|alpine.sh
+          alpine320|$(ACR_REGISTRY)/import/alpine:3.20|alpine.sh
+          alpine321|$(ACR_REGISTRY)/import/alpine:3.21|alpine.sh
+          debian|$(ACR_REGISTRY)/import/debian:bookworm|deb-bookworm.sh
+          ubuntu22|$(ACR_REGISTRY)/import/ubuntu:22.04|deb-bookworm.sh
+          ubuntu24|$(ACR_REGISTRY)/import/ubuntu:24.04|deb-bookworm.sh
+          rhel9|$(ACR_REGISTRY)/import/redhat/ubi9:latest|rhel.sh
+          oracle9|$(ACR_REGISTRY)/import/oraclelinux:9|rhel.sh
+          "
+
+          echo "$PROFILES" | while IFS='|' read -r profile base entry; do
+            [ -z "$profile" ] && continue
+            tag="$(ACR_REGISTRY)/kerberos/client:${profile}-latest"
+            echo "==> Building $profile from $base"
+            docker build -f Dockerfile.client.matrix \
+              --build-arg BASE_IMAGE="$base" \
+              --build-arg ENTRY_SCRIPT="$entry" \
+              -t "$tag" .
+            docker push "$tag"
+            echo "✅ $tag"
+          done
 
   - job: BuildARM64Images
     displayName: Build ARM64 Images
@@ -1033,6 +1108,7 @@ stages:
     dependsOn:
     - BuildX64Images
     - BuildARM64Images
+    - BuildKerberosImages
     - CreateMultiArchManifests
     condition: always()
     pool:
@@ -1221,6 +1297,17 @@ stages:
         python-build/manylinux_2_28_aarch64_rust:latest
         build/ubuntu:22.04
         build/alpine:3.18
+        kerberos/samba-dc:latest
+        kerberos/mssql-ad:latest
+        kerberos/client:alpine318-latest
+        kerberos/client:alpine319-latest
+        kerberos/client:alpine320-latest
+        kerberos/client:alpine321-latest
+        kerberos/client:debian-latest
+        kerberos/client:ubuntu22-latest
+        kerberos/client:ubuntu24-latest
+        kerberos/client:rhel9-latest
+        kerberos/client:oracle9-latest
         import/debian:bookworm
         import/debian:bullseye
         import/debian:trixie

--- a/kerberos-test/Dockerfile.client.matrix
+++ b/kerberos-test/Dockerfile.client.matrix
@@ -1,4 +1,6 @@
 # Parameterized Kerberos test client
+# Pre-built per profile by .pipeline/sync-container-images.yml and published as
+# kerberos/client:<profile>-latest.
 # Usage: docker build --build-arg BASE_IMAGE=tdslibrs.azurecr.io/import/alpine:3.18 \
 #                     --build-arg ENTRY_SCRIPT=alpine.sh \
 #                     -f Dockerfile.client.matrix .
@@ -42,6 +44,14 @@ RUN if [ -f /etc/alpine-release ]; then \
 # Install Rust
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Pre-install cargo-nextest. Without this, run-kerberos-tests.sh compiles it
+# from source inside every client container on every CI run.
+ARG NEXTEST_VERSION=0.9.99
+RUN if [ -f /etc/alpine-release ]; then NEXTEST_PLATFORM=linux-musl; else NEXTEST_PLATFORM=linux; fi \
+    && curl -LsSf "https://get.nexte.st/${NEXTEST_VERSION}/${NEXTEST_PLATFORM}" \
+        | tar zxf - -C /root/.cargo/bin \
+    && cargo nextest --version
 
 # Install go-sqlcmd for debugging (optional, skip if it fails on some platforms)
 RUN curl -sSL -o /tmp/sqlcmd.tar.bz2 "https://github.com/microsoft/go-sqlcmd/releases/download/v1.8.0/sqlcmd-linux-amd64.tar.bz2" 2>/dev/null \

--- a/kerberos-test/Dockerfile.client.matrix
+++ b/kerberos-test/Dockerfile.client.matrix
@@ -47,10 +47,16 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Pre-install cargo-nextest. Without this, run-kerberos-tests.sh compiles it
 # from source inside every client container on every CI run.
+#
+# Deliberately installed to /usr/local/bin rather than /root/.cargo/bin: a
+# tarball drop has no .crates.toml entry, so a plain `cargo install` would not
+# short-circuit and would abort with "binary already exists in destination".
+# Keeping it outside Cargo's bin dir means an unguarded `cargo install` still
+# succeeds, so this image is safe regardless of which PR lands first.
 ARG NEXTEST_VERSION=0.9.99
 RUN if [ -f /etc/alpine-release ]; then NEXTEST_PLATFORM=linux-musl; else NEXTEST_PLATFORM=linux; fi \
     && curl -LsSf "https://get.nexte.st/${NEXTEST_VERSION}/${NEXTEST_PLATFORM}" \
-        | tar zxf - -C /root/.cargo/bin \
+        | tar zxf - -C /usr/local/bin \
     && cargo nextest --version
 
 # Install go-sqlcmd for debugging (optional, skip if it fails on some platforms)

--- a/kerberos-test/Dockerfile.mssql-ad
+++ b/kerberos-test/Dockerfile.mssql-ad
@@ -1,5 +1,9 @@
 # SQL Server on Linux with AD integration (sssd/realmd)
-FROM mcr.microsoft.com/mssql/server:2022-latest
+# Pre-built and published by .pipeline/sync-container-images.yml. The init
+# script is mounted from ./scripts at runtime rather than baked in, so the
+# pre-built image stays valid when a PR edits the script.
+ARG BASE_IMAGE=mcr.microsoft.com/mssql/server:2022-latest
+FROM ${BASE_IMAGE}
 
 USER root
 
@@ -19,9 +23,5 @@ RUN apt-get update && ACCEPT_EULA=Y apt-get install -y \
     vim \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy initialization script
-COPY scripts/init-mssql-ad.sh /init-mssql-ad.sh
-RUN chmod +x /init-mssql-ad.sh
-
 # SQL Server runs as mssql user, but we need root for domain join
-ENTRYPOINT ["/init-mssql-ad.sh"]
+ENTRYPOINT ["/bin/bash", "/scripts/init-mssql-ad.sh"]

--- a/kerberos-test/Dockerfile.samba-dc
+++ b/kerberos-test/Dockerfile.samba-dc
@@ -1,6 +1,10 @@
 # Samba Active Directory Domain Controller
 # Use ACR-imported image to avoid Docker Hub rate limits
-FROM tdslibrs.azurecr.io/import/debian:bookworm
+# Pre-built and published by .pipeline/sync-container-images.yml. The init
+# script is mounted from ./scripts at runtime rather than baked in, so the
+# pre-built image stays valid when a PR edits the script.
+ARG BASE_IMAGE=tdslibrs.azurecr.io/import/debian:bookworm
+FROM ${BASE_IMAGE}
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -19,12 +23,8 @@ RUN apt-get update && apt-get install -y \
     expect \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy initialization script
-COPY scripts/init-samba-dc.sh /init-samba-dc.sh
-RUN chmod +x /init-samba-dc.sh
-
 EXPOSE 53 88 135 139 389 445 464 636 3268 3269
 
 VOLUME /var/lib/samba
 
-CMD ["/init-samba-dc.sh"]
+CMD ["/bin/bash", "/scripts/init-samba-dc.sh"]

--- a/kerberos-test/README.md
+++ b/kerberos-test/README.md
@@ -28,8 +28,8 @@ This directory contains a containerized Kerberos authentication test environment
 | `docker-compose-matrix.yml` | Docker Compose for multi-distro matrix testing |
 | `Dockerfile.client` | Default client container (based on .NET SDK) |
 | `Dockerfile.client.matrix` | Parameterized client for all distros (uses build args) |
-| `Dockerfile.samba-dc` | Samba AD Domain Controller |
-| `Dockerfile.mssql-ad` | SQL Server with AD integration |
+| `Dockerfile.samba-dc` | Samba AD Domain Controller (init script mounted from `scripts/`) |
+| `Dockerfile.mssql-ad` | SQL Server with AD integration (init script mounted from `scripts/`) |
 | `configure-kerberos.sh` | Script to configure Kerberos after containers start |
 | `run-kerberos-tests.sh` | Run tests on a specific distro |
 | `run-all-distros.sh` | Run tests on all distros in the matrix |

--- a/kerberos-test/docker-compose-matrix.yml
+++ b/kerberos-test/docker-compose-matrix.yml
@@ -58,6 +58,7 @@ services:
       - KERBEROS_ADMIN_PASSWORD=${KERBEROS_ADMIN_PASSWORD}
     volumes:
       - samba-data:/var/lib/samba
+      - ./scripts:/scripts:ro
     networks:
       kerberos-net:
         ipv4_address: 172.20.0.10

--- a/kerberos-test/docker-compose-samba.yml
+++ b/kerberos-test/docker-compose-samba.yml
@@ -21,6 +21,7 @@ services:
       - KERBEROS_ADMIN_PASSWORD=${KERBEROS_ADMIN_PASSWORD}
     volumes:
       - samba-data:/var/lib/samba
+      - ./scripts:/scripts:ro
     networks:
       kerberos-net:
         ipv4_address: 172.20.0.10

--- a/kerberos-test/docker-compose-validation.yml
+++ b/kerberos-test/docker-compose-validation.yml
@@ -54,6 +54,7 @@ services:
       - KERBEROS_ADMIN_PASSWORD=${KERBEROS_ADMIN_PASSWORD}
     volumes:
       - samba-data:/var/lib/samba
+      - ./scripts:/scripts:ro
     networks:
       kerberos-net:
         ipv4_address: 172.20.0.10

--- a/kerberos-test/run-kerberos-tests.sh
+++ b/kerberos-test/run-kerberos-tests.sh
@@ -175,8 +175,11 @@ if [ "$ARCHIVE_MODE" = true ]; then
     echo ""
     echo "Step 4: Install cargo-nextest..."
     echo "----------------------------------------------"
+    # Pre-built client images ship cargo-nextest in /usr/local/bin. Skip the
+    # source build when it is already present; still install on images without it.
     docker exec "$CONTAINER_NAME" bash -c '
-        cargo install cargo-nextest --version 0.9.99 --locked
+        command -v cargo-nextest >/dev/null 2>&1 \
+          || cargo install cargo-nextest --version 0.9.99 --locked
     '
     echo "✓ cargo-nextest installed"
     
@@ -259,8 +262,11 @@ OUTER_EOF
         echo ""
         echo "Step 4: Install cargo-nextest (CI mode)..."
         echo "----------------------------------------------"
+        # Pre-built client images ship cargo-nextest in /usr/local/bin. Skip the
+        # source build when it is already present; still install on images without it.
         docker exec "$CONTAINER_NAME" bash -c '
-            cargo install cargo-nextest --version 0.9.99 --locked
+            command -v cargo-nextest >/dev/null 2>&1 \
+              || cargo install cargo-nextest --version 0.9.99 --locked
         '
         echo "✓ cargo-nextest installed"
     fi


### PR DESCRIPTION
## Description

Expands the container sync pipeline (`.pipeline/sync-container-images.yml`) so the GHCR mirror covers all the base images consumers need, and adds pre-built Kerberos CI images.

**1. Mirror the vanilla PyPA images (#162)**

Previously only the custom `python-build/*_rust` images built in stage 2 were mirrored. The vanilla imports from stage 1 are now included:

- `import/python-build/manylinux_2_34_x86_64:latest` / `..._aarch64:latest`
- `import/python-build/manylinux_2_28_x86_64:latest` / `..._aarch64:latest`
- `import/python-build/musllinux_1_2_x86_64:latest` / `..._aarch64:latest`

**2. Add the Linux base images msphpsql needs (#166)**

New imports in `Import_Base_Images`, each also added to the mirror list:

| GHCR path | Upstream source |
|---|---|
| `import/alpine:3.22` | `docker.io/library/alpine:3.22` |
| `import/alpine:3.23` | `docker.io/library/alpine:3.23` |
| `import/debian:bullseye` | `docker.io/library/debian:bullseye` |
| `import/debian:trixie` | `docker.io/library/debian:trixie` |
| `import/centos:stream9` | `quay.io/centos/centos:stream9` |
| `import/redhat/ubi10:latest` | `registry.access.redhat.com/ubi10/ubi:latest` |
| `import/opensuse/leap:15.6` | `docker.io/opensuse/leap:15.6` |

`import/redhat/ubi8:latest` was already imported and mirrored, so it needed no change.

New queue-time toggles follow the existing per-group pattern: `syncAlpine3`, `syncCentOS`, `syncSUSE`. Debian bullseye/trixie and UBI10 ride along with the existing `syncDebianRHEL` group (job renamed from "Import Debian & RHEL UBI9" to "Import Debian & RHEL UBI").

Sources not on Docker Hub (quay.io CentOS, `registry.access.redhat.com` UBI10) skip the Docker Hub credential args, matching the existing quay.io manylinux/musllinux steps.

All 31 mirrored images have been verified as anonymously pullable from `ghcr.io/microsoft/mssql-rs/...`.

**3. Pre-build the Kerberos CI images (producer side)**

The ADO Kerberos test stage currently rebuilds a Samba AD DC image, a SQL Server+AD image, and up to 9 per-distro client images on every PR/CI run. This adds a `BuildKerberosImages` job to `BuildAndPushImages` that builds and pushes them once, plus a `buildKerberosImages` toggle, and mirrors them to GHCR:

- `kerberos/samba-dc:latest`, `kerberos/mssql-ad:latest`
- `kerberos/client:<profile>-latest` for alpine318/319/320/321, debian, ubuntu22, ubuntu24, rhel9, oracle9

Supporting changes:

- `Dockerfile.samba-dc` / `Dockerfile.mssql-ad`: base image is now a `BASE_IMAGE` build arg, and the init scripts are mounted from `./scripts` at runtime instead of baked in — so a pre-built image stays valid when a PR edits a script. The `dc` service in all three compose files gains the `./scripts:/scripts:ro` mount the `mssql` service already had.
- `Dockerfile.client.matrix`: pre-installs `cargo-nextest` 0.9.99 from the release tarball rather than compiling it from source inside every container at test time.

The pipeline's profile → base image → entry script table was verified against the rendered `docker-compose-matrix.yml` config; all 9 profiles match exactly.

**Consumer side** (compose `image:` refs and the test template pulling instead of building) lands in a separate PR.

`cargo-nextest` is installed to `/usr/local/bin` rather than `/root/.cargo/bin`, and both `cargo install` call sites in `run-kerberos-tests.sh` are now guarded with `command -v cargo-nextest >/dev/null 2>&1 || ...`. Two things made this necessary: a tarball drop has no `.crates.toml` entry, so an unguarded `cargo install` into `CARGO_HOME/bin` aborts with "binary already exists in destination"; and because `ENV PATH` puts `/root/.cargo/bin` first, an unguarded install would otherwise still compile from source and shadow the pre-installed copy, making the pre-install dead weight. Verified in a container: skipped in 0s when the binary is present, installs normally (53s) on an image without it, and a genuine install failure still propagates.

> [!IMPORTANT]
> **The GHCR mirror stage is load-bearing for the Kerberos CI stage.** The consumer pipeline pulls the Kerberos images exclusively from `ghcr.io/microsoft/mssql-rs/kerberos/*` and does not reference ACR at all. The ACR build/push in `BuildKerberosImages` is only the build target that `Mirror_To_GHCR` copies from. If the mirror stage is skipped, or those 11 `kerberos/*` entries are dropped from `images.txt`, the Kerberos stage silently falls back to building every image locally and the speedup disappears with no failure signal.

> [!NOTE]
> New GHCR packages are created private, and visibility is settable only per-package in the UI — there is no REST or GraphQL endpoint for it. The 11 `kerberos/*` packages have been published and flipped to public; verified anonymously pullable.

## Related Issues

Fixes #162
Fixes #166

## Checklist

- [x] `cargo bfmt` passes — n/a, no Rust changes
- [x] `cargo bclippy` passes — n/a, no Rust changes
- [x] `cargo btest` passes — n/a, no Rust changes
- [x] New/changed functionality has tests — n/a; pipeline and compose files YAML-validated, `docker compose config` confirms the `dc` `/scripts` mount in all three files, mirror list cross-checked against import/build targets, and the Kerberos profile table diffed against the rendered compose config
- [x] Public API changes are documented — n/a, no public API change

