### PR TITLE
Skip astral surrogate-carry GetData test on msodbcsql parity leg

### DIFF
--- a/mssql-odbc/tests/e2e/tests/get_data_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/get_data_test.cpp
@@ -752,8 +752,12 @@ TEST_F(GetDataLiveTest, NvarcharMaxToCharChunkedAsciiRoundTrip) {
 // chunk, so a high surrogate is left without its low half at the boundary; the
 // driver must carry it to the next chunk rather than emit U+FFFD. Any framing or
 // surrogate-carry defect shows up as replacement characters (EF BF BD) or a
-// wrong byte count. Codepage-neutral by construction, so it runs on both legs.
+// wrong byte count. This asserts mssql-odbc-specific behavior: the reference
+// msodbcsql driver does not carry a split high surrogate across a sub-character
+// SQL_C_CHAR buffer boundary (it emits U+FFFD), so the assertion is skipped on
+// the msodbcsql comparison leg.
 TEST_F(GetDataLiveTest, NvarcharMaxToCharChunkedAstralRoundTrip) {
+    SKIP_IF_COMPARING_MSODBCSQL();
     const std::string emoji = "\xF0\x9F\x98\x80";       // U+1F600, 4 UTF-8 bytes
     const std::string expected = RepeatToken(emoji, 500);  // 2000 bytes
     ASSERT_SQL_OK(


### PR DESCRIPTION
## Description

Fixes a pre-existing failure on `main`: the Windows ODBC C++ e2e parity stage (`mssql-odbc/tests/e2e/run_e2e.ps1 -CompareWithMsodbcsql`) fails because `GetDataLiveTest.NvarcharMaxToCharChunkedAstralRoundTrip` diverges between drivers.

The test forces a UTF-16 surrogate pair (U+1F600) to straddle a 16-byte `SQL_C_CHAR` chunk boundary:
- **mssql-odbc PASSES** — it correctly carries the split high surrogate across the sub-character buffer boundary (`pending_high_surrogate` handling in `src/api/get_data.rs`).
- **msodbcsql18 FAILS** — the reference driver does not carry the split surrogate; it emits U+FFFD (`EF BF BD`) replacement bytes, yielding a wrong byte count.

Since our driver passes and msodbcsql fails, the parity harness reports "1 divergence" and fails the whole Windows stage. It's deterministic (survived 4 ctest retries in CI) and unrelated to any other in-flight work.

## Fix

Follows the repo's own established mechanism for this exact situation. `SKIP_IF_COMPARING_MSODBCSQL()` (in `tests/e2e/include/odbc_test_fixture.h`) makes a test `GTEST_SKIP()` on the msodbcsql leg only, so the parity run stays green while the test still runs and must pass against our driver. Two sibling tests in the same file already use it for the same class of msodbcsql behavioral divergence (`PlpZeroCapacityBufferDoesNotSpin`, `UnsupportedColumnTypeHyc00PreservesValue`).

Changes (one C++ test file):
1. Added `SKIP_IF_COMPARING_MSODBCSQL();` as the first statement in the test body.
2. Updated the doc comment: the old claim "Codepage-neutral by construction, so it runs on both legs" was wrong; replaced it with an accurate explanation that msodbcsql does not carry a split high surrogate across a sub-character `SQL_C_CHAR` boundary (emits U+FFFD), so the assertion is mssql-odbc-specific and skipped on the comparison leg.

This does not weaken our driver or change expectations — mssql-odbc is still fully asserted on its own leg; we only align the parity-leg gating with msodbcsql's actual behavior, exactly as the repo already does for sibling tests.

## Related Issues

CI-parity fix for a pre-existing `main` failure. No dedicated issue/work item.

## Validation

- Built the e2e `get_data_test` target locally on Windows (MSVC + Ninja via VS 2022) — `get_data_test.cpp` compiled and `get_data_test.exe` linked cleanly.
- A live SQL Server and registered msodbcsql18 were not available locally, so the full `run_e2e.ps1 -CompareWithMsodbcsql` parity run will be validated in CI (expected: astral test shows mssql-odbc PASS / msodbcsql SKIP, 0 divergences).

## Checklist

- [ ] `cargo bfmt` passes — N/A, no `.rs` changed
- [ ] `cargo bclippy` passes — N/A, no `.rs` changed
- [ ] `cargo btest` passes — N/A, C++ e2e test only
- [x] New/changed functionality has tests — modifies an existing test's parity gating
- [ ] Public API changes are documented — N/A