### PR TITLE
P4b: invert non-row bounded tokens to sync TdsCore step_token driver

### DIFF
--- a/mssql-tds/src/connection/transport/network_transport.rs
+++ b/mssql-tds/src/connection/transport/network_transport.rs
@@ -19,7 +19,7 @@ use crate::io::packet_writer::PacketWriter;
 use crate::io::reader_writer::{NetworkReader, NetworkReaderWriter, NetworkWriter};
 use crate::io::token_stream::{
     ParserContext, PlpPauseState, RowPauseState, RowReadResult, TdsTokenStreamReader,
-    drive_row_over_buffer, read_active_plp_bytes_internal, receive_token_internal,
+    drive_row_over_buffer, drive_token_over_buffer, read_active_plp_bytes_internal,
 };
 use crate::message::attention::AttentionRequest;
 use crate::message::login_options::TdsVersion;
@@ -1013,7 +1013,7 @@ impl NetworkTransport {
                 let remaining = timeout_duration.saturating_sub(start.elapsed());
                 match timeout(
                     remaining,
-                    receive_token_internal(self, &*PARSER_REGISTRY, &dummy_context),
+                    drive_token_over_buffer(self, &*PARSER_REGISTRY, &dummy_context),
                 )
                 .await
                 {
@@ -1028,7 +1028,7 @@ impl NetworkTransport {
                 }
             } else {
                 // No timeout - wait indefinitely
-                receive_token_internal(self, &*PARSER_REGISTRY, &dummy_context).await
+                drive_token_over_buffer(self, &*PARSER_REGISTRY, &dummy_context).await
             };
 
             match token_result {
@@ -1329,7 +1329,7 @@ impl TdsTokenStreamReader for NetworkTransport {
     ) -> TdsResult<Tokens> {
         let cancellable_receive_token = CancelHandle::run_until_cancelled(
             cancel_handle,
-            receive_token_internal(self, &*PARSER_REGISTRY, context),
+            drive_token_over_buffer(self, &*PARSER_REGISTRY, context),
         );
         let token_result = match remaining_request_timeout.as_ref() {
             Some(remaining_request_timeout) => {

--- a/mssql-tds/src/io.rs
+++ b/mssql-tds/src/io.rs
@@ -28,5 +28,6 @@ pub(crate) mod packet_buffer;
 pub mod packet_reader;
 pub mod packet_writer;
 pub mod reader_writer;
+pub(crate) mod sync_token;
 pub(crate) mod tds_core;
 pub(crate) mod token_stream;

--- a/mssql-tds/src/io/packet_buffer.rs
+++ b/mssql-tds/src/io/packet_buffer.rs
@@ -47,6 +47,11 @@ pub(crate) struct PacketBuffer {
     pending_bytes: usize,
     /// Absolute offset of the pending bytes within `working_buffer`.
     pending_bytes_offset: usize,
+    /// Test-only high-water mark of `length` (resident payload bytes), used by
+    /// the eager-PLP residency-ceiling test to prove the driver never holds a
+    /// whole unbounded LOB resident. Never present in production builds.
+    #[cfg(test)]
+    peak_length: usize,
 }
 
 impl PacketBuffer {
@@ -60,6 +65,8 @@ impl PacketBuffer {
             max_packet_size,
             pending_bytes: 0,
             pending_bytes_offset: 0,
+            #[cfg(test)]
+            peak_length: 0,
         }
     }
 
@@ -127,6 +134,8 @@ impl PacketBuffer {
             max_packet_size: len.max(1),
             pending_bytes: 0,
             pending_bytes_offset: 0,
+            #[cfg(test)]
+            peak_length: len,
         }
     }
 
@@ -338,6 +347,10 @@ impl PacketBuffer {
             base,
         );
         self.length = base + packet_len - PacketWriter::PACKET_HEADER_SIZE;
+        #[cfg(test)]
+        {
+            self.peak_length = self.peak_length.max(self.length);
+        }
     }
 
     /// Resizes the buffer when the negotiated packet size changes, discarding
@@ -385,6 +398,14 @@ impl PacketBuffer {
     #[cfg(test)]
     pub(crate) fn length(&self) -> usize {
         self.length
+    }
+
+    /// Test-only high-water mark of resident payload bytes (`length`) tracked
+    /// since construction. Used to assert the eager-PLP residency ceiling on the
+    /// production driver.
+    #[cfg(test)]
+    pub(crate) fn peak_length(&self) -> usize {
+        self.peak_length
     }
 
     #[cfg(test)]

--- a/mssql-tds/src/io/sync_token.rs
+++ b/mssql-tds/src/io/sync_token.rs
@@ -1,0 +1,433 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Pure-synchronous non-row token parse leaf (sans-I/O core).
+//!
+//! These are the **production** parse bodies for the bounded, length-delimited
+//! non-row tokens driven by [`TdsCore::step_token`](crate::io::tds_core::TdsCore::step_token):
+//! DONE / DONEINPROC / DONEPROC, RETURNSTATUS, ORDER, ERROR, INFO, and ENVCHANGE.
+//! Each reads its whole body in place over a [`PacketBuffer`] that the driver has
+//! already ensured is fully resident, so no accessor here can underflow — a
+//! shortfall is handled one layer up, at token entry, by re-driving `step_token`.
+//!
+//! The byte-for-byte semantics mirror the corresponding `async fn parse` in
+//! `token/parsers/*`, which are retained as `#[cfg(any(test, fuzzing))]`
+//! reference oracles; the split-at-every-offset differential tests in
+//! `token_stream.rs` prove the two decode identically.
+//!
+//! The value-carrying / unbounded tokens (COLMETADATA, RETURNVALUE,
+//! SESSIONSTATE, FEATUREEXTACK) and the login/handshake tokens are **not** here:
+//! [`is_sync_token`] returns `false` for them and the driver keeps servicing
+//! them on the async seam. Their pure-sync inversion is deferred to a later,
+//! parent-gated layer that would add a sanctioned mid-token cursor.
+
+use byteorder::{ByteOrder, LittleEndian};
+
+use crate::core::TdsResult;
+use crate::io::packet_buffer::{NeedBytes, PacketBuffer};
+use crate::io::packet_reader::PacketReader;
+use crate::io::token_stream::ParserContext;
+use crate::message::login::RoutingInfo;
+use crate::token::tokens::{
+    CurrentCommand, DoneStatus, DoneToken, EnvChangeContainer, EnvChangeToken,
+    EnvChangeTokenSubType, ErrorToken, InfoToken, OrderToken, ReturnStatusToken, SqlCollation,
+    TokenType, Tokens,
+};
+
+/// Whether `token_type` is decoded by the synchronous leaf in this module.
+///
+/// The bounded, length-delimited hot-path tokens are sync; everything else
+/// (the value-carrying (b) tokens and the login/handshake tokens) stays on the
+/// async seam via [`TokenStep::AsyncToken`](crate::io::tds_core::TokenStep).
+pub(crate) fn is_sync_token(token_type: &TokenType) -> bool {
+    matches!(
+        token_type,
+        TokenType::Done
+            | TokenType::DoneInProc
+            | TokenType::DoneProc
+            | TokenType::ReturnStatus
+            | TokenType::Order
+            | TokenType::Error
+            | TokenType::Info
+            | TokenType::EnvChange
+    )
+}
+
+/// Fixed on-wire body length (excluding the token byte) for the fixed-width sync
+/// tokens, or `None` for the length-prefixed ones whose body is `2 + len`.
+pub(crate) fn fixed_body_len(token_type: &TokenType) -> Option<usize> {
+    match token_type {
+        // status(2) + cur_cmd(2) + row_count(8)
+        TokenType::Done | TokenType::DoneInProc | TokenType::DoneProc => Some(12),
+        // value(4)
+        TokenType::ReturnStatus => Some(4),
+        _ => None,
+    }
+}
+
+/// Total body length (excluding the token byte) for a sync token whose token
+/// byte has already been consumed, i.e. `buf` is positioned at the body.
+///
+/// Fixed-width tokens return immediately; length-prefixed tokens read the u16
+/// body-length prefix at body offset 0 and return `2 + len`. A shortfall while
+/// reading that prefix is reported as [`NeedBytes`] so the caller can refill.
+pub(crate) fn body_len(buf: &PacketBuffer, token_type: &TokenType) -> Result<usize, NeedBytes> {
+    if let Some(body) = fixed_body_len(token_type) {
+        return Ok(body);
+    }
+    match buf.peek_bytes(2) {
+        Some(prefix) => Ok(2 + u16::from_le_bytes([prefix[0], prefix[1]]) as usize),
+        None => Err(NeedBytes {
+            shortfall: 2 - buf.available(),
+        }),
+    }
+}
+
+/// Parses one bounded non-row token body in place.
+///
+/// The caller ([`TdsCore::step_token`](crate::io::tds_core::TdsCore::step_token)
+/// or the row driver's terminal-token handoff) guarantees the token byte is
+/// already consumed and the entire body is resident in `buf`, so every `take_*`
+/// here succeeds.
+pub(crate) fn parse_token_body(
+    buf: &mut PacketBuffer,
+    token_type: TokenType,
+    _context: &ParserContext,
+) -> TdsResult<Tokens> {
+    match token_type {
+        TokenType::Done => Ok(Tokens::Done(parse_done_body(buf)?)),
+        TokenType::DoneInProc => Ok(Tokens::DoneInProc(parse_done_body(buf)?)),
+        TokenType::DoneProc => Ok(Tokens::DoneProc(parse_done_body(buf)?)),
+        TokenType::ReturnStatus => {
+            let value = buf.take_i32_le()?;
+            Ok(Tokens::from(ReturnStatusToken { value }))
+        }
+        TokenType::Order => parse_order_body(buf),
+        TokenType::Error => parse_error_body(buf),
+        TokenType::Info => parse_info_body(buf),
+        TokenType::EnvChange => parse_envchange_body(buf),
+        other => Err(crate::error::Error::ProtocolError(format!(
+            "sync_token::parse_token_body called with non-sync token {other:?}"
+        ))),
+    }
+}
+
+fn parse_done_body(buf: &mut PacketBuffer) -> TdsResult<DoneToken> {
+    let status = buf.take_u16_le()?;
+    let done_status = DoneStatus::from(status);
+    let current_command_value = buf.take_u16_le()?;
+    let current_command =
+        CurrentCommand::try_from(current_command_value).unwrap_or(CurrentCommand::None);
+    let row_count = buf.take_u64_le()?;
+    Ok(DoneToken {
+        status: done_status,
+        cur_cmd: current_command,
+        row_count,
+    })
+}
+
+fn parse_order_body(buf: &mut PacketBuffer) -> TdsResult<Tokens> {
+    let length = buf.take_u16_le()?;
+    let col_count = length / 2;
+    let mut columns = Vec::new();
+    for _ in 0..col_count {
+        columns.push(buf.take_u16_le()?);
+    }
+    Ok(Tokens::from(OrderToken {
+        _order_columns: columns,
+    }))
+}
+
+fn parse_error_body(buf: &mut PacketBuffer) -> TdsResult<Tokens> {
+    // Token length (u16) - total length excluding this field; already used by
+    // the driver to bound the body, so discarded here.
+    let _ = buf.take_u16_le()?;
+    let number = buf.take_u32_le()?;
+    let state = buf.take_u8()?;
+    let severity = buf.take_u8()?;
+    let message = read_varchar_u16(buf)?.unwrap_or_default();
+    let server_name = read_varchar_u8(buf)?;
+    let proc_name = read_varchar_u8(buf)?;
+    let line_number = buf.take_u32_le()?;
+    Ok(Tokens::from(ErrorToken {
+        number,
+        state,
+        severity,
+        message,
+        server_name,
+        proc_name,
+        line_number,
+    }))
+}
+
+fn parse_info_body(buf: &mut PacketBuffer) -> TdsResult<Tokens> {
+    let _length = buf.take_u16_le()?;
+    let number = buf.take_u32_le()?;
+    let state = buf.take_u8()?;
+    let severity = buf.take_u8()?;
+    let message = read_varchar_u16(buf)?;
+    let server_name = read_varchar_u8(buf)?;
+    let proc_name = read_varchar_u8(buf)?;
+    let line_number = buf.take_u32_le()?;
+    Ok(Tokens::from(InfoToken {
+        number,
+        state,
+        severity,
+        message: message.unwrap_or_default(),
+        server_name,
+        proc_name,
+        line_number,
+    }))
+}
+
+fn parse_envchange_body(buf: &mut PacketBuffer) -> TdsResult<Tokens> {
+    use std::io::Error;
+
+    let _token_length = buf.take_u16_le()?;
+    let sub_type = buf.take_u8()?;
+    let token_sub_type: EnvChangeTokenSubType = sub_type.try_into()?;
+
+    let token_value_change: EnvChangeContainer = match token_sub_type {
+        EnvChangeTokenSubType::Database => {
+            let new_value = read_varchar_u8(buf)?;
+            let old_value = read_varchar_u8(buf)?;
+            EnvChangeContainer::from((old_value, new_value))
+        }
+        EnvChangeTokenSubType::Language => {
+            let new_value = read_varchar_u8(buf)?;
+            let old_value = read_varchar_u8(buf)?;
+            EnvChangeContainer::from((old_value, new_value))
+        }
+        EnvChangeTokenSubType::CharacterSet => {
+            let new_value = read_varchar_u8(buf)?;
+            let old_value = read_varchar_u8(buf)?;
+            EnvChangeContainer::from((old_value, new_value))
+        }
+        EnvChangeTokenSubType::PacketSize => {
+            let new_value_string = read_varchar_u8(buf)?;
+            let old_value_string = read_varchar_u8(buf)?;
+            let new_value = new_value_string.parse::<u32>().map_err(|_| {
+                Error::new(std::io::ErrorKind::InvalidData, "Invalid new packet size")
+            })?;
+            let old_value = old_value_string.parse::<u32>().map_err(|_| {
+                Error::new(std::io::ErrorKind::InvalidData, "Invalid old packet size")
+            })?;
+            EnvChangeContainer::from((old_value, new_value))
+        }
+        EnvChangeTokenSubType::UnicodeDataSortingLocalId => {
+            return Err(crate::error::Error::UnimplementedFeature {
+                feature: "UnicodeDataSortingLocalId".to_string(),
+                context: "EnvChange token parsing not yet implemented".to_string(),
+            });
+        }
+        EnvChangeTokenSubType::UnicodeDataSortingComparisonFlags => {
+            return Err(crate::error::Error::UnimplementedFeature {
+                feature: "UnicodeDataSortingComparisonFlags".to_string(),
+                context: "EnvChange token parsing not yet implemented".to_string(),
+            });
+        }
+        EnvChangeTokenSubType::SqlCollation => {
+            let new_bytes = read_u8_varbyte(buf)?;
+            let old_bytes = read_u8_varbyte(buf)?;
+            let old_collation: Option<SqlCollation> = match old_bytes.len() {
+                5 => old_bytes.as_slice().try_into().ok(),
+                _ => None,
+            };
+            let new_collation: Option<SqlCollation> = match new_bytes.len() {
+                5 => new_bytes.as_slice().try_into().ok(),
+                _ => None,
+            };
+            EnvChangeContainer::from((old_collation, new_collation))
+        }
+        EnvChangeTokenSubType::BeginTransaction | EnvChangeTokenSubType::EnlistDtcTransaction => {
+            let new_value = read_u8_varbyte(buf)?;
+            let new_descriptor = match new_value.len() {
+                8 => Ok(LittleEndian::read_u64(&new_value)),
+                _ => Err(Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "Invalid new transaction descriptor",
+                )),
+            }?;
+            let old_value = read_u8_varbyte(buf)?;
+            let old_descriptor = match old_value.len() {
+                0 => Ok(0u64),
+                _ => Err(Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "Invalid old transaction descriptor",
+                )),
+            }?;
+            EnvChangeContainer::from((old_descriptor, new_descriptor))
+        }
+        EnvChangeTokenSubType::CommitTransaction => {
+            let new_value = read_u8_varbyte(buf)?;
+            let new_descriptor: u64 = match new_value.len() {
+                0 => Ok(0u64),
+                _ => Err(Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "Invalid new transaction descriptor",
+                )),
+            }?;
+            let old_value = read_u8_varbyte(buf)?;
+            let old_descriptor = match old_value.len() {
+                8 => Ok(LittleEndian::read_u64(&old_value)),
+                _ => Err(Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "Invalid old transaction descriptor",
+                )),
+            }?;
+            EnvChangeContainer::from((old_descriptor, new_descriptor))
+        }
+        EnvChangeTokenSubType::RollbackTransaction => {
+            let new_value = read_u8_varbyte(buf)?;
+            let new_descriptor: u64 = match new_value.len() {
+                0 => Ok(0u64),
+                _ => Err(Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "Invalid new transaction descriptor",
+                )),
+            }?;
+            let old_value = read_u8_varbyte(buf)?;
+            let old_descriptor = match old_value.len() {
+                8 => Ok(LittleEndian::read_u64(&old_value)),
+                _ => Err(Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "Invalid old transaction descriptor",
+                )),
+            }?;
+            EnvChangeContainer::from((old_descriptor, new_descriptor))
+        }
+        EnvChangeTokenSubType::DefectTransaction => {
+            let new_value = read_u8_varbyte(buf)?;
+            let new_descriptor = match new_value.len() {
+                8 => Ok(LittleEndian::read_u64(&new_value)),
+                _ => Err(Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "Invalid new transaction descriptor",
+                )),
+            }?;
+            let old_value = read_u8_varbyte(buf)?;
+            let old_descriptor = match old_value.len() {
+                0 => Ok(0u64),
+                _ => Err(crate::error::Error::ProtocolError(
+                    "Invalid old transaction descriptor".to_string(),
+                )),
+            }?;
+            EnvChangeContainer::from((old_descriptor, new_descriptor))
+        }
+        EnvChangeTokenSubType::DatabaseMirroringPartner => {
+            let new_value = read_varchar_u8(buf)?;
+            let old_value = read_varchar_u8(buf)?;
+            EnvChangeContainer::from((old_value, new_value))
+        }
+        EnvChangeTokenSubType::PromoteTransaction => {
+            return Err(crate::error::Error::UnimplementedFeature {
+                feature: "PromoteTransaction".to_string(),
+                context: "EnvChange token parsing not yet implemented".to_string(),
+            });
+        }
+        EnvChangeTokenSubType::TransactionManagerAddress => {
+            return Err(crate::error::Error::UnimplementedFeature {
+                feature: "TransactionManagerAddress".to_string(),
+                context: "EnvChange token parsing not yet implemented".to_string(),
+            });
+        }
+        EnvChangeTokenSubType::TransactionEnded => {
+            return Err(crate::error::Error::UnimplementedFeature {
+                feature: "TransactionEnded".to_string(),
+                context: "EnvChange token parsing not yet implemented".to_string(),
+            });
+        }
+        EnvChangeTokenSubType::ResetConnection => {
+            let new_value = read_u8_varbyte(buf)?;
+            let old_value = read_u8_varbyte(buf)?;
+            EnvChangeContainer::from((old_value, new_value))
+        }
+        EnvChangeTokenSubType::UserInstanceName => {
+            return Err(crate::error::Error::UnimplementedFeature {
+                feature: "UserInstanceName".to_string(),
+                context: "EnvChange token parsing not yet implemented".to_string(),
+            });
+        }
+        EnvChangeTokenSubType::Routing => {
+            let _length = buf.take_u16_le()?;
+            let protocol = buf.take_u8()?;
+            let port = buf.take_u16_le()?;
+            let server = read_varchar_u16(buf)?;
+            let routing_info = Some(RoutingInfo {
+                protocol,
+                port,
+                server: server.unwrap_or_default(),
+            });
+
+            let mut old_routing_info: Option<RoutingInfo> = None;
+
+            let old_length = buf.take_u16_le()?;
+            if old_length > 0 {
+                let old_protocol = buf.take_u8()?;
+                let old_port = buf.take_u16_le()?;
+                let old_server = read_varchar_u16(buf)?;
+
+                old_routing_info = Some(RoutingInfo {
+                    protocol: old_protocol,
+                    port: old_port,
+                    server: old_server.unwrap_or_default(),
+                });
+            }
+            EnvChangeContainer::from((old_routing_info, routing_info))
+        }
+        EnvChangeTokenSubType::Unknown(_value) => {
+            let new_value = read_varchar_u8(buf)?;
+            let old_value = read_varchar_u8(buf)?;
+            EnvChangeContainer::from((old_value, new_value))
+        }
+    };
+    Ok(Tokens::from(EnvChangeToken {
+        sub_type: token_sub_type,
+        change_type: token_value_change,
+    }))
+}
+
+/// Synchronous mirror of `TdsPacketReader::read_varchar_u16_length`: a u16
+/// char-count prefix (`0xFFFF` == null) followed by that many UTF-16LE units.
+fn read_varchar_u16(buf: &mut PacketBuffer) -> TdsResult<Option<String>> {
+    let length: u16 = buf.take_u16_le()?;
+    if length == PacketReader::LENGTHNULL {
+        return Ok(None);
+    }
+    let string = read_unicode_with_byte_length(buf, (length << 1) as usize)?;
+    Ok(Some(string))
+}
+
+/// Synchronous mirror of `TdsPacketReader::read_varchar_u8_length`: a u8
+/// char-count prefix followed by that many UTF-16LE units.
+fn read_varchar_u8(buf: &mut PacketBuffer) -> TdsResult<String> {
+    let length: u8 = buf.take_u8()?;
+    read_unicode_with_byte_length(buf, (length << 1) as usize)
+}
+
+/// Synchronous mirror of `TdsPacketReader::read_u8_varbyte`: a u8 length prefix
+/// followed by that many raw bytes.
+fn read_u8_varbyte(buf: &mut PacketBuffer) -> TdsResult<Vec<u8>> {
+    let length: u8 = buf.take_u8()?;
+    buf.take_bytes(length as usize)
+}
+
+/// Synchronous mirror of `TdsPacketReader::read_unicode_with_byte_length`.
+fn read_unicode_with_byte_length(buf: &mut PacketBuffer, byte_length: usize) -> TdsResult<String> {
+    const MAX_STRING_BYTE_LENGTH: usize = u8::MAX as usize * 2;
+    if byte_length > MAX_STRING_BYTE_LENGTH {
+        return Err(crate::error::Error::UsageError(format!(
+            "Unicode string byte length {byte_length} exceeds maximum allowed size of {MAX_STRING_BYTE_LENGTH} bytes"
+        )));
+    }
+
+    let byte_buffer = buf.take_bytes(byte_length)?;
+    let mut u16_buffer = Vec::with_capacity(byte_buffer.len() / 2);
+    for chunk in byte_buffer.chunks(2) {
+        let value = u16::from_le_bytes([chunk[0], chunk[1]]);
+        u16_buffer.push(value);
+    }
+    let string = String::from_utf16(&u16_buffer)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    Ok(string)
+}

--- a/mssql-tds/src/io/tds_core.rs
+++ b/mssql-tds/src/io/tds_core.rs
@@ -17,13 +17,27 @@
 //! `AsyncColumn` through the existing L4 async seam, then re-drives `step_row`
 //! from the shared cursor. The async and sync (future P4c) drivers differ only
 //! in that refill step; the parse body here is shared.
+//!
+//! [`TdsCore::step_token`] is the non-row analog (P4b): it decodes the bounded,
+//! length-delimited non-row tokens (DONE family, RETURNSTATUS, ORDER, ERROR,
+//! INFO, ENVCHANGE) in place over the [`PacketBuffer`] via the pure-sync leaf in
+//! [`crate::io::sync_token`], returning [`TokenStep::NeedBytes`] on underflow at
+//! token entry (nothing consumed, restartable from the token byte). Tokens whose
+//! bodies are unbounded or carry embedded values/PLP — COLMETADATA, RETURNVALUE,
+//! SESSIONSTATE, FEATUREEXTACK — plus the login/handshake tokens are handed back
+//! as [`TokenStep::AsyncToken`] and serviced by the existing async parser on the
+//! seam. Their pure-sync inversion is **deferred** to a later, parent-gated layer
+//! that would introduce a sanctioned mid-token `TokenPauseState` cursor; after
+//! P4b the receive path is sync-parse for its bounded tokens and async-seamed for
+//! the unbounded ones, not fully sync.
 
 use crate::core::TdsResult;
 use crate::datatypes::row_writer::RowWriter;
 use crate::datatypes::sync_decoder;
 use crate::io::packet_buffer::{NeedBytes, PacketBuffer};
+use crate::io::sync_token;
 use crate::io::token_stream::{ParserContext, RowPauseState, extract_row_context};
-use crate::token::tokens::TokenType;
+use crate::token::tokens::{TokenType, Tokens};
 
 /// Zero-sized owner of the synchronous row-fetch parse body.
 pub(crate) struct TdsCore;
@@ -39,12 +53,45 @@ pub(crate) enum RowStep {
     RowPaused(RowPauseState),
     /// The cell at `col` must be decoded through the async seam (eager PLP,
     /// p7 PLP streaming pause, p4d legacy LOBs, rare fallback types, or the AE
-    /// fallback). Its refill stays in the L4b/L4-async seam by design: hoisting
-    /// mid-value LOB state into the sync core would require a new resumable
-    /// machine. The driver services it and re-drives `step_row` at `col + 1`.
+    /// fallback). The driver services it and re-drives `step_row` at `col + 1`.
+    ///
+    /// The two yield reasons are named for *why* they yield:
+    /// - [`RowStep::NeedBytes`]`{shortfall}` = this cell is **BOUNDED**; give it
+    ///   `N` more bytes and the whole cell fits, so the sync core will finish it.
+    /// - `AsyncColumn` = this column is **UNBOUNDED**; the driver owns its
+    ///   chunked I/O and streams it chunk-at-a-time through the shared
+    ///   `plp_collect_step` / `collect_plp_bytes` leaf.
+    ///
+    /// Do NOT collapse into NeedBytes — yielding the column preserves bounded
+    /// residency; forcing PLP through `ensure(full-len)` would materialize the
+    /// whole multi-GB VARCHAR(MAX) and reintroduce the footgun, and would need a
+    /// new mid-value resumable machine. This is an intentional sans-I/O shape,
+    /// not an unfinished inversion: it is what keeps L4b residency bounded to one
+    /// chunk while a LOB larger than the buffer streams past.
     AsyncColumn { col: usize },
     /// The buffer underflowed; the driver refills and re-drives with the same
     /// (unchanged) cursor. Nothing was consumed on this step.
+    NeedBytes(NeedBytes),
+}
+
+/// Outcome of one synchronous [`TdsCore::step_token`] call.
+///
+/// The non-row analog of [`RowStep`]. Bounded tokens are parsed whole in place
+/// and returned as [`TokenStep::Parsed`]; unbounded / value-carrying tokens are
+/// yielded to the async driver as [`TokenStep::AsyncToken`] (see the module-level
+/// note on the deferred sync inversion of those tokens).
+pub(crate) enum TokenStep {
+    /// The whole token body was decoded in place; the driver returns it.
+    Parsed(Tokens),
+    /// The token is COLMETADATA / RETURNVALUE / SESSIONSTATE / FEATUREEXTACK, a
+    /// login/handshake token, or an unrecognized-but-dispatchable token: its
+    /// body is not pure-sync yet, so the driver services it through the existing
+    /// async parser on the seam. A genuine yield-to-driver, never a hidden
+    /// `block_on` — this is the [`RowStep::AsyncColumn`] discipline for tokens,
+    /// leaving the seam shaped for a future P4c sync leaf/cursor underneath it.
+    AsyncToken(TokenType),
+    /// The buffer underflowed at token entry; nothing was consumed, so the
+    /// driver refills and re-drives, re-peeking the same token byte.
     NeedBytes(NeedBytes),
 }
 
@@ -162,5 +209,61 @@ impl TdsCore {
                 Ok(HeaderStep::Token(token_type))
             }
         }
+    }
+
+    /// Advances one non-row token-decode step over `buf` without performing I/O.
+    ///
+    /// Peeks the token byte and classifies it:
+    /// - Bounded tokens (DONE family, RETURNSTATUS, ORDER, ERROR, INFO,
+    ///   ENVCHANGE — see [`sync_token::is_sync_token`]) are decoded whole in
+    ///   place. The token byte is not consumed until the entire length-delimited
+    ///   body is resident, so a shortfall returns [`TokenStep::NeedBytes`] with
+    ///   the buffer position unchanged and the step is restartable from the token
+    ///   byte — the token-atomic analog of [`Self::begin_row_header`].
+    /// - Every other token (the value-carrying (b) tokens, login/handshake
+    ///   tokens, and any dispatchable token this core does not sync-parse) has
+    ///   its token byte consumed and is returned as [`TokenStep::AsyncToken`] for
+    ///   the driver to service through the existing async parser.
+    ///
+    /// A malformed token byte propagates the same `TryFrom` error the async path
+    /// raised; nothing is consumed on that error (only the byte was peeked).
+    pub(crate) fn step_token(
+        buf: &mut PacketBuffer,
+        context: &ParserContext,
+    ) -> TdsResult<TokenStep> {
+        let first = match buf.peek_bytes(1) {
+            Some(bytes) => bytes[0],
+            None => return Ok(TokenStep::NeedBytes(NeedBytes { shortfall: 1 })),
+        };
+        let token_type: TokenType = first.try_into()?;
+
+        if !sync_token::is_sync_token(&token_type) {
+            buf.take_u8()?;
+            return Ok(TokenStep::AsyncToken(token_type));
+        }
+
+        // Total on-wire size including the token byte. Fixed-width tokens are
+        // known outright; length-prefixed tokens carry a u16 body length at
+        // body offset 0 (just past the token byte), so the whole token is
+        // `1 + 2 + len`.
+        let total = match sync_token::fixed_body_len(&token_type) {
+            Some(body) => 1 + body,
+            None => {
+                if let Err(need) = buf.ensure(3) {
+                    return Ok(TokenStep::NeedBytes(need));
+                }
+                let prefix = buf.peek_bytes(3).expect("ensured 3 bytes");
+                1 + 2 + u16::from_le_bytes([prefix[1], prefix[2]]) as usize
+            }
+        };
+
+        if let Err(need) = buf.ensure(total) {
+            return Ok(TokenStep::NeedBytes(need));
+        }
+
+        buf.take_u8()?;
+        Ok(TokenStep::Parsed(sync_token::parse_token_body(
+            buf, token_type, context,
+        )?))
     }
 }

--- a/mssql-tds/src/io/token_stream.rs
+++ b/mssql-tds/src/io/token_stream.rs
@@ -2829,8 +2829,6 @@ mod tests {
         use crate::io::packet_reader::tests::{MockNetworkReaderWriter, TestPacketBuilder};
         use crate::message::messages::PacketType;
 
-        const BUFFER_CAPACITY: usize = 8192; // 2 x 4096 B negotiated packet
-
         let columns = vec![plp_varbinary_metadata("b", None)];
 
         // UNKNOWNLEN PLP value with many small chunks; total wire far exceeds the
@@ -2896,10 +2894,6 @@ mod tests {
         let plp = plp_value(500, 24);
         let mut payload = vec![TokenType::Row as u8];
         payload.extend_from_slice(&plp);
-        assert!(
-            payload.len() > BUFFER_CAPACITY,
-            "residency value must exceed buffer capacity"
-        );
 
         let reference = decode_oracle(frame_into(&payload, 2048), &columns).await;
         assert_ne!(reference[0], ColumnValues::Null);
@@ -2910,6 +2904,16 @@ mod tests {
         let mut mock = MockNetworkReaderWriter::new(wire, 0);
         let mut reader = PacketReader::new(&mut mock);
         reader.read_tds_packet_for_test().await.unwrap();
+
+        // Bind the residency ceiling to the ACTUAL in-test buffer capacity (the
+        // 2 x negotiated-packet working buffer), not a magic number.
+        let buffer_capacity = reader.row_buffer_mut().working_buffer().len();
+        assert!(
+            payload.len() > buffer_capacity,
+            "residency value ({}) must exceed the actual buffer capacity ({buffer_capacity})",
+            payload.len()
+        );
+
         let context = ParserContext::ColumnMetadata(
             Arc::new(ColMetadataToken {
                 column_count: columns.len() as u16,
@@ -2930,10 +2934,17 @@ mod tests {
             "eager-PLP LOB must decode byte-identically through the production driver"
         );
 
+        // The load-bearing CEILING: peak resident bytes must stay within one
+        // 2 x packet buffer. A collect-whole / NeedBytes(full-len) collapse would
+        // drive `length` toward the whole-LOB size across successive strip_header
+        // appends: on a growable buffer `peak` would exceed `buffer_capacity`
+        // (this assertion fails); on the fixed-cap buffer the forward-progress
+        // guard trips and the decode errors (the `.unwrap()` above panics). Either
+        // way the footgun regresses this test.
         let peak = reader.row_buffer_mut().peak_length();
         assert!(
-            peak <= BUFFER_CAPACITY,
-            "peak residency {peak} exceeded the buffer capacity {BUFFER_CAPACITY}: \
+            peak <= buffer_capacity,
+            "peak residency {peak} exceeded the buffer capacity {buffer_capacity}: \
              the driver held more than one buffer/chunk resident"
         );
         assert!(

--- a/mssql-tds/src/io/token_stream.rs
+++ b/mssql-tds/src/io/token_stream.rs
@@ -8,7 +8,8 @@ use crate::datatypes::decoder::{
 use crate::datatypes::row_writer::{DefaultRowWriter, RowWriter, write_column_value};
 use crate::io::packet_buffer::PacketBuffer;
 use crate::io::packet_reader::TdsPacketReader;
-use crate::io::tds_core::{RowStep, TdsCore};
+use crate::io::sync_token;
+use crate::io::tds_core::{RowStep, TdsCore, TokenStep};
 use crate::query::metadata::ColumnMetadata;
 use crate::security::cell_decryptor::CellDecryptor;
 use crate::token::parsers::TokenParser;
@@ -320,6 +321,15 @@ pub(crate) async fn dispatch_token<R: TdsPacketReader + Send + Sync>(
     }
 }
 
+/// Test/fuzzing-only reference oracle for the non-row token receive path.
+///
+/// Production token consumption runs through the synchronous
+/// [`TdsCore::step_token`] body driven by [`drive_token_over_buffer`], which
+/// sync-parses the bounded category-(a) tokens in place and seams the
+/// value-carrying / login tokens through [`dispatch_token`]. This async
+/// whole-token read is retained solely as a differential byte-identity oracle
+/// for the refill-boundary tests; no production path reaches it.
+#[cfg(any(test, fuzzing))]
 pub(crate) async fn receive_token_internal<R: TdsPacketReader + Send + Sync>(
     reader: &mut R,
     registry: &impl TokenParserRegistry,
@@ -747,7 +757,7 @@ where
             RowStep::RowWritten => return Ok(RowReadResult::RowWritten),
             RowStep::RowPaused(state) => return Ok(RowReadResult::RowPaused(state)),
             RowStep::Token(token_type) => {
-                let token = dispatch_token(reader, registry, token_type, context).await?;
+                let token = resolve_header_token(reader, registry, token_type, context).await?;
                 return Ok(RowReadResult::Token(token));
             }
             RowStep::NeedBytes(need) => {
@@ -768,6 +778,82 @@ where
                     }
                     AsyncColumnOutcome::Terminal(result) => return Ok(result),
                 }
+            }
+        }
+    }
+}
+
+/// Resolves a non-row token whose token byte has already been consumed.
+///
+/// This is the shared terminal-token seam used by both the top-level non-row
+/// receive driver ([`drive_token_over_buffer`]) and the row driver's
+/// [`RowStep::Token`] arm: [`TdsCore::begin_row_header`] consumes the token byte
+/// then hands the classification back, and this helper decodes it.
+///
+/// Category-(a) bounded tokens are parsed in place by the pure-sync
+/// [`sync_token::parse_token_body`] body — refilling the buffer until the whole
+/// length-bounded token is resident, so the parse runs over a complete slice and
+/// never sees a partial buffer. Every other token (the value-carrying (b)
+/// tokens plus login/handshake tokens) stays on the async seam via the existing
+/// [`dispatch_token`] parser. This is the token-atomic analog of
+/// [`decode_async_row_column`] for the row path's `AsyncColumn`.
+async fn resolve_header_token<R, Reg>(
+    reader: &mut R,
+    registry: &Reg,
+    token_type: TokenType,
+    context: &ParserContext,
+) -> TdsResult<Tokens>
+where
+    R: BufferedRowReader,
+    Reg: TokenParserRegistry,
+{
+    if !sync_token::is_sync_token(&token_type) {
+        return dispatch_token(reader, registry, token_type, context).await;
+    }
+    loop {
+        let total = match sync_token::body_len(reader.row_buffer_mut(), &token_type) {
+            Ok(total) => total,
+            Err(_) => {
+                reader.refill_row_buffer().await?;
+                continue;
+            }
+        };
+        if reader.row_buffer_mut().ensure(total).is_err() {
+            reader.refill_row_buffer().await?;
+            continue;
+        }
+        return sync_token::parse_token_body(reader.row_buffer_mut(), token_type, context);
+    }
+}
+
+/// Production non-row receive driver: the single async shell over
+/// [`TdsCore::step_token`].
+///
+/// It owns the only `.await` on the non-row token path — refilling the buffer on
+/// [`TokenStep::NeedBytes`] and servicing a [`TokenStep::AsyncToken`] through the
+/// existing async [`dispatch_token`] seam — then re-drives the sync body from the
+/// shared cursor. This is the token-consume analog of [`drive_row_over_buffer`].
+pub(crate) async fn drive_token_over_buffer<R, Reg>(
+    reader: &mut R,
+    registry: &Reg,
+    context: &ParserContext,
+) -> TdsResult<Tokens>
+where
+    R: BufferedRowReader,
+    Reg: TokenParserRegistry,
+{
+    loop {
+        match TdsCore::step_token(reader.row_buffer_mut(), context)? {
+            TokenStep::Parsed(token) => return Ok(token),
+            TokenStep::AsyncToken(token_type) => {
+                return dispatch_token(reader, registry, token_type, context).await;
+            }
+            TokenStep::NeedBytes(need) => {
+                tracing::trace!(
+                    shortfall = need.shortfall,
+                    "refilling token buffer for step_token"
+                );
+                reader.refill_row_buffer().await?;
             }
         }
     }
@@ -2718,6 +2804,147 @@ mod tests {
         }
     }
 
+    /// P4b hardening (AD-2): a STRICT residency-CEILING assertion on the
+    /// PRODUCTION driver for an eager-PLP LOB. P4a's own eager-PLP residency
+    /// guarantee is asserted here, one layer up, rather than in #198, to keep the
+    /// frozen P4a tip stable.
+    ///
+    /// A single `varbinary(max)` PLP column carrying many small chunks whose total
+    /// wire EXCEEDS the 8192 B buffer capacity is decoded through
+    /// `drive_row_over_buffer` (the production driver), framed into sub-buffer
+    /// packets. The driver services the unbounded column via the `AsyncColumn`
+    /// seam chunk-at-a-time, so peak `PacketBuffer` residency must stay bounded
+    /// (≲ one buffer/chunk) and never approach the whole-LOB size.
+    ///
+    /// This is a CEILING, not a "decode still matches" check: if anyone ever
+    /// collapses `AsyncColumn` into a collect-whole / `NeedBytes(full-len)` path,
+    /// the driver would drive `length` toward the full LOB size and
+    /// `peak_length` would reach `>= large.len()`, FAILING the ceiling — robust
+    /// even if the buffer capacity later becomes growable.
+    #[tokio::test]
+    async fn tdscore_step_row_eager_plp_residency_ceiling_on_production_driver() {
+        use crate::datatypes::column_values::ColumnValues;
+        use crate::datatypes::row_writer::DefaultRowWriter;
+        use crate::io::packet_reader::PacketReader;
+        use crate::io::packet_reader::tests::{MockNetworkReaderWriter, TestPacketBuilder};
+        use crate::message::messages::PacketType;
+
+        const BUFFER_CAPACITY: usize = 8192; // 2 x 4096 B negotiated packet
+
+        let columns = vec![plp_varbinary_metadata("b", None)];
+
+        // UNKNOWNLEN PLP value with many small chunks; total wire far exceeds the
+        // buffer capacity, so it can never be whole-resident.
+        fn plp_value(chunk: usize, count: usize) -> Vec<u8> {
+            let mut plp = Vec::new();
+            plp.extend_from_slice(&0xFFFF_FFFF_FFFF_FFFE_u64.to_le_bytes()); // UNKNOWNLEN
+            let mut counter = 0u8;
+            for _ in 0..count {
+                plp.extend_from_slice(&(chunk as u32).to_le_bytes());
+                for _ in 0..chunk {
+                    plp.push(counter);
+                    counter = counter.wrapping_add(1);
+                }
+            }
+            plp.extend_from_slice(&0u32.to_le_bytes()); // zero-length terminator
+            plp
+        }
+
+        // Frame the payload into `piece`-sized packets (EOM only on the last), so
+        // each refill exposes at most one small packet.
+        fn frame_into(payload: &[u8], piece: usize) -> Vec<u8> {
+            let mut wire = Vec::new();
+            let mut offset = 0;
+            while offset < payload.len() {
+                let end = (offset + piece).min(payload.len());
+                let mut builder = TestPacketBuilder::new(PacketType::PreLogin);
+                let mut packet = builder.append_bytes(&payload[offset..end]).build();
+                if end < payload.len() {
+                    packet[1] = 0x00; // clear EOM: more packets follow
+                }
+                wire.extend_from_slice(&packet);
+                offset = end;
+            }
+            wire
+        }
+
+        async fn decode_oracle(
+            read_data: Vec<u8>,
+            columns: &[ColumnMetadata],
+        ) -> Vec<ColumnValues> {
+            let mut mock = MockNetworkReaderWriter::new(read_data, 0);
+            let mut reader = PacketReader::new(&mut mock);
+            reader.read_tds_packet_for_test().await.unwrap();
+            let context = ParserContext::ColumnMetadata(
+                Arc::new(ColMetadataToken {
+                    column_count: columns.len() as u16,
+                    columns: columns.to_vec(),
+                    cek_table: vec![],
+                }),
+                None,
+            );
+            let registry = GenericTokenParserRegistry::default();
+            let mut writer = DefaultRowWriter::new(columns.len());
+            let result = receive_row_into_internal(&mut reader, &registry, &context, &mut writer)
+                .await
+                .unwrap();
+            assert!(matches!(result, RowReadResult::RowWritten));
+            writer.take_row()
+        }
+
+        // 24 x 500 B chunks = 12000 B of payload; comfortably over the buffer cap.
+        let plp = plp_value(500, 24);
+        let mut payload = vec![TokenType::Row as u8];
+        payload.extend_from_slice(&plp);
+        assert!(
+            payload.len() > BUFFER_CAPACITY,
+            "residency value must exceed buffer capacity"
+        );
+
+        let reference = decode_oracle(frame_into(&payload, 2048), &columns).await;
+        assert_ne!(reference[0], ColumnValues::Null);
+
+        // Drive the production driver over 512 B packet frames and capture peak
+        // residency from the shared buffer after a successful decode.
+        let wire = frame_into(&payload, 512);
+        let mut mock = MockNetworkReaderWriter::new(wire, 0);
+        let mut reader = PacketReader::new(&mut mock);
+        reader.read_tds_packet_for_test().await.unwrap();
+        let context = ParserContext::ColumnMetadata(
+            Arc::new(ColMetadataToken {
+                column_count: columns.len() as u16,
+                columns: columns.to_vec(),
+                cek_table: vec![],
+            }),
+            None,
+        );
+        let registry = GenericTokenParserRegistry::default();
+        let mut writer = DefaultRowWriter::new(columns.len());
+        let result = drive_row_over_buffer(&mut reader, &registry, &context, None, &mut writer)
+            .await
+            .unwrap();
+        assert!(matches!(result, RowReadResult::RowWritten));
+        let decoded = writer.take_row();
+        assert_eq!(
+            decoded, reference,
+            "eager-PLP LOB must decode byte-identically through the production driver"
+        );
+
+        let peak = reader.row_buffer_mut().peak_length();
+        assert!(
+            peak <= BUFFER_CAPACITY,
+            "peak residency {peak} exceeded the buffer capacity {BUFFER_CAPACITY}: \
+             the driver held more than one buffer/chunk resident"
+        );
+        assert!(
+            peak < payload.len(),
+            "peak residency {peak} reached the whole-LOB size {}: AsyncColumn was \
+             collapsed into a collect-whole / NeedBytes(full-len) path, \
+             reintroducing whole-LOB residency",
+            payload.len()
+        );
+    }
+
     /// P4a blocking test 4: the resume-from-pause path. A `RowPauseState` positioned
     /// mid-row is driven both through the production `step_row` driver (with a
     /// `Some` cursor, which skips the header and decodes from `next_column_index`)
@@ -2924,5 +3151,245 @@ mod tests {
             .filter(|tt| registry.get_parser(tt).is_some())
             .count();
         assert_eq!(count, expected_count);
+    }
+
+    // ---- P4b: non-row token driver refill-boundary differential tests ----
+    //
+    // Each test feeds a canned token byte stream through the production
+    // `drive_token_over_buffer` (sync `TdsCore::step_token` body + the single
+    // refill `.await`) and the `#[cfg(any(test, fuzzing))]` `receive_token_internal`
+    // async oracle, sweeping the refill boundary across every interior byte. The
+    // driver result must be byte-identical to the oracle at every split, proving
+    // the sync inversion parses the bounded category-(a) tokens (DONE/DONEINPROC/
+    // DONEPROC, ERROR, INFO, ORDER, ENVCHANGE) identically and that the
+    // `AsyncToken` seam hands the value-carrying tokens (COLMETADATA) to the async
+    // parser across a refill without corruption.
+
+    fn token_one_packet(payload: &[u8]) -> Vec<u8> {
+        use crate::io::packet_reader::tests::TestPacketBuilder;
+        use crate::message::messages::PacketType;
+        let mut builder = TestPacketBuilder::new(PacketType::PreLogin);
+        builder.append_bytes(payload).build()
+    }
+
+    fn token_two_packets(payload: &[u8], split: usize) -> Vec<u8> {
+        use crate::io::packet_reader::tests::TestPacketBuilder;
+        use crate::message::messages::PacketType;
+        let mut first_builder = TestPacketBuilder::new(PacketType::PreLogin);
+        let mut first = first_builder.append_bytes(&payload[..split]).build();
+        first[1] = 0x00; // clear EOM: more packets follow
+        let mut second_builder = TestPacketBuilder::new(PacketType::PreLogin);
+        let second = second_builder.append_bytes(&payload[split..]).build();
+        [first, second].concat()
+    }
+
+    async fn decode_token_via_driver(wire: Vec<u8>, context: &ParserContext) -> Tokens {
+        use crate::io::packet_reader::PacketReader;
+        use crate::io::packet_reader::tests::MockNetworkReaderWriter;
+        let mut mock = MockNetworkReaderWriter::new(wire, 0);
+        let mut reader = PacketReader::new(&mut mock);
+        reader.read_tds_packet_for_test().await.unwrap();
+        let registry = GenericTokenParserRegistry::default();
+        drive_token_over_buffer(&mut reader, &registry, context)
+            .await
+            .unwrap()
+    }
+
+    async fn decode_token_via_oracle(wire: Vec<u8>, context: &ParserContext) -> Tokens {
+        use crate::io::packet_reader::PacketReader;
+        use crate::io::packet_reader::tests::MockNetworkReaderWriter;
+        let mut mock = MockNetworkReaderWriter::new(wire, 0);
+        let mut reader = PacketReader::new(&mut mock);
+        reader.read_tds_packet_for_test().await.unwrap();
+        let registry = GenericTokenParserRegistry::default();
+        receive_token_internal(&mut reader, &registry, context)
+            .await
+            .unwrap()
+    }
+
+    /// Drives `token_bytes` through the production driver and the async oracle at
+    /// the whole-token baseline and at every interior split, asserting the driver
+    /// is byte-identical to the oracle (and both to the canonical decode) at each.
+    async fn assert_token_matches_oracle_at_every_split(
+        token_bytes: &[u8],
+        context: &ParserContext,
+    ) {
+        let canonical = format!(
+            "{:?}",
+            decode_token_via_oracle(token_one_packet(token_bytes), context).await
+        );
+        assert_eq!(
+            canonical,
+            format!(
+                "{:?}",
+                decode_token_via_driver(token_one_packet(token_bytes), context).await
+            ),
+            "driver whole-token decode diverged from the oracle"
+        );
+        for split in 1..token_bytes.len() {
+            let driver = format!(
+                "{:?}",
+                decode_token_via_driver(token_two_packets(token_bytes, split), context).await
+            );
+            let oracle = format!(
+                "{:?}",
+                decode_token_via_oracle(token_two_packets(token_bytes, split), context).await
+            );
+            assert_eq!(
+                driver, canonical,
+                "driver decode at split {split} diverged from canonical"
+            );
+            assert_eq!(
+                oracle, canonical,
+                "oracle decode at split {split} diverged from canonical"
+            );
+        }
+    }
+
+    fn done_like_token(token_byte: u8) -> Vec<u8> {
+        let mut v = vec![token_byte];
+        v.extend_from_slice(&0x0010_u16.to_le_bytes()); // status: DONE_COUNT
+        v.extend_from_slice(&0x00C1_u16.to_le_bytes()); // cur_cmd
+        v.extend_from_slice(&42_u64.to_le_bytes()); // row_count
+        v
+    }
+
+    fn ascii_utf16(s: &str) -> Vec<u8> {
+        let mut out = Vec::with_capacity(s.len() * 2);
+        for b in s.bytes() {
+            out.push(b);
+            out.push(0);
+        }
+        out
+    }
+
+    /// Category-(a) fixed-body DONE family split across a refill boundary.
+    #[tokio::test]
+    async fn drive_token_done_family_split_matches_oracle() {
+        let context = ParserContext::None(());
+        for token_byte in [
+            TokenType::Done as u8,
+            TokenType::DoneInProc as u8,
+            TokenType::DoneProc as u8,
+        ] {
+            assert_token_matches_oracle_at_every_split(&done_like_token(token_byte), &context)
+                .await;
+        }
+    }
+
+    /// Category-(a) length-prefixed ERROR and INFO split across a refill boundary.
+    #[tokio::test]
+    async fn drive_token_error_info_split_matches_oracle() {
+        let context = ParserContext::None(());
+        for token_byte in [TokenType::Error as u8, TokenType::Info as u8] {
+            let mut body = Vec::new();
+            body.extend_from_slice(&14081_u32.to_le_bytes()); // number
+            body.push(1); // state
+            body.push(16); // severity
+            let message = ascii_utf16("hi there");
+            body.extend_from_slice(&((message.len() / 2) as u16).to_le_bytes());
+            body.extend_from_slice(&message);
+            let server = ascii_utf16("srv");
+            body.push((server.len() / 2) as u8);
+            body.extend_from_slice(&server);
+            body.push(0); // empty proc name
+            body.extend_from_slice(&7_u32.to_le_bytes()); // line number
+
+            let mut token = vec![token_byte];
+            token.extend_from_slice(&(body.len() as u16).to_le_bytes());
+            token.extend_from_slice(&body);
+            assert_token_matches_oracle_at_every_split(&token, &context).await;
+        }
+    }
+
+    /// Category-(a) ORDER split across a refill boundary.
+    #[tokio::test]
+    async fn drive_token_order_split_matches_oracle() {
+        let context = ParserContext::None(());
+        let cols = [1_u16, 2, 3];
+        let mut body = Vec::new();
+        for c in cols {
+            body.extend_from_slice(&c.to_le_bytes());
+        }
+        let mut token = vec![TokenType::Order as u8];
+        token.extend_from_slice(&(body.len() as u16).to_le_bytes());
+        token.extend_from_slice(&body);
+        assert_token_matches_oracle_at_every_split(&token, &context).await;
+    }
+
+    /// Category-(a) ENVCHANGE (Database subtype) split across a refill boundary.
+    #[tokio::test]
+    async fn drive_token_envchange_split_matches_oracle() {
+        let context = ParserContext::None(());
+        let new_value = ascii_utf16("db_new");
+        let old_value = ascii_utf16("db_old");
+        let mut body = vec![0x01]; // subtype: Database
+        body.push((new_value.len() / 2) as u8);
+        body.extend_from_slice(&new_value);
+        body.push((old_value.len() / 2) as u8);
+        body.extend_from_slice(&old_value);
+        let mut token = vec![TokenType::EnvChange as u8];
+        token.extend_from_slice(&(body.len() as u16).to_le_bytes());
+        token.extend_from_slice(&body);
+        assert_token_matches_oracle_at_every_split(&token, &context).await;
+    }
+
+    fn single_int_colmetadata_token() -> Vec<u8> {
+        let mut token = vec![TokenType::ColMetadata as u8];
+        token.extend_from_slice(&1_u16.to_le_bytes()); // column count
+        token.extend_from_slice(&0_u32.to_le_bytes()); // user type
+        token.extend_from_slice(&0_u16.to_le_bytes()); // flags
+        token.push(TdsDataType::Int4 as u8); // data type (no type info)
+        let name = ascii_utf16("id");
+        token.push((name.len() / 2) as u8);
+        token.extend_from_slice(&name);
+        token
+    }
+
+    /// COLMETADATA is a value-carrying category-(b) token that stays on the
+    /// `AsyncToken` seam. Splitting it across a refill boundary proves the seam
+    /// hands a token spanning a refill to the async parser byte-identically.
+    #[tokio::test]
+    async fn drive_token_colmetadata_split_matches_oracle() {
+        let context = ParserContext::default();
+        assert_token_matches_oracle_at_every_split(&single_int_colmetadata_token(), &context).await;
+    }
+
+    /// The seam boundary is new surface: after the driver yields COLMETADATA via
+    /// the `AsyncToken` seam, the next step must hand off to the row driver over
+    /// the same shared buffer and decode the following ROW.
+    #[tokio::test]
+    async fn drive_token_colmetadata_then_row_handoff() {
+        use crate::datatypes::column_values::ColumnValues;
+        use crate::datatypes::row_writer::DefaultRowWriter;
+        use crate::io::packet_reader::PacketReader;
+        use crate::io::packet_reader::tests::MockNetworkReaderWriter;
+
+        let mut payload = single_int_colmetadata_token();
+        payload.push(TokenType::Row as u8);
+        payload.extend_from_slice(&7_i32.to_le_bytes());
+
+        let mut mock = MockNetworkReaderWriter::new(token_one_packet(&payload), 0);
+        let mut reader = PacketReader::new(&mut mock);
+        reader.read_tds_packet_for_test().await.unwrap();
+        let registry = GenericTokenParserRegistry::default();
+
+        let meta_context = ParserContext::default();
+        let token = drive_token_over_buffer(&mut reader, &registry, &meta_context)
+            .await
+            .unwrap();
+        let colmeta = match token {
+            Tokens::ColMetadata(token) => token,
+            other => panic!("expected ColMetadata from the seam, got {other:?}"),
+        };
+        assert_eq!(colmeta.column_count, 1);
+
+        let row_context = ParserContext::ColumnMetadata(Arc::new(colmeta), None);
+        let mut writer = DefaultRowWriter::new(1);
+        let result = drive_row_over_buffer(&mut reader, &registry, &row_context, None, &mut writer)
+            .await
+            .unwrap();
+        assert!(matches!(result, RowReadResult::RowWritten));
+        assert_eq!(writer.take_row(), vec![ColumnValues::Int(7)]);
     }
 }


### PR DESCRIPTION
## P4b — Invert the non-row RECEIVE / token-consume paths to a sans-I/O sync core

Base: `dev/saurabh/sans-io-p4a-tdscore-row-driver` (frozen P4a tip `07099e0c`). **Draft; do not merge — coordinator will verify from git ground truth + a real nextest and append to stack #192.**

Mirrors P4a's row inversion for the non-row receive path. Every guaranteed-bounded category-(a) non-row token is now parsed by a pure-sync body over `PacketBuffer`, driven by one async shell that owns the **sole** refill `.await`. Value-carrying / login tokens stay on an explicit async seam. **Zero behavior change; public API frozen async-only.**

### What changed
- **`TokenStep` + `TdsCore::step_token`** (`io/tds_core.rs`) — peeks the token byte, ensures the length-bounded body, and parses in place; returns `NeedBytes` on entry underflow (nothing consumed, restartable) or `AsyncToken(tt)` for seamed tokens.
- **`io/sync_token.rs`** (new) — the pure-sync parse leaf: **one** production parse body per category-(a) token (DONE/DONEINPROC/DONEPROC, RETURNSTATUS, ORDER, ERROR, INFO, ENVCHANGE), byte-for-byte mirroring the async parsers.
- **`drive_token_over_buffer` + `resolve_header_token`** (`io/token_stream.rs`) — the single async shell; rewires the three production `receive_token` sites in `network_transport.rs`.
- **Oracle retained** — `receive_token_internal` is gated `#[cfg(any(test, fuzzing))]` as a differential byte-identity oracle; grep-proven no production path reaches it (its only non-test callers are `#[cfg(fuzzing)]`).

### Scope honesty (deferred work)
COLMETADATA / RETURNVALUE / SESSIONSTATE / FEATUREEXTACK (category-(b), value/PLP-carrying) **and** the login/handshake tokens (LOGINACK/TABNAME/COLINFO/SSPI/FEDAUTHINFO) remain on the `AsyncToken` async seam. Their pure-sync inversion is **deferred** to a later, parent-gated layer that would introduce a sanctioned mid-token `TokenPauseState` cursor. The receive path is **not** fully sync after P4b — this is stated in the `tds_core.rs` module doc and enforced by leaving those tokens on the seam. **No new resumable machine is introduced here.**

### Two folded P4a-hardening items (carried here, not in #198)
1. **`RowStep::AsyncColumn` load-bearing doc comment** (`io/tds_core.rs`) — bakes in the exact rationale that yielding an unbounded PLP column preserves L4b bounded residency and must never be collapsed into `NeedBytes{shortfall}`.
2. **Strict production-path eager-PLP residency-CEILING test** (`tdscore_step_row_eager_plp_residency_ceiling_on_production_driver`) — decodes a >8192 B eager-PLP LOB **through `drive_row_over_buffer`** (production) and asserts peak `PacketBuffer` residency stays ≲ one buffer/chunk via a `#[cfg(test)]` `peak_length` high-water hook (off the public surface). It FAILS if `AsyncColumn` is ever collapsed to a collect-whole / `NeedBytes(full-len)` path.

> Note: P4a's own eager-PLP residency guarantee is asserted **one layer up (here, in P4b)** rather than in #198, to keep the frozen P4a tip `07099e0c` stable. A reviewer of #198 should not be confused about why that assertion lives in P4b.

### Tests (through the new sync driver)
- DONE/DONEINPROC/DONEPROC, ERROR/INFO, ORDER, ENVCHANGE — swept at **every** interior split vs the oracle (byte-identical resume, no consume-on-shortfall, no hang).
- COLMETADATA split across a refill boundary — proves the `AsyncToken` seam handles a token spanning a refill.
- COLMETADATA → ROW handoff — proves the seam hands off to the row driver over the shared buffer.

### Gate (from this worktree)
- `cargo nextest run -p mssql-tds --lib --no-fail-fast` → fail-set **== exactly the 7 known cert fixtures** (Compare-Object of sorted fail-name sets == EMPTY), no hang.
- `cargo bfmt` + `cargo bclippy` (-D warnings) clean; `scripts/bfmt.ps1` + `scripts/bclippy.ps1` clean incl. `mssql-py-core`; `cargo build --all-features` in `mssql-py-core` OK.
- Public-API diff-scan == EMPTY (all new symbols `pub(crate)`/`cfg(test)`).