### PR TITLE
Sans-I/O TDS core (3/N): invert token/decoder to a sync step() core

### DIFF
--- a/mssql-tds/src/connection/transport/network_transport.rs
+++ b/mssql-tds/src/connection/transport/network_transport.rs
@@ -777,6 +777,33 @@ impl NetworkTransport {
         Ok(())
     }
 
+    /// Async shell over the sync core: drives [`PacketBuffer::ensure`] in a loop,
+    /// refilling on `NeedBytes` and retrying until `byte_count` bytes are
+    /// readable. The paired atomic `take_*` accessors never advance on a short
+    /// read, so re-driving after a refill is always safe.
+    async fn ensure_or_refill(&mut self, byte_count: usize) -> TdsResult<()> {
+        loop {
+            match self.tds_read_buffer.ensure(byte_count) {
+                Ok(()) => return Ok(()),
+                Err(need) => {
+                    tracing::trace!(shortfall = need.shortfall, "refilling TDS read buffer");
+                    let before = self.tds_read_buffer.available();
+                    self.read_tds_packet().await?;
+                    // Loop-termination invariant: a refill must expose at least
+                    // one new byte. Without this guard a zero-payload packet
+                    // would spin the driver forever, so fail loudly instead.
+                    let progressed = self.tds_read_buffer.available() > before;
+                    debug_assert!(progressed, "TDS refill made no forward progress");
+                    if !progressed {
+                        return Err(crate::error::Error::ProtocolError(format!(
+                            "TDS packet refill made no progress while {byte_count} bytes were needed"
+                        )));
+                    }
+                }
+            }
+        }
+    }
+
     /// Reads a complete TDS packet from the network into the working buffer.
     ///
     /// This method handles the case where a single `read()` call returns data for multiple
@@ -1062,86 +1089,60 @@ impl TdsPacketReader for NetworkTransport {
     }
 
     async fn read_byte(&mut self) -> TdsResult<u8> {
-        if !self.tds_read_buffer.has(1) {
-            self.read_tds_packet().await?;
-        }
+        self.ensure_or_refill(1).await?;
         self.tds_read_buffer.take_u8()
     }
 
     async fn read_int16_big_endian(&mut self) -> TdsResult<i16> {
-        if !self.tds_read_buffer.has(2) {
-            self.read_tds_packet().await?;
-        }
+        self.ensure_or_refill(2).await?;
         self.tds_read_buffer.take_i16_be()
     }
     async fn read_int32_big_endian(&mut self) -> TdsResult<i32> {
-        if !self.tds_read_buffer.has(4) {
-            self.read_tds_packet().await?;
-        }
+        self.ensure_or_refill(4).await?;
         self.tds_read_buffer.take_i32_be()
     }
 
     async fn read_uint40(&mut self) -> TdsResult<u64> {
-        if !self.tds_read_buffer.has(5) {
-            self.read_tds_packet().await?;
-        }
+        self.ensure_or_refill(5).await?;
         self.tds_read_buffer.take_uint40_le()
     }
 
     async fn read_float32(&mut self) -> TdsResult<f32> {
-        if !self.tds_read_buffer.has(4) {
-            self.read_tds_packet().await?;
-        }
+        self.ensure_or_refill(4).await?;
         self.tds_read_buffer.take_f32_le()
     }
     async fn read_float64(&mut self) -> TdsResult<f64> {
-        if !self.tds_read_buffer.has(8) {
-            self.read_tds_packet().await?;
-        }
+        self.ensure_or_refill(8).await?;
         self.tds_read_buffer.take_f64_le()
     }
     async fn read_int16(&mut self) -> TdsResult<i16> {
-        if !self.tds_read_buffer.has(2) {
-            self.read_tds_packet().await?;
-        }
+        self.ensure_or_refill(2).await?;
         self.tds_read_buffer.take_i16_le()
     }
     async fn read_uint16(&mut self) -> TdsResult<u16> {
-        if !self.tds_read_buffer.has(2) {
-            self.read_tds_packet().await?;
-        }
+        self.ensure_or_refill(2).await?;
         self.tds_read_buffer.take_u16_le()
     }
     async fn read_uint24(&mut self) -> TdsResult<u32> {
-        if !self.tds_read_buffer.has(3) {
-            self.read_tds_packet().await?;
-        }
+        self.ensure_or_refill(3).await?;
         self.tds_read_buffer.take_u24_le()
     }
 
     async fn read_int32(&mut self) -> TdsResult<i32> {
-        if !self.tds_read_buffer.has(4) {
-            self.read_tds_packet().await?;
-        }
+        self.ensure_or_refill(4).await?;
         self.tds_read_buffer.take_i32_le()
     }
 
     async fn read_uint32(&mut self) -> TdsResult<u32> {
-        if !self.tds_read_buffer.has(4) {
-            self.read_tds_packet().await?;
-        }
+        self.ensure_or_refill(4).await?;
         self.tds_read_buffer.take_u32_le()
     }
     async fn read_int64(&mut self) -> TdsResult<i64> {
-        if !self.tds_read_buffer.has(8) {
-            self.read_tds_packet().await?;
-        }
+        self.ensure_or_refill(8).await?;
         self.tds_read_buffer.take_i64_le()
     }
     async fn read_uint64(&mut self) -> TdsResult<u64> {
-        if !self.tds_read_buffer.has(8) {
-            self.read_tds_packet().await?;
-        }
+        self.ensure_or_refill(8).await?;
         self.tds_read_buffer.take_u64_le()
     }
 
@@ -1150,6 +1151,11 @@ impl TdsPacketReader for NetworkTransport {
         while total_read < buffer.len() {
             if self.tds_read_buffer.available() == 0 {
                 self.read_tds_packet().await?;
+                if self.tds_read_buffer.available() == 0 {
+                    return Err(crate::error::Error::ProtocolError(
+                        "TDS packet refill made no progress while reading bytes".to_string(),
+                    ));
+                }
             }
             total_read += self.tds_read_buffer.copy_out(&mut buffer[total_read..]);
         }
@@ -1217,6 +1223,11 @@ impl TdsPacketReader for NetworkTransport {
         while remaining > 0 {
             if self.tds_read_buffer.available() == 0 {
                 self.read_tds_packet().await?;
+                if self.tds_read_buffer.available() == 0 {
+                    return Err(crate::error::Error::ProtocolError(
+                        "TDS packet refill made no progress while skipping bytes".to_string(),
+                    ));
+                }
             }
             remaining -= self.tds_read_buffer.skip_available(remaining);
         }
@@ -1272,10 +1283,10 @@ impl TdsTokenStreamReader for NetworkTransport {
         cancel_handle: Option<&CancelHandle>,
         writer: &mut (dyn RowWriter + Send),
     ) -> TdsResult<RowReadResult> {
-        let cancellable = CancelHandle::run_until_cancelled(
+        let cancellable = Box::pin(CancelHandle::run_until_cancelled(
             cancel_handle,
             receive_row_into_internal(self, &*PARSER_REGISTRY, context, writer),
-        );
+        ));
         let result = match remaining_request_timeout.as_ref() {
             Some(t) => match timeout(*t, cancellable).await {
                 Ok(r) => r,
@@ -1303,10 +1314,10 @@ impl TdsTokenStreamReader for NetworkTransport {
         cancel_handle: Option<&CancelHandle>,
         writer: &mut (dyn RowWriter + Send),
     ) -> TdsResult<RowReadResult> {
-        let cancellable = CancelHandle::run_until_cancelled(
+        let cancellable = Box::pin(CancelHandle::run_until_cancelled(
             cancel_handle,
             resume_row_into_internal(self, pause_state, writer),
-        );
+        ));
         let result = match remaining_request_timeout.as_ref() {
             Some(t) => match timeout(*t, cancellable).await {
                 Ok(r) => r,

--- a/mssql-tds/src/datatypes/decoder.rs
+++ b/mssql-tds/src/datatypes/decoder.rs
@@ -974,99 +974,36 @@ impl GenericDecoder {
         Ok(ColumnValues::Vector(vector))
     }
 
-    async fn read_plp_bytes<T>(reader: &mut T) -> TdsResult<Option<Vec<u8>>>
+    /// Reads an entire PLP value into one `Vec`, returning `None` for SQL NULL.
+    ///
+    /// The eager collect-all counterpart to [`PlpColumnStream`]: incremental
+    /// callers stream chunks on demand, while value decoders that materialize
+    /// the whole column funnel through here. All wire-level chunk framing and
+    /// size guards live in [`PlpChunkStreamReader`], so this stays a thin
+    /// accumulation loop over the shared streaming reader instead of a second
+    /// copy of the chunk-decoding logic.
+    async fn collect_plp<T>(reader: &mut T) -> TdsResult<Option<Vec<u8>>>
     where
         T: TdsPacketReader + Send + Sync,
     {
-        let long_len_i64 = reader.read_int64().await?;
-        let long_len = long_len_i64 as u64;
+        const COLLECT_CHUNK: usize = 8192;
 
-        // If the length is SQL_PLP_NULL, it means the value is NULL.
-        if long_len as usize == Self::SQL_PLP_NULL {
-            Ok(None)
-        } else {
-            // If the length is SQL_PLP_UNKNOWNLEN, it means the length is unknown and we have to
-            // gather all the chunks until we reach the end of the PLP data which is a zero length
-            // chunk.
-            let mut vector_capacity = if long_len as usize != Self::SQL_PLP_UNKNOWNLEN {
-                let capacity = long_len as usize;
-                // Check for overflow or excessively large values
-                // If long_len_i64 was negative, casting to u64 then usize can produce huge values
-                if long_len_i64 < 0 || capacity > MAX_PLP_SIZE {
-                    return Err(crate::error::Error::ProtocolError(format!(
-                        "PLP length {capacity} (raw i64: {long_len_i64}) exceeds maximum allowed size of {MAX_PLP_SIZE} bytes"
-                    )));
-                }
-                capacity
-            } else {
-                0
-            };
-            let mut plp_buffer = vec![0u8; vector_capacity];
-            let mut chunk_len = reader.read_uint32().await? as usize;
-            let mut offset: usize = 0;
-            let mut chunk_count = 0u32;
+        let reader: &mut (dyn TdsPacketReader + Send + Sync) = reader;
+        let mut stream = match PlpChunkStreamReader::begin(reader).await? {
+            None => return Ok(None),
+            Some(stream) => stream,
+        };
 
-            while chunk_len > 0 {
-                chunk_count += 1;
-
-                #[cfg(fuzzing)]
-                {
-                    eprintln!(
-                        "[ALLOC] read_plp_bytes: chunk #{chunk_count}, chunk_len={chunk_len}, total_capacity={vector_capacity}"
-                    );
-                }
-
-                if chunk_count > Self::MAX_PLP_CHUNKS {
-                    return Err(crate::error::Error::ProtocolError(format!(
-                        "Too many PLP chunks: {chunk_count} (max {})",
-                        Self::MAX_PLP_CHUNKS
-                    )));
-                }
-
-                // Limit individual chunk size
-                if chunk_len > Self::MAX_PLP_CHUNK_SIZE {
-                    return Err(crate::error::Error::ProtocolError(format!(
-                        "PLP chunk size {chunk_len} exceeds maximum allowed chunk size of {} bytes",
-                        Self::MAX_PLP_CHUNK_SIZE
-                    )));
-                }
-
-                if long_len as usize == Self::SQL_PLP_UNKNOWNLEN {
-                    // Use checked_add to prevent capacity overflow
-                    vector_capacity = vector_capacity.checked_add(chunk_len).ok_or_else(|| {
-                        crate::error::Error::ProtocolError(format!(
-                            "PLP chunk accumulation would overflow capacity: {vector_capacity} + {chunk_len}"
-                        ))
-                    })?;
-                    // Validate against MAX_PLP_SIZE after accumulation
-                    if vector_capacity > MAX_PLP_SIZE {
-                        return Err(crate::error::Error::ProtocolError(format!(
-                            "PLP accumulated size {vector_capacity} exceeds maximum allowed size of {MAX_PLP_SIZE} bytes (SQL Server limit: 2GB)"
-                        )));
-                    }
-                    plp_buffer.resize(vector_capacity, 0);
-                } else {
-                    // For known length, validate that chunk fits within the allocated buffer
-                    let end_offset = offset.checked_add(chunk_len).ok_or_else(|| {
-                        crate::error::Error::ProtocolError(format!(
-                            "PLP chunk offset would overflow: {offset} + {chunk_len}"
-                        ))
-                    })?;
-                    if end_offset > plp_buffer.len() {
-                        return Err(crate::error::Error::ProtocolError(format!(
-                            "PLP chunk exceeds declared length: offset={offset}, chunk_len={chunk_len}, buffer_len={}, declared_len={long_len}",
-                            plp_buffer.len()
-                        )));
-                    }
-                }
-                let chunk_size_read = reader
-                    .read_bytes(&mut plp_buffer[offset..offset + chunk_len])
-                    .await?;
-                offset += chunk_size_read;
-                chunk_len = reader.read_uint32().await? as usize;
+        let mut collected = Vec::new();
+        let mut chunk = [0u8; COLLECT_CHUNK];
+        while !stream.reached_end() {
+            let read = stream.read_into(reader, &mut chunk).await?;
+            if read == 0 {
+                break;
             }
-            Ok(Some(plp_buffer))
+            collected.extend_from_slice(&chunk[..read]);
         }
+        Ok(Some(collected))
     }
 
     /// Decodes a column value from the wire and writes it directly into a
@@ -1208,7 +1145,7 @@ impl GenericDecoder {
             }
             TdsDataType::BigVarBinary => {
                 if metadata.is_plp() {
-                    match GenericDecoder::read_plp_bytes(reader).await? {
+                    match GenericDecoder::collect_plp(reader).await? {
                         Some(bytes) => writer.write_bytes(col, bytes),
                         None => writer.write_null(col),
                     }
@@ -1452,7 +1389,7 @@ impl SqlTypeDecode for GenericDecoder {
             }
             TdsDataType::BigVarBinary => {
                 if metadata.is_plp() {
-                    let some_bytes = GenericDecoder::read_plp_bytes(reader).await?;
+                    let some_bytes = GenericDecoder::collect_plp(reader).await?;
                     match some_bytes {
                         Some(bytes) => ColumnValues::Bytes(bytes),
                         None => ColumnValues::Null,
@@ -1480,7 +1417,7 @@ impl SqlTypeDecode for GenericDecoder {
                         "XML column metadata is not partially-length-prefixed".to_string(),
                     ));
                 }
-                let some_bytes = GenericDecoder::read_plp_bytes(reader).await?;
+                let some_bytes = GenericDecoder::collect_plp(reader).await?;
                 match some_bytes {
                     Some(bytes) => ColumnValues::Xml(SqlXml { bytes }),
                     None => ColumnValues::Null,
@@ -1492,7 +1429,7 @@ impl SqlTypeDecode for GenericDecoder {
                         "JSON column metadata is not partially-length-prefixed".to_string(),
                     ));
                 }
-                let some_bytes = GenericDecoder::read_plp_bytes(reader).await?;
+                let some_bytes = GenericDecoder::collect_plp(reader).await?;
                 match some_bytes {
                     Some(bytes) => ColumnValues::Json(SqlJson::new(bytes)),
                     None => ColumnValues::Null,
@@ -1631,7 +1568,7 @@ impl SqlTypeDecode for GenericDecoder {
                         "UDT column metadata is not partially-length-prefixed".to_string(),
                     ));
                 }
-                let some_bytes = GenericDecoder::read_plp_bytes(reader).await?;
+                let some_bytes = GenericDecoder::collect_plp(reader).await?;
                 match some_bytes {
                     Some(bytes) => ColumnValues::Bytes(bytes),
                     None => ColumnValues::Null,
@@ -1700,7 +1637,7 @@ impl StringDecoder {
         let encoding_type = get_encoding_type(metadata);
 
         if metadata.is_plp() {
-            match GenericDecoder::read_plp_bytes(reader).await? {
+            match GenericDecoder::collect_plp(reader).await? {
                 Some(bytes) => writer.write_string(col, SqlString::new(bytes, encoding_type)),
                 None => writer.write_null(col),
             }
@@ -1755,7 +1692,7 @@ impl SqlTypeDecode for StringDecoder {
 
         // If Plp Column. (BIGVARCHARTYPE, BIGVARBINARYTYPE, NVARCHARTYPE with md.length == ushort.max)
         if metadata.is_plp() {
-            let some_bytes = GenericDecoder::read_plp_bytes(reader).await?;
+            let some_bytes = GenericDecoder::collect_plp(reader).await?;
             match some_bytes {
                 Some(bytes) => Ok(ColumnValues::String(SqlString::new(bytes, encoding_type))),
                 None => Ok(ColumnValues::Null),
@@ -4000,16 +3937,14 @@ mod test {
         }
 
         #[tokio::test]
-        async fn read_plp_bytes_rejects_oversized_chunk_in_existing_path() {
+        async fn collect_plp_rejects_oversized_chunk_in_existing_path() {
             let mut buf = Vec::new();
             buf.extend_from_slice(&0xFFFFFFFFFFFFFFFEu64.to_le_bytes());
             let oversized = (GenericDecoder::MAX_PLP_CHUNK_SIZE + 1) as u32;
             buf.extend_from_slice(&oversized.to_le_bytes());
 
             let mut reader = ByteReader::new(buf);
-            let err = GenericDecoder::read_plp_bytes(&mut reader)
-                .await
-                .unwrap_err();
+            let err = GenericDecoder::collect_plp(&mut reader).await.unwrap_err();
             assert!(
                 err.to_string()
                     .contains("exceeds maximum allowed chunk size"),

--- a/mssql-tds/src/io/packet_buffer.rs
+++ b/mssql-tds/src/io/packet_buffer.rs
@@ -22,6 +22,20 @@ use byteorder::{BigEndian, ByteOrder, LittleEndian};
 use crate::core::TdsResult;
 use crate::io::packet_writer::PacketWriter;
 
+/// Sans-I/O signal that a synchronous read needs more bytes than are currently
+/// buffered.
+///
+/// This is the one thing the sync core cannot resolve on its own. Returned by
+/// [`PacketBuffer::ensure`] without consuming anything, it tells the async shell
+/// exactly how many more bytes to pull off the wire before re-driving the read.
+/// Because the guard is a pure check, the paired `take_*` accessors stay atomic:
+/// they only advance the read position when the full width is present.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct NeedBytes {
+    /// Additional bytes required beyond what is currently available.
+    pub(crate) shortfall: usize,
+}
+
 /// Synchronous, I/O-free buffer of reassembled TDS packet payload bytes.
 pub(crate) struct PacketBuffer {
     working_buffer: Vec<u8>,
@@ -57,6 +71,25 @@ impl PacketBuffer {
     /// Whether `byte_count` bytes can be read without a refill.
     pub(crate) fn has(&self, byte_count: usize) -> bool {
         self.available() >= byte_count
+    }
+
+    /// Sync-core guard for a fixed-width read: succeeds when `byte_count` bytes
+    /// can be taken without a refill, otherwise reports the [`NeedBytes`]
+    /// shortfall without consuming anything.
+    ///
+    /// This is the sole suspension point of the inverted read path. The async
+    /// shell drives it in a loop — refilling on `NeedBytes` and retrying — while
+    /// the paired atomic `take_*` accessors guarantee no partial advance, so a
+    /// read is always safe to re-drive after a refill.
+    pub(crate) fn ensure(&self, byte_count: usize) -> Result<(), NeedBytes> {
+        let available = self.available();
+        if available >= byte_count {
+            Ok(())
+        } else {
+            Err(NeedBytes {
+                shortfall: byte_count - available,
+            })
+        }
     }
 
     /// Readable bytes as a slice (from the current position to the filled end).
@@ -482,5 +515,36 @@ mod tests {
         buf.working_buffer_mut()[2] = 0x00;
         buf.working_buffer_mut()[3] = 0x40; // 64
         assert_eq!(buf.validate_packet_length(0).unwrap(), 64);
+    }
+
+    /// ensure() is a pure guard: it never consumes, reports the exact shortfall
+    /// on an empty/short buffer, and succeeds once enough bytes are present.
+    #[test]
+    fn ensure_reports_shortfall_without_consuming() {
+        let mut buf = PacketBuffer::with_packet_size(4096);
+
+        // Empty buffer: a 4-byte read is short by the full width.
+        assert_eq!(buf.ensure(4), Err(NeedBytes { shortfall: 4 }));
+        assert_eq!(buf.available(), 0);
+
+        // Expose exactly 2 payload bytes.
+        buf.working_buffer_mut()[8] = 0xDE;
+        buf.working_buffer_mut()[9] = 0xAD;
+        buf.set_positions_for_test(0, 0);
+        buf.strip_header(10);
+        assert_eq!(buf.available(), 2);
+
+        // Short read reports the remaining shortfall and consumes nothing.
+        assert_eq!(buf.ensure(4), Err(NeedBytes { shortfall: 2 }));
+        assert_eq!(buf.available(), 2);
+
+        // Exact-boundary read is allowed and still non-consuming.
+        assert_eq!(buf.ensure(2), Ok(()));
+        assert_eq!(buf.available(), 2);
+
+        // The atomic take advances only after a satisfied guard.
+        assert_eq!(buf.take_u16_le().unwrap(), 0xADDE);
+        assert_eq!(buf.available(), 0);
+        assert_eq!(buf.ensure(1), Err(NeedBytes { shortfall: 1 }));
     }
 }

--- a/mssql-tds/src/io/packet_buffer.rs
+++ b/mssql-tds/src/io/packet_buffer.rs
@@ -547,4 +547,155 @@ mod tests {
         assert_eq!(buf.available(), 0);
         assert_eq!(buf.ensure(1), Err(NeedBytes { shortfall: 1 }));
     }
+
+    /// Stages `bytes` as fully-buffered readable payload at position 0, without
+    /// staging a header or socket read — the fast path for exercising the
+    /// positional accessors directly.
+    fn staged(bytes: &[u8]) -> PacketBuffer {
+        let mut buf = PacketBuffer::with_packet_size(4096);
+        buf.working_buffer_mut()[..bytes.len()].copy_from_slice(bytes);
+        buf.set_positions_for_test(0, bytes.len());
+        buf
+    }
+
+    /// Each fixed-width accessor decodes the right bytes and advances the read
+    /// position by exactly its width. A trailing sentinel byte keeps the buffer
+    /// live so the advance is observable (a full drain resets the cursor — see
+    /// [`take_exact_drain_resets_cursor`]).
+    #[test]
+    fn take_scalars_roundtrip_and_advance() {
+        let mut buf = staged(&[0x7F, 0xFF]);
+        assert_eq!(buf.take_u8().unwrap(), 0x7F);
+        assert_eq!(buf.position(), 1);
+        assert_eq!(buf.available(), 1);
+
+        let mut buf = staged(&[0x34, 0x12, 0x00]);
+        assert_eq!(buf.take_u16_le().unwrap(), 0x1234);
+        assert_eq!(buf.position(), 2);
+
+        let mut buf = staged(&[0x12, 0x34, 0x00]);
+        assert_eq!(buf.take_i16_be().unwrap(), 0x1234);
+        assert_eq!(buf.position(), 2);
+
+        let mut buf = staged(&[0x56, 0x34, 0x12, 0x00]);
+        assert_eq!(buf.take_u24_le().unwrap(), 0x0012_3456);
+        assert_eq!(buf.position(), 3);
+
+        let mut buf = staged(&[0x78, 0x56, 0x34, 0x12, 0x00]);
+        assert_eq!(buf.take_u32_le().unwrap(), 0x1234_5678);
+        assert_eq!(buf.position(), 4);
+
+        let mut buf = staged(&[0x12, 0x34, 0x56, 0x78, 0x00]);
+        assert_eq!(buf.take_i32_be().unwrap(), 0x1234_5678);
+        assert_eq!(buf.position(), 4);
+
+        let mut buf = staged(&[1, 0, 0, 0, 0, 0, 0, 0, 0xFF]);
+        assert_eq!(buf.take_u64_le().unwrap(), 1);
+        assert_eq!(buf.position(), 8);
+    }
+
+    /// The remaining signed/float/40-bit accessors round-trip through their
+    /// little-endian decoders.
+    #[test]
+    fn take_scalar_breadth_decodes_all_widths() {
+        let mut buf = staged(&(-12345i16).to_le_bytes());
+        assert_eq!(buf.take_i16_le().unwrap(), -12345);
+
+        let mut buf = staged(&(-123456789i32).to_le_bytes());
+        assert_eq!(buf.take_i32_le().unwrap(), -123456789);
+
+        let mut buf = staged(&(-1234567890123i64).to_le_bytes());
+        assert_eq!(buf.take_i64_le().unwrap(), -1234567890123);
+
+        let mut buf = staged(&std::f32::consts::PI.to_le_bytes());
+        assert_eq!(buf.take_f32_le().unwrap(), std::f32::consts::PI);
+
+        let mut buf = staged(&std::f64::consts::E.to_le_bytes());
+        assert_eq!(buf.take_f64_le().unwrap(), std::f64::consts::E);
+
+        // 40-bit unsigned: the low five bytes, little-endian.
+        let mut buf = staged(&[0x05, 0x04, 0x03, 0x02, 0x01]);
+        assert_eq!(buf.take_uint40_le().unwrap(), 0x01_0203_0405);
+    }
+
+    /// A read that consumes the last buffered byte collapses the cursor back to
+    /// the front, leaving a clean empty buffer ready for the next refill.
+    #[test]
+    fn take_exact_drain_resets_cursor() {
+        let mut buf = staged(&[0x34, 0x12]);
+        assert_eq!(buf.take_u16_le().unwrap(), 0x1234);
+        assert_eq!(buf.position(), 0);
+        assert_eq!(buf.length(), 0);
+        assert_eq!(buf.available(), 0);
+    }
+
+    /// Atomicity: a fixed-width read wider than the buffer holds must not
+    /// partially advance. The bytes stay intact so the read is safe to re-drive
+    /// after a refill.
+    #[test]
+    fn take_on_short_buffer_is_noop() {
+        let mut buf = staged(&[0xAA, 0xBB]);
+        assert!(buf.take_u32_le().is_err());
+        assert_eq!(buf.position(), 0);
+        assert_eq!(buf.available(), 2);
+        assert_eq!(buf.take_u16_le().unwrap(), 0xBBAA);
+    }
+
+    /// `skip_available` and `copy_out` operate from the current position and are
+    /// bounded by what is buffered — never reading or discarding past the end.
+    #[test]
+    fn skip_and_copy_out_advance_from_current_position() {
+        let mut buf = staged(&[0x01, 0x02, 0x03, 0x04, 0x05]);
+
+        assert_eq!(buf.skip_available(2), 2);
+        assert_eq!(buf.position(), 2);
+        assert_eq!(buf.available(), 3);
+
+        let mut dst = [0u8; 2];
+        assert_eq!(buf.copy_out(&mut dst), 2);
+        assert_eq!(dst, [0x03, 0x04]);
+        assert_eq!(buf.available(), 1);
+
+        // Requesting more than remains copies only the tail — no over-read.
+        let mut big = [0u8; 8];
+        assert_eq!(buf.copy_out(&mut big), 1);
+        assert_eq!(big[0], 0x05);
+        assert_eq!(buf.position(), 0);
+        assert_eq!(buf.length(), 0);
+    }
+
+    /// `skip_available` saturates at what is buffered instead of advancing the
+    /// cursor past the filled end.
+    #[test]
+    fn skip_available_saturates_at_available() {
+        let mut buf = staged(&[0xAA, 0xBB]);
+        assert_eq!(buf.skip_available(10), 2);
+        assert_eq!(buf.available(), 0);
+        assert_eq!(buf.position(), 0);
+    }
+
+    /// Over-consume bounds guard: a `take` wider than what is buffered is
+    /// rejected outright and leaves the cursor untouched — no silent under-read,
+    /// no corruption. This is the backstop for the L3 loop-termination
+    /// invariant: a failed read reports a shortfall to re-drive rather than
+    /// returning garbage or advancing past the end.
+    #[test]
+    fn take_beyond_available_errors_without_corrupting_cursor() {
+        let mut buf = staged(&[0xAA, 0xBB, 0xCC]);
+
+        let err = buf.take_u32_le().unwrap_err();
+        assert!(
+            err.to_string().contains("Buffer underflow"),
+            "expected underflow guard, got: {err}"
+        );
+        assert_eq!(buf.position(), 0);
+        assert_eq!(buf.length(), 3);
+        assert_eq!(buf.available(), 3);
+
+        // ensure agrees a refill is needed rather than signalling readiness.
+        assert_eq!(buf.ensure(4), Err(NeedBytes { shortfall: 1 }));
+
+        // After a satisfied guard the same bytes read back intact.
+        assert_eq!(buf.take_u8().unwrap(), 0xAA);
+    }
 }

--- a/mssql-tds/src/io/packet_reader.rs
+++ b/mssql-tds/src/io/packet_reader.rs
@@ -97,13 +97,31 @@ impl<'a> PacketReader<'a> {
         }
     }
 
-    /// Ensures at least `byte_count` bytes are readable, refilling once if not.
-    /// A scalar never exceeds one packet, so a single refill always suffices.
+    /// Async shell over the sync core: drives [`PacketBuffer::ensure`] in a loop,
+    /// refilling on `NeedBytes` and retrying until `byte_count` bytes are
+    /// readable. A scalar never exceeds one packet, so a single refill usually
+    /// suffices; the loop covers a value split across a packet boundary.
     async fn ensure(&mut self, byte_count: usize) -> TdsResult<()> {
-        if !self.buffer.has(byte_count) {
-            self.read_tds_packet().await?;
+        loop {
+            match self.buffer.ensure(byte_count) {
+                Ok(()) => return Ok(()),
+                Err(need) => {
+                    tracing::trace!(shortfall = need.shortfall, "refilling TDS read buffer");
+                    let before = self.buffer.available();
+                    self.read_tds_packet().await?;
+                    // Loop-termination invariant: a refill must expose at least
+                    // one new byte. If it does not, re-driving the read would
+                    // spin forever, so fail loudly instead of hanging.
+                    let progressed = self.buffer.available() > before;
+                    debug_assert!(progressed, "TDS refill made no forward progress");
+                    if !progressed {
+                        return Err(crate::error::Error::ProtocolError(format!(
+                            "TDS packet refill made no progress while {byte_count} bytes were needed"
+                        )));
+                    }
+                }
+            }
         }
-        Ok(())
     }
 
     async fn read_tds_packet(&mut self) -> TdsResult<()> {
@@ -258,6 +276,11 @@ impl TdsPacketReader for PacketReader<'_> {
         while total_read < buffer.len() {
             if self.buffer.available() == 0 {
                 self.read_tds_packet().await?;
+                if self.buffer.available() == 0 {
+                    return Err(crate::error::Error::ProtocolError(
+                        "TDS packet refill made no progress while reading bytes".to_string(),
+                    ));
+                }
             }
             total_read += self.buffer.copy_out(&mut buffer[total_read..]);
         }
@@ -344,6 +367,11 @@ impl TdsPacketReader for PacketReader<'_> {
         while remaining > 0 {
             if self.buffer.available() == 0 {
                 self.read_tds_packet().await?;
+                if self.buffer.available() == 0 {
+                    return Err(crate::error::Error::ProtocolError(
+                        "TDS packet refill made no progress while skipping bytes".to_string(),
+                    ));
+                }
             }
             remaining -= self.buffer.skip_available(remaining);
         }
@@ -1015,5 +1043,45 @@ pub(crate) mod tests {
         let varchar = packet_reader.read_varchar_u8_length().await.unwrap();
         // assert_eq!(varchar, Some("ab".to_string()));
         assert_eq!(varchar, unicode_string.to_string());
+    }
+
+    /// A refill that returns a valid but empty (header-only) packet exposes zero
+    /// new payload bytes. The inverted reader's driver loop must detect the lack
+    /// of forward progress instead of spinning forever: in debug builds the
+    /// `debug_assert!` fires loudly (asserted here); release builds fall back to
+    /// a `ProtocolError` return covered by the runtime guard.
+    #[tokio::test]
+    #[should_panic(expected = "no forward progress")]
+    async fn empty_packet_refill_fails_without_spinning() {
+        // Header-only packet: valid framing, EOM set, zero payload bytes.
+        let empty_packet = TestPacketBuilder::new(PacketType::PreLogin).build();
+
+        let mut mock_reader = MockNetworkReaderWriter::new(empty_packet, 0);
+        let mut packet_reader = PacketReader::new(&mut mock_reader);
+
+        let _ = packet_reader.read_byte().await;
+    }
+
+    /// Reading exactly to the packet boundary must succeed; the next read then
+    /// drives a refill that hits end-of-stream and terminates with an error
+    /// rather than looping.
+    #[tokio::test]
+    async fn exact_packet_boundary_reads_then_terminates() {
+        let mut binding = TestPacketBuilder::new(PacketType::PreLogin);
+        let builder = binding.append_byte(0xAB);
+        let mut mock_reader = MockNetworkReaderWriter::new(builder.build(), 0);
+        let mut packet_reader = PacketReader::new(&mut mock_reader);
+
+        // Consumes the sole payload byte, landing exactly on the boundary.
+        assert_eq!(packet_reader.read_byte().await.unwrap(), 0xAB);
+
+        // One byte past the boundary: the refill reaches end-of-stream and the
+        // loop must terminate with an error, never hang.
+        let err = packet_reader.read_byte().await.unwrap_err();
+        assert!(
+            err.to_string().contains("Connection closed")
+                || err.to_string().contains("no progress"),
+            "expected termination error, got: {err}"
+        );
     }
 }


### PR DESCRIPTION
> ⚠️ **Perf-neutral layer — does NOT move the ~2× fetch gap.** This PR is pure enabling/plumbing. The async/`block_on` tax this effort targets lives in the **parser core**, which lands in **L4** (parser-level column-atomic `step()`). "L3 green" means the reader seam is inverted and safe — **not** that any benchmark improved. The P8 fetch A/B is intentionally **not** re-measured until L4 lands, to avoid reproducing ~2× mid-stack and polluting the record.

## Layer 3 of the green-at-every-step sans-I/O stack

Base: `dev/saurabh/sans-io-layer2-transport` (#191). Public API is **frozen** — `mssql-odbc` and `mssql-py-core` build unchanged.

### What this lands
This slice inverts the **reader seam** to a synchronous, I/O-free core while the async shell remains the only public driver. It is the foundation the parser-level `step()` core builds on next.

- **Sync core:** `PacketBuffer::ensure(n) -> Result<(), NeedBytes>` — an atomic, non-consuming guard reporting the exact byte shortfall. Paired with the existing atomic `take_*` accessors, a fixed-width read never advances on a short buffer and is always safe to re-drive after a refill.
- **Inverted readers:** both `TdsPacketReader` impls (test `PacketReader` + production `NetworkTransport`) are now thin async driver loops: `loop { match buf.ensure(n) { Ok => take, NeedBytes => refill().await } }`. Trait signatures are unchanged, so `TdsClient` and the frozen API are untouched. Both `#[cfg(fuzzing)]` / `#[cfg(not(fuzzing))]` trait defs are maintained.
- **Anti-spin invariant (the L2 hang class):** every refill must expose ≥1 new byte or the loop fails loudly (`debug_assert`) / returns a `ProtocolError` — never spins on a zero-payload packet.
- **PLP dedup:** deleted the `read_plp_bytes` collect-all duplicate (~90 lines of copied chunk framing) and routed eager materialization through the shared `PlpChunkStreamReader` via a thin `collect_plp` helper. All size/chunk guards now live in one place.
- **Tests:** empty-input and exact-packet-boundary termination (proving no hang), plus `ensure` shortfall/atomicity invariants, plus direct `PacketBuffer` accessor + over-consume bounds-guard coverage.

### Scope note (honest labeling)
The reader-seam inversion + sync `NeedBytes` core + PLP dedup are landed here as a self-contained, low-risk layer. The **parser-level column-atomic `step()` core** (re-driving `decode_row_columns` / NBCROW / PLP chunk parsing over the sync buffer) is **L4** — kept separate so every step stays green, and it is the layer that actually removes the async tax. `DecodePolicy` / `BatchExit` enums were intentionally **not** introduced: no existing `bool` / `unreachable!` in the touched code maps cleanly to them, so adding them would be noise per the repo's no-AI-slop charter.

### Validation (green)
- `cargo build` ✅
- `cargo bclippy` (warnings = errors) ✅
- `cargo bfmt` ✅
- `cargo btest` (nextest): lib green except the 7 pre-existing `test_certificates` / `win_tls` cert-fixture failures (integration tests needing a live SQL Server are environmental); failing set verified byte-for-byte identical to the base branch. ✅
- `cargo build --manifest-path mssql-py-core/Cargo.toml` (outside workspace) ✅

LOC delta reported on the final rebased commit.