### PR TITLE
perf(lab): cap improvement verification, align cross-platform rounding, fix docs wording

### DIFF
--- a/docs/perf-testing-plan.md
+++ b/docs/perf-testing-plan.md
@@ -196,7 +196,12 @@ record exactly as much as an anomalously slow candidate one, and since both dire
 one re-measure set the extra confidence costs nothing per run. This never fails the run: it
 exists so a one-off artifact is not reported as a real gain, and because a win that *does*
 reproduce is itself worth a look — an implausible speed-up can mean the candidate is doing
-less work rather than the same work faster.
+less work rather than the same work faster. Unlike regressions, improvements are **not
+self-limiting** — a PR that genuinely optimizes a hot path can turn many benchmarks green
+at once, and each one added to the set costs a full round of re-runs on both sides — so the
+set is capped at the largest apparent wins (`BENCH_IMPROVEMENT_VERIFY_MAX`, default 3).
+Benchmarks beyond the cap are still reported with their first-pass numbers, just not
+re-measured.
 
 **Compilation failures fail loudly.** Both runners compile the candidate and baseline
 bench binaries in an explicit `cargo bench --no-run` step with human-readable output
@@ -312,8 +317,8 @@ binaries keep the per-binary interleaving effective (see §2).
   costs dual code paths; reserve it for when a pre-break baseline is specifically needed.
   Building each side from its own bench source is *not* an option: it reintroduces the
   variable the harness exists to eliminate.) Bumping the baseline can also surface
-  *runtime* breaks that still compile — e.g. a value that moved from the generic
-  return-value buffer to a dedicated accessor.
+  *runtime* breaks that still compile — e.g. a value that stopped being pushed to the
+  generic return-value buffer, so the bench must now read it via its dedicated accessor.
 - Perf-lab pipeline runs on a **dedicated host VM** via the shared `PerfTest` lab
   `extends` template; the build happens on the VM (the lab's documented model).
 - Comparison is **interleaved per bench binary** (not two full passes), and the run

--- a/docs/perf-testing-plan.md
+++ b/docs/perf-testing-plan.md
@@ -193,7 +193,8 @@ the same re-measure set, and the summary reports whether the win reproduced in a
 re-runs. Verifying both directions at the same magnitude matters because the measurements are
 recorded for run-over-run trend comparison: an anomalously slow *baseline* pass corrupts that
 record exactly as much as an anomalously slow candidate one, and since both directions share
-one re-measure set the extra confidence costs nothing per run. This never fails the run: it
+one re-measure set the extra confidence adds no extra *pass* — though each benchmark in the
+set does add its own re-run time, which is what the cap below bounds. This never fails the run: it
 exists so a one-off artifact is not reported as a real gain, and because a win that *does*
 reproduce is itself worth a look — an implausible speed-up can mean the candidate is doing
 less work rather than the same work faster. Unlike regressions, improvements are **not

--- a/mssql-tds-bench/perf-lab/run-benchmarks.ps1
+++ b/mssql-tds-bench/perf-lab/run-benchmarks.ps1
@@ -472,7 +472,20 @@ $impThr = [double]($env:BENCH_IMPROVEMENT_VERIFY_RATIO)
 # exactly as much as a candidate-slower one, and both directions share one
 # re-measure set.
 if (-not $impThr) { $impThr = $thr }
-$improvements = @(Get-CritcmpImprovements $comparison $impThr)
+# Unlike regressions, improvements are not self-limiting: a PR that genuinely
+# optimizes a hot path can turn a dozen benchmarks green at once, and each one
+# added to the verify set costs $confirmRuns release-grade re-runs of BOTH sides.
+# Cap the set at the largest apparent wins so the re-run budget stays bounded;
+# the rest are still reported, just not re-measured.
+$impMax = if ($env:BENCH_IMPROVEMENT_VERIFY_MAX) { [int]$env:BENCH_IMPROVEMENT_VERIFY_MAX } else { 3 }
+if ($impMax -lt 1) { throw "BENCH_IMPROVEMENT_VERIFY_MAX must be >= 1 (got: $impMax); use a higher BENCH_IMPROVEMENT_VERIFY_RATIO to verify fewer." }
+$improvementsAll = @(Get-CritcmpImprovements $comparison $impThr | Sort-Object -Property Ratio -Descending)
+$improvements = @($improvementsAll | Select-Object -First $impMax)
+$impTotal = $improvementsAll.Count
+$impSkipped = $impTotal - $improvements.Count
+if ($impSkipped -gt 0) {
+    Write-Host ">>> $impTotal benchmark(s) look faster by >= $([int][math]::Round(($impThr - 1) * 100, [MidpointRounding]::AwayFromZero))%; verifying the largest $impMax (BENCH_IMPROVEMENT_VERIFY_MAX)."
+}
 # One re-measure set covers both directions, so the re-runs cost one pass.
 $verifyNames = @(@($regressions | ForEach-Object { $_.Name }) + @($improvements | ForEach-Object { $_.Name }) | Select-Object -Unique)
 
@@ -570,13 +583,16 @@ foreach ($name in $verifyNames) {
 }
 
 # --- Verdict (based on the majority-confirmed regressions) ---
-$pct = [int][math]::Round(($thr - 1) * 100)
-$impPct = [int][math]::Round(($impThr - 1) * 100)
+# AwayFromZero to match the bash runner's half-up `printf "%d", x + 0.5`;
+# [math]::Round defaults to banker's rounding, which would render an exact .5%
+# differently on the two platforms.
+$pct = [int][math]::Round(($thr - 1) * 100, [MidpointRounding]::AwayFromZero)
+$impPct = [int][math]::Round(($impThr - 1) * 100, [MidpointRounding]::AwayFromZero)
 $warn = [char]::ConvertFromUtf32(0x26A0) + [char]::ConvertFromUtf32(0xFE0F)
 $check = [char]::ConvertFromUtf32(0x2705)
 if ($confirmed.Count -gt 0) {
     $worstName = $confirmed | Sort-Object { $worstRatio[$_] } -Descending | Select-Object -First 1
-    $wpct = [int][math]::Round(($worstRatio[$worstName] - 1) * 100)
+    $wpct = [int][math]::Round(($worstRatio[$worstName] - 1) * 100, [MidpointRounding]::AwayFromZero)
     $whits = $tally[$worstName]
     $verdict = "$warn $($confirmed.Count) benchmark(s) consistently slower by >=$pct% vs baseline (worst: $worstName +$wpct%, tripped $whits/$confirmRuns re-runs)"
 } else {
@@ -609,7 +625,7 @@ function Get-EmojiBarTable {
         '|---|--:|:--:|:--|'
     )
     foreach ($row in ($rows | Sort-Object Pct)) {
-        $p = $row.Pct; $n = [int][math]::Round([math]::Abs($p)); if ($n -gt 12) { $n = 12 }
+        $p = $row.Pct; $n = [int][math]::Round([math]::Abs($p), [MidpointRounding]::AwayFromZero); if ($n -gt 12) { $n = 12 }
         $gs = ''; $rs = ''
         if ($p -le -1) { $gs = $g * $n } elseif ($p -ge 1) { $rs = $r * $n }
         if ($p -le -0.05) { $lbl = ('{0:0.0}' -f $p) }
@@ -669,7 +685,7 @@ if ($regressions.Count -gt 0) {
     foreach ($r in $regressions) {
         $hits = if ($tally.ContainsKey($r.Name)) { $tally[$r.Name] } else { 0 }
         if ($worstRatio.ContainsKey($r.Name)) {
-            $wcell = '+' + [string][int][math]::Round(($worstRatio[$r.Name] - 1) * 100) + '%'
+            $wcell = '+' + [string][int][math]::Round(($worstRatio[$r.Name] - 1) * 100, [MidpointRounding]::AwayFromZero) + '%'
         } else {
             $wcell = [string][char]0x2014
         }
@@ -685,6 +701,11 @@ if ($improvements.Count -gt 0) {
         ''
         "_Baseline slower by at least $impPct%. These never fail the gate; they are re-measured so a one-off artifact is not published as a real gain. A win that **does** reproduce is also worth a look - it can mean the candidate is doing less work rather than the same work faster._"
         ''
+    )
+    if ($impSkipped -gt 0) {
+        $summaryLines += @("_$impTotal benchmark(s) qualified; the largest $impMax were re-measured (``BENCH_IMPROVEMENT_VERIFY_MAX``). The other $impSkipped keep their first-pass numbers in the chart, unverified._", '')
+    }
+    $summaryLines += @(
         '| benchmark | reproduced | best |'
         '|-----------|------------|------|'
     )

--- a/mssql-tds-bench/perf-lab/run-benchmarks.ps1
+++ b/mssql-tds-bench/perf-lab/run-benchmarks.ps1
@@ -34,6 +34,22 @@ function Invoke-Native {
     }
 }
 
+# Read an integer knob strictly. A bare [int] cast silently ROUNDS a fractional
+# string ("1.5" -> 2), which the bash runner rejects outright, so the same
+# environment would produce different settings on the two platforms. NumberStyles
+# None (no sign, no surrounding whitespace) and the invariant culture match the
+# bash guard's `case $x in *[!0-9]*)` exactly.
+function Get-IntEnv {
+    param([Parameter(Mandatory)][string]$Name, [Parameter(Mandatory)][int]$Default)
+    $raw = [Environment]::GetEnvironmentVariable($Name)
+    if ($null -eq $raw -or $raw -eq '') { return $Default }
+    $parsed = 0
+    if (-not [int]::TryParse($raw, [System.Globalization.NumberStyles]::None, [System.Globalization.CultureInfo]::InvariantCulture, [ref]$parsed)) {
+        throw "$Name must be a non-negative integer (got: '$raw')."
+    }
+    return $parsed
+}
+
 # Convert a taskset-style CPU list ("16-31", "8,9,10", "8-11,14") into a Win32
 # process-affinity bitmask. Returns $null when the list is empty. Mirrors the
 # `taskset -c` contract that run-benchmarks.sh consumes on Linux.
@@ -477,7 +493,7 @@ if (-not $impThr) { $impThr = $thr }
 # added to the verify set costs $confirmRuns release-grade re-runs of BOTH sides.
 # Cap the set at the largest apparent wins so the re-run budget stays bounded;
 # the rest are still reported, just not re-measured.
-$impMax = if ($env:BENCH_IMPROVEMENT_VERIFY_MAX) { [int]$env:BENCH_IMPROVEMENT_VERIFY_MAX } else { 3 }
+$impMax = Get-IntEnv 'BENCH_IMPROVEMENT_VERIFY_MAX' 3
 if ($impMax -lt 1) { throw "BENCH_IMPROVEMENT_VERIFY_MAX must be >= 1 (got: $impMax); use a higher BENCH_IMPROVEMENT_VERIFY_RATIO to verify fewer." }
 $improvementsAll = @(Get-CritcmpImprovements $comparison $impThr | Sort-Object -Property Ratio -Descending)
 $improvements = @($improvementsAll | Select-Object -First $impMax)
@@ -500,8 +516,8 @@ $verifyNames = @(@($regressions | ForEach-Object { $_.Name }) + @($improvements 
 # offenders are a small subset, so the extra re-runs stay cheap.
 #   BENCH_CONFIRM_RUNS   (default 4)                - number of re-runs
 #   BENCH_CONFIRM_QUORUM (default majority = N/2+1)  - re-runs required to confirm
-$confirmRuns = if ($env:BENCH_CONFIRM_RUNS) { [int]$env:BENCH_CONFIRM_RUNS } else { 4 }
-$quorum = if ($env:BENCH_CONFIRM_QUORUM) { [int]$env:BENCH_CONFIRM_QUORUM } else { [int][math]::Floor($confirmRuns / 2) + 1 }
+$confirmRuns = Get-IntEnv 'BENCH_CONFIRM_RUNS' 4
+$quorum = Get-IntEnv 'BENCH_CONFIRM_QUORUM' ([int][math]::Floor($confirmRuns / 2) + 1)
 # Reject settings that would silently disable the gate rather than tune it:
 # 0 re-runs skips the loop and clears every regression, and a quorum above the
 # run count can never be met, so nothing is ever confirmed.

--- a/mssql-tds-bench/perf-lab/run-benchmarks.sh
+++ b/mssql-tds-bench/perf-lab/run-benchmarks.sh
@@ -350,11 +350,12 @@ OFFENDERS=$(regression_ids "$RESULTS_DIR/comparison.txt")
 # The gate is one-directional, so a *baseline*-slower result is never challenged
 # and an unverified "3x faster" gets published. critcmp normalizes the faster
 # side to 1.00, so field 2 carries the baseline's ratio: select IDs where the
-# baseline is slower by at least IMP_THR and re-measure them too.
-improvement_ids() {
+# baseline is slower by at least IMP_THR and re-measure them too, ranked by
+# magnitude so the cap below keeps the largest (most suspicious) claims.
+improvement_ranked() {
     awk -v thr="$IMP_THR" '
-        $2 ~ /^[0-9]+\.[0-9]+$/ && $6 ~ /^[0-9]+\.[0-9]+$/ && ($2 + 0) >= thr { print $1 }
-    ' "$1"
+        $2 ~ /^[0-9]+\.[0-9]+$/ && $6 ~ /^[0-9]+\.[0-9]+$/ && ($2 + 0) >= thr { print $2, $1 }
+    ' "$1" | sort -rn | awk '{ print $2 }'
 }
 improvement_pairs() {
     awk -v thr="$IMP_THR" '
@@ -362,7 +363,25 @@ improvement_pairs() {
     ' "$1"
 }
 
-IMPROVEMENTS=$(improvement_ids "$RESULTS_DIR/comparison.txt")
+# Unlike regressions, improvements are not self-limiting: a PR that genuinely
+# optimizes a hot path can turn a dozen benchmarks green at once, and each one
+# added to the verify set costs CONFIRM_RUNS release-grade re-runs of BOTH sides.
+# Cap the set at the largest apparent wins so the re-run budget stays bounded on
+# exactly the PRs that most deserve a fast signal; the rest are still reported,
+# just not re-measured.
+IMP_MAX="${BENCH_IMPROVEMENT_VERIFY_MAX:-3}"
+case "$IMP_MAX" in ''|*[!0-9]*) echo "ERROR: BENCH_IMPROVEMENT_VERIFY_MAX must be a positive integer (got: '${IMP_MAX}')" >&2; exit 1 ;; esac
+if [ "$IMP_MAX" -lt 1 ]; then
+    echo "ERROR: BENCH_IMPROVEMENT_VERIFY_MAX must be >= 1 (got: ${IMP_MAX}); use a higher BENCH_IMPROVEMENT_VERIFY_RATIO to verify fewer." >&2
+    exit 1
+fi
+IMP_RANKED=$(improvement_ranked "$RESULTS_DIR/comparison.txt")
+IMP_TOTAL=$(printf '%s\n' "$IMP_RANKED" | awk 'NF' | wc -l | tr -d ' ')
+IMPROVEMENTS=$(printf '%s\n' "$IMP_RANKED" | awk 'NF' | head -n "$IMP_MAX")
+IMP_SKIPPED=$(( IMP_TOTAL > IMP_MAX ? IMP_TOTAL - IMP_MAX : 0 ))
+if [ "$IMP_SKIPPED" -gt 0 ]; then
+    echo ">>> ${IMP_TOTAL} benchmark(s) look faster by >=$(awk -v t="$IMP_THR" 'BEGIN { printf "%d", (t - 1) * 100 + 0.5 }')%; verifying the largest ${IMP_MAX} (BENCH_IMPROVEMENT_VERIFY_MAX)."
+fi
 # One re-measure set covers both directions, so the re-runs cost one pass.
 # awk 'NF' drops the blank lines rather than grep, which would exit 1 when both
 # lists are empty (a clean run) and kill the script under set -e.
@@ -576,6 +595,10 @@ emoji_bar_table() {
         echo "### Large improvements (verification)"
         echo ""
         echo "_Baseline slower by ≥${IMP_PCT}%. These never fail the gate; they are re-measured so a one-off artifact is not published as a real gain. A win that **does** reproduce is also worth a look — it can mean the candidate is doing less work rather than the same work faster._"
+        if [ "$IMP_SKIPPED" -gt 0 ]; then
+            echo ""
+            echo "_${IMP_TOTAL} benchmark(s) qualified; the largest ${IMP_MAX} were re-measured (\`BENCH_IMPROVEMENT_VERIFY_MAX\`). The other ${IMP_SKIPPED} keep their first-pass numbers in the chart, unverified._"
+        fi
         echo ""
         echo "| benchmark | reproduced | best |"
         echo "|-----------|------------|------|"

--- a/mssql-tds-bench/perf-lab/run-benchmarks.sh
+++ b/mssql-tds-bench/perf-lab/run-benchmarks.sh
@@ -371,6 +371,7 @@ improvement_pairs() {
 # just not re-measured.
 IMP_MAX="${BENCH_IMPROVEMENT_VERIFY_MAX:-3}"
 case "$IMP_MAX" in ''|*[!0-9]*) echo "ERROR: BENCH_IMPROVEMENT_VERIFY_MAX must be a positive integer (got: '${IMP_MAX}')" >&2; exit 1 ;; esac
+IMP_MAX=$((10#$IMP_MAX))
 if [ "$IMP_MAX" -lt 1 ]; then
     echo "ERROR: BENCH_IMPROVEMENT_VERIFY_MAX must be >= 1 (got: ${IMP_MAX}); use a higher BENCH_IMPROVEMENT_VERIFY_RATIO to verify fewer." >&2
     exit 1
@@ -405,12 +406,17 @@ CONFIRM_RUNS="${BENCH_CONFIRM_RUNS:-4}"
 # checked before QUORUM is derived, since that default is an arithmetic
 # expansion that would fail confusingly on a non-numeric value.
 case "$CONFIRM_RUNS" in ''|*[!0-9]*) echo "ERROR: BENCH_CONFIRM_RUNS must be a positive integer (got: '${CONFIRM_RUNS}')" >&2; exit 1 ;; esac
+# Force base 10: bash arithmetic reads a leading zero as octal, so "08"/"09" are
+# invalid literals that abort the script, and "010" would silently mean 8 here
+# while the PowerShell runner reads it as 10.
+CONFIRM_RUNS=$((10#$CONFIRM_RUNS))
 if [ "$CONFIRM_RUNS" -lt 1 ]; then
     echo "ERROR: BENCH_CONFIRM_RUNS must be >= 1 (got: ${CONFIRM_RUNS}); 0 would clear every regression unconfirmed." >&2
     exit 1
 fi
 QUORUM="${BENCH_CONFIRM_QUORUM:-$(( CONFIRM_RUNS / 2 + 1 ))}"
 case "$QUORUM" in ''|*[!0-9]*) echo "ERROR: BENCH_CONFIRM_QUORUM must be a positive integer (got: '${QUORUM}')" >&2; exit 1 ;; esac
+QUORUM=$((10#$QUORUM))
 if [ "$QUORUM" -lt 1 ] || [ "$QUORUM" -gt "$CONFIRM_RUNS" ]; then
     echo "ERROR: BENCH_CONFIRM_QUORUM must be between 1 and BENCH_CONFIRM_RUNS (got: ${QUORUM} of ${CONFIRM_RUNS})." >&2
     exit 1


### PR DESCRIPTION
## Description

Follow-ups from the [#139](https://github.com/microsoft/mssql-rs/pull/139) review. All three were raised as non-blocking, so they were deferred out of that PR and are addressed here.

## Changes

**1. Cap the improvement-verify set (@saurabh500's cost-model point)**

Regressions are self-limiting — a healthy PR has none — but improvements are not. A PR that legitimately optimizes a hot path can turn a dozen benchmarks green at once, and every benchmark added to the verify set costs `BENCH_CONFIRM_RUNS` (default 4) release-grade re-runs of **both** sides at `BENCH_SECS=30`/`BENCH_SAMPLES=30`. That lands the cost squarely on the PR that most deserves a fast signal.

Improvements are now ranked by magnitude and capped at `BENCH_IMPROVEMENT_VERIFY_MAX` (default 3), so the re-run budget is bounded no matter how many benchmarks come in faster. The largest — and therefore most suspicious — apparent wins are the ones verified. Benchmarks beyond the cap are still charted with their first-pass numbers, and the summary states how many qualified versus how many were re-measured, so nothing is silently dropped.

Regressions remain deliberately uncapped: they gate the run, and their count is bounded by the PR being healthy.

**2. Align PowerShell rounding with bash**

`[math]::Round` defaults to `MidpointRounding.ToEven` (banker's rounding) while the bash runner uses half-up (`printf "%d", x + 0.5`), so an exact `.5%` delta rendered as `3%` on Linux and `2%` on Windows. The summary display sites now pass `[MidpointRounding]::AwayFromZero`. Cosmetic only — selections, quorum, and medians were never affected.

**3. Fix docs wording**

The baseline-coupling note read as if the API break introduced `take_prepared_statement_handle()`. The accessor and its `prepared_statement_handle` slot already existed on `main`; what actually changed is that the `sp_prepexec` `@handle` stopped being pushed into the generic `return_values` buffer, so the bench's `get_return_values()` scan came up empty and its `.expect(...)` panicked. The accessor is the fix, not the thing that moved.

**Files**

- `mssql-tds-bench/perf-lab/run-benchmarks.sh` — `improvement_ranked()` replaces `improvement_ids()`; `BENCH_IMPROVEMENT_VERIFY_MAX` with validation; truncation notice in the log and summary.
- `mssql-tds-bench/perf-lab/run-benchmarks.ps1` — same cap via `Sort-Object Ratio -Descending` + `Select-Object -First`; `AwayFromZero` at the percentage display sites.
- `docs/perf-testing-plan.md` — document the cap; correct the accessor wording.

## Validation

- **Cap**: against a table with 5 qualifying wins (4.10×, 3.35×, 1.80×, 1.12×, 1.11×) plus a 1.02× noise row, both runners select the same top 3 (`d_huge_win`, `b_big_win`, `c_mid_win`), report `skipped=2`, and correctly exclude the sub-threshold row.
- **Rounding**: the new call matches bash at `2.5 → 3`, `3.5 → 4`, `-2.5 → -3`, `0.5 → 1`, `1.5 → 2`; banker's rounding diverged at three of those five.
- **Guard**: `BENCH_IMPROVEMENT_VERIFY_MAX` of `0`, `-1`, and `abc` are all rejected with explicit messages; `5` and the default are accepted.
- **Empty path**: a run with no qualifying improvements still yields an empty verify set (the regression that broke Linux build 165147 does not recur).
- `bash -n` and PowerShell AST parse both clean.

No perf-lab run is required to validate these: the cap and rounding are pure selection/display logic, exercised above against real and synthetic critcmp tables. A Linux/Windows pass can be run before merge if you'd like end-to-end confirmation.

## Related Issues

[AB#46061](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46061)

## Checklist

- [x] New/changed functionality has tests — N/A: perf-lab runner logic (no product code); validated via the selection, rounding, guard, and empty-path checks above
- [x] Public API changes are documented — N/A: no public API changes
