### PR TITLE
Sans-I/O TDS core (4b/N): invert PLP/LOB column streaming to the sync core

### DIFF
--- a/mssql-tds/src/connection/transport/network_transport.rs
+++ b/mssql-tds/src/connection/transport/network_transport.rs
@@ -1115,6 +1115,30 @@ impl TdsPacketReader for NetworkTransport {
         }
     }
 
+    async fn collect_plp_bytes(&mut self) -> TdsResult<Option<Vec<u8>>> {
+        use crate::datatypes::decoder::PlpChunkStreamReader;
+        use crate::datatypes::sync_decoder::{PlpProgress, plp_collect_step};
+
+        // Sync PLP driver over the owned read buffer: classify the 8-byte header,
+        // then pull one chunk header / body slice at a time. Residency stays
+        // bounded to ~one packet — the whole value is never ensured into the
+        // buffer. Refill is lifted to `ensure_or_refill`.
+        self.ensure_or_refill(8).await?;
+        let raw = self.tds_read_buffer.take_i64_le()?;
+        let mut plp = match PlpChunkStreamReader::classify_length(raw)? {
+            None => return Ok(None),
+            Some(len) => PlpChunkStreamReader::new(len),
+        };
+
+        let mut out = Vec::new();
+        loop {
+            match plp_collect_step(&mut plp, &mut self.tds_read_buffer, &mut out)? {
+                PlpProgress::Done => return Ok(Some(out)),
+                PlpProgress::NeedMore(n) => self.ensure_or_refill(n).await?,
+            }
+        }
+    }
+
     async fn read_byte(&mut self) -> TdsResult<u8> {
         self.ensure_or_refill(1).await?;
         self.tds_read_buffer.take_u8()

--- a/mssql-tds/src/datatypes/decoder.rs
+++ b/mssql-tds/src/datatypes/decoder.rs
@@ -197,7 +197,7 @@ pub(crate) struct PlpChunkStreamReader {
 
 #[cfg_attr(not(test), allow(dead_code))]
 impl PlpChunkStreamReader {
-    fn new(length: PlpChunkReadLength) -> Self {
+    pub(crate) fn new(length: PlpChunkReadLength) -> Self {
         Self {
             length,
             chunk_remaining: 0,
@@ -211,6 +211,18 @@ impl PlpChunkStreamReader {
         reader: &mut (dyn TdsPacketReader + Send + Sync),
     ) -> TdsResult<Option<Self>> {
         let raw_len_i64 = reader.read_int64().await?;
+        Ok(Self::classify_length(raw_len_i64)?.map(Self::new))
+    }
+
+    /// Classifies the 8-byte PLP length/sentinel header (already read) into a
+    /// [`PlpChunkReadLength`], or `None` for the SQL NULL sentinel.
+    ///
+    /// Byte-source-agnostic leaf shared by both refill drivers: the async
+    /// [`begin`](Self::begin) (over `read_int64().await`) and the synchronous
+    /// PLP driver (over `PacketBuffer::take_i64_le`). Keeping the sentinel and
+    /// declared-length validation here is what stops the framing from drifting
+    /// between the two drivers.
+    pub(crate) fn classify_length(raw_len_i64: i64) -> TdsResult<Option<PlpChunkReadLength>> {
         let raw_len = raw_len_i64 as u64;
         let raw_len_usize = raw_len as usize;
 
@@ -218,21 +230,19 @@ impl PlpChunkStreamReader {
             return Ok(None);
         }
 
-        let length = if raw_len_usize == GenericDecoder::SQL_PLP_UNKNOWNLEN
+        if raw_len_usize == GenericDecoder::SQL_PLP_UNKNOWNLEN
             || raw_len_usize == GenericDecoder::SQL_PLP_MAXLEN
         {
-            PlpChunkReadLength::Unknown
-        } else {
-            let declared_len = raw_len as usize;
-            if raw_len_i64 < 0 || declared_len > MAX_PLP_SIZE {
-                return Err(crate::error::Error::ProtocolError(format!(
-                    "PLP length {declared_len} (raw i64: {raw_len_i64}) exceeds maximum allowed size of {MAX_PLP_SIZE} bytes"
-                )));
-            }
-            PlpChunkReadLength::Known(raw_len)
-        };
+            return Ok(Some(PlpChunkReadLength::Unknown));
+        }
 
-        Ok(Some(Self::new(length)))
+        let declared_len = raw_len as usize;
+        if raw_len_i64 < 0 || declared_len > MAX_PLP_SIZE {
+            return Err(crate::error::Error::ProtocolError(format!(
+                "PLP length {declared_len} (raw i64: {raw_len_i64}) exceeds maximum allowed size of {MAX_PLP_SIZE} bytes"
+            )));
+        }
+        Ok(Some(PlpChunkReadLength::Known(raw_len)))
     }
 
     pub(crate) fn total_read(&self) -> usize {
@@ -243,19 +253,21 @@ impl PlpChunkStreamReader {
         self.reached_end
     }
 
-    async fn ensure_active_chunk(
-        &mut self,
-        reader: &mut (dyn TdsPacketReader + Send + Sync),
-    ) -> TdsResult<bool> {
-        if self.reached_end {
-            return Ok(false);
-        }
+    /// Bytes still owed in the current chunk before its header must be re-read.
+    pub(crate) fn chunk_remaining(&self) -> usize {
+        self.chunk_remaining
+    }
 
-        if self.chunk_remaining > 0 {
-            return Ok(true);
-        }
-
-        let chunk_len = reader.read_uint32().await? as usize;
+    /// Applies a just-read 4-byte chunk-length prefix to the stream state.
+    ///
+    /// Byte-source-agnostic leaf shared by both refill drivers: the async
+    /// [`ensure_active_chunk`](Self::ensure_active_chunk) and the synchronous
+    /// PLP driver both read the raw `u32` their own way, then converge here for
+    /// the terminator handling and every guard (chunk count, chunk size,
+    /// accumulation overflow, `MAX_PLP_SIZE`, declared-length checks). Returns
+    /// `Ok(false)` for the zero-length terminator (marking the stream ended) and
+    /// `Ok(true)` once a non-empty chunk is armed.
+    pub(crate) fn on_chunk_header(&mut self, chunk_len: usize) -> TdsResult<bool> {
         if chunk_len == 0 {
             self.reached_end = true;
             if let PlpChunkReadLength::Known(known_len) = self.length
@@ -310,6 +322,30 @@ impl PlpChunkStreamReader {
         Ok(true)
     }
 
+    /// Advances the cursors after `n` payload bytes were copied out of the
+    /// current chunk. Shared leaf: both drivers pull chunk bytes their own way
+    /// (`read_bytes().await` vs `PacketBuffer::copy_out`) and account here.
+    pub(crate) fn note_read(&mut self, n: usize) {
+        self.chunk_remaining -= n;
+        self.total_read += n;
+    }
+
+    async fn ensure_active_chunk(
+        &mut self,
+        reader: &mut (dyn TdsPacketReader + Send + Sync),
+    ) -> TdsResult<bool> {
+        if self.reached_end {
+            return Ok(false);
+        }
+
+        if self.chunk_remaining > 0 {
+            return Ok(true);
+        }
+
+        let chunk_len = reader.read_uint32().await? as usize;
+        self.on_chunk_header(chunk_len)
+    }
+
     pub(crate) async fn read_into(
         &mut self,
         reader: &mut (dyn TdsPacketReader + Send + Sync),
@@ -338,8 +374,7 @@ impl PlpChunkStreamReader {
                 ));
             }
 
-            self.chunk_remaining -= bytes_read;
-            self.total_read += bytes_read;
+            self.note_read(bytes_read);
             written += bytes_read;
         }
 
@@ -358,9 +393,9 @@ impl PlpChunkStreamReader {
     ) -> TdsResult<()> {
         while self.ensure_active_chunk(reader).await? {
             if self.chunk_remaining > 0 {
-                reader.skip_bytes(self.chunk_remaining).await?;
-                self.total_read += self.chunk_remaining;
-                self.chunk_remaining = 0;
+                let n = self.chunk_remaining;
+                reader.skip_bytes(n).await?;
+                self.note_read(n);
             }
         }
         Ok(())
@@ -996,7 +1031,7 @@ impl GenericDecoder {
     /// size guards live in [`PlpChunkStreamReader`], so this stays a thin
     /// accumulation loop over the shared streaming reader instead of a second
     /// copy of the chunk-decoding logic.
-    async fn collect_plp<T>(reader: &mut T) -> TdsResult<Option<Vec<u8>>>
+    pub(crate) async fn collect_plp<T>(reader: &mut T) -> TdsResult<Option<Vec<u8>>>
     where
         T: TdsPacketReader + Send + Sync,
     {
@@ -1058,7 +1093,7 @@ impl GenericDecoder {
             }
 
             // === PLP binary (varbinary(max)); non-PLP binary uses the sync path. ===
-            TdsDataType::BigVarBinary => match GenericDecoder::collect_plp(reader).await? {
+            TdsDataType::BigVarBinary => match reader.collect_plp_bytes().await? {
                 Some(bytes) => writer.write_bytes(col, bytes),
                 None => writer.write_null(col),
             },
@@ -1171,7 +1206,7 @@ impl SqlTypeDecode for GenericDecoder {
             }
             TdsDataType::BigVarBinary => {
                 if metadata.is_plp() {
-                    let some_bytes = GenericDecoder::collect_plp(reader).await?;
+                    let some_bytes = reader.collect_plp_bytes().await?;
                     match some_bytes {
                         Some(bytes) => ColumnValues::Bytes(bytes),
                         None => ColumnValues::Null,
@@ -1199,7 +1234,7 @@ impl SqlTypeDecode for GenericDecoder {
                         "XML column metadata is not partially-length-prefixed".to_string(),
                     ));
                 }
-                let some_bytes = GenericDecoder::collect_plp(reader).await?;
+                let some_bytes = reader.collect_plp_bytes().await?;
                 match some_bytes {
                     Some(bytes) => ColumnValues::Xml(SqlXml { bytes }),
                     None => ColumnValues::Null,
@@ -1211,7 +1246,7 @@ impl SqlTypeDecode for GenericDecoder {
                         "JSON column metadata is not partially-length-prefixed".to_string(),
                     ));
                 }
-                let some_bytes = GenericDecoder::collect_plp(reader).await?;
+                let some_bytes = reader.collect_plp_bytes().await?;
                 match some_bytes {
                     Some(bytes) => ColumnValues::Json(SqlJson::new(bytes)),
                     None => ColumnValues::Null,
@@ -1350,7 +1385,7 @@ impl SqlTypeDecode for GenericDecoder {
                         "UDT column metadata is not partially-length-prefixed".to_string(),
                     ));
                 }
-                let some_bytes = GenericDecoder::collect_plp(reader).await?;
+                let some_bytes = reader.collect_plp_bytes().await?;
                 match some_bytes {
                     Some(bytes) => ColumnValues::Bytes(bytes),
                     None => ColumnValues::Null,
@@ -1419,7 +1454,7 @@ impl StringDecoder {
         let encoding_type = get_encoding_type(metadata);
 
         if metadata.is_plp() {
-            match GenericDecoder::collect_plp(reader).await? {
+            match reader.collect_plp_bytes().await? {
                 Some(bytes) => writer.write_string(col, SqlString::new(bytes, encoding_type)),
                 None => writer.write_null(col),
             }
@@ -1474,7 +1509,7 @@ impl SqlTypeDecode for StringDecoder {
 
         // If Plp Column. (BIGVARCHARTYPE, BIGVARBINARYTYPE, NVARCHARTYPE with md.length == ushort.max)
         if metadata.is_plp() {
-            let some_bytes = GenericDecoder::collect_plp(reader).await?;
+            let some_bytes = reader.collect_plp_bytes().await?;
             match some_bytes {
                 Some(bytes) => Ok(ColumnValues::String(SqlString::new(bytes, encoding_type))),
                 None => Ok(ColumnValues::Null),

--- a/mssql-tds/src/datatypes/sync_decoder.rs
+++ b/mssql-tds/src/datatypes/sync_decoder.rs
@@ -19,7 +19,7 @@ use crate::datatypes::column_values::{
     ColumnValues, SqlDate, SqlDateTime, SqlDateTime2, SqlDateTimeOffset, SqlMoney,
     SqlSmallDateTime, SqlSmallMoney, SqlTime,
 };
-use crate::datatypes::decoder::{DecimalParts, MAX_ALLOC_SIZE};
+use crate::datatypes::decoder::{DecimalParts, MAX_ALLOC_SIZE, PlpChunkStreamReader};
 use crate::datatypes::row_writer::{RowWriter, write_column_value};
 use crate::datatypes::sql_string::{EncodingType, SqlString, get_encoding_type};
 use crate::datatypes::sqldatatypes::{FixedLengthTypes, TdsDataType, TypeInfoVariant};
@@ -330,6 +330,79 @@ pub(crate) fn decode_column_body(
         }
     }
     Ok(())
+}
+
+/// Outcome of one synchronous PLP collection step.
+pub(crate) enum PlpProgress {
+    /// The zero-length terminator was consumed; the value is fully collected.
+    Done,
+    /// The buffer was exhausted mid-header or mid-chunk. The driver must refill
+    /// at least `shortfall` more bytes and re-drive. All resume state lives in
+    /// the [`PlpChunkStreamReader`], so the re-drive continues exactly where it
+    /// left off with nothing lost.
+    NeedMore(usize),
+}
+
+/// Drains currently-buffered PLP bytes into `out`, advancing the resumable
+/// [`PlpChunkStreamReader`] one chunk at a time.
+///
+/// This is the synchronous refill-driver counterpart to the async
+/// [`PlpChunkStreamReader::read_into`] loop: it pulls bytes from an owned
+/// [`PacketBuffer`] via `take_*`/`copy_out` instead of `read_*().await`, sharing
+/// the exact framing leaves ([`PlpChunkStreamReader::on_chunk_header`],
+/// [`PlpChunkStreamReader::note_read`]) so no chunk-decoding logic is duplicated.
+///
+/// The atomic unit is the **chunk**: this `ensure`s only a 4-byte chunk-length
+/// prefix or a slice of the current chunk body — **never the whole value** — so
+/// `PacketBuffer` residency stays bounded to ~one packet regardless of total
+/// value size (a `varchar(max)` may be multi-GB). The chunk boundary is the
+/// natural yield point for a future streamed-LOB byte-budget cap (p7); L4b
+/// leaves the boundary visible but builds no budget policy.
+///
+/// Protocol/guard violations surface via `?` from the shared leaves. `out`
+/// accumulates the whole value (unchanged eager-collect behavior); only *where*
+/// the wire bytes are pulled changes.
+pub(crate) fn plp_collect_step(
+    plp: &mut PlpChunkStreamReader,
+    buf: &mut PacketBuffer,
+    out: &mut Vec<u8>,
+) -> TdsResult<PlpProgress> {
+    loop {
+        if plp.reached_end() {
+            return Ok(PlpProgress::Done);
+        }
+
+        if plp.chunk_remaining() == 0 {
+            // Need the next 4-byte chunk-length prefix before more body bytes.
+            // `NeedMore` carries the ABSOLUTE header width (not the buffer's
+            // delta shortfall) so the driver's `ensure(4)` refills whenever fewer
+            // than 4 bytes are buffered — including when the prefix straddles a
+            // packet boundary. A delta would let `ensure` no-op and spin.
+            if buf.ensure(4).is_err() {
+                return Ok(PlpProgress::NeedMore(4));
+            }
+            let chunk_len = buf.take_u32_le()? as usize;
+            if !plp.on_chunk_header(chunk_len)? {
+                return Ok(PlpProgress::Done);
+            }
+            continue;
+        }
+
+        let available = buf.available();
+        if available == 0 {
+            // Mid-chunk exhaustion: ask for one more byte. The refill exposes a
+            // whole packet, so residency stays chunk/packet-bounded rather than
+            // ballooning to the whole value.
+            return Ok(PlpProgress::NeedMore(1));
+        }
+
+        let take = plp.chunk_remaining().min(available);
+        let start = out.len();
+        out.resize(start + take, 0);
+        let copied = buf.copy_out(&mut out[start..]);
+        debug_assert_eq!(copied, take, "copy_out drained fewer bytes than available");
+        plp.note_read(copied);
+    }
 }
 
 fn scale_of(meta: &ColumnMetadata, type_name: &str) -> TdsResult<u8> {

--- a/mssql-tds/src/io/packet_reader.rs
+++ b/mssql-tds/src/io/packet_reader.rs
@@ -77,6 +77,21 @@ pub(crate) trait TdsPacketReader {
             cell.extend_from_slice(&extra);
         }
     }
+
+    /// Collects a whole PLP value into one `Vec`, returning `None` for SQL NULL.
+    ///
+    /// The eager PLP counterpart to [`decode_column_into`]. The default runs the
+    /// shared async framing (`GenericDecoder::collect_plp`) for readers that do
+    /// not own a [`PacketBuffer`]; buffer-owning readers override this to drive
+    /// the synchronous chunk-at-a-time PLP core in place. There is a single
+    /// framing body — the override differs only in pulling bytes via `take_*`
+    /// instead of `read_*().await`.
+    async fn collect_plp_bytes(&mut self) -> TdsResult<Option<Vec<u8>>>
+    where
+        Self: Sized + Send + Sync,
+    {
+        crate::datatypes::decoder::GenericDecoder::collect_plp(self).await
+    }
 }
 
 /// Low-level TDS packet reading operations (public under `fuzzing` cfg).
@@ -140,6 +155,21 @@ pub trait TdsPacketReader {
             self.read_bytes(&mut extra).await?;
             cell.extend_from_slice(&extra);
         }
+    }
+
+    /// Collects a whole PLP value into one `Vec`, returning `None` for SQL NULL.
+    ///
+    /// The eager PLP counterpart to [`decode_column_into`]. The default runs the
+    /// shared async framing (`GenericDecoder::collect_plp`) for readers that do
+    /// not own a [`PacketBuffer`]; buffer-owning readers override this to drive
+    /// the synchronous chunk-at-a-time PLP core in place. There is a single
+    /// framing body — the override differs only in pulling bytes via `take_*`
+    /// instead of `read_*().await`.
+    async fn collect_plp_bytes(&mut self) -> TdsResult<Option<Vec<u8>>>
+    where
+        Self: Sized + Send + Sync,
+    {
+        crate::datatypes::decoder::GenericDecoder::collect_plp(self).await
     }
 }
 
@@ -291,6 +321,31 @@ impl TdsPacketReader for PacketReader<'_> {
                     return sync_decoder::decode_column_body(&mut self.buffer, meta, col, writer);
                 }
                 Err(need) => self.ensure(need.shortfall).await?,
+            }
+        }
+    }
+
+    async fn collect_plp_bytes(&mut self) -> TdsResult<Option<Vec<u8>>> {
+        use crate::datatypes::decoder::PlpChunkStreamReader;
+        use crate::datatypes::sync_decoder::{PlpProgress, plp_collect_step};
+
+        // Sync PLP driver over the owned buffer: classify the 8-byte header, then
+        // pull one chunk header / body slice at a time. Residency stays bounded
+        // to ~one packet — the whole (possibly multi-GB) value is never ensured
+        // into the buffer. Refill is lifted to `ensure`, which carries the
+        // forward-progress debug_assert.
+        self.ensure(8).await?;
+        let raw = self.buffer.take_i64_le()?;
+        let mut plp = match PlpChunkStreamReader::classify_length(raw)? {
+            None => return Ok(None),
+            Some(len) => PlpChunkStreamReader::new(len),
+        };
+
+        let mut out = Vec::new();
+        loop {
+            match plp_collect_step(&mut plp, &mut self.buffer, &mut out)? {
+                PlpProgress::Done => return Ok(Some(out)),
+                PlpProgress::NeedMore(n) => self.ensure(n).await?,
             }
         }
     }

--- a/mssql-tds/src/io/token_stream.rs
+++ b/mssql-tds/src/io/token_stream.rs
@@ -1626,6 +1626,366 @@ mod tests {
         }
     }
 
+    /// L4b blocking test 1: a single-chunk PLP `varbinary(max)` value decoded
+    /// through the buffer-owning `PacketReader` — the reader whose sync PLP
+    /// driver L4b inverts. The refill boundary is swept across EVERY interior
+    /// byte offset, including inside the 8-byte PLP length header and inside the
+    /// 4-byte chunk-length prefix, so mid-header, mid-prefix, and mid-chunk-body
+    /// resume are all exercised. Every split must decode byte-identically to the
+    /// single-packet baseline, proving the sync driver resumes exactly from the
+    /// resumable `PlpChunkStreamReader` state after each packet-boundary refill.
+    #[tokio::test]
+    async fn plp_single_chunk_mid_chunk_resume_is_byte_identical_across_refill_boundary() {
+        use crate::datatypes::column_values::ColumnValues;
+        use crate::datatypes::row_writer::DefaultRowWriter;
+        use crate::io::packet_reader::PacketReader;
+        use crate::io::packet_reader::tests::{MockNetworkReaderWriter, TestPacketBuilder};
+        use crate::message::messages::PacketType;
+
+        let columns = vec![plp_varbinary_metadata("v", None)];
+
+        // ROW payload: [Row token][varbinary(max) PLP: UNKNOWNLEN, one 12-byte
+        // chunk, zero-length terminator].
+        let body: Vec<u8> = (0u8..12).collect();
+        let mut payload = vec![TokenType::Row as u8];
+        payload.extend_from_slice(&0xFFFF_FFFF_FFFF_FFFE_u64.to_le_bytes()); // SQL_PLP_UNKNOWNLEN
+        payload.extend_from_slice(&(body.len() as u32).to_le_bytes());
+        payload.extend_from_slice(&body);
+        payload.extend_from_slice(&0u32.to_le_bytes()); // zero-length terminator
+
+        async fn decode(read_data: Vec<u8>, columns: &[ColumnMetadata]) -> Vec<ColumnValues> {
+            let mut mock = MockNetworkReaderWriter::new(read_data, 0);
+            let mut reader = PacketReader::new(&mut mock);
+            reader.read_tds_packet_for_test().await.unwrap();
+            let context = ParserContext::ColumnMetadata(
+                Arc::new(ColMetadataToken {
+                    column_count: columns.len() as u16,
+                    columns: columns.to_vec(),
+                    cek_table: vec![],
+                }),
+                None,
+            );
+            let registry = GenericTokenParserRegistry::default();
+            let mut writer = DefaultRowWriter::new(columns.len());
+            let result = receive_row_into_internal(&mut reader, &registry, &context, &mut writer)
+                .await
+                .unwrap();
+            assert!(matches!(result, RowReadResult::RowWritten));
+            writer.take_row()
+        }
+
+        fn one_packet(payload: &[u8]) -> Vec<u8> {
+            let mut builder = TestPacketBuilder::new(PacketType::PreLogin);
+            builder.append_bytes(payload).build()
+        }
+        fn two_packets(payload: &[u8], split: usize) -> Vec<u8> {
+            let mut first_builder = TestPacketBuilder::new(PacketType::PreLogin);
+            let mut first = first_builder.append_bytes(&payload[..split]).build();
+            first[1] = 0x00; // clear EOM so the buffer keeps reading into the second packet
+            let mut second_builder = TestPacketBuilder::new(PacketType::PreLogin);
+            let second = second_builder.append_bytes(&payload[split..]).build();
+            [first, second].concat()
+        }
+
+        let baseline = decode(one_packet(&payload), &columns).await;
+        assert_eq!(baseline.len(), 1);
+        assert_ne!(baseline[0], ColumnValues::Null);
+
+        for split in 1..payload.len() {
+            let got = decode(two_packets(&payload, split), &columns).await;
+            assert_eq!(
+                got, baseline,
+                "single-chunk PLP decode diverged when the refill boundary landed at offset {split}"
+            );
+        }
+    }
+
+    /// L4b blocking test 2: a MULTI-chunk PLP `varbinary(max)` value spanning
+    /// MULTIPLE refills, terminating on the zero-length chunk. Two parts:
+    ///
+    /// (a) A small multi-chunk value swept across every interior refill offset —
+    /// boundaries land both BETWEEN chunks and MID-chunk-body — each byte-
+    /// identical to the single-packet baseline.
+    ///
+    /// (b) Residency (req-1): a LARGE multi-chunk value whose total wire size
+    /// exceeds the `PacketReader`'s 2-packet buffer capacity (8192 B) decodes
+    /// byte-identically to the async-default baseline when fed as many packet-
+    /// sized frames. This proves BY CONSTRUCTION that the sync driver keeps
+    /// `PacketBuffer` residency chunk-bounded and never ensures the whole value:
+    /// a whole-value `ensure` on a >8192 B value could never be satisfied by the
+    /// 8192 B buffer and would trip the forward-progress guard, so a successful
+    /// byte-identical decode is only possible with chunk-at-a-time `ensure`.
+    #[tokio::test]
+    async fn plp_multi_chunk_across_refills_is_byte_identical_with_bounded_residency() {
+        use crate::datatypes::column_values::ColumnValues;
+        use crate::datatypes::row_writer::DefaultRowWriter;
+        use crate::io::packet_reader::PacketReader;
+        use crate::io::packet_reader::tests::{MockNetworkReaderWriter, TestPacketBuilder};
+        use crate::message::messages::PacketType;
+
+        let columns = vec![plp_varbinary_metadata("v", None)];
+
+        fn plp_value(chunk_sizes: &[usize]) -> Vec<u8> {
+            let mut plp = Vec::new();
+            plp.extend_from_slice(&0xFFFF_FFFF_FFFF_FFFE_u64.to_le_bytes()); // UNKNOWNLEN
+            let mut counter = 0u8;
+            for &n in chunk_sizes {
+                plp.extend_from_slice(&(n as u32).to_le_bytes());
+                for _ in 0..n {
+                    plp.push(counter);
+                    counter = counter.wrapping_add(1);
+                }
+            }
+            plp.extend_from_slice(&0u32.to_le_bytes()); // zero-length terminator
+            plp
+        }
+
+        // Row from a flat byte stream via the async-default seam (TestByteReader),
+        // exercising the trait's default `collect_plp_bytes` — the reference the
+        // sync driver must match byte-for-byte.
+        async fn decode_async_default(plp: &[u8], columns: &[ColumnMetadata]) -> Vec<ColumnValues> {
+            let mut flat = vec![TokenType::Row as u8];
+            flat.extend_from_slice(plp);
+            let mut reader = TestByteReader::new(flat);
+            let context = ParserContext::ColumnMetadata(
+                Arc::new(ColMetadataToken {
+                    column_count: columns.len() as u16,
+                    columns: columns.to_vec(),
+                    cek_table: vec![],
+                }),
+                None,
+            );
+            let registry = GenericTokenParserRegistry::default();
+            let mut writer = DefaultRowWriter::new(columns.len());
+            let result = receive_row_into_internal(&mut reader, &registry, &context, &mut writer)
+                .await
+                .unwrap();
+            assert!(matches!(result, RowReadResult::RowWritten));
+            writer.take_row()
+        }
+
+        // Row through the buffer-owning PacketReader (sync PLP driver) over a
+        // wire framed into `piece`-sized packets; EOM is set only on the last.
+        async fn decode_framed(
+            plp: &[u8],
+            columns: &[ColumnMetadata],
+            piece: usize,
+        ) -> Vec<ColumnValues> {
+            let mut payload = vec![TokenType::Row as u8];
+            payload.extend_from_slice(plp);
+            let mut wire = Vec::new();
+            let mut offset = 0;
+            while offset < payload.len() {
+                let end = (offset + piece).min(payload.len());
+                let mut builder = TestPacketBuilder::new(PacketType::PreLogin);
+                let mut packet = builder.append_bytes(&payload[offset..end]).build();
+                if end < payload.len() {
+                    packet[1] = 0x00; // clear EOM: more packets follow
+                }
+                wire.extend_from_slice(&packet);
+                offset = end;
+            }
+            let mut mock = MockNetworkReaderWriter::new(wire, 0);
+            let mut reader = PacketReader::new(&mut mock);
+            reader.read_tds_packet_for_test().await.unwrap();
+            let context = ParserContext::ColumnMetadata(
+                Arc::new(ColMetadataToken {
+                    column_count: columns.len() as u16,
+                    columns: columns.to_vec(),
+                    cek_table: vec![],
+                }),
+                None,
+            );
+            let registry = GenericTokenParserRegistry::default();
+            let mut writer = DefaultRowWriter::new(columns.len());
+            let result = receive_row_into_internal(&mut reader, &registry, &context, &mut writer)
+                .await
+                .unwrap();
+            assert!(matches!(result, RowReadResult::RowWritten));
+            writer.take_row()
+        }
+
+        fn one_packet(payload: &[u8]) -> Vec<u8> {
+            let mut builder = TestPacketBuilder::new(PacketType::PreLogin);
+            builder.append_bytes(payload).build()
+        }
+        fn two_packets(payload: &[u8], split: usize) -> Vec<u8> {
+            let mut first_builder = TestPacketBuilder::new(PacketType::PreLogin);
+            let mut first = first_builder.append_bytes(&payload[..split]).build();
+            first[1] = 0x00;
+            let mut second_builder = TestPacketBuilder::new(PacketType::PreLogin);
+            let second = second_builder.append_bytes(&payload[split..]).build();
+            [first, second].concat()
+        }
+        async fn decode_pr(read_data: Vec<u8>, columns: &[ColumnMetadata]) -> Vec<ColumnValues> {
+            let mut mock = MockNetworkReaderWriter::new(read_data, 0);
+            let mut reader = PacketReader::new(&mut mock);
+            reader.read_tds_packet_for_test().await.unwrap();
+            let context = ParserContext::ColumnMetadata(
+                Arc::new(ColMetadataToken {
+                    column_count: columns.len() as u16,
+                    columns: columns.to_vec(),
+                    cek_table: vec![],
+                }),
+                None,
+            );
+            let registry = GenericTokenParserRegistry::default();
+            let mut writer = DefaultRowWriter::new(columns.len());
+            let result = receive_row_into_internal(&mut reader, &registry, &context, &mut writer)
+                .await
+                .unwrap();
+            assert!(matches!(result, RowReadResult::RowWritten));
+            writer.take_row()
+        }
+
+        // (a) Small multi-chunk value: three chunks, boundaries swept everywhere.
+        let small = plp_value(&[5, 7, 3]);
+        let mut small_payload = vec![TokenType::Row as u8];
+        small_payload.extend_from_slice(&small);
+        let baseline = decode_pr(one_packet(&small_payload), &columns).await;
+        assert_eq!(baseline.len(), 1);
+        assert_ne!(baseline[0], ColumnValues::Null);
+        assert_eq!(baseline, decode_async_default(&small, &columns).await);
+        for split in 1..small_payload.len() {
+            let got = decode_pr(two_packets(&small_payload, split), &columns).await;
+            assert_eq!(
+                got, baseline,
+                "multi-chunk PLP decode diverged when the refill boundary landed at offset {split}"
+            );
+        }
+
+        // (b) Large multi-chunk value: total wire far exceeds the 8192 B buffer
+        // capacity, so it can never be whole-resident. Fed as 2000-byte packet
+        // frames; must equal the async-default decode. Success proves the driver
+        // ensures one chunk at a time (bounded residency), never the whole value.
+        let large = plp_value(&[3000, 3000, 3000, 2500]);
+        assert!(
+            large.len() > 8192,
+            "residency value must exceed buffer capacity"
+        );
+        let large_ref = decode_async_default(&large, &columns).await;
+        assert_ne!(large_ref[0], ColumnValues::Null);
+        let large_framed = decode_framed(&large, &columns, 2000).await;
+        assert_eq!(
+            large_framed, large_ref,
+            "large multi-chunk PLP value must decode byte-identically under packet-sized refills"
+        );
+    }
+
+    /// L4b blocking test 3: a fully-synchronous mixed row
+    /// `[int4][varchar][varbinary(max) PLP]` decoded through the buffer-owning
+    /// `PacketReader`. After L4b every cell runs on the sync core: `int4` and
+    /// `varchar` via the L4a non-PLP step, and the `varbinary(max)` PLP cell via
+    /// the L4b sync PLP driver — no async decode remnant in the row. The refill
+    /// boundary is swept across every interior offset (including the
+    /// `varchar -> PLP` seam and inside the PLP header/chunk-prefix), and the
+    /// exact decoded values are asserted against the single-packet baseline,
+    /// proving the whole row is byte-identical no matter where the packet
+    /// boundary lands.
+    #[tokio::test]
+    async fn fully_sync_mixed_row_with_plp_is_byte_identical_across_refill_boundary() {
+        use crate::datatypes::column_values::ColumnValues;
+        use crate::datatypes::row_writer::DefaultRowWriter;
+        use crate::io::packet_reader::PacketReader;
+        use crate::io::packet_reader::tests::{MockNetworkReaderWriter, TestPacketBuilder};
+        use crate::message::messages::PacketType;
+
+        let collation = SqlCollation {
+            info: 0x0409,
+            lcid_language_id: 0x0409,
+            col_flags: 0,
+            sort_id: 52,
+        };
+        let columns = vec![
+            ColumnMetadata {
+                user_type: 0,
+                flags: 0,
+                data_type: TdsDataType::Int4,
+                type_info: TypeInfo::fixed_len(TdsDataType::Int4).unwrap(),
+                column_name: "n".to_string(),
+                multi_part_name: None,
+                crypto_metadata: None,
+            },
+            ColumnMetadata {
+                user_type: 0,
+                flags: 0,
+                data_type: TdsDataType::BigVarChar,
+                type_info: TypeInfo::var_len_string(TdsDataType::BigVarChar, 64, Some(collation))
+                    .unwrap(),
+                column_name: "v".to_string(),
+                multi_part_name: None,
+                crypto_metadata: None,
+            },
+            plp_varbinary_metadata("b", None),
+        ];
+
+        // ROW: [Row][int4 = 7][varchar "ab"][varbinary(max) PLP two chunks].
+        let mut payload = vec![TokenType::Row as u8];
+        payload.extend_from_slice(&7_i32.to_le_bytes());
+        let ab = [0x61u8, 0x62]; // "ab"
+        payload.extend_from_slice(&(ab.len() as u16).to_le_bytes());
+        payload.extend_from_slice(&ab);
+        payload.extend_from_slice(&0xFFFF_FFFF_FFFF_FFFE_u64.to_le_bytes()); // UNKNOWNLEN
+        let c0: [u8; 4] = [0xDE, 0xAD, 0xBE, 0xEF];
+        let c1: [u8; 3] = [0x01, 0x02, 0x03];
+        payload.extend_from_slice(&(c0.len() as u32).to_le_bytes());
+        payload.extend_from_slice(&c0);
+        payload.extend_from_slice(&(c1.len() as u32).to_le_bytes());
+        payload.extend_from_slice(&c1);
+        payload.extend_from_slice(&0u32.to_le_bytes()); // zero-length terminator
+
+        async fn decode(read_data: Vec<u8>, columns: &[ColumnMetadata]) -> Vec<ColumnValues> {
+            let mut mock = MockNetworkReaderWriter::new(read_data, 0);
+            let mut reader = PacketReader::new(&mut mock);
+            reader.read_tds_packet_for_test().await.unwrap();
+            let context = ParserContext::ColumnMetadata(
+                Arc::new(ColMetadataToken {
+                    column_count: columns.len() as u16,
+                    columns: columns.to_vec(),
+                    cek_table: vec![],
+                }),
+                None,
+            );
+            let registry = GenericTokenParserRegistry::default();
+            let mut writer = DefaultRowWriter::new(columns.len());
+            let result = receive_row_into_internal(&mut reader, &registry, &context, &mut writer)
+                .await
+                .unwrap();
+            assert!(matches!(result, RowReadResult::RowWritten));
+            writer.take_row()
+        }
+
+        fn one_packet(payload: &[u8]) -> Vec<u8> {
+            let mut builder = TestPacketBuilder::new(PacketType::PreLogin);
+            builder.append_bytes(payload).build()
+        }
+        fn two_packets(payload: &[u8], split: usize) -> Vec<u8> {
+            let mut first_builder = TestPacketBuilder::new(PacketType::PreLogin);
+            let mut first = first_builder.append_bytes(&payload[..split]).build();
+            first[1] = 0x00;
+            let mut second_builder = TestPacketBuilder::new(PacketType::PreLogin);
+            let second = second_builder.append_bytes(&payload[split..]).build();
+            [first, second].concat()
+        }
+
+        let baseline = decode(one_packet(&payload), &columns).await;
+        assert_eq!(baseline.len(), 3);
+        assert_eq!(baseline[0], ColumnValues::Int(7));
+        assert_ne!(baseline[1], ColumnValues::Null);
+        assert_eq!(
+            baseline[2],
+            ColumnValues::Bytes(vec![0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03])
+        );
+
+        for split in 1..payload.len() {
+            let got = decode(two_packets(&payload, split), &columns).await;
+            assert_eq!(
+                got, baseline,
+                "fully-sync mixed row diverged when the refill boundary landed at offset {split}"
+            );
+        }
+    }
+
     struct MockTokenParserRegistry {
         parsers: HashMap<TokenType, TokenParsers>,
     }

--- a/mssql-tds/src/io/token_stream.rs
+++ b/mssql-tds/src/io/token_stream.rs
@@ -464,14 +464,25 @@ async fn decode_or_decrypt_column<R: TdsPacketReader + Send + Sync>(
             if crate::datatypes::sync_decoder::is_supported(meta) {
                 // Non-PLP ciphertext: buffer + decode the cipher cell atomically
                 // via the shared sync step, then run the synchronous cell
-                // decryptor and write the plaintext. PLP ciphertext
-                // (varbinary(max)) falls through to the async path (L4b).
+                // decryptor and write the plaintext.
                 let mut cipher_cell = DefaultRowWriter::new(1);
                 reader.decode_column_into(meta, 0, &mut cipher_cell).await?;
                 let cipher = cipher_cell
                     .take_row()
                     .pop()
                     .unwrap_or(crate::datatypes::column_values::ColumnValues::Null);
+                let value = decrypt_cipher_value(meta, dec, cipher)?;
+                write_column_value(writer, col, value);
+            } else if meta.is_plp() {
+                // PLP ciphertext (varbinary(max)): collect the whole ciphertext
+                // via the sync PLP core, then run the synchronous decryptor.
+                // Whole-value materialization before decrypt is required (AE
+                // needs the full cipher block); only the byte pull is inverted
+                // to the sync buffer, mirroring the non-PLP AE fold above.
+                let cipher = match reader.collect_plp_bytes().await? {
+                    Some(bytes) => crate::datatypes::column_values::ColumnValues::Bytes(bytes),
+                    None => crate::datatypes::column_values::ColumnValues::Null,
+                };
                 let value = decrypt_cipher_value(meta, dec, cipher)?;
                 write_column_value(writer, col, value);
             } else {


### PR DESCRIPTION
## Summary

Layer 4b of the sans-I/O restructure. Inverts the eager PLP/MAX column collect path to run synchronously over the in-memory `PacketBuffer`, reusing the existing `PlpChunkStreamReader` resumable state — **no new state machine**. The async `decode_into` PLP branch and the buffer-driven sync driver converge on **one shared framing body** (two refill drivers differing only by `.await`).

Base: `dev/saurabh/sans-io-l4a-fixed-width-step` (frozen tip `8bddc4fc`).

## Related Issues

N/A — internal sans-I/O refactor, no tracking issue (consistent with #189/#191/#194/#195).

## What changed

- **Factor byte-source-agnostic framing leaves out of `PlpChunkStreamReader`** (`decoder.rs`): `classify_length`, `on_chunk_header`, `note_read`, `chunk_remaining`, `reached_end`, `total_read`. The async `begin`/`ensure_active_chunk`/`read_into` are rewritten to call these leaves — single-copy framing, no drift.
- **Sync PLP driver** (`sync_decoder.rs`): `plp_collect_step` + `PlpProgress` step the `PlpChunkStreamReader` over an owned `PacketBuffer` **one chunk at a time** — `ensure(4)` for a chunk header or a slice of the current chunk body, **never the whole value** — so wire residency stays bounded to ≲ one packet regardless of total value size. `NeedMore` carries the absolute header/body width so refill always makes forward progress across packet-straddling prefixes.
- **Reader seam** (`packet_reader.rs`): `collect_plp_bytes` — async framing default for non-buffer readers, sync driver override on `PacketReader` and `NetworkTransport`. All `GenericDecoder::collect_plp` call sites rewired through the seam; **value arms unchanged** → byte-identical.
- **Always-Encrypted over `varbinary(max)`** (`token_stream.rs`): collect ciphertext via the sync seam then `decrypt_cipher_value`, folding collect+decrypt into the sync path (mirrors L4a's non-PLP AE fold).

## Scope boundary

`text`/`ntext`/`image` are `is_plp() == false` legacy text-pointer LOBs (not the PLP chunk protocol) and stay on the legacy async path, unchanged and byte-identical — consistent with L4a's boundary. (Coordinator-tracked as a separate p4d follow-up.)

## Tests (buffer-driven `PacketReader`)

- `plp_single_chunk_mid_chunk_resume_is_byte_identical_across_refill_boundary` — refill boundary swept across every interior offset incl. inside the 8-byte PLP header and 4-byte chunk-length prefix.
- `plp_multi_chunk_across_refills_is_byte_identical_with_bounded_residency` — multi-chunk to the zero-length terminator + a large value exceeding the 8192-byte buffer capacity decoded under packet-sized refills, proving chunk-bounded residency by construction.
- `fully_sync_mixed_row_with_plp_is_byte_identical_across_refill_boundary` — `[int4][varchar][varbinary(max)]` with every cell on the sync core, exact values asserted across every refill offset.

## Validation

- `cargo btest` (nextest) terminates; FAIL name-set byte-for-byte identical to base (the 7 known cert fixtures).
- `cargo bfmt` + `cargo bclippy` clean; `scripts/bfmt.ps1` + `scripts/bclippy.ps1` clean (mssql-py-core builds).

No PLP framing logic duplicated; no new resumable machine introduced.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
Copilot-Session: e2c378f8-3ba1-4b48-9ebe-5a4ea2bd2761