### PR TITLE
Fix CredScan false positive in version check

### DIFF
--- a/.pipeline/scripts/check-version-not-published.py
+++ b/.pipeline/scripts/check-version-not-published.py
@@ -10,9 +10,8 @@ the pipeline fail in seconds instead of building seven wheels and only hitting
 the duplicate-version rejection at ``twine upload``.
 
 The ``mssql-rs_Public`` feed allows anonymous reads, so the simple index URL is
-passed in directly (no credentials). For convenience an embedded-credential URL
-(``https://user:token@.../pypi/simple/``) is still accepted, as is a fallback to
-the ``PIP_INDEX_URL`` environment variable.
+passed in directly (no credentials). Authenticated simple index URLs are also
+accepted, as is a fallback to the ``PIP_INDEX_URL`` environment variable.
 
 Best-effort: if the feed cannot be reached or the index URL is missing, we WARN
 and exit 0. The duplicate-version rejection at upload time remains the


### PR DESCRIPTION
## Description

Remove the credential-shaped URL example from the version preflight script docstring. The script continues to accept authenticated simple-index URLs, but no longer embeds an illustrative value that triggers CSCAN-GENERAL0060.

Focused validation:
- Python syntax compilation passes.
- No credential-shaped URL user-info pattern remains in the file.
- The script's no-index fallback smoke test passes.
- `git diff --check` passes.

## Related Issues

Fixes #173

## Checklist

- [ ] `cargo bfmt` passes
- [ ] `cargo bclippy` passes
- [ ] `cargo btest` passes
- [x] New/changed functionality has tests (not applicable; documentation-only change)
- [x] Public API changes are documented (not applicable; no public API change)