### PR TITLE
Add a disabled mssql-python ODBC parity test suite

### DIFF
--- a/mssql-odbc/tests/e2e/CMakeLists.txt
+++ b/mssql-odbc/tests/e2e/CMakeLists.txt
@@ -125,3 +125,20 @@ add_odbc_test(more_results_test  tests/more_results_test.cpp)
 add_odbc_test(execute_test       tests/execute_test.cpp)
 add_odbc_test(get_type_info_test tests/get_type_info_test.cpp)
 add_odbc_test(row_count_test     tests/row_count_test.cpp)
+
+# The mssql-python parity suite binds the driver by path instead of going
+# through the Driver Manager, mirroring how mssql-python loads it. It needs no
+# odbc_test_lib and no registered driver, only MSSQL_ODBC_DLL/MSSQL_ODBC_CONNSTR.
+#
+# Every case in it is DISABLED (see the header of the .cpp): the file tracks
+# behaviour the driver does not implement yet, and cases are enabled one at a
+# time as the API work lands. It runs in CI and reports them as skipped.
+#
+# Windows-only for now: the loader uses LoadLibraryW/GetProcAddress and the
+# fixtures assume a 2-byte wchar_t for SQLWCHAR. Porting it to dlopen and an
+# explicit UTF-16 string type is tracked as future work.
+if(WIN32)
+    add_executable(mssql_python_parity_test tests/mssql_python_parity_test.cpp)
+    target_link_libraries(mssql_python_parity_test PRIVATE gtest)
+    add_test(NAME mssql_python_parity_test COMMAND mssql_python_parity_test)
+endif()

--- a/mssql-odbc/tests/e2e/README-parity.md
+++ b/mssql-odbc/tests/e2e/README-parity.md
@@ -1,0 +1,82 @@
+# mssql-python parity suite
+
+`tests/mssql_python_parity_test.cpp` is a conformance backlog for the ODBC
+surface that [mssql-python](https://github.com/microsoft/mssql-python) drives.
+
+It exists because mssql-python does **not** use a Driver Manager. It calls
+`LoadLibraryW` on `msodbcsql18.dll` and resolves the entrypoints itself, so this
+driver alone owns the entire ODBC contract — there is no Driver Manager to
+normalise arguments, sequence calls, or paper over a missing export. The suite
+loads the driver the same way, which makes it a faithful stand-in for the Python
+integration suite and far faster to run.
+
+## Every case is disabled
+
+The cases describe behaviour the driver is expected to have, ahead of the driver
+having it. They all carry the gtest `DISABLED_` prefix, so CI builds and runs the
+binary but reports them as skipped, and the build stays green.
+
+**To enable a case, drop its `DISABLED_` prefix in the same pull request that
+implements the behaviour.** Two rules:
+
+- Do not enable a case without the corresponding driver work.
+- Do not re-disable a case to make CI pass. A case that starts failing is a
+  driver regression, not a test problem.
+
+## Running it
+
+```powershell
+cmake --build build --config Release
+$env:MSSQL_ODBC_DLL  = "<repo>\target\release\msodbcsql18.dll"
+$env:MSSQL_ODBC_CONNSTR = "Server=localhost;Database=<db>;Uid=<u>;Pwd=<p>;Encrypt=no;TrustServerCertificate=yes;"
+
+# Enabled cases only (what CI does):
+.\build\mssql_python_parity_test.exe
+
+# Everything, to see where the driver actually stands:
+.\build\mssql_python_parity_test.exe --gtest_also_run_disabled_tests
+```
+
+Windows-only for now: the loader uses `LoadLibraryW`/`GetProcAddress`, and the
+fixtures assume a 2-byte `wchar_t` for `SQLWCHAR`. Porting to `dlopen` plus an
+explicit UTF-16 string type is future work; `CMakeLists.txt` guards the target
+with `if(WIN32)`.
+
+## Cases
+
+| Case | ODBC surface | Notes |
+| --- | --- | --- |
+| `AutocommitRoundTrips` | `SQLSetConnectAttr`, `SQLGetConnectAttr` | `SQL_ATTR_AUTOCOMMIT` set and read back |
+| `ManualCommitPersistsRows` | `SQLEndTran` | |
+| `ManualRollbackDiscardsRows` | `SQLEndTran` | |
+| `EndTranInAutocommitIsANoOp` | `SQLEndTran` | Must succeed, not error |
+| `BlockFetchFillsColumnWiseArrays` | `SQLBindCol`, `SQLFetchScroll` | Row stride comes from `SQL_ATTR_ROW_ARRAY_SIZE`, **not** `BufferLength`, for fixed-width C types |
+| `BlockFetchReportsNullIndicators` | `SQLBindCol` | Indicator array must receive `SQL_NULL_DATA` |
+| `FetchScrollRejectsNonForwardOrientations` | `SQLFetchScroll` | Forward-only cursor must reject, not crash |
+| `SecondCursorRunsWhileFirstIsOpen` | `SQLAllocHandle` | Two live statements on one connection |
+| `GetDataConvertsCommonTypes` | `SQLGetData` | tinyint 128–255, money precision, 100ns time ticks, ANSI code page |
+| `GetDataReportsNullAndTruncation` | `SQLGetData` | NULL with a null indicator must be `SQL_ERROR` + `22002`; truncation must be `22001` |
+| `ColAttributeReportsNameTypeAndCount` | `SQLColAttribute` | `numeric` vs `decimal`, UDT sizes, ODBC 2.x date codes |
+| `ColAttributeVariantTypeDoesNotCrash` | `SQLColAttribute` | Driver-specific field 1215 is queried on *every* column |
+| `TablesReturnsOdbcShapedResultSet` | `SQLTables` | ODBC 3 column names |
+| `ColumnsAndPrimaryKeysSucceed` | `SQLColumns`, `SQLPrimaryKeys` | |
+| `ProceduresAndStatisticsSucceed` | `SQLProcedures`, `SQLStatistics` | |
+| `BoundParametersRoundTrip` | `SQLBindParameter`, `SQLPrepare`, `SQLExecute` | |
+| `DataAtExecutionStreamsParameterInChunks` | `SQLParamData`, `SQLPutData` | `SQL_NEED_DATA` loop; token must round-trip unchanged |
+| `GetDataStreamsLobInChunks` | `SQLGetData` | Partial reads must report bytes *remaining*; final call returns `SQL_SUCCESS` |
+| `SetDescFieldOnApdSucceedsForNumeric` | `SQLSetDescField` | Precision/scale on the APD for every decimal argument |
+| `UnbindClearsPreviousBindings` | `SQLFreeStmt` | |
+| `RowCountReportsAffectedRows` | `SQLRowCount` | |
+| `MoreResultsWalksMultiStatementBatch` | `SQLMoreResults` | Also surfaces `PRINT` output and deferred errors |
+
+## Suggested order
+
+Roughly the order in which failures block each other:
+
+1. Exports resolve at all — a missing symbol fails `LoadLibrary` binding and every case skips.
+2. `BlockFetch*` — a wrong row stride corrupts memory and makes every later result unreliable.
+3. `GetDataReportsNullAndTruncation` — silently returning success for NULL yields garbage values rather than errors.
+4. `GetDataConvertsCommonTypes` — remaining silent-corruption conversions.
+5. `DataAtExecution*`, `BoundParametersRoundTrip`, `SetDescFieldOnApd*` — parameter binding.
+6. Catalog cases.
+7. `MoreResultsWalksMultiStatementBatch` and diagnostics.

--- a/mssql-odbc/tests/e2e/tests/mssql_python_parity_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/mssql_python_parity_test.cpp
@@ -1,0 +1,908 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// mssql_python_parity_test.cpp
+//
+// Single-file GoogleTest suite covering the ODBC surface that mssql-python
+// drives directly. mssql-python does not go through a Driver Manager: it
+// LoadLibrary's the driver and calls the exported entrypoints itself, so the
+// contract exercised here is exactly the set of calls its pybind layer makes
+// (ddbc_bindings.cpp). Every case below maps to a behaviour the Python suite
+// depends on, which makes this file the fast regression gate for the
+// mssql-python parity work.
+//
+// The suite is deliberately self-contained: it binds the driver by path
+// (MSSQL_ODBC_DLL, defaulting to msodbcsql18.dll next to the binary) instead of
+// linking odbc32.lib, so it exercises the same load path as mssql-python and
+// needs no Driver Manager registration.
+//
+// Configure with MSSQL_ODBC_DLL and MSSQL_ODBC_CONNSTR.
+//
+// ---------------------------------------------------------------------------
+// EVERY CASE HERE IS DISABLED.
+//
+// This file is a conformance backlog: it describes the behaviour the driver is
+// expected to have, ahead of the driver having it. Cases carry the gtest
+// DISABLED_ prefix so the suite reports them as skipped and CI stays green.
+//
+// To enable one, drop the DISABLED_ prefix from its name in the same pull
+// request that implements the behaviour. Do not enable a case without the
+// corresponding driver work, and do not re-disable a case to make CI pass --
+// a case that regresses is a driver regression.
+//
+// Run the disabled cases locally to see where the driver stands:
+//
+//     mssql_python_parity_test --gtest_also_run_disabled_tests
+//
+// See README-parity.md for the current status of each case.
+// ---------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <windows.h>
+
+#include <sql.h>
+#include <sqlext.h>
+#include <sqltypes.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+/// mssql-python asks for SQL_CA_SS_VARIANT_TYPE on every column of a result
+/// set to detect sql_variant; the value is a SQL Server driver-specific field.
+constexpr SQLUSMALLINT kSqlCaSsVariantType = 1215;
+
+using SqlTString = std::wstring;
+
+std::wstring ToWide(const std::string& s) {
+    return std::wstring(s.begin(), s.end());
+}
+
+std::string GetEnvOr(const char* name, const char* fallback) {
+    char* buf = nullptr;
+    size_t len = 0;
+    if (_dupenv_s(&buf, &len, name) == 0 && buf != nullptr) {
+        std::string value(buf);
+        free(buf);
+        if (!value.empty()) {
+            return value;
+        }
+    }
+    return fallback;
+}
+
+// ---------------------------------------------------------------------------
+// Driver binding
+//
+// mssql-python resolves each entrypoint by name from the loaded module. The
+// table below mirrors that, so a missing export shows up here as a load
+// failure rather than as an opaque Python traceback.
+// ---------------------------------------------------------------------------
+
+struct DriverApi {
+    HMODULE module = nullptr;
+
+    SQLRETURN(SQL_API* AllocHandle)(SQLSMALLINT, SQLHANDLE, SQLHANDLE*) = nullptr;
+    SQLRETURN(SQL_API* FreeHandle)(SQLSMALLINT, SQLHANDLE) = nullptr;
+    SQLRETURN(SQL_API* SetEnvAttr)(SQLHENV, SQLINTEGER, SQLPOINTER, SQLINTEGER) = nullptr;
+    SQLRETURN(SQL_API* DriverConnect)(SQLHDBC, SQLHWND, SQLWCHAR*, SQLSMALLINT, SQLWCHAR*,
+                                      SQLSMALLINT, SQLSMALLINT*, SQLUSMALLINT) = nullptr;
+    SQLRETURN(SQL_API* Disconnect)(SQLHDBC) = nullptr;
+    SQLRETURN(SQL_API* GetDiagRec)(SQLSMALLINT, SQLHANDLE, SQLSMALLINT, SQLWCHAR*, SQLINTEGER*,
+                                   SQLWCHAR*, SQLSMALLINT, SQLSMALLINT*) = nullptr;
+
+    SQLRETURN(SQL_API* SetConnectAttr)(SQLHDBC, SQLINTEGER, SQLPOINTER, SQLINTEGER) = nullptr;
+    SQLRETURN(SQL_API* GetConnectAttr)(SQLHDBC, SQLINTEGER, SQLPOINTER, SQLINTEGER,
+                                       SQLINTEGER*) = nullptr;
+    SQLRETURN(SQL_API* EndTran)(SQLSMALLINT, SQLHANDLE, SQLSMALLINT) = nullptr;
+
+    SQLRETURN(SQL_API* ExecDirect)(SQLHSTMT, SQLWCHAR*, SQLINTEGER) = nullptr;
+    SQLRETURN(SQL_API* Prepare)(SQLHSTMT, SQLWCHAR*, SQLINTEGER) = nullptr;
+    SQLRETURN(SQL_API* Execute)(SQLHSTMT) = nullptr;
+    SQLRETURN(SQL_API* Fetch)(SQLHSTMT) = nullptr;
+    SQLRETURN(SQL_API* FetchScroll)(SQLHSTMT, SQLSMALLINT, SQLLEN) = nullptr;
+    SQLRETURN(SQL_API* GetData)(SQLHSTMT, SQLUSMALLINT, SQLSMALLINT, SQLPOINTER, SQLLEN,
+                                SQLLEN*) = nullptr;
+    SQLRETURN(SQL_API* BindCol)(SQLHSTMT, SQLUSMALLINT, SQLSMALLINT, SQLPOINTER, SQLLEN,
+                                SQLLEN*) = nullptr;
+    SQLRETURN(SQL_API* BindParameter)(SQLHSTMT, SQLUSMALLINT, SQLSMALLINT, SQLSMALLINT, SQLSMALLINT,
+                                      SQLULEN, SQLSMALLINT, SQLPOINTER, SQLLEN, SQLLEN*) = nullptr;
+    SQLRETURN(SQL_API* NumResultCols)(SQLHSTMT, SQLSMALLINT*) = nullptr;
+    SQLRETURN(SQL_API* RowCount)(SQLHSTMT, SQLLEN*) = nullptr;
+    SQLRETURN(SQL_API* MoreResults)(SQLHSTMT) = nullptr;
+    SQLRETURN(SQL_API* FreeStmt)(SQLHSTMT, SQLUSMALLINT) = nullptr;
+    SQLRETURN(SQL_API* SetStmtAttr)(SQLHSTMT, SQLINTEGER, SQLPOINTER, SQLINTEGER) = nullptr;
+    SQLRETURN(SQL_API* GetStmtAttr)(SQLHSTMT, SQLINTEGER, SQLPOINTER, SQLINTEGER,
+                                    SQLINTEGER*) = nullptr;
+    SQLRETURN(SQL_API* SetDescField)(SQLHDESC, SQLSMALLINT, SQLSMALLINT, SQLPOINTER,
+                                     SQLINTEGER) = nullptr;
+    SQLRETURN(SQL_API* ColAttribute)(SQLHSTMT, SQLUSMALLINT, SQLUSMALLINT, SQLPOINTER, SQLSMALLINT,
+                                     SQLSMALLINT*, SQLLEN*) = nullptr;
+
+    SQLRETURN(SQL_API* Tables)(SQLHSTMT, SQLWCHAR*, SQLSMALLINT, SQLWCHAR*, SQLSMALLINT, SQLWCHAR*,
+                               SQLSMALLINT, SQLWCHAR*, SQLSMALLINT) = nullptr;
+    SQLRETURN(SQL_API* Columns)(SQLHSTMT, SQLWCHAR*, SQLSMALLINT, SQLWCHAR*, SQLSMALLINT, SQLWCHAR*,
+                                SQLSMALLINT, SQLWCHAR*, SQLSMALLINT) = nullptr;
+    SQLRETURN(SQL_API* PrimaryKeys)(SQLHSTMT, SQLWCHAR*, SQLSMALLINT, SQLWCHAR*, SQLSMALLINT,
+                                    SQLWCHAR*, SQLSMALLINT) = nullptr;
+    SQLRETURN(SQL_API* Procedures)(SQLHSTMT, SQLWCHAR*, SQLSMALLINT, SQLWCHAR*, SQLSMALLINT,
+                                   SQLWCHAR*, SQLSMALLINT) = nullptr;
+    SQLRETURN(SQL_API* Statistics)(SQLHSTMT, SQLWCHAR*, SQLSMALLINT, SQLWCHAR*, SQLSMALLINT,
+                                   SQLWCHAR*, SQLSMALLINT, SQLUSMALLINT, SQLUSMALLINT) = nullptr;
+
+    SQLRETURN(SQL_API* ParamData)(SQLHSTMT, SQLPOINTER*) = nullptr;
+    SQLRETURN(SQL_API* PutData)(SQLHSTMT, SQLPOINTER, SQLLEN) = nullptr;
+    SQLRETURN(SQL_API* DescribeParam)(SQLHSTMT, SQLUSMALLINT, SQLSMALLINT*, SQLULEN*, SQLSMALLINT*,
+                                      SQLSMALLINT*) = nullptr;
+
+    std::string load_error;
+};
+
+DriverApi& Api() {
+    static DriverApi api;
+    return api;
+}
+
+template <typename Fn>
+bool Bind(HMODULE module, const char* name, Fn& slot, std::string& error) {
+    auto proc = GetProcAddress(module, name);
+    if (proc == nullptr) {
+        if (error.empty()) {
+            error = "missing export: ";
+            error += name;
+        }
+        return false;
+    }
+    slot = reinterpret_cast<Fn>(proc);
+    return true;
+}
+
+bool LoadDriver(DriverApi& api) {
+    const std::string path = GetEnvOr("MSSQL_ODBC_DLL", "msodbcsql18.dll");
+    api.module = LoadLibraryA(path.c_str());
+    if (api.module == nullptr) {
+        api.load_error = "LoadLibrary failed for " + path + " (error " +
+                         std::to_string(static_cast<unsigned long>(GetLastError())) + ")";
+        return false;
+    }
+
+    std::string& err = api.load_error;
+    bool ok = true;
+    ok &= Bind(api.module, "SQLAllocHandle", api.AllocHandle, err);
+    ok &= Bind(api.module, "SQLFreeHandle", api.FreeHandle, err);
+    ok &= Bind(api.module, "SQLSetEnvAttr", api.SetEnvAttr, err);
+    ok &= Bind(api.module, "SQLDriverConnectW", api.DriverConnect, err);
+    ok &= Bind(api.module, "SQLDisconnect", api.Disconnect, err);
+    ok &= Bind(api.module, "SQLGetDiagRecW", api.GetDiagRec, err);
+    ok &= Bind(api.module, "SQLSetConnectAttrW", api.SetConnectAttr, err);
+    ok &= Bind(api.module, "SQLGetConnectAttrW", api.GetConnectAttr, err);
+    ok &= Bind(api.module, "SQLEndTran", api.EndTran, err);
+    ok &= Bind(api.module, "SQLExecDirectW", api.ExecDirect, err);
+    ok &= Bind(api.module, "SQLPrepareW", api.Prepare, err);
+    ok &= Bind(api.module, "SQLExecute", api.Execute, err);
+    ok &= Bind(api.module, "SQLFetch", api.Fetch, err);
+    ok &= Bind(api.module, "SQLFetchScroll", api.FetchScroll, err);
+    ok &= Bind(api.module, "SQLGetData", api.GetData, err);
+    ok &= Bind(api.module, "SQLBindCol", api.BindCol, err);
+    ok &= Bind(api.module, "SQLBindParameter", api.BindParameter, err);
+    ok &= Bind(api.module, "SQLNumResultCols", api.NumResultCols, err);
+    ok &= Bind(api.module, "SQLRowCount", api.RowCount, err);
+    ok &= Bind(api.module, "SQLMoreResults", api.MoreResults, err);
+    ok &= Bind(api.module, "SQLFreeStmt", api.FreeStmt, err);
+    ok &= Bind(api.module, "SQLSetStmtAttrW", api.SetStmtAttr, err);
+    ok &= Bind(api.module, "SQLGetStmtAttrW", api.GetStmtAttr, err);
+    ok &= Bind(api.module, "SQLSetDescFieldW", api.SetDescField, err);
+    ok &= Bind(api.module, "SQLColAttributeW", api.ColAttribute, err);
+    ok &= Bind(api.module, "SQLTablesW", api.Tables, err);
+    ok &= Bind(api.module, "SQLColumnsW", api.Columns, err);
+    ok &= Bind(api.module, "SQLPrimaryKeysW", api.PrimaryKeys, err);
+    ok &= Bind(api.module, "SQLProceduresW", api.Procedures, err);
+    ok &= Bind(api.module, "SQLStatisticsW", api.Statistics, err);
+    ok &= Bind(api.module, "SQLParamData", api.ParamData, err);
+    ok &= Bind(api.module, "SQLPutData", api.PutData, err);
+    ok &= Bind(api.module, "SQLDescribeParam", api.DescribeParam, err);
+    return ok;
+}
+
+// The tests below are written against the plain ODBC names; route them at the
+// loaded module so the file stays readable while bypassing the Driver Manager.
+#define SQLAllocHandle       Api().AllocHandle
+#define SQLFreeHandle        Api().FreeHandle
+#define SQLSetEnvAttr        Api().SetEnvAttr
+#define SQLDriverConnectW    Api().DriverConnect
+#define SQLDisconnect        Api().Disconnect
+#define SQLGetDiagRecW       Api().GetDiagRec
+#undef SQLSetConnectAttr
+#define SQLSetConnectAttr    Api().SetConnectAttr
+#define SQLGetConnectAttrW   Api().GetConnectAttr
+#define SQLEndTran           Api().EndTran
+#define SQLExecDirectW       Api().ExecDirect
+#define SQLPrepareW          Api().Prepare
+#define SQLExecute           Api().Execute
+#define SQLFetch             Api().Fetch
+#define SQLFetchScroll       Api().FetchScroll
+#define SQLGetData           Api().GetData
+#define SQLBindCol           Api().BindCol
+#define SQLBindParameter     Api().BindParameter
+#define SQLNumResultCols     Api().NumResultCols
+#define SQLRowCount          Api().RowCount
+#define SQLMoreResults       Api().MoreResults
+#define SQLFreeStmt          Api().FreeStmt
+#undef SQLSetStmtAttr
+#define SQLSetStmtAttr       Api().SetStmtAttr
+#undef SQLGetStmtAttr
+#define SQLGetStmtAttr       Api().GetStmtAttr
+#define SQLSetDescFieldW     Api().SetDescField
+#define SQLColAttributeW     Api().ColAttribute
+#define SQLTablesW           Api().Tables
+#define SQLColumnsW          Api().Columns
+#define SQLPrimaryKeysW      Api().PrimaryKeys
+#define SQLProceduresW       Api().Procedures
+#define SQLStatisticsW       Api().Statistics
+#define SQLParamData         Api().ParamData
+#define SQLPutData           Api().PutData
+#define SQLDescribeParam     Api().DescribeParam
+
+std::wstring DiagField(SQLSMALLINT handle_type, SQLHANDLE handle, bool want_state) {
+    SQLWCHAR state[6] = {};
+    SQLWCHAR message[1024] = {};
+    SQLINTEGER native = 0;
+    SQLSMALLINT length = 0;
+    if (!SQL_SUCCEEDED(SQLGetDiagRecW(handle_type, handle, 1, state, &native, message,
+                                      static_cast<SQLSMALLINT>(std::size(message)), &length))) {
+        return L"";
+    }
+    return want_state ? std::wstring(state) : std::wstring(message);
+}
+
+std::string Narrow(const std::wstring& value) {
+    return std::string(value.begin(), value.end());
+}
+
+std::string DiagMessage(SQLSMALLINT handle_type, SQLHANDLE handle) {
+    return "[" + Narrow(DiagField(handle_type, handle, true)) + "] " +
+           Narrow(DiagField(handle_type, handle, false));
+}
+
+std::string DiagState(SQLSMALLINT handle_type, SQLHANDLE handle) {
+    return Narrow(DiagField(handle_type, handle, true));
+}
+
+#define ASSERT_SQL_OK(rc, handle_type, handle)                                                     \
+    do {                                                                                           \
+        SQLRETURN _rc = (rc);                                                                      \
+        ASSERT_TRUE(SQL_SUCCEEDED(_rc)) << "rc=" << _rc << " " << DiagMessage(handle_type, handle); \
+    } while (0)
+
+#define EXPECT_SQL_OK(rc, handle_type, handle)                                                     \
+    do {                                                                                           \
+        SQLRETURN _rc = (rc);                                                                      \
+        EXPECT_TRUE(SQL_SUCCEEDED(_rc)) << "rc=" << _rc << " " << DiagMessage(handle_type, handle); \
+    } while (0)
+
+#define EXPECT_SQLSTATE(handle_type, handle, expected_state)                                       \
+    EXPECT_EQ(std::string(expected_state), DiagState(handle_type, handle))
+
+/// Compatibility shim so the test bodies keep the shared-fixture spelling.
+struct ODBCTestUtils {
+    static SqlTString ToSqlTStr(const std::string& s) { return ToWide(s); }
+    static std::string ToNarrow(const SqlTString& s) { return Narrow(s); }
+};
+
+/// Fixture that connects once per test and exposes helpers for the
+/// mssql-python call patterns.
+class PythonParityTest : public ::testing::Test {
+protected:
+    SQLHENV env_ = nullptr;
+    SQLHDBC dbc_ = nullptr;
+    SQLHSTMT stmt_ = nullptr;
+
+    void SetUp() override {
+        if (Api().module == nullptr) {
+            GTEST_SKIP() << "driver not loaded: " << Api().load_error;
+        }
+        const std::string conn = GetEnvOr("MSSQL_ODBC_CONNSTR", "");
+        if (conn.empty()) {
+            GTEST_SKIP() << "set MSSQL_ODBC_CONNSTR to run parity tests";
+        }
+
+        ASSERT_SQL_OK(SQLAllocHandle(SQL_HANDLE_ENV, nullptr, &env_), SQL_HANDLE_ENV, env_);
+        ASSERT_SQL_OK(SQLSetEnvAttr(env_, SQL_ATTR_ODBC_VERSION,
+                                    reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0),
+                      SQL_HANDLE_ENV, env_);
+        ASSERT_SQL_OK(SQLAllocHandle(SQL_HANDLE_DBC, env_, &dbc_), SQL_HANDLE_ENV, env_);
+
+        std::wstring wide = ToWide(conn);
+        ASSERT_SQL_OK(SQLDriverConnectW(dbc_, nullptr, wide.data(),
+                                        static_cast<SQLSMALLINT>(wide.size()), nullptr, 0, nullptr,
+                                        SQL_DRIVER_NOPROMPT),
+                      SQL_HANDLE_DBC, dbc_);
+        ASSERT_SQL_OK(SQLAllocHandle(SQL_HANDLE_STMT, dbc_, &stmt_), SQL_HANDLE_DBC, dbc_);
+    }
+
+    void TearDown() override {
+        if (stmt_ != nullptr) {
+            SQLFreeHandle(SQL_HANDLE_STMT, stmt_);
+        }
+        if (dbc_ != nullptr) {
+            SQLDisconnect(dbc_);
+            SQLFreeHandle(SQL_HANDLE_DBC, dbc_);
+        }
+        if (env_ != nullptr) {
+            SQLFreeHandle(SQL_HANDLE_ENV, env_);
+        }
+    }
+
+    /// Runs |sql| on |hstmt| and asserts it succeeded.
+    void Exec(SQLHSTMT hstmt, const std::string& sql) {
+        std::wstring text = ToWide(sql);
+        ASSERT_SQL_OK(SQLExecDirectW(hstmt, text.data(), SQL_NTS), SQL_HANDLE_STMT, hstmt);
+    }
+
+    /// Runs |sql| and swallows failures; used for best-effort cleanup.
+    void ExecDirectIgnoreError(const std::string& sql) {
+        std::wstring text = ToWide(sql);
+        SQLExecDirectW(stmt_, text.data(), SQL_NTS);
+        SQLFreeStmt(stmt_, SQL_CLOSE);
+    }
+
+    /// Allocates an extra statement on the same connection.
+    SQLHSTMT AllocStmt() {
+        SQLHSTMT handle = nullptr;
+        EXPECT_SQL_OK(SQLAllocHandle(SQL_HANDLE_STMT, dbc_, &handle), SQL_HANDLE_DBC, dbc_);
+        return handle;
+    }
+
+    void FreeStmt(SQLHSTMT handle) { SQLFreeHandle(SQL_HANDLE_STMT, handle); }
+
+    /// Fetches a single SQL_C_SLONG column from a one-row query.
+    SQLINTEGER ScalarLong(const std::string& sql) {
+        Exec(stmt_, sql);
+        EXPECT_EQ(SQL_SUCCESS, SQLFetch(stmt_));
+        SQLINTEGER value = 0;
+        SQLLEN indicator = 0;
+        EXPECT_SQL_OK(SQLGetData(stmt_, 1, SQL_C_SLONG, &value, sizeof(value), &indicator),
+                      SQL_HANDLE_STMT, stmt_);
+        SQLFreeStmt(stmt_, SQL_CLOSE);
+        return value;
+    }
+};
+
+
+// ---------------------------------------------------------------------------
+// Connection attributes and transactions
+//
+// mssql-python calls SQLSetConnectAttr(SQL_ATTR_AUTOCOMMIT) immediately after
+// connecting and raises if it fails, then drives commit/rollback exclusively
+// through SQLEndTran. A failure in any of these aborts every Python test.
+// ---------------------------------------------------------------------------
+
+TEST_F(PythonParityTest, DISABLED_AutocommitRoundTrips) {
+    ASSERT_SQL_OK(SQLSetConnectAttr(dbc_, SQL_ATTR_AUTOCOMMIT,
+                                    reinterpret_cast<SQLPOINTER>(SQL_AUTOCOMMIT_OFF), 0),
+                  SQL_HANDLE_DBC, dbc_);
+
+    SQLUINTEGER value = 0xFFFF;
+    SQLINTEGER length = 0;
+    ASSERT_SQL_OK(SQLGetConnectAttrW(dbc_, SQL_ATTR_AUTOCOMMIT, &value, sizeof(value), &length),
+                  SQL_HANDLE_DBC, dbc_);
+    EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_AUTOCOMMIT_OFF), value);
+
+    ASSERT_SQL_OK(SQLSetConnectAttr(dbc_, SQL_ATTR_AUTOCOMMIT,
+                                    reinterpret_cast<SQLPOINTER>(SQL_AUTOCOMMIT_ON), 0),
+                  SQL_HANDLE_DBC, dbc_);
+    ASSERT_SQL_OK(SQLGetConnectAttrW(dbc_, SQL_ATTR_AUTOCOMMIT, &value, sizeof(value), &length),
+                  SQL_HANDLE_DBC, dbc_);
+    EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_AUTOCOMMIT_ON), value);
+}
+
+TEST_F(PythonParityTest, DISABLED_ManualCommitPersistsRows) {
+    ExecDirectIgnoreError("DROP TABLE IF EXISTS #parity_commit");
+    Exec(stmt_, "CREATE TABLE #parity_commit (id INT)");
+
+    ASSERT_SQL_OK(SQLSetConnectAttr(dbc_, SQL_ATTR_AUTOCOMMIT,
+                                    reinterpret_cast<SQLPOINTER>(SQL_AUTOCOMMIT_OFF), 0),
+                  SQL_HANDLE_DBC, dbc_);
+    Exec(stmt_, "INSERT INTO #parity_commit VALUES (1)");
+    ASSERT_SQL_OK(SQLEndTran(SQL_HANDLE_DBC, dbc_, SQL_COMMIT), SQL_HANDLE_DBC, dbc_);
+
+    EXPECT_EQ(1, ScalarLong("SELECT COUNT(*) FROM #parity_commit"));
+    SQLSetConnectAttr(dbc_, SQL_ATTR_AUTOCOMMIT, reinterpret_cast<SQLPOINTER>(SQL_AUTOCOMMIT_ON), 0);
+}
+
+TEST_F(PythonParityTest, DISABLED_ManualRollbackDiscardsRows) {
+    ExecDirectIgnoreError("DROP TABLE IF EXISTS #parity_rollback");
+    Exec(stmt_, "CREATE TABLE #parity_rollback (id INT)");
+
+    ASSERT_SQL_OK(SQLSetConnectAttr(dbc_, SQL_ATTR_AUTOCOMMIT,
+                                    reinterpret_cast<SQLPOINTER>(SQL_AUTOCOMMIT_OFF), 0),
+                  SQL_HANDLE_DBC, dbc_);
+    Exec(stmt_, "INSERT INTO #parity_rollback VALUES (1)");
+    ASSERT_SQL_OK(SQLEndTran(SQL_HANDLE_DBC, dbc_, SQL_ROLLBACK), SQL_HANDLE_DBC, dbc_);
+
+    EXPECT_EQ(0, ScalarLong("SELECT COUNT(*) FROM #parity_rollback"));
+    SQLSetConnectAttr(dbc_, SQL_ATTR_AUTOCOMMIT, reinterpret_cast<SQLPOINTER>(SQL_AUTOCOMMIT_ON), 0);
+}
+
+TEST_F(PythonParityTest, DISABLED_EndTranInAutocommitIsANoOp) {
+    // Python's Connection.commit() is unconditional, so committing while
+    // autocommit is on must succeed instead of raising 25000.
+    EXPECT_SQL_OK(SQLEndTran(SQL_HANDLE_DBC, dbc_, SQL_COMMIT), SQL_HANDLE_DBC, dbc_);
+    EXPECT_SQL_OK(SQLEndTran(SQL_HANDLE_DBC, dbc_, SQL_ROLLBACK), SQL_HANDLE_DBC, dbc_);
+}
+
+// ---------------------------------------------------------------------------
+// Block fetch — the fetchmany()/fetchall() hot path
+//
+// FetchBatchData() unbinds, binds every column column-wise with an array of
+// |fetchSize| elements, then calls SQLFetchScroll(SQL_FETCH_NEXT, 0) and reads
+// SQL_ATTR_ROWS_FETCHED_PTR. Column-wise offsets and the indicator array are
+// the parts most likely to regress.
+// ---------------------------------------------------------------------------
+
+TEST_F(PythonParityTest, DISABLED_BlockFetchFillsColumnWiseArrays) {
+    constexpr SQLULEN kRowsetSize = 4;
+
+    ASSERT_SQL_OK(SQLSetStmtAttr(stmt_, SQL_ATTR_ROW_ARRAY_SIZE,
+                                 reinterpret_cast<SQLPOINTER>(kRowsetSize), 0),
+                  SQL_HANDLE_STMT, stmt_);
+    SQLULEN rows_fetched = 0;
+    ASSERT_SQL_OK(SQLSetStmtAttr(stmt_, SQL_ATTR_ROWS_FETCHED_PTR, &rows_fetched, 0),
+                  SQL_HANDLE_STMT, stmt_);
+
+    Exec(stmt_,
+         "SELECT v, CAST(v AS VARCHAR(16)) AS t FROM (VALUES (10),(20),(30)) AS s(v) ORDER BY v");
+
+    SQLINTEGER ints[kRowsetSize] = {};
+    SQLLEN int_ind[kRowsetSize] = {};
+    SQLWCHAR text[kRowsetSize][32] = {};
+    SQLLEN text_ind[kRowsetSize] = {};
+
+    ASSERT_SQL_OK(SQLFreeStmt(stmt_, SQL_UNBIND), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLBindCol(stmt_, 1, SQL_C_SLONG, ints, sizeof(SQLINTEGER), int_ind),
+                  SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLBindCol(stmt_, 2, SQL_C_WCHAR, text, sizeof(text[0]), text_ind),
+                  SQL_HANDLE_STMT, stmt_);
+
+    ASSERT_TRUE(SQL_SUCCEEDED(SQLFetchScroll(stmt_, SQL_FETCH_NEXT, 0)));
+    ASSERT_EQ(3u, rows_fetched);
+    EXPECT_EQ(10, ints[0]);
+    EXPECT_EQ(20, ints[1]);
+    EXPECT_EQ(30, ints[2]);
+    EXPECT_EQ(static_cast<SQLLEN>(sizeof(SQLINTEGER)), int_ind[0]);
+    EXPECT_EQ(std::string("10"), ODBCTestUtils::ToNarrow(SqlTString(
+                                     reinterpret_cast<const SQLTCHAR*>(text[0]))));
+    EXPECT_EQ(std::string("30"), ODBCTestUtils::ToNarrow(SqlTString(
+                                     reinterpret_cast<const SQLTCHAR*>(text[2]))));
+
+    EXPECT_EQ(SQL_NO_DATA, SQLFetchScroll(stmt_, SQL_FETCH_NEXT, 0));
+}
+
+TEST_F(PythonParityTest, DISABLED_BlockFetchReportsNullIndicators) {
+    constexpr SQLULEN kRowsetSize = 2;
+    ASSERT_SQL_OK(SQLSetStmtAttr(stmt_, SQL_ATTR_ROW_ARRAY_SIZE,
+                                 reinterpret_cast<SQLPOINTER>(kRowsetSize), 0),
+                  SQL_HANDLE_STMT, stmt_);
+    SQLULEN rows_fetched = 0;
+    ASSERT_SQL_OK(SQLSetStmtAttr(stmt_, SQL_ATTR_ROWS_FETCHED_PTR, &rows_fetched, 0),
+                  SQL_HANDLE_STMT, stmt_);
+
+    Exec(stmt_, "SELECT CAST(NULL AS INT) UNION ALL SELECT 7");
+
+    SQLINTEGER values[kRowsetSize] = {};
+    SQLLEN indicators[kRowsetSize] = {};
+    ASSERT_SQL_OK(SQLFreeStmt(stmt_, SQL_UNBIND), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLBindCol(stmt_, 1, SQL_C_SLONG, values, sizeof(SQLINTEGER), indicators),
+                  SQL_HANDLE_STMT, stmt_);
+
+    ASSERT_TRUE(SQL_SUCCEEDED(SQLFetchScroll(stmt_, SQL_FETCH_NEXT, 0)));
+    ASSERT_EQ(2u, rows_fetched);
+    EXPECT_EQ(SQL_NULL_DATA, indicators[0]);
+    EXPECT_EQ(7, values[1]);
+}
+
+TEST_F(PythonParityTest, DISABLED_FetchScrollRejectsNonForwardOrientations) {
+    Exec(stmt_, "SELECT 1");
+    EXPECT_EQ(SQL_ERROR, SQLFetchScroll(stmt_, SQL_FETCH_PRIOR, 0));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "HY106");
+}
+
+// ---------------------------------------------------------------------------
+// Interleaved cursors on one connection
+//
+// Connection.cursor() allocates another HSTMT on the same HDBC. Without MARS
+// the driver must still serve the second statement once the first result set
+// is buffered, and the first cursor's remaining rows must survive.
+// ---------------------------------------------------------------------------
+
+TEST_F(PythonParityTest, DISABLED_SecondCursorRunsWhileFirstIsOpen) {
+    Exec(stmt_, "SELECT 1 AS n UNION ALL SELECT 2 ORDER BY n");
+    ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt_));
+
+    SQLINTEGER first = 0;
+    SQLLEN ind = 0;
+    ASSERT_SQL_OK(SQLGetData(stmt_, 1, SQL_C_SLONG, &first, sizeof(first), &ind), SQL_HANDLE_STMT,
+                  stmt_);
+    EXPECT_EQ(1, first);
+
+    SQLHSTMT other = AllocStmt();
+    Exec(other, "SELECT 42");
+    ASSERT_EQ(SQL_SUCCESS, SQLFetch(other));
+    SQLINTEGER answer = 0;
+    ASSERT_SQL_OK(SQLGetData(other, 1, SQL_C_SLONG, &answer, sizeof(answer), &ind), SQL_HANDLE_STMT,
+                  other);
+    EXPECT_EQ(42, answer);
+    FreeStmt(other);
+
+    // The first cursor keeps its position across the interleaved statement.
+    ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt_));
+    SQLINTEGER second = 0;
+    ASSERT_SQL_OK(SQLGetData(stmt_, 1, SQL_C_SLONG, &second, sizeof(second), &ind), SQL_HANDLE_STMT,
+                  stmt_);
+    EXPECT_EQ(2, second);
+}
+
+// ---------------------------------------------------------------------------
+// SQLGetData conversions
+//
+// Python materializes every cell through SQLGetData with the C type chosen
+// from the column's SQL type, so the conversion matrix is load-bearing for the
+// whole data-type test module.
+// ---------------------------------------------------------------------------
+
+TEST_F(PythonParityTest, DISABLED_GetDataConvertsCommonTypes) {
+    Exec(stmt_,
+         "SELECT CAST('abc' AS NVARCHAR(10)), CAST(1.5 AS FLOAT), CAST(3 AS BIGINT), "
+         "CAST('2024-02-29' AS DATE), CAST(1 AS BIT)");
+    ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt_));
+
+    SQLWCHAR text[32] = {};
+    SQLLEN ind = 0;
+    ASSERT_SQL_OK(SQLGetData(stmt_, 1, SQL_C_WCHAR, text, sizeof(text), &ind), SQL_HANDLE_STMT,
+                  stmt_);
+    EXPECT_EQ(std::string("abc"),
+              ODBCTestUtils::ToNarrow(SqlTString(reinterpret_cast<const SQLTCHAR*>(text))));
+
+    double real = 0.0;
+    ASSERT_SQL_OK(SQLGetData(stmt_, 2, SQL_C_DOUBLE, &real, sizeof(real), &ind), SQL_HANDLE_STMT,
+                  stmt_);
+    EXPECT_DOUBLE_EQ(1.5, real);
+
+    SQLBIGINT big = 0;
+    ASSERT_SQL_OK(SQLGetData(stmt_, 3, SQL_C_SBIGINT, &big, sizeof(big), &ind), SQL_HANDLE_STMT,
+                  stmt_);
+    EXPECT_EQ(3, big);
+
+    SQL_DATE_STRUCT date{};
+    ASSERT_SQL_OK(SQLGetData(stmt_, 4, SQL_C_TYPE_DATE, &date, sizeof(date), &ind), SQL_HANDLE_STMT,
+                  stmt_);
+    EXPECT_EQ(2024, date.year);
+    EXPECT_EQ(2, date.month);
+    EXPECT_EQ(29, date.day);
+
+    unsigned char bit = 0;
+    ASSERT_SQL_OK(SQLGetData(stmt_, 5, SQL_C_BIT, &bit, sizeof(bit), &ind), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(1, bit);
+}
+
+TEST_F(PythonParityTest, DISABLED_GetDataReportsNullAndTruncation) {
+    Exec(stmt_, "SELECT CAST(NULL AS INT), CAST('abcdef' AS VARCHAR(10))");
+    ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt_));
+
+    SQLINTEGER value = 123;
+    SQLLEN ind = 0;
+    ASSERT_SQL_OK(SQLGetData(stmt_, 1, SQL_C_SLONG, &value, sizeof(value), &ind), SQL_HANDLE_STMT,
+                  stmt_);
+    EXPECT_EQ(SQL_NULL_DATA, ind);
+
+    SQLCHAR tiny_buf[4] = {};
+    EXPECT_EQ(SQL_SUCCESS_WITH_INFO, SQLGetData(stmt_, 2, SQL_C_CHAR, tiny_buf, sizeof(tiny_buf), &ind));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "01004");
+}
+
+// ---------------------------------------------------------------------------
+// SQLColAttributeW
+//
+// Python queries SQL_CA_SS_VARIANT_TYPE per column and falls back to None when
+// it fails; it also relies on the standard descriptor fields for cursor
+// metadata.
+// ---------------------------------------------------------------------------
+
+TEST_F(PythonParityTest, DISABLED_ColAttributeReportsNameTypeAndCount) {
+    Exec(stmt_, "SELECT CAST(1 AS INT) AS answer");
+
+    SQLLEN numeric = 0;
+    ASSERT_SQL_OK(SQLColAttributeW(stmt_, 0, SQL_DESC_COUNT, nullptr, 0, nullptr, &numeric),
+                  SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(1, numeric);
+
+    SQLWCHAR name[64] = {};
+    SQLSMALLINT name_len = 0;
+    ASSERT_SQL_OK(
+        SQLColAttributeW(stmt_, 1, SQL_DESC_NAME, name, sizeof(name), &name_len, nullptr),
+        SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(std::string("answer"),
+              ODBCTestUtils::ToNarrow(SqlTString(reinterpret_cast<const SQLTCHAR*>(name))));
+
+    ASSERT_SQL_OK(SQLColAttributeW(stmt_, 1, SQL_DESC_CONCISE_TYPE, nullptr, 0, nullptr, &numeric),
+                  SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(SQL_INTEGER, numeric);
+}
+
+TEST_F(PythonParityTest, DISABLED_ColAttributeVariantTypeDoesNotCrash) {
+    Exec(stmt_, "SELECT CAST(1 AS INT)");
+    SQLLEN numeric = 0;
+    // Either answer is acceptable — Python treats a failure as "not a variant" —
+    // but the call must not fault or leave the statement unusable.
+    SQLColAttributeW(stmt_, 1, kSqlCaSsVariantType, nullptr, 0, nullptr, &numeric);
+    EXPECT_EQ(SQL_SUCCESS, SQLFetch(stmt_));
+}
+
+// ---------------------------------------------------------------------------
+// Catalog functions
+//
+// Cursor.tables()/columns()/primaryKeys()/... map one-to-one onto these calls
+// and assert on the ODBC-defined column layout.
+// ---------------------------------------------------------------------------
+
+TEST_F(PythonParityTest, DISABLED_TablesReturnsOdbcShapedResultSet) {
+    ExecDirectIgnoreError("DROP TABLE dbo.parity_catalog");
+    Exec(stmt_, "CREATE TABLE dbo.parity_catalog (id INT NOT NULL PRIMARY KEY, label NVARCHAR(20))");
+    SQLFreeStmt(stmt_, SQL_CLOSE);
+
+    SqlTString table = ODBCTestUtils::ToSqlTStr("parity_catalog");
+    ASSERT_SQL_OK(SQLTablesW(stmt_, nullptr, 0, nullptr, 0,
+                             reinterpret_cast<SQLWCHAR*>(table.data()), SQL_NTS, nullptr, 0),
+                  SQL_HANDLE_STMT, stmt_);
+
+    SQLSMALLINT columns = 0;
+    ASSERT_SQL_OK(SQLNumResultCols(stmt_, &columns), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(5, columns);
+    EXPECT_EQ(SQL_SUCCESS, SQLFetch(stmt_));
+    SQLFreeStmt(stmt_, SQL_CLOSE);
+
+    ExecDirectIgnoreError("DROP TABLE dbo.parity_catalog");
+}
+
+TEST_F(PythonParityTest, DISABLED_ColumnsAndPrimaryKeysSucceed) {
+    ExecDirectIgnoreError("DROP TABLE dbo.parity_keys");
+    Exec(stmt_, "CREATE TABLE dbo.parity_keys (id INT NOT NULL PRIMARY KEY, label NVARCHAR(20))");
+    SQLFreeStmt(stmt_, SQL_CLOSE);
+
+    SqlTString table = ODBCTestUtils::ToSqlTStr("parity_keys");
+    ASSERT_SQL_OK(SQLColumnsW(stmt_, nullptr, 0, nullptr, 0,
+                              reinterpret_cast<SQLWCHAR*>(table.data()), SQL_NTS, nullptr, 0),
+                  SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(SQL_SUCCESS, SQLFetch(stmt_));
+    SQLFreeStmt(stmt_, SQL_CLOSE);
+
+    table = ODBCTestUtils::ToSqlTStr("parity_keys");
+    ASSERT_SQL_OK(SQLPrimaryKeysW(stmt_, nullptr, 0, nullptr, 0,
+                                  reinterpret_cast<SQLWCHAR*>(table.data()), SQL_NTS),
+                  SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(SQL_SUCCESS, SQLFetch(stmt_));
+    SQLFreeStmt(stmt_, SQL_CLOSE);
+
+    ExecDirectIgnoreError("DROP TABLE dbo.parity_keys");
+}
+
+TEST_F(PythonParityTest, DISABLED_ProceduresAndStatisticsSucceed) {
+    ASSERT_SQL_OK(SQLProceduresW(stmt_, nullptr, 0, nullptr, 0, nullptr, 0), SQL_HANDLE_STMT,
+                  stmt_);
+    SQLFreeStmt(stmt_, SQL_CLOSE);
+
+    ExecDirectIgnoreError("DROP TABLE dbo.parity_stats");
+    Exec(stmt_, "CREATE TABLE dbo.parity_stats (id INT NOT NULL PRIMARY KEY)");
+    SQLFreeStmt(stmt_, SQL_CLOSE);
+
+    SqlTString table = ODBCTestUtils::ToSqlTStr("parity_stats");
+    ASSERT_SQL_OK(SQLStatisticsW(stmt_, nullptr, 0, nullptr, 0,
+                                 reinterpret_cast<SQLWCHAR*>(table.data()), SQL_NTS,
+                                 SQL_INDEX_ALL, SQL_QUICK),
+                  SQL_HANDLE_STMT, stmt_);
+    SQLFreeStmt(stmt_, SQL_CLOSE);
+
+    ExecDirectIgnoreError("DROP TABLE dbo.parity_stats");
+}
+
+// ---------------------------------------------------------------------------
+// Parameter binding
+//
+// BindParameters() feeds SQLBindParameter for every Python argument, and the
+// SQL_C_NUMERIC path additionally sets precision/scale on the APD through
+// SQLSetDescFieldW — a failure there makes every decimal parameter raise.
+// ---------------------------------------------------------------------------
+
+TEST_F(PythonParityTest, DISABLED_BoundParametersRoundTrip) {
+    SqlTString sql = ODBCTestUtils::ToSqlTStr("SELECT ? + ?, ?");
+    ASSERT_SQL_OK(SQLPrepareW(stmt_, reinterpret_cast<SQLWCHAR*>(sql.data()), SQL_NTS),
+                  SQL_HANDLE_STMT, stmt_);
+
+    SQLINTEGER left = 40;
+    SQLINTEGER right = 2;
+    SQLWCHAR text[] = {L'h', L'i', 0};
+    SQLLEN int_len = 0;
+    SQLLEN text_len = SQL_NTS;
+
+    ASSERT_SQL_OK(SQLBindParameter(stmt_, 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0, &left,
+                                   0, &int_len),
+                  SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLBindParameter(stmt_, 2, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0,
+                                   &right, 0, &int_len),
+                  SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLBindParameter(stmt_, 3, SQL_PARAM_INPUT, SQL_C_WCHAR, SQL_WVARCHAR, 2, 0, text,
+                                   sizeof(text), &text_len),
+                  SQL_HANDLE_STMT, stmt_);
+
+    ASSERT_SQL_OK(SQLExecute(stmt_), SQL_HANDLE_STMT, stmt_);
+    ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt_));
+
+    SQLINTEGER sum = 0;
+    SQLLEN ind = 0;
+    ASSERT_SQL_OK(SQLGetData(stmt_, 1, SQL_C_SLONG, &sum, sizeof(sum), &ind), SQL_HANDLE_STMT,
+                  stmt_);
+    EXPECT_EQ(42, sum);
+}
+
+// ---------------------------------------------------------------------------
+// Data-at-execution: SQLParamData / SQLPutData.
+//
+// mssql-python streams any parameter larger than its inline threshold rather
+// than materialising it in one buffer: it binds with SQL_LEN_DATA_AT_EXEC, then
+// drives the SQL_NEED_DATA loop. SQLExecute must return SQL_NEED_DATA, each
+// SQLParamData must hand back the token the parameter was bound with, and the
+// statement must not complete until the loop is drained.
+// ---------------------------------------------------------------------------
+
+TEST_F(PythonParityTest, DISABLED_DataAtExecutionStreamsParameterInChunks) {
+    Exec(stmt_, "IF OBJECT_ID('tempdb..#dae') IS NOT NULL DROP TABLE #dae");
+    Exec(stmt_, "CREATE TABLE #dae (payload varchar(max))");
+
+    SqlTString sql = ODBCTestUtils::ToSqlTStr("INSERT INTO #dae (payload) VALUES (?)");
+    ASSERT_SQL_OK(SQLPrepareW(stmt_, reinterpret_cast<SQLWCHAR*>(sql.data()), SQL_NTS),
+                  SQL_HANDLE_STMT, stmt_);
+
+    // The token is opaque to the driver: it must come back from SQLParamData
+    // unchanged so the caller can tell which parameter is being asked for.
+    int token = 0xDA7A;
+    SQLLEN dae_len = SQL_LEN_DATA_AT_EXEC(0);
+    ASSERT_SQL_OK(SQLBindParameter(stmt_, 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_LONGVARCHAR, 0, 0,
+                                   &token, 0, &dae_len),
+                  SQL_HANDLE_STMT, stmt_);
+
+    ASSERT_EQ(SQL_NEED_DATA, SQLExecute(stmt_));
+
+    SQLPOINTER returned = nullptr;
+    ASSERT_EQ(SQL_NEED_DATA, SQLParamData(stmt_, &returned));
+    EXPECT_EQ(static_cast<SQLPOINTER>(&token), returned);
+
+    const std::string first(600, 'a');
+    const std::string second(600, 'b');
+    ASSERT_SQL_OK(SQLPutData(stmt_, const_cast<char*>(first.data()),
+                             static_cast<SQLLEN>(first.size())),
+                  SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLPutData(stmt_, const_cast<char*>(second.data()),
+                             static_cast<SQLLEN>(second.size())),
+                  SQL_HANDLE_STMT, stmt_);
+
+    // Draining the loop completes the statement.
+    ASSERT_SQL_OK(SQLParamData(stmt_, &returned), SQL_HANDLE_STMT, stmt_);
+
+    SQLHSTMT verify = AllocStmt();
+    Exec(verify, "SELECT LEN(payload) FROM #dae");
+    ASSERT_EQ(SQL_SUCCESS, SQLFetch(verify));
+    SQLINTEGER length = 0;
+    SQLLEN ind = 0;
+    ASSERT_SQL_OK(SQLGetData(verify, 1, SQL_C_SLONG, &length, sizeof(length), &ind), SQL_HANDLE_STMT,
+                  verify);
+    EXPECT_EQ(1200, length);
+    SQLFreeHandle(SQL_HANDLE_STMT, verify);
+}
+
+// ---------------------------------------------------------------------------
+// SQLGetData against a LOB, called repeatedly.
+//
+// mssql-python reads varchar(max)/varbinary(max) by calling SQLGetData in a
+// loop until it stops seeing SQL_SUCCESS_WITH_INFO. Each partial call must
+// report the number of bytes *remaining*, not the number written, and the final
+// call must return SQL_SUCCESS. Returning -1 or a written-byte count makes the
+// Python layer either truncate or spin.
+// ---------------------------------------------------------------------------
+
+TEST_F(PythonParityTest, DISABLED_GetDataStreamsLobInChunks) {
+    Exec(stmt_, "SELECT CAST(REPLICATE('x', 1000) AS varchar(max))");
+    ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt_));
+
+    std::string assembled;
+    char chunk[256];
+    SQLLEN ind = 0;
+    SQLRETURN rc = SQL_SUCCESS_WITH_INFO;
+    int guard = 0;
+
+    while (rc == SQL_SUCCESS_WITH_INFO && guard++ < 32) {
+        rc = SQLGetData(stmt_, 1, SQL_C_CHAR, chunk, sizeof(chunk), &ind);
+        ASSERT_TRUE(SQL_SUCCEEDED(rc));
+        ASSERT_NE(SQL_NO_TOTAL, ind) << "driver must report the remaining length";
+        const size_t copied =
+            (ind >= static_cast<SQLLEN>(sizeof(chunk))) ? sizeof(chunk) - 1 : static_cast<size_t>(ind);
+        assembled.append(chunk, copied);
+    }
+
+    EXPECT_EQ(SQL_SUCCESS, rc) << "the final chunk must return SQL_SUCCESS";
+    EXPECT_EQ(1000u, assembled.size());
+}
+
+TEST_F(PythonParityTest, DISABLED_SetDescFieldOnApdSucceedsForNumeric) {
+    SQLHDESC apd = nullptr;
+    SQLINTEGER length = 0;
+    if (!SQL_SUCCEEDED(SQLGetStmtAttr(stmt_, SQL_ATTR_APP_PARAM_DESC, &apd, 0, &length))) {
+        GTEST_SKIP() << "APD handle unavailable";
+    }
+    // Python sets these three fields, in this order, for every decimal argument.
+    EXPECT_SQL_OK(SQLSetDescFieldW(apd, 1, SQL_DESC_TYPE, reinterpret_cast<SQLPOINTER>(SQL_C_NUMERIC),
+                                   0),
+                  SQL_HANDLE_DESC, apd);
+    EXPECT_SQL_OK(SQLSetDescFieldW(apd, 1, SQL_DESC_PRECISION, reinterpret_cast<SQLPOINTER>(18), 0),
+                  SQL_HANDLE_DESC, apd);
+    EXPECT_SQL_OK(SQLSetDescFieldW(apd, 1, SQL_DESC_SCALE, reinterpret_cast<SQLPOINTER>(4), 0),
+                  SQL_HANDLE_DESC, apd);
+}
+
+// ---------------------------------------------------------------------------
+// Statement lifecycle
+// ---------------------------------------------------------------------------
+
+TEST_F(PythonParityTest, DISABLED_UnbindClearsPreviousBindings) {
+    Exec(stmt_, "SELECT 1, 2");
+    SQLINTEGER first = 0;
+    SQLLEN ind = 0;
+    ASSERT_SQL_OK(SQLBindCol(stmt_, 1, SQL_C_SLONG, &first, sizeof(first), &ind), SQL_HANDLE_STMT,
+                  stmt_);
+    ASSERT_SQL_OK(SQLFreeStmt(stmt_, SQL_UNBIND), SQL_HANDLE_STMT, stmt_);
+
+    ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt_));
+    EXPECT_EQ(0, first) << "SQL_UNBIND must detach the buffer";
+}
+
+TEST_F(PythonParityTest, DISABLED_RowCountReportsAffectedRows) {
+    ExecDirectIgnoreError("DROP TABLE IF EXISTS #parity_rowcount");
+    Exec(stmt_, "CREATE TABLE #parity_rowcount (id INT)");
+    SQLFreeStmt(stmt_, SQL_CLOSE);
+
+    Exec(stmt_, "INSERT INTO #parity_rowcount VALUES (1),(2),(3)");
+    SQLLEN affected = 0;
+    ASSERT_SQL_OK(SQLRowCount(stmt_, &affected), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(3, affected);
+}
+
+TEST_F(PythonParityTest, DISABLED_MoreResultsWalksMultiStatementBatch) {
+    Exec(stmt_, "SELECT 1; SELECT 2");
+    ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt_));
+
+    SQLINTEGER value = 0;
+    SQLLEN ind = 0;
+    ASSERT_SQL_OK(SQLGetData(stmt_, 1, SQL_C_SLONG, &value, sizeof(value), &ind), SQL_HANDLE_STMT,
+                  stmt_);
+    EXPECT_EQ(1, value);
+
+    ASSERT_TRUE(SQL_SUCCEEDED(SQLMoreResults(stmt_)));
+    ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt_));
+    ASSERT_SQL_OK(SQLGetData(stmt_, 1, SQL_C_SLONG, &value, sizeof(value), &ind), SQL_HANDLE_STMT,
+                  stmt_);
+    EXPECT_EQ(2, value);
+
+    EXPECT_EQ(SQL_NO_DATA, SQLMoreResults(stmt_));
+}
+
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    if (!LoadDriver(Api())) {
+        fprintf(stderr, "warning: %s\n", Api().load_error.c_str());
+    }
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## What this adds

A single-file GoogleTest suite pinning the ODBC behaviour that [mssql-python](https://github.com/microsoft/mssql-python) depends on, plus `README-parity.md` describing how to work through it.

mssql-python does not use a Driver Manager. It calls `LoadLibraryW` on `msodbcsql18.dll` and resolves the entrypoints itself, so this driver alone owns the entire ODBC contract -- nothing normalises arguments, sequences calls, or covers for a missing export. The suite loads the driver the same way, which makes it a faithful stand-in for the Python integration suite and much faster to run.

## Every case is disabled

All 22 cases carry the gtest `DISABLED_` prefix. CI builds and runs the binary, reports them as skipped, and exits 0. No database is needed for the skipped run.

These describe behaviour the driver is expected to have, **ahead of it having that behaviour**. The intent is that cases are enabled one at a time, each in the pull request that implements the corresponding API work.

Two rules, also stated in the file header and the README:

- Do not enable a case without the corresponding driver work.
- Do not re-disable a case to make CI pass. A case that starts failing is a driver regression.

To see where the driver currently stands:

`mssql_python_parity_test.exe --gtest_also_run_disabled_tests`

## Coverage

Transactions, block fetch and row-array binding, concurrent cursors, `SQLGetData` conversions and NULL/truncation reporting, `SQLColAttribute`, the five catalog functions, parameter binding, APD descriptor fields, `SQLRowCount`, and `SQLMoreResults`.

Includes two cases for the data-at-execution path -- `SQLParamData`/`SQLPutData` for streamed parameters, and chunked `SQLGetData` for LOB reads -- since mssql-python uses both for anything above its inline size threshold and neither was previously covered.

`README-parity.md` has the full table and a suggested order to work through them, sequenced by which failures mask others.

## Notes

- Windows-only for now: the loader uses `LoadLibraryW`/`GetProcAddress` and the fixtures assume a 2-byte `wchar_t` for `SQLWCHAR`. `CMakeLists.txt` guards the target with `if(WIN32)`. Porting to `dlopen` and an explicit UTF-16 string type is future work.
- No driver code is touched, so nothing here can change runtime behaviour.

## Related Issues

Follow-up to the mssql-python parity investigation in #175.
