### PR TITLE
Return ProtocolError instead of panicking on non-PLP XML/JSON/UDT metadata

### DIFF
--- a/mssql-tds/src/datatypes/decoder.rs
+++ b/mssql-tds/src/datatypes/decoder.rs
@@ -1475,7 +1475,11 @@ impl SqlTypeDecode for GenericDecoder {
                 }
             }
             TdsDataType::Xml => {
-                assert!(metadata.is_plp());
+                if !metadata.is_plp() {
+                    return Err(crate::error::Error::ProtocolError(
+                        "XML column metadata is not partially-length-prefixed".to_string(),
+                    ));
+                }
                 let some_bytes = GenericDecoder::read_plp_bytes(reader).await?;
                 match some_bytes {
                     Some(bytes) => ColumnValues::Xml(SqlXml { bytes }),
@@ -1483,7 +1487,11 @@ impl SqlTypeDecode for GenericDecoder {
                 }
             }
             TdsDataType::Json => {
-                assert!(metadata.is_plp());
+                if !metadata.is_plp() {
+                    return Err(crate::error::Error::ProtocolError(
+                        "JSON column metadata is not partially-length-prefixed".to_string(),
+                    ));
+                }
                 let some_bytes = GenericDecoder::read_plp_bytes(reader).await?;
                 match some_bytes {
                     Some(bytes) => ColumnValues::Json(SqlJson::new(bytes)),
@@ -1618,7 +1626,11 @@ impl SqlTypeDecode for GenericDecoder {
                 }
             }
             TdsDataType::Udt => {
-                assert!(metadata.is_plp());
+                if !metadata.is_plp() {
+                    return Err(crate::error::Error::ProtocolError(
+                        "UDT column metadata is not partially-length-prefixed".to_string(),
+                    ));
+                }
                 let some_bytes = GenericDecoder::read_plp_bytes(reader).await?;
                 match some_bytes {
                     Some(bytes) => ColumnValues::Bytes(bytes),
@@ -3858,6 +3870,45 @@ mod test {
             let err = PlpColumnStream::begin(&md, &mut reader).await.unwrap_err();
             assert!(
                 err.to_string().contains("is not a PLP type"),
+                "unexpected: {err}"
+            );
+        }
+
+        #[tokio::test]
+        async fn decode_xml_rejects_non_plp_metadata() {
+            let md = varlen_metadata(TdsDataType::Xml, 100);
+            let decoder = GenericDecoder::default();
+            let mut reader = ByteReader::new(plp_wire(b"x"));
+            let err = decoder.decode(&mut reader, &md).await.unwrap_err();
+            assert!(
+                err.to_string()
+                    .contains("XML column metadata is not partially-length-prefixed"),
+                "unexpected: {err}"
+            );
+        }
+
+        #[tokio::test]
+        async fn decode_json_rejects_non_plp_metadata() {
+            let md = varlen_metadata(TdsDataType::Json, 100);
+            let decoder = GenericDecoder::default();
+            let mut reader = ByteReader::new(plp_wire(b"x"));
+            let err = decoder.decode(&mut reader, &md).await.unwrap_err();
+            assert!(
+                err.to_string()
+                    .contains("JSON column metadata is not partially-length-prefixed"),
+                "unexpected: {err}"
+            );
+        }
+
+        #[tokio::test]
+        async fn decode_udt_rejects_non_plp_metadata() {
+            let md = varlen_metadata(TdsDataType::Udt, 100);
+            let decoder = GenericDecoder::default();
+            let mut reader = ByteReader::new(plp_wire(b"x"));
+            let err = decoder.decode(&mut reader, &md).await.unwrap_err();
+            assert!(
+                err.to_string()
+                    .contains("UDT column metadata is not partially-length-prefixed"),
                 "unexpected: {err}"
             );
         }


### PR DESCRIPTION
## Description

Follow-up to #161. The `Xml`, `Json`, and `Udt` arms of `GenericDecoder::decode` still used `assert!(metadata.is_plp())`. Since `metadata` is parsed from untrusted wire data, a crafted stream advertising an XML/JSON/UDT column whose `TYPE_INFO` is not a `PartialLen` variant would abort the process — the same latent panic class as the SQL_VARIANT fuzz crash.

Each assertion is replaced with a guarded `Error::ProtocolError` return, consistent with the sibling decode arms (`BigVarBinary`, `decode_two_propbyte_variant`, `PlpColumnStream::begin`). `decode_into` routes these types through `decode`, so both paths are covered.

Added three regression tests (`decode_{xml,json,udt}_rejects_non_plp_metadata`) that feed non-PLP metadata and assert a graceful error instead of a panic.

## Related Issues

Fixes #164

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes — new tests pass; the 7 pre-existing failures in `certificate_validator` / `win_tls::validate` are unrelated to this change
- [x] New/changed functionality has tests
- [x] Public API changes are documented — n/a, no public API change