### PR TITLE
Report client-side rows_copied for bulk copy (fix 2x on Fabric Warehouse)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   fired via `fire_triggers`) remain retrievable via `info_messages()` after the
   operation completes. On a mid-stream failure the completed batches' INFO is
   preserved and remains retrievable alongside the returned error.
+- `mssql-tds`: `BulkCopyResult::rows_affected` now reports the number of rows the
+  client serialized to the wire (matching `SqlBulkCopy.RowsCopied`) instead of the
+  server's `DONE_COUNT`. Fixes a doubled count on distributed engines that
+  acknowledge one load with multiple `DONE_COUNT` tokens (issue #209).
 
 ### Removed
 

--- a/mssql-py-core/Cargo.toml
+++ b/mssql-py-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mssql-py-core"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 publish = false
 

--- a/mssql-py-core/src/cursor.rs
+++ b/mssql-py-core/src/cursor.rs
@@ -243,7 +243,12 @@ impl PyCoreCursor {
     /// # Returns
     ///
     /// Dictionary containing:
-    /// - `rows_copied` (int): Number of rows successfully copied
+    /// - `rows_copied` (int): Number of rows serialized to the wire by the
+    ///   client, matching `Microsoft.Data.SqlClient`'s `SqlBulkCopy.RowsCopied`.
+    ///   This is a client-side count, not a guarantee of the number of rows
+    ///   inserted on the server (server-side triggers, for example, can change
+    ///   the row count). It is also unaffected by distributed engines that
+    ///   acknowledge one load with multiple DONE_COUNT tokens (issue #209).
     /// - `batch_count` (int): Number of batches sent
     /// - `elapsed_time` (float): Time taken in seconds
     /// - `rows_per_second` (float): Throughput in rows per second

--- a/mssql-py-core/tests/test_bulkcopy_rows_copied_accuracy.py
+++ b/mssql-py-core/tests/test_bulkcopy_rows_copied_accuracy.py
@@ -1,0 +1,74 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Regression tests for bulkcopy row-count accuracy (issue #209).
+
+`rows_copied` must equal the number of rows actually inserted, and
+`batch_count` must equal the number of batches actually sent, on every engine.
+Distributed engines (Fabric Warehouse) acknowledge one load with multiple
+DONE_COUNT tokens; the core must not sum them into a doubled count.
+"""
+import pytest
+import mssql_py_core
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "row_count,batch_size,expected_batches",
+    [
+        (1, 0, 1),
+        (1, 1000, 1),
+        (1000, 0, 1),
+        (5000, 1000, 5),
+    ],
+)
+def test_bulkcopy_rows_copied_matches_actual(
+    client_context, row_count, batch_size, expected_batches
+):
+    conn = mssql_py_core.PyCoreConnection(client_context)
+    cursor = conn.cursor()
+
+    table_name = "#BulkCopyRowsCopiedAccuracy"
+    cursor.execute(f"CREATE TABLE {table_name} (id BIGINT)")
+
+    data = [(i,) for i in range(row_count)]
+
+    result = cursor.bulkcopy(
+        table_name, iter(data), batch_size=batch_size, timeout=60
+    )
+
+    cursor.execute(f"SELECT COUNT(*) FROM {table_name}")
+    actual = cursor.fetchone()[0]
+
+    assert actual == row_count
+    assert result["rows_copied"] == actual
+    assert result["batch_count"] == expected_batches
+
+    conn.close()
+
+
+@pytest.mark.integration
+def test_bulkcopy_arrow_rows_copied_matches_actual(client_context):
+    pa = pytest.importorskip("pyarrow")
+
+    conn = mssql_py_core.PyCoreConnection(client_context)
+    cursor = conn.cursor()
+
+    table_name = "#BulkCopyArrowRowsCopiedAccuracy"
+    cursor.execute(f"CREATE TABLE {table_name} (id BIGINT)")
+
+    row_count = 5000
+    table = pa.table({"id": pa.array(list(range(row_count)), pa.int64())})
+
+    result = cursor.bulkcopy_arrow(
+        table_name, table, batch_size=1000, timeout=60
+    )
+
+    cursor.execute(f"SELECT COUNT(*) FROM {table_name}")
+    actual = cursor.fetchone()[0]
+
+    assert actual == row_count
+    assert result["rows_copied"] == actual
+    assert result["batch_count"] == 5
+
+    conn.close()

--- a/mssql-py-core/tests/test_bulkcopy_rows_copied_accuracy.py
+++ b/mssql-py-core/tests/test_bulkcopy_rows_copied_accuracy.py
@@ -3,13 +3,13 @@
 
 """Regression tests for bulkcopy row-count accuracy (issue #209).
 
-`rows_copied` must equal the number of rows actually inserted, and
-`batch_count` must equal the number of batches actually sent, on every engine.
-Distributed engines (Fabric Warehouse) acknowledge one load with multiple
-DONE_COUNT tokens; the core must not sum them into a doubled count.
+`rows_copied` must equal the client-side count of rows serialized to the wire,
+and `batch_count` must equal the number of batches derived from that count and
+the batch size, on every engine. Distributed engines (Fabric Warehouse)
+acknowledge one load with multiple DONE_COUNT tokens; the core must not sum them
+into a doubled count.
 """
 import pytest
-import mssql_py_core
 
 
 @pytest.mark.integration
@@ -23,10 +23,9 @@ import mssql_py_core
     ],
 )
 def test_bulkcopy_rows_copied_matches_actual(
-    client_context, row_count, batch_size, expected_batches
+    connection, row_count, batch_size, expected_batches
 ):
-    conn = mssql_py_core.PyCoreConnection(client_context)
-    cursor = conn.cursor()
+    cursor = connection.cursor()
 
     table_name = "#BulkCopyRowsCopiedAccuracy"
     cursor.execute(f"CREATE TABLE {table_name} (id BIGINT)")
@@ -44,15 +43,12 @@ def test_bulkcopy_rows_copied_matches_actual(
     assert result["rows_copied"] == actual
     assert result["batch_count"] == expected_batches
 
-    conn.close()
-
 
 @pytest.mark.integration
-def test_bulkcopy_arrow_rows_copied_matches_actual(client_context):
+def test_bulkcopy_arrow_rows_copied_matches_actual(connection):
     pa = pytest.importorskip("pyarrow")
 
-    conn = mssql_py_core.PyCoreConnection(client_context)
-    cursor = conn.cursor()
+    cursor = connection.cursor()
 
     table_name = "#BulkCopyArrowRowsCopiedAccuracy"
     cursor.execute(f"CREATE TABLE {table_name} (id BIGINT)")
@@ -70,5 +66,3 @@ def test_bulkcopy_arrow_rows_copied_matches_actual(client_context):
     assert actual == row_count
     assert result["rows_copied"] == actual
     assert result["batch_count"] == 5
-
-    conn.close()

--- a/mssql-tds/src/connection/bulk_copy.rs
+++ b/mssql-tds/src/connection/bulk_copy.rs
@@ -260,7 +260,12 @@ impl BulkCopyProgress {
 /// Contains statistics about the completed operation.
 #[derive(Debug, Clone)]
 pub struct BulkCopyResult {
-    /// Number of rows successfully copied
+    /// Number of rows serialized to the wire by the client, matching
+    /// `Microsoft.Data.SqlClient`'s `SqlBulkCopy.RowsCopied`. This is a
+    /// client-side count, not a guarantee of the number of rows inserted on
+    /// the server (server-side triggers, for example, can change the row
+    /// count), and it is unaffected by distributed engines that acknowledge
+    /// one load with multiple DONE_COUNT tokens (issue #209).
     pub rows_affected: u64,
     /// Time taken for the operation
     pub elapsed: Duration,

--- a/mssql-tds/src/connection/bulk_copy.rs
+++ b/mssql-tds/src/connection/bulk_copy.rs
@@ -41,7 +41,7 @@
 //!     .timeout(30);
 //!
 //! let result = bulk_copy.write_to_server(users.into_iter()).await?;
-//! println!("Inserted {} rows", result.rows_affected);
+//! println!("Copied {} rows", result.rows_affected);
 //! ```
 
 use crate::connection::bulk_copy_state::{ATTENTION_TIMEOUT_SECONDS, BulkCopyTimeoutState};
@@ -263,9 +263,9 @@ pub struct BulkCopyResult {
     /// Number of rows serialized to the wire by the client, matching
     /// `Microsoft.Data.SqlClient`'s `SqlBulkCopy.RowsCopied`. This is a
     /// client-side count, not a guarantee of the number of rows inserted on
-    /// the server (server-side triggers, for example, can change the row
-    /// count), and it is unaffected by distributed engines that acknowledge
-    /// one load with multiple DONE_COUNT tokens (issue #209).
+    /// the server: server-side triggers or an `IGNORE_DUP_KEY` index can make
+    /// the committed row count differ. It is unaffected by distributed engines
+    /// that acknowledge one load with multiple DONE_COUNT tokens (issue #209).
     pub rows_affected: u64,
     /// Time taken for the operation
     pub elapsed: Duration,
@@ -310,7 +310,7 @@ impl BulkCopyResult {
 ///
 /// let rows = vec![/* your data */];
 /// let result = bulk_copy.write_to_server(rows.into_iter()).await?;
-/// println!("Inserted {} rows in {:?}", result.rows_affected, result.elapsed);
+/// println!("Copied {} rows in {:?}", result.rows_affected, result.elapsed);
 /// ```
 pub struct BulkCopy<'a> {
     /// Reference to the TDS client connection

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -1065,8 +1065,17 @@ impl TdsClient {
                         ));
                     }
 
-                    // Accumulate row count from multiple DONE tokens
-                    rows_affected += done.row_count;
+                    // The bulk-load response reports its authoritative row count in
+                    // the DONE token(s) carrying the DONE_COUNT flag. A single INSERT
+                    // BULK yields one such count, but distributed engines (e.g. Fabric
+                    // Warehouse, EngineEdition 11) acknowledge the same load with more
+                    // than one DONE_COUNT token, each carrying the full count. Summing
+                    // them double-counts (issue #209). Take the last counted DONE, which
+                    // matches the authoritative "last DONE_COUNT wins" semantics used
+                    // for SQLRowCount elsewhere and is correct on every engine.
+                    if done.has_count() {
+                        rows_affected = done.row_count;
+                    }
 
                     // Stop when we receive a DONE token without the MORE flag
                     if !done.has_more() {
@@ -4719,6 +4728,47 @@ mod tests {
         let messages = client.take_info_messages();
         assert_eq!(messages.len(), 2);
         assert!(client.info_messages().is_empty());
+    }
+
+    #[tokio::test]
+    async fn consume_done_token_takes_single_counted_done() {
+        // A normal (non-distributed) engine reports the bulk-load row count in a
+        // single DONE_COUNT token.
+        let mut client =
+            create_test_client_with_tokens(vec![done_count(CurrentCommand::Insert, 5000, false)]);
+
+        let rows_affected = client.consume_done_token().await.unwrap();
+
+        assert_eq!(rows_affected, 5000);
+    }
+
+    #[tokio::test]
+    async fn consume_done_token_does_not_double_count_distributed_dones() {
+        // Regression for #209: a distributed engine (Fabric Warehouse) acknowledges
+        // one bulk load with two DONE_COUNT tokens, each carrying the full count.
+        // Summing them would report 2x; the authoritative value is the count itself.
+        let mut client = create_test_client_with_tokens(vec![
+            done_count(CurrentCommand::Insert, 5000, true),
+            done_count(CurrentCommand::Insert, 5000, false),
+        ]);
+
+        let rows_affected = client.consume_done_token().await.unwrap();
+
+        assert_eq!(rows_affected, 5000);
+    }
+
+    #[tokio::test]
+    async fn consume_done_token_ignores_uncounted_dones() {
+        // DONE tokens without the COUNT flag carry a meaningless row_count and must
+        // not contribute to the total. Only the final DONE_COUNT value is reported.
+        let mut client = create_test_client_with_tokens(vec![
+            done_more(),
+            done_count(CurrentCommand::Insert, 3000, false),
+        ]);
+
+        let rows_affected = client.consume_done_token().await.unwrap();
+
+        assert_eq!(rows_affected, 3000);
     }
 
     #[test]

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -856,7 +856,12 @@ impl TdsClient {
     ///
     /// # Returns
     ///
-    /// Returns the number of rows actually inserted by SQL Server.
+    /// Returns the number of rows this client serialized to the wire, matching
+    /// `Microsoft.Data.SqlClient`'s `SqlBulkCopy.RowsCopied` semantics. This is
+    /// a client-side count, not the server's DONE token row count, so it is not
+    /// affected by distributed engines that acknowledge one load with multiple
+    /// DONE_COUNT tokens (issue #209). It also does not reflect server-side row
+    /// count changes from triggers on the destination table.
     #[instrument(skip(self, rows), level = "info")]
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn execute_bulk_load_streaming_zerocopy<R>(

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -1024,12 +1024,20 @@ impl TdsClient {
         }
 
         // STEP 4: End streaming (write DONE token and finalize)
-        let _rows_written = writer.end().await?;
+        let rows_written = writer.end().await?;
 
-        // STEP 5: Read the final response with row count
-        let rows_affected = self.consume_done_token().await?;
+        // STEP 5: Consume the server response for error handling, INFO capture,
+        // and to drain the connection to an idle state. The count reported to
+        // callers is the client-side `rows_written` (the number of rows this
+        // client serialized to the wire), matching SqlClient's
+        // `SqlBulkCopy.RowsCopied` semantics. We deliberately do NOT use the
+        // server's DONE token row count: distributed engines (e.g. Fabric
+        // Warehouse, EngineEdition 11) acknowledge one bulk load with multiple
+        // DONE_COUNT tokens, each carrying the full count, which inflated the
+        // reported total (issue #209).
+        self.consume_done_token().await?;
 
-        Ok(rows_affected)
+        Ok(rows_written)
     }
 
     /// Consumes response tokens until a DONE token is received.
@@ -4769,6 +4777,76 @@ mod tests {
         let rows_affected = client.consume_done_token().await.unwrap();
 
         assert_eq!(rows_affected, 3000);
+    }
+
+    /// A single-INT-column row used to drive the streaming bulk-load path.
+    struct IntRow(i32);
+
+    #[async_trait]
+    impl BulkLoadRow for IntRow {
+        async fn write_to_packet(
+            &self,
+            writer: &mut StreamingBulkLoadWriter<'_>,
+            column_index: &mut usize,
+        ) -> TdsResult<()> {
+            use crate::datatypes::column_values::ColumnValues;
+            writer
+                .write_column_value(*column_index, &ColumnValues::Int(self.0))
+                .await?;
+            *column_index += 1;
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn bulk_load_reports_client_rows_not_server_done_count() {
+        // Regression for #209: the count reported to callers must be the number
+        // of rows the client streamed to the wire — matching
+        // `SqlBulkCopy.RowsCopied` and ODBC bcp (`llRowsCopiedInLastBCP`), both
+        // of which count outgoing rows client-side — and must never be derived
+        // from the server's DONE_COUNT. Distributed engines (Fabric Warehouse,
+        // EngineEdition 11) acknowledge one bulk load with more than one
+        // DONE_COUNT token, so trusting the server count double-counted.
+        //
+        // The mock server here returns a deliberately wrong count (999) in each
+        // DONE_COUNT token; the client wrote 3 rows and must report exactly 3,
+        // which is only possible if the reported value is the client-side count.
+        use crate::datatypes::bulk_copy_metadata::{SqlDbType, TypeLength};
+        use crate::datatypes::sqldatatypes::TdsDataType;
+
+        let mut client = create_test_client_with_tokens(vec![
+            // STEP 2: response to the INSERT BULK preamble command.
+            done_no_more(),
+            // STEP 5: distributed bulk-load acknowledgement — two DONE_COUNT
+            // tokens, each carrying a bogus (non-client) count.
+            done_count(CurrentCommand::Insert, 999, true),
+            done_count(CurrentCommand::BulkInsert, 999, false),
+        ]);
+
+        let column_metadata = vec![
+            BulkCopyColumnMetadata::new("id", SqlDbType::Int, TdsDataType::Int4 as u8)
+                .with_length(4, TypeLength::Fixed(4)),
+        ];
+
+        let rows = vec![IntRow(10), IntRow(20), IntRow(30)];
+
+        let reported = client
+            .execute_bulk_load_streaming_zerocopy(
+                "#t".to_string(),
+                column_metadata,
+                BulkCopyOptions::default(),
+                None,
+                None,
+                rows.into_iter(),
+                &[],
+            )
+            .await
+            .expect("bulk load should succeed against the mock transport");
+
+        assert_eq!(
+            reported, 3,
+            "must report the 3 client-written rows, not the server DONE_COUNT (999)"
+        );
     }
 
     #[test]

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -1031,22 +1031,20 @@ impl TdsClient {
         // STEP 4: End streaming (write DONE token and finalize)
         let rows_written = writer.end().await?;
 
-        // STEP 5: Consume the server response for error handling, INFO capture,
-        // and to drain the connection to an idle state. The count reported to
-        // callers is the client-side `rows_written` (the number of rows this
-        // client serialized to the wire), matching SqlClient's
-        // `SqlBulkCopy.RowsCopied` semantics. We deliberately do NOT use the
-        // server's DONE token row count: distributed engines (e.g. Fabric
-        // Warehouse, EngineEdition 11) acknowledge one bulk load with multiple
-        // DONE_COUNT tokens, each carrying the full count, which inflated the
-        // reported total (issue #209).
+        // STEP 5: Drain the server response for error handling and INFO capture.
+        // Its returned count is informational only; callers receive the client-side
+        // `rows_written` (see the `# Returns` doc and `consume_done_token`).
         self.consume_done_token().await?;
 
         Ok(rows_written)
     }
 
     /// Consumes response tokens until a DONE token is received.
-    /// Returns the row count from the DONE token.
+    ///
+    /// Returns the last counted DONE row count. This value is currently
+    /// informational: both call sites discard it, and the bulk-load path reports
+    /// the client-side rows written instead (issue #209). It is retained for
+    /// error/INFO draining and as defensive last-DONE_COUNT-wins hardening.
     ///
     /// This helper method implements the standard TDS response consumption pattern,
     /// handling INFO, ERROR, and DONE tokens appropriately.
@@ -1078,14 +1076,9 @@ impl TdsClient {
                         ));
                     }
 
-                    // The bulk-load response reports its authoritative row count in
-                    // the DONE token(s) carrying the DONE_COUNT flag. A single INSERT
-                    // BULK yields one such count, but distributed engines (e.g. Fabric
-                    // Warehouse, EngineEdition 11) acknowledge the same load with more
-                    // than one DONE_COUNT token, each carrying the full count. Summing
-                    // them double-counts (issue #209). Take the last counted DONE, which
-                    // matches the authoritative "last DONE_COUNT wins" semantics used
-                    // for SQLRowCount elsewhere and is correct on every engine.
+                    // Distributed engines send multiple DONE_COUNT tokens each
+                    // carrying the full count; summing them double-counts (#209).
+                    // Last counted DONE wins.
                     if done.has_count() {
                         rows_affected = done.row_count;
                     }
@@ -1137,7 +1130,8 @@ impl TdsClient {
     /// Sends a SQL batch and consumes the response without expecting column metadata.
     /// This is used for commands that don't return result sets (DML statements, etc.).
     ///
-    /// Returns the row count from the DONE token.
+    /// Returns the DONE token row count. Its only caller (the INSERT BULK preamble)
+    /// discards it; see `consume_done_token` for why the count is informational.
     async fn send_batch_and_consume_response(
         &mut self,
         sql_command: String,
@@ -4772,10 +4766,16 @@ mod tests {
 
     #[tokio::test]
     async fn consume_done_token_ignores_uncounted_dones() {
-        // DONE tokens without the COUNT flag carry a meaningless row_count and must
-        // not contribute to the total. Only the final DONE_COUNT value is reported.
+        // A DONE without the COUNT flag carries a meaningless row_count that must
+        // not contribute to the total. This uncounted token deliberately carries a
+        // non-zero row_count (7) so the pre-fix summing behavior would report 3007;
+        // reporting 3000 proves the has_count() guard, not an incidental zero.
         let mut client = create_test_client_with_tokens(vec![
-            done_more(),
+            Tokens::Done(DoneToken {
+                status: DoneStatus::MORE,
+                cur_cmd: CurrentCommand::Insert,
+                row_count: 7,
+            }),
             done_count(CurrentCommand::Insert, 3000, false),
         ]);
 

--- a/mssql-tds/src/token/tokens.rs
+++ b/mssql-tds/src/token/tokens.rs
@@ -926,6 +926,13 @@ impl DoneToken {
     pub fn has_error(&self) -> bool {
         self.status.contains(DoneStatus::ERROR)
     }
+
+    /// Whether the `DONE_COUNT` flag is set, meaning [`row_count`](Self::row_count)
+    /// carries a valid row count. When unset, `row_count` is meaningless and must
+    /// be ignored (DDL, `SET NOCOUNT ON`, control DONEs, etc.).
+    pub fn has_count(&self) -> bool {
+        self.status.contains(DoneStatus::COUNT)
+    }
 }
 
 /// RETURNSTATUS Token - Return value from a stored procedure


### PR DESCRIPTION
## Description

`cursor.bulkcopy()` and `cursor.bulkcopy_arrow()` returned `rows_copied` (and the derived `batch_count` / `rows_per_second`) as exactly **2x** the truth against a Fabric Warehouse target, while the data written was always correct.

The root cause is in the core TDS layer, not Python. Bulk copy derived its reported count from the server's `DONE` token(s). `consume_done_token` accumulated `row_count` across **every** `DONE` token it saw:

```rust
rows_affected += done.row_count;
```

A single `INSERT BULK` on a normal engine emits one `DONE_COUNT` token, so summing was harmless there. A distributed engine (Fabric Warehouse, `EngineEdition = 11`) acknowledges the same load with **two** `DONE_COUNT` tokens, each carrying the *full* count, so the sum came back `2N`. This is duplication, not partitioning (proven by 1 row → reported 2). `batch_count` is derived as `rows_copied.div_ceil(batch_size)` in `mssql-py-core`, which is why it doubled in lockstep.

### The fix

Report the **client-side** count — the number of rows this client actually serialized to the wire (`StreamingBulkLoadWriter::end`) — instead of trusting the server's `DONE_COUNT`. The server response is still fully consumed for error handling, INFO capture, and to drain the connection to idle; its row count simply no longer determines what we report.

This matches how Microsoft's own bulk-copy clients count, so it is the canonical behavior and is immune to any server-side `DONE` quirk:

| Client | Reported field | Source |
|---|---|---|
| `Microsoft.Data.SqlClient` | `SqlBulkCopy.RowsCopied64` | client-side rows written |
| msodbcsql / ODBC `bcp` | `llRowsCopiedInLastBCP` | client-side rows sent (`++` per `SendBulkRow`) |
| **mssql-rs (this PR)** | `rows_written` from `writer.end()` | client-side rows written |

As defensive hardening, `consume_done_token` was also changed to take the **last** `DONE_COUNT` token rather than summing (ignoring uncounted DONEs), matching the "last `DONE_COUNT` wins" semantics used for `SQLRowCount` elsewhere.

## Validation

Reproduced and verified against a **real Fabric Warehouse** (`EngineEdition 11`), 1 / 1000 / 5000 row loads:

- **Before:** reported `2 / 2000 / 10000` (2x).
- **After:** reported `1 / 1000 / 5000` (correct).
- **TDS trace** confirmed the engine sends two `DONE_COUNT` tokens per load (`DONE(MORE|COUNT, N)` then `DONE(COUNT, N)`), each with the full count. An EngineEdition 12 Fabric SQL database sends a single counted DONE and was never affected (consistent with the issue).
- **Cross-check with `.NET Microsoft.Data.SqlClient`** against the same Warehouse: `SqlBulkCopy.RowsCopied64` reported the correct `1 / 1000 / 5000`, confirming client-side counting is the right approach — and that our previous server-count reconciliation was the defect.

## Related Issues

Fixes #209

## Testing

- **Rust unit tests** (`mssql-tds`):
  - `bulk_load_reports_client_rows_not_server_done_count` — end-to-end test that drives the full streaming bulk-load path against a mock transport which replies with two `DONE_COUNT` tokens carrying a deliberately wrong count; asserts the client reports the rows it actually wrote. (Fails with the old server-count behavior, passes with the fix.)
  - `consume_done_token_takes_single_counted_done`, `consume_done_token_does_not_double_count_distributed_dones`, `consume_done_token_ignores_uncounted_dones` — cover the de-dup hardening.
- **Python integration tests** (`mssql-py-core/tests/test_bulkcopy_rows_copied_accuracy.py`): assert `rows_copied == COUNT(*)` and `batch_count == batches` for both `bulkcopy` and `bulkcopy_arrow` across `batch_size` 0/1000. Passing against local SQL Server 2022 (Docker).
- `cargo fmt --check` and `cargo clippy --workspace --all-features --all-targets -- -D warnings` pass.

> Note: a standalone SQL Server (EngineEdition 3) cannot emit the extra DONE token, so the distributed doubling is reproduced deterministically at the token level in the Rust end-to-end test, while the Python tests guard the count contract end-to-end.

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] Test suites pass (new Rust unit test + Python integration tests; validated on real Fabric Warehouse)
- [x] New/changed functionality has tests
- [ ] Public API changes are documented (no public API change)

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>