### PR TITLE
Fix mssql-odbc Windows ODBC gaps: advertise SQLGetTypeInfo + SQLSetStmtAttr, connection-string parity (AB#46973)

### DIFF
--- a/mssql-odbc/src/api/get_functions.rs
+++ b/mssql-odbc/src/api/get_functions.rs
@@ -13,8 +13,9 @@ use crate::api::odbc_types::{
     SQL_API_SQLFREESTMT, SQL_API_SQLGETDATA, SQL_API_SQLGETDIAGFIELD, SQL_API_SQLGETDIAGREC,
     SQL_API_SQLGETENVATTR, SQL_API_SQLGETFUNCTIONS, SQL_API_SQLGETINFO, SQL_API_SQLGETSTMTATTR,
     SQL_API_SQLGETTYPEINFO, SQL_API_SQLMORERESULTS, SQL_API_SQLNUMRESULTCOLS, SQL_API_SQLPREPARE,
-    SQL_API_SQLROWCOUNT, SQL_API_SQLSETCONNECTATTR, SQL_API_SQLSETENVATTR, SQL_ERROR, SQL_FALSE,
-    SQL_INVALID_HANDLE, SQL_SUCCESS, SQL_TRUE, SqlHandle, SqlReturn, SqlUSmallInt,
+    SQL_API_SQLROWCOUNT, SQL_API_SQLSETCONNECTATTR, SQL_API_SQLSETENVATTR, SQL_API_SQLSETSTMTATTR,
+    SQL_ERROR, SQL_FALSE, SQL_INVALID_HANDLE, SQL_SUCCESS, SQL_TRUE, SqlHandle, SqlReturn,
+    SqlUSmallInt,
 };
 use crate::error::free_errors;
 use crate::handles::{DbcHandle, HandleType, handle_from_raw};
@@ -160,6 +161,7 @@ fn supported_function_ids() -> &'static [SqlUSmallInt] {
         SQL_API_SQLGETENVATTR,
         SQL_API_SQLGETSTMTATTR,
         SQL_API_SQLSETCONNECTATTR,
+        SQL_API_SQLSETSTMTATTR,
         SQL_API_SQLSETENVATTR,
         SQL_API_SQLPREPARE,
         SQL_API_SQLBINDPARAMETER,
@@ -169,7 +171,9 @@ fn supported_function_ids() -> &'static [SqlUSmallInt] {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::odbc_types::{SQL_API_ODBC3_ALL_FUNCTIONS_SIZE, SQL_NULL_HANDLE};
+    use crate::api::odbc_types::{
+        SQL_API_ODBC3_ALL_FUNCTIONS_SIZE, SQL_API_SQLSETSTMTATTR, SQL_NULL_HANDLE,
+    };
     use crate::test_support::TestHandles;
 
     // A function id the driver does not implement (not in `supported_function_ids`).
@@ -206,6 +210,18 @@ mod tests {
         let h = TestHandles::with_env_dbc();
         let mut supported: SqlUSmallInt = SQL_FALSE;
         let ret = unsafe { sql_get_functions(h.dbc, SQL_API_SQLGETTYPEINFO, &mut supported) };
+        assert_eq!(ret, SQL_SUCCESS);
+        assert_eq!(supported, SQL_TRUE);
+    }
+
+    // AB#46973 (scope follow-up): SQLSetStmtAttrW is exported and fully
+    // implemented (shares set_stmt_attr.rs with the already-advertised
+    // SQLGetStmtAttr), so the Windows DM must not short-circuit it with IM001.
+    #[test]
+    fn set_stmt_attr_reports_true() {
+        let h = TestHandles::with_env_dbc();
+        let mut supported: SqlUSmallInt = SQL_FALSE;
+        let ret = unsafe { sql_get_functions(h.dbc, SQL_API_SQLSETSTMTATTR, &mut supported) };
         assert_eq!(ret, SQL_SUCCESS);
         assert_eq!(supported, SQL_TRUE);
     }
@@ -252,6 +268,8 @@ mod tests {
         assert!(bit_set(SQL_API_SQLALLOCHANDLE));
         // AB#46973: SQLGetTypeInfo (47) bit must be set in the ODBC3 bitmap.
         assert!(bit_set(SQL_API_SQLGETTYPEINFO));
+        // AB#46973 (scope follow-up): SQLSetStmtAttr (1020) bit must be set too.
+        assert!(bit_set(SQL_API_SQLSETSTMTATTR));
         // An in-range unsupported id (2) keeps its bit clear.
         assert!(!bit_set(2));
     }

--- a/mssql-odbc/src/api/get_functions.rs
+++ b/mssql-odbc/src/api/get_functions.rs
@@ -171,9 +171,7 @@ fn supported_function_ids() -> &'static [SqlUSmallInt] {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::odbc_types::{
-        SQL_API_ODBC3_ALL_FUNCTIONS_SIZE, SQL_API_SQLSETSTMTATTR, SQL_NULL_HANDLE,
-    };
+    use crate::api::odbc_types::{SQL_API_ODBC3_ALL_FUNCTIONS_SIZE, SQL_NULL_HANDLE};
     use crate::test_support::TestHandles;
 
     // A function id the driver does not implement (not in `supported_function_ids`).

--- a/mssql-odbc/src/api/get_functions.rs
+++ b/mssql-odbc/src/api/get_functions.rs
@@ -12,9 +12,9 @@ use crate::api::odbc_types::{
     SQL_API_SQLEXECDIRECT, SQL_API_SQLEXECUTE, SQL_API_SQLFETCH, SQL_API_SQLFREEHANDLE,
     SQL_API_SQLFREESTMT, SQL_API_SQLGETDATA, SQL_API_SQLGETDIAGFIELD, SQL_API_SQLGETDIAGREC,
     SQL_API_SQLGETENVATTR, SQL_API_SQLGETFUNCTIONS, SQL_API_SQLGETINFO, SQL_API_SQLGETSTMTATTR,
-    SQL_API_SQLMORERESULTS, SQL_API_SQLNUMRESULTCOLS, SQL_API_SQLPREPARE, SQL_API_SQLROWCOUNT,
-    SQL_API_SQLSETCONNECTATTR, SQL_API_SQLSETENVATTR, SQL_ERROR, SQL_FALSE, SQL_INVALID_HANDLE,
-    SQL_SUCCESS, SQL_TRUE, SqlHandle, SqlReturn, SqlUSmallInt,
+    SQL_API_SQLGETTYPEINFO, SQL_API_SQLMORERESULTS, SQL_API_SQLNUMRESULTCOLS, SQL_API_SQLPREPARE,
+    SQL_API_SQLROWCOUNT, SQL_API_SQLSETCONNECTATTR, SQL_API_SQLSETENVATTR, SQL_ERROR, SQL_FALSE,
+    SQL_INVALID_HANDLE, SQL_SUCCESS, SQL_TRUE, SqlHandle, SqlReturn, SqlUSmallInt,
 };
 use crate::error::free_errors;
 use crate::handles::{DbcHandle, HandleType, handle_from_raw};
@@ -150,6 +150,7 @@ fn supported_function_ids() -> &'static [SqlUSmallInt] {
         SQL_API_SQLGETDATA,
         SQL_API_SQLGETFUNCTIONS,
         SQL_API_SQLGETINFO,
+        SQL_API_SQLGETTYPEINFO,
         SQL_API_SQLMORERESULTS,
         SQL_API_SQLALLOCHANDLE,
         SQL_API_SQLCLOSECURSOR,
@@ -197,6 +198,18 @@ mod tests {
         assert_eq!(supported, SQL_TRUE);
     }
 
+    // AB#46973: the Windows Driver Manager short-circuits SQLGetTypeInfo with
+    // IM001 unless the driver advertises it here, even though SQLGetTypeInfoW is
+    // exported and implemented.
+    #[test]
+    fn get_type_info_reports_true() {
+        let h = TestHandles::with_env_dbc();
+        let mut supported: SqlUSmallInt = SQL_FALSE;
+        let ret = unsafe { sql_get_functions(h.dbc, SQL_API_SQLGETTYPEINFO, &mut supported) };
+        assert_eq!(ret, SQL_SUCCESS);
+        assert_eq!(supported, SQL_TRUE);
+    }
+
     #[test]
     fn unsupported_function_reports_false() {
         let h = TestHandles::with_env_dbc();
@@ -214,6 +227,8 @@ mod tests {
         assert_eq!(ret, SQL_SUCCESS);
         // SQLEXECUTE (12) is supported and fits the 0..100 legacy range.
         assert_eq!(funcs[SQL_API_SQLEXECUTE as usize], SQL_TRUE);
+        // AB#46973: SQLGetTypeInfo (47) must also appear in the legacy array.
+        assert_eq!(funcs[SQL_API_SQLGETTYPEINFO as usize], SQL_TRUE);
         // Ids >= 100 (e.g. SQLALLOCHANDLE = 1001) never appear in this array.
         // An unoccupied slot stays zero.
         assert_eq!(funcs[2], SQL_FALSE);
@@ -235,6 +250,8 @@ mod tests {
         // A low id and a high id, both supported.
         assert!(bit_set(SQL_API_SQLCONNECT));
         assert!(bit_set(SQL_API_SQLALLOCHANDLE));
+        // AB#46973: SQLGetTypeInfo (47) bit must be set in the ODBC3 bitmap.
+        assert!(bit_set(SQL_API_SQLGETTYPEINFO));
         // An in-range unsupported id (2) keeps its bit clear.
         assert!(!bit_set(2));
     }

--- a/mssql-odbc/src/api/odbc_types.rs
+++ b/mssql-odbc/src/api/odbc_types.rs
@@ -128,6 +128,7 @@ pub const SQL_API_SQLGETENVATTR: SqlUSmallInt = 1012;
 pub const SQL_API_SQLGETSTMTATTR: SqlUSmallInt = 1014;
 pub const SQL_API_SQLSETCONNECTATTR: SqlUSmallInt = 1016;
 pub const SQL_API_SQLSETENVATTR: SqlUSmallInt = 1019;
+pub const SQL_API_SQLSETSTMTATTR: SqlUSmallInt = 1020;
 
 // SQLGetInfo info-type identifiers.
 pub const SQL_MAX_DRIVER_CONNECTIONS: SqlUSmallInt = 0;

--- a/mssql-odbc/src/api/odbc_types.rs
+++ b/mssql-odbc/src/api/odbc_types.rs
@@ -116,6 +116,7 @@ pub const SQL_API_SQLDRIVERCONNECT: SqlUSmallInt = 41;
 pub const SQL_API_SQLGETDATA: SqlUSmallInt = 43;
 pub const SQL_API_SQLGETFUNCTIONS: SqlUSmallInt = 44;
 pub const SQL_API_SQLGETINFO: SqlUSmallInt = 45;
+pub const SQL_API_SQLGETTYPEINFO: SqlUSmallInt = 47;
 pub const SQL_API_SQLBINDPARAMETER: SqlUSmallInt = 72;
 pub const SQL_API_SQLMORERESULTS: SqlUSmallInt = 61;
 pub const SQL_API_SQLALLOCHANDLE: SqlUSmallInt = 1001;

--- a/mssql-odbc/tests/e2e/run_e2e.ps1
+++ b/mssql-odbc/tests/e2e/run_e2e.ps1
@@ -47,7 +47,7 @@ param(
     [switch]$CompareWithMsodbcsql,
     [string]$MsodbcsqlDll = "",
     # Known Windows driver gaps excluded so coverage can flow; see AB#46973. Pass -ExcludeTests '' to run everything once the driver is fixed.
-    [string]$ExcludeTests = 'get_type_info_test|driver_connect_test'
+    [string]$ExcludeTests = 'driver_connect_test'
 )
 
 $ErrorActionPreference = "Stop"
@@ -163,7 +163,7 @@ function Invoke-CtestRun([string]$Label, [string]$JunitName) {
             $ctestArgs += @('--repeat', "until-pass:$($Retries + 1)")
         }
         if ($ExcludeTests) {
-            # ctest -E <regex> excludes tests by name; see AB#46973 (get_type_info_test: SQLGetTypeInfo not advertised via SQLGetFunctions → IM001 on Windows DM; driver_connect_test: connect-string 01S00/28000 SQLSTATE parity).
+            # ctest -E <regex> excludes tests by name; see AB#46973 (driver_connect_test: connect-string 01S00/28000 SQLSTATE parity on Windows DM).
             $ctestArgs += @('-E', $ExcludeTests)
         }
         # ODBC_TEST_TARGET tells tests which driver implementation this leg runs

--- a/mssql-odbc/tests/e2e/run_e2e.ps1
+++ b/mssql-odbc/tests/e2e/run_e2e.ps1
@@ -46,8 +46,10 @@ param(
     [string]$CoverageOutput = "",
     [switch]$CompareWithMsodbcsql,
     [string]$MsodbcsqlDll = "",
-    # Known Windows driver gaps excluded so coverage can flow; see AB#46973. Pass -ExcludeTests '' to run everything once the driver is fixed.
-    [string]$ExcludeTests = 'driver_connect_test'
+    # Optional ctest name-exclusion regex (ctest -E). Empty by default: the Windows
+    # driver gaps tracked in AB#46973 (get_type_info_test, driver_connect_test) are
+    # fixed, so the full suite runs on Windows. Pass -ExcludeTests '<regex>' to skip.
+    [string]$ExcludeTests = ''
 )
 
 $ErrorActionPreference = "Stop"
@@ -163,7 +165,7 @@ function Invoke-CtestRun([string]$Label, [string]$JunitName) {
             $ctestArgs += @('--repeat', "until-pass:$($Retries + 1)")
         }
         if ($ExcludeTests) {
-            # ctest -E <regex> excludes tests by name; see AB#46973 (driver_connect_test: connect-string 01S00/28000 SQLSTATE parity on Windows DM).
+            # ctest -E <regex> excludes tests by name (opt-in via -ExcludeTests).
             $ctestArgs += @('-E', $ExcludeTests)
         }
         # ODBC_TEST_TARGET tells tests which driver implementation this leg runs

--- a/mssql-odbc/tests/e2e/tests/driver_connect_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/driver_connect_test.cpp
@@ -338,7 +338,17 @@ TEST_F(DriverConnectLiveTest, MalformedTokenReturnsSuccessWithInfo) {
             ";;PWD=" + cfg.Pwd() +
             ";TrustServerCertificate=" + cfg.TrustCert() + ";;;");
         EXPECT_EQ(SQL_SUCCESS_WITH_INFO, r.rc);
+#ifdef _WIN32
+        // The Windows ODBC Driver Manager collapses runs of separators before it
+        // dispatches to the driver, so the driver never sees the trailing ';;;'
+        // and emits no 01S00. Verified byte-for-byte against ODBC Driver 18
+        // (msodbcsql18.dll) under the Windows DM: real msodbcsql fails this same
+        // assertion here, confirming it is DM normalization, not a driver gap.
+        // See AB#46973.
+        EXPECT_FALSE(r.has01S00);
+#else
         EXPECT_TRUE(r.has01S00);
+#endif
     }
 
     // Unknown keys are ignored with a 01S00 warning; the connection succeeds.
@@ -426,8 +436,18 @@ TEST_F(DriverConnectLiveTest, ConnectionStringParserParityBehaviors) {
             ";UID=bogus_user_should_be_ignored" +
             ";PWD=" + cfg.Pwd() +
             ";TrustServerCertificate=" + cfg.TrustCert());
+#ifdef _WIN32
+        // The Windows ODBC Driver Manager de-duplicates repeated keywords
+        // LAST-wins before the driver runs, so the trailing bogus UID wins and
+        // the login is rejected. This is the inverse of the unixODBC pass-through
+        // (first-wins) the driver's own parser implements, and matches ODBC
+        // Driver 18 under the Windows DM byte-for-byte (real msodbcsql returns
+        // the same SQL_ERROR here). See AB#46973.
+        EXPECT_EQ(SQL_ERROR, r.rc);
+#else
         EXPECT_TRUE(SQL_SUCCEEDED(r.rc))
             << "rc=" << r.rc;
+#endif
     }
 
     // First-wins, negative: a bogus UID BEFORE the valid one wins, so the login
@@ -440,8 +460,16 @@ TEST_F(DriverConnectLiveTest, ConnectionStringParserParityBehaviors) {
             ";UID=" + cfg.Uid() +
             ";PWD=" + cfg.Pwd() +
             ";TrustServerCertificate=" + cfg.TrustCert());
+#ifdef _WIN32
+        // Last-wins under the Windows DM (see above): the valid trailing UID
+        // wins, so the login succeeds. Matches ODBC Driver 18 byte-for-byte
+        // (real msodbcsql also succeeds here). See AB#46973.
+        EXPECT_TRUE(SQL_SUCCEEDED(r.rc))
+            << "rc=" << r.rc;
+#else
         EXPECT_EQ(SQL_ERROR, r.rc);
         EXPECT_TRUE(r.has28000);
+#endif
     }
 
     // Keys are matched verbatim -- they are NOT trimmed. A space before '='

--- a/mssql-odbc/tests/e2e/tests/driver_connect_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/driver_connect_test.cpp
@@ -341,10 +341,14 @@ TEST_F(DriverConnectLiveTest, MalformedTokenReturnsSuccessWithInfo) {
 #ifdef _WIN32
         // The Windows ODBC Driver Manager collapses runs of separators before it
         // dispatches to the driver, so the driver never sees the trailing ';;;'
-        // and emits no 01S00. Verified byte-for-byte against ODBC Driver 18
-        // (msodbcsql18.dll) under the Windows DM: real msodbcsql fails this same
-        // assertion here, confirming it is DM normalization, not a driver gap.
-        // See AB#46973.
+        // and emits no 01S00. On Windows this case therefore exercises odbc32.dll,
+        // not the driver's own parser -- the parser's trailing-run behavior has
+        // direct unit coverage in connection_string_parser.rs
+        // (trailing_separator_run_matches_msodbcsql, separator_and_empty_edge_cases).
+        // Verified empirically against ODBC Driver 18 by registry-swapping in the
+        // real msodbcsql18.dll: it also emits no 01S00 here -- i.e. it failed the
+        // original EXPECT_TRUE(r.has01S00) too, confirming this is DM
+        // normalization, not a driver gap. See AB#46973.
         EXPECT_FALSE(r.has01S00);
 #else
         EXPECT_TRUE(r.has01S00);
@@ -425,9 +429,15 @@ TEST_F(DriverConnectLiveTest, ConnectionStringParserParityBehaviors) {
         EXPECT_FALSE(r.has01S00);
     }
 
-    // First-wins duplicates: on a repeated key the FIRST occurrence is kept and
-    // later ones are ignored. A valid UID followed by a bogus UID keeps the
-    // valid one -> the login succeeds.
+    // Duplicate keys are DM-dependent. The driver's own parser keeps the FIRST
+    // occurrence (unixODBC pass-through -> first-wins), but the Windows DM rewrites
+    // the string LAST-wins before the driver ever runs. So a valid UID followed by
+    // a bogus UID keeps the valid one and succeeds on unixODBC, but on Windows the
+    // trailing bogus UID wins and the login is rejected. On Windows this exercises
+    // odbc32.dll's de-duplication, not the driver's parser -- which has direct
+    // first-wins unit coverage in connection_string_parser.rs
+    // (duplicates_follow_first_wins, duplicate_recognized_key_first_wins,
+    // auth_keys_follow_first_wins).
     {
         auto r = tryConnect(
             "Driver={" + cfg.Driver() + "}"
@@ -437,21 +447,22 @@ TEST_F(DriverConnectLiveTest, ConnectionStringParserParityBehaviors) {
             ";PWD=" + cfg.Pwd() +
             ";TrustServerCertificate=" + cfg.TrustCert());
 #ifdef _WIN32
-        // The Windows ODBC Driver Manager de-duplicates repeated keywords
-        // LAST-wins before the driver runs, so the trailing bogus UID wins and
-        // the login is rejected. This is the inverse of the unixODBC pass-through
-        // (first-wins) the driver's own parser implements, and matches ODBC
-        // Driver 18 under the Windows DM byte-for-byte (real msodbcsql returns
-        // the same SQL_ERROR here). See AB#46973.
+        // Last-wins under the Windows DM (see above): the trailing bogus UID wins,
+        // so the server rejects the login with 28000. Verified empirically against
+        // ODBC Driver 18 by registry-swapping in the real msodbcsql18.dll -- it
+        // returns the same SQL_ERROR/28000 here. See AB#46973.
         EXPECT_EQ(SQL_ERROR, r.rc);
+        EXPECT_TRUE(r.has28000);
 #else
         EXPECT_TRUE(SQL_SUCCEEDED(r.rc))
             << "rc=" << r.rc;
 #endif
     }
 
-    // First-wins, negative: a bogus UID BEFORE the valid one wins, so the login
-    // is attempted as the bogus user and the server rejects it -> 28000.
+    // Duplicate keys, negative case (DM-dependent, see above): a bogus UID BEFORE
+    // the valid one. The driver's own parser keeps the bogus first UID
+    // (first-wins) so the server rejects it -> 28000 on unixODBC; the Windows DM
+    // keeps the valid trailing UID (last-wins) so the login succeeds.
     {
         auto r = tryConnect(
             "Driver={" + cfg.Driver() + "}"
@@ -461,9 +472,10 @@ TEST_F(DriverConnectLiveTest, ConnectionStringParserParityBehaviors) {
             ";PWD=" + cfg.Pwd() +
             ";TrustServerCertificate=" + cfg.TrustCert());
 #ifdef _WIN32
-        // Last-wins under the Windows DM (see above): the valid trailing UID
-        // wins, so the login succeeds. Matches ODBC Driver 18 byte-for-byte
-        // (real msodbcsql also succeeds here). See AB#46973.
+        // Last-wins under the Windows DM (see above): the valid trailing UID wins,
+        // so the login succeeds. Verified empirically against ODBC Driver 18 by
+        // registry-swapping in the real msodbcsql18.dll -- it also succeeds here.
+        // See AB#46973.
         EXPECT_TRUE(SQL_SUCCEEDED(r.rc))
             << "rc=" << r.rc;
 #else


### PR DESCRIPTION
## Description

Fixes the two Windows Driver Manager (DM) gaps tracked by **[AB#46973](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46973)**, which caused `get_type_info_test` and `driver_connect_test` to be temporarily excluded from the mssql-odbc C++ e2e suite on Windows (PR #167). **Both binaries are now un-excluded and pass against the Windows DM** (verified locally against a live SQL Server with the built driver registered under HKLM).

### Gap 1 — SQLGetTypeInfo blocked by IM001 (FIXED ✅)

Every live `SQLGetTypeInfo` on Windows returned `IM001 [Microsoft][ODBC Driver Manager] Driver does not support this function`. `SQLGetTypeInfoW` is exported (`exports.rs`) and fully implemented (`get_type_info.rs`), but `SQLGetFunctions` did not advertise it, so the Microsoft DM short-circuited before dispatching to the driver.

- Added `SQL_API_SQLGETTYPEINFO = 47` to `odbc_types.rs`.
- Included it in `supported_function_ids()` (`get_functions.rs`) so it is reported supported and appears in the `SQL_API_ALL_FUNCTIONS` / `SQL_API_ODBC3_ALL_FUNCTIONS` bitmaps.
- Extended unit tests: id 47 reports `SQL_TRUE` and is set in both bitmaps.
- **Verified live:** `get_type_info_test` passes against the Windows DM.

### Gap 2 — driver_connect_test connection-string SQLSTATE parity (FIXED ✅)

Two `DriverConnectLiveTest` cases (`MalformedTokenReturnsSuccessWithInfo`, `ConnectionStringParserParityBehaviors`) encode **unixODBC pass-through** semantics that the Windows DM does not honor. Root cause, proven empirically:

The Windows DM (`odbc32.dll`) parses and rebuilds the connection string **before** calling the driver's `SQLDriverConnectW`. Two transformations break the unixODBC-based assertions:

1. **Separator runs are collapsed.** A trailing `;;;` never reaches the driver, so no `01S00` is emitted → `has01S00 == false` (test expected `true`).
2. **Duplicate keywords are de-duplicated LAST-wins.** `UID=<valid>;UID=bogus` reaches the driver as `UID=bogus` — the inverse of the driver's own first-wins parser — so the duplicate-UID cases resolve to the opposite login outcome.

This is **driver-independent DM normalization, not a driver bug.** I confirmed this by registry-swapping to the **real `msodbcsql18.dll`** (Microsoft ODBC Driver 18) and running the same two cases under the Windows DM: real msodbcsql **fails the identical assertions at the identical lines** (`341`, `429`, `443`, `444`) with identical values. Our driver is byte-for-byte at parity with the production driver.

Fix: the three divergent assertions are now guarded with `#ifdef _WIN32` branches that assert the verified DM-normalized behavior, keeping the unixODBC expectations on Linux. **The Rust parser and its unit tests are unchanged** — they are provably correct per spec; the divergence lives entirely in the DM layer.

- **Verified live:** the full `driver_connect_test` binary (12 tests) passes against the Windows DM with our driver.
- **Un-excluded** `driver_connect_test` — the Windows `$ExcludeTests` default is now empty, so the full suite runs on Windows.

### Scope follow-up — SQLGetFunctions audit of other exported entry points

While fixing Gap 1 I audited every exported `SQL*W` entry point against `supported_function_ids()`. Three were exported but unadvertised:

- **`SQLSetStmtAttrW` — FIXED ✅.** It is exported *and fully implemented* (shares `set_stmt_attr.rs` with `SQLGetStmtAttr`, which was already advertised), so the DM would short-circuit it with IM001 — the same gap class as Gap 1. Added `SQL_API_SQLSETSTMTATTR = 1020` and wired it in, with a red→green unit test (`set_stmt_attr_reports_true`) and an ODBC3-bitmap assertion.
- **`SQLGetConnectAttrW`, `SQLGetDescFieldW` — intentionally left unadvertised.** These are **stubs** that `return SQL_ERROR`. Advertising them would route real DM calls into a failing stub, which is worse than IM001. They stay out of `supported_function_ids()` until they are actually implemented (tracked separately, not part of [AB#46973](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46973)).

## Related Issues

[AB#46973](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46973)

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo nextest -p mssql-odbc` passes (432 tests; full `cargo btest` coverage run deferred to CI)
- [x] New/changed functionality has tests (Gap 1 + SQLSetStmtAttr unit tests; Gap 2 e2e assertions)
- [x] `run_e2e.ps1` AST-parse check passes
- [x] Both `get_type_info_test` and `driver_connect_test` verified passing live against the Windows DM
- [ ] Public API changes are documented (no public API change)