### PR TITLE
Consume pre-built Kerberos test images in CI

### DIFF
--- a/.pipeline/templates/kerberos-test-template.yml
+++ b/.pipeline/templates/kerberos-test-template.yml
@@ -2,13 +2,15 @@
 # Runs Kerberos/GSSAPI tests using Samba AD DC as the domain controller
 #
 # ARCHITECTURE (Efficient single-agent approach):
-#   1. Start DC + SQL Server once (shared infrastructure)
-#   2. Configure Kerberos once
-#   3. Loop through client profiles sequentially:
-#      - Build & start client
+#   1. Pull pre-built DC / SQL / client images (built by sync-container-images.yml).
+#      This stage never builds images; a pull failure fails the stage.
+#   2. Start DC + SQL Server once (shared infrastructure)
+#   3. Configure Kerberos once
+#   4. Loop through client profiles sequentially:
+#      - Start client
 #      - Run tests
 #      - Stop client
-#   4. Clean up at end
+#   5. Clean up at end
 #
 # This is much faster than spinning up separate DC+SQL for each distro.
 #
@@ -41,6 +43,12 @@ parameters:
   - name: useArchive
     type: boolean
     default: true  # Use pre-built nextest archive for faster tests
+  - name: imageRegistry
+    type: string
+    default: 'ghcr.io/microsoft/mssql-rs'
+  - name: imageTag
+    type: string
+    default: 'latest'
 
 jobs:
   - job: Kerberos_Test
@@ -55,6 +63,8 @@ jobs:
     variables:
       profileList: ${{ join(',', parameters.profiles) }}
       useArchive: ${{ parameters.useArchive }}
+      KERBEROS_IMAGE_REGISTRY: ${{ parameters.imageRegistry }}
+      KERBEROS_IMAGE_TAG: ${{ parameters.imageTag }}
     
     steps:
       - task: DockerInstaller@0
@@ -75,12 +85,6 @@ jobs:
           installAzCli: false
           installDocker: true
       
-      - script: |
-          set -euo pipefail
-          # Pull base images needed for Kerberos tests
-          docker pull ghcr.io/microsoft/mssql-rs/import/debian:bookworm
-        displayName: 'Pull base images'
-
       # Download nextest archives (for --archive mode)
       # Both glibc and musl archives are in Build_Linux artifact
       - ${{ if eq(parameters.useArchive, true) }}:
@@ -122,43 +126,36 @@ jobs:
         workingDirectory: '$(Build.SourcesDirectory)'
 
       - script: |
+          set -euo pipefail
           echo "=============================================="
-          echo "Building infrastructure containers"
-          echo "=============================================="
-          
-          cd kerberos-test
-          
-          # Source credentials
-          set -a && source .env && set +a
-          
-          # Build DC and SQL Server (shared by all clients)
-          docker compose -f docker-compose-matrix.yml build dc mssql
-          
-          echo "✓ Infrastructure images built"
-        displayName: 'Build infrastructure'
-        workingDirectory: '$(Build.SourcesDirectory)'
-
-      - script: |
-          echo "=============================================="
-          echo "Pre-building all client images"
+          echo "Pulling pre-built Kerberos images"
+          echo "Registry: ${{ parameters.imageRegistry }}"
+          echo "Tag:      ${{ parameters.imageTag }}"
           echo "Profiles: $(profileList)"
           echo "=============================================="
-          
+
           cd kerberos-test
           set -a && source .env && set +a
-          
-          # Build all client images in parallel (they share layers)
+
+          PROFILE_ARGS=()
           IFS=',' read -ra PROFILES <<< "$(profileList)"
           for profile in "${PROFILES[@]}"; do
-            echo "Building client: $profile"
-            docker compose -f docker-compose-matrix.yml --profile "$profile" build &
+            PROFILE_ARGS+=(--profile "$profile")
           done
-          
-          # Wait for all builds to complete
-          wait
-          
-          echo "✓ All client images built"
-        displayName: 'Build all client images'
+
+          # Images are published by the sync-container-images pipeline. This
+          # stage never builds them: a pull failure means the image is missing,
+          # private or unpublished, and must be fixed at the source rather than
+          # masked by a slow local rebuild.
+          if ! docker compose -f docker-compose-matrix.yml "${PROFILE_ARGS[@]}" pull --quiet; then
+            echo "ERROR: Failed to pull one or more pre-built Kerberos images."
+            echo "  Registry: ${{ parameters.imageRegistry }}, tag: ${{ parameters.imageTag }}"
+            echo "  Confirm the sync-container-images pipeline has published them"
+            echo "  and that the GHCR packages are public."
+            exit 1
+          fi
+          echo "✓ Pulled pre-built images"
+        displayName: 'Pull pre-built images'
         workingDirectory: '$(Build.SourcesDirectory)'
 
       - script: |

--- a/kerberos-test/README.md
+++ b/kerberos-test/README.md
@@ -140,8 +140,11 @@ docker compose -f docker-compose-matrix.yml --profile ubuntu22 build  # build lo
 Override the source registry/tag with `KERBEROS_IMAGE_REGISTRY` and
 `KERBEROS_IMAGE_TAG`.
 
-The DC and SQL images mount `./scripts` at runtime rather than baking the init
-scripts in, so edits to `scripts/init-*.sh` take effect without a rebuild.
+The DC and SQL containers run their init script from the mounted `./scripts`
+directory rather than the copy baked into the image (via `command:` /
+`entrypoint:` overrides in the compose files), so edits to `scripts/init-*.sh`
+take effect without republishing the image.
+
 ### Test a Specific Distro
 
 ```bash

--- a/kerberos-test/README.md
+++ b/kerberos-test/README.md
@@ -115,6 +115,33 @@ base images as the CI matrix (from `validation-pipeline.yml`).
 
 All images come from `tdslibrs.azurecr.io/import/` - the same ACR used by CI.
 
+### Pre-built images
+
+The DC, SQL+AD and per-distro client images are pre-built weekly by
+`.pipeline/sync-container-images.yml` and published to
+`ghcr.io/microsoft/mssql-rs/kerberos/*`. CI pulls them instead of rebuilding,
+which skips the Rust toolchain install, the distro dev packages and the
+Samba/SSSD stacks on every run.
+
+**CI never builds these images.** If a pull fails the stage fails, so a missing,
+unpublished or private image surfaces immediately instead of being masked by a
+slow rebuild. Changes to `Dockerfile.samba-dc`, `Dockerfile.mssql-ad` or
+`Dockerfile.client.matrix` therefore only take effect in CI once the sync
+pipeline has republished the images.
+
+Because `docker-compose-*.yml` declare both `image:` and `build:`, local
+workflows can still pull or build:
+
+```bash
+docker compose -f docker-compose-matrix.yml --profile ubuntu22 pull   # use pre-built
+docker compose -f docker-compose-matrix.yml --profile ubuntu22 build  # build locally
+```
+
+Override the source registry/tag with `KERBEROS_IMAGE_REGISTRY` and
+`KERBEROS_IMAGE_TAG`.
+
+The DC and SQL images mount `./scripts` at runtime rather than baking the init
+scripts in, so edits to `scripts/init-*.sh` take effect without a rebuild.
 ### Test a Specific Distro
 
 ```bash

--- a/kerberos-test/docker-compose-matrix.yml
+++ b/kerberos-test/docker-compose-matrix.yml
@@ -60,6 +60,10 @@ services:
     volumes:
       - samba-data:/var/lib/samba
       - ./scripts:/scripts:ro
+    # Run the mounted script, not the copy baked into the image, so edits to
+    # scripts/ take effect without republishing the image. bash is required:
+    # the scripts are not executable in git.
+    command: ["bash", "/scripts/init-samba-dc.sh"]
     networks:
       kerberos-net:
         ipv4_address: 172.20.0.10
@@ -101,6 +105,8 @@ services:
     volumes:
       - mssql-data:/var/opt/mssql
       - ./scripts:/scripts:ro
+    # See the dc service above: run the mounted script, not the baked copy.
+    entrypoint: ["bash", "/scripts/init-mssql-ad.sh"]
     networks:
       kerberos-net:
         ipv4_address: 172.20.0.20

--- a/kerberos-test/docker-compose-matrix.yml
+++ b/kerberos-test/docker-compose-matrix.yml
@@ -38,6 +38,7 @@ x-client-common: &client-common
 services:
   # Samba AD Domain Controller (shared by all clients)
   dc:
+    image: ${KERBEROS_IMAGE_REGISTRY:-ghcr.io/microsoft/mssql-rs}/kerberos/samba-dc:${KERBEROS_IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: Dockerfile.samba-dc
@@ -58,6 +59,7 @@ services:
       - KERBEROS_ADMIN_PASSWORD=${KERBEROS_ADMIN_PASSWORD}
     volumes:
       - samba-data:/var/lib/samba
+      - ./scripts:/scripts:ro
     networks:
       kerberos-net:
         ipv4_address: 172.20.0.10
@@ -77,6 +79,7 @@ services:
 
   # SQL Server on Linux with SSSD/AD integration (shared by all clients)
   mssql:
+    image: ${KERBEROS_IMAGE_REGISTRY:-ghcr.io/microsoft/mssql-rs}/kerberos/mssql-ad:${KERBEROS_IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: Dockerfile.mssql-ad
@@ -118,6 +121,7 @@ services:
   
   client-alpine318:
     <<: *client-common
+    image: ${KERBEROS_IMAGE_REGISTRY:-ghcr.io/microsoft/mssql-rs}/kerberos/client:alpine318-${KERBEROS_IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: Dockerfile.client.matrix
@@ -133,6 +137,7 @@ services:
 
   client-alpine319:
     <<: *client-common
+    image: ${KERBEROS_IMAGE_REGISTRY:-ghcr.io/microsoft/mssql-rs}/kerberos/client:alpine319-${KERBEROS_IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: Dockerfile.client.matrix
@@ -148,6 +153,7 @@ services:
 
   client-alpine320:
     <<: *client-common
+    image: ${KERBEROS_IMAGE_REGISTRY:-ghcr.io/microsoft/mssql-rs}/kerberos/client:alpine320-${KERBEROS_IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: Dockerfile.client.matrix
@@ -163,6 +169,7 @@ services:
 
   client-alpine321:
     <<: *client-common
+    image: ${KERBEROS_IMAGE_REGISTRY:-ghcr.io/microsoft/mssql-rs}/kerberos/client:alpine321-${KERBEROS_IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: Dockerfile.client.matrix
@@ -182,6 +189,7 @@ services:
 
   client-debian:
     <<: *client-common
+    image: ${KERBEROS_IMAGE_REGISTRY:-ghcr.io/microsoft/mssql-rs}/kerberos/client:debian-${KERBEROS_IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: Dockerfile.client.matrix
@@ -201,6 +209,7 @@ services:
 
   client-ubuntu22:
     <<: *client-common
+    image: ${KERBEROS_IMAGE_REGISTRY:-ghcr.io/microsoft/mssql-rs}/kerberos/client:ubuntu22-${KERBEROS_IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: Dockerfile.client.matrix
@@ -216,6 +225,7 @@ services:
 
   client-ubuntu24:
     <<: *client-common
+    image: ${KERBEROS_IMAGE_REGISTRY:-ghcr.io/microsoft/mssql-rs}/kerberos/client:ubuntu24-${KERBEROS_IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: Dockerfile.client.matrix
@@ -235,6 +245,7 @@ services:
 
   client-rhel9:
     <<: *client-common
+    image: ${KERBEROS_IMAGE_REGISTRY:-ghcr.io/microsoft/mssql-rs}/kerberos/client:rhel9-${KERBEROS_IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: Dockerfile.client.matrix
@@ -254,6 +265,7 @@ services:
 
   client-oracle9:
     <<: *client-common
+    image: ${KERBEROS_IMAGE_REGISTRY:-ghcr.io/microsoft/mssql-rs}/kerberos/client:oracle9-${KERBEROS_IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: Dockerfile.client.matrix

--- a/kerberos-test/docker-compose-samba.yml
+++ b/kerberos-test/docker-compose-samba.yml
@@ -23,6 +23,10 @@ services:
     volumes:
       - samba-data:/var/lib/samba
       - ./scripts:/scripts:ro
+    # Run the mounted script, not the copy baked into the image, so edits to
+    # scripts/ take effect without republishing the image. bash is required:
+    # the scripts are not executable in git.
+    command: ["bash", "/scripts/init-samba-dc.sh"]
     networks:
       kerberos-net:
         ipv4_address: 172.20.0.10
@@ -64,6 +68,8 @@ services:
     volumes:
       - mssql-data:/var/opt/mssql
       - ./scripts:/scripts:ro
+    # See the dc service above: run the mounted script, not the baked copy.
+    entrypoint: ["bash", "/scripts/init-mssql-ad.sh"]
     networks:
       kerberos-net:
         ipv4_address: 172.20.0.20

--- a/kerberos-test/docker-compose-samba.yml
+++ b/kerberos-test/docker-compose-samba.yml
@@ -1,6 +1,7 @@
 services:
   # Samba AD Domain Controller
   dc:
+    image: ${KERBEROS_IMAGE_REGISTRY:-ghcr.io/microsoft/mssql-rs}/kerberos/samba-dc:${KERBEROS_IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: Dockerfile.samba-dc
@@ -21,6 +22,7 @@ services:
       - KERBEROS_ADMIN_PASSWORD=${KERBEROS_ADMIN_PASSWORD}
     volumes:
       - samba-data:/var/lib/samba
+      - ./scripts:/scripts:ro
     networks:
       kerberos-net:
         ipv4_address: 172.20.0.10
@@ -40,6 +42,7 @@ services:
 
   # SQL Server on Linux with SSSD/AD integration
   mssql:
+    image: ${KERBEROS_IMAGE_REGISTRY:-ghcr.io/microsoft/mssql-rs}/kerberos/mssql-ad:${KERBEROS_IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: Dockerfile.mssql-ad

--- a/kerberos-test/docker-compose-validation.yml
+++ b/kerberos-test/docker-compose-validation.yml
@@ -34,6 +34,7 @@ x-client-common: &client-common
 services:
   # Samba AD Domain Controller (shared by all clients)
   dc:
+    image: ${KERBEROS_IMAGE_REGISTRY:-ghcr.io/microsoft/mssql-rs}/kerberos/samba-dc:${KERBEROS_IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: Dockerfile.samba-dc
@@ -54,6 +55,7 @@ services:
       - KERBEROS_ADMIN_PASSWORD=${KERBEROS_ADMIN_PASSWORD}
     volumes:
       - samba-data:/var/lib/samba
+      - ./scripts:/scripts:ro
     networks:
       kerberos-net:
         ipv4_address: 172.20.0.10
@@ -73,6 +75,7 @@ services:
 
   # SQL Server on Linux with SSSD/AD integration (shared by all clients)
   mssql:
+    image: ${KERBEROS_IMAGE_REGISTRY:-ghcr.io/microsoft/mssql-rs}/kerberos/mssql-ad:${KERBEROS_IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: Dockerfile.mssql-ad

--- a/kerberos-test/docker-compose-validation.yml
+++ b/kerberos-test/docker-compose-validation.yml
@@ -6,6 +6,8 @@
 # Key difference from docker-compose-matrix.yml:
 #   - Uses Dockerfile.client.validation (no Rust, ~5s build vs ~30s)
 #   - Only validates kinit/klist works
+#   - dc/mssql use the pre-built images; the client-* services are always built
+#     locally, since no pre-built validation-client images are published
 #
 # Usage: 
 #   docker compose -f docker-compose-validation.yml --profile <distro> up -d
@@ -56,6 +58,10 @@ services:
     volumes:
       - samba-data:/var/lib/samba
       - ./scripts:/scripts:ro
+    # Run the mounted script, not the copy baked into the image, so edits to
+    # scripts/ take effect without republishing the image. bash is required:
+    # the scripts are not executable in git.
+    command: ["bash", "/scripts/init-samba-dc.sh"]
     networks:
       kerberos-net:
         ipv4_address: 172.20.0.10
@@ -97,6 +103,8 @@ services:
     volumes:
       - mssql-data:/var/opt/mssql
       - ./scripts:/scripts:ro
+    # See the dc service above: run the mounted script, not the baked copy.
+    entrypoint: ["bash", "/scripts/init-mssql-ad.sh"]
     networks:
       kerberos-net:
         ipv4_address: 172.20.0.20

--- a/kerberos-test/run-kerberos-tests.sh
+++ b/kerberos-test/run-kerberos-tests.sh
@@ -176,6 +176,7 @@ if [ "$ARCHIVE_MODE" = true ]; then
     echo "Step 4: Install cargo-nextest..."
     echo "----------------------------------------------"
     docker exec "$CONTAINER_NAME" bash -c '
+        command -v cargo-nextest >/dev/null && exit 0
         cargo install cargo-nextest --version 0.9.99 --locked
     '
     echo "✓ cargo-nextest installed"
@@ -260,6 +261,7 @@ OUTER_EOF
         echo "Step 4: Install cargo-nextest (CI mode)..."
         echo "----------------------------------------------"
         docker exec "$CONTAINER_NAME" bash -c '
+            command -v cargo-nextest >/dev/null && exit 0
             cargo install cargo-nextest --version 0.9.99 --locked
         '
         echo "✓ cargo-nextest installed"

--- a/kerberos-test/run-kerberos-tests.sh
+++ b/kerberos-test/run-kerberos-tests.sh
@@ -176,8 +176,15 @@ if [ "$ARCHIVE_MODE" = true ]; then
     echo "Step 4: Install cargo-nextest..."
     echo "----------------------------------------------"
     docker exec "$CONTAINER_NAME" bash -c '
-        command -v cargo-nextest >/dev/null && exit 0
-        cargo install cargo-nextest --version 0.9.99 --locked
+        NEXTEST_VERSION=0.9.99
+        HAVE=$(cargo nextest --version 2>/dev/null)
+        case "$HAVE" in
+            *"$NEXTEST_VERSION"*)
+                echo "cargo-nextest $NEXTEST_VERSION already present (pre-built image)"
+                exit 0 ;;
+        esac
+        [ -n "$HAVE" ] && echo "Found [$HAVE], want $NEXTEST_VERSION; reinstalling"
+        cargo install cargo-nextest --version "$NEXTEST_VERSION" --locked --force
     '
     echo "✓ cargo-nextest installed"
     
@@ -261,8 +268,15 @@ OUTER_EOF
         echo "Step 4: Install cargo-nextest (CI mode)..."
         echo "----------------------------------------------"
         docker exec "$CONTAINER_NAME" bash -c '
-            command -v cargo-nextest >/dev/null && exit 0
-            cargo install cargo-nextest --version 0.9.99 --locked
+            NEXTEST_VERSION=0.9.99
+            HAVE=$(cargo nextest --version 2>/dev/null)
+            case "$HAVE" in
+                *"$NEXTEST_VERSION"*)
+                    echo "cargo-nextest $NEXTEST_VERSION already present (pre-built image)"
+                    exit 0 ;;
+            esac
+            [ -n "$HAVE" ] && echo "Found [$HAVE], want $NEXTEST_VERSION; reinstalling"
+            cargo install cargo-nextest --version "$NEXTEST_VERSION" --locked --force
         '
         echo "✓ cargo-nextest installed"
     fi


### PR DESCRIPTION
## Description

Makes the Kerberos test stage **consume** pre-built container images from GHCR instead of rebuilding them on every PR/CI run.

Today `.pipeline/templates/kerberos-test-template.yml` builds the Samba AD DC image, the SQL Server + AD image, and up to 9 per-distro client images (each installing a full Rust toolchain via rustup) on every run. `run-kerberos-tests.sh` then compiles `cargo-nextest` from source *inside each running container*.

### Changes

- **`.pipeline/templates/kerberos-test-template.yml`**
  - New parameters `imageRegistry` (default `ghcr.io/microsoft/mssql-rs`) and `imageTag` (default `latest`).
  - The two "Build infrastructure" / "Build all client images" steps are replaced by a single **Pull pre-built images** step.
  - The now-dead "Pull base images" step is removed — base images were only needed for the local build path.
- **`kerberos-test/docker-compose-*.yml`** — `image:` refs for `dc`, `mssql` and all 9 `client-*` services, parameterised by `KERBEROS_IMAGE_REGISTRY` / `KERBEROS_IMAGE_TAG`. `build:` is kept alongside so local workflows (`validate-local.sh`, `run-all-distros.sh`) are unchanged. The `dc` service now mounts `./scripts` so the pre-built image can pick up init-script edits at runtime.
- **`kerberos-test/run-kerberos-tests.sh`** — skip `cargo install cargo-nextest` when nextest is already on `PATH`. The guard runs inside the `docker exec ... bash -c` subshell, so it short-circuits before cargo is invoked; without it, `cargo install` would rebuild from source and then fail with `binary 'cargo-nextest' already exists` (the tarball-installed binary has no `.crates.toml` entry).
- **`kerberos-test/README.md`** — documents the pull-only behaviour and the registry/tag overrides.

### No local build fallback

CI never builds these images. A failed pull fails the stage with a diagnostic pointing at the registry and tag, so a missing, unpublished or private image is fixed at the source rather than silently masked by a slow rebuild.

Consequence worth noting: a PR that edits `Dockerfile.samba-dc`, `Dockerfile.mssql-ad` or `Dockerfile.client.matrix` is validated against the currently published images, not against its own edits. Those changes take effect in CI only after the sync pipeline republishes.

### ⚠️ Prerequisite

GHCR package visibility is **per-package, not per-namespace**, and newly pushed packages default to **private**. Once #163's sync pipeline first publishes the 11 `kerberos/*` images, someone with admin on the org's packages must flip each to Public (package page → Package settings → Danger Zone → Change visibility). There is no REST/GraphQL API and no `gh` command for this, and changes can take a few minutes to propagate.

**Because there is no fallback, this PR must not merge before those images are published and public** — otherwise the Kerberos stage fails on pull. #163 is the producer.

## Related Issues

Fixes #170

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes
- [x] New/changed functionality has tests
- [x] Public API changes are documented

<sub>No Rust code is touched by this PR; validation was YAML parsing of all changed pipeline/compose files, `bash -n` on `run-kerberos-tests.sh`, and `docker compose config` to confirm the rendered image names and `/scripts` mounts.</sub>
