### PR TITLE
Sans-I/O TDS core (4/N): invert the non-PLP column decode to a column-atomic step()

### DIFF
--- a/mssql-tds/src/connection/transport/network_transport.rs
+++ b/mssql-tds/src/connection/transport/network_transport.rs
@@ -1088,6 +1088,33 @@ impl TdsPacketReader for NetworkTransport {
         self.tds_read_buffer.reset_to_length(0);
     }
 
+    async fn decode_column_into(
+        &mut self,
+        meta: &crate::query::metadata::ColumnMetadata,
+        col: usize,
+        writer: &mut (dyn crate::datatypes::row_writer::RowWriter + Send),
+    ) -> TdsResult<()> {
+        use crate::datatypes::sync_decoder;
+
+        // Sync driver over the owned read buffer: peek the wire width, ensure the
+        // whole cell, then decode in place. `column_wire_len` only peeks, so a
+        // shortfall re-drives from the column start with nothing consumed.
+        loop {
+            match sync_decoder::column_wire_len(&self.tds_read_buffer, meta) {
+                Ok(total) => {
+                    self.ensure_or_refill(total).await?;
+                    return sync_decoder::decode_column_body(
+                        &mut self.tds_read_buffer,
+                        meta,
+                        col,
+                        writer,
+                    );
+                }
+                Err(need) => self.ensure_or_refill(need.shortfall).await?,
+            }
+        }
+    }
+
     async fn read_byte(&mut self) -> TdsResult<u8> {
         self.ensure_or_refill(1).await?;
         self.tds_read_buffer.take_u8()

--- a/mssql-tds/src/datatypes.rs
+++ b/mssql-tds/src/datatypes.rs
@@ -29,4 +29,6 @@ pub mod sql_vector;
 pub mod sqldatatypes;
 /// Input parameter types for RPC calls.
 pub mod sqltypes;
+/// Column-atomic synchronous decode of non-PLP cells over [`PacketBuffer`].
+pub(crate) mod sync_decoder;
 pub(crate) mod tds_value_serializer;

--- a/mssql-tds/src/datatypes/decoder.rs
+++ b/mssql-tds/src/datatypes/decoder.rs
@@ -48,7 +48,21 @@ where
     D: SqlTypeDecode,
     T: TdsPacketReader + Send + Sync,
 {
-    let cipher = match decoder.decode(reader, metadata).await? {
+    let cipher = decoder.decode(reader, metadata).await?;
+    decrypt_cipher_value(metadata, decryptor, cipher)
+}
+
+/// Runs the synchronous cell decryptor over an already-decoded ciphertext cell.
+///
+/// The ciphertext arrives as a `varbinary` value; non-PLP ciphertext is decoded
+/// by the column-atomic sync step and PLP ciphertext by the async path, but both
+/// converge here for the (already synchronous) decrypt + plaintext production.
+pub(crate) fn decrypt_cipher_value(
+    metadata: &ColumnMetadata,
+    decryptor: &Arc<dyn CellDecryptor>,
+    cipher: ColumnValues,
+) -> TdsResult<ColumnValues> {
+    let cipher = match cipher {
         ColumnValues::Null => return Ok(ColumnValues::Null),
         ColumnValues::Bytes(bytes) => bytes,
         other => {

--- a/mssql-tds/src/datatypes/decoder.rs
+++ b/mssql-tds/src/datatypes/decoder.rs
@@ -1010,109 +1010,26 @@ impl GenericDecoder {
     /// [`RowWriter`], bypassing the intermediate `ColumnValues` enum for
     /// common types. Rare types (XML, JSON, Vector, Image, UDT, SsVariant)
     /// fall back to `decode()` + `write_column_value()`.
-    pub(crate) async fn decode_into<T, W>(
+    pub(crate) async fn decode_into<T>(
         &self,
         reader: &mut T,
         metadata: &ColumnMetadata,
         col: usize,
-        writer: &mut W,
+        writer: &mut (dyn RowWriter + Send),
     ) -> TdsResult<()>
     where
         T: TdsPacketReader + Send + Sync,
-        W: RowWriter + ?Sized,
     {
+        // Non-PLP cells owned by the column-atomic sync path route through the
+        // single shared `decode_column_body` (one body, refill lifted to the
+        // column boundary). No non-PLP leaf logic is duplicated here.
+        if crate::datatypes::sync_decoder::is_supported(metadata) {
+            return reader.decode_column_into(metadata, col, writer).await;
+        }
+
         match metadata.data_type {
-            // === Fixed-length integer types ===
-            TdsDataType::Int1 => {
-                writer.write_u8(col, reader.read_byte().await?);
-            }
-            TdsDataType::Int2 => {
-                writer.write_i16(col, reader.read_int16().await?);
-            }
-            TdsDataType::Int4 => {
-                writer.write_i32(col, reader.read_int32().await?);
-            }
-            TdsDataType::Int8 => {
-                writer.write_i64(col, reader.read_int64().await?);
-            }
-            TdsDataType::IntN => {
-                let byte_len = reader.read_byte().await?;
-                match byte_len {
-                    1 => writer.write_u8(col, reader.read_byte().await?),
-                    2 => writer.write_i16(col, reader.read_int16().await?),
-                    4 => writer.write_i32(col, reader.read_int32().await?),
-                    8 => writer.write_i64(col, reader.read_int64().await?),
-                    0 => writer.write_null(col),
-                    _ => {
-                        return Err(crate::error::Error::from(Error::new(
-                            std::io::ErrorKind::InvalidData,
-                            "Invalid IntN length",
-                        )));
-                    }
-                }
-            }
-
-            // === Fixed-length float types ===
-            TdsDataType::Flt4 => {
-                writer.write_f32(col, reader.read_float32().await?);
-            }
-            TdsDataType::Flt8 => {
-                writer.write_f64(col, reader.read_float64().await?);
-            }
-            TdsDataType::FltN => {
-                let length = reader.read_byte().await?;
-                match length {
-                    0 => writer.write_null(col),
-                    4 => writer.write_f32(col, reader.read_float32().await?),
-                    _ => writer.write_f64(col, reader.read_float64().await?),
-                }
-            }
-
-            // === Bit types ===
-            TdsDataType::Bit => {
-                writer.write_bool(col, reader.read_byte().await? == 1);
-            }
-            TdsDataType::BitN => {
-                let byte_len = reader.read_byte().await?;
-                if byte_len > 0 {
-                    writer.write_bool(col, reader.read_byte().await? == 1);
-                } else {
-                    writer.write_null(col);
-                }
-            }
-
-            // === Money types ===
-            TdsDataType::Money4 => {
-                writer.write_smallmoney(col, self.read_money4(reader).await?);
-            }
-            TdsDataType::Money => {
-                writer.write_money(col, self.read_money8(reader).await?);
-            }
-            TdsDataType::MoneyN => {
-                let byte_len = reader.read_byte().await?;
-                match byte_len {
-                    4 => writer.write_smallmoney(col, self.read_money4(reader).await?),
-                    8 => writer.write_money(col, self.read_money8(reader).await?),
-                    0 => writer.write_null(col),
-                    _ => {
-                        return Err(crate::error::Error::ProtocolError(format!(
-                            "Invalid MoneyN length - {byte_len}"
-                        )));
-                    }
-                }
-            }
-
-            // === Decimal / Numeric ===
-            TdsDataType::DecimalN => match self.read_decimal(reader, metadata).await? {
-                Some(val) => writer.write_decimal(col, val),
-                None => writer.write_null(col),
-            },
-            TdsDataType::NumericN => match self.read_decimal(reader, metadata).await? {
-                Some(val) => writer.write_numeric(col, val),
-                None => writer.write_null(col),
-            },
-
-            // === String types — delegate to StringDecoder ===
+            // === String types — StringDecoder owns PLP strings + Text/NText LOB.
+            // Non-PLP, non-LOB strings are handled by the sync path above. ===
             TdsDataType::NChar
             | TdsDataType::NVarChar
             | TdsDataType::BigChar
@@ -1126,160 +1043,11 @@ impl GenericDecoder {
                     .await?;
             }
 
-            // === Binary types ===
-            TdsDataType::BigBinary => {
-                let length = reader.read_uint16().await?;
-                // 0xFFFF is the USHORTLEN NULL marker (CHARBIN_NULL).
-                if length == 0xFFFF {
-                    writer.write_null(col);
-                } else {
-                    if length as usize > MAX_ALLOC_SIZE {
-                        return Err(crate::error::Error::ProtocolError(format!(
-                            "BigBinary length {length} exceeds maximum allowed size of {MAX_ALLOC_SIZE} bytes"
-                        )));
-                    }
-                    let mut bytes = vec![0u8; length as usize];
-                    reader.read_bytes(&mut bytes).await?;
-                    writer.write_bytes(col, bytes);
-                }
-            }
-            TdsDataType::BigVarBinary => {
-                if metadata.is_plp() {
-                    match GenericDecoder::collect_plp(reader).await? {
-                        Some(bytes) => writer.write_bytes(col, bytes),
-                        None => writer.write_null(col),
-                    }
-                } else {
-                    let length = reader.read_uint16().await?;
-                    // 0xFFFF is the USHORTLEN NULL marker (CHARBIN_NULL).
-                    if length == 0xFFFF {
-                        writer.write_null(col);
-                    } else {
-                        if length as usize > MAX_ALLOC_SIZE {
-                            return Err(crate::error::Error::ProtocolError(format!(
-                                "BigVarBinary length {length} exceeds maximum allowed size of {MAX_ALLOC_SIZE} bytes"
-                            )));
-                        }
-                        let mut bytes = vec![0u8; length as usize];
-                        reader.read_bytes(&mut bytes).await?;
-                        writer.write_bytes(col, bytes);
-                    }
-                }
-            }
-
-            // === DateTime types ===
-            TdsDataType::DateTime => {
-                writer.write_datetime(col, self.read_datetime(reader).await?);
-            }
-            TdsDataType::DateTim4 => {
-                let daypart = reader.read_uint16().await?;
-                let timepart = reader.read_uint16().await?;
-                writer.write_smalldatetime(
-                    col,
-                    SqlSmallDateTime {
-                        days: daypart,
-                        time: timepart,
-                    },
-                );
-            }
-            TdsDataType::DateTimeN => {
-                let length = reader.read_byte().await?;
-                match length {
-                    0 => writer.write_null(col),
-                    4 => writer.write_smalldatetime(col, self.read_small_datetime(reader).await?),
-                    _ => writer.write_datetime(col, self.read_datetime(reader).await?),
-                }
-            }
-            TdsDataType::DateN => {
-                let length = reader.read_byte().await?;
-                if length == 0 {
-                    writer.write_null(col);
-                } else {
-                    writer.write_date(col, Self::read_date(reader).await?);
-                }
-            }
-            TdsDataType::TimeN => {
-                let length = reader.read_byte().await?;
-                if length == 0 {
-                    writer.write_null(col);
-                } else {
-                    writer.write_time(
-                        col,
-                        self.read_time(
-                            reader,
-                            length,
-                            metadata.get_scale().ok_or_else(|| {
-                                crate::error::Error::ImplementationError(
-                                    "TimeN type should have scale".to_string(),
-                                )
-                            })?,
-                        )
-                        .await?,
-                    );
-                }
-            }
-            TdsDataType::DateTime2N => {
-                let length = reader.read_byte().await?;
-                if length == 0 {
-                    writer.write_null(col);
-                } else {
-                    let cv = self
-                        .read_datetime2(
-                            reader,
-                            length,
-                            metadata.get_scale().ok_or_else(|| {
-                                crate::error::Error::ImplementationError(
-                                    "DateTime2N type should have scale".to_string(),
-                                )
-                            })?,
-                        )
-                        .await?;
-                    if let ColumnValues::DateTime2(dt2) = cv {
-                        writer.write_datetime2(col, dt2);
-                    }
-                }
-            }
-            TdsDataType::DateTimeOffsetN => {
-                let length = reader.read_byte().await?;
-                if length == 0 {
-                    writer.write_null(col);
-                } else {
-                    let cv = self
-                        .read_datetime_offset(
-                            reader,
-                            length,
-                            metadata.get_scale().ok_or_else(|| {
-                                crate::error::Error::ImplementationError(
-                                    "DateTimeOffsetN type should have scale".to_string(),
-                                )
-                            })?,
-                        )
-                        .await?;
-                    if let ColumnValues::DateTimeOffset(dto) = cv {
-                        writer.write_datetimeoffset(col, dto);
-                    }
-                }
-            }
-
-            // === GUID ===
-            TdsDataType::Guid => {
-                let length = reader.read_byte().await?;
-                if length == 0 {
-                    writer.write_null(col);
-                } else {
-                    if length != 16 {
-                        return Err(crate::error::Error::ProtocolError(format!(
-                            "Invalid GUID length: expected 16 bytes, got {length}"
-                        )));
-                    }
-                    let mut bytes = [0u8; 16];
-                    reader.read_bytes(&mut bytes).await?;
-                    let uuid = uuid::Uuid::from_slice_le(&bytes).map_err(|e| {
-                        crate::error::Error::ProtocolError(format!("Failed to parse UUID: {e}"))
-                    })?;
-                    writer.write_uuid(col, uuid);
-                }
-            }
+            // === PLP binary (varbinary(max)); non-PLP binary uses the sync path. ===
+            TdsDataType::BigVarBinary => match GenericDecoder::collect_plp(reader).await? {
+                Some(bytes) => writer.write_bytes(col, bytes),
+                None => writer.write_null(col),
+            },
 
             // === Fallback: rare types go through decode() → write_column_value() ===
             _ => {

--- a/mssql-tds/src/datatypes/decoder.rs
+++ b/mssql-tds/src/datatypes/decoder.rs
@@ -73,9 +73,9 @@ where
 // Maximum reasonable allocation size for a single value (100MB)
 // This prevents fuzzer-induced capacity overflow panics
 #[cfg(fuzzing)]
-const MAX_ALLOC_SIZE: usize = 64 * 1024; // 64KB for fuzzing
+pub(crate) const MAX_ALLOC_SIZE: usize = 64 * 1024; // 64KB for fuzzing
 #[cfg(not(fuzzing))]
-const MAX_ALLOC_SIZE: usize = 100 * 1024 * 1024;
+pub(crate) const MAX_ALLOC_SIZE: usize = 100 * 1024 * 1024;
 
 // Maximum allocation size for PLP (Partial Length Pointer) types
 // SQL Server supports PLP types up to 2GB (i32::MAX is approximately 2.1GB)

--- a/mssql-tds/src/datatypes/sync_decoder.rs
+++ b/mssql-tds/src/datatypes/sync_decoder.rs
@@ -16,16 +16,17 @@
 
 use crate::core::TdsResult;
 use crate::datatypes::column_values::{
-    SqlDate, SqlDateTime, SqlDateTime2, SqlDateTimeOffset, SqlMoney, SqlSmallDateTime,
-    SqlSmallMoney, SqlTime,
+    ColumnValues, SqlDate, SqlDateTime, SqlDateTime2, SqlDateTimeOffset, SqlMoney,
+    SqlSmallDateTime, SqlSmallMoney, SqlTime,
 };
-use crate::datatypes::decoder::DecimalParts;
-use crate::datatypes::row_writer::RowWriter;
-use crate::datatypes::sql_string::{SqlString, get_encoding_type};
-use crate::datatypes::sqldatatypes::{TdsDataType, TypeInfoVariant};
+use crate::datatypes::decoder::{DecimalParts, MAX_ALLOC_SIZE};
+use crate::datatypes::row_writer::{RowWriter, write_column_value};
+use crate::datatypes::sql_string::{EncodingType, SqlString, get_encoding_type};
+use crate::datatypes::sqldatatypes::{FixedLengthTypes, TdsDataType, TypeInfoVariant};
 use crate::error::Error;
 use crate::io::packet_buffer::{NeedBytes, PacketBuffer};
 use crate::query::metadata::ColumnMetadata;
+use crate::token::tokens::SqlCollation;
 
 /// Returns `true` when `meta` names a non-PLP type whose cell decode is owned by
 /// this synchronous path. Callers must route PLP cells and any unsupported type
@@ -73,6 +74,8 @@ pub(crate) fn is_supported(meta: &ColumnMetadata) -> bool {
             // Variable-length non-PLP binary (USHORT length prefix, 0xFFFF = NULL).
             | TdsDataType::BigBinary
             | TdsDataType::BigVarBinary
+            // SQL_VARIANT: 4-byte (ULONG) length prefix wrapping a base type.
+            | TdsDataType::SsVariant
     )
 }
 
@@ -128,6 +131,18 @@ pub(crate) fn column_wire_len(
                 }
             }
             None => Err(NeedBytes { shortfall: 2 }),
+        };
+    }
+
+    // SQL_VARIANT carries a 4-byte (ULONG) length prefix covering the base type
+    // byte, the property bytes, and the data; total wire width is 4 + length.
+    if matches!(meta.data_type, TdsDataType::SsVariant) {
+        return match buf.peek_bytes(4) {
+            Some(prefix) => {
+                let length = u32::from_le_bytes([prefix[0], prefix[1], prefix[2], prefix[3]]);
+                Ok(4 + length as usize)
+            }
+            None => Err(NeedBytes { shortfall: 4 }),
         };
     }
 
@@ -304,6 +319,12 @@ pub(crate) fn decode_column_body(
             }
         }
 
+        // === SQL_VARIANT ===
+        TdsDataType::SsVariant => {
+            let value = take_sql_variant(buf)?;
+            write_column_value(writer, col, value);
+        }
+
         other => {
             unreachable!("decode_column_body called for unsupported type {other:?}");
         }
@@ -421,6 +442,15 @@ fn take_decimal(buf: &mut PacketBuffer, meta: &ColumnMetadata) -> TdsResult<Opti
             meta.type_info.type_info_variant
         )));
     };
+    take_decimal_data(buf, length, precision, scale)
+}
+
+fn take_decimal_data(
+    buf: &mut PacketBuffer,
+    length: u8,
+    precision: u8,
+    scale: u8,
+) -> TdsResult<Option<DecimalParts>> {
     if length == 0 {
         return Ok(None);
     }
@@ -450,4 +480,264 @@ fn take_decimal(buf: &mut PacketBuffer, meta: &ColumnMetadata) -> TdsResult<Opti
         precision,
         int_parts,
     }))
+}
+
+/// Synchronous port of `read_sql_variant`. The whole cell is buffered, so every
+/// `take_*` is infallible for buffer reasons; it returns the same `ColumnValues`
+/// as the async path, which the caller bridges via `write_column_value`.
+fn take_sql_variant(buf: &mut PacketBuffer) -> TdsResult<ColumnValues> {
+    let length = buf.take_u32_le()?;
+    let variant_base_type = buf.take_u8()?;
+    let tds_type = TdsDataType::try_from(variant_base_type)?;
+    let variant_prop_bytes = buf.take_u8()?;
+    let bytes_for_type_and_properties_byte = 2u32;
+
+    let data_length = length
+        .checked_sub(bytes_for_type_and_properties_byte)
+        .and_then(|v| v.checked_sub(variant_prop_bytes as u32))
+        .ok_or_else(|| {
+            Error::ProtocolError(format!(
+                "SQL_VARIANT data length calculation underflow: length={length}, prop_bytes={variant_prop_bytes}"
+            ))
+        })?;
+
+    match variant_prop_bytes {
+        0 => take_zero_propbyte_variant(buf, tds_type, data_length),
+        1 => take_one_byte_variant(buf, tds_type, data_length),
+        2 => take_two_propbyte_variant(buf, variant_base_type, tds_type, data_length),
+        7 => take_seven_propbyte_variant(buf, tds_type, data_length),
+        other => Err(Error::ProtocolError(format!(
+            "Unexpected SQL variant properties length: {other}. Expected 0, 1, 2, or 7. This indicates malformed or invalid data."
+        ))),
+    }
+}
+
+fn take_zero_propbyte_variant(
+    buf: &mut PacketBuffer,
+    tds_type: TdsDataType,
+    data_length: u32,
+) -> TdsResult<ColumnValues> {
+    if let Ok(fixed) = FixedLengthTypes::try_from(tds_type) {
+        return Ok(match fixed {
+            FixedLengthTypes::Int1 => ColumnValues::from(buf.take_u8()?),
+            FixedLengthTypes::Bit => ColumnValues::Bit(buf.take_u8()? == 1),
+            FixedLengthTypes::Int2 => ColumnValues::SmallInt(buf.take_i16_le()?),
+            FixedLengthTypes::Int4 => ColumnValues::from(buf.take_i32_le()?),
+            FixedLengthTypes::DateTim4 => ColumnValues::SmallDateTime(take_small_datetime(buf)?),
+            FixedLengthTypes::Flt4 => ColumnValues::Real(buf.take_f32_le()?),
+            FixedLengthTypes::Money4 => ColumnValues::SmallMoney(take_money4(buf)?),
+            FixedLengthTypes::Money => ColumnValues::Money(take_money8(buf)?),
+            FixedLengthTypes::DateTime => ColumnValues::DateTime(take_datetime(buf)?),
+            FixedLengthTypes::Flt8 => ColumnValues::Float(buf.take_f64_le()?),
+            FixedLengthTypes::Int8 => ColumnValues::BigInt(buf.take_i64_le()?),
+        });
+    }
+    match tds_type {
+        TdsDataType::Guid => take_variant_guid(buf, data_length as u8),
+        TdsDataType::DateN => {
+            if data_length == 0 {
+                Ok(ColumnValues::Null)
+            } else {
+                Ok(ColumnValues::Date(take_date(buf)?))
+            }
+        }
+        _ => Err(Error::ProtocolError(format!(
+            "For 0 byte property, only Guid and DateN are expected, but got: {tds_type:?}"
+        ))),
+    }
+}
+
+fn take_variant_guid(buf: &mut PacketBuffer, length: u8) -> TdsResult<ColumnValues> {
+    if length == 0 {
+        return Ok(ColumnValues::Null);
+    }
+    if length != 16 {
+        return Err(Error::ProtocolError(format!(
+            "Invalid GUID length: expected 16 bytes, got {length}"
+        )));
+    }
+    let bytes = take_bytes(buf, 16);
+    let uuid = uuid::Uuid::from_slice_le(&bytes)
+        .map_err(|e| Error::ProtocolError(format!("Failed to parse UUID: {e}")))?;
+    Ok(ColumnValues::Uuid(uuid))
+}
+
+fn take_one_byte_variant(
+    buf: &mut PacketBuffer,
+    tds_type: TdsDataType,
+    data_length: u32,
+) -> TdsResult<ColumnValues> {
+    let scale = buf.take_u8()?;
+    Ok(match tds_type {
+        TdsDataType::TimeN => ColumnValues::Time(take_time(buf, data_length as u8, scale)?),
+        TdsDataType::DateTime2N => {
+            ColumnValues::DateTime2(take_datetime2(buf, data_length as u8, scale)?)
+        }
+        TdsDataType::DateTimeOffsetN => {
+            ColumnValues::DateTimeOffset(take_datetime_offset(buf, data_length as u8, scale)?)
+        }
+        _ => {
+            return Err(Error::ProtocolError(format!(
+                "Invalid SQL_VARIANT: 1-byte property is only valid for TimeN, DateTime2N, and DateTimeOffsetN types, but got: {tds_type:?}"
+            )));
+        }
+    })
+}
+
+fn take_two_propbyte_variant(
+    buf: &mut PacketBuffer,
+    variant_base_type: u8,
+    tds_type: TdsDataType,
+    data_length: u32,
+) -> TdsResult<ColumnValues> {
+    Ok(match tds_type {
+        TdsDataType::BigVarBinary | TdsDataType::BigBinary => {
+            let _max_length = buf.take_u16_le()?;
+            if data_length as usize > MAX_ALLOC_SIZE {
+                return Err(Error::ProtocolError(format!(
+                    "SQL Variant binary data length {data_length} exceeds maximum allowed size of {MAX_ALLOC_SIZE} bytes"
+                )));
+            }
+            ColumnValues::Bytes(take_bytes(buf, data_length as usize))
+        }
+        TdsDataType::NumericN | TdsDataType::DecimalN => {
+            let precision = buf.take_u8()?;
+            let scale = buf.take_u8()?;
+            let decimal_parts = take_decimal_data(buf, data_length as u8, precision, scale)?;
+            if matches!(tds_type, TdsDataType::NumericN) {
+                match decimal_parts {
+                    Some(value) => ColumnValues::Numeric(value),
+                    None => ColumnValues::Null,
+                }
+            } else {
+                match decimal_parts {
+                    Some(value) => ColumnValues::Decimal(value),
+                    None => ColumnValues::Null,
+                }
+            }
+        }
+        _ => {
+            return Err(Error::ProtocolError(format!(
+                "Unexpected SQL variant base type for len(2) prop bytes: {variant_base_type:#04X}. Expected binary or numeric types."
+            )));
+        }
+    })
+}
+
+fn take_seven_propbyte_variant(
+    buf: &mut PacketBuffer,
+    tds_type: TdsDataType,
+    data_length: u32,
+) -> TdsResult<ColumnValues> {
+    if !matches!(
+        tds_type,
+        TdsDataType::BigVarChar | TdsDataType::BigChar | TdsDataType::NVarChar | TdsDataType::NChar
+    ) {
+        return Err(Error::ProtocolError(format!(
+            "Unexpected SQL variant base type for len(7) prop bytes: {tds_type:?}. Expected a character type."
+        )));
+    }
+    let collation_bytes = take_bytes(buf, 5);
+    let _max_length = buf.take_u16_le()?;
+    let collation: SqlCollation = collation_bytes.as_slice().try_into()?;
+    if data_length as usize > MAX_ALLOC_SIZE {
+        return Err(Error::ProtocolError(format!(
+            "SQL Variant string data length {data_length} exceeds maximum allowed size of {MAX_ALLOC_SIZE} bytes"
+        )));
+    }
+    let buffer = take_bytes(buf, data_length as usize);
+    let encoding = if matches!(tds_type, TdsDataType::NVarChar | TdsDataType::NChar) {
+        EncodingType::Utf16
+    } else if collation.utf8() {
+        EncodingType::Utf8
+    } else {
+        EncodingType::LcidBased(collation)
+    };
+    Ok(ColumnValues::String(SqlString::new(buffer, encoding)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn variant(payload: &[u8]) -> ColumnValues {
+        let mut buf = PacketBuffer::from_bytes(payload);
+        take_sql_variant(&mut buf).expect("variant decode")
+    }
+
+    // length counts the bytes after the ULONG length field: base_type + the
+    // prop-count byte + prop bytes + data (i.e. 1 + prop_and_data).
+    fn framed(base_type: TdsDataType, prop_and_data: &[u8]) -> Vec<u8> {
+        let length = (1 + prop_and_data.len()) as u32;
+        let mut out = length.to_le_bytes().to_vec();
+        out.push(base_type as u8);
+        out.extend_from_slice(prop_and_data);
+        out
+    }
+
+    #[test]
+    fn variant_int4_zero_prop() {
+        // prop_bytes=0, then 4-byte int value.
+        let payload = framed(TdsDataType::Int4, &[0, 0x2A, 0, 0, 0]);
+        assert_eq!(variant(&payload), ColumnValues::Int(42));
+    }
+
+    #[test]
+    fn variant_int8_zero_prop() {
+        let mut body = vec![0u8]; // prop_bytes
+        body.extend_from_slice(&1234567890123i64.to_le_bytes());
+        let payload = framed(TdsDataType::Int8, &body);
+        assert_eq!(variant(&payload), ColumnValues::BigInt(1234567890123));
+    }
+
+    #[test]
+    fn variant_guid_zero_prop() {
+        let guid = [
+            0x10u8, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d,
+            0x1e, 0x1f,
+        ];
+        let mut body = vec![0u8]; // prop_bytes
+        body.extend_from_slice(&guid);
+        let payload = framed(TdsDataType::Guid, &body);
+        let expected = uuid::Uuid::from_slice_le(&guid).unwrap();
+        assert_eq!(variant(&payload), ColumnValues::Uuid(expected));
+    }
+
+    #[test]
+    fn variant_bigvarbinary_two_prop() {
+        // prop_bytes=2 (max_length USHORT), then 3 data bytes.
+        let payload = framed(
+            TdsDataType::BigVarBinary,
+            &[2, 0xFF, 0x7F, 0xAA, 0xBB, 0xCC],
+        );
+        assert_eq!(
+            variant(&payload),
+            ColumnValues::Bytes(vec![0xAA, 0xBB, 0xCC])
+        );
+    }
+
+    #[test]
+    fn variant_timen_one_prop() {
+        // prop_bytes=1 (scale), scale=7, then 5-byte time (data_length=5).
+        let scaled: u64 = 3_600 * 10_000_000; // one hour in 100ns units
+        let time_bytes = &scaled.to_le_bytes()[..5];
+        let mut body = vec![1u8, 7u8];
+        body.extend_from_slice(time_bytes);
+        let payload = framed(TdsDataType::TimeN, &body);
+        match variant(&payload) {
+            ColumnValues::Time(t) => {
+                assert_eq!(t.scale, 7);
+                assert_eq!(t.time_nanoseconds, scaled);
+            }
+            other => panic!("expected Time, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn variant_unexpected_prop_bytes_errors() {
+        // prop_bytes=5 is invalid.
+        let payload = framed(TdsDataType::Int4, &[5, 0, 0, 0, 0]);
+        let mut buf = PacketBuffer::from_bytes(&payload);
+        assert!(take_sql_variant(&mut buf).is_err());
+    }
 }

--- a/mssql-tds/src/datatypes/sync_decoder.rs
+++ b/mssql-tds/src/datatypes/sync_decoder.rs
@@ -1,0 +1,375 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Column-atomic synchronous decode of non-PLP row cells.
+//!
+//! The row path suspends only at column boundaries. Within a column this module
+//! runs entirely over an in-memory [`PacketBuffer`]: [`column_wire_len`] peeks
+//! the length prefix (never consuming) to compute the total wire width, and once
+//! the whole cell is buffered [`decode_column_body`] consumes it with infallible
+//! `take_*` reads and performs exactly one `write_*`/`write_null`.
+//!
+//! Because the length computation only peeks, a `NeedBytes` shortfall lets the
+//! driver re-run from the column start with nothing consumed and nothing
+//! written — the atomicity that lets `RowPauseState.next_column_index` stay the
+//! sole resume granularity, with no new pause/step machine.
+
+use crate::core::TdsResult;
+use crate::datatypes::column_values::{
+    SqlDate, SqlDateTime, SqlDateTime2, SqlDateTimeOffset, SqlMoney, SqlSmallDateTime,
+    SqlSmallMoney, SqlTime,
+};
+use crate::datatypes::decoder::DecimalParts;
+use crate::datatypes::row_writer::RowWriter;
+use crate::datatypes::sqldatatypes::{TdsDataType, TypeInfoVariant};
+use crate::error::Error;
+use crate::io::packet_buffer::{NeedBytes, PacketBuffer};
+use crate::query::metadata::ColumnMetadata;
+
+/// Returns `true` when `meta` names a non-PLP type whose cell decode is owned by
+/// this synchronous path. Callers must route PLP cells and any unsupported type
+/// to the legacy async decoder instead.
+///
+/// The set grows as families are ported; it is the single gate that keeps the
+/// sync driver and [`decode_column_body`] in lockstep.
+pub(crate) fn is_supported(meta: &ColumnMetadata) -> bool {
+    if meta.is_plp() {
+        return false;
+    }
+    matches!(
+        meta.data_type,
+        TdsDataType::Int1
+            | TdsDataType::Int2
+            | TdsDataType::Int4
+            | TdsDataType::Int8
+            | TdsDataType::IntN
+            | TdsDataType::Flt4
+            | TdsDataType::Flt8
+            | TdsDataType::FltN
+            | TdsDataType::Bit
+            | TdsDataType::BitN
+            | TdsDataType::Money4
+            | TdsDataType::Money
+            | TdsDataType::MoneyN
+            | TdsDataType::DecimalN
+            | TdsDataType::NumericN
+            | TdsDataType::DateTime
+            | TdsDataType::DateTim4
+            | TdsDataType::DateTimeN
+            | TdsDataType::DateN
+            | TdsDataType::TimeN
+            | TdsDataType::DateTime2N
+            | TdsDataType::DateTimeOffsetN
+            | TdsDataType::Guid
+    )
+}
+
+/// Total wire byte width of the cell for `meta`, including any length prefix.
+///
+/// Peeks (never consumes) the 1-byte length prefix of `N`/scale types; fixed
+/// types have no prefix. Returns `NeedBytes` when the prefix itself is not yet
+/// buffered, so the caller refills and re-drives from the column start.
+///
+/// Only valid for types where [`is_supported`] returns `true`; other types hit
+/// the `unreachable!` guard, which indicates a routing bug at the call site.
+pub(crate) fn column_wire_len(
+    buf: &PacketBuffer,
+    meta: &ColumnMetadata,
+) -> Result<usize, NeedBytes> {
+    let fixed = match meta.data_type {
+        TdsDataType::Int1 | TdsDataType::Bit => Some(1),
+        TdsDataType::Int2 => Some(2),
+        TdsDataType::Int4 | TdsDataType::Flt4 | TdsDataType::Money4 | TdsDataType::DateTim4 => {
+            Some(4)
+        }
+        TdsDataType::Int8 | TdsDataType::Flt8 | TdsDataType::Money | TdsDataType::DateTime => {
+            Some(8)
+        }
+        _ => None,
+    };
+    if let Some(width) = fixed {
+        return Ok(width);
+    }
+
+    // Every remaining supported type is 1-byte length-prefixed; the prefix value
+    // is the body width, so the total is 1 + prefix.
+    match buf.peek_bytes(1) {
+        Some(prefix) => Ok(1 + prefix[0] as usize),
+        None => Err(NeedBytes { shortfall: 1 }),
+    }
+}
+
+/// Decodes the whole cell for `meta` from `buf`, which is guaranteed to hold at
+/// least [`column_wire_len`] bytes. Every `take_*` is therefore infallible for
+/// buffer reasons; the only errors returned are genuine protocol violations
+/// (bad `IntN`/`MoneyN`/`GUID` lengths, missing scale metadata, etc.). Performs
+/// exactly one `write_*`/`write_null`.
+pub(crate) fn decode_column_body(
+    buf: &mut PacketBuffer,
+    meta: &ColumnMetadata,
+    col: usize,
+    writer: &mut (dyn RowWriter + Send),
+) -> TdsResult<()> {
+    match meta.data_type {
+        // === Fixed-length integer types ===
+        TdsDataType::Int1 => writer.write_u8(col, buf.take_u8()?),
+        TdsDataType::Int2 => writer.write_i16(col, buf.take_i16_le()?),
+        TdsDataType::Int4 => writer.write_i32(col, buf.take_i32_le()?),
+        TdsDataType::Int8 => writer.write_i64(col, buf.take_i64_le()?),
+        TdsDataType::IntN => match buf.take_u8()? {
+            0 => writer.write_null(col),
+            1 => writer.write_u8(col, buf.take_u8()?),
+            2 => writer.write_i16(col, buf.take_i16_le()?),
+            4 => writer.write_i32(col, buf.take_i32_le()?),
+            8 => writer.write_i64(col, buf.take_i64_le()?),
+            other => {
+                return Err(Error::ProtocolError(format!(
+                    "Invalid IntN length - {other}"
+                )));
+            }
+        },
+
+        // === Fixed-length float types ===
+        TdsDataType::Flt4 => writer.write_f32(col, buf.take_f32_le()?),
+        TdsDataType::Flt8 => writer.write_f64(col, buf.take_f64_le()?),
+        TdsDataType::FltN => match buf.take_u8()? {
+            0 => writer.write_null(col),
+            4 => writer.write_f32(col, buf.take_f32_le()?),
+            _ => writer.write_f64(col, buf.take_f64_le()?),
+        },
+
+        // === Bit types ===
+        TdsDataType::Bit => writer.write_bool(col, buf.take_u8()? == 1),
+        TdsDataType::BitN => {
+            if buf.take_u8()? > 0 {
+                writer.write_bool(col, buf.take_u8()? == 1);
+            } else {
+                writer.write_null(col);
+            }
+        }
+
+        // === Money types ===
+        TdsDataType::Money4 => writer.write_smallmoney(col, take_money4(buf)?),
+        TdsDataType::Money => writer.write_money(col, take_money8(buf)?),
+        TdsDataType::MoneyN => match buf.take_u8()? {
+            0 => writer.write_null(col),
+            4 => writer.write_smallmoney(col, take_money4(buf)?),
+            8 => writer.write_money(col, take_money8(buf)?),
+            other => {
+                return Err(Error::ProtocolError(format!(
+                    "Invalid MoneyN length - {other}"
+                )));
+            }
+        },
+
+        // === Decimal / Numeric ===
+        TdsDataType::DecimalN => match take_decimal(buf, meta)? {
+            Some(val) => writer.write_decimal(col, val),
+            None => writer.write_null(col),
+        },
+        TdsDataType::NumericN => match take_decimal(buf, meta)? {
+            Some(val) => writer.write_numeric(col, val),
+            None => writer.write_null(col),
+        },
+
+        // === DateTime types ===
+        TdsDataType::DateTime => writer.write_datetime(col, take_datetime(buf)?),
+        TdsDataType::DateTim4 => writer.write_smalldatetime(col, take_small_datetime(buf)?),
+        TdsDataType::DateTimeN => match buf.take_u8()? {
+            0 => writer.write_null(col),
+            4 => writer.write_smalldatetime(col, take_small_datetime(buf)?),
+            _ => writer.write_datetime(col, take_datetime(buf)?),
+        },
+        TdsDataType::DateN => {
+            if buf.take_u8()? == 0 {
+                writer.write_null(col);
+            } else {
+                writer.write_date(col, take_date(buf)?);
+            }
+        }
+        TdsDataType::TimeN => {
+            let length = buf.take_u8()?;
+            if length == 0 {
+                writer.write_null(col);
+            } else {
+                writer.write_time(col, take_time(buf, length, scale_of(meta, "TimeN")?)?);
+            }
+        }
+        TdsDataType::DateTime2N => {
+            let length = buf.take_u8()?;
+            if length == 0 {
+                writer.write_null(col);
+            } else {
+                writer.write_datetime2(
+                    col,
+                    take_datetime2(buf, length, scale_of(meta, "DateTime2N")?)?,
+                );
+            }
+        }
+        TdsDataType::DateTimeOffsetN => {
+            let length = buf.take_u8()?;
+            if length == 0 {
+                writer.write_null(col);
+            } else {
+                writer.write_datetimeoffset(
+                    col,
+                    take_datetime_offset(buf, length, scale_of(meta, "DateTimeOffsetN")?)?,
+                );
+            }
+        }
+
+        // === GUID ===
+        TdsDataType::Guid => {
+            let length = buf.take_u8()?;
+            if length == 0 {
+                writer.write_null(col);
+            } else if length == 16 {
+                let mut bytes = [0u8; 16];
+                for slot in bytes.iter_mut() {
+                    *slot = buf.take_u8()?;
+                }
+                let uuid = uuid::Uuid::from_slice_le(&bytes)
+                    .map_err(|e| Error::ProtocolError(format!("Failed to parse UUID: {e}")))?;
+                writer.write_uuid(col, uuid);
+            } else {
+                return Err(Error::ProtocolError(format!(
+                    "Invalid GUID length: expected 16 bytes, got {length}"
+                )));
+            }
+        }
+
+        other => {
+            unreachable!("decode_column_body called for unsupported type {other:?}");
+        }
+    }
+    Ok(())
+}
+
+fn scale_of(meta: &ColumnMetadata, type_name: &str) -> TdsResult<u8> {
+    meta.get_scale()
+        .ok_or_else(|| Error::ImplementationError(format!("{type_name} type should have scale")))
+}
+
+fn take_money4(buf: &mut PacketBuffer) -> TdsResult<SqlSmallMoney> {
+    Ok(buf.take_i32_le()?.into())
+}
+
+fn take_money8(buf: &mut PacketBuffer) -> TdsResult<SqlMoney> {
+    let msb = buf.take_i32_le()?;
+    let lsb = buf.take_i32_le()?;
+    Ok(SqlMoney {
+        lsb_part: lsb,
+        msb_part: msb,
+    })
+}
+
+fn take_datetime(buf: &mut PacketBuffer) -> TdsResult<SqlDateTime> {
+    let days = buf.take_i32_le()?;
+    let ticks = buf.take_u32_le()?;
+    Ok(SqlDateTime { days, time: ticks })
+}
+
+fn take_small_datetime(buf: &mut PacketBuffer) -> TdsResult<SqlSmallDateTime> {
+    let days = buf.take_u16_le()?;
+    let minutes = buf.take_u16_le()?;
+    Ok(SqlSmallDateTime {
+        days,
+        time: minutes,
+    })
+}
+
+fn take_date(buf: &mut PacketBuffer) -> TdsResult<SqlDate> {
+    Ok(SqlDate::unchecked_create(buf.take_u24_le()?))
+}
+
+fn take_time(buf: &mut PacketBuffer, byte_len: u8, scale: u8) -> TdsResult<SqlTime> {
+    let scaled_value = match byte_len {
+        3 => buf.take_u24_le()? as u64,
+        4 => buf.take_u32_le()? as u64,
+        _ => buf.take_uint40_le()?,
+    };
+    let time_nanoseconds = match scale {
+        0 => scaled_value * 10_000_000,
+        1 => scaled_value * 1_000_000,
+        2 => scaled_value * 100_000,
+        3 => scaled_value * 10_000,
+        4 => scaled_value * 1_000,
+        5 => scaled_value * 100,
+        6 => scaled_value * 10,
+        _ => scaled_value,
+    };
+    Ok(SqlTime {
+        time_nanoseconds,
+        scale,
+    })
+}
+
+fn take_datetime2(buf: &mut PacketBuffer, byte_len: u8, scale: u8) -> TdsResult<SqlDateTime2> {
+    let time_byte_len = byte_len.checked_sub(3).ok_or_else(|| {
+        Error::ProtocolError(format!(
+            "Invalid DateTime2 byte length: {byte_len}. Expected at least 3 bytes for date component."
+        ))
+    })?;
+    let time = take_time(buf, time_byte_len, scale)?;
+    let date = take_date(buf)?;
+    Ok(SqlDateTime2 {
+        days: date.get_days(),
+        time,
+    })
+}
+
+fn take_datetime_offset(
+    buf: &mut PacketBuffer,
+    byte_len: u8,
+    scale: u8,
+) -> TdsResult<SqlDateTimeOffset> {
+    let datetime2_byte_len = byte_len.checked_sub(2).ok_or_else(|| {
+        Error::ProtocolError(format!(
+            "Invalid DateTimeOffset byte length: {byte_len}. Expected at least 2 bytes for offset component."
+        ))
+    })?;
+    let datetime2 = take_datetime2(buf, datetime2_byte_len, scale)?;
+    let offset = buf.take_i16_le()?;
+    Ok(SqlDateTimeOffset { datetime2, offset })
+}
+
+fn take_decimal(buf: &mut PacketBuffer, meta: &ColumnMetadata) -> TdsResult<Option<DecimalParts>> {
+    let length = buf.take_u8()?;
+    let TypeInfoVariant::VarLenPrecisionScale(_, _, precision, scale) =
+        meta.type_info.type_info_variant
+    else {
+        return Err(Error::ProtocolError(format!(
+            "Invalid type info variant for Decimal/Numeric: expected VarLenPrecisionScale, got: {:?}",
+            meta.type_info.type_info_variant
+        )));
+    };
+    if length == 0 {
+        return Ok(None);
+    }
+    let sign = buf.take_u8()?;
+    let is_positive = sign == 1;
+    let number_of_int_parts = (length - 1) >> 2;
+
+    #[cfg(fuzzing)]
+    const MAX_DECIMAL_INT_PARTS: u8 = 10;
+    #[cfg(not(fuzzing))]
+    const MAX_DECIMAL_INT_PARTS: u8 = 64;
+
+    if number_of_int_parts > MAX_DECIMAL_INT_PARTS {
+        return Err(Error::ProtocolError(format!(
+            "Decimal int parts {number_of_int_parts} exceeds maximum allowed {MAX_DECIMAL_INT_PARTS} (length was {length})"
+        )));
+    }
+
+    let mut int_parts = vec![0i32; number_of_int_parts as usize];
+    for part in int_parts.iter_mut() {
+        *part = buf.take_i32_le()?;
+    }
+
+    Ok(Some(DecimalParts {
+        is_positive,
+        scale,
+        precision,
+        int_parts,
+    }))
+}

--- a/mssql-tds/src/datatypes/sync_decoder.rs
+++ b/mssql-tds/src/datatypes/sync_decoder.rs
@@ -21,6 +21,7 @@ use crate::datatypes::column_values::{
 };
 use crate::datatypes::decoder::DecimalParts;
 use crate::datatypes::row_writer::RowWriter;
+use crate::datatypes::sql_string::{SqlString, get_encoding_type};
 use crate::datatypes::sqldatatypes::{TdsDataType, TypeInfoVariant};
 use crate::error::Error;
 use crate::io::packet_buffer::{NeedBytes, PacketBuffer};
@@ -61,6 +62,17 @@ pub(crate) fn is_supported(meta: &ColumnMetadata) -> bool {
             | TdsDataType::DateTime2N
             | TdsDataType::DateTimeOffsetN
             | TdsDataType::Guid
+            // Variable-length non-PLP strings (USHORT length prefix, 0xFFFF = NULL).
+            // Long-length LOB types (Text/NText) keep the legacy async path.
+            | TdsDataType::Char
+            | TdsDataType::VarChar
+            | TdsDataType::BigChar
+            | TdsDataType::BigVarChar
+            | TdsDataType::NChar
+            | TdsDataType::NVarChar
+            // Variable-length non-PLP binary (USHORT length prefix, 0xFFFF = NULL).
+            | TdsDataType::BigBinary
+            | TdsDataType::BigVarBinary
     )
 }
 
@@ -89,6 +101,34 @@ pub(crate) fn column_wire_len(
     };
     if let Some(width) = fixed {
         return Ok(width);
+    }
+
+    // Variable-length non-PLP strings and binary are 2-byte (USHORT) length
+    // prefixed; 0xFFFF is the NULL marker (no body). The prefix width is the
+    // absolute byte count needed to compute the total, so a shortfall re-drives
+    // ensure() for the whole prefix.
+    if matches!(
+        meta.data_type,
+        TdsDataType::Char
+            | TdsDataType::VarChar
+            | TdsDataType::BigChar
+            | TdsDataType::BigVarChar
+            | TdsDataType::NChar
+            | TdsDataType::NVarChar
+            | TdsDataType::BigBinary
+            | TdsDataType::BigVarBinary
+    ) {
+        return match buf.peek_bytes(2) {
+            Some(prefix) => {
+                let length = u16::from_le_bytes([prefix[0], prefix[1]]);
+                if length == 0xFFFF {
+                    Ok(2)
+                } else {
+                    Ok(2 + length as usize)
+                }
+            }
+            None => Err(NeedBytes { shortfall: 2 }),
+        };
     }
 
     // Every remaining supported type is 1-byte length-prefixed; the prefix value
@@ -238,6 +278,32 @@ pub(crate) fn decode_column_body(
             }
         }
 
+        // === Variable-length non-PLP strings (USHORT prefix, 0xFFFF = NULL) ===
+        TdsDataType::Char
+        | TdsDataType::VarChar
+        | TdsDataType::BigChar
+        | TdsDataType::BigVarChar
+        | TdsDataType::NChar
+        | TdsDataType::NVarChar => {
+            let length = buf.take_u16_le()?;
+            if length == 0xFFFF {
+                writer.write_null(col);
+            } else {
+                let bytes = take_bytes(buf, length as usize);
+                writer.write_string(col, SqlString::new(bytes, get_encoding_type(meta)));
+            }
+        }
+
+        // === Variable-length non-PLP binary (USHORT prefix, 0xFFFF = NULL) ===
+        TdsDataType::BigBinary | TdsDataType::BigVarBinary => {
+            let length = buf.take_u16_le()?;
+            if length == 0xFFFF {
+                writer.write_null(col);
+            } else {
+                writer.write_bytes(col, take_bytes(buf, length as usize));
+            }
+        }
+
         other => {
             unreachable!("decode_column_body called for unsupported type {other:?}");
         }
@@ -248,6 +314,18 @@ pub(crate) fn decode_column_body(
 fn scale_of(meta: &ColumnMetadata, type_name: &str) -> TdsResult<u8> {
     meta.get_scale()
         .ok_or_else(|| Error::ImplementationError(format!("{type_name} type should have scale")))
+}
+
+/// Consumes exactly `n` bytes from `buf`. The column driver guarantees the whole
+/// cell is buffered before calling into the body, so the copy always fills.
+fn take_bytes(buf: &mut PacketBuffer, n: usize) -> Vec<u8> {
+    let mut bytes = vec![0u8; n];
+    let copied = buf.copy_out(&mut bytes);
+    debug_assert_eq!(
+        copied, n,
+        "cell not fully buffered before decode_column_body"
+    );
+    bytes
 }
 
 fn take_money4(buf: &mut PacketBuffer) -> TdsResult<SqlSmallMoney> {

--- a/mssql-tds/src/io/packet_buffer.rs
+++ b/mssql-tds/src/io/packet_buffer.rs
@@ -97,6 +97,39 @@ impl PacketBuffer {
         &self.working_buffer[self.position..self.length]
     }
 
+    /// Non-consuming view of the first `n` readable bytes, or `None` when fewer
+    /// than `n` are buffered.
+    ///
+    /// Unlike [`take`](Self::take) this never advances the read position, so the
+    /// column-atomic decode path can inspect a length prefix and then re-drive
+    /// from the column start after a refill without having consumed anything.
+    pub(crate) fn peek_bytes(&self, n: usize) -> Option<&[u8]> {
+        if self.has(n) {
+            Some(&self.working_buffer[self.position..self.position + n])
+        } else {
+            None
+        }
+    }
+
+    /// Builds a transient, refill-free buffer whose entire readable payload is
+    /// `bytes`.
+    ///
+    /// Used by the async column driver to stage a fully-assembled non-PLP cell
+    /// so the single synchronous `decode_column_body` can run over it, without a
+    /// socket or packet framing. There is no header and no refill source, so the
+    /// paired `take_*` accessors serve straight from `bytes`.
+    pub(crate) fn from_bytes(bytes: &[u8]) -> Self {
+        let len = bytes.len();
+        PacketBuffer {
+            working_buffer: bytes.to_vec(),
+            position: 0,
+            length: len,
+            max_packet_size: len.max(1),
+            pending_bytes: 0,
+            pending_bytes_offset: 0,
+        }
+    }
+
     /// Returns the first `n` readable bytes, erroring if fewer are buffered.
     ///
     /// Callers ensure enough bytes are present (via a refill) before calling; a
@@ -697,5 +730,29 @@ mod tests {
 
         // After a satisfied guard the same bytes read back intact.
         assert_eq!(buf.take_u8().unwrap(), 0xAA);
+    }
+
+    /// `peek_bytes` returns a non-consuming prefix view and yields `None` once
+    /// the request exceeds what is buffered — the length-prefix inspection the
+    /// column-atomic decode path relies on to re-drive without consuming.
+    #[test]
+    fn peek_bytes_is_non_consuming_and_bounded() {
+        let mut buf = staged(&[0x04, 0x00, 0xAA, 0xBB]);
+
+        // Peeking the 2-byte USHORT length prefix does not advance the cursor.
+        assert_eq!(buf.peek_bytes(2), Some([0x04, 0x00].as_slice()));
+        assert_eq!(buf.position(), 0);
+        assert_eq!(buf.available(), 4);
+
+        // Repeated peeks are idempotent.
+        assert_eq!(buf.peek_bytes(1), Some([0x04].as_slice()));
+        assert_eq!(buf.peek_bytes(4), Some([0x04, 0x00, 0xAA, 0xBB].as_slice()));
+
+        // Beyond what is buffered => None (a refill request, not a peek).
+        assert_eq!(buf.peek_bytes(5), None);
+
+        // The bytes are still fully readable afterwards.
+        assert_eq!(buf.take_u16_le().unwrap(), 0x0004);
+        assert_eq!(buf.position(), 2);
     }
 }

--- a/mssql-tds/src/io/packet_reader.rs
+++ b/mssql-tds/src/io/packet_reader.rs
@@ -6,10 +6,12 @@ use tracing::event;
 
 use super::packet_writer::PacketWriter;
 use crate::core::TdsResult;
+use crate::datatypes::row_writer::RowWriter;
 use crate::io::packet_buffer::PacketBuffer;
 use crate::io::reader_writer::NetworkReaderWriter;
 use crate::message::attention::AttentionRequest;
 use crate::message::messages::Request;
+use crate::query::metadata::ColumnMetadata;
 use std::io::{Error, ErrorKind};
 
 #[async_trait]
@@ -42,6 +44,39 @@ pub(crate) trait TdsPacketReader {
     async fn skip_bytes(&mut self, skip_count: usize) -> TdsResult<()>;
     async fn cancel_read_stream(&mut self) -> TdsResult<()>;
     fn reset_reader(&mut self);
+
+    /// Decodes one non-PLP column cell into `writer` as a column-atomic step.
+    ///
+    /// The caller guarantees `meta` is a non-PLP type accepted by
+    /// [`sync_decoder::is_supported`](crate::datatypes::sync_decoder::is_supported).
+    /// The default assembles the whole cell via `read_bytes` (for readers that do
+    /// not own a [`PacketBuffer`]) and runs the shared `decode_column_body`;
+    /// buffer-owning readers override this to drive the sync core in place.
+    async fn decode_column_into(
+        &mut self,
+        meta: &ColumnMetadata,
+        col: usize,
+        writer: &mut (dyn RowWriter + Send),
+    ) -> TdsResult<()> {
+        use crate::datatypes::sync_decoder;
+        use crate::io::packet_buffer::PacketBuffer;
+
+        let mut cell: Vec<u8> = Vec::new();
+        loop {
+            let probe = PacketBuffer::from_bytes(&cell);
+            let needed = match sync_decoder::column_wire_len(&probe, meta) {
+                Ok(total) if cell.len() >= total => {
+                    let mut body = PacketBuffer::from_bytes(&cell[..total]);
+                    return sync_decoder::decode_column_body(&mut body, meta, col, writer);
+                }
+                Ok(total) => total - cell.len(),
+                Err(need) => need.shortfall,
+            };
+            let mut extra = vec![0u8; needed];
+            self.read_bytes(&mut extra).await?;
+            cell.extend_from_slice(&extra);
+        }
+    }
 }
 
 /// Low-level TDS packet reading operations (public under `fuzzing` cfg).
@@ -73,6 +108,39 @@ pub trait TdsPacketReader {
     async fn skip_bytes(&mut self, skip_count: usize) -> TdsResult<()>;
     async fn cancel_read_stream(&mut self) -> TdsResult<()>;
     fn reset_reader(&mut self);
+
+    /// Decodes one non-PLP column cell into `writer` as a column-atomic step.
+    ///
+    /// The caller guarantees `meta` is a non-PLP type accepted by
+    /// [`sync_decoder::is_supported`](crate::datatypes::sync_decoder::is_supported).
+    /// The default assembles the whole cell via `read_bytes` (for readers that do
+    /// not own a [`PacketBuffer`]) and runs the shared `decode_column_body`;
+    /// buffer-owning readers override this to drive the sync core in place.
+    async fn decode_column_into(
+        &mut self,
+        meta: &ColumnMetadata,
+        col: usize,
+        writer: &mut (dyn RowWriter + Send),
+    ) -> TdsResult<()> {
+        use crate::datatypes::sync_decoder;
+        use crate::io::packet_buffer::PacketBuffer;
+
+        let mut cell: Vec<u8> = Vec::new();
+        loop {
+            let probe = PacketBuffer::from_bytes(&cell);
+            let needed = match sync_decoder::column_wire_len(&probe, meta) {
+                Ok(total) if cell.len() >= total => {
+                    let mut body = PacketBuffer::from_bytes(&cell[..total]);
+                    return sync_decoder::decode_column_body(&mut body, meta, col, writer);
+                }
+                Ok(total) => total - cell.len(),
+                Err(need) => need.shortfall,
+            };
+            let mut extra = vec![0u8; needed];
+            self.read_bytes(&mut extra).await?;
+            cell.extend_from_slice(&extra);
+        }
+    }
 }
 
 /// Buffered reader that reassembles TDS packets from the network stream.
@@ -196,6 +264,29 @@ impl TdsPacketReader for PacketReader<'_> {
         // Make sure that we have read all the data from the buffer.
         assert!(self.buffer.is_drained());
         // No Op after this.
+    }
+
+    async fn decode_column_into(
+        &mut self,
+        meta: &ColumnMetadata,
+        col: usize,
+        writer: &mut (dyn RowWriter + Send),
+    ) -> TdsResult<()> {
+        use crate::datatypes::sync_decoder;
+
+        // Sync driver: peek the wire width over the owned buffer, ensure the
+        // whole cell, then decode it in place with zero copy. `column_wire_len`
+        // only peeks, so a shortfall (missing length prefix) re-drives from the
+        // column start with nothing consumed or written.
+        loop {
+            match sync_decoder::column_wire_len(&self.buffer, meta) {
+                Ok(total) => {
+                    self.ensure(total).await?;
+                    return sync_decoder::decode_column_body(&mut self.buffer, meta, col, writer);
+                }
+                Err(need) => self.ensure(need.shortfall).await?,
+            }
+        }
     }
 
     async fn cancel_read_stream(&mut self) -> TdsResult<()> {
@@ -472,6 +563,15 @@ impl TdsPacketReader for Box<dyn TdsPacketReader + Send + Sync> {
 
     fn reset_reader(&mut self) {
         (**self).reset_reader()
+    }
+
+    async fn decode_column_into(
+        &mut self,
+        meta: &ColumnMetadata,
+        col: usize,
+        writer: &mut (dyn RowWriter + Send),
+    ) -> TdsResult<()> {
+        (**self).decode_column_into(meta, col, writer).await
     }
 }
 

--- a/mssql-tds/src/io/packet_reader.rs
+++ b/mssql-tds/src/io/packet_reader.rs
@@ -194,8 +194,8 @@ impl<'a> PacketReader<'a> {
 
     async fn read_tds_packet(&mut self) -> TdsResult<()> {
         let (base, already) = self.buffer.begin_refill()?;
-        let received = self.receive_packet(base, already).await?;
-        self.buffer.strip_header(received);
+        let packet_len = self.receive_packet(base, already).await?;
+        self.buffer.strip_header(packet_len);
         Ok(())
     }
 
@@ -205,10 +205,10 @@ impl<'a> PacketReader<'a> {
         self.read_tds_packet().await
     }
 
-    /// Reads one TDS packet's raw bytes into the buffer and returns the total
-    /// number of bytes read (header + payload). The header's declared length is
-    /// used only as a lower bound on how much to read; the caller strips the
-    /// header from whatever was actually received.
+    /// Reads one TDS packet into the buffer and returns that packet's declared
+    /// length (header + payload). A single socket read may pull bytes past this
+    /// packet; the surplus is carried forward via `record_pending` so the next
+    /// refill strips its header too, exactly as the production transport does.
     async fn receive_packet(&mut self, base: usize, already: usize) -> TdsResult<usize> {
         let mut received = already;
 
@@ -227,7 +227,7 @@ impl<'a> PacketReader<'a> {
             received += bytes_read;
         }
 
-        let packet_size_from_header = self.buffer.packet_header_length(base);
+        let packet_size_from_header = self.buffer.validate_packet_length(base)?;
         while received < packet_size_from_header {
             let bytes_read = self
                 .network_reader_writer
@@ -241,20 +241,26 @@ impl<'a> PacketReader<'a> {
             received += bytes_read;
         }
 
+        // Bytes read past this packet belong to the next one; carry them forward.
+        self.buffer
+            .record_pending(base, packet_size_from_header, received);
+
         event!(
             tracing::Level::DEBUG,
             "Received packet of size: {:?}",
-            received
+            packet_size_from_header
         );
 
         use pretty_hex::PrettyHex;
         event!(
             tracing::Level::DEBUG,
             "Packet content: {:?}",
-            self.buffer.raw_packet(base, received).hex_dump()
+            self.buffer
+                .raw_packet(base, packet_size_from_header)
+                .hex_dump()
         );
 
-        Ok(received)
+        Ok(packet_size_from_header)
     }
 }
 
@@ -659,7 +665,11 @@ pub(crate) mod tests {
         append_method!(append_u64, u64, 8, write_u64);
 
         pub(crate) fn build(&mut self) -> Vec<u8> {
-            BigEndian::write_u16(&mut self.data[2..4], self.payload_length);
+            // The TDS header length field is the total packet size (header +
+            // payload), matching the production serializer and what
+            // `validate_packet_length` expects.
+            let total_length = self.payload_length + PacketWriter::PACKET_HEADER_SIZE as u16;
+            BigEndian::write_u16(&mut self.data[2..4], total_length);
             self.data.clone()
         }
     }
@@ -1183,5 +1193,83 @@ pub(crate) mod tests {
                 || err.to_string().contains("no progress"),
             "expected termination error, got: {err}"
         );
+    }
+
+    /// Mandatory blocking test (L4a test B): an inverted variable-length non-PLP
+    /// cell (nvarchar) whose bytes are split across a packet refill boundary at
+    /// every interior offset — including inside the 2-byte length prefix
+    /// (peek-only re-drive from the column start) and mid-data (whole-cell
+    /// `ensure` across the boundary). Every split must decode identically to the
+    /// single-packet cell, proving the sync driver never partially consumes the
+    /// buffer or writes to the row before the shortfall is satisfied.
+    #[tokio::test]
+    async fn var_length_cell_redrive_is_byte_identical_across_refill_boundary() {
+        use crate::datatypes::column_values::ColumnValues;
+        use crate::datatypes::row_writer::DefaultRowWriter;
+        use crate::datatypes::sqldatatypes::{TdsDataType, TypeInfo};
+        use crate::token::tokens::SqlCollation;
+
+        let collation = SqlCollation {
+            info: 0x0409,
+            lcid_language_id: 0x0409,
+            col_flags: 0,
+            sort_id: 52,
+        };
+        let meta = ColumnMetadata {
+            user_type: 0,
+            flags: 0,
+            data_type: TdsDataType::NVarChar,
+            type_info: TypeInfo::partial_len(TdsDataType::NVarChar, 100, Some(collation)).unwrap(),
+            column_name: "s".to_string(),
+            multi_part_name: None,
+            crypto_metadata: None,
+        };
+
+        // nvarchar cell wire: [u16 byte length][utf16-le data]. "Hello" = 5 units.
+        let hello: Vec<u8> = "Hello"
+            .encode_utf16()
+            .flat_map(|u| u.to_le_bytes())
+            .collect();
+        let mut cell = (hello.len() as u16).to_le_bytes().to_vec();
+        cell.extend_from_slice(&hello);
+
+        async fn decode(read_data: Vec<u8>, meta: &ColumnMetadata) -> Vec<ColumnValues> {
+            let mut mock = MockNetworkReaderWriter::new(read_data, 0);
+            let mut reader = PacketReader::new(&mut mock);
+            let mut writer = DefaultRowWriter::new(1);
+            reader
+                .decode_column_into(meta, 0, &mut writer)
+                .await
+                .unwrap();
+            writer.take_row()
+        }
+
+        fn one_packet(payload: &[u8]) -> Vec<u8> {
+            let mut builder = TestPacketBuilder::new(PacketType::PreLogin);
+            builder.append_bytes(payload).build()
+        }
+        fn two_packets(payload: &[u8], split: usize) -> Vec<u8> {
+            let mut first_builder = TestPacketBuilder::new(PacketType::PreLogin);
+            let mut first = first_builder.append_bytes(&payload[..split]).build();
+            // Clear EOM so the buffer keeps reading into the second packet.
+            first[1] = 0x00;
+            let mut second_builder = TestPacketBuilder::new(PacketType::PreLogin);
+            let second = second_builder.append_bytes(&payload[split..]).build();
+            [first, second].concat()
+        }
+
+        let baseline = decode(one_packet(&cell), &meta).await;
+        assert_eq!(baseline.len(), 1);
+        assert_ne!(baseline[0], ColumnValues::Null);
+
+        // split == 1 lands inside the 2-byte length prefix (peek-only re-drive);
+        // splits >= 2 land mid-data (whole-cell ensure across the boundary).
+        for split in 1..cell.len() {
+            let got = decode(two_packets(&cell, split), &meta).await;
+            assert_eq!(
+                got, baseline,
+                "cell decode diverged when the refill boundary landed at offset {split}"
+            );
+        }
     }
 }

--- a/mssql-tds/src/io/token_stream.rs
+++ b/mssql-tds/src/io/token_stream.rs
@@ -2,8 +2,10 @@
 // Licensed under the MIT License.
 
 use crate::core::{CancelHandle, TdsResult};
-use crate::datatypes::decoder::{GenericDecoder, PlpColumnStream, decrypt_encrypted_column};
-use crate::datatypes::row_writer::{RowWriter, write_column_value};
+use crate::datatypes::decoder::{
+    GenericDecoder, PlpColumnStream, decrypt_cipher_value, decrypt_encrypted_column,
+};
+use crate::datatypes::row_writer::{DefaultRowWriter, RowWriter, write_column_value};
 use crate::io::packet_reader::TdsPacketReader;
 use crate::query::metadata::ColumnMetadata;
 use crate::security::cell_decryptor::CellDecryptor;
@@ -459,8 +461,23 @@ async fn decode_or_decrypt_column<R: TdsPacketReader + Send + Sync>(
 ) -> TdsResult<()> {
     match (meta.crypto_metadata.is_some(), decryptor) {
         (true, Some(dec)) => {
-            let value = decrypt_encrypted_column(decoder, reader, meta, dec).await?;
-            write_column_value(writer, col, value);
+            if crate::datatypes::sync_decoder::is_supported(meta) {
+                // Non-PLP ciphertext: buffer + decode the cipher cell atomically
+                // via the shared sync step, then run the synchronous cell
+                // decryptor and write the plaintext. PLP ciphertext
+                // (varbinary(max)) falls through to the async path (L4b).
+                let mut cipher_cell = DefaultRowWriter::new(1);
+                reader.decode_column_into(meta, 0, &mut cipher_cell).await?;
+                let cipher = cipher_cell
+                    .take_row()
+                    .pop()
+                    .unwrap_or(crate::datatypes::column_values::ColumnValues::Null);
+                let value = decrypt_cipher_value(meta, dec, cipher)?;
+                write_column_value(writer, col, value);
+            } else {
+                let value = decrypt_encrypted_column(decoder, reader, meta, dec).await?;
+                write_column_value(writer, col, value);
+            }
         }
         (true, None) => {
             tracing::info!(

--- a/mssql-tds/src/io/token_stream.rs
+++ b/mssql-tds/src/io/token_stream.rs
@@ -1442,21 +1442,16 @@ mod tests {
     /// decode byte-identically to the single-packet baseline, proving the
     /// inverted step and the async PLP path share ONE coherent row cursor
     /// (`next_column_index`) no matter where the packet boundary lands.
-    #[tokio::test]
-    async fn mixed_row_inverted_then_plp_is_byte_identical_across_refill_boundary() {
-        use crate::datatypes::column_values::ColumnValues;
-        use crate::datatypes::row_writer::DefaultRowWriter;
-        use crate::io::packet_reader::PacketReader;
-        use crate::io::packet_reader::tests::{MockNetworkReaderWriter, TestPacketBuilder};
-        use crate::message::messages::PacketType;
-
+    /// Shared fixture for the hybrid non-PLP -> PLP mid-row seam tests: a row
+    /// `[int4 (fixed inverted)][varchar(64) (var-length inverted)][nvarchar(max) PLP (legacy async)]`.
+    fn mixed_seam_columns() -> Vec<ColumnMetadata> {
         let collation = SqlCollation {
             info: 0x0409,
             lcid_language_id: 0x0409,
             col_flags: 0,
             sort_id: 52,
         };
-        let columns = vec![
+        vec![
             ColumnMetadata {
                 user_type: 0,
                 flags: 0,
@@ -1486,65 +1481,136 @@ mod tests {
                 multi_part_name: None,
                 crypto_metadata: None,
             },
-        ];
+        ]
+    }
 
-        // ROW payload: [Row token][int4 = 42][varchar "ab"][nvarchar(max) PLP "Hi"].
+    /// ROW payload `[Row token][int4 = 42][varchar "ab"][nvarchar(max) PLP "Hi"]`.
+    ///
+    /// Returns `(payload, varchar_cell_range, nonplp_to_plp_transition_offset)`.
+    /// `varchar_cell_range` is the interior byte range of the inverted varchar cell
+    /// (USHORT prefix + data); `transition_offset` is the first byte of the PLP column —
+    /// the exact whole-column non-PLP -> PLP boundary governed by `next_column_index`.
+    fn mixed_seam_payload() -> (Vec<u8>, std::ops::Range<usize>, usize) {
         let mut payload = vec![TokenType::Row as u8];
         payload.extend_from_slice(&42_i32.to_le_bytes());
+        let varchar_start = payload.len();
         let ab = [0x61u8, 0x62]; // "ab"
         payload.extend_from_slice(&(ab.len() as u16).to_le_bytes()); // USHORT length prefix
         payload.extend_from_slice(&ab);
+        let transition = payload.len(); // first byte of the PLP column
         payload.extend_from_slice(&0xFFFF_FFFF_FFFF_FFFE_u64.to_le_bytes()); // SQL_PLP_UNKNOWNLEN
         let hi_utf16 = [0x48u8, 0x00, 0x69, 0x00]; // "Hi"
         payload.extend_from_slice(&(hi_utf16.len() as u32).to_le_bytes());
         payload.extend_from_slice(&hi_utf16);
         payload.extend_from_slice(&0u32.to_le_bytes()); // PLP zero-length terminator
+        (payload, varchar_start..transition, transition)
+    }
 
-        async fn decode(read_data: Vec<u8>, columns: &[ColumnMetadata]) -> Vec<ColumnValues> {
-            let mut mock = MockNetworkReaderWriter::new(read_data, 0);
-            let mut reader = PacketReader::new(&mut mock);
-            reader.read_tds_packet_for_test().await.unwrap();
-            let context = ParserContext::ColumnMetadata(
-                Arc::new(ColMetadataToken {
-                    column_count: columns.len() as u16,
-                    columns: columns.to_vec(),
-                    cek_table: vec![],
-                }),
-                None,
-            );
-            let registry = GenericTokenParserRegistry::default();
-            let mut writer = DefaultRowWriter::new(columns.len());
-            let result = receive_row_into_internal(&mut reader, &registry, &context, &mut writer)
-                .await
-                .unwrap();
-            assert!(matches!(result, RowReadResult::RowWritten));
-            writer.take_row()
-        }
+    async fn decode_mixed_seam(
+        read_data: Vec<u8>,
+    ) -> Vec<crate::datatypes::column_values::ColumnValues> {
+        use crate::datatypes::row_writer::DefaultRowWriter;
+        use crate::io::packet_reader::PacketReader;
+        use crate::io::packet_reader::tests::MockNetworkReaderWriter;
 
-        fn one_packet(payload: &[u8]) -> Vec<u8> {
-            let mut builder = TestPacketBuilder::new(PacketType::PreLogin);
-            builder.append_bytes(payload).build()
-        }
-        fn two_packets(payload: &[u8], split: usize) -> Vec<u8> {
-            let mut first_builder = TestPacketBuilder::new(PacketType::PreLogin);
-            let mut first = first_builder.append_bytes(&payload[..split]).build();
-            first[1] = 0x00; // clear EOM so the buffer keeps reading into the second packet
-            let mut second_builder = TestPacketBuilder::new(PacketType::PreLogin);
-            let second = second_builder.append_bytes(&payload[split..]).build();
-            [first, second].concat()
-        }
+        let columns = mixed_seam_columns();
+        let mut mock = MockNetworkReaderWriter::new(read_data, 0);
+        let mut reader = PacketReader::new(&mut mock);
+        reader.read_tds_packet_for_test().await.unwrap();
+        let context = ParserContext::ColumnMetadata(
+            Arc::new(ColMetadataToken {
+                column_count: columns.len() as u16,
+                columns: columns.clone(),
+                cek_table: vec![],
+            }),
+            None,
+        );
+        let registry = GenericTokenParserRegistry::default();
+        let mut writer = DefaultRowWriter::new(columns.len());
+        let result = receive_row_into_internal(&mut reader, &registry, &context, &mut writer)
+            .await
+            .unwrap();
+        assert!(matches!(result, RowReadResult::RowWritten));
+        writer.take_row()
+    }
 
-        let baseline = decode(one_packet(&payload), &columns).await;
+    fn seam_one_packet(payload: &[u8]) -> Vec<u8> {
+        use crate::io::packet_reader::tests::TestPacketBuilder;
+        use crate::message::messages::PacketType;
+        let mut builder = TestPacketBuilder::new(PacketType::PreLogin);
+        builder.append_bytes(payload).build()
+    }
+
+    fn seam_two_packets(payload: &[u8], split: usize) -> Vec<u8> {
+        use crate::io::packet_reader::tests::TestPacketBuilder;
+        use crate::message::messages::PacketType;
+        let mut first_builder = TestPacketBuilder::new(PacketType::PreLogin);
+        let mut first = first_builder.append_bytes(&payload[..split]).build();
+        first[1] = 0x00; // clear EOM so the buffer keeps reading into the second packet
+        let mut second_builder = TestPacketBuilder::new(PacketType::PreLogin);
+        let second = second_builder.append_bytes(&payload[split..]).build();
+        [first, second].concat()
+    }
+
+    #[tokio::test]
+    async fn mixed_row_inverted_then_plp_is_byte_identical_across_refill_boundary() {
+        use crate::datatypes::column_values::ColumnValues;
+
+        let (payload, _varchar, _transition) = mixed_seam_payload();
+        let baseline = decode_mixed_seam(seam_one_packet(&payload)).await;
         assert_eq!(baseline.len(), 3);
         assert_eq!(baseline[0], ColumnValues::Int(42));
         assert_ne!(baseline[1], ColumnValues::Null); // varchar "ab"
         assert_ne!(baseline[2], ColumnValues::Null); // nvarchar(max) "Hi"
 
         for split in 1..payload.len() {
-            let got = decode(two_packets(&payload, split), &columns).await;
+            let got = decode_mixed_seam(seam_two_packets(&payload, split)).await;
             assert_eq!(
                 got, baseline,
                 "mixed row decode diverged when the refill boundary landed at offset {split}"
+            );
+        }
+    }
+
+    /// Mandatory blocking test (L4a sharpened): the refill boundary lands EXACTLY at the
+    /// whole-column non-PLP -> PLP transition. The inverted step fully consumes the last
+    /// non-PLP cell (varchar) inside packet 1; the PLP column's first `ensure()` then
+    /// returns `NeedBytes` -> refill -> the legacy async PLP path resumes at
+    /// `next_column_index`. Proves the whole-column seam (governed by `RowPauseState`'s
+    /// column cursor, not a mid-value pause) hands off cleanly and byte-identically.
+    #[tokio::test]
+    async fn refill_boundary_at_nonplp_to_plp_column_transition_resumes_into_async_plp() {
+        use crate::datatypes::column_values::ColumnValues;
+
+        let (payload, _varchar, transition) = mixed_seam_payload();
+        let baseline = decode_mixed_seam(seam_one_packet(&payload)).await;
+        assert_eq!(baseline.len(), 3);
+        assert_eq!(baseline[0], ColumnValues::Int(42));
+        assert_ne!(baseline[2], ColumnValues::Null); // PLP nvarchar(max) "Hi"
+
+        let got = decode_mixed_seam(seam_two_packets(&payload, transition)).await;
+        assert_eq!(
+            got, baseline,
+            "resume into the async PLP path diverged when the refill boundary landed exactly \
+             at the non-PLP -> PLP column transition (offset {transition})"
+        );
+    }
+
+    /// Cheap companion: the refill boundary lands inside the inverted var-length varchar
+    /// cell — both inside its 2-byte USHORT length prefix (peek-only re-drive) and
+    /// mid-data. Confirms the inverted step's OWN resume is coherent, independent of the
+    /// downstream PLP handoff.
+    #[tokio::test]
+    async fn refill_boundary_within_inverted_varchar_cell_resumes_coherently() {
+        let (payload, varchar, _transition) = mixed_seam_payload();
+        let baseline = decode_mixed_seam(seam_one_packet(&payload)).await;
+
+        for split in varchar {
+            let got = decode_mixed_seam(seam_two_packets(&payload, split)).await;
+            assert_eq!(
+                got, baseline,
+                "inverted varchar cell resume diverged when the refill boundary landed at \
+                 offset {split}"
             );
         }
     }

--- a/mssql-tds/src/io/token_stream.rs
+++ b/mssql-tds/src/io/token_stream.rs
@@ -1325,6 +1325,112 @@ mod tests {
         }
     }
 
+    /// Mandatory blocking test (L4a test A): a non-PLP column followed by a PLP
+    /// column decoded through the buffer-owning `PacketReader` — the reader whose
+    /// sync driver L4a inverts. The refill boundary is swept across every byte
+    /// offset (including the exact non-PLP -> PLP transition and mid-cell splits)
+    /// and every split must decode byte-identically to the single-packet
+    /// baseline. This proves the inverted sync step consumes the non-PLP cell
+    /// atomically and hands off to the async PLP path with a coherent shared
+    /// cursor, regardless of where the packet boundary lands.
+    #[tokio::test]
+    async fn nonplp_to_plp_transition_is_byte_identical_across_refill_boundary() {
+        use crate::datatypes::column_values::ColumnValues;
+        use crate::datatypes::row_writer::DefaultRowWriter;
+        use crate::io::packet_reader::PacketReader;
+        use crate::io::packet_reader::tests::{MockNetworkReaderWriter, TestPacketBuilder};
+        use crate::message::messages::PacketType;
+
+        let collation = SqlCollation {
+            info: 0x0409,
+            lcid_language_id: 0x0409,
+            col_flags: 0,
+            sort_id: 52,
+        };
+        let columns = vec![
+            ColumnMetadata {
+                user_type: 0,
+                flags: 0,
+                data_type: TdsDataType::Int4,
+                type_info: TypeInfo::fixed_len(TdsDataType::Int4).unwrap(),
+                column_name: "n".to_string(),
+                multi_part_name: None,
+                crypto_metadata: None,
+            },
+            ColumnMetadata {
+                user_type: 0,
+                flags: 0,
+                data_type: TdsDataType::NVarChar,
+                type_info: TypeInfo::partial_len(TdsDataType::NVarChar, 0xFFFF, Some(collation))
+                    .unwrap(),
+                column_name: "s".to_string(),
+                multi_part_name: None,
+                crypto_metadata: None,
+            },
+        ];
+
+        // ROW payload: [Row token][int4 = 42][nvarchar(max) PLP = "Hi"].
+        let mut payload = vec![TokenType::Row as u8];
+        payload.extend_from_slice(&42_i32.to_le_bytes());
+        payload.extend_from_slice(&0xFFFF_FFFF_FFFF_FFFE_u64.to_le_bytes()); // SQL_PLP_UNKNOWNLEN
+        let hi_utf16 = [0x48u8, 0x00, 0x69, 0x00]; // "Hi"
+        payload.extend_from_slice(&(hi_utf16.len() as u32).to_le_bytes());
+        payload.extend_from_slice(&hi_utf16);
+        payload.extend_from_slice(&0u32.to_le_bytes()); // PLP zero-length terminator
+
+        async fn decode(read_data: Vec<u8>, columns: &[ColumnMetadata]) -> Vec<ColumnValues> {
+            let mut mock = MockNetworkReaderWriter::new(read_data, 0);
+            let mut reader = PacketReader::new(&mut mock);
+            reader.read_tds_packet_for_test().await.unwrap();
+            let context = ParserContext::ColumnMetadata(
+                Arc::new(ColMetadataToken {
+                    column_count: columns.len() as u16,
+                    columns: columns.to_vec(),
+                    cek_table: vec![],
+                }),
+                None,
+            );
+            let registry = GenericTokenParserRegistry::default();
+            let mut writer = DefaultRowWriter::new(columns.len());
+            let result = receive_row_into_internal(&mut reader, &registry, &context, &mut writer)
+                .await
+                .unwrap();
+            assert!(matches!(result, RowReadResult::RowWritten));
+            writer.take_row()
+        }
+
+        fn one_packet(payload: &[u8]) -> Vec<u8> {
+            let mut builder = TestPacketBuilder::new(PacketType::PreLogin);
+            builder.append_bytes(payload).build()
+        }
+        fn two_packets(payload: &[u8], split: usize) -> Vec<u8> {
+            let mut first_builder = TestPacketBuilder::new(PacketType::PreLogin);
+            let mut first = first_builder.append_bytes(&payload[..split]).build();
+            // Clear EOM on the first packet so the buffer keeps reading into the second.
+            first[1] = 0x00;
+            let mut second_builder = TestPacketBuilder::new(PacketType::PreLogin);
+            let second = second_builder.append_bytes(&payload[split..]).build();
+            [first, second].concat()
+        }
+
+        let wire = one_packet(&payload);
+        let baseline = decode(wire, &columns).await;
+        assert_eq!(baseline.len(), 2);
+        assert_eq!(baseline[0], ColumnValues::Int(42));
+        assert_ne!(baseline[1], ColumnValues::Null);
+
+        // Sweep the refill boundary across every interior byte offset. Offset 5
+        // is the exact non-PLP -> PLP transition (token + int4); others land
+        // mid-int4 and mid-PLP-chunk. All must match the single-packet decode.
+        for split in 1..payload.len() {
+            let got = decode(two_packets(&payload, split), &columns).await;
+            assert_eq!(
+                got, baseline,
+                "row decode diverged when the refill boundary landed at offset {split}"
+            );
+        }
+    }
+
     struct MockTokenParserRegistry {
         parsers: HashMap<TokenType, TokenParsers>,
     }

--- a/mssql-tds/src/io/token_stream.rs
+++ b/mssql-tds/src/io/token_stream.rs
@@ -1431,6 +1431,124 @@ mod tests {
         }
     }
 
+    /// Mandatory blocking test (L4a hybrid mid-row seam): a row that MIXES two
+    /// inverted non-PLP cells (fixed-width `int4` + variable-length `varchar`,
+    /// both driven by the new sync `step()`) followed by a not-yet-inverted PLP
+    /// `nvarchar(max)` cell (legacy async `decode_into`), all in ONE row. The
+    /// refill boundary is swept across every interior byte offset — including
+    /// the `int4 -> varchar` seam, inside the varchar's 2-byte USHORT length
+    /// prefix (peek-only re-drive), and the higher-risk `varchar -> PLP` seam
+    /// where an inverted cell hands off to the async path. Every split must
+    /// decode byte-identically to the single-packet baseline, proving the
+    /// inverted step and the async PLP path share ONE coherent row cursor
+    /// (`next_column_index`) no matter where the packet boundary lands.
+    #[tokio::test]
+    async fn mixed_row_inverted_then_plp_is_byte_identical_across_refill_boundary() {
+        use crate::datatypes::column_values::ColumnValues;
+        use crate::datatypes::row_writer::DefaultRowWriter;
+        use crate::io::packet_reader::PacketReader;
+        use crate::io::packet_reader::tests::{MockNetworkReaderWriter, TestPacketBuilder};
+        use crate::message::messages::PacketType;
+
+        let collation = SqlCollation {
+            info: 0x0409,
+            lcid_language_id: 0x0409,
+            col_flags: 0,
+            sort_id: 52,
+        };
+        let columns = vec![
+            ColumnMetadata {
+                user_type: 0,
+                flags: 0,
+                data_type: TdsDataType::Int4,
+                type_info: TypeInfo::fixed_len(TdsDataType::Int4).unwrap(),
+                column_name: "n".to_string(),
+                multi_part_name: None,
+                crypto_metadata: None,
+            },
+            ColumnMetadata {
+                user_type: 0,
+                flags: 0,
+                data_type: TdsDataType::BigVarChar,
+                type_info: TypeInfo::var_len_string(TdsDataType::BigVarChar, 64, Some(collation))
+                    .unwrap(),
+                column_name: "v".to_string(),
+                multi_part_name: None,
+                crypto_metadata: None,
+            },
+            ColumnMetadata {
+                user_type: 0,
+                flags: 0,
+                data_type: TdsDataType::NVarChar,
+                type_info: TypeInfo::partial_len(TdsDataType::NVarChar, 0xFFFF, Some(collation))
+                    .unwrap(),
+                column_name: "s".to_string(),
+                multi_part_name: None,
+                crypto_metadata: None,
+            },
+        ];
+
+        // ROW payload: [Row token][int4 = 42][varchar "ab"][nvarchar(max) PLP "Hi"].
+        let mut payload = vec![TokenType::Row as u8];
+        payload.extend_from_slice(&42_i32.to_le_bytes());
+        let ab = [0x61u8, 0x62]; // "ab"
+        payload.extend_from_slice(&(ab.len() as u16).to_le_bytes()); // USHORT length prefix
+        payload.extend_from_slice(&ab);
+        payload.extend_from_slice(&0xFFFF_FFFF_FFFF_FFFE_u64.to_le_bytes()); // SQL_PLP_UNKNOWNLEN
+        let hi_utf16 = [0x48u8, 0x00, 0x69, 0x00]; // "Hi"
+        payload.extend_from_slice(&(hi_utf16.len() as u32).to_le_bytes());
+        payload.extend_from_slice(&hi_utf16);
+        payload.extend_from_slice(&0u32.to_le_bytes()); // PLP zero-length terminator
+
+        async fn decode(read_data: Vec<u8>, columns: &[ColumnMetadata]) -> Vec<ColumnValues> {
+            let mut mock = MockNetworkReaderWriter::new(read_data, 0);
+            let mut reader = PacketReader::new(&mut mock);
+            reader.read_tds_packet_for_test().await.unwrap();
+            let context = ParserContext::ColumnMetadata(
+                Arc::new(ColMetadataToken {
+                    column_count: columns.len() as u16,
+                    columns: columns.to_vec(),
+                    cek_table: vec![],
+                }),
+                None,
+            );
+            let registry = GenericTokenParserRegistry::default();
+            let mut writer = DefaultRowWriter::new(columns.len());
+            let result = receive_row_into_internal(&mut reader, &registry, &context, &mut writer)
+                .await
+                .unwrap();
+            assert!(matches!(result, RowReadResult::RowWritten));
+            writer.take_row()
+        }
+
+        fn one_packet(payload: &[u8]) -> Vec<u8> {
+            let mut builder = TestPacketBuilder::new(PacketType::PreLogin);
+            builder.append_bytes(payload).build()
+        }
+        fn two_packets(payload: &[u8], split: usize) -> Vec<u8> {
+            let mut first_builder = TestPacketBuilder::new(PacketType::PreLogin);
+            let mut first = first_builder.append_bytes(&payload[..split]).build();
+            first[1] = 0x00; // clear EOM so the buffer keeps reading into the second packet
+            let mut second_builder = TestPacketBuilder::new(PacketType::PreLogin);
+            let second = second_builder.append_bytes(&payload[split..]).build();
+            [first, second].concat()
+        }
+
+        let baseline = decode(one_packet(&payload), &columns).await;
+        assert_eq!(baseline.len(), 3);
+        assert_eq!(baseline[0], ColumnValues::Int(42));
+        assert_ne!(baseline[1], ColumnValues::Null); // varchar "ab"
+        assert_ne!(baseline[2], ColumnValues::Null); // nvarchar(max) "Hi"
+
+        for split in 1..payload.len() {
+            let got = decode(two_packets(&payload, split), &columns).await;
+            assert_eq!(
+                got, baseline,
+                "mixed row decode diverged when the refill boundary landed at offset {split}"
+            );
+        }
+    }
+
     struct MockTokenParserRegistry {
         parsers: HashMap<TokenType, TokenParsers>,
     }

--- a/mssql-tds/src/io/token_stream.rs
+++ b/mssql-tds/src/io/token_stream.rs
@@ -469,13 +469,34 @@ async fn decode_or_decrypt_column<R: TdsPacketReader + Send + Sync>(
                  (Always Encrypted disabled for this command, or no key-store \
                  provider registered); returning the raw ciphertext varbinary"
             );
-            decoder.decode_into(reader, meta, col, writer).await?;
+            decode_non_plp_column(decoder, reader, meta, col, writer).await?;
         }
         (false, _) => {
-            decoder.decode_into(reader, meta, col, writer).await?;
+            decode_non_plp_column(decoder, reader, meta, col, writer).await?;
         }
     }
     Ok(())
+}
+
+/// Decodes a single non-encrypted, non-PLP-or-PLP column.
+///
+/// Routes cells whose type is owned by the synchronous column-atomic path
+/// (`sync_decoder::is_supported`) through `reader.decode_column_into`, which
+/// lifts the `.await` out of the middle of the cell to the column boundary.
+/// PLP cells and not-yet-ported types fall back to the legacy async
+/// `decode_into`, preserving byte-identical decoding.
+async fn decode_non_plp_column<R: TdsPacketReader + Send + Sync>(
+    decoder: &GenericDecoder,
+    reader: &mut R,
+    meta: &ColumnMetadata,
+    col: usize,
+    writer: &mut (dyn RowWriter + Send),
+) -> TdsResult<()> {
+    if crate::datatypes::sync_decoder::is_supported(meta) {
+        reader.decode_column_into(meta, col, writer).await
+    } else {
+        decoder.decode_into(reader, meta, col, writer).await
+    }
 }
 
 pub(crate) async fn receive_row_into_internal<R: TdsPacketReader + Send + Sync>(


### PR DESCRIPTION
> ⚠️ **Perf-neutral layer.** Part 4 of the green-at-every-step sans-I/O stack. Base: `dev/saurabh/sans-io-l3-token-decoder` (#194). Public API is unchanged; `mssql-odbc` and `mssql-py-core` build unchanged.

## Description

Inverts the **entire non-PLP column decode path** into a column-atomic, re-drivable synchronous `step()`, moving the `.await` refill point out of the middle of a column to the **column boundary**. This removes the last class of mid-value suspension in the row decode path (the risk L2's `NeedBytes` + L3's sync token decode were built to eliminate) without introducing any new resumable state machine — `RowPauseState.next_column_index` remains the only resume granularity and `NeedBytes { shortfall }` the only suspension signal.

### What this lands (6 commits, green at each)

- **`edc7aa83`** — invert non-PLP fixed-width column decode to a column-atomic `step()` over `column_wire_len` (peek) + whole-cell `ensure` + `decode_column_body` (infallible `take_*`).
- **`50dae22d`** — extend the step to variable-length non-PLP cells (`char`/`varchar`/`nchar`/`nvarchar` non-max, `binary`/`varbinary` non-max, `decimal`/`numeric`).
- **`952db191`** — extend the step to `SQL_VARIANT` cells.
- **`0d5e9619`** — converge the async row decoder onto the **single** shared `decode_column_body` so no non-PLP leaf logic is duplicated between `decoder.rs` and `sync_decoder.rs`.
- **`ca80c4ab`** — fold the Always-Encrypted non-PLP ciphertext whole-cell buffer into the sync step.
- **`1d46dd27`** — mandatory refill-boundary tests (below).

### Design

`decode_or_decrypt_column` owns buffering for **all** non-PLP cells, so it is inverted as one unit — there is no fixed-width-only seam inside it, and a partial inversion would fork it into a half-sync/half-async mid-column path. Per column the driver runs: `column_wire_len` (peek-only length) → `ensure(total)` (whole cell) → `decode_column_body` (pure sync, exactly one `write_*`). Because steps 1–2 only peek, a `NeedBytes` re-drive after refill re-runs from the column start with nothing consumed and nothing written → atomic.

`decode_column_body` (+ `column_wire_len` + the sync leaf ports) has **exactly one definition** in `sync_decoder.rs`; two refill drivers (sync `PacketReader`, async `GenericDecoder::decode_into`) wrap it and differ only by the `.await` on refill.

### Out of scope (unchanged)

- **PLP/LOB streaming** (`PlpColumnStream` / `PlpChunkStreamReader`, incl. AE over `varbinary(max)`) — L4b, behind the existing pause branch.
- **NBCROW body** — L4c; the sync step is written so it can be reused verbatim there.

### Tests

Five mandatory boundary tests drive the buffer-owning test `PacketReader`, so they genuinely exercise `decode_column_body`:

1. **non-PLP → PLP transition at every refill boundary** (`nonplp_to_plp_transition_is_byte_identical_across_refill_boundary`) — a `[int4][nvarchar(max) PLP]` row swept with the packet boundary at each interior offset; the inverted step fully consumes the int4, then the PLP column resumes byte-identically across every split.
2. **mid-cell re-drive** (`var_length_cell_redrive_is_byte_identical_across_refill_boundary`) of an inverted var-length cell, including inside the 2-byte length prefix (peek-only re-drive) and mid-data.
3. **hybrid mid-row seam** (`mixed_row_inverted_then_plp_is_byte_identical_across_refill_boundary`) — a `[int4][varchar][nvarchar(max) PLP]` row that mixes two inverted non-PLP cells with a not-yet-inverted (legacy async) PLP cell in ONE row, swept across every offset (int4→varchar seam, inside the varchar length prefix, and the varchar→PLP handoff). Proves the inverted step and the async PLP path share one coherent row cursor (`next_column_index`) regardless of where the packet boundary lands — the L4a→L4b hybrid-window correctness guarantee.
4. **exact whole-column non-PLP → PLP transition** (`refill_boundary_at_nonplp_to_plp_column_transition_resumes_into_async_plp`) — same `[int4][varchar][nvarchar(max) PLP]` row, but the packet boundary is forced to land **exactly** at the varchar→PLP column transition: the inverted step fully consumes the varchar cell, `ensure` on the PLP column's first bytes returns `NeedBytes`, refill happens, and the still-async PLP path resumes at `next_column_index`. Asserts byte-identical to the single-packet baseline — the precise whole-column seam the hybrid window depends on.
5. **inverted var-length cell own re-drive** (`refill_boundary_within_inverted_varchar_cell_resumes_coherently`) — the boundary is swept **inside** the inverted varchar cell (within its 2-byte length prefix and mid-data), proving the inverted step's own re-drive from the column start is coherent independent of the PLP handoff.

Making these meaningful required fixing the test `PacketReader` to be faithful to the production transport: `receive_packet` now validates the header length, returns the single packet's length, and carries surplus bytes forward via `record_pending` (previously it returned the raw coalesced byte count and stripped only the first header). `TestPacketBuilder` now writes the TDS **total** length (header + payload) into the header field, matching the production serializer and `validate_packet_length`.

## Related Issues

N/A — internal sans-I/O refactor, no tracking issue (consistent with #189/#191/#194).

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes (lib green; failing-name set byte-for-byte identical to base = 359 pre-existing env/cert failures)
- [x] New/changed functionality has tests
- [x] Public API changes are documented (no public API change)
