### PR TITLE
Fix broken main: remove stale NetworkReader::receive impl on ByteStreamTransport

### DIFF
--- a/mssql-tds/src/test_client_support.rs
+++ b/mssql-tds/src/test_client_support.rs
@@ -407,9 +407,6 @@ pub(crate) mod byte_stream {
 
     #[async_trait]
     impl NetworkReader for ByteStreamTransport {
-        async fn receive(&mut self, _buffer: &mut [u8]) -> TdsResult<usize> {
-            Ok(0)
-        }
         fn packet_size(&self) -> u32 {
             4096
         }


### PR DESCRIPTION
## Description

`main` currently fails to compile test targets. Removes the orphaned `receive` method from `impl NetworkReader for ByteStreamTransport` in `mssql-tds/src/test_client_support.rs`.

**Root cause — semantic merge conflict between #188 and #221.** Neither PR is wrong in isolation; they were validated against bases that did not contain each other, and git merged them cleanly because they touched different regions of the file:

| Commit | PR | Change |
| --- | --- | --- |
| `5d11fa0d` | #188 | Added `ByteStreamTransport`, including `impl NetworkReader { async fn receive(..) }` |
| `fc33c148` | #221 | Removed `receive` from the `NetworkReader` trait and from the `TokenReplayTransport` impl |

The result is `error[E0407]: method 'receive' is not a member of trait 'NetworkReader'` at `test_client_support.rs:410`, exit code 101. Failing CI build: [166358](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build/results?buildId=166358&view=results) @ `f6cdda79`.

This change makes the `ByteStreamTransport` impl match the `TokenReplayTransport` impl that #221 already updated.

**Why only Linux was red.** Not platform-specific. `byte_stream` is a `#[cfg(test)]` module, so only test-target builds compile it. On a non-PR run of `main`, the only step that builds test targets is `Archive nextest results`, which is wrapped in `${{ if eq(parameters.osType, 'Linux') }}`; every other compile/lint/test step is gated on `Build.Reason == 'PullRequest'` and is skipped. Windows and macOS therefore never compiled the offending code.

Issue #228 records the CI-gating gap as a follow-up.

## Related Issues

Fixes #228

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes — `cargo nextest run -p mssql-tds --lib --no-fail-fast`: 1703/1703 passed
- [x] New/changed functionality has tests — n/a; this restores compilation of the existing test suite. Verified by reproducing CI's exact failing command locally (`cd mssql-tds && cargo nextest archive`), which now succeeds.
- [x] Public API changes are documented — n/a; `NetworkReader` is `pub(crate)` and the removed method is test-only dead code.