### PR TITLE
Introduce ByteSource seam under async client (sans-I/O expose L1)

### DIFF
--- a/mssql-tds/src/connection/transport/network_transport.rs
+++ b/mssql-tds/src/connection/transport/network_transport.rs
@@ -13,9 +13,9 @@ use crate::datatypes::row_writer::RowWriter;
 use crate::error::Error::{OperationCancelledError, TimeoutError};
 use crate::error::TimeoutErrorType;
 use crate::handler::handler_factory::SessionSettings;
+use crate::io::byte_source::{AsyncByteSource, assemble_tds_packet};
 use crate::io::packet_buffer::PacketBuffer;
 use crate::io::packet_reader::{PacketReader, TdsPacketReader};
-use crate::io::packet_writer::PacketWriter;
 use crate::io::reader_writer::{NetworkReader, NetworkReaderWriter, NetworkWriter};
 use crate::io::token_stream::{
     ParserContext, PlpPauseState, RowPauseState, RowReadResult, TdsTokenStreamReader,
@@ -33,7 +33,7 @@ use std::time::Duration;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::{self, TcpStream};
 use tokio::time::timeout;
-use tracing::{debug, error, event, info, trace};
+use tracing::{debug, error, info, trace};
 
 #[cfg(windows)]
 use crate::connection::transport::localdb::resolve_localdb_instance;
@@ -886,86 +886,13 @@ impl NetworkTransport {
     ///
     /// The fix ensures all bytes from `read()` are accounted for, not just the first packet.
     async fn get_new_tds_packet(&mut self) -> TdsResult<usize> {
-        // Compact readable bytes and replay any pending bytes from a prior
-        // multi-packet read; `base` is where this raw packet begins and
-        // `already` is how many of its bytes are already buffered.
-        let (base, already) = self.tds_read_buffer.begin_refill()?;
-        let mut bytes_available = already;
-
-        let stream = self.stream.as_mut().ok_or_else(|| {
+        let stream = self.stream.as_deref_mut().ok_or_else(|| {
             crate::error::Error::ConnectionClosed(
                 "Cannot read TDS packet: connection has been closed".to_string(),
             )
         })?;
-
-        // Read more data if we don't have enough for the header
-        while bytes_available < PacketWriter::PACKET_HEADER_SIZE {
-            let bytes_read = match stream
-                .read(self.tds_read_buffer.refill_window(base, bytes_available))
-                .await
-            {
-                Ok(n) => n,
-                Err(e) => {
-                    // A read failure means the socket is broken; record it so the
-                    // cached liveness check reports the connection as dead.
-                    self.known_dead = true;
-                    return Err(e.into());
-                }
-            };
-            if bytes_read == 0 {
-                self.known_dead = true;
-                return Err(crate::error::Error::ConnectionClosed(
-                    "Connection closed by server while reading TDS packet header".to_string(),
-                ));
-            }
-            bytes_available += bytes_read;
-        }
-
-        // Validate the declared length (>= header, <= max packet size, fits in
-        // the buffer) before trusting it to bound the payload read.
-        let packet_size_from_header = self.tds_read_buffer.validate_packet_length(base)?;
-
-        // Keep reading until we have the complete packet in memory.
-        while bytes_available < packet_size_from_header {
-            let bytes_read = match stream
-                .read(self.tds_read_buffer.refill_window(base, bytes_available))
-                .await
-            {
-                Ok(n) => n,
-                Err(e) => {
-                    self.known_dead = true;
-                    return Err(e.into());
-                }
-            };
-            if bytes_read == 0 {
-                self.known_dead = true;
-                return Err(crate::error::Error::ConnectionClosed(
-                    "Connection closed by server while reading TDS packet payload".to_string(),
-                ));
-            }
-            bytes_available += bytes_read;
-        }
-
-        // Bytes read past this packet belong to the next one; carry them forward.
-        self.tds_read_buffer
-            .record_pending(base, packet_size_from_header, bytes_available);
-
-        event!(
-            tracing::Level::DEBUG,
-            "Received packet of size: {:?}",
-            packet_size_from_header
-        );
-
-        use pretty_hex::PrettyHex;
-
-        event!(
-            tracing::Level::DEBUG,
-            "Packet content: {:?}",
-            self.tds_read_buffer
-                .raw_packet(base, packet_size_from_header)
-                .hex_dump()
-        );
-        Ok(packet_size_from_header)
+        let mut source = AsyncByteSource::new(stream, &mut self.known_dead);
+        assemble_tds_packet(&mut source, &mut self.tds_read_buffer).await
     }
 
     /// Tells the server to stop sending tokens for the token stream being read and waits for

--- a/mssql-tds/src/io.rs
+++ b/mssql-tds/src/io.rs
@@ -24,6 +24,7 @@
 //! Most users will not interact with this module directly. Instead, use the higher-level
 //! [`crate::connection`] APIs which handle packet I/O internally.
 
+pub(crate) mod byte_source;
 pub(crate) mod packet_buffer;
 pub mod packet_reader;
 pub mod packet_writer;

--- a/mssql-tds/src/io/byte_source.rs
+++ b/mssql-tds/src/io/byte_source.rs
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! The `ByteSource` seam: the single "give me more bytes" edge that TDS packet
+//! assembly pulls through.
+//!
+//! Packet framing ([`assemble_tds_packet`]) is byte-source-agnostic — it only
+//! ever needs one primitive from the outside world: pull some more bytes into a
+//! caller-owned window. Formalizing that edge as [`ByteSource`] lets the one
+//! assembly body run over either the live socket ([`AsyncByteSource`]) or any
+//! [`NetworkReader`] (the buffer-owning test reader) without duplicating the
+//! header/payload loops. The seam is generic, not `dyn`: callers pass a concrete
+//! source and the body is monomorphized per source.
+
+use async_trait::async_trait;
+use tokio::io::AsyncReadExt;
+use tracing::event;
+
+use crate::connection::transport::network_transport::Stream;
+use crate::core::TdsResult;
+use crate::io::packet_buffer::PacketBuffer;
+use crate::io::packet_writer::PacketWriter;
+use crate::io::reader_writer::{NetworkReader, NetworkReaderWriter};
+
+/// The sole primitive TDS packet assembly needs from the outside world.
+///
+/// Pull up to `buffer.len()` more bytes into `buffer`, returning how many were
+/// read. A return of `0` means the peer has no more bytes (EOF); the assembly
+/// body turns that into a [`ConnectionClosed`](crate::error::Error::ConnectionClosed).
+#[async_trait]
+pub(crate) trait ByteSource: Send {
+    async fn receive(&mut self, buffer: &mut [u8]) -> TdsResult<usize>;
+}
+
+/// Bridges the buffer-owning test reader onto the seam: a `NetworkReader` is
+/// already a byte pull, so forward it unchanged and share the one assembly body.
+#[async_trait]
+impl<'a> ByteSource for dyn NetworkReaderWriter + 'a {
+    async fn receive(&mut self, buffer: &mut [u8]) -> TdsResult<usize> {
+        NetworkReader::receive(self, buffer).await
+    }
+}
+
+/// The single production byte source: the live socket. Reads straight off the
+/// stream and records a broken connection so the cached liveness check reports
+/// it dead, exactly as the transport's inline packet read did before the seam.
+pub(crate) struct AsyncByteSource<'a> {
+    stream: &'a mut dyn Stream,
+    known_dead: &'a mut bool,
+}
+
+impl<'a> AsyncByteSource<'a> {
+    pub(crate) fn new(stream: &'a mut dyn Stream, known_dead: &'a mut bool) -> Self {
+        Self { stream, known_dead }
+    }
+}
+
+#[async_trait]
+impl ByteSource for AsyncByteSource<'_> {
+    async fn receive(&mut self, buffer: &mut [u8]) -> TdsResult<usize> {
+        match self.stream.read(buffer).await {
+            Ok(0) => {
+                // EOF mid-read: the peer closed the connection. Record it so the
+                // cached liveness check reports the connection as dead; the
+                // caller turns the `0` into a `ConnectionClosed` error.
+                *self.known_dead = true;
+                Ok(0)
+            }
+            Ok(n) => Ok(n),
+            Err(e) => {
+                // A read failure means the socket is broken; record it so the
+                // cached liveness check reports the connection as dead.
+                *self.known_dead = true;
+                Err(e.into())
+            }
+        }
+    }
+}
+
+/// Reads one complete TDS packet from `source` into `buffer` and returns that
+/// packet's declared length (header + payload).
+///
+/// The single packet-framing body, pulling through the [`ByteSource`] seam. The
+/// 8-byte header may arrive split across reads, so it keeps reading until the
+/// header is complete before trusting its declared length. A single read may
+/// pull bytes past this packet (TCP coalescing, Named Pipes message mode); the
+/// surplus is carried forward via `record_pending` so the next refill strips its
+/// header too.
+pub(crate) async fn assemble_tds_packet<S: ByteSource + ?Sized>(
+    source: &mut S,
+    buffer: &mut PacketBuffer,
+) -> TdsResult<usize> {
+    // Compact readable bytes and replay any pending bytes from a prior
+    // multi-packet read; `base` is where this raw packet begins and `already`
+    // is how many of its bytes are already buffered.
+    let (base, already) = buffer.begin_refill()?;
+    let mut received = already;
+
+    while received < PacketWriter::PACKET_HEADER_SIZE {
+        let bytes_read = source.receive(buffer.refill_window(base, received)).await?;
+        if bytes_read == 0 {
+            return Err(crate::error::Error::ConnectionClosed(
+                "Connection closed by server while reading TDS packet header".to_string(),
+            ));
+        }
+        received += bytes_read;
+    }
+
+    // Validate the declared length (>= header, <= max packet size, fits in the
+    // buffer) before trusting it to bound the payload read.
+    let packet_size_from_header = buffer.validate_packet_length(base)?;
+    while received < packet_size_from_header {
+        let bytes_read = source.receive(buffer.refill_window(base, received)).await?;
+        if bytes_read == 0 {
+            return Err(crate::error::Error::ConnectionClosed(
+                "Connection closed by server while reading TDS packet payload".to_string(),
+            ));
+        }
+        received += bytes_read;
+    }
+
+    // Bytes read past this packet belong to the next one; carry them forward.
+    buffer.record_pending(base, packet_size_from_header, received);
+
+    event!(
+        tracing::Level::DEBUG,
+        "Received packet of size: {:?}",
+        packet_size_from_header
+    );
+
+    use pretty_hex::PrettyHex;
+    event!(
+        tracing::Level::DEBUG,
+        "Packet content: {:?}",
+        buffer.raw_packet(base, packet_size_from_header).hex_dump()
+    );
+
+    Ok(packet_size_from_header)
+}

--- a/mssql-tds/src/io/packet_reader.rs
+++ b/mssql-tds/src/io/packet_reader.rs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 use async_trait::async_trait;
-use tracing::event;
 
+#[cfg(test)]
 use super::packet_writer::PacketWriter;
 use crate::core::TdsResult;
 use crate::datatypes::row_writer::RowWriter;
@@ -251,8 +251,11 @@ impl<'a> PacketReader<'a> {
     }
 
     async fn read_tds_packet(&mut self) -> TdsResult<()> {
-        let (base, already) = self.buffer.begin_refill()?;
-        let packet_len = self.receive_packet(base, already).await?;
+        let packet_len = crate::io::byte_source::assemble_tds_packet(
+            self.network_reader_writer,
+            &mut self.buffer,
+        )
+        .await?;
         self.buffer.strip_header(packet_len);
         Ok(())
     }
@@ -261,64 +264,6 @@ impl<'a> PacketReader<'a> {
     #[cfg(test)]
     pub(crate) async fn read_tds_packet_for_test(&mut self) -> TdsResult<()> {
         self.read_tds_packet().await
-    }
-
-    /// Reads one TDS packet into the buffer and returns that packet's declared
-    /// length (header + payload). A single socket read may pull bytes past this
-    /// packet; the surplus is carried forward via `record_pending` so the next
-    /// refill strips its header too, exactly as the production transport does.
-    async fn receive_packet(&mut self, base: usize, already: usize) -> TdsResult<usize> {
-        let mut received = already;
-
-        // The 8-byte header may arrive split across reads; keep reading until it
-        // is complete before trusting its declared length.
-        while received < PacketWriter::PACKET_HEADER_SIZE {
-            let bytes_read = self
-                .network_reader_writer
-                .receive(self.buffer.refill_window(base, received))
-                .await?;
-            if bytes_read == 0 {
-                return Err(crate::error::Error::ConnectionClosed(
-                    "Connection closed by server while reading TDS packet header".to_string(),
-                ));
-            }
-            received += bytes_read;
-        }
-
-        let packet_size_from_header = self.buffer.validate_packet_length(base)?;
-        while received < packet_size_from_header {
-            let bytes_read = self
-                .network_reader_writer
-                .receive(self.buffer.refill_window(base, received))
-                .await?;
-            if bytes_read == 0 {
-                return Err(crate::error::Error::ConnectionClosed(
-                    "Connection closed by server while reading TDS packet payload".to_string(),
-                ));
-            }
-            received += bytes_read;
-        }
-
-        // Bytes read past this packet belong to the next one; carry them forward.
-        self.buffer
-            .record_pending(base, packet_size_from_header, received);
-
-        event!(
-            tracing::Level::DEBUG,
-            "Received packet of size: {:?}",
-            packet_size_from_header
-        );
-
-        use pretty_hex::PrettyHex;
-        event!(
-            tracing::Level::DEBUG,
-            "Packet content: {:?}",
-            self.buffer
-                .raw_packet(base, packet_size_from_header)
-                .hex_dump()
-        );
-
-        Ok(packet_size_from_header)
     }
 }
 


### PR DESCRIPTION
## Sans-I/O expose — Layer 1: the ByteSource seam

Bottom layer of the sans-I/O expose stack. Formalizes the "give me more bytes" edge as a `ByteSource` seam and routes all TDS packet framing through a single shared body.

### What changed
- **New `mssql-tds/src/io/byte_source.rs`** (all `pub(crate)`):
  - `ByteSource` trait — the sole outside-world primitive: `receive(&mut [u8]) -> usize`.
  - `AsyncByteSource` — the single production impl, reading off the live socket (`Box<dyn Stream>`) and recording a broken/EOF connection as dead exactly as the transport did before.
  - `assemble_tds_packet` — the one packet-framing body (header loop → `validate_packet_length` → payload loop → `record_pending`), generic over `S: ByteSource + ?Sized` (monomorphic seam, **not** `dyn`).
- **Rewired both call sites** to pull through the seam and deleted the two duplicated framing loops:
  - Production `NetworkTransport::get_new_tds_packet` now builds an `AsyncByteSource` and calls `assemble_tds_packet` (~74 lines → ~9).
  - Test-path `PacketReader::read_tds_packet` calls `assemble_tds_packet` over its buffer-owning reader; `receive_packet` removed.

Net: **12 insertions / 139 deletions** across the two call sites (plus the new seam module).

### Guarantees
- **No behavior change.** EOF/error semantics preserved: `0`-byte read → `ConnectionClosed`; socket EOF/error still sets `known_dead`. The regression tests asserting `ConnectionClosed` on empty/truncated input still pass.
- **`TdsClient` public-API diff is EMPTY.** The only new `pub` line anywhere is `pub(crate) mod byte_source;` (crate-internal). The generic seam is fully encapsulated inside transport/reader internals and appears in no public signature. `tds_client.rs` is untouched.
- **Test baseline preserved.** `cargo nextest run -p mssql-tds --lib` fail-set = the same 7 pre-existing cert fixtures as the base (empty `Compare-Object` delta, no hang). `cargo bfmt` / `cargo bclippy -D warnings` / the `scripts/bfmt.ps1` + `scripts/bclippy.ps1` (mssql-py-core) all clean.

This layer is the seam + async impl + internal rewiring only. No sync driver / sync client here (those are later layers).

Draft pending coordinator re-verification.