### PR TITLE
Decouple TC-clash auth e2e tests from mssql-python internals

### DIFF
--- a/mssql-py-core/src/odbc_auth/odbc_authentication_validator.rs
+++ b/mssql-py-core/src/odbc_auth/odbc_authentication_validator.rs
@@ -243,41 +243,28 @@ mod tests {
     // Authentication + TC mutual exclusion
     // ---------------------------------------------------------------
 
-    #[test]
-    fn tc_plus_sqlpassword() {
-        let err = validate_auth(Some("SqlPassword"), Some(true), "sa", "secret", None).unwrap_err();
-        assert!(err.to_string().contains("Trusted_Connection"));
-    }
-
-    #[test]
-    fn tc_plus_ad_password() {
-        let err =
-            validate_auth(Some("ActiveDirectoryPassword"), Some(true), "u", "p", None).unwrap_err();
-        assert!(err.to_string().contains("Trusted_Connection"));
-    }
-
-    #[test]
-    fn tc_plus_ad_integrated() {
-        let err =
-            validate_auth(Some("ActiveDirectoryIntegrated"), Some(true), "", "", None).unwrap_err();
-        assert!(err.to_string().contains("Trusted_Connection"));
-    }
-
     /// Durable, Python-free guard for the class of drift in #223: pins the exact
-    /// clash message across representative modes (incl. the AD modes whose Python
-    /// e2e coverage was removed because mssql-python strips Trusted_Connection).
+    /// clash message across every Authentication mode (incl. the AD modes whose
+    /// Python e2e coverage was removed because mssql-python strips
+    /// Trusted_Connection). Empty UID/PWD with SqlPassword also proves the TC
+    /// clash is reported before the "Both User and Password" rule, covering
+    /// ordering in `validate_auth`.
     #[test]
     fn auth_plus_tc_rejected() {
         for auth in [
             "SqlPassword",
+            "ActiveDirectoryPassword",
+            "ActiveDirectoryIntegrated",
             "ActiveDirectoryInteractive",
             "ActiveDirectoryDefault",
+            "ActiveDirectoryMSI",
+            "ActiveDirectoryServicePrincipal",
         ] {
             let err = validate_auth(Some(auth), Some(true), "", "", None).unwrap_err();
-            assert!(
-                err.to_string()
-                    .contains("Cannot use Authentication with Trusted_Connection"),
-                "unexpected error for {auth}: {err}"
+            assert_eq!(
+                err.to_string(),
+                "Usage Error: Cannot use Authentication with Trusted_Connection.",
+                "unexpected error for {auth}"
             );
         }
     }

--- a/mssql-py-core/src/odbc_auth/odbc_authentication_validator.rs
+++ b/mssql-py-core/src/odbc_auth/odbc_authentication_validator.rs
@@ -263,6 +263,25 @@ mod tests {
         assert!(err.to_string().contains("Trusted_Connection"));
     }
 
+    /// Durable, Python-free guard for the class of drift in #223: pins the exact
+    /// clash message across representative modes (incl. the AD modes whose Python
+    /// e2e coverage was removed because mssql-python strips Trusted_Connection).
+    #[test]
+    fn auth_plus_tc_rejected() {
+        for auth in [
+            "SqlPassword",
+            "ActiveDirectoryInteractive",
+            "ActiveDirectoryDefault",
+        ] {
+            let err = validate_auth(Some(auth), Some(true), "", "", None).unwrap_err();
+            assert!(
+                err.to_string()
+                    .contains("Cannot use Authentication with Trusted_Connection"),
+                "unexpected error for {auth}: {err}"
+            );
+        }
+    }
+
     // ---------------------------------------------------------------
     // SqlPassword requires UID + PWD
     // ---------------------------------------------------------------

--- a/mssql-py-core/src/odbc_auth/odbc_authentication_validator.rs
+++ b/mssql-py-core/src/odbc_auth/odbc_authentication_validator.rs
@@ -244,8 +244,8 @@ mod tests {
     // ---------------------------------------------------------------
 
     /// Durable, Python-free guard for the class of drift in #223: pins the exact
-    /// clash message across every Authentication mode (incl. the AD modes whose
-    /// Python e2e coverage was removed because mssql-python strips
+    /// clash message across all nine recognized Authentication modes (incl. the
+    /// AD modes whose Python e2e coverage was removed because mssql-python strips
     /// Trusted_Connection). Empty UID/PWD with SqlPassword also proves the TC
     /// clash is reported before the "Both User and Password" rule, covering
     /// ordering in `validate_auth`.
@@ -259,6 +259,8 @@ mod tests {
             "ActiveDirectoryDefault",
             "ActiveDirectoryMSI",
             "ActiveDirectoryServicePrincipal",
+            "ActiveDirectoryDeviceCodeFlow",
+            "ActiveDirectoryWorkloadIdentity",
         ] {
             let err = validate_auth(Some(auth), Some(true), "", "", None).unwrap_err();
             assert_eq!(

--- a/mssql-py-core/tests/mssql_python/test_auth_resolution_e2e.py
+++ b/mssql-py-core/tests/mssql_python/test_auth_resolution_e2e.py
@@ -385,7 +385,12 @@ class TestADServicePrincipal:
 class TestAuthTcClash:
     """§3.3 Auth keyword + TC=Yes is always an error (#24–#26, #28–#29).
 
-    #27 (ADInteractive) is covered by test_auth_resolution.py, not here.
+    #27 (ADInteractive) and ADDefault are not testable at this layer:
+    mssql-python strips Trusted_Connection for token-bearing AD modes, so
+    ODBC never sees the clash. Covered in test_auth_resolution.py
+    (TestAuthTcClashes::test_27_ad_interactive_tc,
+    TestAuthTcClashesExtended::test_ad_default_tc) and in Rust
+    (odbc_authentication_validator::tests::auth_plus_tc_rejected).
     """
 
     def test_row24_tc_yes_sqlpassword(self):

--- a/mssql-py-core/tests/mssql_python/test_auth_resolution_e2e.py
+++ b/mssql-py-core/tests/mssql_python/test_auth_resolution_e2e.py
@@ -379,11 +379,14 @@ class TestADServicePrincipal:
 
 
 # ═════════════════════════════════════════════════════════════════
-#  SECTION 10 — §3.3 Auth + TC clashes (#24–#29)
+#  SECTION 10 — §3.3 Auth + TC clashes (#24–#26, #28–#29)
 # ═════════════════════════════════════════════════════════════════
 
 class TestAuthTcClash:
-    """§3.3 #24–#29 — Auth keyword + TC=Yes is always an error."""
+    """§3.3 Auth keyword + TC=Yes is always an error (#24–#26, #28–#29).
+
+    #27 (ADInteractive) is covered by test_auth_resolution.py, not here.
+    """
 
     def test_row24_tc_yes_sqlpassword(self):
         """#24  TC=Yes + SqlPassword → ERROR."""

--- a/mssql-py-core/tests/mssql_python/test_auth_resolution_e2e.py
+++ b/mssql-py-core/tests/mssql_python/test_auth_resolution_e2e.py
@@ -400,23 +400,6 @@ class TestAuthTcClash:
         cs = _base(tc="Yes", auth="ActiveDirectoryIntegrated")
         _expect_connect_error(cs)
 
-    # #27 (ADInteractive) and ADDefault are intentionally NOT exercised here.
-    #
-    # The mssql-rs behavior (reject TC=Yes + an Authentication keyword) is
-    # asserted deterministically against py-core in the normal, mssql-python-
-    # decoupled suite:
-    #   tests/test_auth_resolution.py::TestAuthTcClashes::test_27_ad_interactive_tc
-    #   tests/test_auth_resolution.py::TestAuthTcClashesExtended::test_ad_default_tc
-    #
-    # An ODBC/mssql-python "parity" leg can't add signal for these two rows:
-    # mssql-python strips Trusted_Connection for token-bearing AD modes
-    # (Default and non-Windows Interactive go through the token factory, whose
-    # keys — including Trusted_Connection — are removed by remove_sensitive_params
-    # before ODBC sees them), so the driver never observes a clash. A test here
-    # could only "pass" by faulting elsewhere (stubbed/absent Entra infra),
-    # which is unfalsifiable. ODBC's own behavior for these modes is covered by
-    # mssql-python's suite.
-
     def test_row28_tc_yes_admsi(self):
         """#28  TC=Yes + ADMSI → ERROR."""
         cs = _base(tc="Yes", auth="ActiveDirectoryMSI")

--- a/mssql-py-core/tests/mssql_python/test_auth_resolution_e2e.py
+++ b/mssql-py-core/tests/mssql_python/test_auth_resolution_e2e.py
@@ -20,6 +20,7 @@ Tests that need real Azure AD infra or Kerberos are skipped unless env vars are 
 
 import os
 import re
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
@@ -132,6 +133,78 @@ def _expect_connect_error(conn_str, pattern=None):
             f"Expected pattern '{pattern}' in error: {exc_info.value}"
         )
     return exc_info
+
+
+@contextmanager
+def _no_real_entra_auth():
+    """Stub the azure-identity credential boundary so AD-mode connects never
+    trigger a real interactive/default/managed-identity flow in CI.
+
+    mssql_python.auth imports these credential classes lazily from
+    ``azure.identity`` inside its token method, so patching the public
+    ``azure.identity`` symbols is picked up at call time. We deliberately patch
+    this stable public boundary instead of any mssql-python-internal token
+    helper (the old ``auth.get_auth_token`` was renamed upstream), so this test
+    stays decoupled from mssql-python refactors.
+    """
+    try:
+        import azure.identity  # noqa: F401
+    except ImportError:
+        # azure-identity absent: the AD path fails on its own, still an error.
+        yield
+        return
+
+    patchers = []
+    for name in (
+        "InteractiveBrowserCredential",
+        "DefaultAzureCredential",
+        "DeviceCodeCredential",
+        "ManagedIdentityCredential",
+    ):
+        if hasattr(azure.identity, name):
+            stub = MagicMock()
+            stub.return_value.get_token.side_effect = RuntimeError(
+                "stubbed: no real Entra auth in CI"
+            )
+            patchers.append(patch(f"azure.identity.{name}", stub))
+    for p in patchers:
+        p.start()
+    try:
+        yield
+    finally:
+        for p in patchers:
+            p.stop()
+
+
+def _assert_tc_auth_clash(auth_mode):
+    """TC=Yes + an Authentication keyword is a clash that must be rejected.
+
+    Two independent legs:
+      1. py-core (the mssql-rs behavior): ``validate_auth`` rejects the clash at
+         ``PyCoreConnection`` construction, before any token acquisition. This
+         is deterministic and needs neither mssql-python nor Azure infra.
+      2. mssql-python/ODBC parity: with real Entra auth stubbed out, ``connect``
+         must still reject the combo rather than succeed or block.
+    """
+    # Leg 1 — py-core, fully decoupled from mssql-python.
+    import mssql_py_core
+
+    ctx = {
+        "server": _server(),
+        "database": _database(),
+        "trust_server_certificate": True,
+        "encryption": "Optional",
+        "trusted_connection": "Yes",
+        "authentication": auth_mode,
+    }
+    with pytest.raises(Exception) as exc_info:
+        mssql_py_core.PyCoreConnection(ctx)
+    assert "Cannot use Authentication with Trusted_Connection" in str(exc_info.value)
+
+    # Leg 2 — mssql-python/ODBC parity, decoupled from internal token symbols.
+    cs = _base(tc="Yes", auth=auth_mode)
+    with _no_real_entra_auth():
+        _expect_connect_error(cs)
 
 
 # ═════════════════════════════════════════════════════════════════
@@ -402,12 +475,12 @@ class TestAuthTcClash:
 
     def test_row27_tc_yes_ad_interactive(self):
         """#27  TC=Yes + ADInteractive → ERROR.
-        Must mock token acquisition — mssql_python's auth.py intercepts
-        Interactive before ODBC sees the conn string.
+
+        py-core rejects the TC+Authentication clash at construction; the
+        mssql-python parity leg runs with Entra auth stubbed so no real
+        interactive browser login is attempted in CI.
         """
-        cs = _base(tc="Yes", auth="ActiveDirectoryInteractive")
-        with patch("mssql_python.auth.get_auth_token", return_value=None):
-            _expect_connect_error(cs)
+        _assert_tc_auth_clash("ActiveDirectoryInteractive")
 
     def test_row28_tc_yes_admsi(self):
         """#28  TC=Yes + ADMSI → ERROR."""
@@ -420,12 +493,14 @@ class TestAuthTcClash:
         _expect_connect_error(cs)
 
     def test_tc_yes_ad_default(self):
-        """TC=Yes + ADDefault → ERROR (not in §3.3 — ADDefault is mssql-python-specific).
-        Must mock — auth.py intercepts Default before ODBC sees the clash.
+        """TC=Yes + ADDefault → ERROR (not in §3.3 — ADDefault is
+        mssql-python-specific).
+
+        py-core rejects the TC+Authentication clash at construction; the
+        mssql-python parity leg runs with Entra auth stubbed so the default
+        credential chain is not exercised in CI.
         """
-        cs = _base(tc="Yes", auth="ActiveDirectoryDefault")
-        with patch("mssql_python.auth.get_auth_token", return_value=None):
-            _expect_connect_error(cs)
+        _assert_tc_auth_clash("ActiveDirectoryDefault")
 
 
 # ═════════════════════════════════════════════════════════════════

--- a/mssql-py-core/tests/mssql_python/test_auth_resolution_e2e.py
+++ b/mssql-py-core/tests/mssql_python/test_auth_resolution_e2e.py
@@ -20,9 +20,8 @@ Tests that need real Azure AD infra or Kerberos are skipped unless env vars are 
 
 import os
 import re
-from contextlib import contextmanager
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 from dotenv import load_dotenv
@@ -133,78 +132,6 @@ def _expect_connect_error(conn_str, pattern=None):
             f"Expected pattern '{pattern}' in error: {exc_info.value}"
         )
     return exc_info
-
-
-@contextmanager
-def _no_real_entra_auth():
-    """Stub the azure-identity credential boundary so AD-mode connects never
-    trigger a real interactive/default/managed-identity flow in CI.
-
-    mssql_python.auth imports these credential classes lazily from
-    ``azure.identity`` inside its token method, so patching the public
-    ``azure.identity`` symbols is picked up at call time. We deliberately patch
-    this stable public boundary instead of any mssql-python-internal token
-    helper (the old ``auth.get_auth_token`` was renamed upstream), so this test
-    stays decoupled from mssql-python refactors.
-    """
-    try:
-        import azure.identity  # noqa: F401
-    except ImportError:
-        # azure-identity absent: the AD path fails on its own, still an error.
-        yield
-        return
-
-    patchers = []
-    for name in (
-        "InteractiveBrowserCredential",
-        "DefaultAzureCredential",
-        "DeviceCodeCredential",
-        "ManagedIdentityCredential",
-    ):
-        if hasattr(azure.identity, name):
-            stub = MagicMock()
-            stub.return_value.get_token.side_effect = RuntimeError(
-                "stubbed: no real Entra auth in CI"
-            )
-            patchers.append(patch(f"azure.identity.{name}", stub))
-    for p in patchers:
-        p.start()
-    try:
-        yield
-    finally:
-        for p in patchers:
-            p.stop()
-
-
-def _assert_tc_auth_clash(auth_mode):
-    """TC=Yes + an Authentication keyword is a clash that must be rejected.
-
-    Two independent legs:
-      1. py-core (the mssql-rs behavior): ``validate_auth`` rejects the clash at
-         ``PyCoreConnection`` construction, before any token acquisition. This
-         is deterministic and needs neither mssql-python nor Azure infra.
-      2. mssql-python/ODBC parity: with real Entra auth stubbed out, ``connect``
-         must still reject the combo rather than succeed or block.
-    """
-    # Leg 1 — py-core, fully decoupled from mssql-python.
-    import mssql_py_core
-
-    ctx = {
-        "server": _server(),
-        "database": _database(),
-        "trust_server_certificate": True,
-        "encryption": "Optional",
-        "trusted_connection": "Yes",
-        "authentication": auth_mode,
-    }
-    with pytest.raises(Exception) as exc_info:
-        mssql_py_core.PyCoreConnection(ctx)
-    assert "Cannot use Authentication with Trusted_Connection" in str(exc_info.value)
-
-    # Leg 2 — mssql-python/ODBC parity, decoupled from internal token symbols.
-    cs = _base(tc="Yes", auth=auth_mode)
-    with _no_real_entra_auth():
-        _expect_connect_error(cs)
 
 
 # ═════════════════════════════════════════════════════════════════
@@ -473,14 +400,22 @@ class TestAuthTcClash:
         cs = _base(tc="Yes", auth="ActiveDirectoryIntegrated")
         _expect_connect_error(cs)
 
-    def test_row27_tc_yes_ad_interactive(self):
-        """#27  TC=Yes + ADInteractive → ERROR.
-
-        py-core rejects the TC+Authentication clash at construction; the
-        mssql-python parity leg runs with Entra auth stubbed so no real
-        interactive browser login is attempted in CI.
-        """
-        _assert_tc_auth_clash("ActiveDirectoryInteractive")
+    # #27 (ADInteractive) and ADDefault are intentionally NOT exercised here.
+    #
+    # The mssql-rs behavior (reject TC=Yes + an Authentication keyword) is
+    # asserted deterministically against py-core in the normal, mssql-python-
+    # decoupled suite:
+    #   tests/test_auth_resolution.py::TestAuthTcClashes::test_27_ad_interactive_tc
+    #   tests/test_auth_resolution.py::TestAuthTcClashesExtended::test_ad_default_tc
+    #
+    # An ODBC/mssql-python "parity" leg can't add signal for these two rows:
+    # mssql-python strips Trusted_Connection for token-bearing AD modes
+    # (Default and non-Windows Interactive go through the token factory, whose
+    # keys — including Trusted_Connection — are removed by remove_sensitive_params
+    # before ODBC sees them), so the driver never observes a clash. A test here
+    # could only "pass" by faulting elsewhere (stubbed/absent Entra infra),
+    # which is unfalsifiable. ODBC's own behavior for these modes is covered by
+    # mssql-python's suite.
 
     def test_row28_tc_yes_admsi(self):
         """#28  TC=Yes + ADMSI → ERROR."""
@@ -491,16 +426,6 @@ class TestAuthTcClash:
         """#29  TC=Yes + ADSPA → ERROR."""
         cs = _base(tc="Yes", auth="ActiveDirectoryServicePrincipal", uid="c", pwd="s")
         _expect_connect_error(cs)
-
-    def test_tc_yes_ad_default(self):
-        """TC=Yes + ADDefault → ERROR (not in §3.3 — ADDefault is
-        mssql-python-specific).
-
-        py-core rejects the TC+Authentication clash at construction; the
-        mssql-python parity leg runs with Entra auth stubbed so the default
-        credential chain is not exercised in CI.
-        """
-        _assert_tc_auth_clash("ActiveDirectoryDefault")
 
 
 # ═════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Description

`TestAuthTcClash::test_row27_tc_yes_ad_interactive` and `TestAuthTcClash::test_tc_yes_ad_default` in `mssql-py-core/tests/mssql_python/test_auth_resolution_e2e.py` failed in the cross-repo "Build mssql-python (cross-repo)" job with:

```
AttributeError: <module 'mssql_python.auth' ...> does not have the attribute 'get_auth_token'
```

They patched `mssql_python.auth.get_auth_token` — an upstream-**internal** symbol that `microsoft/mssql-python` renamed (it now exposes `get_auth_token_info` and defers token acquisition to a native pool-miss callback). `unittest.mock.patch` refuses to patch a missing attribute, so the tests errored at `__enter__`. The step is `continueOnError: true` so it doesn't block, but it's persistent red noise driven by upstream drift, not mssql-rs behavior.

## Fix

### 1. Durable guard: a Rust unit test that runs on every PR

The root-cause fix for the class of problem in #223 is to assert the mssql-rs behavior where it belongs — in Rust, with zero Python, zero Docker, and zero cross-repo coupling. `odbc_authentication_validator.rs` had `tc_plus_sqlpassword`/`tc_plus_ad_password`/`tc_plus_ad_integrated` tests, but they only checked for the `Trusted_Connection` substring (which the access-token conflict text also contains); none pinned the exact clash message. Those three are replaced by one table-driven `auth_plus_tc_rejected` that loops over every Authentication mode (`SqlPassword`, `ActiveDirectoryPassword`, `ActiveDirectoryIntegrated`, `ActiveDirectoryInteractive`, `ActiveDirectoryDefault`, `ActiveDirectoryMSI`, `ActiveDirectoryServicePrincipal`) and pins the full message with `assert_eq!` (`"Usage Error: Cannot use Authentication with Trusted_Connection."`, trailing period included). Passing empty UID/PWD with `SqlPassword` also proves the TC clash is reported before the "Both User and Password" rule, covering ordering in `validate_auth`.

### 2. Delete the two flaky Python e2e tests

Rather than re-target another mssql-python internal, remove both tests and their helpers. Two reasons, established while working through review:

- **The mssql-rs behavior is already covered, decoupled from mssql-python.** The TC=Yes + `Authentication` clash is py-core's own `validate_auth`, asserted deterministically (no Azure infra, no `mssql_python` import) in the normal py-core suite: `tests/test_auth_resolution.py::TestAuthTcClashes::test_27_ad_interactive_tc` (ActiveDirectoryInteractive) and `TestAuthTcClashesExtended::test_ad_default_tc` (ActiveDirectoryDefault). The e2e "Leg 1" I initially added just duplicated these.
- **An ODBC/mssql-python "parity" leg can't add signal for these two rows.** mssql-python **strips `Trusted_Connection`** for token-bearing AD modes: `ActiveDirectoryDefault` and non-Windows `ActiveDirectoryInteractive` route through the token factory, and `remove_sensitive_params` drops `_SENSITIVE_KEYS` (which includes `_KEY_TRUSTED_CONNECTION`) before the string reaches ODBC. So the driver never observes a clash for these modes — a test here could only "pass" by faulting elsewhere (stubbed/absent Entra infra), i.e. it's unfalsifiable. ODBC's actual behavior for these modes is covered by mssql-python's own suite.

The two tests are deleted along with the `_no_real_entra_auth` / `_assert_tc_auth_clash` helpers and the now-unused `contextmanager` / `MagicMock` imports.

Follow-up (not in this PR): three other tests in the same file still patch `mssql_python.auth.AADAuth.get_raw_token` (that symbol still exists upstream, so they pass today) and carry the same coupling risk — tracked in the issue.

## Related Issues

Fixes #223

## Checklist

- [x] `cargo bfmt` passes — `mssql-py-core` `cargo fmt -- --check` clean
- [x] `cargo bclippy` passes — `mssql-py-core` `cargo clippy --all-features --all-targets -- -D warnings` clean
- [x] `cargo btest` passes — new `auth_plus_tc_rejected` passes under `cargo nextest` in `mssql-py-core`
- [x] New/changed functionality has tests — Rust `auth_plus_tc_rejected`, plus the retained `test_auth_resolution.py` clash cases
- [x] Public API changes are documented — n/a (test-only change)
