### PR TITLE
Sans-I/O TDS core (1/N): extract PacketBuffer

### DIFF
--- a/mssql-tds/src/io.rs
+++ b/mssql-tds/src/io.rs
@@ -24,6 +24,7 @@
 //! Most users will not interact with this module directly. Instead, use the higher-level
 //! [`crate::connection`] APIs which handle packet I/O internally.
 
+pub(crate) mod packet_buffer;
 pub mod packet_reader;
 pub mod packet_writer;
 pub mod reader_writer;

--- a/mssql-tds/src/io/packet_buffer.rs
+++ b/mssql-tds/src/io/packet_buffer.rs
@@ -1,0 +1,204 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Sans-I/O packet buffer: the synchronous, I/O-free half of packet reading.
+//!
+//! [`PacketBuffer`] owns the reassembled TDS payload bytes and serves every
+//! scalar and byte read straight from memory. It knows nothing about sockets or
+//! `async`. The only thing it cannot do itself is obtain more bytes; when a read
+//! needs more than [`available`](PacketBuffer::available), the caller (a thin
+//! I/O shell) refills the buffer via [`begin_refill`](PacketBuffer::begin_refill)
+//! / [`commit_packet`](PacketBuffer::commit_packet) and retries.
+//!
+//! This is the foundation of the sans-I/O split: protocol decode is pure
+//! computation over this buffer, and the `.await` lives only at the refill edge.
+
+use byteorder::{BigEndian, ByteOrder, LittleEndian};
+
+use crate::core::TdsResult;
+use crate::io::packet_writer::PacketWriter;
+
+/// Synchronous, I/O-free buffer of reassembled TDS packet payload bytes.
+pub(crate) struct PacketBuffer {
+    working_buffer: Vec<u8>,
+    position: usize,
+    length: usize,
+    max_packet_size: usize,
+}
+
+impl PacketBuffer {
+    /// Creates a buffer sized to hold two packets, matching the historic
+    /// `PacketReader` storage so a value that straddles a packet boundary still
+    /// fits after a single refill.
+    #[cfg(test)]
+    pub(crate) fn with_packet_size(max_packet_size: usize) -> Self {
+        PacketBuffer {
+            working_buffer: vec![0; max_packet_size * 2],
+            position: 0,
+            length: 0,
+            max_packet_size,
+        }
+    }
+
+    /// Bytes currently readable without a refill.
+    pub(crate) fn available(&self) -> usize {
+        self.length - self.position
+    }
+
+    /// Whether `byte_count` bytes can be read without a refill.
+    pub(crate) fn has(&self, byte_count: usize) -> bool {
+        self.available() >= byte_count
+    }
+
+    /// Readable bytes as a slice (from the current position to the filled end).
+    fn peek(&self) -> &[u8] {
+        &self.working_buffer[self.position..self.length]
+    }
+
+    /// Returns the first `n` readable bytes, erroring if fewer are buffered.
+    ///
+    /// Callers ensure enough bytes are present (via a refill) before calling; a
+    /// shortfall here is a protocol/logic error, not a request for more data.
+    fn take(&mut self, n: usize) -> TdsResult<&[u8]> {
+        if !self.has(n) {
+            return Err(crate::error::Error::ProtocolError(format!(
+                "Buffer underflow: needed {} bytes but only {} available",
+                n,
+                self.available()
+            )));
+        }
+        let start = self.position;
+        self.position += n;
+        if self.position == self.length {
+            self.position = 0;
+            self.length = 0;
+        }
+        Ok(&self.working_buffer[start..start + n])
+    }
+
+    pub(crate) fn take_u8(&mut self) -> TdsResult<u8> {
+        Ok(self.take(1)?[0])
+    }
+
+    pub(crate) fn take_i16_be(&mut self) -> TdsResult<i16> {
+        Ok(BigEndian::read_i16(self.take(2)?))
+    }
+
+    pub(crate) fn take_i32_be(&mut self) -> TdsResult<i32> {
+        Ok(BigEndian::read_i32(self.take(4)?))
+    }
+
+    pub(crate) fn take_uint40_le(&mut self) -> TdsResult<u64> {
+        Ok(LittleEndian::read_uint(self.take(5)?, 5))
+    }
+
+    pub(crate) fn take_f32_le(&mut self) -> TdsResult<f32> {
+        Ok(LittleEndian::read_f32(self.take(4)?))
+    }
+
+    pub(crate) fn take_f64_le(&mut self) -> TdsResult<f64> {
+        Ok(LittleEndian::read_f64(self.take(8)?))
+    }
+
+    pub(crate) fn take_i16_le(&mut self) -> TdsResult<i16> {
+        Ok(LittleEndian::read_i16(self.take(2)?))
+    }
+
+    pub(crate) fn take_u16_le(&mut self) -> TdsResult<u16> {
+        Ok(LittleEndian::read_u16(self.take(2)?))
+    }
+
+    pub(crate) fn take_u24_le(&mut self) -> TdsResult<u32> {
+        Ok(LittleEndian::read_u24(self.take(3)?))
+    }
+
+    pub(crate) fn take_i32_le(&mut self) -> TdsResult<i32> {
+        Ok(LittleEndian::read_i32(self.take(4)?))
+    }
+
+    pub(crate) fn take_u32_le(&mut self) -> TdsResult<u32> {
+        Ok(LittleEndian::read_u32(self.take(4)?))
+    }
+
+    pub(crate) fn take_i64_le(&mut self) -> TdsResult<i64> {
+        Ok(LittleEndian::read_i64(self.take(8)?))
+    }
+
+    pub(crate) fn take_u64_le(&mut self) -> TdsResult<u64> {
+        Ok(LittleEndian::read_u64(self.take(8)?))
+    }
+
+    /// Copies up to `dst.len()` readable bytes into `dst`, consuming them, and
+    /// returns how many were copied (bounded by what is currently buffered).
+    pub(crate) fn copy_out(&mut self, dst: &mut [u8]) -> usize {
+        let to_copy = dst.len().min(self.available());
+        if to_copy > 0 {
+            dst[..to_copy].copy_from_slice(&self.peek()[..to_copy]);
+            self.position += to_copy;
+            if self.position == self.length {
+                self.position = 0;
+                self.length = 0;
+            }
+        }
+        to_copy
+    }
+
+    /// Discards up to `count` readable bytes, returning how many were skipped
+    /// (bounded by what is currently buffered).
+    pub(crate) fn skip_available(&mut self, count: usize) -> usize {
+        let to_skip = count.min(self.available());
+        self.position += to_skip;
+        if self.position == self.length {
+            self.position = 0;
+            self.length = 0;
+        }
+        to_skip
+    }
+
+    /// Compacts leftover bytes to the front and returns the offset at which the
+    /// next raw packet (header included) should be written. Pair with
+    /// [`commit_packet`](Self::commit_packet) once the packet has been read.
+    pub(crate) fn begin_refill(&mut self) -> usize {
+        let remaining = self.available();
+        if remaining > 0 {
+            self.working_buffer
+                .copy_within(self.position..self.length, 0);
+        }
+        self.length = remaining;
+        self.position = 0;
+        self.length
+    }
+
+    /// The window a raw packet is read into, starting `already` bytes past
+    /// `base`. The receive edge fills this incrementally until a full packet is
+    /// present.
+    pub(crate) fn refill_window(&mut self, base: usize, already: usize) -> &mut [u8] {
+        &mut self.working_buffer[base + already..base + self.max_packet_size]
+    }
+
+    /// Strips the 8-byte packet header from a raw packet written at `base` and
+    /// makes its `raw_len - 8` payload bytes readable.
+    pub(crate) fn commit_packet(&mut self, base: usize, raw_len: usize) {
+        self.working_buffer.copy_within(
+            base + PacketWriter::PACKET_HEADER_SIZE..base + raw_len,
+            base,
+        );
+        self.length = base + raw_len - PacketWriter::PACKET_HEADER_SIZE;
+    }
+
+    /// Big-endian packet length recorded in the header of the raw packet at
+    /// `base` (bytes 2..4 of the TDS packet header).
+    pub(crate) fn packet_header_length(&self, base: usize) -> usize {
+        BigEndian::read_u16(&self.working_buffer[base + 2..base + 4]) as usize
+    }
+
+    /// Debug view of the raw bytes read for the packet at `base`.
+    pub(crate) fn raw_packet(&self, base: usize, raw_len: usize) -> &[u8] {
+        &self.working_buffer[base..base + raw_len]
+    }
+
+    /// True once every buffered byte has been consumed.
+    pub(crate) fn is_drained(&self) -> bool {
+        self.position == self.length
+    }
+}

--- a/mssql-tds/src/io/packet_reader.rs
+++ b/mssql-tds/src/io/packet_reader.rs
@@ -2,18 +2,15 @@
 // Licensed under the MIT License.
 
 use async_trait::async_trait;
-use byteorder::{BigEndian, ByteOrder, LittleEndian};
 use tracing::event;
 
 use super::packet_writer::PacketWriter;
 use crate::core::TdsResult;
+use crate::io::packet_buffer::PacketBuffer;
 use crate::io::reader_writer::NetworkReaderWriter;
 use crate::message::attention::AttentionRequest;
 use crate::message::messages::Request;
-use std::{
-    cmp::min,
-    io::{Error, ErrorKind},
-};
+use std::io::{Error, ErrorKind};
 
 #[async_trait]
 #[cfg(not(fuzzing))]
@@ -79,12 +76,13 @@ pub trait TdsPacketReader {
 }
 
 /// Buffered reader that reassembles TDS packets from the network stream.
+///
+/// The buffer math and every scalar/byte read live in the I/O-free
+/// [`PacketBuffer`]; this type only adds the one thing the buffer cannot do
+/// itself — pull more bytes off the socket when a read needs them.
 pub struct PacketReader<'a> {
     network_reader_writer: &'a mut dyn NetworkReaderWriter,
-    buffer_position: usize,
-    buffer_length: usize,
-    max_packet_size: usize,
-    working_buffer: Vec<u8>,
+    buffer: PacketBuffer,
 }
 
 impl<'a> PacketReader<'a> {
@@ -93,47 +91,25 @@ impl<'a> PacketReader<'a> {
     #[cfg(test)]
     pub(crate) fn new(network_reader_writer: &'a mut dyn NetworkReaderWriter) -> PacketReader<'a> {
         let packet_size: usize = network_reader_writer.as_writer().packet_size() as usize;
-        let packet_storage = packet_size * 2;
-        let buffer: Vec<u8> = vec![0; packet_storage]; // Adjust the capacity as needed
-
         PacketReader {
             network_reader_writer,
-            buffer_length: 0,
-            buffer_position: 0,
-            working_buffer: buffer,
-            max_packet_size: packet_size,
+            buffer: PacketBuffer::with_packet_size(packet_size),
         }
     }
 
-    fn do_we_have_enough_data(&self, byte_count: usize) -> bool {
-        let remaining_bytes = self.buffer_length - self.buffer_position;
-        remaining_bytes >= byte_count
+    /// Ensures at least `byte_count` bytes are readable, refilling once if not.
+    /// A scalar never exceeds one packet, so a single refill always suffices.
+    async fn ensure(&mut self, byte_count: usize) -> TdsResult<()> {
+        if !self.buffer.has(byte_count) {
+            self.read_tds_packet().await?;
+        }
+        Ok(())
     }
 
     async fn read_tds_packet(&mut self) -> TdsResult<()> {
-        let remaining_bytes = self.buffer_length - self.buffer_position;
-
-        if remaining_bytes > 0 {
-            // Move the remaining bytes to the beginning of the buffer.
-            self.working_buffer
-                .copy_within(self.buffer_position..(self.buffer_length), 0);
-            self.buffer_length = remaining_bytes;
-            self.buffer_position = 0;
-            let new_packet_size = self.get_new_tds_packet().await?;
-            self.working_buffer.copy_within(
-                self.buffer_length + 8..self.buffer_length + new_packet_size,
-                self.buffer_length,
-            );
-            self.buffer_length += new_packet_size;
-            self.buffer_length -= 8;
-        } else {
-            self.buffer_length = 0;
-            self.buffer_position = 0;
-            let new_packet_size = self.get_new_tds_packet().await?;
-            self.working_buffer
-                .copy_within(8..new_packet_size, self.buffer_length);
-            self.buffer_length = new_packet_size - 8;
-        }
+        let base = self.buffer.begin_refill();
+        let raw_len = self.receive_packet(base).await?;
+        self.buffer.commit_packet(base, raw_len);
         Ok(())
     }
 
@@ -143,98 +119,42 @@ impl<'a> PacketReader<'a> {
         self.read_tds_packet().await
     }
 
-    async fn get_new_tds_packet(&mut self) -> TdsResult<usize> {
-        let packet_buffer: &mut Vec<u8> = &mut self.working_buffer;
-        let base_offset_to_write = self.buffer_length;
-
-        let mut bytes_read_from_transport = self
+    async fn receive_packet(&mut self, base: usize) -> TdsResult<usize> {
+        let mut received = self
             .network_reader_writer
-            .receive(&mut packet_buffer[base_offset_to_write..])
+            .receive(self.buffer.refill_window(base, 0))
             .await?;
 
-        // We need the 8 byte header. Re-read, in case the new_packet_byte_length has less bytes than 8 bytes to complete
-        // the header.
-        while bytes_read_from_transport < PacketWriter::PACKET_HEADER_SIZE {
-            bytes_read_from_transport += self
+        // The 8-byte header may arrive split across reads; keep reading until it
+        // is complete before trusting its declared length.
+        while received < PacketWriter::PACKET_HEADER_SIZE {
+            received += self
                 .network_reader_writer
-                .receive(
-                    &mut packet_buffer[base_offset_to_write + bytes_read_from_transport
-                        ..base_offset_to_write + self.max_packet_size],
-                )
+                .receive(self.buffer.refill_window(base, received))
                 .await?;
         }
 
-        let length_from_packet_header =
-            BigEndian::read_u16(&packet_buffer[base_offset_to_write + 2..base_offset_to_write + 4]);
-
-        let packet_size_from_header: usize = length_from_packet_header as usize;
-
-        // Keep reading until we have the complete packet in memory.
-        while bytes_read_from_transport < packet_size_from_header {
-            bytes_read_from_transport += self
+        let packet_size_from_header = self.buffer.packet_header_length(base);
+        while received < packet_size_from_header {
+            received += self
                 .network_reader_writer
-                .receive(
-                    &mut packet_buffer[base_offset_to_write + bytes_read_from_transport
-                        ..base_offset_to_write + self.max_packet_size],
-                )
+                .receive(self.buffer.refill_window(base, received))
                 .await?;
         }
+
         event!(
             tracing::Level::DEBUG,
             "Received packet of size: {:?}",
-            bytes_read_from_transport
+            received
         );
 
         use pretty_hex::PrettyHex;
-
         event!(
             tracing::Level::DEBUG,
             "Packet content: {:?}",
-            &packet_buffer[base_offset_to_write..base_offset_to_write + bytes_read_from_transport]
-                .hex_dump()
+            self.buffer.raw_packet(base, received).hex_dump()
         );
-        Ok(bytes_read_from_transport)
-    }
-
-    fn consume_bytes(&mut self, byte_count: usize) -> TdsResult<()> {
-        if byte_count > (self.buffer_length - self.buffer_position) {
-            return Err(crate::error::Error::ProtocolError(format!(
-                "Buffer underflow: attempted to consume {} bytes but only {} available",
-                byte_count,
-                self.buffer_length - self.buffer_position
-            )));
-        }
-
-        self.buffer_position += byte_count;
-        if self.buffer_length == self.buffer_position {
-            self.buffer_length = 0;
-            self.buffer_position = 0;
-        }
-        Ok(())
-    }
-
-    /// Skips a specified number of bytes in the packet stream.
-    #[allow(dead_code)]
-    pub async fn skip_bytes(&mut self, skip_count: usize) -> TdsResult<()> {
-        let mut length_to_read = skip_count;
-        while length_to_read > 0 {
-            // If we don't have enough data, read a new TDS packet.
-            if !self.do_we_have_enough_data(min(self.max_packet_size - 8, length_to_read)) {
-                self.read_tds_packet().await?;
-            }
-            let available = self.buffer_length - self.buffer_position;
-
-            // We still may not have enough data, and we can, at a time, only skip a max of packet payload.
-            // We can read the minimum of what is available, or the actual length needed or the packet size.
-            // If we have a need to skip a large amount of data, then we will skip in chunks.
-            let to_read = min(available, min(length_to_read, self.max_packet_size - 8));
-
-            if to_read > 0 {
-                length_to_read -= to_read;
-                self.consume_bytes(to_read)?;
-            }
-        }
-        Ok(())
+        Ok(received)
     }
 }
 
@@ -242,7 +162,7 @@ impl<'a> PacketReader<'a> {
 impl TdsPacketReader for PacketReader<'_> {
     fn reset_reader(&mut self) {
         // Make sure that we have read all the data from the buffer.
-        assert!(self.buffer_length == self.buffer_position);
+        assert!(self.buffer.is_drained());
         // No Op after this.
     }
 
@@ -255,147 +175,77 @@ impl TdsPacketReader for PacketReader<'_> {
     }
 
     async fn read_byte(&mut self) -> TdsResult<u8> {
-        if !self.do_we_have_enough_data(1) {
-            self.read_tds_packet().await?;
-        }
-        let result: u8 = self.working_buffer[self.buffer_position];
-        self.consume_bytes(1)?;
-        Ok(result)
+        self.ensure(1).await?;
+        self.buffer.take_u8()
     }
 
     async fn read_int16_big_endian(&mut self) -> TdsResult<i16> {
-        if !self.do_we_have_enough_data(2) {
-            self.read_tds_packet().await?;
-        }
-        let result = BigEndian::read_i16(&self.working_buffer[self.buffer_position..]);
-        self.consume_bytes(2)?;
-        Ok(result)
+        self.ensure(2).await?;
+        self.buffer.take_i16_be()
     }
 
     async fn read_int32_big_endian(&mut self) -> TdsResult<i32> {
-        if !self.do_we_have_enough_data(4) {
-            self.read_tds_packet().await?;
-        }
-        let result = BigEndian::read_i32(&self.working_buffer[self.buffer_position..]);
-        self.consume_bytes(4)?;
-        Ok(result)
+        self.ensure(4).await?;
+        self.buffer.take_i32_be()
     }
 
     async fn read_uint40(&mut self) -> TdsResult<u64> {
-        if !self.do_we_have_enough_data(5) {
-            self.read_tds_packet().await?;
-        }
-
-        let result = LittleEndian::read_uint(&self.working_buffer[self.buffer_position..], 5);
-        self.consume_bytes(5)?;
-        Ok(result)
+        self.ensure(5).await?;
+        self.buffer.take_uint40_le()
     }
 
     async fn read_float32(&mut self) -> TdsResult<f32> {
-        if !self.do_we_have_enough_data(4) {
-            self.read_tds_packet().await?;
-        }
-        let result = LittleEndian::read_f32(&self.working_buffer[self.buffer_position..]);
-        self.consume_bytes(4)?;
-        Ok(result)
+        self.ensure(4).await?;
+        self.buffer.take_f32_le()
     }
 
     async fn read_float64(&mut self) -> TdsResult<f64> {
-        if !self.do_we_have_enough_data(8) {
-            self.read_tds_packet().await?;
-        }
-        let result = LittleEndian::read_f64(&self.working_buffer[self.buffer_position..]);
-        self.consume_bytes(8)?;
-        Ok(result)
+        self.ensure(8).await?;
+        self.buffer.take_f64_le()
     }
 
     async fn read_int16(&mut self) -> TdsResult<i16> {
-        if !self.do_we_have_enough_data(2) {
-            self.read_tds_packet().await?;
-        }
-        let result = LittleEndian::read_i16(&self.working_buffer[self.buffer_position..]);
-        self.consume_bytes(2)?;
-        Ok(result)
+        self.ensure(2).await?;
+        self.buffer.take_i16_le()
     }
 
     async fn read_uint16(&mut self) -> TdsResult<u16> {
-        if !self.do_we_have_enough_data(2) {
-            self.read_tds_packet().await?;
-        }
-        let result = LittleEndian::read_u16(&self.working_buffer[self.buffer_position..]);
-        self.consume_bytes(2)?;
-        Ok(result)
+        self.ensure(2).await?;
+        self.buffer.take_u16_le()
     }
 
     async fn read_uint24(&mut self) -> TdsResult<u32> {
-        if !self.do_we_have_enough_data(3) {
-            self.read_tds_packet().await?;
-        }
-        let result = LittleEndian::read_u24(&self.working_buffer[self.buffer_position..]);
-        self.consume_bytes(3)?;
-        Ok(result)
+        self.ensure(3).await?;
+        self.buffer.take_u24_le()
     }
 
     async fn read_int32(&mut self) -> TdsResult<i32> {
-        if !self.do_we_have_enough_data(4) {
-            self.read_tds_packet().await?;
-        }
-        let result = LittleEndian::read_i32(&self.working_buffer[self.buffer_position..]);
-        self.consume_bytes(4)?;
-        Ok(result)
+        self.ensure(4).await?;
+        self.buffer.take_i32_le()
     }
 
     async fn read_uint32(&mut self) -> TdsResult<u32> {
-        if !self.do_we_have_enough_data(4) {
-            self.read_tds_packet().await?;
-        }
-        let result = LittleEndian::read_u32(&self.working_buffer[self.buffer_position..]);
-        self.consume_bytes(4)?;
-        Ok(result)
+        self.ensure(4).await?;
+        self.buffer.take_u32_le()
     }
 
     async fn read_int64(&mut self) -> TdsResult<i64> {
-        if !self.do_we_have_enough_data(8) {
-            self.read_tds_packet().await?;
-        }
-        let result = LittleEndian::read_i64(&self.working_buffer[self.buffer_position..]);
-        self.consume_bytes(8)?;
-        Ok(result)
+        self.ensure(8).await?;
+        self.buffer.take_i64_le()
     }
 
     async fn read_uint64(&mut self) -> TdsResult<u64> {
-        if !self.do_we_have_enough_data(8) {
-            self.read_tds_packet().await?;
-        }
-        let result = LittleEndian::read_u64(&self.working_buffer[self.buffer_position..]);
-        self.consume_bytes(8)?;
-        Ok(result)
+        self.ensure(8).await?;
+        self.buffer.take_u64_le()
     }
 
     async fn read_bytes(&mut self, buffer: &mut [u8]) -> TdsResult<usize> {
         let mut total_read = 0;
-        let mut length_to_read = buffer.len();
-        let mut offset = 0;
-        while length_to_read > 0 {
-            if !self.do_we_have_enough_data(min(self.max_packet_size, length_to_read)) {
+        while total_read < buffer.len() {
+            if self.buffer.available() == 0 {
                 self.read_tds_packet().await?;
             }
-            let available = self.buffer_length - self.buffer_position;
-
-            // We can read the minimum of what is available, or the actual length needed or the packet size.
-            let to_read = min(available, min(length_to_read, self.max_packet_size - 8));
-
-            if to_read > 0 {
-                // Copy from self.working_buffer to buffer from self.buffer_position to offset.
-                buffer[offset..offset + to_read].copy_from_slice(
-                    &self.working_buffer[self.buffer_position..self.buffer_position + to_read],
-                );
-                offset += to_read;
-                length_to_read -= to_read;
-                total_read += to_read;
-
-                self.consume_bytes(to_read)?;
-            }
+            total_read += self.buffer.copy_out(&mut buffer[total_read..]);
         }
         Ok(total_read)
     }
@@ -476,20 +326,12 @@ impl TdsPacketReader for PacketReader<'_> {
 
     /// Skips a specified number of bytes in the packet stream.
     async fn skip_bytes(&mut self, skip_count: usize) -> TdsResult<()> {
-        let mut length_to_read = skip_count;
-        while length_to_read > 0 {
-            if !self.do_we_have_enough_data(min(self.max_packet_size - 8, length_to_read)) {
+        let mut remaining = skip_count;
+        while remaining > 0 {
+            if self.buffer.available() == 0 {
                 self.read_tds_packet().await?;
             }
-            let available = self.buffer_length - self.buffer_position;
-
-            // We can read the minimum of what is available, or the actual length needed or the packet size.
-            let to_read = min(available, min(length_to_read, self.max_packet_size - 8));
-
-            if to_read > 0 {
-                length_to_read -= to_read;
-                self.consume_bytes(to_read)?;
-            }
+            remaining -= self.buffer.skip_available(remaining);
         }
         Ok(())
     }
@@ -601,7 +443,9 @@ pub(crate) mod tests {
     use crate::handler::handler_factory::SessionSettings;
     use crate::io::reader_writer::{NetworkReader, NetworkWriter};
     use async_trait::async_trait;
+    use byteorder::{BigEndian, ByteOrder, LittleEndian};
     use rand::Rng;
+    use std::cmp::min;
 
     //append_method!(append_i64, i64, 8, write_i64);
     macro_rules! append_method {


### PR DESCRIPTION
## Stack

Bottom layer of the sans-I/O `mssql-tds` restructure. This is layer 1 of a GitHub PR stack; higher layers build on this branch.

## What this layer does

Introduces `PacketBuffer` — the **synchronous, I/O-free half of packet reading**. It owns the reassembled TDS payload bytes and serves every scalar/byte read straight from memory, knowing nothing about sockets or `async`. The only thing it can't do itself is obtain more bytes; when a read needs more than what's buffered, the caller (a thin I/O shell) refills via `begin_refill` / `commit_packet` and retries.

`PacketReader` is rewired onto `PacketBuffer`, so the buffer math and scalar decode now live in one place. The reader keeps only the one thing the buffer can't do — pull bytes off the socket on refill (`receive_packet`). The four ad-hoc buffer fields collapse to a single `buffer: PacketBuffer`, and the duplicated `consume_bytes` / `do_we_have_enough_data` logic is gone.

**Public API is unchanged** — this is a pure internal refactor that establishes the sans-I/O abstraction.

## Why

The TDS protocol logic (framing, scalar decode) is pure computation over an in-memory byte buffer; the only real I/O is "the buffer is empty, give me more bytes." Making that split explicit lets a sync shell and an async shell later drive the same protocol core with the `.await` confined to a ~10-line refill loop.

## Next layers (preview)

- **(2/N)** Adopt `PacketBuffer` in the production `NetworkTransport` read path, deleting the duplicated `TdsReadBuffer` scalar/refill logic.
- Later layers: invert the token/decoder parsers to a sync `step()` core, add the blocking shell + sync `TdsClient` surface, rewire `mssql-odbc` off `block_on`.

## Validation

- `cargo build -p mssql-tds` — clean
- `cargo bclippy` — clean (`-D warnings`)
- `cargo bfmt` — clean
- `cargo nextest run -p mssql-tds packet_reader` — 15/15 pass

## Framing (correctness / architecture, not a perf win yet)

This PR is the bottom of a 15-PR sans-I/O stack (#189 through #208) restructuring `mssql-tds` into **one protocol core with a sync shell and an async shell**. The whole effort is a **correctness/architecture** refactor: it deletes the per-row `block_on` tax and the `fast::*` sync-fake hack, and lets sync consumers (`mssql-odbc`, the `mssql-py-core` sync cursor) and async consumers (the `mssql-py-core` coroutine cursor) drive the same buffer-driven parser with `.await` confined to a ~10-line refill loop.

It is **not** yet a native-beating performance win, and nothing in this stack claims to beat `msodbcsql18`. The remaining performance debt to burn down next: VarcharMax/PLP streaming (~818x on both the async-before and sync-after variants, pre-existing), the Decimal/DateTime2 conversion gaps, and the per-column `SQLGetData` conversion/alloc path.

Related work item / issue: Tracked as part of the sans-I/O native stack (#192)
