### PR TITLE
[DRAFT/DO NOT MERGE] Disk throughput probe: old pool vs NVMe pool

### DIFF
--- a/.pipeline/scripts/Measure-DiskThroughput.ps1
+++ b/.pipeline/scripts/Measure-DiskThroughput.ps1
@@ -42,8 +42,10 @@ try {
     $letter = $drive.TrimEnd(':')
     $part = Get-Partition -DriveLetter $letter -ErrorAction Stop
     $pdisk = Get-Disk -Number $part.DiskNumber | Get-PhysicalDisk
+    $busType = [string]$pdisk.BusType
+    $mediaType = [string]$pdisk.MediaType
     Write-Host ("Target volume {0} -> disk #{1}: {2} BusType={3} MediaType={4}" -f `
-        $drive, $part.DiskNumber, $pdisk.FriendlyName, $pdisk.BusType, $pdisk.MediaType)
+        $drive, $part.DiskNumber, $pdisk.FriendlyName, $busType, $mediaType)
 } catch { Write-Host "volume->disk mapping failed: $($_.Exception.Message)" }
 
 # --- Download diskspd ---
@@ -72,8 +74,16 @@ function Invoke-Scenario($name, [string[]]$scArgs) {
     Section "Scenario: $name"
     $all = @($scArgs + @('-L', '-W3', "-d$DurationSec", "-c${FileSizeGB}G", $testFile))
     Write-Host "diskspd $($all -join ' ')"
+    # diskspd writes warnings to stderr; don't let that become a terminating error.
+    $prev = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
     $out = & $diskspd.FullName @all 2>&1 | Out-String
+    $code = $LASTEXITCODE
+    $ErrorActionPreference = $prev
     Write-Host $out
+    if ($code -ne 0) {
+        Write-Host "##vso[task.logissue type=warning]diskspd exited $code for scenario $name"
+    }
     $mib = $null; $iops = $null
     foreach ($line in ($out -split "`r?`n")) {
         if ($line -match '^total:\s+\d+\s*\|\s*\d+\s*\|\s*([\d.]+)\s*\|\s*([\d.]+)') {
@@ -84,9 +94,10 @@ function Invoke-Scenario($name, [string[]]$scArgs) {
     $results.Add([pscustomobject]@{ Scenario = $name; 'MB/s' = $mib; 'IOPS' = $iops })
 }
 
-# block size / pattern / queue depth / threads chosen to mirror build-like I/O
-Invoke-Scenario 'seq-write-1M'   @('-w100','-b1M','-o8','-t4','-Sh')
-Invoke-Scenario 'seq-read-1M'    @('-w0','-b1M','-o8','-t4','-Sh')
+# block size / pattern / queue depth / threads chosen to mirror build-like I/O.
+# Sequential runs use a single thread (-t1) so the pattern stays truly sequential.
+Invoke-Scenario 'seq-write-1M'   @('-w100','-b1M','-o8','-t1','-Sh')
+Invoke-Scenario 'seq-read-1M'    @('-w0','-b1M','-o8','-t1','-Sh')
 Invoke-Scenario 'rand-read-4K'   @('-w0','-r','-b4K','-o8','-t4','-Sh')
 Invoke-Scenario 'rand-write-4K'  @('-w100','-r','-b4K','-o8','-t4','-Sh')
 Invoke-Scenario 'rand-rw-64K-30w' @('-w30','-r','-b64K','-o8','-t4','-Sh')
@@ -100,4 +111,30 @@ $results | Format-Table -AutoSize | Out-String | Write-Host
 Write-Host "##[section]DISK-THROUGHPUT-RESULT label=$Label"
 foreach ($r in $results) {
     Write-Host ("RESULT|{0}|{1}|{2:N2}|{3:N2}" -f $Label, $r.Scenario, $r.'MB/s', $r.'IOPS')
+}
+
+# --- Publish a per-job markdown summary to the build Summary tab ---
+$md = New-Object System.Text.StringBuilder
+[void]$md.AppendLine("### Disk throughput - $Label")
+[void]$md.AppendLine("")
+[void]$md.AppendLine("Work dir ``$TargetDir`` on drive $drive (BusType=$busType, MediaType=$mediaType), cache-bypass (diskspd -Sh).")
+[void]$md.AppendLine("")
+[void]$md.AppendLine("| Scenario | MB/s | IOPS |")
+[void]$md.AppendLine("|---|---:|---:|")
+foreach ($r in $results) {
+    [void]$md.AppendLine("| {0} | {1:N2} | {2:N2} |" -f $r.Scenario, $r.'MB/s', $r.'IOPS')
+}
+$tempDir = $env:AGENT_TEMPDIRECTORY; if (-not $tempDir) { $tempDir = $TargetDir }
+$summaryPath = Join-Path $tempDir 'disk-summary.md'
+[System.IO.File]::WriteAllText($summaryPath, $md.ToString())
+Write-Host "##vso[task.uploadsummary]$summaryPath"
+
+# --- Emit machine-readable results for the aggregation job ---
+$staging = $env:BUILD_ARTIFACTSTAGINGDIRECTORY
+if ($staging) {
+    New-Item -ItemType Directory -Force -Path $staging | Out-Null
+    $lines = foreach ($r in $results) {
+        "RESULT|{0}|{1}|{2:N2}|{3:N2}" -f $Label, $r.Scenario, $r.'MB/s', $r.'IOPS'
+    }
+    Set-Content -Path (Join-Path $staging 'results.txt') -Value $lines
 }

--- a/.pipeline/scripts/Measure-DiskThroughput.ps1
+++ b/.pipeline/scripts/Measure-DiskThroughput.ps1
@@ -48,6 +48,39 @@ try {
         $drive, $part.DiskNumber, $pdisk.FriendlyName, $busType, $mediaType)
 } catch { Write-Host "volume->disk mapping failed: $($_.Exception.Message)" }
 
+# --- Agent CPU / RAM / Azure SKU ---
+Section "Agent info"
+try {
+    $cpu = Get-CimInstance Win32_Processor | Select-Object -First 1
+    $cs  = Get-CimInstance Win32_ComputerSystem
+    Write-Host ("CPU        : {0}" -f $cpu.Name.Trim())
+    Write-Host ("Cores      : {0} physical / {1} logical" -f $cpu.NumberOfCores, $cpu.NumberOfLogicalProcessors)
+    Write-Host ("RAM        : {0:N1} GB" -f ($cs.TotalPhysicalMemory / 1GB))
+} catch { Write-Host "cpu info failed: $($_.Exception.Message)" }
+try {
+    $imds = Invoke-RestMethod -Headers @{Metadata='true'} -TimeoutSec 5 `
+        -Uri 'http://169.254.169.254/metadata/instance/compute?api-version=2021-02-01'
+    Write-Host ("Azure VM   : size={0} location={1} zone={2}" -f $imds.vmSize, $imds.location, $imds.zone)
+} catch { Write-Host "IMDS query failed: $($_.Exception.Message)" }
+
+# --- Rust / cargo cache warmth (fresh ephemeral images start cold) ---
+Section "Rust / cargo cache warmth"
+foreach ($exe in 'rustc', 'cargo') {
+    $cmd = Get-Command $exe -ErrorAction SilentlyContinue
+    if ($cmd) { Write-Host ("{0}: {1}" -f $exe, (& $exe --version)) }
+    else { Write-Host "$exe: not on PATH" }
+}
+$cargoHome = $env:CARGO_HOME
+if (-not $cargoHome) { $cargoHome = Join-Path $env:USERPROFILE '.cargo' }
+$registry = Join-Path $cargoHome 'registry'
+if (Test-Path $registry) {
+    $files = Get-ChildItem -Path $registry -Recurse -File -ErrorAction SilentlyContinue
+    $szMB = (($files | Measure-Object Length -Sum).Sum) / 1MB
+    Write-Host ("cargo registry cache: {0} files, {1:N1} MB at {2}" -f $files.Count, $szMB, $registry)
+} else {
+    Write-Host "cargo registry cache: NONE at $registry (cold)"
+}
+
 # --- Download diskspd ---
 Section "Downloading diskspd"
 $toolDir = Join-Path $env:AGENT_TEMPDIRECTORY 'diskspd'

--- a/.pipeline/scripts/Measure-DiskThroughput.ps1
+++ b/.pipeline/scripts/Measure-DiskThroughput.ps1
@@ -68,7 +68,7 @@ Section "Rust / cargo cache warmth"
 foreach ($exe in 'rustc', 'cargo') {
     $cmd = Get-Command $exe -ErrorAction SilentlyContinue
     if ($cmd) { Write-Host ("{0}: {1}" -f $exe, (& $exe --version)) }
-    else { Write-Host "$exe: not on PATH" }
+    else { Write-Host "${exe}: not on PATH" }
 }
 $cargoHome = $env:CARGO_HOME
 if (-not $cargoHome) { $cargoHome = Join-Path $env:USERPROFILE '.cargo' }

--- a/.pipeline/scripts/Measure-DiskThroughput.ps1
+++ b/.pipeline/scripts/Measure-DiskThroughput.ps1
@@ -1,0 +1,103 @@
+# Measure raw disk throughput where the agent work folder lives (Windows).
+# Uses Microsoft diskspd with cache bypass (-Sh) so results reflect the disk,
+# not the OS file cache. Reports sequential + random throughput and IOPS.
+[CmdletBinding()]
+param(
+    [string]$Label = "unknown-pool",
+    [string]$TargetDir = "",
+    [int]$FileSizeGB = 4,
+    [int]$DurationSec = 20
+)
+
+$ErrorActionPreference = 'Stop'
+function Section($t) { Write-Host "`n==== $t ====" -ForegroundColor Cyan }
+
+# --- Resolve the work folder (where build I/O actually happens) ---
+if (-not $TargetDir) { $TargetDir = $env:PIPELINE_WORKSPACE }
+if (-not $TargetDir) { $TargetDir = $env:AGENT_BUILDDIRECTORY }
+if (-not $TargetDir) { $TargetDir = $env:AGENT_WORKFOLDER }
+if (-not $TargetDir) { $TargetDir = (Get-Location).Path }
+$TargetDir = (Resolve-Path $TargetDir).Path
+$drive = (Split-Path -Qualifier $TargetDir)
+Write-Host "Label            : $Label"
+Write-Host "Work/target dir  : $TargetDir"
+Write-Host "Target drive     : $drive"
+
+# --- Report the physical disk backing that drive ---
+Section "Disk topology"
+try {
+    Get-PhysicalDisk |
+        Select-Object DeviceId, FriendlyName, MediaType, BusType,
+            @{n='SizeGB';e={[math]::Round($_.Size/1GB)}} |
+        Format-Table -AutoSize | Out-String | Write-Host
+} catch { Write-Host "Get-PhysicalDisk failed: $($_.Exception.Message)" }
+try {
+    Get-Volume |
+        Select-Object DriveLetter, FileSystemType,
+            @{n='SizeGB';e={[math]::Round($_.Size/1GB)}},
+            @{n='FreeGB';e={[math]::Round($_.SizeRemaining/1GB)}} |
+        Format-Table -AutoSize | Out-String | Write-Host
+} catch {}
+try {
+    $letter = $drive.TrimEnd(':')
+    $part = Get-Partition -DriveLetter $letter -ErrorAction Stop
+    $pdisk = Get-Disk -Number $part.DiskNumber | Get-PhysicalDisk
+    Write-Host ("Target volume {0} -> disk #{1}: {2} BusType={3} MediaType={4}" -f `
+        $drive, $part.DiskNumber, $pdisk.FriendlyName, $pdisk.BusType, $pdisk.MediaType)
+} catch { Write-Host "volume->disk mapping failed: $($_.Exception.Message)" }
+
+# --- Download diskspd ---
+Section "Downloading diskspd"
+$toolDir = Join-Path $env:AGENT_TEMPDIRECTORY 'diskspd'
+if (-not $toolDir) { $toolDir = Join-Path $TargetDir 'diskspd' }
+New-Item -ItemType Directory -Force -Path $toolDir | Out-Null
+$zip = Join-Path $toolDir 'DiskSpd.zip'
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+Invoke-WebRequest -Uri 'https://github.com/microsoft/diskspd/releases/download/v2.2/DiskSpd.zip' `
+    -OutFile $zip -UseBasicParsing
+Expand-Archive -Path $zip -DestinationPath $toolDir -Force
+$diskspd = Get-ChildItem -Path $toolDir -Recurse -Filter 'diskspd.exe' |
+    Where-Object { $_.FullName -match '\\amd64\\' } | Select-Object -First 1
+if (-not $diskspd) {
+    $diskspd = Get-ChildItem -Path $toolDir -Recurse -Filter 'diskspd.exe' | Select-Object -First 1
+}
+if (-not $diskspd) { throw "diskspd.exe not found after extraction" }
+Write-Host "diskspd: $($diskspd.FullName)"
+
+# --- Run scenarios ---
+$testFile = Join-Path $TargetDir 'diskspd_probe.dat'
+$results = New-Object System.Collections.Generic.List[object]
+
+function Invoke-Scenario($name, [string[]]$scArgs) {
+    Section "Scenario: $name"
+    $all = @($scArgs + @('-L', '-W3', "-d$DurationSec", "-c${FileSizeGB}G", $testFile))
+    Write-Host "diskspd $($all -join ' ')"
+    $out = & $diskspd.FullName @all 2>&1 | Out-String
+    Write-Host $out
+    $mib = $null; $iops = $null
+    foreach ($line in ($out -split "`r?`n")) {
+        if ($line -match '^total:\s+\d+\s*\|\s*\d+\s*\|\s*([\d.]+)\s*\|\s*([\d.]+)') {
+            $mib = [double]$Matches[1]; $iops = [double]$Matches[2]
+            break
+        }
+    }
+    $results.Add([pscustomobject]@{ Scenario = $name; 'MB/s' = $mib; 'IOPS' = $iops })
+}
+
+# block size / pattern / queue depth / threads chosen to mirror build-like I/O
+Invoke-Scenario 'seq-write-1M'   @('-w100','-b1M','-o8','-t4','-Sh')
+Invoke-Scenario 'seq-read-1M'    @('-w0','-b1M','-o8','-t4','-Sh')
+Invoke-Scenario 'rand-read-4K'   @('-w0','-r','-b4K','-o8','-t4','-Sh')
+Invoke-Scenario 'rand-write-4K'  @('-w100','-r','-b4K','-o8','-t4','-Sh')
+Invoke-Scenario 'rand-rw-64K-30w' @('-w30','-r','-b64K','-o8','-t4','-Sh')
+
+# --- Cleanup ---
+Remove-Item -Path $testFile -Force -ErrorAction SilentlyContinue
+
+# --- Summary ---
+Section "SUMMARY [$Label]"
+$results | Format-Table -AutoSize | Out-String | Write-Host
+Write-Host "##[section]DISK-THROUGHPUT-RESULT label=$Label"
+foreach ($r in $results) {
+    Write-Host ("RESULT|{0}|{1}|{2:N2}|{3:N2}" -f $Label, $r.Scenario, $r.'MB/s', $r.'IOPS')
+}

--- a/.pipeline/scripts/Measure-DiskThroughput.ps1
+++ b/.pipeline/scripts/Measure-DiskThroughput.ps1
@@ -110,7 +110,7 @@ Section "SUMMARY [$Label]"
 $results | Format-Table -AutoSize | Out-String | Write-Host
 Write-Host "##[section]DISK-THROUGHPUT-RESULT label=$Label"
 foreach ($r in $results) {
-    Write-Host ("RESULT|{0}|{1}|{2:N2}|{3:N2}" -f $Label, $r.Scenario, $r.'MB/s', $r.'IOPS')
+    Write-Host ("RESULT|{0}|{1}|{2:F2}|{3:F2}" -f $Label, $r.Scenario, $r.'MB/s', $r.'IOPS')
 }
 
 # --- Publish a per-job markdown summary to the build Summary tab ---
@@ -122,7 +122,7 @@ $md = New-Object System.Text.StringBuilder
 [void]$md.AppendLine("| Scenario | MB/s | IOPS |")
 [void]$md.AppendLine("|---|---:|---:|")
 foreach ($r in $results) {
-    [void]$md.AppendLine("| {0} | {1:N2} | {2:N2} |" -f $r.Scenario, $r.'MB/s', $r.'IOPS')
+    [void]$md.AppendLine(("| {0} | {1:F2} | {2:F2} |" -f $r.Scenario, $r.'MB/s', $r.'IOPS'))
 }
 $tempDir = $env:AGENT_TEMPDIRECTORY; if (-not $tempDir) { $tempDir = $TargetDir }
 $summaryPath = Join-Path $tempDir 'disk-summary.md'
@@ -134,7 +134,7 @@ $staging = $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 if ($staging) {
     New-Item -ItemType Directory -Force -Path $staging | Out-Null
     $lines = foreach ($r in $results) {
-        "RESULT|{0}|{1}|{2:N2}|{3:N2}" -f $Label, $r.Scenario, $r.'MB/s', $r.'IOPS'
+        "RESULT|{0}|{1}|{2:F2}|{3:F2}" -f $Label, $r.Scenario, $r.'MB/s', $r.'IOPS'
     }
     Set-Content -Path (Join-Path $staging 'results.txt') -Value $lines
 }

--- a/.pipeline/scripts/measure-disk-throughput.sh
+++ b/.pipeline/scripts/measure-disk-throughput.sh
@@ -30,8 +30,10 @@ lsblk -o NAME,SIZE,TYPE,TRAN,ROTA,MODEL,MOUNTPOINT 2>/dev/null || true
 # rotational + transport for the specific backing device
 BASE_DEV="$(lsblk -no PKNAME "$SRC_DEV" 2>/dev/null | head -1)"
 [ -z "$BASE_DEV" ] && BASE_DEV="$(basename "${SRC_DEV:-}")"
+ROTA="?"
 if [ -n "$BASE_DEV" ] && [ -e "/sys/block/$BASE_DEV/queue/rotational" ]; then
-  echo "Device $BASE_DEV rotational=$(cat /sys/block/$BASE_DEV/queue/rotational) (0=SSD/NVMe, 1=HDD)"
+  ROTA="$(cat /sys/block/$BASE_DEV/queue/rotational)"
+  echo "Device $BASE_DEV rotational=$ROTA (0=SSD/NVMe, 1=HDD)"
 fi
 
 # --- Ensure fio is available ---
@@ -54,6 +56,7 @@ fio --version
 
 TEST="$TARGET_DIR/fio_probe.dat"
 IOENGINE="libaio"
+RESULTS_FILE="$(mktemp)"
 
 run_scenario() { # name rw bs iodepth numjobs [rwmixread]
   local name="$1" rw="$2" bs="$3" iod="$4" nj="$5" mix="${6:-}"
@@ -65,7 +68,8 @@ run_scenario() { # name rw bs iodepth numjobs [rwmixread]
       --size="${SIZE_GB}G" --runtime="$DURATION" --time_based --rw="$rw" --bs="$bs" \
       --iodepth="$iod" --numjobs="$nj" --group_reporting --output-format=json $extra 2>/tmp/fio.err)"
   if [ -z "$json" ]; then echo "fio failed:"; cat /tmp/fio.err; return; fi
-  echo "$json" | python3 -c "
+  local pyout
+  pyout="$(echo "$json" | python3 -c "
 import sys,json
 d=json.load(sys.stdin); j=d['jobs'][0]
 r=j['read']; w=j['write']
@@ -74,7 +78,9 @@ print(f'  read : {rb:8.2f} MB/s  {r[\"iops\"]:10.1f} IOPS')
 print(f'  write: {wb:8.2f} MB/s  {w[\"iops\"]:10.1f} IOPS')
 tot=rb+wb; tiops=r['iops']+w['iops']
 print(f'RESULT|$LABEL|$name|{tot:.2f}|{tiops:.2f}')
-"
+")"
+  echo "$pyout"
+  echo "$pyout" | grep '^RESULT|' >> "$RESULTS_FILE"
 }
 
 # block size / pattern / queue depth chosen to mirror build-like I/O
@@ -86,4 +92,19 @@ run_scenario 'rand-rw-64K-30w' randrw    64k 8 4 70
 
 rm -f "$TEST"
 section "SUMMARY [$LABEL]"
-echo "See RESULT| lines above (aggregate MB/s and IOPS per scenario)."
+cat "$RESULTS_FILE"
+
+# Publish a per-job markdown summary to the build Summary tab.
+SUMMARY_MD="$(mktemp --suffix=.md)"
+{
+  echo "### Disk throughput - $LABEL"
+  echo ""
+  echo "Work dir \`$TARGET_DIR\` backed by \`${SRC_DEV:-unknown}\` (rotational=$ROTA), cache-bypass (fio --direct=1)."
+  echo ""
+  echo "| Scenario | MB/s | IOPS |"
+  echo "|---|---:|---:|"
+  while IFS='|' read -r _ _lbl scen mbs iops; do
+    echo "| $scen | $mbs | $iops |"
+  done < "$RESULTS_FILE"
+} > "$SUMMARY_MD"
+echo "##vso[task.uploadsummary]$SUMMARY_MD"

--- a/.pipeline/scripts/measure-disk-throughput.sh
+++ b/.pipeline/scripts/measure-disk-throughput.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Measure raw disk throughput where the agent work folder lives (Linux).
+# Uses fio with direct=1 (O_DIRECT) so results reflect the disk, not page cache.
+# Reports sequential + random throughput and IOPS.
+set -uo pipefail
+
+LABEL="${1:-unknown-pool}"
+TARGET_DIR="${2:-}"
+SIZE_GB="${3:-4}"
+DURATION="${4:-20}"
+
+section() { echo ""; echo "==== $1 ===="; }
+
+# --- Resolve the work folder (where build I/O actually happens) ---
+if [ -z "$TARGET_DIR" ]; then TARGET_DIR="${PIPELINE_WORKSPACE:-}"; fi
+if [ -z "$TARGET_DIR" ]; then TARGET_DIR="${AGENT_BUILDDIRECTORY:-}"; fi
+if [ -z "$TARGET_DIR" ]; then TARGET_DIR="${AGENT_WORKFOLDER:-}"; fi
+if [ -z "$TARGET_DIR" ]; then TARGET_DIR="$(pwd)"; fi
+mkdir -p "$TARGET_DIR"
+echo "Label           : $LABEL"
+echo "Work/target dir : $TARGET_DIR"
+
+# --- Report the block device backing that directory ---
+section "Disk topology"
+SRC_DEV="$(findmnt -no SOURCE --target "$TARGET_DIR" 2>/dev/null || true)"
+echo "Backing source  : ${SRC_DEV:-unknown}"
+findmnt -o TARGET,SOURCE,FSTYPE,SIZE,USED,AVAIL --target "$TARGET_DIR" 2>/dev/null || true
+echo ""
+lsblk -o NAME,SIZE,TYPE,TRAN,ROTA,MODEL,MOUNTPOINT 2>/dev/null || true
+# rotational + transport for the specific backing device
+BASE_DEV="$(lsblk -no PKNAME "$SRC_DEV" 2>/dev/null | head -1)"
+[ -z "$BASE_DEV" ] && BASE_DEV="$(basename "${SRC_DEV:-}")"
+if [ -n "$BASE_DEV" ] && [ -e "/sys/block/$BASE_DEV/queue/rotational" ]; then
+  echo "Device $BASE_DEV rotational=$(cat /sys/block/$BASE_DEV/queue/rotational) (0=SSD/NVMe, 1=HDD)"
+fi
+
+# --- Ensure fio is available ---
+section "Ensuring fio is installed"
+if ! command -v fio >/dev/null 2>&1; then
+  echo "fio not found; attempting install..."
+  sudo apt-get update -y >/dev/null 2>&1 && sudo apt-get install -y fio >/dev/null 2>&1 || true
+fi
+if ! command -v fio >/dev/null 2>&1; then
+  echo "ERROR: fio unavailable; falling back to dd sequential-only."
+  TEST="$TARGET_DIR/dd_probe.dat"
+  echo "-- dd sequential write (O_DIRECT) --"
+  dd if=/dev/zero of="$TEST" bs=1M count=$((SIZE_GB*1024)) oflag=direct conv=fdatasync 2>&1 | tail -1
+  echo "-- dd sequential read (O_DIRECT) --"
+  dd if="$TEST" of=/dev/null bs=1M iflag=direct 2>&1 | tail -1
+  rm -f "$TEST"
+  exit 0
+fi
+fio --version
+
+TEST="$TARGET_DIR/fio_probe.dat"
+IOENGINE="libaio"
+
+run_scenario() { # name rw bs iodepth numjobs [rwmixread]
+  local name="$1" rw="$2" bs="$3" iod="$4" nj="$5" mix="${6:-}"
+  section "Scenario: $name"
+  local extra=""
+  [ -n "$mix" ] && extra="--rwmixread=$mix"
+  local json
+  json="$(fio --name="$name" --filename="$TEST" --direct=1 --ioengine="$IOENGINE" \
+      --size="${SIZE_GB}G" --runtime="$DURATION" --time_based --rw="$rw" --bs="$bs" \
+      --iodepth="$iod" --numjobs="$nj" --group_reporting --output-format=json $extra 2>/tmp/fio.err)"
+  if [ -z "$json" ]; then echo "fio failed:"; cat /tmp/fio.err; return; fi
+  echo "$json" | python3 -c "
+import sys,json
+d=json.load(sys.stdin); j=d['jobs'][0]
+r=j['read']; w=j['write']
+rb=r['bw_bytes']/1e6; wb=w['bw_bytes']/1e6
+print(f'  read : {rb:8.2f} MB/s  {r[\"iops\"]:10.1f} IOPS')
+print(f'  write: {wb:8.2f} MB/s  {w[\"iops\"]:10.1f} IOPS')
+tot=rb+wb; tiops=r['iops']+w['iops']
+print(f'RESULT|$LABEL|$name|{tot:.2f}|{tiops:.2f}')
+"
+}
+
+# block size / pattern / queue depth chosen to mirror build-like I/O
+run_scenario 'seq-write-1M'    write     1M 8 1
+run_scenario 'seq-read-1M'     read      1M 8 1
+run_scenario 'rand-read-4K'    randread  4k 8 4
+run_scenario 'rand-write-4K'   randwrite 4k 8 4
+run_scenario 'rand-rw-64K-30w' randrw    64k 8 4 70
+
+rm -f "$TEST"
+section "SUMMARY [$LABEL]"
+echo "See RESULT| lines above (aggregate MB/s and IOPS per scenario)."

--- a/.pipeline/scripts/measure-disk-throughput.sh
+++ b/.pipeline/scripts/measure-disk-throughput.sh
@@ -36,6 +36,31 @@ if [ -n "$BASE_DEV" ] && [ -e "/sys/block/$BASE_DEV/queue/rotational" ]; then
   echo "Device $BASE_DEV rotational=$ROTA (0=SSD/NVMe, 1=HDD)"
 fi
 
+# --- Agent CPU / RAM / Azure SKU ---
+section "Agent info"
+echo "CPU model : $(grep -m1 'model name' /proc/cpuinfo | cut -d: -f2- | sed 's/^ //')"
+echo "Cores     : $(nproc) logical"
+echo "RAM       : $(grep MemTotal /proc/meminfo | awk '{printf "%.1f GB", $2/1024/1024}')"
+VM="$(curl -s -H Metadata:true --max-time 5 'http://169.254.169.254/metadata/instance/compute?api-version=2021-02-01' 2>/dev/null)"
+if [ -n "$VM" ]; then
+  echo "$VM" | python3 -c "import sys,json;d=json.load(sys.stdin);print('Azure VM  : size=%s location=%s zone=%s'%(d.get('vmSize'),d.get('location'),d.get('zone')))" 2>/dev/null || echo "Azure VM  : (parse failed)"
+else
+  echo "Azure VM  : IMDS unreachable"
+fi
+
+# --- Rust / cargo cache warmth (fresh ephemeral images start cold) ---
+section "Rust / cargo cache warmth"
+for e in rustc cargo; do
+  if command -v "$e" >/dev/null 2>&1; then echo "$e: $($e --version)"; else echo "$e: not on PATH"; fi
+done
+CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
+REG="$CARGO_HOME/registry"
+if [ -d "$REG" ]; then
+  echo "cargo registry cache: $(du -sh "$REG" 2>/dev/null | cut -f1) at $REG"
+else
+  echo "cargo registry cache: NONE at $REG (cold)"
+fi
+
 # --- Ensure fio is available ---
 section "Ensuring fio is installed"
 if ! command -v fio >/dev/null 2>&1; then

--- a/.pipeline/validation-pipeline.yml
+++ b/.pipeline/validation-pipeline.yml
@@ -3,47 +3,141 @@
 trigger:
 - development
 
+# =============================================================================
+# TEMPORARILY HIJACKED: disk-throughput probe (old pool vs NVMe pool).
+# Spawns 4 short jobs (Windows old/new, Linux old/new) that measure raw disk
+# throughput where the agent work folder lives, using cache-bypass I/O.
+# The original validation entry point is preserved (commented) at the bottom.
+# REVERT this file before merge.
+# =============================================================================
+
 parameters:
-- name: buildType
-  displayName: Type of the build to produce
-  type: string
-  values:
-  - Both
-  - Debug
-  - Release
-  default: Both
-
-- name: RunFuzz
-  displayName: Run Fuzz Tests (30 min)
-  type: boolean
-  default: false
-
-- name: RunLongHaul
-  displayName: Run Long-Haul BCP Test (30 min)
-  type: boolean
-  default: false
-
-- name: sqlInstanceMode
-  displayName: SQL host cardinality for ARM test stages
-  type: string
-  values:
-  - shared
-  - per-job
-  default: shared
-
-- name: sqlImageTag
-  displayName: SQL Server docker image tag for ARM test stages
-  type: string
-  default: '2025-latest'
+- name: fileSizeGB
+  displayName: Probe file size (GB)
+  type: number
+  default: 4
+- name: durationSec
+  displayName: Duration per scenario (seconds)
+  type: number
+  default: 20
 
 stages:
-- template: templates/validation-stages.yml
-  parameters:
-    buildType: ${{ parameters.buildType }}
-    RunFuzz: ${{ parameters.RunFuzz }}
-    RunLongHaul: ${{ parameters.RunLongHaul }}
-    sqlInstanceMode: ${{ parameters.sqlInstanceMode }}
-    sqlImageTag: ${{ parameters.sqlImageTag }}
-    # PR validation for internal ADO and GitHub PRs. GitHub PRs run in the public
-    # project, which lacks 'Magnitude Test', so exclude the infra stages here.
-    includeInfraStages: false
+- stage: DiskThroughput
+  displayName: Disk throughput (old vs NVMe pool)
+  jobs:
+  - job: WindowsOld
+    displayName: Windows disk throughput - OLD pool
+    timeoutInMinutes: 30
+    pool:
+      name: RUST-1ES-POOL-WUS3
+      demands:
+        - imageOverride -equals RUST-Win22-Sql25-1P
+    steps:
+    - checkout: self
+      fetchDepth: 1
+    - task: PowerShell@2
+      displayName: Measure disk throughput (diskspd)
+      inputs:
+        filePath: .pipeline/scripts/Measure-DiskThroughput.ps1
+        arguments: >-
+          -Label "WINDOWS-OLD (RUST-1ES-POOL-WUS3)"
+          -FileSizeGB ${{ parameters.fileSizeGB }}
+          -DurationSec ${{ parameters.durationSec }}
+
+  - job: WindowsNvme
+    displayName: Windows disk throughput - NVMe pool
+    timeoutInMinutes: 30
+    pool:
+      name: RUST-1ES-POOL-WUS3-NVME
+      demands:
+        - imageOverride -equals RUST-Win22-Sql25-1P-NVME
+    steps:
+    - checkout: self
+      fetchDepth: 1
+    - task: PowerShell@2
+      displayName: Measure disk throughput (diskspd)
+      inputs:
+        filePath: .pipeline/scripts/Measure-DiskThroughput.ps1
+        arguments: >-
+          -Label "WINDOWS-NVMe (RUST-1ES-POOL-WUS3-NVME)"
+          -FileSizeGB ${{ parameters.fileSizeGB }}
+          -DurationSec ${{ parameters.durationSec }}
+
+  - job: LinuxOld
+    displayName: Linux disk throughput - OLD pool
+    timeoutInMinutes: 30
+    pool:
+      name: RUST-1ES-POOL-WUS3
+      demands:
+        - imageOverride -equals RUST-1ES-UBUSLIM
+    steps:
+    - checkout: self
+      fetchDepth: 1
+    - bash: |
+        chmod +x .pipeline/scripts/measure-disk-throughput.sh
+        .pipeline/scripts/measure-disk-throughput.sh "LINUX-OLD (RUST-1ES-POOL-WUS3)" "" "${{ parameters.fileSizeGB }}" "${{ parameters.durationSec }}"
+      displayName: Measure disk throughput (fio)
+
+  - job: LinuxNvme
+    displayName: Linux disk throughput - NVMe pool
+    timeoutInMinutes: 30
+    pool:
+      name: RUST-1ES-POOL-WUS3-NVME
+      demands:
+        - imageOverride -equals RUST-1ES-UBUSLIM-NVME
+    steps:
+    - checkout: self
+      fetchDepth: 1
+    - bash: |
+        chmod +x .pipeline/scripts/measure-disk-throughput.sh
+        .pipeline/scripts/measure-disk-throughput.sh "LINUX-NVMe (RUST-1ES-POOL-WUS3-NVME)" "" "${{ parameters.fileSizeGB }}" "${{ parameters.durationSec }}"
+      displayName: Measure disk throughput (fio)
+
+# =============================================================================
+# ORIGINAL VALIDATION ENTRY POINT (restore when un-hijacking):
+#
+# parameters:
+# - name: buildType
+#   displayName: Type of the build to produce
+#   type: string
+#   values:
+#   - Both
+#   - Debug
+#   - Release
+#   default: Both
+#
+# - name: RunFuzz
+#   displayName: Run Fuzz Tests (30 min)
+#   type: boolean
+#   default: false
+#
+# - name: RunLongHaul
+#   displayName: Run Long-Haul BCP Test (30 min)
+#   type: boolean
+#   default: false
+#
+# - name: sqlInstanceMode
+#   displayName: SQL host cardinality for ARM test stages
+#   type: string
+#   values:
+#   - shared
+#   - per-job
+#   default: shared
+#
+# - name: sqlImageTag
+#   displayName: SQL Server docker image tag for ARM test stages
+#   type: string
+#   default: '2025-latest'
+#
+# stages:
+# - template: templates/validation-stages.yml
+#   parameters:
+#     buildType: ${{ parameters.buildType }}
+#     RunFuzz: ${{ parameters.RunFuzz }}
+#     RunLongHaul: ${{ parameters.RunLongHaul }}
+#     sqlInstanceMode: ${{ parameters.sqlInstanceMode }}
+#     sqlImageTag: ${{ parameters.sqlImageTag }}
+#     # PR validation for internal ADO and GitHub PRs. GitHub PRs run in the public
+#     # project, which lacks 'Magnitude Test', so exclude the infra stages here.
+#     includeInfraStages: false
+# =============================================================================


### PR DESCRIPTION
## Purpose (temporary diagnostic)

Investigating why the **Windows build got ~slower** on the new NVMe 1ES pool while Linux got faster. This PR temporarily **hijacks** `.pipeline/validation-pipeline.yml` to run 4 short jobs that measure **raw disk throughput where the agent work folder lives**, comparing the old and new pools head-to-head.

## Jobs
| Job | Pool | Image |
|---|---|---|
| WindowsOld | `RUST-1ES-POOL-WUS3` | `RUST-Win22-Sql25-1P` |
| WindowsNvme | `RUST-1ES-POOL-WUS3-NVME` | `RUST-Win22-Sql25-1P-NVME` |
| LinuxOld | `RUST-1ES-POOL-WUS3` | `RUST-1ES-UBUSLIM` |
| LinuxNvme | `RUST-1ES-POOL-WUS3-NVME` | `RUST-1ES-UBUSLIM-NVME` |

## Method
- **Windows:** Microsoft `diskspd` with `-Sh` (software + hardware cache bypass).
- **Linux:** `fio --direct=1` (O_DIRECT, bypasses page cache).
- Both target the agent work folder and report the backing physical disk (BusType / rotational / transport), then run: sequential write/read (1M), random read/write (4K), and mixed random 64K (30% write) — patterns representative of a Rust build.
- Each scenario emits a `RESULT|<label>|<scenario>|<MB/s>|<IOPS>` line for easy comparison.

## Notes
- **Do not merge.** `validation-pipeline.yml` is hijacked; the original entry point is preserved as comments and must be restored before this branch could ever merge.
- Assumes the old pool/images still exist. If they've been deleted, the `*Old` jobs will fail to find agents.