### PR TITLE
Heap-allocate the PLP drain scratch buffer

### DIFF
--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -3234,8 +3234,16 @@ impl TdsClient {
     }
 
     /// Reads and discards all remaining bytes of an active PLP stream.
+    ///
+    /// The scratch buffer is heap-allocated rather than a stack array: it is live
+    /// across the await below, so a stack array would be stored inline in this
+    /// future and propagate into every caller that awaits it — `read_row_column`
+    /// directly, plus `drain_rows`, `get_next_row_into` and `next_row_cursor` via
+    /// `drain_active_row`. Abandoning a partially read PLP column is rare and
+    /// already network-bound, so the allocation is free here while an 8 KiB
+    /// per-row state machine is not.
     async fn drain_active_plp(&mut self, plp_state: &mut PlpPauseState) -> TdsResult<()> {
-        let mut buffer = [0u8; 8192];
+        let mut buffer = vec![0u8; 8192];
         while !plp_state.reached_end() {
             let start = Instant::now();
             let read = self
@@ -4277,6 +4285,36 @@ mod tests {
             execution_context,
             client_context,
         )
+    }
+
+    /// Guards the fix for #225: a large local held across an `.await` in
+    /// `drain_active_plp` is stored inline in that future and propagates into
+    /// every caller in the await chain, costing a memcpy per row on the hot path.
+    #[test]
+    fn row_fetch_futures_stay_small() {
+        const MAX: usize = 4096;
+
+        let mut client = create_test_client();
+        let mut sink = DiscardRowWriter;
+
+        // Constructing an async fn's future runs none of its body, so these are
+        // free to build and drop unpolled. Each borrow ends with its statement.
+        let next_row_cursor = std::mem::size_of_val(&client.next_row_cursor());
+        let read_row_column = std::mem::size_of_val(&client.read_row_column(0));
+        let drain_rows = std::mem::size_of_val(&client.drain_rows());
+        let get_next_row_into = std::mem::size_of_val(&client.get_next_row_into(&mut sink));
+
+        for (name, size) in [
+            ("next_row_cursor", next_row_cursor),
+            ("read_row_column", read_row_column),
+            ("drain_rows", drain_rows),
+            ("get_next_row_into", get_next_row_into),
+        ] {
+            assert!(
+                size <= MAX,
+                "{name} future is {size} B, expected <= {MAX} B"
+            );
+        }
     }
 
     #[test]

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -3038,7 +3038,9 @@ impl TdsClient {
     ///
     /// After this returns `true`, individual columns are pulled with
     /// [`read_row_column`](Self::read_row_column). Any previously positioned row
-    /// is drained first (allocation-free).
+    /// is drained first without materializing column values. That drain is
+    /// allocation-free unless it abandons a partially read PLP column, which
+    /// allocates a single scratch buffer to skip the remaining bytes.
     #[instrument(skip(self), level = "info")]
     pub async fn next_row_cursor(&mut self) -> TdsResult<bool> {
         if self.current_metadata.is_none() {
@@ -3240,7 +3242,7 @@ impl TdsClient {
     /// future and propagate into every caller that awaits it — `read_row_column`
     /// directly, plus `drain_rows`, `get_next_row_into` and `next_row_cursor` via
     /// `drain_active_row`. Abandoning a partially read PLP column is rare and
-    /// already network-bound, so the allocation is free here while an 8 KiB
+    /// already network-bound, so one allocation there is negligible; an 8 KiB
     /// per-row state machine is not.
     async fn drain_active_plp(&mut self, plp_state: &mut PlpPauseState) -> TdsResult<()> {
         let mut buffer = vec![0u8; 8192];

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -3038,9 +3038,8 @@ impl TdsClient {
     ///
     /// After this returns `true`, individual columns are pulled with
     /// [`read_row_column`](Self::read_row_column). Any previously positioned row
-    /// is drained first without materializing column values. That drain is
-    /// allocation-free unless it abandons a partially read PLP column, which
-    /// allocates a single scratch buffer to skip the remaining bytes.
+    /// is drained first; its remaining column bytes are read and discarded rather
+    /// than returned to the caller.
     #[instrument(skip(self), level = "info")]
     pub async fn next_row_cursor(&mut self) -> TdsResult<bool> {
         if self.current_metadata.is_none() {


### PR DESCRIPTION
## Description

`drain_active_plp` held an 8 KiB scratch array on the stack across an `.await`, so rustc stored it inline in the generated future and that size propagated into every caller in the await chain. The row-fetch hot path therefore paid to construct and move ~8.5 KB of state per row for a cleanup path that only runs when a caller abandons a partially read PLP column.

The fix is one line — `[0u8; 8192]` → `vec![0u8; 8192]` — plus a doc comment on `drain_active_plp` recording *why* the buffer is heap-allocated, so it doesn't get "optimized" back into a stack array later.

**#225 has the full explanation, the standalone criterion repro, and the measured numbers. Please read it there rather than expecting the analysis restated here.**

### Measured impact

Per-row future size and cost, from the standalone repro in the issue (5000 rows per sample, drain branch never taken):

| | before | after |
|---|---|---|
| per-row future | 8248 B | **80 B** |
| per-row cost | 136.1 ns | **15.8 ns** (8.6×) |

Measured in the driver itself: `next_row_cursor` 8520 B → 928 B, `read_row_column` 8464 B → 432 B. Fetch cost fell **20% on the ODBC path and 33% on the TDS column path.**

The change is entirely inside `mssql-tds`, so `mssql-js`, `mssql-py-core`, `mssql-tds-cli` and `mssql-odbc` all benefit. No API change, no growth in steady-state memory.

### Regression guard

The issue floated a `size_of_val` assertion to keep this from silently regressing. It came out clean, so it's included: `row_fetch_futures_stay_small` builds each of the four hot-path futures via the existing `create_test_client()` helper and asserts each stays under 4096 B. Constructing an `async fn`'s future runs none of its body, so the futures are built and dropped unpolled — no I/O, no mock traffic.

Measured sizes under the test profile are 928 / 408 / 1208 / 960 B, giving ~3.4× headroom while still catching an 8 KiB regression. Verified it works by temporarily reverting the one-liner: the test fails with `next_row_cursor future is 8480 B, expected <= 4096 B`.

### Doc correction

The public doc on `next_row_cursor` promised an "allocation-free" drain. Copilot flagged that the PLP scratch buffer invalidates it; @David-Engel then pointed out the replacement wording was still wrong, because skipping any non-PLP column already materializes and discards its value (see the `TODO(#47154)` in `token_stream.rs`). The doc now describes observable behavior only and makes no allocation claim.

### Scope

- This is the **standalone extraction** of a one-line change that also appears inside the much larger in-flight perf PR #215, bundled there with many unrelated optimizations. Split out so it can land independently. No coordination with or rebase onto #215 is intended.
- `mssql-tds/src/connection/transport/win_tls/stream.rs:387` has an identical-looking `[0u8; 8192]` and is **deliberately left alone** — it sits in a synchronous `poll_read` returning `Poll` with no await spanning it, so it is an ordinary stack local and is correct as written. #225 calls this out explicitly; `drain_active_plp` was the only live instance.

## Related Issues

Fixes #225

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes — see note below
- [x] New/changed functionality has tests
- [x] Public API changes are documented — no API change; stale `next_row_cursor` doc corrected

Validation was run via `.\scripts\bfmt.ps1` and `.\scripts\bclippy.ps1` (both also cover `mssql-py-core`, which is excluded from the workspace) and both are green.

Tests were scoped with `cargo nextest run --workspace --lib --no-fail-fast` because integration tests require a `.env` that isn't present locally. Result: **2216 passed, 7 failed** — the 7 are the pre-existing expired-certificate fixture tests in `certificate_validator` and `win_tls::validate`. Confirmed identical failures on a stashed, unmodified tree, so they are unrelated to this change.

