### PR TITLE
Register the Rust ODBC driver under its own name and run e2e parity comparison in CI

### DIFF
--- a/.pipeline/scripts/containerized-odbc-e2e.sh
+++ b/.pipeline/scripts/containerized-odbc-e2e.sh
@@ -37,10 +37,18 @@ compare_args=()
 case "$(printf '%s' "${ODBC_E2E_COMPARE:-0}" | tr '[:upper:]' '[:lower:]')" in
     1|true|yes)
         apt-get install -y --no-install-recommends curl gnupg ca-certificates
+        # Install the signing key into its own keyring and scope it to just the
+        # Microsoft repo via signed-by, rather than trusting it for every apt
+        # source on the box (a global trusted.gpg.d drop-in would do that).
+        install -d -m 0755 /usr/share/keyrings
         curl -fsSL https://packages.microsoft.com/keys/microsoft.asc \
-            -o /etc/apt/trusted.gpg.d/microsoft.asc
+            -o /usr/share/keyrings/microsoft.asc
         curl -fsSL "https://packages.microsoft.com/config/ubuntu/$(. /etc/os-release && echo "$VERSION_ID")/prod.list" \
             -o /etc/apt/sources.list.d/mssql-release.list
+        sed -i 's#^deb \[#deb [signed-by=/usr/share/keyrings/microsoft.asc #' \
+            /etc/apt/sources.list.d/mssql-release.list
+        grep -q 'signed-by=/usr/share/keyrings/microsoft.asc' /etc/apt/sources.list.d/mssql-release.list \
+            || { echo "Error: failed to scope the Microsoft apt key to its repo" >&2; exit 1; }
         apt-get update
         ACCEPT_EULA=Y apt-get install -y --no-install-recommends "msodbcsql18=$MSODBCSQL_VERSION"
         # msodbcsql18 registers itself as [ODBC Driver 18 for SQL Server] in

--- a/.pipeline/scripts/containerized-odbc-e2e.sh
+++ b/.pipeline/scripts/containerized-odbc-e2e.sh
@@ -13,6 +13,8 @@
 # ODBC_E2E_RETRIES controls the ctest until-pass retry count (default 3).
 # ODBC_E2E_COVERAGE=1 builds the driver instrumented and emits a Cobertura
 # report (x64 Linux PR builds only).
+# ODBC_E2E_COMPARE=1 additionally installs the Microsoft ODBC Driver 18 and
+# reruns the same suite against it, failing on any parity divergence.
 
 set -euo pipefail
 
@@ -21,6 +23,27 @@ source ~/.cargo/env
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install -y --no-install-recommends cmake unixodbc-dev
+
+# The reference driver for comparison mode. Pinned so a new upstream release
+# can't silently change what the parity table is comparing against.
+MSODBCSQL_VERSION="18.6.2.1-1"
+
+compare_args=()
+case "$(printf '%s' "${ODBC_E2E_COMPARE:-0}" | tr '[:upper:]' '[:lower:]')" in
+    1|true|yes)
+        apt-get install -y --no-install-recommends curl gnupg ca-certificates
+        curl -fsSL https://packages.microsoft.com/keys/microsoft.asc \
+            -o /etc/apt/trusted.gpg.d/microsoft.asc
+        curl -fsSL "https://packages.microsoft.com/config/ubuntu/$(. /etc/os-release && echo "$VERSION_ID")/prod.list" \
+            -o /etc/apt/sources.list.d/mssql-release.list
+        apt-get update
+        ACCEPT_EULA=Y apt-get install -y --no-install-recommends "msodbcsql18=$MSODBCSQL_VERSION"
+        # msodbcsql18 registers itself as [ODBC Driver 18 for SQL Server] in
+        # /etc/odbcinst.ini, which is run_e2e.sh's default --msodbcsql-ini.
+        compare_args+=(--compare-with-msodbcsql)
+        ;;
+esac
+
 rm -rf /var/lib/apt/lists/*
 
 # When ODBC_E2E_COVERAGE=1 (x64 Linux PR builds), build the driver with LLVM
@@ -34,4 +57,5 @@ case "$(printf '%s' "${ODBC_E2E_COVERAGE:-0}" | tr '[:upper:]' '[:lower:]')" in
         ;;
 esac
 
-exec /workspace/mssql-odbc/tests/e2e/run_e2e.sh --retries="${ODBC_E2E_RETRIES:-3}" "${coverage_args[@]}"
+exec /workspace/mssql-odbc/tests/e2e/run_e2e.sh --retries="${ODBC_E2E_RETRIES:-3}" \
+    "${coverage_args[@]}" "${compare_args[@]}"

--- a/.pipeline/scripts/containerized-odbc-e2e.sh
+++ b/.pipeline/scripts/containerized-odbc-e2e.sh
@@ -15,6 +15,8 @@
 # report (x64 Linux PR builds only).
 # ODBC_E2E_COMPARE=1 additionally installs the Microsoft ODBC Driver 18 and
 # reruns the same suite against it, failing on any parity divergence.
+# ODBC_E2E_MSODBCSQL_VERSION overrides the reference driver's upstream version
+# (default 18.6.2.1); the Debian package revision is appended automatically.
 
 set -euo pipefail
 
@@ -24,9 +26,12 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install -y --no-install-recommends cmake unixodbc-dev
 
-# The reference driver for comparison mode. Pinned so a new upstream release
-# can't silently change what the parity table is comparing against.
-MSODBCSQL_VERSION="18.6.2.1-1"
+# The reference driver for comparison mode. The upstream version defaults to a
+# pinned value but can be overridden by the msodbcsqlVersion pipeline variable
+# (passed as ODBC_E2E_MSODBCSQL_VERSION), so a new release can't silently change
+# what the parity table compares against. apt pins the full <upstream>-<revision>
+# package; the Debian revision suffix is appended here.
+MSODBCSQL_VERSION="${ODBC_E2E_MSODBCSQL_VERSION:-18.6.2.1}-1"
 
 compare_args=()
 case "$(printf '%s' "${ODBC_E2E_COMPARE:-0}" | tr '[:upper:]' '[:lower:]')" in

--- a/.pipeline/scripts/install-msodbcsql.ps1
+++ b/.pipeline/scripts/install-msodbcsql.ps1
@@ -25,12 +25,44 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+# Collapse zero-padded version segments (e.g. 18.06.0002.0001 -> 18.6.2.1) so a
+# DLL's ProductVersion can be compared to the semantic -Version regardless of
+# padding or ',' vs '.' separators.
+function Normalize-Version([string]$v) {
+    if (-not $v) { return '' }
+    (($v -split '[.,]') | ForEach-Object {
+        $n = 0
+        if ([int]::TryParse($_.Trim(), [ref]$n)) { $n } else { $_.Trim() }
+    }) -join '.'
+}
+
 $name = 'ODBC Driver 18 for SQL Server'
 $key  = "HKLM:\Software\ODBC\ODBCINST.INI\$name"
 
 if (Test-Path $key) {
-    Write-Host "$name is already registered; skipping install."
+    Write-Host "$name is already registered; verifying its version instead of installing."
     Get-ItemProperty -Path $key | Format-List | Out-String | Write-Host
+
+    # A pre-installed driver on a self-hosted/persistent agent could be a version
+    # other than the pinned one, which would silently change what the parity table
+    # compares against. Resolve the registered DLL and fail loudly on a mismatch.
+    $dll = (Get-ItemProperty -Path $key -Name 'Driver' -ErrorAction SilentlyContinue).Driver
+    if ($dll -and (Test-Path $dll)) {
+        $info = (Get-Item $dll).VersionInfo
+        Write-Host "Registered '$name' -> $dll (FileVersion=$($info.FileVersion), ProductVersion=$($info.ProductVersion))"
+
+        $want = Normalize-Version $Version
+        $have = Normalize-Version $info.ProductVersion
+        if (-not $have) {
+            Write-Warning "Could not read a ProductVersion from $dll; skipping the version check."
+        } elseif ($have -ne $want) {
+            throw "Registered '$name' is version $($info.ProductVersion) (normalized $have) but the pipeline pins $Version (normalized $want). Uninstall the pre-installed driver, or update the msodbcsqlVersion variable and the pinned MSI in this script."
+        } else {
+            Write-Host "Version check passed: registered driver matches the pinned $Version."
+        }
+    } else {
+        Write-Warning "'$name' is registered but its Driver DLL path could not be resolved; skipping the version check."
+    }
     exit 0
 }
 

--- a/.pipeline/scripts/install-msodbcsql.ps1
+++ b/.pipeline/scripts/install-msodbcsql.ps1
@@ -9,10 +9,10 @@
 #
 # winget is the intended path, but it is not present on every Windows Server
 # image, so fall back to the MSI winget itself would download. Skipping the
-# install is deliberately not an option when the driver is absent: it would
-# silently downgrade the job to a single-leg run, so every install failure path
-# throws. A driver that is already registered at a different patch version is a
-# softer case (see below): it warns rather than throwing.
+# install is deliberately not an option: it would silently downgrade the job to a
+# single-leg run, so every install failure path throws. A driver already
+# registered at a different version is warned about and then upgraded to the
+# pinned version, and the post-install check throws if the upgrade did not take.
 #
 # The MSI URL and hash are pinned to the -Version default. Bumping -Version (via
 # the msodbcsqlVersion pipeline variable) without also updating -MsiUrl/-MsiSha256
@@ -42,16 +42,15 @@ $name = 'ODBC Driver 18 for SQL Server'
 $key  = "HKLM:\Software\ODBC\ODBCINST.INI\$name"
 
 if (Test-Path $key) {
-    Write-Host "$name is already registered; verifying its version instead of installing."
+    Write-Host "$name is already registered; checking its version before deciding whether to install."
     Get-ItemProperty -Path $key | Format-List | Out-String | Write-Host
 
     # A pre-installed driver on a hosted/persistent agent (the Windows 1ES image
     # ships 18.5.2.1) may be a version other than the pinned one, which changes
-    # what the parity table compares against. Resolve the registered DLL and warn
-    # loudly on a mismatch, but do not throw: the driver is present and usable, the
-    # reference leg runs fine against it, and the comparison itself is what gates
-    # the build. Hard-failing here would block every PR on an agent whose baked-in
-    # driver version is outside this repo's control.
+    # what the parity table compares against. Resolve the registered DLL: if it
+    # already matches the pin, skip the install; otherwise warn and fall through to
+    # upgrade it to the pinned version so the comparison always runs against a known
+    # driver.
     $dll = (Get-ItemProperty -Path $key -Name 'Driver' -ErrorAction SilentlyContinue).Driver
     if ($dll -and (Test-Path $dll)) {
         $info = (Get-Item $dll).VersionInfo
@@ -59,22 +58,24 @@ if (Test-Path $key) {
 
         $want = Normalize-Version $Version
         $have = Normalize-Version $info.ProductVersion
-        if (-not $have) {
-            Write-Warning "Could not read a ProductVersion from $dll; skipping the version check."
-        } elseif ($have -ne $want) {
-            Write-Warning "Registered '$name' is version $($info.ProductVersion) (normalized $have) but the pipeline pins $Version (normalized $want). The comparison leg will run against the installed version. To close the gap, uninstall the pre-installed driver so this script installs the pinned MSI, or update the msodbcsqlVersion variable and the pinned MSI to match the agent."
+        if ($have -and $have -eq $want) {
+            Write-Host "Version check passed: registered driver matches the pinned $Version; skipping install."
+            exit 0
+        } elseif ($have) {
+            Write-Warning "Registered '$name' is version $($info.ProductVersion) (normalized $have) but the pipeline pins $Version (normalized $want); upgrading the pre-installed driver to the pinned version."
         } else {
-            Write-Host "Version check passed: registered driver matches the pinned $Version."
+            Write-Warning "Could not read a ProductVersion from $dll; reinstalling the pinned $Version to be safe."
         }
     } else {
-        Write-Warning "'$name' is registered but its Driver DLL path could not be resolved; skipping the version check."
+        Write-Warning "'$name' is registered but its Driver DLL path could not be resolved; reinstalling the pinned $Version."
     }
-    exit 0
 }
 
 if (Get-Command winget -ErrorAction SilentlyContinue) {
     Write-Host "Installing msodbcsql $Version via winget..."
-    winget install --id Microsoft.msodbcsql.18 --version $Version --exact `
+    # --force so winget upgrades/reinstalls even when a different version is already
+    # present, rather than reporting "no applicable update" and leaving it in place.
+    winget install --id Microsoft.msodbcsql.18 --version $Version --exact --force `
         --silent --accept-package-agreements --accept-source-agreements `
         --disable-interactivity
     if ($LASTEXITCODE -ne 0) {
@@ -88,6 +89,7 @@ if (Get-Command winget -ErrorAction SilentlyContinue) {
     if ($actual -ne $MsiSha256) {
         throw "msodbcsql MSI hash mismatch: expected $MsiSha256, got $actual"
     }
+    # A same-UpgradeCode MSI performs a major upgrade over any pre-installed 18.x.
     $p = Start-Process msiexec.exe -Wait -PassThru -ArgumentList @(
         '/i', "`"$msi`"", '/qn', '/norestart', 'IACCEPTMSODBCSQLLICENSETERMS=YES'
     )
@@ -99,4 +101,18 @@ if (Get-Command winget -ErrorAction SilentlyContinue) {
 if (-not (Test-Path $key)) {
     throw "Install reported success but '$name' is not registered under HKLM."
 }
-Write-Host "Installed and registered '$name'."
+
+# Confirm the install/upgrade actually produced the pinned version. Now that we
+# fall through and attempt an upgrade, a persistent mismatch is a real failure
+# (the upgrade did not take) rather than an uncontrollable pre-existing driver.
+$dll = (Get-ItemProperty -Path $key -Name 'Driver' -ErrorAction SilentlyContinue).Driver
+if ($dll -and (Test-Path $dll)) {
+    $info = (Get-Item $dll).VersionInfo
+    $want = Normalize-Version $Version
+    $have = Normalize-Version $info.ProductVersion
+    Write-Host "Post-install '$name' -> $dll (ProductVersion=$($info.ProductVersion))"
+    if ($have -and $have -ne $want) {
+        throw "After install/upgrade, '$name' is version $($info.ProductVersion) (normalized $have) but the pipeline pins $Version (normalized $want); the upgrade did not take effect."
+    }
+}
+Write-Host "Installed and registered '$name' ($Version)."

--- a/.pipeline/scripts/install-msodbcsql.ps1
+++ b/.pipeline/scripts/install-msodbcsql.ps1
@@ -1,0 +1,64 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# Installs the Microsoft ODBC Driver 18 for SQL Server (msodbcsql18) as the
+# parity reference driver for the ODBC C++ e2e comparison run on Windows. It
+# registers as "ODBC Driver 18 for SQL Server"; the Rust driver registers
+# separately as "... (Rust)", so the two coexist and run_e2e.ps1 selects between
+# them per leg.
+#
+# winget is the intended path, but it is not present on every Windows Server
+# image, so fall back to the MSI winget itself would download. Skipping the
+# install is deliberately not an option: it would silently downgrade the job to a
+# single-leg run, so every failure path throws.
+#
+# The MSI URL and hash are pinned to the -Version default. Bumping -Version (via
+# the msodbcsqlVersion pipeline variable) without also updating -MsiUrl/-MsiSha256
+# leaves the winget path working while the MSI fallback fails loudly on a hash
+# mismatch rather than installing an unverified binary.
+[CmdletBinding()]
+param(
+    [string]$Version   = '18.6.2.1',
+    [string]$MsiUrl    = 'https://download.microsoft.com/download/7bf9fad4-0f21-486d-a750-fc990ded5624/amd64/1033/msodbcsql.msi',
+    [string]$MsiSha256 = '20314529110da3365a252164a657bdc837a18be5839105aa5f5acf0a8d2f4b82'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$name = 'ODBC Driver 18 for SQL Server'
+$key  = "HKLM:\Software\ODBC\ODBCINST.INI\$name"
+
+if (Test-Path $key) {
+    Write-Host "$name is already registered; skipping install."
+    Get-ItemProperty -Path $key | Format-List | Out-String | Write-Host
+    exit 0
+}
+
+if (Get-Command winget -ErrorAction SilentlyContinue) {
+    Write-Host "Installing msodbcsql $Version via winget..."
+    winget install --id Microsoft.msodbcsql.18 --version $Version --exact `
+        --silent --accept-package-agreements --accept-source-agreements `
+        --disable-interactivity
+    if ($LASTEXITCODE -ne 0) {
+        throw "winget install of msodbcsql $Version failed (exit $LASTEXITCODE)"
+    }
+} else {
+    $msi = Join-Path $env:TEMP 'msodbcsql.msi'
+    Write-Host "winget not available; downloading msodbcsql $Version MSI..."
+    Invoke-WebRequest -Uri $MsiUrl -OutFile $msi -UseBasicParsing
+    $actual = (Get-FileHash $msi -Algorithm SHA256).Hash
+    if ($actual -ne $MsiSha256) {
+        throw "msodbcsql MSI hash mismatch: expected $MsiSha256, got $actual"
+    }
+    $p = Start-Process msiexec.exe -Wait -PassThru -ArgumentList @(
+        '/i', "`"$msi`"", '/qn', '/norestart', 'IACCEPTMSODBCSQLLICENSETERMS=YES'
+    )
+    if ($p.ExitCode -ne 0) {
+        throw "msiexec install of msodbcsql $Version failed (exit $($p.ExitCode))"
+    }
+}
+
+if (-not (Test-Path $key)) {
+    throw "Install reported success but '$name' is not registered under HKLM."
+}
+Write-Host "Installed and registered '$name'."

--- a/.pipeline/scripts/install-msodbcsql.ps1
+++ b/.pipeline/scripts/install-msodbcsql.ps1
@@ -9,8 +9,10 @@
 #
 # winget is the intended path, but it is not present on every Windows Server
 # image, so fall back to the MSI winget itself would download. Skipping the
-# install is deliberately not an option: it would silently downgrade the job to a
-# single-leg run, so every failure path throws.
+# install is deliberately not an option when the driver is absent: it would
+# silently downgrade the job to a single-leg run, so every install failure path
+# throws. A driver that is already registered at a different patch version is a
+# softer case (see below): it warns rather than throwing.
 #
 # The MSI URL and hash are pinned to the -Version default. Bumping -Version (via
 # the msodbcsqlVersion pipeline variable) without also updating -MsiUrl/-MsiSha256
@@ -43,9 +45,13 @@ if (Test-Path $key) {
     Write-Host "$name is already registered; verifying its version instead of installing."
     Get-ItemProperty -Path $key | Format-List | Out-String | Write-Host
 
-    # A pre-installed driver on a self-hosted/persistent agent could be a version
-    # other than the pinned one, which would silently change what the parity table
-    # compares against. Resolve the registered DLL and fail loudly on a mismatch.
+    # A pre-installed driver on a hosted/persistent agent (the Windows 1ES image
+    # ships 18.5.2.1) may be a version other than the pinned one, which changes
+    # what the parity table compares against. Resolve the registered DLL and warn
+    # loudly on a mismatch, but do not throw: the driver is present and usable, the
+    # reference leg runs fine against it, and the comparison itself is what gates
+    # the build. Hard-failing here would block every PR on an agent whose baked-in
+    # driver version is outside this repo's control.
     $dll = (Get-ItemProperty -Path $key -Name 'Driver' -ErrorAction SilentlyContinue).Driver
     if ($dll -and (Test-Path $dll)) {
         $info = (Get-Item $dll).VersionInfo
@@ -56,7 +62,7 @@ if (Test-Path $key) {
         if (-not $have) {
             Write-Warning "Could not read a ProductVersion from $dll; skipping the version check."
         } elseif ($have -ne $want) {
-            throw "Registered '$name' is version $($info.ProductVersion) (normalized $have) but the pipeline pins $Version (normalized $want). Uninstall the pre-installed driver, or update the msodbcsqlVersion variable and the pinned MSI in this script."
+            Write-Warning "Registered '$name' is version $($info.ProductVersion) (normalized $have) but the pipeline pins $Version (normalized $want). The comparison leg will run against the installed version. To close the gap, uninstall the pre-installed driver so this script installs the pinned MSI, or update the msodbcsqlVersion variable and the pinned MSI to match the agent."
         } else {
             Write-Host "Version check passed: registered driver matches the pinned $Version."
         }

--- a/.pipeline/templates/build-template-container.yml
+++ b/.pipeline/templates/build-template-container.yml
@@ -265,6 +265,11 @@ steps:
   # job already uses. Runs inside the build container; the containerized script
   # installs cmake + unixODBC-dev (absent from the build image) then invokes
   # run_e2e.sh. PR-only, matching the Rust test pass above.
+  #
+  # ODBC_E2E_COMPARE also installs the Microsoft ODBC Driver 18 and reruns the
+  # suite against it, so a behavioural divergence between the Rust driver and
+  # msodbcsql18 fails the build. Only this leg does it: it owns a local SQL
+  # Server in docker, so the doubled test time is contained.
   - script: |
       BUILD_IMAGE="ghcr.io/microsoft/mssql-rs/build/ubuntu:22.04"
 
@@ -280,11 +285,12 @@ steps:
         -e ODBC_TEST_TRUST_CERT="Yes" \
         -e ODBC_E2E_RETRIES="3" \
         -e ODBC_E2E_COVERAGE="${{ lower(parameters.collectRustCoverage) }}" \
+        -e ODBC_E2E_COMPARE="1" \
         -e RUST_BACKTRACE=full \
         -w /workspace \
         $BUILD_IMAGE \
         /workspace/.pipeline/scripts/containerized-odbc-e2e.sh
-    displayName: Run ODBC e2e tests
+    displayName: Run ODBC e2e tests (with msodbcsql parity comparison)
     condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
     env:
       SQL_PASSWORD: $(SQL_PASSWORD)
@@ -376,6 +382,20 @@ steps:
     testResultsFormat: JUnit
     testResultsFiles: $(Build.SourcesDirectory)/mssql-odbc/tests/e2e/build/junit-mssql-odbc.xml
     testRunTitle: $(System.PhaseName)-ODBC
+    failTaskOnFailedTests: false
+    publishRunAttachments: true
+
+# Reference-driver leg, produced only by the x64 job (ODBC_E2E_COMPARE=1).
+# Published so a parity divergence can be triaged from the test tab rather than
+# by reading the build log. Absent on ARM, where the task just warns.
+- task: PublishTestResults@2
+  condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
+  displayName: Publish ODBC e2e test results (msodbcsql reference)
+  continueOnError: true
+  inputs:
+    testResultsFormat: JUnit
+    testResultsFiles: $(Build.SourcesDirectory)/mssql-odbc/tests/e2e/build/junit-msodbcsql.xml
+    testRunTitle: $(System.PhaseName)-ODBC-msodbcsql
     failTaskOnFailedTests: false
     publishRunAttachments: true
 

--- a/.pipeline/templates/build-template-container.yml
+++ b/.pipeline/templates/build-template-container.yml
@@ -387,17 +387,18 @@ steps:
 
 # Reference-driver leg, produced only by the x64 job (ODBC_E2E_COMPARE=1).
 # Published so a parity divergence can be triaged from the test tab rather than
-# by reading the build log. Absent on ARM, where the task just warns.
-- task: PublishTestResults@2
-  condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
-  displayName: Publish ODBC e2e test results (msodbcsql reference)
-  continueOnError: true
-  inputs:
-    testResultsFormat: JUnit
-    testResultsFiles: $(Build.SourcesDirectory)/mssql-odbc/tests/e2e/build/junit-msodbcsql.xml
-    testRunTitle: $(System.PhaseName)-ODBC-msodbcsql
-    failTaskOnFailedTests: false
-    publishRunAttachments: true
+# by reading the build log.
+- ${{ if ne(parameters.architecture, 'ARM64') }}:
+  - task: PublishTestResults@2
+    condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
+    displayName: Publish ODBC e2e test results (msodbcsql reference)
+    continueOnError: true
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: $(Build.SourcesDirectory)/mssql-odbc/tests/e2e/build/junit-msodbcsql.xml
+      testRunTitle: $(System.PhaseName)-ODBC-msodbcsql
+      failTaskOnFailedTests: false
+      publishRunAttachments: true
 
 # Coverage is not published to the ADO coverage tab from this job. The Linux
 # mssql-tds Rust Cobertura report is published as a per-OS artifact; the

--- a/.pipeline/templates/build-template-container.yml
+++ b/.pipeline/templates/build-template-container.yml
@@ -286,6 +286,7 @@ steps:
         -e ODBC_E2E_RETRIES="3" \
         -e ODBC_E2E_COVERAGE="${{ lower(parameters.collectRustCoverage) }}" \
         -e ODBC_E2E_COMPARE="1" \
+        -e ODBC_E2E_MSODBCSQL_VERSION="$(msodbcsqlVersion)" \
         -e RUST_BACKTRACE=full \
         -w /workspace \
         $BUILD_IMAGE \

--- a/.pipeline/templates/build-template.yml
+++ b/.pipeline/templates/build-template.yml
@@ -194,59 +194,18 @@ steps:
 # mssql-tds). The report is unioned into the Merge Coverage stage so lines
 # reachable only via the ODBC surface count toward PR diff coverage.
 - ${{ if and(eq(parameters.osType, 'Windows'), eq(parameters.enableOdbcE2E, true)) }}:
-  # Reference driver for the parity comparison below. Pinned so a new upstream
-  # release can't silently change what the parity table is comparing against.
-  # It installs as "ODBC Driver 18 for SQL Server"; the Rust driver registers
-  # separately as "... (Rust)", so the two coexist.
-  #
-  # winget is the intended path, but it is not present on every Windows Server
-  # image, so fall back to the MSI winget itself would download (URL and hash
-  # taken from the pinned winget manifest). Skipping the install is deliberately
-  # not an option: it would silently downgrade the job to a single-leg run.
-  - pwsh: |
-      $ErrorActionPreference = 'Stop'
-      $name = 'ODBC Driver 18 for SQL Server'
-      $key  = "HKLM:\Software\ODBC\ODBCINST.INI\$name"
-      $version = '18.6.2.1'
-
-      if (Test-Path $key) {
-        Write-Host "$name is already registered; skipping install."
-        Get-ItemProperty -Path $key | Format-List | Out-String | Write-Host
-        exit 0
-      }
-
-      if (Get-Command winget -ErrorAction SilentlyContinue) {
-        Write-Host "Installing msodbcsql $version via winget..."
-        winget install --id Microsoft.msodbcsql.18 --version $version --exact `
-          --silent --accept-package-agreements --accept-source-agreements `
-          --disable-interactivity
-        if ($LASTEXITCODE -ne 0) {
-          throw "winget install of msodbcsql $version failed (exit $LASTEXITCODE)"
-        }
-      } else {
-        $url    = 'https://download.microsoft.com/download/7bf9fad4-0f21-486d-a750-fc990ded5624/amd64/1033/msodbcsql.msi'
-        $sha256 = '20314529110da3365a252164a657bdc837a18be5839105aa5f5acf0a8d2f4b82'
-        $msi    = Join-Path $env:TEMP 'msodbcsql.msi'
-        Write-Host "winget not available; downloading msodbcsql $version MSI..."
-        Invoke-WebRequest -Uri $url -OutFile $msi -UseBasicParsing
-        $actual = (Get-FileHash $msi -Algorithm SHA256).Hash
-        if ($actual -ne $sha256) {
-          throw "msodbcsql MSI hash mismatch: expected $sha256, got $actual"
-        }
-        $p = Start-Process msiexec.exe -Wait -PassThru -ArgumentList @(
-          '/i', "`"$msi`"", '/qn', '/norestart', 'IACCEPTMSODBCSQLLICENSETERMS=YES'
-        )
-        if ($p.ExitCode -ne 0) {
-          throw "msiexec install of msodbcsql $version failed (exit $($p.ExitCode))"
-        }
-      }
-
-      if (-not (Test-Path $key)) {
-        throw "Install reported success but '$name' is not registered under HKLM."
-      }
-      Write-Host "Installed and registered '$name'."
-    displayName: Install msodbcsql 18.6.2.1 (parity reference driver)
+  # Reference driver for the parity comparison below, installed by
+  # install-msodbcsql.ps1. Pinned to the msodbcsqlVersion pipeline variable so a
+  # new upstream release can't silently change what the parity table compares
+  # against. It installs as "ODBC Driver 18 for SQL Server"; the Rust driver
+  # registers separately as "... (Rust)", so the two coexist.
+  - task: PowerShell@2
+    displayName: Install msodbcsql $(msodbcsqlVersion) (parity reference driver)
     condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+    inputs:
+      pwsh: true
+      filePath: $(Build.SourcesDirectory)/.pipeline/scripts/install-msodbcsql.ps1
+      arguments: -Version '$(msodbcsqlVersion)'
 
   - pwsh: |
       $env:ODBC_TEST_SERVER   = 'localhost'

--- a/.pipeline/templates/build-template.yml
+++ b/.pipeline/templates/build-template.yml
@@ -194,6 +194,60 @@ steps:
 # mssql-tds). The report is unioned into the Merge Coverage stage so lines
 # reachable only via the ODBC surface count toward PR diff coverage.
 - ${{ if and(eq(parameters.osType, 'Windows'), eq(parameters.enableOdbcE2E, true)) }}:
+  # Reference driver for the parity comparison below. Pinned so a new upstream
+  # release can't silently change what the parity table is comparing against.
+  # It installs as "ODBC Driver 18 for SQL Server"; the Rust driver registers
+  # separately as "... (Rust)", so the two coexist.
+  #
+  # winget is the intended path, but it is not present on every Windows Server
+  # image, so fall back to the MSI winget itself would download (URL and hash
+  # taken from the pinned winget manifest). Skipping the install is deliberately
+  # not an option: it would silently downgrade the job to a single-leg run.
+  - pwsh: |
+      $ErrorActionPreference = 'Stop'
+      $name = 'ODBC Driver 18 for SQL Server'
+      $key  = "HKLM:\Software\ODBC\ODBCINST.INI\$name"
+      $version = '18.6.2.1'
+
+      if (Test-Path $key) {
+        Write-Host "$name is already registered; skipping install."
+        Get-ItemProperty -Path $key | Format-List | Out-String | Write-Host
+        exit 0
+      }
+
+      if (Get-Command winget -ErrorAction SilentlyContinue) {
+        Write-Host "Installing msodbcsql $version via winget..."
+        winget install --id Microsoft.msodbcsql.18 --version $version --exact `
+          --silent --accept-package-agreements --accept-source-agreements `
+          --disable-interactivity
+        if ($LASTEXITCODE -ne 0) {
+          throw "winget install of msodbcsql $version failed (exit $LASTEXITCODE)"
+        }
+      } else {
+        $url    = 'https://download.microsoft.com/download/7bf9fad4-0f21-486d-a750-fc990ded5624/amd64/1033/msodbcsql.msi'
+        $sha256 = '20314529110da3365a252164a657bdc837a18be5839105aa5f5acf0a8d2f4b82'
+        $msi    = Join-Path $env:TEMP 'msodbcsql.msi'
+        Write-Host "winget not available; downloading msodbcsql $version MSI..."
+        Invoke-WebRequest -Uri $url -OutFile $msi -UseBasicParsing
+        $actual = (Get-FileHash $msi -Algorithm SHA256).Hash
+        if ($actual -ne $sha256) {
+          throw "msodbcsql MSI hash mismatch: expected $sha256, got $actual"
+        }
+        $p = Start-Process msiexec.exe -Wait -PassThru -ArgumentList @(
+          '/i', "`"$msi`"", '/qn', '/norestart', 'IACCEPTMSODBCSQLLICENSETERMS=YES'
+        )
+        if ($p.ExitCode -ne 0) {
+          throw "msiexec install of msodbcsql $version failed (exit $($p.ExitCode))"
+        }
+      }
+
+      if (-not (Test-Path $key)) {
+        throw "Install reported success but '$name' is not registered under HKLM."
+      }
+      Write-Host "Installed and registered '$name'."
+    displayName: Install msodbcsql 18.6.2.1 (parity reference driver)
+    condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+
   - pwsh: |
       $env:ODBC_TEST_SERVER   = 'localhost'
       $env:ODBC_TEST_UID      = 'sa'
@@ -201,9 +255,12 @@ steps:
       $env:ODBC_TEST_TRUST_CERT = 'Yes'
       # Explicit -CoverageOutput under $(Build.SourcesDirectory)/target keeps the
       # publish path deterministic regardless of the job's CARGO_TARGET_DIR.
+      # -CompareWithMsodbcsql reruns the suite against the driver installed
+      # above; the script fails on any parity divergence.
       ./mssql-odbc/tests/e2e/run_e2e.ps1 -Retries 3 -Coverage `
+        -CompareWithMsodbcsql `
         -CoverageOutput "$(Build.SourcesDirectory)/target/cobertura-odbc-e2e.xml"
-    displayName: Run ODBC C++ e2e tests (Windows) with coverage
+    displayName: Run ODBC C++ e2e tests (Windows) with coverage and msodbcsql parity comparison
     condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
     env:
       SQL_PASSWORD: $(SQL_PASSWORD)
@@ -216,6 +273,17 @@ steps:
       testResultsFormat: "JUnit"
       testResultsFiles: $(Build.SourcesDirectory)/mssql-odbc/tests/e2e/build/junit-mssql-odbc.xml
       testRunTitle: $(System.PhaseName)-OdbcE2E
+
+  # Reference-driver leg. Published so a parity divergence can be triaged from
+  # the test tab rather than by reading the build log.
+  - task: PublishTestResults@2
+    condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
+    displayName: "Publish ODBC e2e test results (Windows, msodbcsql reference)"
+    continueOnError: true
+    inputs:
+      testResultsFormat: "JUnit"
+      testResultsFiles: $(Build.SourcesDirectory)/mssql-odbc/tests/e2e/build/junit-msodbcsql.xml
+      testRunTitle: $(System.PhaseName)-OdbcE2E-msodbcsql
 
   # Best-effort (continueOnError) so a coverage hiccup never fails the build; the
   # Merge Coverage stage skips it if absent.

--- a/.pipeline/validation-pipeline-ci.yml
+++ b/.pipeline/validation-pipeline-ci.yml
@@ -39,6 +39,13 @@ parameters:
   type: string
   default: '2025-latest'
 
+variables:
+  # msodbcsql18 reference-driver version for the ODBC C++ e2e parity comparison.
+  # Pinned so an upstream release can't silently change what the parity table
+  # compares against. Consumed on Windows by install-msodbcsql.ps1 and on Linux
+  # by containerized-odbc-e2e.sh (which appends the Debian package revision).
+  msodbcsqlVersion: '18.6.2.1'
+
 stages:
 - template: templates/validation-stages.yml
   parameters:

--- a/.pipeline/validation-pipeline.yml
+++ b/.pipeline/validation-pipeline.yml
@@ -36,6 +36,13 @@ parameters:
   type: string
   default: '2025-latest'
 
+variables:
+  # msodbcsql18 reference-driver version for the ODBC C++ e2e parity comparison.
+  # Pinned so an upstream release can't silently change what the parity table
+  # compares against. Consumed on Windows by install-msodbcsql.ps1 and on Linux
+  # by containerized-odbc-e2e.sh (which appends the Debian package revision).
+  msodbcsqlVersion: '18.6.2.1'
+
 stages:
 - template: templates/validation-stages.yml
   parameters:

--- a/mssql-odbc/tests/e2e/README.md
+++ b/mssql-odbc/tests/e2e/README.md
@@ -98,6 +98,37 @@ Summary: 15 parity, 1 divergence(s), 0 shared failure(s), 0 skipped
 === Parity check FAILED (mssql-odbc rc=0, msodbcsql rc=0, parity rc=1) ===
 ```
 
+### Intentional divergence: `SKIP_IF_COMPARING_MSODBCSQL()`
+
+Some tests assert behavior that is deliberately stricter in the Rust driver than
+in msodbcsql — for example rejecting an invalid connection-attribute value with
+`HY024` where msodbcsql accepts it. Comparing those on the reference leg would
+always report a divergence and fail the run, even though the difference is
+intended.
+
+The escape hatch is `SKIP_IF_COMPARING_MSODBCSQL()` (defined in
+`include/odbc_test_fixture.h`). Each leg exports `ODBC_TEST_TARGET`
+(`mssql-odbc` on the Rust leg, `msodbcsql` on the reference leg); the macro
+`GTEST_SKIP()`s when it sees `msodbcsql`. The test still runs — and asserts — on
+the Rust leg, so its coverage is preserved; it is simply not run on the reference
+leg, so there is nothing to diverge.
+
+Prefer this over inline `if (ODBC_TEST_TARGET == ...)` guards around individual
+assertions. An inline guard that changes what a test asserts per leg still
+reports `PASS`/`PASS`, which hides the fact that the two drivers behaved
+differently at all. Skipping the whole case on the reference leg keeps the
+comparison honest; put a genuinely reference-incompatible case in its own test
+(as `DriverConnectLiveTest.InvalidConnectionAttributeValuesRejected` is) so the
+surrounding parity assertions still compare.
+
+**Granularity:** ctest compares at the *test-binary* level — each `*_test`
+executable is a single ctest case and the parity table is keyed on that binary
+name, not on individual gtest cases. A gtest skip is not a failure, so a case
+guarded by `SKIP_IF_COMPARING_MSODBCSQL()` leaves its binary passing on both
+legs: it shows up as `parity`, not `skipped`. The `skipped (not compared)`
+verdict only appears when an *entire* binary is skipped in one leg. Either way
+the divergent assertions never execute on the reference leg.
+
 CI runs this comparison on the Linux x64 PR build, which owns a SQL Server in
 docker. `.pipeline/scripts/containerized-odbc-e2e.sh` installs a pinned
 `msodbcsql18` from `packages.microsoft.com` when `ODBC_E2E_COMPARE=1`.

--- a/mssql-odbc/tests/e2e/README.md
+++ b/mssql-odbc/tests/e2e/README.md
@@ -165,7 +165,11 @@ winget install --id Microsoft.msodbcsql.18 --version 18.6.2.1 --exact
 ```
 
 CI runs this comparison on the Windows x64 PR build (the leg with a local SQL
-Server), installing the same pinned version before the suite.
+Server), installing the same pinned version before the suite. The version is
+set once via the `msodbcsqlVersion` pipeline variable (in
+`.pipeline/validation-pipeline*.yml`) and consumed on Windows by
+`.pipeline/scripts/install-msodbcsql.ps1` and on Linux by
+`.pipeline/scripts/containerized-odbc-e2e.sh`.
 
 When `ODBC_TEST_SERVER` is unset, a dev SQL Server on `localhost:1433` is
 auto-detected — the password is taken from `ODBC_TEST_PWD`, then `SQL_PASSWORD`,

--- a/mssql-odbc/tests/e2e/README.md
+++ b/mssql-odbc/tests/e2e/README.md
@@ -77,9 +77,18 @@ the two drivers.
 ./run_e2e.sh --compare-with-msodbcsql --msodbcsql-ini=/opt/msodbcsql/odbcinst.ini
 ```
 
-Both INIs must register the driver under the same section name
-(`[ODBC Driver 18 for SQL Server]`). The script exits `0` only if **both**
-runs pass.
+The two drivers register under **different** names, so both can be installed
+side by side:
+
+| Leg | Driver name (`ODBC_TEST_DRIVER`) |
+|---|---|
+| `mssql-odbc` | `ODBC Driver 18 for SQL Server (Rust)` |
+| `msodbcsql` | `ODBC Driver 18 for SQL Server` |
+
+Each leg exports `ODBC_TEST_DRIVER` so the same test binaries connect through
+the right driver. Setting `ODBC_TEST_CONNSTR` overrides the whole connection
+string and would pin both legs to one driver, so comparison mode rejects it.
+The script exits `0` only if **both** runs pass.
 
 ### Collecting coverage
 
@@ -112,9 +121,10 @@ and the Merge Coverage stage unions it into the diff-coverage report.
 ```
 
 Like `run_e2e.sh`, it can rerun the suite against msodbcsql 18 and print a
-parity table.
+parity table. The Rust driver registers under its own name, so no registry swap
+happens between the two legs.
 ```powershell
-# Use the currently registered msodbcsql18.dll as the reference
+# Use the installed "ODBC Driver 18 for SQL Server" registration as the reference
 .\run_e2e.ps1 -CompareWithMsodbcsql
 
 # Point at a specific reference driver
@@ -158,31 +168,41 @@ infrastructure works (`runtests.c`).
 ### How the scripts register the driver
 
 - **Linux / macOS (`run_e2e.sh`)**: Creates a temp directory with an
-  `odbcinst.ini` file and sets `ODBCSYSINI` to point at it. The env var is
-  scoped to the script process, so the parent shell is never affected. A
-  `trap cleanup EXIT` ensures the temp directory is removed even on failure.
+  `odbcinst.ini` file registering the Rust driver as
+  `[ODBC Driver 18 for SQL Server (Rust)]`, and sets `ODBCSYSINI` to point at
+  it. The env var is scoped to the script process, so the parent shell is never
+  affected. A `trap cleanup EXIT` ensures the temp directory is removed even on
+  failure.
 
 - **Windows (`run_e2e.ps1`)**: Writes `Driver` and `Setup` values under
-  `HKLM\Software\ODBC\ODBCINST.INI\ODBC Driver 18 for SQL Server`. The
-  original values are saved beforehand and restored in a `try/finally` block,
-  so an existing production driver installation is not permanently overwritten.
+  `HKLM\Software\ODBC\ODBCINST.INI\ODBC Driver 18 for SQL Server (Rust)`, so an
+  installed msodbcsql18 registration is left untouched. Any pre-existing values
+  under that key are saved beforehand and restored in a `try/finally` block.
+  Only `-MsodbcsqlDll` temporarily repoints the reference registration, and it
+  too is restored on exit.
 
 ### Manual registration (without the scripts)
 
-If you prefer not to use the scripts, register the driver yourself:
+If you prefer not to use the scripts, register the driver yourself. You can use
+either name — the canonical `ODBC Driver 18 for SQL Server` (the default when
+`ODBC_TEST_DRIVER` is unset), or a distinct name such as
+`ODBC Driver 18 for SQL Server (Rust)` if you want it installed alongside
+msodbcsql18. With a distinct name, set `ODBC_TEST_DRIVER` to match before
+running the tests.
 
 - **Linux / macOS**: Either add an entry to `/etc/odbcinst.ini`, or create
   your own `odbcinst.ini` in any directory and set `ODBCSYSINI` env var to that
   directory before running the tests.
 
-- **Windows**: Add the following registry values (requires Administrator):
+- **Windows**: Add the following registry values (requires Administrator),
+  substituting your chosen driver name for `<driver name>`:
   ```
-  HKLM\Software\ODBC\ODBCINST.INI\ODBC Driver 18 for SQL Server
+  HKLM\Software\ODBC\ODBCINST.INI\<driver name>
       Driver = <path to msodbcsql18.dll>
       Setup  = <path to msodbcsql18.dll>
 
   HKLM\Software\ODBC\ODBCINST.INI\ODBC Drivers
-      ODBC Driver 18 for SQL Server = Installed
+      <driver name> = Installed
   ```
 
 ## Manual Build
@@ -240,7 +260,7 @@ To bring up a local SQL Server in Docker:
 | `ODBC_TEST_UID` | Yes (for SQL auth) | *(none)* | SQL login username (e.g. `sa`) |
 | `ODBC_TEST_PWD` | Yes (for SQL auth) | *(none)* | SQL login password |
 | `ODBC_TEST_DATABASE` | No | `tempdb` | Database to connect to |
-| `ODBC_TEST_DRIVER` | No | `ODBC Driver 18 for SQL Server` | ODBC driver name |
+| `ODBC_TEST_DRIVER` | No | `ODBC Driver 18 for SQL Server` | ODBC driver name (the run scripts set this per leg) |
 | `ODBC_TEST_DSN` | No | *(none)* | Pre-configured DSN (overrides server/driver) |
 | `ODBC_TEST_CONNSTR` | No | *(none)* | Full connection string (overrides all above) |
 | `ODBC_TEST_TRUST_CERT` | No | `Yes` | Trust server certificate (`Yes`/`No`) |

--- a/mssql-odbc/tests/e2e/README.md
+++ b/mssql-odbc/tests/e2e/README.md
@@ -88,7 +88,33 @@ side by side:
 Each leg exports `ODBC_TEST_DRIVER` so the same test binaries connect through
 the right driver. Setting `ODBC_TEST_CONNSTR` overrides the whole connection
 string and would pin both legs to one driver, so comparison mode rejects it.
-The script exits `0` only if **both** runs pass.
+
+The script exits `0` only if **both** runs pass *and* every test reaches the
+same verdict in both legs. A divergence, a shared failure, or a test that ran
+in only one leg fails the run:
+
+```
+Summary: 15 parity, 1 divergence(s), 0 shared failure(s), 0 skipped
+=== Parity check FAILED (mssql-odbc rc=0, msodbcsql rc=0, parity rc=1) ===
+```
+
+CI runs this comparison on the Linux x64 PR build, which owns a SQL Server in
+docker. `.pipeline/scripts/containerized-odbc-e2e.sh` installs a pinned
+`msodbcsql18` from `packages.microsoft.com` when `ODBC_E2E_COMPARE=1`.
+
+### Failure modes that are never silently green
+
+Both runners abort — locally and in CI — when:
+
+- `cargo build` or either `cmake` invocation exits non-zero.
+- A ctest leg executes zero tests. ctest exits `0` and prints
+  `No tests were found!!!` in that case, which previously turned a broken CMake
+  configure into a passing run reporting `0 parity`.
+- Any test diverges between the two legs (comparison mode).
+
+In CI the scripts additionally dump `CMakeOutput.log`, `CMakeError.log`,
+`LastTest.log`, and the discovered test executables, since there is no working
+copy left to inspect afterwards.
 
 ### Collecting coverage
 
@@ -122,7 +148,8 @@ and the Merge Coverage stage unions it into the diff-coverage report.
 
 Like `run_e2e.sh`, it can rerun the suite against msodbcsql 18 and print a
 parity table. The Rust driver registers under its own name, so no registry swap
-happens between the two legs.
+happens between the two legs, and the same parity gate applies: any divergence
+fails the run.
 ```powershell
 # Use the installed "ODBC Driver 18 for SQL Server" registration as the reference
 .\run_e2e.ps1 -CompareWithMsodbcsql
@@ -130,6 +157,20 @@ happens between the two legs.
 # Point at a specific reference driver
 .\run_e2e.ps1 -CompareWithMsodbcsql -MsodbcsqlDll 'C:\path\to\msodbcsql18.dll'
 ```
+
+Install the reference driver with:
+
+```powershell
+winget install --id Microsoft.msodbcsql.18 --version 18.6.2.1 --exact
+```
+
+CI runs this comparison on the Windows x64 PR build (the leg with a local SQL
+Server), installing the same pinned version before the suite.
+
+When `ODBC_TEST_SERVER` is unset, a dev SQL Server on `localhost:1433` is
+auto-detected — the password is taken from `ODBC_TEST_PWD`, then `SQL_PASSWORD`,
+then `SQL_PASSWORD=` in `mssql-tds\.env`, falling back to integrated auth. This
+matches `run_e2e.sh`.
 
 `run_e2e.ps1 -Coverage` builds the Rust driver with LLVM source-based
 instrumentation so the driver code exercised by the C++ tests — which load the

--- a/mssql-odbc/tests/e2e/include/odbc_test_fixture.h
+++ b/mssql-odbc/tests/e2e/include/odbc_test_fixture.h
@@ -69,6 +69,14 @@ using SqlTString = std::basic_string<SQLTCHAR>;
     EXPECT_EQ(std::string(expected_state),                                     \
               ODBCTestUtils::GetDiagState(handle_type, handle))
 
+// Predicate form of SKIP_IF_COMPARING_MSODBCSQL, for tests whose assertions are
+// only partly mssql-odbc-specific: guard the divergent blocks with this and let
+// the shared ones keep running on both legs.
+inline bool ComparingMsodbcsql() {
+    const char* target = std::getenv("ODBC_TEST_TARGET");
+    return target && std::string(target) == "msodbcsql";
+}
+
 // Skip the current test on the msodbcsql leg of a --compare-with-msodbcsql run.
 // The same test binary runs against both drivers; use this at the top of a test
 // that asserts mssql-odbc-specific behavior the full msodbcsql driver does not
@@ -77,8 +85,7 @@ using SqlTString = std::basic_string<SQLTCHAR>;
 // gtest case does not fail the binary, so the parity run stays green.
 #define SKIP_IF_COMPARING_MSODBCSQL()                                          \
     do {                                                                       \
-        const char* _target = std::getenv("ODBC_TEST_TARGET");                 \
-        if (_target && std::string(_target) == "msodbcsql") {                  \
+        if (ComparingMsodbcsql()) {                                            \
             GTEST_SKIP() << "mssql-odbc-specific test; skipped on msodbcsql "   \
                             "comparison leg";                                  \
         }                                                                      \

--- a/mssql-odbc/tests/e2e/include/odbc_test_fixture.h
+++ b/mssql-odbc/tests/e2e/include/odbc_test_fixture.h
@@ -69,14 +69,6 @@ using SqlTString = std::basic_string<SQLTCHAR>;
     EXPECT_EQ(std::string(expected_state),                                     \
               ODBCTestUtils::GetDiagState(handle_type, handle))
 
-// Predicate form of SKIP_IF_COMPARING_MSODBCSQL, for tests whose assertions are
-// only partly mssql-odbc-specific: guard the divergent blocks with this and let
-// the shared ones keep running on both legs.
-inline bool ComparingMsodbcsql() {
-    const char* target = std::getenv("ODBC_TEST_TARGET");
-    return target && std::string(target) == "msodbcsql";
-}
-
 // Skip the current test on the msodbcsql leg of a --compare-with-msodbcsql run.
 // The same test binary runs against both drivers; use this at the top of a test
 // that asserts mssql-odbc-specific behavior the full msodbcsql driver does not
@@ -85,7 +77,8 @@ inline bool ComparingMsodbcsql() {
 // gtest case does not fail the binary, so the parity run stays green.
 #define SKIP_IF_COMPARING_MSODBCSQL()                                          \
     do {                                                                       \
-        if (ComparingMsodbcsql()) {                                            \
+        const char* _target = std::getenv("ODBC_TEST_TARGET");                 \
+        if (_target && std::string(_target) == "msodbcsql") {                  \
             GTEST_SKIP() << "mssql-odbc-specific test; skipped on msodbcsql "   \
                             "comparison leg";                                  \
         }                                                                      \

--- a/mssql-odbc/tests/e2e/parity_report.py
+++ b/mssql-odbc/tests/e2e/parity_report.py
@@ -1,0 +1,78 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# Parse the two ctest JUnit XMLs from a --compare-with-msodbcsql run and print a
+# parity table. Exits non-zero when any test reached a different verdict in the
+# two legs, so run_e2e.sh fails the run on a divergence or shared failure.
+#
+# Usage: parity_report.py <mssql-odbc-junit.xml> <msodbcsql-junit.xml>
+
+import sys
+import xml.etree.ElementTree as ET
+
+
+def load(path):
+    """Returns {test_name: 'PASS'|'FAIL'|'SKIP'}."""
+    out = {}
+    try:
+        root = ET.parse(path).getroot()
+    except (ET.ParseError, FileNotFoundError):
+        return out
+    # ctest --output-junit emits <testsuite><testcase name="..."> ...
+    for tc in root.iter("testcase"):
+        name = tc.get("name") or "<unnamed>"
+        tags = {child.tag for child in tc}
+        if tags & {"failure", "error"}:
+            out[name] = "FAIL"
+        elif "skipped" in tags:
+            out[name] = "SKIP"
+        else:
+            out[name] = "PASS"
+    return out
+
+
+# Verdicts describe only the observed outcome pairing, not a root cause: a
+# per-test PASS/FAIL divergence does not by itself establish which side is
+# wrong, and a shared failure does not prove the test is buggy.
+def verdict(r, m):
+    if r == "SKIP" or m == "SKIP":  return ("skipped (not compared)", "skip")
+    if r == "PASS" and m == "PASS": return ("parity", "parity")
+    if r == "FAIL" and m == "FAIL": return ("shared failure - investigate", "shared")
+    if r != m:                      return ("divergence - investigate", "divergence")
+    return ("missing run - investigate", "divergence")
+
+
+def main(argv):
+    if len(argv) != 3:
+        print("usage: parity_report.py <mssql-odbc-junit.xml> <msodbcsql-junit.xml>",
+              file=sys.stderr)
+        return 2
+
+    rust = load(argv[1])
+    ms = load(argv[2])
+    names = sorted(set(rust) | set(ms))
+
+    w = max((len(n) for n in names), default=4)
+    print()
+    print("=== Parity report (mssql-odbc vs msodbcsql) ===")
+    print(f"{'Test'.ljust(w)}  {'mssql-odbc':<10}  {'msodbcsql':<10}  Verdict")
+    print(f"{'-'*w}  {'-'*10}  {'-'*10}  {'-'*30}")
+    counts = {"parity": 0, "divergence": 0, "shared": 0, "skip": 0}
+    for n in names:
+        r = rust.get(n, "MISSING")
+        m = ms.get(n, "MISSING")
+        v, kind = verdict(r, m)
+        counts[kind] += 1
+        print(f"{n.ljust(w)}  {r:<10}  {m:<10}  {v}")
+    print()
+    print(f"Summary: {counts['parity']} parity, {counts['divergence']} divergence(s), "
+          f"{counts['shared']} shared failure(s), {counts['skip']} skipped")
+
+    # Any non-parity outcome fails the run. ctest exit codes alone are not enough:
+    # a test present in only one leg leaves both legs green while the comparison is
+    # meaningless.
+    return 1 if counts["divergence"] or counts["shared"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/mssql-odbc/tests/e2e/parity_report.py
+++ b/mssql-odbc/tests/e2e/parity_report.py
@@ -34,6 +34,10 @@ def load(path):
 # Verdicts describe only the observed outcome pairing, not a root cause: a
 # per-test PASS/FAIL divergence does not by itself establish which side is
 # wrong, and a shared failure does not prove the test is buggy.
+#
+# MIRROR: this classification is duplicated in the $verdict scriptblock in
+# run_e2e.ps1 (Windows has no Python dependency). Keep the two in lockstep —
+# any change to the ordering or the labels here must be made there too.
 def verdict(r, m):
     # Classify MISSING first: a test present in only one leg is a divergence,
     # even when its lone result is SKIP (otherwise the skip shortcut below would

--- a/mssql-odbc/tests/e2e/parity_report.py
+++ b/mssql-odbc/tests/e2e/parity_report.py
@@ -35,11 +35,15 @@ def load(path):
 # per-test PASS/FAIL divergence does not by itself establish which side is
 # wrong, and a shared failure does not prove the test is buggy.
 def verdict(r, m):
+    # Classify MISSING first: a test present in only one leg is a divergence,
+    # even when its lone result is SKIP (otherwise the skip shortcut below would
+    # mask a one-sided run as an allowed skip).
+    if r == "MISSING" or m == "MISSING": return ("missing run - investigate", "divergence")
     if r == "SKIP" or m == "SKIP":  return ("skipped (not compared)", "skip")
     if r == "PASS" and m == "PASS": return ("parity", "parity")
     if r == "FAIL" and m == "FAIL": return ("shared failure - investigate", "shared")
     if r != m:                      return ("divergence - investigate", "divergence")
-    return ("missing run - investigate", "divergence")
+    return ("unexpected - investigate", "divergence")
 
 
 def main(argv):

--- a/mssql-odbc/tests/e2e/run_e2e.ps1
+++ b/mssql-odbc/tests/e2e/run_e2e.ps1
@@ -1,8 +1,13 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# Build the Rust ODBC driver, register it in the Windows registry,
-# and run C++ gtest e2e tests against it via the ODBC Driver Manager.
+# Build the Rust ODBC driver, register it in the Windows registry under its own
+# driver name, and run C++ gtest e2e tests against it via the ODBC Driver Manager.
+#
+# The Rust driver registers as "ODBC Driver 18 for SQL Server (Rust)", so an
+# installed msodbcsql18 ("ODBC Driver 18 for SQL Server") is left untouched and
+# both can be used side by side. Each test leg selects its driver by name via
+# ODBC_TEST_DRIVER.
 #
 # The test fixture itself does NOT handle driver registration — this script
 # (or manual registry edits) is required. See run_e2e.sh for Linux/macOS.
@@ -24,15 +29,17 @@
 # reads the .profraw matches the rustc that produced the instrumented DLL.
 #
 # With -CompareWithMsodbcsql, the script reruns the same suite against the
-# Microsoft C++ driver and prints a parity table. Unlike Linux (which uses
-# per-run odbcinst.ini files via ODBCSYSINI), the Windows Driver Manager
-# reads the registry, so the two runs swap the registered driver in HKLM
-# between them and the original registration is restored at the end.
+# Microsoft C++ driver and prints a parity table. Because the two drivers are
+# registered under different names, no registry swap happens between the runs —
+# only the driver name in the connection string changes.
 #
-# The reference driver defaults to whatever msodbcsql18.dll was registered
-# before this script ran (typically C:\WINDOWS\system32\msodbcsql18.dll).
-# Override it with -MsodbcsqlDll PATH. The script exits 0 only if BOTH runs
-# pass.
+# The reference driver defaults to the installed "ODBC Driver 18 for SQL Server"
+# registration (typically C:\WINDOWS\system32\msodbcsql18.dll). Override it with
+# -MsodbcsqlDll PATH, which temporarily repoints that registration and restores
+# it at the end. The script exits 0 only if BOTH runs pass.
+#
+# ODBC_TEST_CONNSTR overrides the whole connection string and would pin both
+# legs to one driver, so comparison mode rejects it.
 #
 # Examples:
 #   .\run_e2e.ps1
@@ -66,14 +73,16 @@ if ($Coverage -and -not $CoverageOutput) {
     $CoverageOutput = Join-Path $WorkspaceDir "target\cobertura-odbc-e2e.xml"
 }
 
-$DriverRegKey  = "HKLM:\Software\ODBC\ODBCINST.INI\ODBC Driver 18 for SQL Server"
-$DriversRegKey = "HKLM:\Software\ODBC\ODBCINST.INI\ODBC Drivers"
-$DriverName    = "ODBC Driver 18 for SQL Server"
+$OdbcInstRoot     = "HKLM:\Software\ODBC\ODBCINST.INI"
+$DriversRegKey    = "$OdbcInstRoot\ODBC Drivers"
+$MsodbcsqlName    = "ODBC Driver 18 for SQL Server"
+$RustDriverName   = "ODBC Driver 18 for SQL Server (Rust)"
+$MsodbcsqlRegKey  = "$OdbcInstRoot\$MsodbcsqlName"
+$RustDriverRegKey = "$OdbcInstRoot\$RustDriverName"
 
-# Track whether we modified the registry so cleanup knows what to do. Each value
-# is snapshotted independently (did it exist, and its prior value) so a partial
-# or custom pre-existing registration is restored exactly, not left pointing at
-# the test DLL or a stray "Installed" entry.
+# The Rust driver registers under its own name, so an installed msodbcsql18 is
+# never touched. Only our own key is snapshotted, in case a developer has a Rust
+# driver permanently installed under the same name.
 $script:OrigDriver = $null
 $script:OrigSetup  = $null
 $script:HadExistingKey = $false
@@ -82,43 +91,85 @@ $script:HadSetupValue = $false
 $script:HadDriversListEntry = $false
 $script:OrigDriversListValue = $null
 $script:Registered = $false
+# Set only when -MsodbcsqlDll overrides the installed reference registration.
+$script:MsodbcsqlOverridden = $false
+$script:OrigMsodbcsqlDriver = $null
 
 function Save-OriginalRegistration {
-    if (Test-Path $DriverRegKey) {
+    if (Test-Path $RustDriverRegKey) {
         $script:HadExistingKey = $true
-        $d = Get-ItemProperty -Path $DriverRegKey -Name "Driver" -ErrorAction SilentlyContinue
+        $d = Get-ItemProperty -Path $RustDriverRegKey -Name "Driver" -ErrorAction SilentlyContinue
         if ($null -ne $d) { $script:HadDriverValue = $true; $script:OrigDriver = $d.Driver }
-        $s = Get-ItemProperty -Path $DriverRegKey -Name "Setup" -ErrorAction SilentlyContinue
+        $s = Get-ItemProperty -Path $RustDriverRegKey -Name "Setup" -ErrorAction SilentlyContinue
         if ($null -ne $s) { $script:HadSetupValue = $true; $script:OrigSetup = $s.Setup }
     }
     if (Test-Path $DriversRegKey) {
-        $e = Get-ItemProperty -Path $DriversRegKey -Name $DriverName -ErrorAction SilentlyContinue
+        $e = Get-ItemProperty -Path $DriversRegKey -Name $RustDriverName -ErrorAction SilentlyContinue
         if ($null -ne $e) {
             $script:HadDriversListEntry = $true
-            $script:OrigDriversListValue = $e.$DriverName
+            $script:OrigDriversListValue = $e.$RustDriverName
         }
     }
 }
 
-# Point the registered driver at $DriverPath without touching the saved
-# original. Used to swap between the Rust and reference drivers across runs.
-function Set-DriverRegistration([string]$DriverPath) {
-    if (-not (Test-Path $DriverRegKey)) {
-        New-Item -Path $DriverRegKey -Force | Out-Null
+# Register the Rust driver under its own name, alongside any installed
+# msodbcsql18. Both legs then run without swapping registrations.
+function Register-RustDriver([string]$DriverPath) {
+    if (-not (Test-Path $RustDriverRegKey)) {
+        New-Item -Path $RustDriverRegKey -Force | Out-Null
     }
-    Set-ItemProperty -Path $DriverRegKey -Name "Driver" -Value $DriverPath
-    Set-ItemProperty -Path $DriverRegKey -Name "Setup"  -Value $DriverPath
+    Set-ItemProperty -Path $RustDriverRegKey -Name "Driver" -Value $DriverPath
+    Set-ItemProperty -Path $RustDriverRegKey -Name "Setup"  -Value $DriverPath
 
     if (-not (Test-Path $DriversRegKey)) {
         New-Item -Path $DriversRegKey -Force | Out-Null
     }
-    Set-ItemProperty -Path $DriversRegKey -Name $DriverName -Value "Installed"
+    Set-ItemProperty -Path $DriversRegKey -Name $RustDriverName -Value "Installed"
 
     $script:Registered = $true
-    Write-Host "[  DRIVER ] Registered in HKLM: $DriverPath"
+    Write-Host "[  DRIVER ] Registered '$RustDriverName' in HKLM: $DriverPath"
+}
+
+# Resolve the installed reference driver from its own registry key.
+function Get-MsodbcsqlDriverPath {
+    $d = Get-ItemProperty -Path $MsodbcsqlRegKey -Name "Driver" -ErrorAction SilentlyContinue
+    if ($null -ne $d) { return $d.Driver }
+    return $null
+}
+
+# Point the reference registration at an explicit DLL for the comparison leg,
+# saving the installed value so Restore-Registration can put it back.
+function Set-MsodbcsqlOverride([string]$DriverPath) {
+    $script:OrigMsodbcsqlDriver = Get-MsodbcsqlDriverPath
+    if (-not (Test-Path $MsodbcsqlRegKey)) {
+        New-Item -Path $MsodbcsqlRegKey -Force | Out-Null
+    }
+    Set-ItemProperty -Path $MsodbcsqlRegKey -Name "Driver" -Value $DriverPath
+    Set-ItemProperty -Path $MsodbcsqlRegKey -Name "Setup"  -Value $DriverPath
+    if (-not (Test-Path $DriversRegKey)) {
+        New-Item -Path $DriversRegKey -Force | Out-Null
+    }
+    Set-ItemProperty -Path $DriversRegKey -Name $MsodbcsqlName -Value "Installed"
+    $script:MsodbcsqlOverridden = $true
+    Write-Host "[  DRIVER ] Overrode '$MsodbcsqlName' in HKLM: $DriverPath"
 }
 
 function Restore-Registration {
+    if ($script:MsodbcsqlOverridden) {
+        if ($script:OrigMsodbcsqlDriver) {
+            Set-ItemProperty -Path $MsodbcsqlRegKey -Name "Driver" -Value $script:OrigMsodbcsqlDriver
+            Set-ItemProperty -Path $MsodbcsqlRegKey -Name "Setup"  -Value $script:OrigMsodbcsqlDriver
+            Write-Host "[  DRIVER ] Restored original HKLM registration for '$MsodbcsqlName'"
+        } else {
+            Remove-Item -Path $MsodbcsqlRegKey -Force -ErrorAction SilentlyContinue
+            if (Test-Path $DriversRegKey) {
+                Remove-ItemProperty -Path $DriversRegKey -Name $MsodbcsqlName -ErrorAction SilentlyContinue
+            }
+            Write-Host "[  DRIVER ] Removed HKLM registration for '$MsodbcsqlName' (no prior driver)"
+        }
+        $script:MsodbcsqlOverridden = $false
+    }
+
     if (-not $script:Registered) { return }
 
     if ($script:HadExistingKey) {
@@ -126,27 +177,27 @@ function Restore-Registration {
         # exist before we ran (leaving a Driver/Setup value behind would point a
         # pre-existing key at the test DLL).
         if ($script:HadDriverValue) {
-            Set-ItemProperty -Path $DriverRegKey -Name "Driver" -Value $script:OrigDriver
+            Set-ItemProperty -Path $RustDriverRegKey -Name "Driver" -Value $script:OrigDriver
         } else {
-            Remove-ItemProperty -Path $DriverRegKey -Name "Driver" -ErrorAction SilentlyContinue
+            Remove-ItemProperty -Path $RustDriverRegKey -Name "Driver" -ErrorAction SilentlyContinue
         }
         if ($script:HadSetupValue) {
-            Set-ItemProperty -Path $DriverRegKey -Name "Setup" -Value $script:OrigSetup
+            Set-ItemProperty -Path $RustDriverRegKey -Name "Setup" -Value $script:OrigSetup
         } else {
-            Remove-ItemProperty -Path $DriverRegKey -Name "Setup" -ErrorAction SilentlyContinue
+            Remove-ItemProperty -Path $RustDriverRegKey -Name "Setup" -ErrorAction SilentlyContinue
         }
-        Write-Host "[  DRIVER ] Restored original HKLM registration"
+        Write-Host "[  DRIVER ] Restored original HKLM registration for '$RustDriverName'"
     } else {
-        Remove-Item -Path $DriverRegKey -Force -ErrorAction SilentlyContinue
-        Write-Host "[  DRIVER ] Removed HKLM registration (no prior driver)"
+        Remove-Item -Path $RustDriverRegKey -Force -ErrorAction SilentlyContinue
+        Write-Host "[  DRIVER ] Removed HKLM registration for '$RustDriverName'"
     }
 
     # Restore or remove the "ODBC Drivers" list entry independently of the driver
     # key above, since the two can pre-exist in either combination.
     if ($script:HadDriversListEntry) {
-        Set-ItemProperty -Path $DriversRegKey -Name $DriverName -Value $script:OrigDriversListValue
+        Set-ItemProperty -Path $DriversRegKey -Name $RustDriverName -Value $script:OrigDriversListValue
     } elseif (Test-Path $DriversRegKey) {
-        Remove-ItemProperty -Path $DriversRegKey -Name $DriverName -ErrorAction SilentlyContinue
+        Remove-ItemProperty -Path $DriversRegKey -Name $RustDriverName -ErrorAction SilentlyContinue
     }
 
     $script:Registered = $false
@@ -154,11 +205,13 @@ function Restore-Registration {
 
 # Run the (already-built) ctest suite, writing JUnit XML to $JunitName inside
 # the build dir. Returns ctest's exit code without aborting the script.
-function Invoke-CtestRun([string]$Label, [string]$JunitName) {
+function Invoke-CtestRun([string]$Label, [string]$JunitName, [string]$DriverName) {
     Write-Host ""
     Write-Host "=== Running e2e tests against $Label ==="
+    Write-Host "ODBC_TEST_DRIVER=$DriverName"
     Push-Location (Join-Path $ScriptDir "build")
     $prevTarget = $env:ODBC_TEST_TARGET
+    $prevDriver = $env:ODBC_TEST_DRIVER
     try {
         $ctestArgs = @('--output-on-failure', '-C', 'Debug', '--output-junit', $JunitName)
         if ($Retries -gt 0) {
@@ -171,13 +224,16 @@ function Invoke-CtestRun([string]$Label, [string]$JunitName) {
         # ODBC_TEST_TARGET tells tests which driver implementation this leg runs
         # against ("mssql-odbc" or "msodbcsql") so mssql-odbc-specific tests can
         # SKIP_IF_COMPARING_MSODBCSQL() on the reference-driver leg.
+        # ODBC_TEST_DRIVER selects the driver by name in the connection string.
         $env:ODBC_TEST_TARGET = $Label
+        $env:ODBC_TEST_DRIVER = $DriverName
         # Stream ctest output to the host so only the exit code is returned
         # from this function (an uncaptured pipeline would be returned too).
         ctest @ctestArgs | Out-Host
         return $LASTEXITCODE
     } finally {
         $env:ODBC_TEST_TARGET = $prevTarget
+        $env:ODBC_TEST_DRIVER = $prevDriver
         Pop-Location
     }
 }
@@ -402,19 +458,23 @@ try {
         Write-Host "Coverage: LLVM_PROFILE_FILE=$($env:LLVM_PROFILE_FILE)"
     }
 
-    # Capture the existing registration before we overwrite it. In comparison
-    # mode this is also the default reference (msodbcsql) driver.
+    # Snapshot our own registration (if a Rust driver is already installed under
+    # the same name) so it can be restored on exit.
     Save-OriginalRegistration
 
-    # Resolve the reference driver for comparison mode.
+    # Resolve the reference driver for comparison mode from its own registration.
     $RefDriverPath = $null
     if ($CompareWithMsodbcsql) {
+        if ($env:ODBC_TEST_CONNSTR) {
+            Write-Error "ODBC_TEST_CONNSTR is set; it overrides the driver name and would pin both comparison legs to the same driver. Unset it to compare."
+        }
         if ($MsodbcsqlDll) {
             $RefDriverPath = $MsodbcsqlDll
-        } elseif ($script:OrigDriver) {
-            $RefDriverPath = $script:OrigDriver
         } else {
-            Write-Error "No existing msodbcsql18.dll registration found. Pass -MsodbcsqlDll PATH to point at the reference driver."
+            $RefDriverPath = Get-MsodbcsqlDriverPath
+        }
+        if (-not $RefDriverPath) {
+            Write-Error "No '$MsodbcsqlName' registration found. Pass -MsodbcsqlDll PATH to point at the reference driver."
         }
         if (-not (Test-Path $RefDriverPath)) {
             Write-Error "Reference driver not found: $RefDriverPath"
@@ -445,9 +505,9 @@ try {
     # read old results if ctest fails to execute (e.g. 0 tests run).
     Remove-Item -Path $RustJunit, $MsJunit -Force -ErrorAction SilentlyContinue
 
-    # Run 1: the Rust driver.
-    Set-DriverRegistration $DriverPath
-    $RustExit = Invoke-CtestRun "mssql-odbc" "junit-mssql-odbc.xml"
+    # Run 1: the Rust driver, registered under its own name.
+    Register-RustDriver $DriverPath
+    $RustExit = Invoke-CtestRun "mssql-odbc" "junit-mssql-odbc.xml" $RustDriverName
 
     # Report on the instrumented mssql-odbc leg before the (uninstrumented)
     # msodbcsql reference leg runs, so the profraw reflects our driver only.
@@ -465,8 +525,14 @@ try {
     }
 
     # Run 2: the reference msodbcsql driver, sharing the same built binaries.
-    Set-DriverRegistration $RefDriverPath
-    $MsExit = Invoke-CtestRun "msodbcsql" "junit-msodbcsql.xml"
+    # No registry swap is needed — the two drivers are registered side by side,
+    # so only the driver name in the connection string changes. When
+    # -MsodbcsqlDll points somewhere other than the installed registration, that
+    # DLL is registered under the reference name for the duration of this leg.
+    if ($MsodbcsqlDll) {
+        Set-MsodbcsqlOverride $RefDriverPath
+    }
+    $MsExit = Invoke-CtestRun "msodbcsql" "junit-msodbcsql.xml" $MsodbcsqlName
 
     Write-ParityReport $RustJunit $MsJunit
 

--- a/mssql-odbc/tests/e2e/run_e2e.ps1
+++ b/mssql-odbc/tests/e2e/run_e2e.ps1
@@ -386,11 +386,15 @@ function Write-ParityReport([string]$RustXml, [string]$MsXml) {
     # investigation rather than asserting blame.
     $verdict = {
         param($r, $m)
+        # Classify MISSING first: a test present in only one leg is a divergence,
+        # even when its lone result is SKIP (otherwise the skip shortcut below
+        # would mask a one-sided run as an allowed skip).
+        if ($r -eq "MISSING" -or $m -eq "MISSING") { return @("missing run - investigate", "divergence") }
         if ($r -eq "SKIP" -or $m -eq "SKIP") { return @("skipped (not compared)", "skip") }
         if ($r -eq "PASS" -and $m -eq "PASS") { return @("parity", "parity") }
         if ($r -eq "FAIL" -and $m -eq "FAIL") { return @("shared failure - investigate", "shared") }
         if ($r -ne $m) { return @("divergence - investigate", "divergence") }
-        return @("missing run - investigate", "divergence")
+        return @("unexpected - investigate", "divergence")
     }
 
     $width = 4

--- a/mssql-odbc/tests/e2e/run_e2e.ps1
+++ b/mssql-odbc/tests/e2e/run_e2e.ps1
@@ -143,8 +143,16 @@ $script:HadDriversListEntry = $false
 $script:OrigDriversListValue = $null
 $script:Registered = $false
 # Set only when -MsodbcsqlDll overrides the installed reference registration.
-$script:MsodbcsqlOverridden = $false
-$script:OrigMsodbcsqlDriver = $null
+# Driver, Setup, and the "ODBC Drivers" list entry are snapshotted independently
+# so each is restored exactly as it was (they can pre-exist in any combination).
+$script:MsodbcsqlOverridden    = $false
+$script:HadMsodbcsqlKey        = $false
+$script:HadMsodbcsqlDriver     = $false
+$script:HadMsodbcsqlSetup      = $false
+$script:OrigMsodbcsqlDriver    = $null
+$script:OrigMsodbcsqlSetup     = $null
+$script:HadMsodbcsqlListEntry  = $false
+$script:OrigMsodbcsqlListValue = $null
 
 function Save-OriginalRegistration {
     if (Test-Path $RustDriverRegKey) {
@@ -189,15 +197,28 @@ function Get-MsodbcsqlDriverPath {
 }
 
 # Point the reference registration at an explicit DLL for the comparison leg,
-# saving the installed value so Restore-Registration can put it back.
+# snapshotting the installed Driver, Setup, and "ODBC Drivers" list values
+# independently so Restore-Registration can put each back exactly as it was.
 function Set-MsodbcsqlOverride([string]$DriverPath) {
-    $script:OrigMsodbcsqlDriver = Get-MsodbcsqlDriverPath
-    if (-not (Test-Path $MsodbcsqlRegKey)) {
+    if (Test-Path $MsodbcsqlRegKey) {
+        $script:HadMsodbcsqlKey = $true
+        $d = Get-ItemProperty -Path $MsodbcsqlRegKey -Name "Driver" -ErrorAction SilentlyContinue
+        if ($null -ne $d) { $script:HadMsodbcsqlDriver = $true; $script:OrigMsodbcsqlDriver = $d.Driver }
+        $s = Get-ItemProperty -Path $MsodbcsqlRegKey -Name "Setup" -ErrorAction SilentlyContinue
+        if ($null -ne $s) { $script:HadMsodbcsqlSetup = $true; $script:OrigMsodbcsqlSetup = $s.Setup }
+    } else {
         New-Item -Path $MsodbcsqlRegKey -Force | Out-Null
     }
     Set-ItemProperty -Path $MsodbcsqlRegKey -Name "Driver" -Value $DriverPath
     Set-ItemProperty -Path $MsodbcsqlRegKey -Name "Setup"  -Value $DriverPath
-    if (-not (Test-Path $DriversRegKey)) {
+
+    if (Test-Path $DriversRegKey) {
+        $e = Get-ItemProperty -Path $DriversRegKey -Name $MsodbcsqlName -ErrorAction SilentlyContinue
+        if ($null -ne $e) {
+            $script:HadMsodbcsqlListEntry = $true
+            $script:OrigMsodbcsqlListValue = $e.$MsodbcsqlName
+        }
+    } else {
         New-Item -Path $DriversRegKey -Force | Out-Null
     }
     Set-ItemProperty -Path $DriversRegKey -Name $MsodbcsqlName -Value "Installed"
@@ -207,17 +228,32 @@ function Set-MsodbcsqlOverride([string]$DriverPath) {
 
 function Restore-Registration {
     if ($script:MsodbcsqlOverridden) {
-        if ($script:OrigMsodbcsqlDriver) {
-            Set-ItemProperty -Path $MsodbcsqlRegKey -Name "Driver" -Value $script:OrigMsodbcsqlDriver
-            Set-ItemProperty -Path $MsodbcsqlRegKey -Name "Setup"  -Value $script:OrigMsodbcsqlDriver
+        if ($script:HadMsodbcsqlKey) {
+            # Restore each value we may have overwritten, or remove it if it did
+            # not exist before, mirroring the Rust driver restore below.
+            if ($script:HadMsodbcsqlDriver) {
+                Set-ItemProperty -Path $MsodbcsqlRegKey -Name "Driver" -Value $script:OrigMsodbcsqlDriver
+            } else {
+                Remove-ItemProperty -Path $MsodbcsqlRegKey -Name "Driver" -ErrorAction SilentlyContinue
+            }
+            if ($script:HadMsodbcsqlSetup) {
+                Set-ItemProperty -Path $MsodbcsqlRegKey -Name "Setup" -Value $script:OrigMsodbcsqlSetup
+            } else {
+                Remove-ItemProperty -Path $MsodbcsqlRegKey -Name "Setup" -ErrorAction SilentlyContinue
+            }
             Write-Host "[  DRIVER ] Restored original HKLM registration for '$MsodbcsqlName'"
         } else {
             Remove-Item -Path $MsodbcsqlRegKey -Force -ErrorAction SilentlyContinue
-            if (Test-Path $DriversRegKey) {
-                Remove-ItemProperty -Path $DriversRegKey -Name $MsodbcsqlName -ErrorAction SilentlyContinue
-            }
-            Write-Host "[  DRIVER ] Removed HKLM registration for '$MsodbcsqlName' (no prior driver)"
+            Write-Host "[  DRIVER ] Removed HKLM registration for '$MsodbcsqlName' (no prior key)"
         }
+
+        # Restore or remove the "ODBC Drivers" list entry independently of the key.
+        if ($script:HadMsodbcsqlListEntry) {
+            Set-ItemProperty -Path $DriversRegKey -Name $MsodbcsqlName -Value $script:OrigMsodbcsqlListValue
+        } elseif (Test-Path $DriversRegKey) {
+            Remove-ItemProperty -Path $DriversRegKey -Name $MsodbcsqlName -ErrorAction SilentlyContinue
+        }
+
         $script:MsodbcsqlOverridden = $false
     }
 
@@ -591,7 +627,7 @@ try {
     $RefDriverPath = $null
     if ($CompareWithMsodbcsql) {
         if ($env:ODBC_TEST_CONNSTR) {
-            Write-Error "ODBC_TEST_CONNSTR is set; it overrides the driver name and would pin both comparison legs to the same driver. Unset it to compare."
+            throw "ODBC_TEST_CONNSTR is set; it overrides the driver name and would pin both comparison legs to the same driver. Unset it to compare."
         }
         if ($MsodbcsqlDll) {
             $RefDriverPath = $MsodbcsqlDll

--- a/mssql-odbc/tests/e2e/run_e2e.ps1
+++ b/mssql-odbc/tests/e2e/run_e2e.ps1
@@ -36,10 +36,14 @@
 # The reference driver defaults to the installed "ODBC Driver 18 for SQL Server"
 # registration (typically C:\WINDOWS\system32\msodbcsql18.dll). Override it with
 # -MsodbcsqlDll PATH, which temporarily repoints that registration and restores
-# it at the end. The script exits 0 only if BOTH runs pass.
+# it at the end. The script exits 0 only if both runs pass AND every test reaches
+# the same verdict in both legs.
 #
 # ODBC_TEST_CONNSTR overrides the whole connection string and would pin both
 # legs to one driver, so comparison mode rejects it.
+#
+# When ODBC_TEST_SERVER is unset, a dev SQL Server on localhost:1433 is
+# auto-detected (matching run_e2e.sh).
 #
 # Examples:
 #   .\run_e2e.ps1
@@ -71,6 +75,53 @@ $BuildType   = if ($Release) { "release" } else { "debug" }
 # on $WorkspaceDir.
 if ($Coverage -and -not $CoverageOutput) {
     $CoverageOutput = Join-Path $WorkspaceDir "target\cobertura-odbc-e2e.xml"
+}
+
+# CI only changes how much diagnostic context is printed on failure. Every
+# failure mode below is fatal locally too — a broken build must never report
+# "passed" just because a developer ran it by hand.
+$script:IsCI = [bool]($env:TF_BUILD -or $env:CI -or $env:GITHUB_ACTIONS)
+
+# Native commands ignore $ErrorActionPreference, so a failing cargo/cmake would
+# otherwise fall through to ctest and produce an empty-but-green run.
+function Invoke-Checked([string]$What, [scriptblock]$Command) {
+    & $Command
+    if ($LASTEXITCODE -ne 0) {
+        throw "$What failed (exit $LASTEXITCODE)"
+    }
+}
+
+# Dump the logs that explain a configure/build/test failure. CI has no working
+# copy to inspect afterwards, so the evidence has to be in the build log.
+function Write-FailureDiagnostics([string]$Context) {
+    if (-not $script:IsCI) { return }
+    Write-Host ""
+    Write-Host "=== CI diagnostics: $Context ==="
+    $buildDir = Join-Path $ScriptDir "build"
+    $logs = @(
+        (Join-Path $buildDir "CMakeFiles\CMakeOutput.log"),
+        (Join-Path $buildDir "CMakeFiles\CMakeError.log"),
+        (Join-Path $buildDir "Testing\Temporary\LastTest.log")
+    )
+    foreach ($log in $logs) {
+        if (Test-Path $log) {
+            Write-Host ""
+            Write-Host "--- tail of $log ---"
+            Get-Content -Path $log -Tail 100 | ForEach-Object { Write-Host $_ }
+        }
+    }
+    if (Test-Path $buildDir) {
+        Write-Host ""
+        Write-Host "--- test executables in $buildDir ---"
+        $exes = @(Get-ChildItem -Path $buildDir -Filter '*_test.exe' -Recurse -ErrorAction SilentlyContinue)
+        if ($exes.Count -eq 0) {
+            Write-Host "(none found)"
+        } else {
+            $exes | ForEach-Object { Write-Host $_.FullName }
+        }
+    } else {
+        Write-Host "build directory does not exist: $buildDir"
+    }
 }
 
 $OdbcInstRoot     = "HKLM:\Software\ODBC\ODBCINST.INI"
@@ -238,6 +289,26 @@ function Invoke-CtestRun([string]$Label, [string]$JunitName, [string]$DriverName
     }
 }
 
+# A ctest run that executed nothing still exits 0 and prints "No tests were
+# found!!!" — historically that turned a broken CMake configure into a green
+# build. Treat an empty JUnit as a hard failure.
+function Assert-TestsExecuted([string]$JunitPath, [string]$Label) {
+    $count = 0
+    if (Test-Path $JunitPath) {
+        try {
+            [xml]$doc = Get-Content -Raw -Path $JunitPath
+            $count = @($doc.SelectNodes("//testcase")).Count
+        } catch {
+            $count = 0
+        }
+    }
+    if ($count -eq 0) {
+        Write-FailureDiagnostics "no tests executed for '$Label'"
+        throw "No tests were executed for '$Label'. The CMake project produced no ctest entries, or ctest failed to run them."
+    }
+    Write-Host "$Label leg executed $count test(s)."
+}
+
 # Parse a ctest JUnit XML into a hashtable of { test-name = 'PASS' | 'FAIL' }.
 function Get-JunitResults([string]$Path) {
     $map = @{}
@@ -267,6 +338,7 @@ function Get-JunitResults([string]$Path) {
 }
 
 # Print a side-by-side parity table comparing the mssql-odbc and msodbcsql runs.
+# Returns the verdict counts so the caller can fail on any non-parity outcome.
 function Write-ParityReport([string]$RustXml, [string]$MsXml) {
     $rust = Get-JunitResults $RustXml
     $ms   = Get-JunitResults $MsXml
@@ -303,6 +375,7 @@ function Write-ParityReport([string]$RustXml, [string]$MsXml) {
     }
     Write-Host ""
     Write-Host ("Summary: {0} parity, {1} divergence(s), {2} shared failure(s), {3} skipped" -f $counts.parity, $counts.divergence, $counts.shared, $counts.skip)
+    return $counts
 }
 
 # Enable LLVM source-based instrumentation for the driver build.
@@ -381,6 +454,53 @@ function New-CoverageReport([string]$OutputPath) {
     }
 }
 
+# Mirror of setup_dev_sql_env in run_e2e.sh: point the tests at a dev SQL Server
+# on localhost:1433 when the caller hasn't configured a server, so `.\run_e2e.ps1`
+# works out of the box against dev\dev-launchsql.
+function Initialize-DevSqlEnv {
+    if ($env:ODBC_TEST_SERVER) { return }
+
+    $reachable = $false
+    $client = $null
+    try {
+        $client = New-Object System.Net.Sockets.TcpClient
+        $reachable = $client.ConnectAsync('localhost', 1433).Wait(2000)
+    } catch {
+        $reachable = $false
+    } finally {
+        if ($client) { $client.Dispose() }
+    }
+    if (-not $reachable) { return }
+
+    $env:ODBC_TEST_SERVER = 'localhost'
+    if (-not $env:ODBC_TEST_UID) { $env:ODBC_TEST_UID = 'sa' }
+    if (-not $env:ODBC_TEST_TRUST_CERT) { $env:ODBC_TEST_TRUST_CERT = 'Yes' }
+
+    if (-not $env:ODBC_TEST_PWD) {
+        if ($env:SQL_PASSWORD) {
+            $env:ODBC_TEST_PWD = $env:SQL_PASSWORD
+        } else {
+            $dotenv = Join-Path $WorkspaceDir "mssql-tds\.env"
+            if (Test-Path $dotenv) {
+                $line = Get-Content -Path $dotenv | Where-Object { $_ -match '^SQL_PASSWORD=' } | Select-Object -First 1
+                if ($line) {
+                    $value = $line.Substring($line.IndexOf('=') + 1).Trim()
+                    if ($value) { $env:ODBC_TEST_PWD = $value }
+                }
+            }
+        }
+    }
+
+    if ($env:ODBC_TEST_PWD) {
+        Write-Host "Auto-detected dev SQL Server at localhost:1433 ($($env:ODBC_TEST_UID) login)"
+    } else {
+        # Without a password the fixture falls back to Trusted_Connection, which
+        # is a valid local setup — warn rather than fail.
+        Write-Host "Warning: SQL Server detected on localhost:1433 but no password found; using integrated auth."
+        Write-Host "  Set SQL_PASSWORD or ODBC_TEST_PWD, or run dev\dev-launchsql.ps1 first, to use SQL auth."
+    }
+}
+
 # Ensure cmake is resolvable. CI Windows agents have Visual Studio (used to link
 # the Rust MSVC build) which bundles CMake, but it isn't on PATH by default.
 # Locate it via vswhere and prepend it, falling back to a standalone install.
@@ -422,14 +542,19 @@ try {
         Enable-CoverageInstrumentation
     }
 
+    Initialize-DevSqlEnv
+
     Write-Host "=== Building mssql-odbc ($BuildType) ==="
     Push-Location $OdbcCrateDir
-    if ($Release) {
-        cargo build --release
-    } else {
-        cargo build
+    try {
+        if ($Release) {
+            Invoke-Checked "cargo build --release" { cargo build --release }
+        } else {
+            Invoke-Checked "cargo build" { cargo build }
+        }
+    } finally {
+        Pop-Location
     }
-    Pop-Location
 
     # Cargo builds into the workspace root's target/ by default, but honors
     # CARGO_TARGET_DIR (set by CI). Resolve via `cargo metadata` so the driver is
@@ -490,12 +615,22 @@ try {
     Write-Host "=== Configuring e2e tests (CMake) ==="
     Initialize-CMake
     Push-Location $ScriptDir
-    cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DODBC_E2E_FORCE_UNICODE=ON
+    try {
+        try {
+            Invoke-Checked "CMake configure" {
+                cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DODBC_E2E_FORCE_UNICODE=ON
+            }
 
-    Write-Host ""
-    Write-Host "=== Building e2e tests ==="
-    cmake --build build --config Debug
-    Pop-Location
+            Write-Host ""
+            Write-Host "=== Building e2e tests ==="
+            Invoke-Checked "CMake build" { cmake --build build --config Debug }
+        } catch {
+            Write-FailureDiagnostics "CMake configure/build failed"
+            throw
+        }
+    } finally {
+        Pop-Location
+    }
 
     $BuildDir  = Join-Path $ScriptDir "build"
     $RustJunit = Join-Path $BuildDir "junit-mssql-odbc.xml"
@@ -508,6 +643,7 @@ try {
     # Run 1: the Rust driver, registered under its own name.
     Register-RustDriver $DriverPath
     $RustExit = Invoke-CtestRun "mssql-odbc" "junit-mssql-odbc.xml" $RustDriverName
+    Assert-TestsExecuted $RustJunit "mssql-odbc"
 
     # Report on the instrumented mssql-odbc leg before the (uninstrumented)
     # msodbcsql reference leg runs, so the profraw reflects our driver only.
@@ -517,6 +653,7 @@ try {
 
     if (-not $CompareWithMsodbcsql) {
         if ($RustExit -ne 0) {
+            Write-FailureDiagnostics "e2e tests failed"
             throw "e2e tests FAILED (ctest exit $RustExit)"
         }
         Write-Host ""
@@ -533,15 +670,22 @@ try {
         Set-MsodbcsqlOverride $RefDriverPath
     }
     $MsExit = Invoke-CtestRun "msodbcsql" "junit-msodbcsql.xml" $MsodbcsqlName
+    Assert-TestsExecuted $MsJunit "msodbcsql"
 
-    Write-ParityReport $RustJunit $MsJunit
+    $parity = Write-ParityReport $RustJunit $MsJunit
 
-    if ($RustExit -eq 0 -and $MsExit -eq 0) {
-        Write-Host ""
-        Write-Host "=== Both runs passed ==="
-    } else {
-        throw "Parity check FAILED (mssql-odbc exit $RustExit, msodbcsql exit $MsExit)"
+    # Any non-parity outcome fails the run. ctest exit codes alone are not
+    # enough: a test present in only one leg leaves both legs green while the
+    # comparison is meaningless.
+    $nonParity = $parity.divergence + $parity.shared
+    if ($RustExit -ne 0 -or $MsExit -ne 0 -or $nonParity -gt 0) {
+        Write-FailureDiagnostics "parity check failed"
+        throw ("Parity check FAILED (mssql-odbc exit $RustExit, msodbcsql exit $MsExit; " +
+               "$($parity.divergence) divergence(s), $($parity.shared) shared failure(s))")
     }
+
+    Write-Host ""
+    Write-Host "=== Both runs passed with full parity ==="
 }
 finally {
     Restore-Registration

--- a/mssql-odbc/tests/e2e/run_e2e.ps1
+++ b/mssql-odbc/tests/e2e/run_e2e.ps1
@@ -174,6 +174,9 @@ function Save-OriginalRegistration {
 # Register the Rust driver under its own name, alongside any installed
 # msodbcsql18. Both legs then run without swapping registrations.
 function Register-RustDriver([string]$DriverPath) {
+    # Arm cleanup before the first write: if any Set-ItemProperty/New-Item throws
+    # partway through, Restore-Registration still runs and unwinds the partial key.
+    $script:Registered = $true
     if (-not (Test-Path $RustDriverRegKey)) {
         New-Item -Path $RustDriverRegKey -Force | Out-Null
     }
@@ -185,7 +188,6 @@ function Register-RustDriver([string]$DriverPath) {
     }
     Set-ItemProperty -Path $DriversRegKey -Name $RustDriverName -Value "Installed"
 
-    $script:Registered = $true
     Write-Host "[  DRIVER ] Registered '$RustDriverName' in HKLM: $DriverPath"
 }
 
@@ -200,6 +202,8 @@ function Get-MsodbcsqlDriverPath {
 # snapshotting the installed Driver, Setup, and "ODBC Drivers" list values
 # independently so Restore-Registration can put each back exactly as it was.
 function Set-MsodbcsqlOverride([string]$DriverPath) {
+    # Arm cleanup before the first write, so a throw mid-registration still unwinds.
+    $script:MsodbcsqlOverridden = $true
     if (Test-Path $MsodbcsqlRegKey) {
         $script:HadMsodbcsqlKey = $true
         $d = Get-ItemProperty -Path $MsodbcsqlRegKey -Name "Driver" -ErrorAction SilentlyContinue
@@ -222,7 +226,6 @@ function Set-MsodbcsqlOverride([string]$DriverPath) {
         New-Item -Path $DriversRegKey -Force | Out-Null
     }
     Set-ItemProperty -Path $DriversRegKey -Name $MsodbcsqlName -Value "Installed"
-    $script:MsodbcsqlOverridden = $true
     Write-Host "[  DRIVER ] Overrode '$MsodbcsqlName' in HKLM: $DriverPath"
 }
 
@@ -384,6 +387,11 @@ function Write-ParityReport([string]$RustXml, [string]$MsXml) {
     # per-test PASS/FAIL divergence does not by itself establish which side is
     # wrong, and a shared failure does not prove the test is buggy. Flag both for
     # investigation rather than asserting blame.
+    #
+    # MIRROR: this classification is duplicated in verdict() in parity_report.py
+    # (the Linux/macOS runner shells out to Python; Windows stays dependency-free
+    # here). Keep the two in lockstep — any change to the ordering or the labels
+    # here must be made there too.
     $verdict = {
         param($r, $m)
         # Classify MISSING first: a test present in only one leg is a divergence,
@@ -524,7 +532,7 @@ function Initialize-DevSqlEnv {
             if (Test-Path $dotenv) {
                 $line = Get-Content -Path $dotenv | Where-Object { $_ -match '^SQL_PASSWORD=' } | Select-Object -First 1
                 if ($line) {
-                    $value = $line.Substring($line.IndexOf('=') + 1).Trim()
+                    $value = $line.Substring($line.IndexOf('=') + 1)
                     if ($value) { $env:ODBC_TEST_PWD = $value }
                 }
             }
@@ -632,6 +640,9 @@ try {
     if ($CompareWithMsodbcsql) {
         if ($env:ODBC_TEST_CONNSTR) {
             throw "ODBC_TEST_CONNSTR is set; it overrides the driver name and would pin both comparison legs to the same driver. Unset it to compare."
+        }
+        if ($env:ODBC_TEST_DSN) {
+            throw "ODBC_TEST_DSN is set; a DSN pins the connection to one driver, so both comparison legs would use the same driver. Unset it to compare."
         }
         if ($MsodbcsqlDll) {
             $RefDriverPath = $MsodbcsqlDll

--- a/mssql-odbc/tests/e2e/run_e2e.sh
+++ b/mssql-odbc/tests/e2e/run_e2e.sh
@@ -85,7 +85,11 @@ print_failure_diagnostics() {
     done
     echo ""
     echo "--- test executables in $BUILD_DIR ---"
-    find "$BUILD_DIR" -type f -name '*_test' 2>/dev/null || echo "(none found)"
+    # `find` exits 0 even when it matches nothing, so `find || echo` never prints
+    # the fallback. Capture the output and test it explicitly instead.
+    local exes
+    exes="$(find "$BUILD_DIR" -type f -name '*_test' 2>/dev/null)"
+    if [ -n "$exes" ]; then echo "$exes"; else echo "(none found)"; fi
 }
 
 # A ctest run that executed nothing still exits 0 and prints "No tests were
@@ -292,14 +296,21 @@ EOF
 }
 
 # ----------------------------------------------------------------------------
-# Step 4: Validate the msodbcsql odbcinst.ini for the comparison run
+# Step 4: Validate comparison-mode preconditions
 # ----------------------------------------------------------------------------
-validate_msodbcsql_ini() {
+validate_compare_preconditions() {
     # A full connection-string override ignores ODBC_TEST_DRIVER, which would
     # silently run both legs against whichever driver it names.
     if [ -n "${ODBC_TEST_CONNSTR:-}" ]; then
         echo "Error: ODBC_TEST_CONNSTR is set; it overrides the driver name and would" >&2
         echo "  pin both comparison legs to the same driver. Unset it to compare." >&2
+        exit 1
+    fi
+    # A DSN pins the connection to one driver just like a full connection string,
+    # so both legs would resolve to the same driver.
+    if [ -n "${ODBC_TEST_DSN:-}" ]; then
+        echo "Error: ODBC_TEST_DSN is set; a DSN pins the connection to one driver, so" >&2
+        echo "  both comparison legs would use the same driver. Unset it to compare." >&2
         exit 1
     fi
     if [ ! -f "$MSODBCSQL_INI" ]; then
@@ -478,7 +489,7 @@ main() {
     build_rust_driver
     register_rust_driver
     if [ "$COMPARE" -eq 1 ]; then
-        validate_msodbcsql_ini
+        validate_compare_preconditions
     fi
     configure_and_build_tests
 

--- a/mssql-odbc/tests/e2e/run_e2e.sh
+++ b/mssql-odbc/tests/e2e/run_e2e.sh
@@ -37,8 +37,14 @@
 # /etc/odbcinst.ini) and prints a parity table. The script exits 0 only
 # if BOTH runs pass.
 #
-# Both INIs must register the driver under the same section name:
-#   [ODBC Driver 18 for SQL Server]
+# The two drivers register under distinct names, so they can be installed side
+# by side:
+#   Rust:      [ODBC Driver 18 for SQL Server (Rust)]
+#   reference: [ODBC Driver 18 for SQL Server]
+# Each leg selects its driver via ODBC_TEST_DRIVER, so the same test binaries
+# run unchanged against both. Setting ODBC_TEST_CONNSTR overrides the whole
+# connection string and would pin both legs to one driver; the script rejects
+# that in comparison mode.
 #
 # Rust driver logs are controlled by MSSQL_TDS_TRACE and
 # MSSQL_TDS_TRACE_LEVEL.
@@ -59,7 +65,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ODBC_CRATE_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 BUILD_DIR="$SCRIPT_DIR/build"
-DRIVER_SECTION="ODBC Driver 18 for SQL Server"
+MSODBCSQL_DRIVER_SECTION="ODBC Driver 18 for SQL Server"
+RUST_DRIVER_SECTION="ODBC Driver 18 for SQL Server (Rust)"
 
 BUILD_TYPE="debug"
 VERBOSE=0
@@ -221,31 +228,39 @@ build_rust_driver() {
 }
 
 # ----------------------------------------------------------------------------
-# Step 3: Register the Rust driver in a temporary odbcinst.ini
+# Step 3: Register the Rust driver in a temporary odbcinst.ini under its own
+# section name, so it never collides with an installed msodbcsql18.
 # ----------------------------------------------------------------------------
 register_rust_driver() {
     RUST_INI_DIR="$(mktemp -d)"
     cat > "$RUST_INI_DIR/odbcinst.ini" <<EOF
-[$DRIVER_SECTION]
+[$RUST_DRIVER_SECTION]
 Description=Microsoft ODBC Driver 18 for SQL Server (Rust)
 Driver=$RUST_DRIVER_PATH
 UsageCount=1
 EOF
     echo "Rust driver registered at: $RUST_INI_DIR/odbcinst.ini"
+    echo "Rust driver name: $RUST_DRIVER_SECTION"
 }
 
 # ----------------------------------------------------------------------------
 # Step 4: Validate the msodbcsql odbcinst.ini for the comparison run
 # ----------------------------------------------------------------------------
 validate_msodbcsql_ini() {
+    # A full connection-string override ignores ODBC_TEST_DRIVER, which would
+    # silently run both legs against whichever driver it names.
+    if [ -n "${ODBC_TEST_CONNSTR:-}" ]; then
+        echo "Error: ODBC_TEST_CONNSTR is set; it overrides the driver name and would" >&2
+        echo "  pin both comparison legs to the same driver. Unset it to compare." >&2
+        exit 1
+    fi
     if [ ! -f "$MSODBCSQL_INI" ]; then
         echo "Error: msodbcsql odbcinst.ini not found: $MSODBCSQL_INI" >&2
         echo "  Pass --msodbcsql-ini=PATH or install the C++ driver." >&2
         exit 1
     fi
-    if ! grep -qE "^\[$DRIVER_SECTION\]" "$MSODBCSQL_INI"; then
-        echo "Error: $MSODBCSQL_INI does not contain a [$DRIVER_SECTION] section." >&2
-        echo "  Both INIs must register the driver under the same name." >&2
+    if ! grep -qE "^\[$MSODBCSQL_DRIVER_SECTION\]" "$MSODBCSQL_INI"; then
+        echo "Error: $MSODBCSQL_INI does not contain a [$MSODBCSQL_DRIVER_SECTION] section." >&2
         exit 1
     fi
     # Resolve to absolute path so subprocesses see the same file regardless of cwd.
@@ -324,13 +339,15 @@ configure_and_build_tests() {
 #   $1 = label (printed in headers)
 #   $2 = ODBCSYSINI directory
 #   $3 = absolute path to JUnit XML output
+#   $4 = odbcinst.ini section name the tests should connect through
 # Returns ctest's exit code (does not abort the script).
 # ----------------------------------------------------------------------------
 run_tests() {
-    local label="$1" ini_dir="$2" junit_out="$3"
+    local label="$1" ini_dir="$2" junit_out="$3" driver_name="$4"
     echo ""
     echo "=== Running e2e tests against $label ==="
     echo "ODBCSYSINI=$ini_dir"
+    echo "ODBC_TEST_DRIVER=$driver_name"
 
     local rc=0
     (
@@ -338,7 +355,9 @@ run_tests() {
         # ODBC_TEST_TARGET tells tests which driver implementation this leg runs
         # against ("mssql-odbc" or "msodbcsql") so mssql-odbc-specific tests can
         # SKIP_IF_COMPARING_MSODBCSQL() on the reference-driver leg.
-        ODBC_TEST_TARGET="$label" ODBCSYSINI="$ini_dir" ctest "${CTEST_ARGS[@]}" --output-junit "$junit_out"
+        # ODBC_TEST_DRIVER selects the driver by name in the connection string.
+        ODBC_TEST_TARGET="$label" ODBC_TEST_DRIVER="$driver_name" \
+            ODBCSYSINI="$ini_dir" ctest "${CTEST_ARGS[@]}" --output-junit "$junit_out"
     ) || rc=$?
     return $rc
 }
@@ -461,7 +480,7 @@ main() {
     local ms_junit="$BUILD_DIR/junit-msodbcsql.xml"
     local rust_rc=0 ms_rc=0
 
-    run_tests "mssql-odbc" "$RUST_INI_DIR" "$rust_junit" || rust_rc=$?
+    run_tests "mssql-odbc" "$RUST_INI_DIR" "$rust_junit" "$RUST_DRIVER_SECTION" || rust_rc=$?
 
     # Report on the instrumented mssql-odbc leg before the (uninstrumented)
     # msodbcsql reference leg runs, so the profraw reflects our driver only.
@@ -482,7 +501,7 @@ main() {
     # Comparison mode: also run against the C++ driver, then print the table.
     local ms_ini_dir
     ms_ini_dir="$(dirname "$MSODBCSQL_INI")"
-    run_tests "msodbcsql"  "$ms_ini_dir"  "$ms_junit" || ms_rc=$?
+    run_tests "msodbcsql"  "$ms_ini_dir"  "$ms_junit" "$MSODBCSQL_DRIVER_SECTION" || ms_rc=$?
 
     print_parity_report "$rust_junit" "$ms_junit"
 

--- a/mssql-odbc/tests/e2e/run_e2e.sh
+++ b/mssql-odbc/tests/e2e/run_e2e.sh
@@ -418,63 +418,7 @@ run_tests() {
 # ----------------------------------------------------------------------------
 print_parity_report() {
     local rust_xml="$1" ms_xml="$2"
-    python3 - "$rust_xml" "$ms_xml" <<'PY'
-import sys, xml.etree.ElementTree as ET
-
-def load(path):
-    """Returns {test_name: 'PASS'|'FAIL'|'SKIP'}."""
-    out = {}
-    try:
-        root = ET.parse(path).getroot()
-    except (ET.ParseError, FileNotFoundError):
-        return out
-    # ctest --output-junit emits <testsuite><testcase name="..."> ...
-    for tc in root.iter("testcase"):
-        name = tc.get("name") or "<unnamed>"
-        tags = {child.tag for child in tc}
-        if tags & {"failure", "error"}:
-            out[name] = "FAIL"
-        elif "skipped" in tags:
-            out[name] = "SKIP"
-        else:
-            out[name] = "PASS"
-    return out
-
-rust = load(sys.argv[1])
-ms   = load(sys.argv[2])
-names = sorted(set(rust) | set(ms))
-
-# Verdicts describe only the observed outcome pairing, not a root cause: a
-# per-test PASS/FAIL divergence does not by itself establish which side is
-# wrong, and a shared failure does not prove the test is buggy.
-def verdict(r, m):
-    if r == "SKIP" or m == "SKIP":  return ("skipped (not compared)", "skip")
-    if r == "PASS" and m == "PASS": return ("parity", "parity")
-    if r == "FAIL" and m == "FAIL": return ("shared failure - investigate", "shared")
-    if r != m:                      return ("divergence - investigate", "divergence")
-    return ("missing run - investigate", "divergence")
-
-w = max((len(n) for n in names), default=4)
-print()
-print("=== Parity report (mssql-odbc vs msodbcsql) ===")
-print(f"{'Test'.ljust(w)}  {'mssql-odbc':<10}  {'msodbcsql':<10}  Verdict")
-print(f"{'-'*w}  {'-'*10}  {'-'*10}  {'-'*30}")
-counts = {"parity":0, "divergence":0, "shared":0, "skip":0}
-for n in names:
-    r = rust.get(n, "MISSING")
-    m = ms.get(n, "MISSING")
-    v, kind = verdict(r, m)
-    counts[kind] += 1
-    print(f"{n.ljust(w)}  {r:<10}  {m:<10}  {v}")
-print()
-print(f"Summary: {counts['parity']} parity, {counts['divergence']} divergence(s), "
-      f"{counts['shared']} shared failure(s), {counts['skip']} skipped")
-
-# Any non-parity outcome fails the run. ctest exit codes alone are not enough:
-# a test present in only one leg leaves both legs green while the comparison is
-# meaningless.
-sys.exit(1 if counts["divergence"] or counts["shared"] else 0)
-PY
+    python3 "$SCRIPT_DIR/parity_report.py" "$rust_xml" "$ms_xml"
 }
 
 # ----------------------------------------------------------------------------

--- a/mssql-odbc/tests/e2e/run_e2e.sh
+++ b/mssql-odbc/tests/e2e/run_e2e.sh
@@ -34,8 +34,8 @@
 #
 # With --compare-with-msodbcsql, the script reruns the same suite against
 # the Microsoft C++ driver registered in --msodbcsql-ini (default
-# /etc/odbcinst.ini) and prints a parity table. The script exits 0 only
-# if BOTH runs pass.
+# /etc/odbcinst.ini) and prints a parity table. The script exits 0 only if both
+# runs pass AND every test reaches the same verdict in both legs.
 #
 # The two drivers register under distinct names, so they can be installed side
 # by side:
@@ -58,6 +58,54 @@
 #   ./run_e2e.sh --compare-with-msodbcsql --msodbcsql-ini=/opt/msodbcsql/odbcinst.ini
 
 set -euo pipefail
+
+# CI only controls how much diagnostic context is printed on failure; every
+# failure mode below is fatal locally too.
+IS_CI=0
+if [ -n "${TF_BUILD:-}" ] || [ -n "${CI:-}" ] || [ -n "${GITHUB_ACTIONS:-}" ]; then
+    IS_CI=1
+fi
+
+# Dump the logs that explain a configure/build/test failure. CI has no working
+# copy to inspect afterwards, so the evidence has to be in the build log.
+print_failure_diagnostics() {
+    [ "$IS_CI" -eq 1 ] || return 0
+    local context="$1"
+    echo ""
+    echo "=== CI diagnostics: $context ==="
+    local log
+    for log in "$BUILD_DIR/CMakeFiles/CMakeOutput.log" \
+               "$BUILD_DIR/CMakeFiles/CMakeError.log" \
+               "$BUILD_DIR/Testing/Temporary/LastTest.log"; do
+        if [ -f "$log" ]; then
+            echo ""
+            echo "--- tail of $log ---"
+            tail -n 100 "$log"
+        fi
+    done
+    echo ""
+    echo "--- test executables in $BUILD_DIR ---"
+    find "$BUILD_DIR" -type f -name '*_test' 2>/dev/null || echo "(none found)"
+}
+
+# A ctest run that executed nothing still exits 0 and prints "No tests were
+# found!!!" — historically that turned a broken CMake configure into a green
+# build. Treat an empty JUnit as a hard failure.
+assert_tests_executed() {
+    local junit="$1" label="$2" count=0
+    if [ -f "$junit" ]; then
+        # -o counts occurrences rather than matching lines, so a JUnit file that
+        # puts several <testcase> elements on one line is still counted correctly.
+        count=$(grep -o '<testcase' "$junit" 2>/dev/null | wc -l) || count=0
+    fi
+    if [ "$count" -eq 0 ]; then
+        print_failure_diagnostics "no tests executed for '$label'"
+        echo "Error: no tests were executed for '$label'." >&2
+        echo "  The CMake project produced no ctest entries, or ctest failed to run them." >&2
+        exit 1
+    fi
+    echo "$label leg executed $count test(s)."
+}
 
 # ----------------------------------------------------------------------------
 # Globals
@@ -366,7 +414,7 @@ run_tests() {
 # Step 8: Parse two JUnit XMLs and print a parity table.
 #   $1 = mssql-odbc JUnit XML
 #   $2 = msodbcsql  JUnit XML
-# Always returns 0 — exit code is decided by the caller.
+# Returns non-zero when any test reached a different verdict in the two legs.
 # ----------------------------------------------------------------------------
 print_parity_report() {
     local rust_xml="$1" ms_xml="$2"
@@ -374,7 +422,7 @@ print_parity_report() {
 import sys, xml.etree.ElementTree as ET
 
 def load(path):
-    """Returns {test_name: 'PASS'|'FAIL'|'MISSING'}."""
+    """Returns {test_name: 'PASS'|'FAIL'|'SKIP'}."""
     out = {}
     try:
         root = ET.parse(path).getroot()
@@ -383,27 +431,35 @@ def load(path):
     # ctest --output-junit emits <testsuite><testcase name="..."> ...
     for tc in root.iter("testcase"):
         name = tc.get("name") or "<unnamed>"
-        failed = any(child.tag in ("failure", "error") for child in tc)
-        out[name] = "FAIL" if failed else "PASS"
+        tags = {child.tag for child in tc}
+        if tags & {"failure", "error"}:
+            out[name] = "FAIL"
+        elif "skipped" in tags:
+            out[name] = "SKIP"
+        else:
+            out[name] = "PASS"
     return out
 
 rust = load(sys.argv[1])
 ms   = load(sys.argv[2])
 names = sorted(set(rust) | set(ms))
 
+# Verdicts describe only the observed outcome pairing, not a root cause: a
+# per-test PASS/FAIL divergence does not by itself establish which side is
+# wrong, and a shared failure does not prove the test is buggy.
 def verdict(r, m):
-    if r == "PASS" and m == "PASS": return ("parity",          "ok")
-    if r == "FAIL" and m == "PASS": return ("FIX mssql-odbc",  "bug")
-    if r == "PASS" and m == "FAIL": return ("mssql-odbc bug, but test hides it (msodbcsql fails)", "warn")
-    if r == "FAIL" and m == "FAIL": return ("test bug (both fail)",       "warn")
-    return ("missing run", "warn")
+    if r == "SKIP" or m == "SKIP":  return ("skipped (not compared)", "skip")
+    if r == "PASS" and m == "PASS": return ("parity", "parity")
+    if r == "FAIL" and m == "FAIL": return ("shared failure - investigate", "shared")
+    if r != m:                      return ("divergence - investigate", "divergence")
+    return ("missing run - investigate", "divergence")
 
 w = max((len(n) for n in names), default=4)
 print()
 print("=== Parity report (mssql-odbc vs msodbcsql) ===")
 print(f"{'Test'.ljust(w)}  {'mssql-odbc':<10}  {'msodbcsql':<10}  Verdict")
 print(f"{'-'*w}  {'-'*10}  {'-'*10}  {'-'*30}")
-counts = {"ok":0, "bug":0, "warn":0}
+counts = {"parity":0, "divergence":0, "shared":0, "skip":0}
 for n in names:
     r = rust.get(n, "MISSING")
     m = ms.get(n, "MISSING")
@@ -411,7 +467,13 @@ for n in names:
     counts[kind] += 1
     print(f"{n.ljust(w)}  {r:<10}  {m:<10}  {v}")
 print()
-print(f"Summary: {counts['ok']} parity, {counts['bug']} mssql-odbc bug(s), {counts['warn']} test issue(s)")
+print(f"Summary: {counts['parity']} parity, {counts['divergence']} divergence(s), "
+      f"{counts['shared']} shared failure(s), {counts['skip']} skipped")
+
+# Any non-parity outcome fails the run. ctest exit codes alone are not enough:
+# a test present in only one leg leaves both legs green while the comparison is
+# meaningless.
+sys.exit(1 if counts["divergence"] or counts["shared"] else 0)
 PY
 }
 
@@ -481,6 +543,7 @@ main() {
     local rust_rc=0 ms_rc=0
 
     run_tests "mssql-odbc" "$RUST_INI_DIR" "$rust_junit" "$RUST_DRIVER_SECTION" || rust_rc=$?
+    assert_tests_executed "$rust_junit" "mssql-odbc"
 
     # Report on the instrumented mssql-odbc leg before the (uninstrumented)
     # msodbcsql reference leg runs, so the profraw reflects our driver only.
@@ -490,6 +553,7 @@ main() {
 
     if [ "$COMPARE" -eq 0 ]; then
         if [ "$rust_rc" -ne 0 ]; then
+            print_failure_diagnostics "e2e tests failed"
             echo "=== e2e tests FAILED (mssql-odbc) ==="
             exit "$rust_rc"
         fi
@@ -502,14 +566,17 @@ main() {
     local ms_ini_dir
     ms_ini_dir="$(dirname "$MSODBCSQL_INI")"
     run_tests "msodbcsql"  "$ms_ini_dir"  "$ms_junit" "$MSODBCSQL_DRIVER_SECTION" || ms_rc=$?
+    assert_tests_executed "$ms_junit" "msodbcsql"
 
-    print_parity_report "$rust_junit" "$ms_junit"
+    local parity_rc=0
+    print_parity_report "$rust_junit" "$ms_junit" || parity_rc=$?
 
-    if [ "$rust_rc" -eq 0 ] && [ "$ms_rc" -eq 0 ]; then
-        echo "=== Both runs passed ==="
+    if [ "$rust_rc" -eq 0 ] && [ "$ms_rc" -eq 0 ] && [ "$parity_rc" -eq 0 ]; then
+        echo "=== Both runs passed with full parity ==="
         exit 0
     fi
-    echo "=== Parity check FAILED (mssql-odbc rc=$rust_rc, msodbcsql rc=$ms_rc) ==="
+    print_failure_diagnostics "parity check failed"
+    echo "=== Parity check FAILED (mssql-odbc rc=$rust_rc, msodbcsql rc=$ms_rc, parity rc=$parity_rc) ==="
     exit 1
 }
 

--- a/mssql-odbc/tests/e2e/tests/driver_connect_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/driver_connect_test.cpp
@@ -77,6 +77,47 @@ protected:
             FAIL() << "No connection configured – set ODBC_TEST_SERVER or ODBC_TEST_CONNSTR";
         }
     }
+
+    // Outcome of one SQLDriverConnect probe. Each SQLSTATE flag is true when that
+    // state appears on ANY diagnostic record of the connection handle: a
+    // successful login interleaves the server's own 01000 info messages, and
+    // msodbcsql 18 appends its 01S00 parse warning AFTER them (record #3), so
+    // scanning only record #1 would miss it.
+    struct ConnResult {
+        SQLRETURN rc;
+        bool has01S00;
+        bool has28000;
+        bool hasHY024;
+    };
+
+    // Connect with |cs| through SQLDriverConnect and report the return code plus
+    // the SQLSTATEs the parity tests assert on. Shared by every parity test in
+    // this file so splitting one out never means copying the boilerplate again.
+    ConnResult TryConnect(const std::string& cs) {
+        SQLHDBC hdbc = SQL_NULL_HDBC;
+        SQLRETURN rc = SQLAllocHandle(SQL_HANDLE_DBC, env_, &hdbc);
+        EXPECT_EQ(SQL_SUCCESS, rc);
+        if (rc != SQL_SUCCESS) return {rc, false, false, false};
+
+        SqlTString connstr = ODBCTestUtils::ToSqlTStr(cs);
+        SQLTCHAR outStr[1024] = {};
+        SQLSMALLINT outLen = 0;
+        rc = SQLDriverConnect(hdbc, nullptr,
+                              const_cast<SQLTCHAR*>(connstr.c_str()),
+                              static_cast<SQLSMALLINT>(connstr.size()),
+                              outStr, 1024, &outLen, SQL_DRIVER_NOPROMPT);
+
+        bool has01S00 = false, has28000 = false, hasHY024 = false;
+        if (rc == SQL_SUCCESS_WITH_INFO || rc == SQL_ERROR) {
+            has01S00 = ODBCTestUtils::HasDiagState(SQL_HANDLE_DBC, hdbc, "01S00");
+            has28000 = ODBCTestUtils::HasDiagState(SQL_HANDLE_DBC, hdbc, "28000");
+            hasHY024 = ODBCTestUtils::HasDiagState(SQL_HANDLE_DBC, hdbc, "HY024");
+        }
+
+        if (SQL_SUCCEEDED(rc)) SQLDisconnect(hdbc);
+        SQLFreeHandle(SQL_HANDLE_DBC, hdbc);
+        return {rc, has01S00, has28000, hasHY024};
+    }
 };
 
 // Connect, verify success, then disconnect.
@@ -236,66 +277,25 @@ TEST_F(DriverConnectLiveTest, MalformedTokenReturnsSuccessWithInfo) {
                        ";UID=" + cfg.Uid() +
                        ";PWD=" + cfg.Pwd() +
                        ";TrustServerCertificate=" + cfg.TrustCert();
-
-    struct ConnResult {
-        SQLRETURN rc;
-        bool has01S00;
-        bool has28000;
-    };
-
-    // Connect with |cs| and report the return code plus whether the parser's
-    // 01S00 warning and/or a 28000 login-failure SQLSTATE appear on ANY
-    // diagnostic record. We scan every record (not just record #1): a
-    // successful login interleaves the server's own 01000 info messages, and
-    // msodbcsql 18 appends its 01S00 parse warning AFTER them (record #3),
-    // whereas mssql-odbc posts it first. Reading only record #1 would miss it.
-    auto tryConnect = [&](const std::string& cs) -> ConnResult {
-        SQLHDBC hdbc = SQL_NULL_HDBC;
-        SQLRETURN rc = SQLAllocHandle(SQL_HANDLE_DBC, env_, &hdbc);
-        EXPECT_EQ(SQL_SUCCESS, rc);
-        if (rc != SQL_SUCCESS) return {rc, false, false};
-
-        SqlTString connstr = ODBCTestUtils::ToSqlTStr(cs);
-        SQLTCHAR outStr[1024] = {};
-        SQLSMALLINT outLen = 0;
-
-        rc = SQLDriverConnect(hdbc, nullptr,
-                              const_cast<SQLTCHAR*>(connstr.c_str()),
-                              static_cast<SQLSMALLINT>(connstr.size()),
-                              outStr, 1024, &outLen,
-                              SQL_DRIVER_NOPROMPT);
-
-        bool has01S00 = false;
-        bool has28000 = false;
-        if (rc == SQL_SUCCESS_WITH_INFO || rc == SQL_ERROR) {
-            has01S00 = ODBCTestUtils::HasDiagState(SQL_HANDLE_DBC, hdbc, "01S00");
-            has28000 = ODBCTestUtils::HasDiagState(SQL_HANDLE_DBC, hdbc, "28000");
-        }
-
-        if (SQL_SUCCEEDED(rc)) SQLDisconnect(hdbc);
-        SQLFreeHandle(SQL_HANDLE_DBC, hdbc);
-        return {rc, has01S00, has28000};
-    };
-
     // A trailing token with no '=' is malformed: the key scan reaches
     // end-of-string without finding '=', so the parser posts 01S00 and keeps
     // whatever it parsed already. The connection still succeeds.
     {
-        auto r = tryConnect(base + ";garbage");
+        auto r = TryConnect(base + ";garbage");
         EXPECT_EQ(SQL_SUCCESS_WITH_INFO, r.rc);
         EXPECT_TRUE(r.has01S00);
     }
 
     // Empty key ("=value"): zero-length key name -> 01S00, connection proceeds.
     {
-        auto r = tryConnect(base + ";=orphan");
+        auto r = TryConnect(base + ";=orphan");
         EXPECT_EQ(SQL_SUCCESS_WITH_INFO, r.rc);
         EXPECT_TRUE(r.has01S00);
     }
 
     // Several malformed tokens after a complete, valid attribute set.
     {
-        auto r = tryConnect(base + ";garbage;=orphan;junk");
+        auto r = TryConnect(base + ";garbage;=orphan;junk");
         EXPECT_EQ(SQL_SUCCESS_WITH_INFO, r.rc);
         EXPECT_TRUE(r.has01S00);
     }
@@ -310,7 +310,7 @@ TEST_F(DriverConnectLiveTest, MalformedTokenReturnsSuccessWithInfo) {
     // parser now reproduces msodbcsql byte-for-byte, verified against ODBC
     // Driver 18.)
     {
-        auto r = tryConnect(
+        auto r = TryConnect(
             "Driver={" + cfg.Driver() + "}"
             ";Server=" + cfg.Server() +
             ";noequals;UID=" + cfg.Uid() +
@@ -332,7 +332,7 @@ TEST_F(DriverConnectLiveTest, MalformedTokenReturnsSuccessWithInfo) {
     // single trailing ';' emit no 01S00, but a trailing ';;'/';;;' does. Our
     // rewritten single-pass parser reproduces this exactly.
     {
-        auto r = tryConnect("Driver={" + cfg.Driver() + "}"
+        auto r = TryConnect("Driver={" + cfg.Driver() + "}"
             ";;;Server=" + cfg.Server() +
             ";;;UID=" + cfg.Uid() +
             ";;PWD=" + cfg.Pwd() +
@@ -357,7 +357,7 @@ TEST_F(DriverConnectLiveTest, MalformedTokenReturnsSuccessWithInfo) {
 
     // Unknown keys are ignored with a 01S00 warning; the connection succeeds.
     {
-        auto r = tryConnect(base + ";FooBar=xyz;Bogus=123");
+        auto r = TryConnect(base + ";FooBar=xyz;Bogus=123");
         EXPECT_EQ(SQL_SUCCESS_WITH_INFO, r.rc);
         EXPECT_TRUE(r.has01S00);
     }
@@ -379,47 +379,12 @@ TEST_F(DriverConnectLiveTest, ConnectionStringParserParityBehaviors) {
         GTEST_SKIP() << "Requires SQL auth (ODBC_TEST_SERVER + ODBC_TEST_UID + "
                         "ODBC_TEST_PWD); see follow-up issue for capability gating";
     }
-
-    struct ConnResult {
-        SQLRETURN rc;
-        bool has01S00;
-        bool has28000;
-    };
-
-    auto tryConnect = [&](const std::string& cs) -> ConnResult {
-        SQLHDBC hdbc = SQL_NULL_HDBC;
-        SQLRETURN rc = SQLAllocHandle(SQL_HANDLE_DBC, env_, &hdbc);
-        EXPECT_EQ(SQL_SUCCESS, rc);
-        if (rc != SQL_SUCCESS) return {rc, false, false};
-
-        SqlTString connstr = ODBCTestUtils::ToSqlTStr(cs);
-        SQLTCHAR outStr[1024] = {};
-        SQLSMALLINT outLen = 0;
-
-        rc = SQLDriverConnect(hdbc, nullptr,
-                              const_cast<SQLTCHAR*>(connstr.c_str()),
-                              static_cast<SQLSMALLINT>(connstr.size()),
-                              outStr, 1024, &outLen,
-                              SQL_DRIVER_NOPROMPT);
-
-        bool has01S00 = false;
-        bool has28000 = false;
-        if (rc == SQL_SUCCESS_WITH_INFO || rc == SQL_ERROR) {
-            has01S00 = ODBCTestUtils::HasDiagState(SQL_HANDLE_DBC, hdbc, "01S00");
-            has28000 = ODBCTestUtils::HasDiagState(SQL_HANDLE_DBC, hdbc, "28000");
-        }
-
-        if (SQL_SUCCEEDED(rc)) SQLDisconnect(hdbc);
-        SQLFreeHandle(SQL_HANDLE_DBC, hdbc);
-        return {rc, has01S00, has28000};
-    };
-
     // Braced values: a leading '{' switches value scanning to "read until the
     // matching '}'", and the braces are stripped from the stored value. Wrapping
     // every value in braces must yield the same successful login as the plain
     // form, with no parse warning.
     {
-        auto r = tryConnect("Driver={" + cfg.Driver() + "}"
+        auto r = TryConnect("Driver={" + cfg.Driver() + "}"
             ";Server={" + cfg.Server() + "}"
             ";UID={" + cfg.Uid() + "}"
             ";PWD={" + cfg.Pwd() + "}"
@@ -439,7 +404,7 @@ TEST_F(DriverConnectLiveTest, ConnectionStringParserParityBehaviors) {
     // (duplicates_follow_first_wins, duplicate_recognized_key_first_wins,
     // auth_keys_follow_first_wins).
     {
-        auto r = tryConnect(
+        auto r = TryConnect(
             "Driver={" + cfg.Driver() + "}"
             ";Server=" + cfg.Server() +
             ";UID=" + cfg.Uid() +
@@ -464,7 +429,7 @@ TEST_F(DriverConnectLiveTest, ConnectionStringParserParityBehaviors) {
     // (first-wins) so the server rejects it -> 28000 on unixODBC; the Windows DM
     // keeps the valid trailing UID (last-wins) so the login succeeds.
     {
-        auto r = tryConnect(
+        auto r = TryConnect(
             "Driver={" + cfg.Driver() + "}"
             ";Server=" + cfg.Server() +
             ";UID=bogus_user_should_win" +
@@ -490,7 +455,7 @@ TEST_F(DriverConnectLiveTest, ConnectionStringParserParityBehaviors) {
     // empty user and the server rejects it -> 28000 (and the unknown key also
     // raises 01S00).
     {
-        auto r = tryConnect(
+        auto r = TryConnect(
             "Driver={" + cfg.Driver() + "}"
             ";Server=" + cfg.Server() +
             ";UID =" + cfg.Uid() +
@@ -514,41 +479,6 @@ TEST_F(DriverConnectLiveTest, NewConnectionAttributesParity) {
         GTEST_SKIP() << "Requires SQL auth (ODBC_TEST_SERVER + ODBC_TEST_UID + "
                         "ODBC_TEST_PWD); see follow-up issue for capability gating";
     }
-
-    struct ConnResult {
-        SQLRETURN rc;
-        bool has01S00;
-        bool hasHY024;
-    };
-
-    auto tryConnect = [&](const std::string& cs) -> ConnResult {
-        SQLHDBC hdbc = SQL_NULL_HDBC;
-        SQLRETURN rc = SQLAllocHandle(SQL_HANDLE_DBC, env_, &hdbc);
-        EXPECT_EQ(SQL_SUCCESS, rc);
-        if (rc != SQL_SUCCESS) return {rc, false, false};
-
-        SqlTString connstr = ODBCTestUtils::ToSqlTStr(cs);
-        SQLTCHAR outStr[1024] = {};
-        SQLSMALLINT outLen = 0;
-
-        rc = SQLDriverConnect(hdbc, nullptr,
-                              const_cast<SQLTCHAR*>(connstr.c_str()),
-                              static_cast<SQLSMALLINT>(connstr.size()),
-                              outStr, 1024, &outLen,
-                              SQL_DRIVER_NOPROMPT);
-
-        bool has01S00 = false;
-        bool hasHY024 = false;
-        if (rc == SQL_SUCCESS_WITH_INFO || rc == SQL_ERROR) {
-            has01S00 = ODBCTestUtils::HasDiagState(SQL_HANDLE_DBC, hdbc, "01S00");
-            hasHY024 = ODBCTestUtils::HasDiagState(SQL_HANDLE_DBC, hdbc, "HY024");
-        }
-
-        if (SQL_SUCCEEDED(rc)) SQLDisconnect(hdbc);
-        SQLFreeHandle(SQL_HANDLE_DBC, hdbc);
-        return {rc, has01S00, hasHY024};
-    };
-
     const std::string base =
         "Driver={" + cfg.Driver() + "}"
         ";Server=" + cfg.Server() +
@@ -559,7 +489,7 @@ TEST_F(DriverConnectLiveTest, NewConnectionAttributesParity) {
     // Recognized canonical attributes with valid values: login succeeds and the
     // parser raises no 01S00 (they are acted-on keys, not unknown ones).
     {
-        auto r = tryConnect(base +
+        auto r = TryConnect(base +
             ";ApplicationIntent=ReadOnly"
             ";MultiSubnetFailover=no"
             ";ConnectRetryCount=1"
@@ -577,7 +507,7 @@ TEST_F(DriverConnectLiveTest, NewConnectionAttributesParity) {
     // at connect time (msodbcsql parity), so the parser raises no error and the
     // connection succeeds without an 01S00 warning.
     {
-        auto r = tryConnect(base + ";IpAddressPreference=IPv7");
+        auto r = TryConnect(base + ";IpAddressPreference=IPv7");
         EXPECT_TRUE(SQL_SUCCEEDED(r.rc)) << "rc=" << r.rc;
         EXPECT_FALSE(r.has01S00);
     }
@@ -596,34 +526,6 @@ TEST_F(DriverConnectLiveTest, InvalidConnectionAttributeValuesRejected) {
         GTEST_SKIP() << "Requires SQL auth (ODBC_TEST_SERVER + ODBC_TEST_UID + "
                         "ODBC_TEST_PWD); see follow-up issue for capability gating";
     }
-
-    struct ConnResult {
-        SQLRETURN rc;
-        bool hasHY024;
-    };
-
-    auto tryConnect = [&](const std::string& cs) -> ConnResult {
-        SQLHDBC hdbc = SQL_NULL_HDBC;
-        SQLRETURN rc = SQLAllocHandle(SQL_HANDLE_DBC, env_, &hdbc);
-        EXPECT_EQ(SQL_SUCCESS, rc);
-        if (rc != SQL_SUCCESS) return {rc, false};
-
-        SqlTString connstr = ODBCTestUtils::ToSqlTStr(cs);
-        SQLTCHAR outStr[1024] = {};
-        SQLSMALLINT outLen = 0;
-        rc = SQLDriverConnect(hdbc, nullptr,
-                              const_cast<SQLTCHAR*>(connstr.c_str()),
-                              static_cast<SQLSMALLINT>(connstr.size()),
-                              outStr, 1024, &outLen, SQL_DRIVER_NOPROMPT);
-
-        bool hasHY024 = (rc == SQL_SUCCESS_WITH_INFO || rc == SQL_ERROR) &&
-                        ODBCTestUtils::HasDiagState(SQL_HANDLE_DBC, hdbc, "HY024");
-
-        if (SQL_SUCCEEDED(rc)) SQLDisconnect(hdbc);
-        SQLFreeHandle(SQL_HANDLE_DBC, hdbc);
-        return {rc, hasHY024};
-    };
-
     const std::string base =
         "Driver={" + cfg.Driver() + "}"
         ";Server=" + cfg.Server() +
@@ -632,14 +534,14 @@ TEST_F(DriverConnectLiveTest, InvalidConnectionAttributeValuesRejected) {
 
     // Invalid enum value on a validated key -> E_FAIL -> HY024, connect fails.
     {
-        auto r = tryConnect(base + ";ApplicationIntent=sideways");
+        auto r = TryConnect(base + ";ApplicationIntent=sideways");
         EXPECT_EQ(SQL_ERROR, r.rc);
         EXPECT_TRUE(r.hasHY024);
     }
 
     // Non-numeric integer value -> HY024, connect fails.
     {
-        auto r = tryConnect(base + ";PacketSize=notanumber");
+        auto r = TryConnect(base + ";PacketSize=notanumber");
         EXPECT_EQ(SQL_ERROR, r.rc);
         EXPECT_TRUE(r.hasHY024);
     }

--- a/mssql-odbc/tests/e2e/tests/driver_connect_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/driver_connect_test.cpp
@@ -573,26 +573,6 @@ TEST_F(DriverConnectLiveTest, NewConnectionAttributesParity) {
         EXPECT_FALSE(r.has01S00);
     }
 
-    // Rejecting invalid attribute values with HY024 is mssql-odbc-specific:
-    // msodbcsql accepts both of these (SQL_ERROR without HY024 for the bad enum,
-    // SQL_SUCCESS_WITH_INFO for the non-numeric integer), so run them on the
-    // driver under test only.
-    if (!ComparingMsodbcsql()) {
-        // Invalid enum value on a validated key -> E_FAIL -> HY024, connect fails.
-        {
-            auto r = tryConnect(base + ";ApplicationIntent=sideways");
-            EXPECT_EQ(SQL_ERROR, r.rc);
-            EXPECT_TRUE(r.hasHY024);
-        }
-
-        // Non-numeric integer value -> HY024, connect fails.
-        {
-            auto r = tryConnect(base + ";PacketSize=notanumber");
-            EXPECT_EQ(SQL_ERROR, r.rc);
-            EXPECT_TRUE(r.hasHY024);
-        }
-    }
-
     // Out-of-domain IpAddressPreference is accepted and falls back to IPv4First
     // at connect time (msodbcsql parity), so the parser raises no error and the
     // connection succeeds without an 01S00 warning.
@@ -600,5 +580,67 @@ TEST_F(DriverConnectLiveTest, NewConnectionAttributesParity) {
         auto r = tryConnect(base + ";IpAddressPreference=IPv7");
         EXPECT_TRUE(SQL_SUCCEEDED(r.rc)) << "rc=" << r.rc;
         EXPECT_FALSE(r.has01S00);
+    }
+}
+
+// mssql-odbc rejects an invalid value on a validated connection-string key with
+// HY024 at connect time. The reference msodbcsql driver is laxer: it treats an
+// invalid ApplicationIntent enum as a plain SQL_ERROR without HY024, and a
+// non-numeric PacketSize as SQL_SUCCESS_WITH_INFO. That strictness is
+// mssql-odbc-specific, so the whole test is skipped on the msodbcsql leg.
+TEST_F(DriverConnectLiveTest, InvalidConnectionAttributeValuesRejected) {
+    SKIP_IF_COMPARING_MSODBCSQL();
+
+    auto& cfg = ODBCTestConfig::Instance();
+    if (!cfg.HasSqlAuth()) {
+        GTEST_SKIP() << "Requires SQL auth (ODBC_TEST_SERVER + ODBC_TEST_UID + "
+                        "ODBC_TEST_PWD); see follow-up issue for capability gating";
+    }
+
+    struct ConnResult {
+        SQLRETURN rc;
+        bool hasHY024;
+    };
+
+    auto tryConnect = [&](const std::string& cs) -> ConnResult {
+        SQLHDBC hdbc = SQL_NULL_HDBC;
+        SQLRETURN rc = SQLAllocHandle(SQL_HANDLE_DBC, env_, &hdbc);
+        EXPECT_EQ(SQL_SUCCESS, rc);
+        if (rc != SQL_SUCCESS) return {rc, false};
+
+        SqlTString connstr = ODBCTestUtils::ToSqlTStr(cs);
+        SQLTCHAR outStr[1024] = {};
+        SQLSMALLINT outLen = 0;
+        rc = SQLDriverConnect(hdbc, nullptr,
+                              const_cast<SQLTCHAR*>(connstr.c_str()),
+                              static_cast<SQLSMALLINT>(connstr.size()),
+                              outStr, 1024, &outLen, SQL_DRIVER_NOPROMPT);
+
+        bool hasHY024 = (rc == SQL_SUCCESS_WITH_INFO || rc == SQL_ERROR) &&
+                        ODBCTestUtils::HasDiagState(SQL_HANDLE_DBC, hdbc, "HY024");
+
+        if (SQL_SUCCEEDED(rc)) SQLDisconnect(hdbc);
+        SQLFreeHandle(SQL_HANDLE_DBC, hdbc);
+        return {rc, hasHY024};
+    };
+
+    const std::string base =
+        "Driver={" + cfg.Driver() + "}"
+        ";Server=" + cfg.Server() +
+        ";UID=" + cfg.Uid() +
+        ";PWD=" + cfg.Pwd() + ";TrustServerCertificate=" + cfg.TrustCert();
+
+    // Invalid enum value on a validated key -> E_FAIL -> HY024, connect fails.
+    {
+        auto r = tryConnect(base + ";ApplicationIntent=sideways");
+        EXPECT_EQ(SQL_ERROR, r.rc);
+        EXPECT_TRUE(r.hasHY024);
+    }
+
+    // Non-numeric integer value -> HY024, connect fails.
+    {
+        auto r = tryConnect(base + ";PacketSize=notanumber");
+        EXPECT_EQ(SQL_ERROR, r.rc);
+        EXPECT_TRUE(r.hasHY024);
     }
 }

--- a/mssql-odbc/tests/e2e/tests/driver_connect_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/driver_connect_test.cpp
@@ -573,18 +573,24 @@ TEST_F(DriverConnectLiveTest, NewConnectionAttributesParity) {
         EXPECT_FALSE(r.has01S00);
     }
 
-    // Invalid enum value on a validated key -> E_FAIL -> HY024, connect fails.
-    {
-        auto r = tryConnect(base + ";ApplicationIntent=sideways");
-        EXPECT_EQ(SQL_ERROR, r.rc);
-        EXPECT_TRUE(r.hasHY024);
-    }
+    // Rejecting invalid attribute values with HY024 is mssql-odbc-specific:
+    // msodbcsql accepts both of these (SQL_ERROR without HY024 for the bad enum,
+    // SQL_SUCCESS_WITH_INFO for the non-numeric integer), so run them on the
+    // driver under test only.
+    if (!ComparingMsodbcsql()) {
+        // Invalid enum value on a validated key -> E_FAIL -> HY024, connect fails.
+        {
+            auto r = tryConnect(base + ";ApplicationIntent=sideways");
+            EXPECT_EQ(SQL_ERROR, r.rc);
+            EXPECT_TRUE(r.hasHY024);
+        }
 
-    // Non-numeric integer value -> HY024, connect fails.
-    {
-        auto r = tryConnect(base + ";PacketSize=notanumber");
-        EXPECT_EQ(SQL_ERROR, r.rc);
-        EXPECT_TRUE(r.hasHY024);
+        // Non-numeric integer value -> HY024, connect fails.
+        {
+            auto r = tryConnect(base + ";PacketSize=notanumber");
+            EXPECT_EQ(SQL_ERROR, r.rc);
+            EXPECT_TRUE(r.hasHY024);
+        }
     }
 
     // Out-of-domain IpAddressPreference is accepted and falls back to IPv4First


### PR DESCRIPTION
## Summary

Two related changes to the ODBC C++ e2e runners.

### 1. Register the Rust driver under its own name

The runners registered the Rust driver under the same name msodbcsql18 uses (`ODBC Driver 18 for SQL Server`). On Windows that collision forced `-CompareWithMsodbcsql` to swap the HKLM registration between the two legs.

The Rust driver now registers as **`ODBC Driver 18 for SQL Server (Rust)`** and each leg selects its driver via `ODBC_TEST_DRIVER`, which `odbc_test_config.cpp` already honors. No C++ changes were needed.

| Leg | `ODBC_TEST_TARGET` | `ODBC_TEST_DRIVER` |
|---|---|---|
| 1 | `mssql-odbc` | `ODBC Driver 18 for SQL Server (Rust)` |
| 2 | `msodbcsql` | `ODBC Driver 18 for SQL Server` |

- `run_e2e.sh`: split `DRIVER_SECTION` into `RUST_DRIVER_SECTION` / `MSODBCSQL_DRIVER_SECTION`; dropped the "both INIs must use the same section name" requirement.
- `run_e2e.ps1`: registers under its own HKLM key, so an installed msodbcsql18 is never touched and **the registry swap between legs is gone**. `-MsodbcsqlDll` still repoints the reference registration, now snapshotted and restored in the existing `finally`.

Both scripts reject `ODBC_TEST_CONNSTR` in comparison mode — it overrides the whole connection string and would silently pin both legs to one driver.

### 2. Actually run the comparison in CI, and stop reporting false greens

Comparison mode existed but **no CI leg ever enabled it**, and no CI agent had msodbcsql installed. Now the two PR legs that own a local SQL Server run it:

| Leg | Reference driver install |
|---|---|
| Windows x64 (`build-template.yml`) | `winget install Microsoft.msodbcsql.18 --version 18.6.2.1`, falling back to the same MSI winget would fetch (URL + SHA256 pinned from the winget manifest) when winget is unavailable on the image |
| Linux x64 docker (`containerized-odbc-e2e.sh`, gated on `ODBC_E2E_COMPARE`) | `apt-get install msodbcsql18=18.6.2.1-1` from `packages.microsoft.com` |

Both publish the reference leg's `junit-msodbcsql.xml` alongside the Rust results (`continueOnError`, since it only exists in comparison mode).

The ARM container leg, the remote-SQL Windows leg, and the Alpine/RHEL distro matrix stay single-leg — they either do not own the SQL Server or are not apt-based.

Runner hardening — a leg can no longer look green when it did nothing:

- `cargo build` and both `cmake` invocations abort on failure. Native command exit codes do not honor `$ErrorActionPreference = 'Stop'`, so `run_e2e.ps1` previously continued past a failed CMake configure, ran ctest against an empty project, and printed `Summary: 0 parity` + `=== Both runs passed ===` with exit code 0.
- A leg that executes zero tests now fails. ctest exits 0 while printing `No tests were found!!!`, so the guard is a zero-`<testcase>` check on the JUnit output.
- **Any parity divergence, shared failure, or one-sided test fails the run** in both scripts. Previously the parity table was informational only.
- In CI, failures dump `CMakeOutput.log`, `CMakeError.log`, `LastTest.log`, and the discovered test executables.

Also ported `run_e2e.sh`'s dev SQL auto-detection (probe `localhost:1433`, resolve the password from `ODBC_TEST_PWD` / `SQL_PASSWORD` / `mssql-tds/.env`, fall back to integrated auth) to `run_e2e.ps1`, which had no equivalent.

## Validation

- [x] `run_e2e.ps1` and every embedded pwsh step in the pipeline YAML parse (PowerShell AST parser); `run_e2e.sh` and `containerized-odbc-e2e.sh` pass `bash -n`; both templates pass `yaml.safe_load`
- [x] Parity-report logic unit-tested against synthetic JUnit fixtures in both languages: identical -> exit 0, divergent -> exit 1, shared failure -> exit 1
- [x] Zero-test guard unit-tested: populated passes, empty fails, missing fails
- [x] Pinned MSI fallback verified: URL downloads, SHA256 matches the winget manifest
- [x] `msodbcsql18=18.6.2.1-1` confirmed present in the MS apt repo for jammy (amd64 and arm64)
- [x] Local `-CompareWithMsodbcsql` run on Windows (elevated, SQL Server 2022, integrated auth): **16 parity, 0 divergences, 0 shared failures, 0 skipped**; both legs passed. Verified each leg logged the expected `ODBC_TEST_DRIVER`, no `IM002`/connection failures in either leg, the msodbcsql override path was never taken, and the registry was left clean afterwards.
- [ ] PR validation pipelines green — in particular the new winget/apt install steps and whether the msodbcsql leg connects on both platforms

No Rust code changed, so `cargo bfmt` / `bclippy` / `btest` are unaffected.


## Related Issues

Closes #182
