### PR TITLE
P4a: sync TdsCore row-fetch driver over PacketBuffer

### DIFF
--- a/mssql-tds/src/connection/transport/network_transport.rs
+++ b/mssql-tds/src/connection/transport/network_transport.rs
@@ -19,8 +19,7 @@ use crate::io::packet_writer::PacketWriter;
 use crate::io::reader_writer::{NetworkReader, NetworkReaderWriter, NetworkWriter};
 use crate::io::token_stream::{
     ParserContext, PlpPauseState, RowPauseState, RowReadResult, TdsTokenStreamReader,
-    read_active_plp_bytes_internal, receive_row_into_internal, receive_token_internal,
-    resume_row_into_internal,
+    drive_row_over_buffer, read_active_plp_bytes_internal, receive_token_internal,
 };
 use crate::message::attention::AttentionRequest;
 use crate::message::login_options::TdsVersion;
@@ -1303,6 +1302,24 @@ impl TdsPacketReader for NetworkTransport {
 }
 
 #[async_trait]
+impl crate::io::token_stream::BufferedRowReader for NetworkTransport {
+    fn row_buffer_mut(&mut self) -> &mut crate::io::packet_buffer::PacketBuffer {
+        &mut self.tds_read_buffer
+    }
+
+    async fn refill_row_buffer(&mut self) -> TdsResult<()> {
+        let before = self.tds_read_buffer.available();
+        self.read_tds_packet().await?;
+        if self.tds_read_buffer.available() <= before {
+            return Err(crate::error::Error::ProtocolError(
+                "TDS packet refill made no progress during row decode".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
 impl TdsTokenStreamReader for NetworkTransport {
     async fn receive_token(
         &mut self,
@@ -1345,7 +1362,7 @@ impl TdsTokenStreamReader for NetworkTransport {
     ) -> TdsResult<RowReadResult> {
         let cancellable = Box::pin(CancelHandle::run_until_cancelled(
             cancel_handle,
-            receive_row_into_internal(self, &*PARSER_REGISTRY, context, writer),
+            drive_row_over_buffer(self, &*PARSER_REGISTRY, context, None, writer),
         ));
         let result = match remaining_request_timeout.as_ref() {
             Some(t) => match timeout(*t, cancellable).await {
@@ -1374,9 +1391,18 @@ impl TdsTokenStreamReader for NetworkTransport {
         cancel_handle: Option<&CancelHandle>,
         writer: &mut (dyn RowWriter + Send),
     ) -> TdsResult<RowReadResult> {
+        // The resume path never reads a token/header, so the registry and
+        // context are inert; a `None` context satisfies the shared driver.
+        let resume_context = ParserContext::None(());
         let cancellable = Box::pin(CancelHandle::run_until_cancelled(
             cancel_handle,
-            resume_row_into_internal(self, pause_state, writer),
+            drive_row_over_buffer(
+                self,
+                &*PARSER_REGISTRY,
+                &resume_context,
+                Some(pause_state),
+                writer,
+            ),
         ));
         let result = match remaining_request_timeout.as_ref() {
             Some(t) => match timeout(*t, cancellable).await {

--- a/mssql-tds/src/io.rs
+++ b/mssql-tds/src/io.rs
@@ -28,4 +28,5 @@ pub(crate) mod packet_buffer;
 pub mod packet_reader;
 pub mod packet_writer;
 pub mod reader_writer;
+pub(crate) mod tds_core;
 pub(crate) mod token_stream;

--- a/mssql-tds/src/io/packet_reader.rs
+++ b/mssql-tds/src/io/packet_reader.rs
@@ -9,6 +9,7 @@ use crate::core::TdsResult;
 use crate::datatypes::row_writer::RowWriter;
 use crate::io::packet_buffer::PacketBuffer;
 use crate::io::reader_writer::NetworkReaderWriter;
+use crate::io::token_stream::BufferedRowReader;
 use crate::message::attention::AttentionRequest;
 use crate::message::messages::Request;
 use crate::query::metadata::ColumnMetadata;
@@ -85,6 +86,7 @@ pub(crate) trait TdsPacketReader {
     /// a [`PacketBuffer`]); buffer-owning readers override this to `ensure` the
     /// whole bitmap and take it atomically. Read once at row entry and carried in
     /// `RowPauseState.nbc_null_bitmap` across pauses, so it is never re-read.
+    #[allow(dead_code)]
     async fn read_null_bitmap(&mut self, bitmap_len: usize) -> TdsResult<Vec<u8>> {
         let mut bitmap = vec![0u8; bitmap_len];
         self.read_bytes(&mut bitmap).await?;
@@ -672,6 +674,24 @@ impl TdsPacketReader for Box<dyn TdsPacketReader + Send + Sync> {
 
     async fn read_null_bitmap(&mut self, bitmap_len: usize) -> TdsResult<Vec<u8>> {
         (**self).read_null_bitmap(bitmap_len).await
+    }
+}
+
+#[async_trait]
+impl BufferedRowReader for PacketReader<'_> {
+    fn row_buffer_mut(&mut self) -> &mut PacketBuffer {
+        &mut self.buffer
+    }
+
+    async fn refill_row_buffer(&mut self) -> TdsResult<()> {
+        let before = self.buffer.available();
+        self.read_tds_packet().await?;
+        if self.buffer.available() <= before {
+            return Err(crate::error::Error::ProtocolError(
+                "TDS packet refill made no progress during row decode".to_string(),
+            ));
+        }
+        Ok(())
     }
 }
 

--- a/mssql-tds/src/io/tds_core.rs
+++ b/mssql-tds/src/io/tds_core.rs
@@ -1,0 +1,166 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Pure-synchronous row-fetch parse body (sans-I/O core).
+//!
+//! [`TdsCore::step_row`] owns the single production framing loop for a ROW /
+//! NBCROW token: it consumes the row header atomically, decodes every
+//! synchronously-supported non-PLP cell in place over the [`PacketBuffer`], and
+//! carries its whole-column cursor in the existing [`RowPauseState`]. It never
+//! performs I/O — on buffer underflow it returns [`RowStep::NeedBytes`], and for
+//! any cell whose byte pull still lives in an async seam (eager PLP, PLP
+//! streaming pause, legacy text-pointer LOBs, rare fallback types, or the
+//! Always-Encrypted fallback) it returns [`RowStep::AsyncColumn`].
+//!
+//! The async driver ([`crate::io::token_stream::drive_row_over_buffer`]) is the
+//! only place that awaits: it refills the buffer on `NeedBytes` and services an
+//! `AsyncColumn` through the existing L4 async seam, then re-drives `step_row`
+//! from the shared cursor. The async and sync (future P4c) drivers differ only
+//! in that refill step; the parse body here is shared.
+
+use crate::core::TdsResult;
+use crate::datatypes::row_writer::RowWriter;
+use crate::datatypes::sync_decoder;
+use crate::io::packet_buffer::{NeedBytes, PacketBuffer};
+use crate::io::token_stream::{ParserContext, RowPauseState, extract_row_context};
+use crate::token::tokens::TokenType;
+
+/// Zero-sized owner of the synchronous row-fetch parse body.
+pub(crate) struct TdsCore;
+
+/// Outcome of one synchronous [`TdsCore::step_row`] call.
+pub(crate) enum RowStep {
+    /// The whole row was decoded into the writer.
+    RowWritten,
+    /// The header byte named a non-row token; the async driver dispatches it.
+    Token(TokenType),
+    /// Decoding paused after a column (`RowWriter::pause_after_column`); resume
+    /// from the carried [`RowPauseState`].
+    RowPaused(RowPauseState),
+    /// The cell at `col` must be decoded through the async seam (eager PLP,
+    /// p7 PLP streaming pause, p4d legacy LOBs, rare fallback types, or the AE
+    /// fallback). Its refill stays in the L4b/L4-async seam by design: hoisting
+    /// mid-value LOB state into the sync core would require a new resumable
+    /// machine. The driver services it and re-drives `step_row` at `col + 1`.
+    AsyncColumn { col: usize },
+    /// The buffer underflowed; the driver refills and re-drives with the same
+    /// (unchanged) cursor. Nothing was consumed on this step.
+    NeedBytes(NeedBytes),
+}
+
+/// Result of consuming the row header at row entry.
+enum HeaderStep {
+    Started(RowPauseState),
+    Token(TokenType),
+    NeedBytes(NeedBytes),
+}
+
+impl TdsCore {
+    /// Advances one row-decode step over `buf` without performing I/O.
+    ///
+    /// `resume` is the driver-owned whole-column cursor. On `None` the header is
+    /// consumed atomically and `resume` is set to the fresh cursor; on `Some` the
+    /// header is skipped and decoding continues from `next_column_index`. This
+    /// unifies the fresh-row and resume-from-pause paths into one body.
+    pub(crate) fn step_row(
+        buf: &mut PacketBuffer,
+        resume: &mut Option<RowPauseState>,
+        context: &ParserContext,
+        writer: &mut (dyn RowWriter + Send),
+    ) -> TdsResult<RowStep> {
+        if resume.is_none() {
+            match Self::begin_row_header(buf, context)? {
+                HeaderStep::Started(state) => *resume = Some(state),
+                HeaderStep::Token(token_type) => return Ok(RowStep::Token(token_type)),
+                HeaderStep::NeedBytes(need) => return Ok(RowStep::NeedBytes(need)),
+            }
+        }
+
+        let state = resume.as_mut().expect("row cursor set after header");
+        let len = state.columns.len();
+        loop {
+            let col = state.next_column_index;
+            if col >= len {
+                return Ok(RowStep::RowWritten);
+            }
+
+            let is_null = state
+                .nbc_null_bitmap
+                .as_ref()
+                .map(|bitmap| bitmap[col / 8] & (1 << (col % 8)) != 0)
+                .unwrap_or(false);
+
+            if is_null {
+                writer.write_null(col);
+            } else {
+                let meta = &state.columns[col];
+                if meta.crypto_metadata.is_none() && sync_decoder::is_supported(meta) {
+                    match sync_decoder::column_wire_len(buf, meta) {
+                        Ok(total) => {
+                            if let Err(need) = buf.ensure(total) {
+                                return Ok(RowStep::NeedBytes(need));
+                            }
+                            sync_decoder::decode_column_body(buf, meta, col, writer)?;
+                        }
+                        Err(need) => return Ok(RowStep::NeedBytes(need)),
+                    }
+                } else {
+                    return Ok(RowStep::AsyncColumn { col });
+                }
+            }
+
+            if writer.pause_after_column(col) && col + 1 < len {
+                return Ok(RowStep::RowPaused(state.resume_at(col + 1)));
+            }
+            state.next_column_index = col + 1;
+        }
+    }
+
+    /// Consumes the ROW / NBCROW header as one atomic step.
+    ///
+    /// The header (token byte, plus the fixed-width NBCROW null bitmap) is
+    /// ensured resident before any byte is taken, so a `NeedBytes` shortfall
+    /// leaves the buffer position unchanged and a re-drive re-peeks the same
+    /// token byte. This is what lets the whole-column [`RowPauseState`] cursor be
+    /// the sole resume granularity: the "token consumed, bitmap pending" state
+    /// never exists, so no new resumable machine is needed for the header.
+    fn begin_row_header(buf: &mut PacketBuffer, context: &ParserContext) -> TdsResult<HeaderStep> {
+        let first = match buf.peek_bytes(1) {
+            Some(bytes) => bytes[0],
+            None => return Ok(HeaderStep::NeedBytes(NeedBytes { shortfall: 1 })),
+        };
+        let token_type: TokenType = first.try_into()?;
+
+        match token_type {
+            TokenType::Row => {
+                buf.take_u8()?;
+                let (columns, decryptor) = extract_row_context(context)?;
+                Ok(HeaderStep::Started(RowPauseState {
+                    next_column_index: 0,
+                    columns: columns.to_vec(),
+                    nbc_null_bitmap: None,
+                    decryptor: decryptor.cloned(),
+                }))
+            }
+            TokenType::NbcRow => {
+                let (columns, decryptor) = extract_row_context(context)?;
+                let bitmap_len = columns.len().div_ceil(8);
+                if let Err(need) = buf.ensure(1 + bitmap_len) {
+                    return Ok(HeaderStep::NeedBytes(need));
+                }
+                buf.take_u8()?;
+                let bitmap = buf.take_bytes(bitmap_len)?;
+                Ok(HeaderStep::Started(RowPauseState {
+                    next_column_index: 0,
+                    columns: columns.to_vec(),
+                    nbc_null_bitmap: Some(bitmap),
+                    decryptor: decryptor.cloned(),
+                }))
+            }
+            _ => {
+                buf.take_u8()?;
+                Ok(HeaderStep::Token(token_type))
+            }
+        }
+    }
+}

--- a/mssql-tds/src/io/token_stream.rs
+++ b/mssql-tds/src/io/token_stream.rs
@@ -6,7 +6,9 @@ use crate::datatypes::decoder::{
     GenericDecoder, PlpColumnStream, decrypt_cipher_value, decrypt_encrypted_column,
 };
 use crate::datatypes::row_writer::{DefaultRowWriter, RowWriter, write_column_value};
+use crate::io::packet_buffer::PacketBuffer;
 use crate::io::packet_reader::TdsPacketReader;
+use crate::io::tds_core::{RowStep, TdsCore};
 use crate::query::metadata::ColumnMetadata;
 use crate::security::cell_decryptor::CellDecryptor;
 use crate::token::parsers::TokenParser;
@@ -86,6 +88,20 @@ pub struct RowPauseState {
     pub columns: Vec<ColumnMetadata>,
     pub nbc_null_bitmap: Option<Vec<u8>>,
     pub decryptor: Option<Arc<dyn CellDecryptor>>,
+}
+
+impl RowPauseState {
+    /// Clones this cursor advanced to `next_column_index`, carrying the column
+    /// metadata, NBCROW bitmap, and AE decryptor forward. Mirrors the pause-state
+    /// construction in the async oracle so the resume cursor is byte-identical.
+    pub(crate) fn resume_at(&self, next_column_index: usize) -> RowPauseState {
+        RowPauseState {
+            next_column_index,
+            columns: self.columns.clone(),
+            nbc_null_bitmap: self.nbc_null_bitmap.clone(),
+            decryptor: self.decryptor.clone(),
+        }
+    }
 }
 
 /// Active PLP stream state captured when row decoding is paused at a PLP column.
@@ -253,7 +269,7 @@ impl ParserContext {
     }
 }
 
-fn extract_row_context(context: &ParserContext) -> TdsResult<RowDecodeContext<'_>> {
+pub(crate) fn extract_row_context(context: &ParserContext) -> TdsResult<RowDecodeContext<'_>> {
     match context {
         ParserContext::ColumnMetadata(metadata, decryptor) => {
             Ok((&metadata.columns, decryptor.as_ref()))
@@ -320,7 +336,11 @@ pub(crate) async fn receive_token_internal<R: TdsPacketReader + Send + Sync>(
 
 /// Decodes columns starting at `start_col` for a plain ROW token.
 ///
-/// Shared by both the initial ROW path and the resume-from-pause path.
+/// Test/fuzzing-only reference oracle. Production row decoding runs through the
+/// synchronous [`TdsCore::step_row`] body driven by [`drive_row_over_buffer`];
+/// this async framing is retained only to differentially cross-check that body
+/// (via the buffer-owning `PacketReader` and the bufferless `TestByteReader`).
+#[cfg(any(test, fuzzing))]
 async fn decode_row_columns<R: TdsPacketReader + Send + Sync>(
     reader: &mut R,
     columns: &[ColumnMetadata],
@@ -385,6 +405,9 @@ async fn decode_row_columns<R: TdsPacketReader + Send + Sync>(
 }
 
 /// Decodes columns starting at `start_col` for an NBCROW token.
+///
+/// Test/fuzzing-only reference oracle (see [`decode_row_columns`]).
+#[cfg(any(test, fuzzing))]
 async fn decode_nbcrow_columns<R: TdsPacketReader + Send + Sync>(
     reader: &mut R,
     columns: &[ColumnMetadata],
@@ -527,6 +550,14 @@ async fn decode_non_plp_column<R: TdsPacketReader + Send + Sync>(
     }
 }
 
+/// Test/fuzzing-only reference oracle for a fresh row read.
+///
+/// Production reads run through [`drive_row_over_buffer`] over the synchronous
+/// [`TdsCore::step_row`] body. This async framing is retained to differentially
+/// cross-check that body: it is exercised by the buffer-owning `PacketReader`
+/// tests and the bufferless `TestByteReader` async-default tests, and by the
+/// `fuzzing` token stream reader.
+#[cfg(any(test, fuzzing))]
 pub(crate) async fn receive_row_into_internal<R: TdsPacketReader + Send + Sync>(
     reader: &mut R,
     registry: &impl TokenParserRegistry,
@@ -558,6 +589,10 @@ pub(crate) async fn receive_row_into_internal<R: TdsPacketReader + Send + Sync>(
 /// Resumes a paused row decode from `pause_state.next_column_index`.
 ///
 /// Does not read a token-type byte — the token has already been consumed.
+///
+/// Test/fuzzing-only reference oracle (see [`receive_row_into_internal`]); the
+/// production resume path drives [`TdsCore::step_row`] with a `Some` cursor.
+#[cfg(any(test, fuzzing))]
 pub(crate) async fn resume_row_into_internal<R: TdsPacketReader + Send + Sync>(
     reader: &mut R,
     pause_state: RowPauseState,
@@ -601,6 +636,141 @@ pub(crate) async fn read_active_plp_bytes_internal<R: TdsPacketReader + Send + S
     out: &mut [u8],
 ) -> TdsResult<usize> {
     plp_state.plp_stream.read_into(reader, out).await
+}
+
+/// A [`TdsPacketReader`] that owns its reassembly [`PacketBuffer`], so the sync
+/// [`TdsCore::step_row`] body can decode cells in place and the driver can lift
+/// the sole refill `.await` out to the column boundary.
+#[async_trait]
+pub(crate) trait BufferedRowReader: TdsPacketReader + Send + Sync {
+    /// The owned reassembly buffer that `step_row` decodes over.
+    fn row_buffer_mut(&mut self) -> &mut PacketBuffer;
+
+    /// Pulls one more TDS packet into the buffer, erroring (rather than
+    /// spinning) if the refill exposes no new bytes.
+    async fn refill_row_buffer(&mut self) -> TdsResult<()>;
+}
+
+/// Outcome of servicing one async-seam column via [`decode_async_row_column`].
+enum AsyncColumnOutcome {
+    /// The column was decoded eagerly; continue the row at `col + 1`.
+    Continue,
+    /// The row read terminated (paused or completed) at this column.
+    Terminal(RowReadResult),
+}
+
+/// Decodes one non-null column whose byte pull lives in an async seam.
+///
+/// This reproduces exactly one iteration of the [`decode_row_columns`] /
+/// [`decode_nbcrow_columns`] non-null body: the pre-payload PLP streaming-pause
+/// block (p7) and the eager [`decode_or_decrypt_column`] call (eager PLP, p4d
+/// legacy LOBs, rare fallback types, AE fallback), plus the post-column pause
+/// check. Calling `decode_or_decrypt_column` verbatim keeps the decoded value
+/// and the resume cursor byte-identical to the reference oracle.
+async fn decode_async_row_column<R: BufferedRowReader>(
+    reader: &mut R,
+    state: &RowPauseState,
+    col: usize,
+    writer: &mut (dyn RowWriter + Send),
+) -> TdsResult<AsyncColumnOutcome> {
+    let decoder = GenericDecoder::default();
+    let columns = &state.columns;
+    let meta = &columns[col];
+    let decryptor = state.decryptor.as_ref();
+    let len = columns.len();
+
+    if meta.is_plp() && writer.pause_after_column(col) {
+        // TODO: Add AE-aware PLP streaming path for paused row reads.
+        // Until then, fail fast to avoid streaming ciphertext bytes to callers.
+        if meta.crypto_metadata.is_some() {
+            return Err(crate::error::Error::UnimplementedFeature {
+                feature: "Always Encrypted paused PLP streaming".to_string(),
+                context: format!(
+                    "Encrypted PLP column '{}' cannot be streamed via read_active_plp_bytes yet.",
+                    meta.column_name
+                ),
+            });
+        }
+        match PlpColumnStream::begin(meta, reader).await? {
+            None => {
+                writer.write_null(col);
+                if col + 1 < len {
+                    return Ok(AsyncColumnOutcome::Terminal(RowReadResult::RowPaused(
+                        state.resume_at(col + 1),
+                    )));
+                }
+                return Ok(AsyncColumnOutcome::Terminal(RowReadResult::RowWritten));
+            }
+            Some(plp_stream) => {
+                return Ok(AsyncColumnOutcome::Terminal(RowReadResult::PlpPaused(
+                    PlpPauseState {
+                        row_pause_state: state.resume_at(col + 1),
+                        plp_stream,
+                    },
+                )));
+            }
+        }
+    }
+
+    decode_or_decrypt_column(&decoder, reader, meta, decryptor, col, writer).await?;
+    if writer.pause_after_column(col) && col + 1 < len {
+        return Ok(AsyncColumnOutcome::Terminal(RowReadResult::RowPaused(
+            state.resume_at(col + 1),
+        )));
+    }
+    Ok(AsyncColumnOutcome::Continue)
+}
+
+/// Production row-fetch driver: the single async shell over [`TdsCore::step_row`].
+///
+/// It owns the only `.await` on the row path — refilling the buffer on
+/// [`RowStep::NeedBytes`] and servicing an [`RowStep::AsyncColumn`] through the
+/// existing async seam — then re-drives the sync body from the shared cursor.
+/// `initial_resume` is `None` for a fresh row (the header is consumed) and
+/// `Some` for a resume-from-pause (the header is skipped); `registry` and
+/// `context` are inert on the resume path.
+pub(crate) async fn drive_row_over_buffer<R, Reg>(
+    reader: &mut R,
+    registry: &Reg,
+    context: &ParserContext,
+    initial_resume: Option<RowPauseState>,
+    writer: &mut (dyn RowWriter + Send),
+) -> TdsResult<RowReadResult>
+where
+    R: BufferedRowReader,
+    Reg: TokenParserRegistry,
+{
+    let mut resume = initial_resume;
+    loop {
+        let step = TdsCore::step_row(reader.row_buffer_mut(), &mut resume, context, writer)?;
+        match step {
+            RowStep::RowWritten => return Ok(RowReadResult::RowWritten),
+            RowStep::RowPaused(state) => return Ok(RowReadResult::RowPaused(state)),
+            RowStep::Token(token_type) => {
+                let token = dispatch_token(reader, registry, token_type, context).await?;
+                return Ok(RowReadResult::Token(token));
+            }
+            RowStep::NeedBytes(need) => {
+                tracing::trace!(
+                    shortfall = need.shortfall,
+                    "refilling row buffer for step_row"
+                );
+                reader.refill_row_buffer().await?;
+            }
+            RowStep::AsyncColumn { col } => {
+                let state = resume.as_ref().expect("row cursor set before AsyncColumn");
+                match decode_async_row_column(reader, state, col, writer).await? {
+                    AsyncColumnOutcome::Continue => {
+                        resume
+                            .as_mut()
+                            .expect("row cursor set before AsyncColumn")
+                            .next_column_index = col + 1;
+                    }
+                    AsyncColumnOutcome::Terminal(result) => return Ok(result),
+                }
+            }
+        }
+    }
 }
 
 #[cfg(fuzzing)]
@@ -2201,6 +2371,494 @@ mod tests {
             assert_eq!(
                 got, baseline,
                 "fully-sync NBCROW row diverged when the refill boundary landed at offset {split}"
+            );
+        }
+    }
+
+    /// P4a blocking test 1: a fully-synchronous non-PLP ROW decoded through the
+    /// production `TdsCore::step_row` driver (`drive_row_over_buffer`) over the
+    /// buffer-owning `PacketReader`. Sweeping the refill boundary across every
+    /// interior offset (including the token byte, mid-length-prefix, and mid-cell)
+    /// must decode byte-identically to the single-packet baseline, proving the
+    /// sync core re-drives from an unchanged buffer position on every `NeedBytes`.
+    #[tokio::test]
+    async fn tdscore_step_row_refill_boundary_swept_all_offsets_is_byte_identical() {
+        use crate::datatypes::column_values::ColumnValues;
+        use crate::datatypes::row_writer::DefaultRowWriter;
+        use crate::io::packet_reader::PacketReader;
+        use crate::io::packet_reader::tests::{MockNetworkReaderWriter, TestPacketBuilder};
+        use crate::message::messages::PacketType;
+
+        let collation = SqlCollation {
+            info: 0x0409,
+            lcid_language_id: 0x0409,
+            col_flags: 0,
+            sort_id: 52,
+        };
+        // [int4][varchar(64)][int2] — all non-PLP, all `is_supported`, so every
+        // cell is decoded inline by `step_row` with no `AsyncColumn` yield.
+        let columns = vec![
+            ColumnMetadata {
+                user_type: 0,
+                flags: 0,
+                data_type: TdsDataType::Int4,
+                type_info: TypeInfo::fixed_len(TdsDataType::Int4).unwrap(),
+                column_name: "n".to_string(),
+                multi_part_name: None,
+                crypto_metadata: None,
+            },
+            ColumnMetadata {
+                user_type: 0,
+                flags: 0,
+                data_type: TdsDataType::BigVarChar,
+                type_info: TypeInfo::var_len_string(TdsDataType::BigVarChar, 64, Some(collation))
+                    .unwrap(),
+                column_name: "v".to_string(),
+                multi_part_name: None,
+                crypto_metadata: None,
+            },
+            ColumnMetadata {
+                user_type: 0,
+                flags: 0,
+                data_type: TdsDataType::Int2,
+                type_info: TypeInfo::fixed_len(TdsDataType::Int2).unwrap(),
+                column_name: "s".to_string(),
+                multi_part_name: None,
+                crypto_metadata: None,
+            },
+        ];
+
+        let mut payload = vec![TokenType::Row as u8];
+        payload.extend_from_slice(&7_i32.to_le_bytes());
+        let abc = [0x61u8, 0x62, 0x63]; // "abc"
+        payload.extend_from_slice(&(abc.len() as u16).to_le_bytes());
+        payload.extend_from_slice(&abc);
+        payload.extend_from_slice(&0x1234_i16.to_le_bytes());
+
+        async fn decode(read_data: Vec<u8>, columns: &[ColumnMetadata]) -> Vec<ColumnValues> {
+            let mut mock = MockNetworkReaderWriter::new(read_data, 0);
+            let mut reader = PacketReader::new(&mut mock);
+            reader.read_tds_packet_for_test().await.unwrap();
+            let context = ParserContext::ColumnMetadata(
+                Arc::new(ColMetadataToken {
+                    column_count: columns.len() as u16,
+                    columns: columns.to_vec(),
+                    cek_table: vec![],
+                }),
+                None,
+            );
+            let registry = GenericTokenParserRegistry::default();
+            let mut writer = DefaultRowWriter::new(columns.len());
+            let result = drive_row_over_buffer(&mut reader, &registry, &context, None, &mut writer)
+                .await
+                .unwrap();
+            assert!(matches!(result, RowReadResult::RowWritten));
+            writer.take_row()
+        }
+
+        fn one_packet(payload: &[u8]) -> Vec<u8> {
+            let mut builder = TestPacketBuilder::new(PacketType::PreLogin);
+            builder.append_bytes(payload).build()
+        }
+        fn two_packets(payload: &[u8], split: usize) -> Vec<u8> {
+            let mut first_builder = TestPacketBuilder::new(PacketType::PreLogin);
+            let mut first = first_builder.append_bytes(&payload[..split]).build();
+            first[1] = 0x00;
+            let mut second_builder = TestPacketBuilder::new(PacketType::PreLogin);
+            let second = second_builder.append_bytes(&payload[split..]).build();
+            [first, second].concat()
+        }
+
+        let baseline = decode(one_packet(&payload), &columns).await;
+        assert_eq!(baseline.len(), 3);
+        assert_eq!(baseline[0], ColumnValues::Int(7));
+        assert_ne!(baseline[1], ColumnValues::Null);
+        assert_eq!(baseline[2], ColumnValues::SmallInt(0x1234));
+
+        for split in 1..payload.len() {
+            let got = decode(two_packets(&payload, split), &columns).await;
+            assert_eq!(
+                got, baseline,
+                "TdsCore driver diverged when the refill boundary landed at offset {split}"
+            );
+        }
+    }
+
+    /// P4a blocking test 2: an NBCROW decoded through the production `step_row`
+    /// driver, with nine columns forcing a two-byte null bitmap. Sweeping the
+    /// refill boundary lands it INSIDE the bitmap (offset 2 splits the two bitmap
+    /// bytes, offset 1 splits token-from-bitmap). This exercises the atomic
+    /// row-header step: a `NeedBytes` at the bitmap leaves the token unconsumed,
+    /// so the re-drive re-peeks the same token byte — proving the binding
+    /// condition holds with zero new resumable state.
+    #[tokio::test]
+    async fn tdscore_step_row_nbcrow_bitmap_split_across_refill_is_byte_identical() {
+        use crate::datatypes::column_values::ColumnValues;
+        use crate::datatypes::row_writer::DefaultRowWriter;
+        use crate::io::packet_reader::PacketReader;
+        use crate::io::packet_reader::tests::{MockNetworkReaderWriter, TestPacketBuilder};
+        use crate::message::messages::PacketType;
+
+        let columns: Vec<ColumnMetadata> = (0..9)
+            .map(|i| ColumnMetadata {
+                user_type: 0,
+                flags: 0,
+                data_type: TdsDataType::Int4,
+                type_info: TypeInfo::fixed_len(TdsDataType::Int4).unwrap(),
+                column_name: format!("c{i}"),
+                multi_part_name: None,
+                crypto_metadata: None,
+            })
+            .collect();
+
+        let null_cols = [0usize, 3, 8];
+        let present: [(usize, i32); 6] = [(1, 11), (2, 22), (4, 44), (5, 55), (6, 66), (7, 77)];
+        let mut bitmap = [0u8; 2];
+        for &c in &null_cols {
+            bitmap[c / 8] |= 1 << (c % 8);
+        }
+
+        let mut payload = vec![TokenType::NbcRow as u8];
+        payload.extend_from_slice(&bitmap);
+        for &(_, v) in &present {
+            payload.extend_from_slice(&v.to_le_bytes());
+        }
+
+        async fn decode(read_data: Vec<u8>, columns: &[ColumnMetadata]) -> Vec<ColumnValues> {
+            let mut mock = MockNetworkReaderWriter::new(read_data, 0);
+            let mut reader = PacketReader::new(&mut mock);
+            reader.read_tds_packet_for_test().await.unwrap();
+            let context = ParserContext::ColumnMetadata(
+                Arc::new(ColMetadataToken {
+                    column_count: columns.len() as u16,
+                    columns: columns.to_vec(),
+                    cek_table: vec![],
+                }),
+                None,
+            );
+            let registry = GenericTokenParserRegistry::default();
+            let mut writer = DefaultRowWriter::new(columns.len());
+            let result = drive_row_over_buffer(&mut reader, &registry, &context, None, &mut writer)
+                .await
+                .unwrap();
+            assert!(matches!(result, RowReadResult::RowWritten));
+            writer.take_row()
+        }
+
+        fn one_packet(payload: &[u8]) -> Vec<u8> {
+            let mut builder = TestPacketBuilder::new(PacketType::PreLogin);
+            builder.append_bytes(payload).build()
+        }
+        fn two_packets(payload: &[u8], split: usize) -> Vec<u8> {
+            let mut first_builder = TestPacketBuilder::new(PacketType::PreLogin);
+            let mut first = first_builder.append_bytes(&payload[..split]).build();
+            first[1] = 0x00;
+            let mut second_builder = TestPacketBuilder::new(PacketType::PreLogin);
+            let second = second_builder.append_bytes(&payload[split..]).build();
+            [first, second].concat()
+        }
+
+        let baseline = decode(one_packet(&payload), &columns).await;
+        assert_eq!(baseline.len(), 9);
+        for &c in &null_cols {
+            assert_eq!(baseline[c], ColumnValues::Null, "column {c} should be NULL");
+        }
+        for &(c, v) in &present {
+            assert_eq!(baseline[c], ColumnValues::Int(v), "column {c} value");
+        }
+
+        for split in 1..payload.len() {
+            let got = decode(two_packets(&payload, split), &columns).await;
+            assert_eq!(
+                got, baseline,
+                "TdsCore NBCROW driver diverged when the refill boundary landed at offset {split}"
+            );
+        }
+    }
+
+    /// P4a blocking test 3 (Fork A): a ROW mixing an inline sync cell and an eager
+    /// PLP `varbinary(max)` cell, decoded through the production `step_row` driver.
+    /// The PLP cell is not `is_supported`, so `step_row` yields `AsyncColumn` and
+    /// the driver services it via the existing `collect_plp_bytes().await` seam,
+    /// then re-drives at the next column. Sweeping the refill boundary (including
+    /// inside the PLP chunk stream) must equal both the single-packet baseline and
+    /// the async reference oracle, proving the yield/resume seam is byte-identical.
+    #[tokio::test]
+    async fn tdscore_step_row_eager_plp_yields_and_resumes_at_next_column() {
+        use crate::datatypes::column_values::ColumnValues;
+        use crate::datatypes::row_writer::DefaultRowWriter;
+        use crate::io::packet_reader::PacketReader;
+        use crate::io::packet_reader::tests::{MockNetworkReaderWriter, TestPacketBuilder};
+        use crate::message::messages::PacketType;
+
+        let collation = SqlCollation {
+            info: 0x0409,
+            lcid_language_id: 0x0409,
+            col_flags: 0,
+            sort_id: 52,
+        };
+        let columns = vec![
+            ColumnMetadata {
+                user_type: 0,
+                flags: 0,
+                data_type: TdsDataType::Int4,
+                type_info: TypeInfo::fixed_len(TdsDataType::Int4).unwrap(),
+                column_name: "n".to_string(),
+                multi_part_name: None,
+                crypto_metadata: None,
+            },
+            ColumnMetadata {
+                user_type: 0,
+                flags: 0,
+                data_type: TdsDataType::BigVarChar,
+                type_info: TypeInfo::var_len_string(TdsDataType::BigVarChar, 64, Some(collation))
+                    .unwrap(),
+                column_name: "v".to_string(),
+                multi_part_name: None,
+                crypto_metadata: None,
+            },
+            plp_varbinary_metadata("b", None),
+        ];
+
+        let mut payload = vec![TokenType::Row as u8];
+        payload.extend_from_slice(&7_i32.to_le_bytes());
+        let ab = [0x61u8, 0x62]; // "ab"
+        payload.extend_from_slice(&(ab.len() as u16).to_le_bytes());
+        payload.extend_from_slice(&ab);
+        payload.extend_from_slice(&0xFFFF_FFFF_FFFF_FFFE_u64.to_le_bytes()); // UNKNOWNLEN
+        let c0: [u8; 4] = [0xDE, 0xAD, 0xBE, 0xEF];
+        let c1: [u8; 3] = [0x01, 0x02, 0x03];
+        payload.extend_from_slice(&(c0.len() as u32).to_le_bytes());
+        payload.extend_from_slice(&c0);
+        payload.extend_from_slice(&(c1.len() as u32).to_le_bytes());
+        payload.extend_from_slice(&c1);
+        payload.extend_from_slice(&0u32.to_le_bytes());
+
+        async fn decode_driver(
+            read_data: Vec<u8>,
+            columns: &[ColumnMetadata],
+        ) -> Vec<ColumnValues> {
+            let mut mock = MockNetworkReaderWriter::new(read_data, 0);
+            let mut reader = PacketReader::new(&mut mock);
+            reader.read_tds_packet_for_test().await.unwrap();
+            let context = ParserContext::ColumnMetadata(
+                Arc::new(ColMetadataToken {
+                    column_count: columns.len() as u16,
+                    columns: columns.to_vec(),
+                    cek_table: vec![],
+                }),
+                None,
+            );
+            let registry = GenericTokenParserRegistry::default();
+            let mut writer = DefaultRowWriter::new(columns.len());
+            let result = drive_row_over_buffer(&mut reader, &registry, &context, None, &mut writer)
+                .await
+                .unwrap();
+            assert!(matches!(result, RowReadResult::RowWritten));
+            writer.take_row()
+        }
+
+        async fn decode_oracle(
+            read_data: Vec<u8>,
+            columns: &[ColumnMetadata],
+        ) -> Vec<ColumnValues> {
+            let mut mock = MockNetworkReaderWriter::new(read_data, 0);
+            let mut reader = PacketReader::new(&mut mock);
+            reader.read_tds_packet_for_test().await.unwrap();
+            let context = ParserContext::ColumnMetadata(
+                Arc::new(ColMetadataToken {
+                    column_count: columns.len() as u16,
+                    columns: columns.to_vec(),
+                    cek_table: vec![],
+                }),
+                None,
+            );
+            let registry = GenericTokenParserRegistry::default();
+            let mut writer = DefaultRowWriter::new(columns.len());
+            let result = receive_row_into_internal(&mut reader, &registry, &context, &mut writer)
+                .await
+                .unwrap();
+            assert!(matches!(result, RowReadResult::RowWritten));
+            writer.take_row()
+        }
+
+        fn one_packet(payload: &[u8]) -> Vec<u8> {
+            let mut builder = TestPacketBuilder::new(PacketType::PreLogin);
+            builder.append_bytes(payload).build()
+        }
+        fn two_packets(payload: &[u8], split: usize) -> Vec<u8> {
+            let mut first_builder = TestPacketBuilder::new(PacketType::PreLogin);
+            let mut first = first_builder.append_bytes(&payload[..split]).build();
+            first[1] = 0x00;
+            let mut second_builder = TestPacketBuilder::new(PacketType::PreLogin);
+            let second = second_builder.append_bytes(&payload[split..]).build();
+            [first, second].concat()
+        }
+
+        let baseline = decode_driver(one_packet(&payload), &columns).await;
+        assert_eq!(baseline.len(), 3);
+        assert_eq!(baseline[0], ColumnValues::Int(7));
+        assert_ne!(baseline[1], ColumnValues::Null);
+        assert_eq!(
+            baseline[2],
+            ColumnValues::Bytes(vec![0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03])
+        );
+        // The driver's yield/resume must match the async reference oracle exactly.
+        assert_eq!(
+            baseline,
+            decode_oracle(one_packet(&payload), &columns).await
+        );
+
+        for split in 1..payload.len() {
+            let got = decode_driver(two_packets(&payload, split), &columns).await;
+            assert_eq!(
+                got, baseline,
+                "TdsCore eager-PLP driver diverged when the refill boundary landed at offset {split}"
+            );
+        }
+    }
+
+    /// P4a blocking test 4: the resume-from-pause path. A `RowPauseState` positioned
+    /// mid-row is driven both through the production `step_row` driver (with a
+    /// `Some` cursor, which skips the header and decodes from `next_column_index`)
+    /// and through the `resume_row_into_internal` reference oracle. Sweeping the
+    /// refill boundary across the resumed cells must produce byte-identical rows,
+    /// proving the unified resume path matches the oracle and keeping that oracle
+    /// exercised under `cargo test`.
+    #[tokio::test]
+    async fn tdscore_resume_from_pause_is_byte_identical_and_matches_oracle() {
+        use crate::datatypes::column_values::ColumnValues;
+        use crate::datatypes::row_writer::DefaultRowWriter;
+        use crate::io::packet_reader::PacketReader;
+        use crate::io::packet_reader::tests::{MockNetworkReaderWriter, TestPacketBuilder};
+        use crate::message::messages::PacketType;
+
+        let collation = SqlCollation {
+            info: 0x0409,
+            lcid_language_id: 0x0409,
+            col_flags: 0,
+            sort_id: 52,
+        };
+        let columns = vec![
+            ColumnMetadata {
+                user_type: 0,
+                flags: 0,
+                data_type: TdsDataType::Int4,
+                type_info: TypeInfo::fixed_len(TdsDataType::Int4).unwrap(),
+                column_name: "n".to_string(),
+                multi_part_name: None,
+                crypto_metadata: None,
+            },
+            ColumnMetadata {
+                user_type: 0,
+                flags: 0,
+                data_type: TdsDataType::BigVarChar,
+                type_info: TypeInfo::var_len_string(TdsDataType::BigVarChar, 64, Some(collation))
+                    .unwrap(),
+                column_name: "v".to_string(),
+                multi_part_name: None,
+                crypto_metadata: None,
+            },
+            ColumnMetadata {
+                user_type: 0,
+                flags: 0,
+                data_type: TdsDataType::Int4,
+                type_info: TypeInfo::fixed_len(TdsDataType::Int4).unwrap(),
+                column_name: "m".to_string(),
+                multi_part_name: None,
+                crypto_metadata: None,
+            },
+        ];
+
+        // Resume at column 1: the wire holds only columns 1 (varchar) and 2 (int4);
+        // no token byte and no bitmap, exactly as the transport resume path feeds it.
+        let mut payload = Vec::new();
+        let ab = [0x61u8, 0x62]; // "ab"
+        payload.extend_from_slice(&(ab.len() as u16).to_le_bytes());
+        payload.extend_from_slice(&ab);
+        payload.extend_from_slice(&99_i32.to_le_bytes());
+
+        fn pause_state(columns: &[ColumnMetadata]) -> RowPauseState {
+            RowPauseState {
+                next_column_index: 1,
+                columns: columns.to_vec(),
+                nbc_null_bitmap: None,
+                decryptor: None,
+            }
+        }
+
+        async fn decode_driver(
+            read_data: Vec<u8>,
+            columns: &[ColumnMetadata],
+        ) -> Vec<ColumnValues> {
+            let mut mock = MockNetworkReaderWriter::new(read_data, 0);
+            let mut reader = PacketReader::new(&mut mock);
+            reader.read_tds_packet_for_test().await.unwrap();
+            let registry = GenericTokenParserRegistry::default();
+            let context = ParserContext::None(());
+            let mut writer = DefaultRowWriter::new(columns.len());
+            let result = drive_row_over_buffer(
+                &mut reader,
+                &registry,
+                &context,
+                Some(pause_state(columns)),
+                &mut writer,
+            )
+            .await
+            .unwrap();
+            assert!(matches!(result, RowReadResult::RowWritten));
+            writer.take_row()
+        }
+
+        async fn decode_oracle(
+            read_data: Vec<u8>,
+            columns: &[ColumnMetadata],
+        ) -> Vec<ColumnValues> {
+            let mut mock = MockNetworkReaderWriter::new(read_data, 0);
+            let mut reader = PacketReader::new(&mut mock);
+            reader.read_tds_packet_for_test().await.unwrap();
+            let mut writer = DefaultRowWriter::new(columns.len());
+            let result = resume_row_into_internal(&mut reader, pause_state(columns), &mut writer)
+                .await
+                .unwrap();
+            assert!(matches!(result, RowReadResult::RowWritten));
+            writer.take_row()
+        }
+
+        fn one_packet(payload: &[u8]) -> Vec<u8> {
+            let mut builder = TestPacketBuilder::new(PacketType::PreLogin);
+            builder.append_bytes(payload).build()
+        }
+        fn two_packets(payload: &[u8], split: usize) -> Vec<u8> {
+            let mut first_builder = TestPacketBuilder::new(PacketType::PreLogin);
+            let mut first = first_builder.append_bytes(&payload[..split]).build();
+            first[1] = 0x00;
+            let mut second_builder = TestPacketBuilder::new(PacketType::PreLogin);
+            let second = second_builder.append_bytes(&payload[split..]).build();
+            [first, second].concat()
+        }
+
+        // Resuming at column 1 decodes only columns 1 (varchar) and 2 (int4);
+        // column 0 was written before the pause, so the resumed row holds 2 cells.
+        let baseline = decode_driver(one_packet(&payload), &columns).await;
+        assert_eq!(baseline.len(), 2);
+        assert_ne!(baseline[0], ColumnValues::Null);
+        assert_eq!(baseline[1], ColumnValues::Int(99));
+        assert_eq!(
+            baseline,
+            decode_oracle(one_packet(&payload), &columns).await
+        );
+
+        for split in 1..payload.len() {
+            let got = decode_driver(two_packets(&payload, split), &columns).await;
+            assert_eq!(
+                got, baseline,
+                "TdsCore resume driver diverged when the refill boundary landed at offset {split}"
+            );
+            let oracle = decode_oracle(two_packets(&payload, split), &columns).await;
+            assert_eq!(
+                got, oracle,
+                "resume driver vs oracle diverged at offset {split}"
             );
         }
     }


### PR DESCRIPTION
## P4a — sync `TdsCore` row-fetch driver (Option A)

Part of the sans-I/O restructuring of `mssql-tds`. **Base:** `dev/saurabh/sans-io-l4c-invert-nbcrow` (stack #192). Draft — do not merge; coordinator will independently verify from git + nextest and append to the stack.

### What this does
Extracts the row-fetch framing, non-PLP column decode, and NBC null-bitmap into ONE pure-sync `TdsCore::step_row(&mut PacketBuffer, …) -> RowStep` that returns `NeedBytes` on underflow. A thin async driver `drive_row_over_buffer` owns the sole refill `.await` and re-drives `step_row`. The async client stays pure delegation.

### Column routing
- **Inlined sync (over `PacketBuffer`, `NeedBytes` on underflow):** non-PLP columns where `crypto_metadata.is_none() && sync_decoder::is_supported(meta)`, plus the NBC null bitmap.
- **Yielded to async leaf (`decode_async_row_column`):** everything else — crypto/AE columns, `!is_supported` non-PLP (p4d text/ntext/image legacy LOBs), and all PLP (`is_supported` returns false for `is_plp()`). Eager PLP is serviced by the existing `collect_plp_bytes().await` seam (Fork A — no new machine); PLP streaming pause reaches the existing `PlpColumnStream`/`PlpPauseState` (p7, unchanged).

### Atomic row-header mechanism (binding condition)
The row header (token byte + optional NBC bitmap) is **ensured-then-taken atomically**: `peek_bytes(1)`/`ensure(1 + bitmap_len)` are non-consuming, so a `NeedBytes` at any header boundary leaves the buffer position unchanged and the re-drive re-peeks the same token byte. The "token consumed, bitmap pending" state never exists → zero new resumable state; the existing `RowPauseState` cursor is held by the driver across refills.

### Invariants
1. **Zero behavior change** — `-p mssql-tds --lib` fail-set == exactly the 7 pre-existing cert fixtures; `Compare-Object` of sorted fail-sets vs base EMPTY; no hang.
2. **One production parse body** — `TdsCore::step_row`. `receive_row_into_internal` retained ONLY as a `#[cfg(any(test, fuzzing))]` reference oracle (Fork B R2); no production caller.
3. **Zero new resumable machines** — reuses `RowPauseState`/`PlpPauseState`/`PlpColumnStream`/`PlpChunkStreamReader`/`NeedBytes`.
4. **Public API frozen** — `TdsCore`/`RowStep`/`step_row`/`drive_row_over_buffer` are `pub(crate)`; diff-scan shows no new `pub fn`/`pub async fn`.
5. **Gates** — `bfmt`, `bclippy` (-D warnings), `scripts/bfmt.ps1` + `scripts/bclippy.ps1` incl. `mssql-py-core`, `mssql-py-core` builds `--all-features`. MIT header on new `io/tds_core.rs`.

### Tests (through the new `TdsCore` driver, refill boundaries swept)
- `tdscore_step_row_refill_boundary_swept_all_offsets_is_byte_identical`
- `tdscore_step_row_nbcrow_bitmap_split_across_refill_is_byte_identical`
- `tdscore_step_row_eager_plp_yields_and_resumes_at_next_column`
- `tdscore_resume_from_pause_is_byte_identical_and_matches_oracle`