### PR TITLE
Run ODBC C++ e2e on Windows ARM against the shared cross-pool SQL host

### DIFF
--- a/.pipeline/scripts/sql-host/New-SqlPassword.ps1
+++ b/.pipeline/scripts/sql-host/New-SqlPassword.ps1
@@ -1,0 +1,47 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# New-SqlPassword.ps1 — Windows counterpart of derive-sql-password.sh.
+#
+# Must produce byte-identical output to the bash version: the SQL host job runs
+# on a Linux x64 agent and derives the SA password there, while this script runs
+# on the Windows agent that connects to it. Any divergence in salt, digest
+# encoding, or truncation silently turns into login failure 18456.
+#
+# Required env:
+#   BUILD_BUILDID         Current build id (System.BuildId).
+#   SYSTEM_COLLECTIONID   ADO collection (organization) GUID.
+#
+# Sets pipeline variables:
+#   SQL_PASSWORD            secret-masked SA password
+#   SQL_PASSWORD_GENERATED  marker so generate-sql-password-template.yml skips
+#                           re-generation if also pulled into the same job.
+
+$ErrorActionPreference = 'Stop'
+
+if ($env:SQL_PASSWORD_GENERATED -eq '1') {
+    Write-Host 'SQL_PASSWORD already established for this job; skipping derivation'
+    exit 0
+}
+
+if (-not $env:BUILD_BUILDID) { throw 'BUILD_BUILDID is required' }
+if (-not $env:SYSTEM_COLLECTIONID) { throw 'SYSTEM_COLLECTIONID is required' }
+
+# Keep in sync with derive-sql-password.sh.
+$salt = 'mssql-tds-arm-cross-pool-sa'
+$material = "$($env:BUILD_BUILDID)-$($env:SYSTEM_COLLECTIONID)-$salt"
+
+$sha256 = [System.Security.Cryptography.SHA256]::Create()
+try {
+    $bytes = $sha256.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($material))
+} finally {
+    $sha256.Dispose()
+}
+
+# sha256sum emits lowercase hex; -f 'x2' matches it.
+$digest = -join ($bytes | ForEach-Object { $_.ToString('x2') })
+$password = 'Aa1!' + $digest.Substring(0, 22)
+
+Write-Host "##vso[task.setvariable variable=SQL_PASSWORD;issecret=true]$password"
+Write-Host '##vso[task.setvariable variable=SQL_PASSWORD_GENERATED]1'
+Write-Host "Derived SQL_PASSWORD (length=$($password.Length)) for build $($env:BUILD_BUILDID)"

--- a/.pipeline/scripts/sql-host/Wait-ForSqlEndpoint.ps1
+++ b/.pipeline/scripts/sql-host/Wait-ForSqlEndpoint.ps1
@@ -1,0 +1,147 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# Wait-ForSqlEndpoint.ps1 — Windows counterpart of poll-for-endpoint.sh.
+#
+# Blocks until the cross-pool SQL host publishes its `sql-ready` sentinel
+# artifact, downloads it, and exports the endpoint as DB_HOST / DB_PORT for
+# downstream steps. See sql-host-template.yml for why the rendezvous uses
+# pipeline artifacts in both directions instead of ADO `dependsOn`.
+#
+# Required env:
+#   ARTIFACT_NAME         Name of the sql-ready sentinel artifact.
+#   BUILD_BUILDID
+#   SYSTEM_COLLECTIONURI
+#   SYSTEM_TEAMPROJECT
+#   SYSTEM_ACCESSTOKEN    Expose via env: in the YAML step.
+#   AGENT_TEMPDIRECTORY
+#
+# Optional env:
+#   POLL_INTERVAL_SECONDS            default 10
+#   MAX_WAIT_SECONDS                 default 3600
+#   SYSTEM_STAGEATTEMPT              used to detect a partial "Rerun failed jobs"
+#   RERUN_HINT_AFTER_SECONDS         default 600
+#   MIN_HOST_LIFE_REMAINING_SECONDS  default 300
+
+$ErrorActionPreference = 'Stop'
+
+foreach ($required in 'ARTIFACT_NAME', 'BUILD_BUILDID', 'SYSTEM_COLLECTIONURI', 'SYSTEM_TEAMPROJECT', 'SYSTEM_ACCESSTOKEN', 'AGENT_TEMPDIRECTORY') {
+    if (-not [Environment]::GetEnvironmentVariable($required)) {
+        throw "$required is required"
+    }
+}
+
+$artifactName = $env:ARTIFACT_NAME
+$pollInterval = if ($env:POLL_INTERVAL_SECONDS) { [int]$env:POLL_INTERVAL_SECONDS } else { 10 }
+$maxWait = if ($env:MAX_WAIT_SECONDS) { [int]$env:MAX_WAIT_SECONDS } else { 3600 }
+$stageAttempt = if ($env:SYSTEM_STAGEATTEMPT) { [int]$env:SYSTEM_STAGEATTEMPT } else { 1 }
+$rerunHintAfter = if ($env:RERUN_HINT_AFTER_SECONDS) { [int]$env:RERUN_HINT_AFTER_SECONDS } else { 600 }
+$minHostLife = if ($env:MIN_HOST_LIFE_REMAINING_SECONDS) { [int]$env:MIN_HOST_LIFE_REMAINING_SECONDS } else { 300 }
+
+$headers = @{ Authorization = "Bearer $($env:SYSTEM_ACCESSTOKEN)" }
+$collection = $env:SYSTEM_COLLECTIONURI.TrimEnd('/')
+$projectEnc = [uri]::EscapeDataString($env:SYSTEM_TEAMPROJECT)
+$url = "$collection/$projectEnc/_apis/build/builds/$($env:BUILD_BUILDID)/artifacts?api-version=7.1"
+
+Write-Host '=== sql-host/Wait-ForSqlEndpoint.ps1 ==='
+Write-Host "  ARTIFACT_NAME = $artifactName"
+Write-Host "  Build         = $($env:BUILD_BUILDID)"
+Write-Host "  Poll URL      = $url"
+Write-Host "  Poll every    = ${pollInterval}s"
+Write-Host "  Max wait      = ${maxWait}s"
+
+# The SQL host is a sibling job released as soon as tests finish, so ADO's
+# "Rerun failed jobs" never restarts it and no host publishes a sentinel for the
+# new attempt. Surface that as actionable guidance rather than a timeout.
+function Write-PartialRerunGuidance {
+    Write-Host "##vso[task.logissue type=error]SQL host endpoint '$artifactName' never appeared for stage attempt $stageAttempt."
+    Write-Host "##vso[task.logissue type=error]The on-demand SQL host runs as a sibling job in this stage and is released once tests finish. 'Rerun failed jobs' does NOT restart it, so this rerun has no SQL server to connect to."
+    Write-Host "##vso[task.logissue type=error]Fix: use 'Rerun stage' (or re-queue the pipeline) instead of 'Rerun failed jobs' so the SQL host job runs again alongside the tests."
+}
+
+$start = Get-Date
+$deadline = $start.AddSeconds($maxWait)
+$downloadUrl = $null
+$rerunHinted = $false
+
+while ($true) {
+    $now = Get-Date
+    if ($now -ge $deadline) {
+        if ($stageAttempt -gt 1) {
+            Write-PartialRerunGuidance
+        } else {
+            Write-Host "##vso[task.logissue type=error]artifact $artifactName did not appear within ${maxWait}s (the SQL host job may have failed to start)."
+        }
+        throw "artifact $artifactName did not appear within ${maxWait}s."
+    }
+
+    try {
+        $response = Invoke-RestMethod -Uri $url -Headers $headers -Method Get
+        $match = $response.value | Where-Object { $_.name -eq $artifactName } | Select-Object -First 1
+        if ($match) {
+            $downloadUrl = $match.resource.downloadUrl
+            Write-Host "Endpoint sentinel $artifactName found."
+            break
+        }
+    } catch {
+        Write-Warning "artifact list HTTP error: $_"
+    }
+
+    $elapsed = ($now - $start).TotalSeconds
+    if (-not $rerunHinted -and $stageAttempt -gt 1 -and $elapsed -ge $rerunHintAfter) {
+        Write-Host "##vso[task.logissue type=warning]No SQL host endpoint after $([int]($elapsed / 60)) min on stage attempt $stageAttempt. If you used 'Rerun failed jobs', the SQL host job was NOT restarted and this will time out — cancel and use 'Rerun stage' instead."
+        $rerunHinted = $true
+    }
+    Write-Host "$($now.ToUniversalTime().ToString('HH:mm:ss')) waiting for $artifactName; $([int]($deadline - $now).TotalSeconds)s left."
+    Start-Sleep -Seconds $pollInterval
+}
+
+$downloadDir = Join-Path $env:AGENT_TEMPDIRECTORY $artifactName
+$extractDir = Join-Path $downloadDir 'extracted'
+Remove-Item -Recurse -Force $downloadDir -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Path $downloadDir -Force | Out-Null
+$zipPath = Join-Path $downloadDir 'artifact.zip'
+
+$downloaded = $false
+foreach ($attempt in 1..5) {
+    try {
+        Invoke-WebRequest -Uri $downloadUrl -Headers $headers -OutFile $zipPath -UseBasicParsing
+        $downloaded = $true
+        break
+    } catch {
+        Write-Warning "artifact download attempt $attempt failed: $_"
+        Start-Sleep -Seconds ($attempt * 5)
+    }
+}
+if (-not $downloaded) {
+    throw "failed to download $artifactName after 5 attempts."
+}
+
+Expand-Archive -Path $zipPath -DestinationPath $extractDir -Force
+
+$endpointFile = Get-ChildItem -Path $extractDir -Filter 'endpoint.txt' -Recurse -File | Select-Object -First 1
+if (-not $endpointFile) {
+    Get-ChildItem -Path $extractDir -Recurse -File | ForEach-Object { Write-Host $_.FullName }
+    throw "endpoint.txt not found inside $artifactName artifact."
+}
+
+# endpoint.txt format: "HOST PORT DEADLINE_EPOCH" on a single line.
+$fields = (Get-Content -Path $endpointFile.FullName -TotalCount 1) -split '\s+' | Where-Object { $_ }
+if ($fields.Count -lt 2) {
+    throw "endpoint.txt is malformed: '$(Get-Content -Path $endpointFile.FullName -Raw)'"
+}
+$dbHost = $fields[0]
+$dbPort = $fields[1]
+
+if ($fields.Count -ge 3) {
+    $remaining = [int]$fields[2] - [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+    if ($remaining -lt $minHostLife) {
+        Write-Host "  This usually means the SQL host hit MAX_LIFETIME_MINUTES while this test job was queued."
+        throw "SQL host endpoint expires in ${remaining}s (need >= ${minHostLife}s)."
+    }
+    Write-Host "SQL host has ${remaining}s of life remaining (over the ${minHostLife}s threshold)."
+}
+
+Write-Host "Resolved SQL endpoint: host=$dbHost port=$dbPort"
+Write-Host "##vso[task.setvariable variable=DB_HOST]$dbHost"
+Write-Host "##vso[task.setvariable variable=DB_PORT]$dbPort"

--- a/.pipeline/templates/odbc-e2e-windows-remote-sql-template.yml
+++ b/.pipeline/templates/odbc-e2e-windows-remote-sql-template.yml
@@ -38,34 +38,61 @@ steps:
   - pwsh: |
       $ErrorActionPreference = 'Continue'
       Write-Host "PSVersion: $($PSVersionTable.PSVersion)  OSArchitecture: $([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)"
+
+      $problems = @()
+
       $admin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
-      Write-Host "Elevated (required to register the driver in HKLM): $admin"
+      Write-Host "Elevated: $admin"
+      if (-not $admin) {
+        $problems += 'The agent is not elevated; run_e2e.ps1 registers the driver under HKLM and will fail.'
+      }
 
-      $cmake = Get-Command cmake -ErrorAction SilentlyContinue
-      if ($cmake) { Write-Host "cmake on PATH: $($cmake.Source)" } else { Write-Host 'cmake NOT on PATH' }
-
+      # Mirror Initialize-CMake in run_e2e.ps1: PATH, then the VS-bundled copy, then
+      # a standalone install. Whatever that function would resolve, we must resolve too.
+      $vsRoot = $null
       $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
       if (Test-Path $vswhere) {
         $vsRoot = & $vswhere -latest -products '*' -property installationPath 2>$null | Select-Object -First 1
-        Write-Host "Visual Studio: $vsRoot"
-        if ($vsRoot) {
-          $vsCMake = Join-Path $vsRoot 'Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe'
-          Write-Host "VS-bundled cmake present: $(Test-Path $vsCMake) ($vsCMake)"
-          Get-ChildItem (Join-Path $vsRoot 'VC\Tools\MSVC') -ErrorAction SilentlyContinue |
-            ForEach-Object {
-              $arm64 = Join-Path $_.FullName 'bin\Hostarm64\arm64\cl.exe'
-              $x64 = Join-Path $_.FullName 'bin\Hostx64\arm64\cl.exe'
-              Write-Host "MSVC $($_.Name): Hostarm64/arm64 cl=$(Test-Path $arm64) Hostx64/arm64 cl=$(Test-Path $x64)"
-            }
-        }
-      } else {
-        Write-Host "vswhere NOT found at $vswhere"
+      }
+      Write-Host "Visual Studio: $(if ($vsRoot) { $vsRoot } else { 'not found' })"
+
+      $cmakeExe = (Get-Command cmake -ErrorAction SilentlyContinue).Source
+      if (-not $cmakeExe) {
+        $cmakeCandidates = @()
+        if ($vsRoot) { $cmakeCandidates += Join-Path $vsRoot 'Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe' }
+        $cmakeCandidates += 'C:\Program Files\CMake\bin\cmake.exe'
+        $cmakeCandidates += Join-Path ${env:ProgramFiles(x86)} 'CMake\bin\cmake.exe'
+        $cmakeExe = $cmakeCandidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+      }
+      Write-Host "cmake: $(if ($cmakeExe) { $cmakeExe } else { 'not found' })"
+      if (-not $cmakeExe) {
+        $problems += 'No cmake found on PATH, in Visual Studio, or in a standalone install.'
       }
 
-      if (-not $cmake -and -not (Test-Path $vswhere)) {
-        Write-Host '##vso[task.logissue type=error]Neither cmake nor Visual Studio was found on this agent; the ODBC e2e suite cannot be built.'
+      # The gtest suite is built for arm64, so we need a compiler that targets arm64.
+      # Either a native arm64 host or an x64 host cross-compiler works.
+      $armCl = $null
+      if ($vsRoot) {
+        foreach ($ver in Get-ChildItem (Join-Path $vsRoot 'VC\Tools\MSVC') -ErrorAction SilentlyContinue) {
+          $native = Join-Path $ver.FullName 'bin\Hostarm64\arm64\cl.exe'
+          $cross = Join-Path $ver.FullName 'bin\Hostx64\arm64\cl.exe'
+          Write-Host "MSVC $($ver.Name): Hostarm64/arm64 cl=$(Test-Path $native) Hostx64/arm64 cl=$(Test-Path $cross)"
+          if (-not $armCl) {
+            $armCl = @($native, $cross) | Where-Object { Test-Path $_ } | Select-Object -First 1
+          }
+        }
+      }
+      Write-Host "arm64 cl.exe: $(if ($armCl) { $armCl } else { 'not found' })"
+      if (-not $armCl) {
+        $problems += 'No MSVC cl.exe targeting arm64 (Hostarm64/arm64 or Hostx64/arm64) was found.'
+      }
+
+      if ($problems) {
+        foreach ($p in $problems) { Write-Host "##vso[task.logissue type=error]$p" }
+        Write-Host '##vso[task.logissue type=error]Preflight failed; skipping the ODBC e2e suite rather than claiming the shared SQL host.'
         exit 1
       }
+      Write-Host 'Preflight OK.'
     displayName: 'Preflight: CMake and C++ toolchain'
     condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
 

--- a/.pipeline/templates/odbc-e2e-windows-remote-sql-template.yml
+++ b/.pipeline/templates/odbc-e2e-windows-remote-sql-template.yml
@@ -1,0 +1,96 @@
+# Template: odbc-e2e-windows-remote-sql-template.yml
+#
+# Runs the mssql-odbc C++ gtest e2e suite on a Windows agent that has no local
+# SQL Server, against the cross-pool x64 SQL host booted by sql-host-template.yml.
+#
+# The Windows ARM agent image ships no SQL Server (unlike RUST-Win22-Sql25-1P used
+# by Build_Windows), so the ARM job joins the same artifact-sentinel rendezvous the
+# Linux ARM jobs use: derive the shared SA password, poll for the sql-ready
+# endpoint sentinel, run the suite, then publish a teardown sentinel to release
+# the host. See sql-host-template.yml for the full contract.
+#
+# Caller contract:
+#   * The consuming job must NOT add `dependsOn` on the SQL host job.
+#   * `sentinelName` must be listed in that host's `expectedSentinels`.
+#   * The host is PR-only (jobCondition), so these steps are PR-only too.
+
+parameters:
+  - name: sqlReadyInstanceId
+    # instanceId of the sql-ready sentinel to consume.
+    type: string
+    default: 'build_arm'
+  - name: sentinelName
+    # Teardown sentinel this job publishes to release the SQL host.
+    type: string
+  - name: testRunTitle
+    type: string
+    default: 'ODBC e2e (Windows ARM)'
+  - name: retries
+    type: number
+    default: 3
+
+steps:
+  - pwsh: ./.pipeline/scripts/sql-host/New-SqlPassword.ps1
+    displayName: 'Derive shared SQL_PASSWORD from build context'
+    condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+    env:
+      BUILD_BUILDID: $(Build.BuildId)
+      SYSTEM_COLLECTIONID: $(System.CollectionId)
+
+  - pwsh: ./.pipeline/scripts/sql-host/Wait-ForSqlEndpoint.ps1
+    displayName: 'Wait for SQL host endpoint sentinel'
+    condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+    env:
+      ARTIFACT_NAME: 'sql-ready-${{ parameters.sqlReadyInstanceId }}-$(System.StageAttempt)'
+      BUILD_BUILDID: $(Build.BuildId)
+      SYSTEM_COLLECTIONURI: $(System.CollectionUri)
+      SYSTEM_TEAMPROJECT: $(System.TeamProject)
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+      SYSTEM_STAGEATTEMPT: $(System.StageAttempt)
+      AGENT_TEMPDIRECTORY: $(Agent.TempDirectory)
+
+  # No -Coverage here: the x64 Windows leg already publishes
+  # CoberturaCoverageOdbcE2E_Windows, and a second artifact under the same name
+  # would collide. This leg exists to prove the ARM64 driver binary works through
+  # the Windows Driver Manager.
+  - pwsh: |
+      $env:ODBC_TEST_SERVER     = "$($env:DB_HOST),$($env:DB_PORT)"
+      $env:ODBC_TEST_UID        = 'sa'
+      $env:ODBC_TEST_PWD        = $env:SQL_PASSWORD
+      $env:ODBC_TEST_TRUST_CERT = 'Yes'
+      ./mssql-odbc/tests/e2e/run_e2e.ps1 -Retries ${{ parameters.retries }}
+    displayName: 'Run ODBC C++ e2e tests'
+    condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+    env:
+      DB_HOST: $(DB_HOST)
+      DB_PORT: $(DB_PORT)
+      SQL_PASSWORD: $(SQL_PASSWORD)
+      RUST_BACKTRACE: full
+
+  - task: PublishTestResults@2
+    condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
+    displayName: 'Publish ODBC e2e test results'
+    inputs:
+      testResultsFormat: 'JUnit'
+      testResultsFiles: $(Build.SourcesDirectory)/mssql-odbc/tests/e2e/build/junit-mssql-odbc.xml
+      testRunTitle: ${{ parameters.testRunTitle }}
+
+  # always() so a failure or cancellation still releases the SQL host instead of
+  # leaving it to burn its MAX_LIFETIME_MINUTES cap.
+  - pwsh: |
+      $dir = Join-Path $env:AGENT_TEMPDIRECTORY 'teardown-${{ parameters.sentinelName }}'
+      New-Item -ItemType Directory -Path $dir -Force | Out-Null
+      "${{ parameters.sentinelName }} done at $([DateTime]::UtcNow.ToString('o'))" |
+        Set-Content -Path (Join-Path $dir 'done.txt')
+    displayName: 'Stage teardown sentinel'
+    condition: and(always(), eq(variables['Build.Reason'], 'PullRequest'))
+    env:
+      AGENT_TEMPDIRECTORY: $(Agent.TempDirectory)
+
+  - task: PublishPipelineArtifact@1
+    displayName: 'Publish teardown sentinel (release SQL host)'
+    condition: and(always(), eq(variables['Build.Reason'], 'PullRequest'))
+    inputs:
+      targetPath: '$(Agent.TempDirectory)/teardown-${{ parameters.sentinelName }}'
+      artifact: '${{ parameters.sentinelName }}-$(System.StageAttempt)'
+      publishLocation: 'pipeline'

--- a/.pipeline/templates/odbc-e2e-windows-remote-sql-template.yml
+++ b/.pipeline/templates/odbc-e2e-windows-remote-sql-template.yml
@@ -30,6 +30,45 @@ parameters:
     default: 3
 
 steps:
+  # Preflight: the ODBC e2e suite needs CMake and an ARM64 C++ toolchain, neither
+  # of which this job otherwise uses. Resolving them before we claim the shared SQL
+  # host turns a missing-toolchain image into an immediate, legible failure instead
+  # of a confusing error deep inside run_e2e.ps1 — and avoids occupying a SQL host
+  # this job could never have used.
+  - pwsh: |
+      $ErrorActionPreference = 'Continue'
+      Write-Host "PSVersion: $($PSVersionTable.PSVersion)  OSArchitecture: $([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)"
+      $admin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+      Write-Host "Elevated (required to register the driver in HKLM): $admin"
+
+      $cmake = Get-Command cmake -ErrorAction SilentlyContinue
+      if ($cmake) { Write-Host "cmake on PATH: $($cmake.Source)" } else { Write-Host 'cmake NOT on PATH' }
+
+      $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+      if (Test-Path $vswhere) {
+        $vsRoot = & $vswhere -latest -products '*' -property installationPath 2>$null | Select-Object -First 1
+        Write-Host "Visual Studio: $vsRoot"
+        if ($vsRoot) {
+          $vsCMake = Join-Path $vsRoot 'Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe'
+          Write-Host "VS-bundled cmake present: $(Test-Path $vsCMake) ($vsCMake)"
+          Get-ChildItem (Join-Path $vsRoot 'VC\Tools\MSVC') -ErrorAction SilentlyContinue |
+            ForEach-Object {
+              $arm64 = Join-Path $_.FullName 'bin\Hostarm64\arm64\cl.exe'
+              $x64 = Join-Path $_.FullName 'bin\Hostx64\arm64\cl.exe'
+              Write-Host "MSVC $($_.Name): Hostarm64/arm64 cl=$(Test-Path $arm64) Hostx64/arm64 cl=$(Test-Path $x64)"
+            }
+        }
+      } else {
+        Write-Host "vswhere NOT found at $vswhere"
+      }
+
+      if (-not $cmake -and -not (Test-Path $vswhere)) {
+        Write-Host '##vso[task.logissue type=error]Neither cmake nor Visual Studio was found on this agent; the ODBC e2e suite cannot be built.'
+        exit 1
+      }
+    displayName: 'Preflight: CMake and C++ toolchain'
+    condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+
   - pwsh: ./.pipeline/scripts/sql-host/New-SqlPassword.ps1
     displayName: 'Derive shared SQL_PASSWORD from build context'
     condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -74,14 +74,15 @@ stages:
       )
     )
   jobs:
-  # On-demand x64 SQL host for the ARM64 build's integration tests. ARM agents
-  # cannot run the x64 SQL Server image natively, so Build_Linux_ARM connects
-  # cross-pool to this host instead. PR-only: the ARM build only runs its test
-  # pass on PRs, and this job would otherwise idle an x64 agent on every merge.
+  # On-demand x64 SQL host for the ARM64 builds' integration tests. ARM agents
+  # cannot run the x64 SQL Server image natively, so Build_Linux_ARM and the
+  # Windows ARM ODBC e2e leg connect cross-pool to this host instead. PR-only:
+  # the ARM builds only run their test pass on PRs, and this job would otherwise
+  # idle an x64 agent on every merge.
   - template: sql-host-template.yml
     parameters:
       instanceId: build_arm
-      expectedSentinels: build_arm
+      expectedSentinels: build_arm,build_win_arm
       sqlImageTag: ${{ parameters.sqlImageTag }}
       jobCondition: eq(variables['Build.Reason'], 'PullRequest')
   - job: Build_Windows
@@ -201,6 +202,15 @@ stages:
           - '3.12'
           - '3.13'
           - '3.14'
+
+      # ODBC C++ e2e against the cross-pool x64 SQL host booted above. This image
+      # has no local SQL Server, so it joins the same artifact-sentinel rendezvous
+      # Build_Linux_ARM uses. Intentionally no `dependsOn` on the SQL host job.
+      - template: odbc-e2e-windows-remote-sql-template.yml
+        parameters:
+          sqlReadyInstanceId: build_arm
+          sentinelName: build_win_arm
+          testRunTitle: 'ODBC e2e (Windows ARM)'
 
   - job: Build_Linux
     displayName: Build Linux


### PR DESCRIPTION
## Description

Adds the mssql-odbc C++ gtest e2e suite to the `Build_Windows_Arm` job.

The Windows ARM agent image (`RUST-WINSRV-ARM`) ships no local SQL Server, unlike the x64 `RUST-Win22-Sql25-1P` image that the existing Windows ODBC e2e leg relies on. So the ARM leg joins the same artifact-sentinel rendezvous the Linux ARM jobs already use: it consumes the `build_arm` cross-pool x64 SQL host booted by `sql-host-template.yml`.

Changes:

- `.pipeline/scripts/sql-host/New-SqlPassword.ps1` — PowerShell port of `derive-sql-password.sh`. Verified byte-identical output (same salt, lowercase hex digest, 22-char truncation).
- `.pipeline/scripts/sql-host/Wait-ForSqlEndpoint.ps1` — PowerShell port of `poll-for-endpoint.sh` (the bash originals need `sha256sum`/`python3`/`curl`, which the Windows ARM image does not provide). Same partial-"Rerun failed jobs" guidance and host-lifetime fail-fast.
- `.pipeline/templates/odbc-e2e-windows-remote-sql-template.yml` — steps template: derive password → poll endpoint → `run_e2e.ps1` → publish JUnit → publish teardown sentinel under `always()`.
- `validation-stages.yml` — `build_arm` host now waits on `build_arm,build_win_arm`; `Build_Windows_Arm` invokes the new template.

Notes:

- PR-only, matching the SQL host's `jobCondition`.
- No `-Coverage` on this leg: the x64 Windows leg already publishes `CoberturaCoverageOdbcE2E_Windows` and a second artifact under that name would collide. This leg exists to prove the ARM64 driver binary loads and works through the Windows Driver Manager.
- No `dependsOn` on the SQL host job, per the `sql-host-template.yml` contract.

## Related Issues

[AB#46987](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46987)

## Checklist

- [x] `cargo bfmt` passes (no Rust changes)
- [x] `cargo bclippy` passes (no Rust changes)
- [x] `cargo btest` passes (no Rust changes)
- [ ] New/changed functionality has tests — validated by the pipeline run itself
- [x] Public API changes are documented (none)