### PR TITLE
Seed session-recovery reconnect baseline from FEATUREEXTACK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Changed
 
+- `mssql-tds`: `TdsClient::language()` now returns the language negotiated at
+  login (from the server's `ENVCHANGE`) instead of always returning an empty
+  string, matching its documentation.
+
 - `mssql-tds`: `TdsClient::read_row_column` now returns `CursorColumn::Value` as a
   struct variant, `CursorColumn::Value { value, variant_base }`, where
   `variant_base` is the underlying `TdsDataType` a `sql_variant` value carried
@@ -74,6 +78,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   federated-auth flows.
 
 ### Fixed
+
+- `mssql-tds`: idle connection resiliency (transparent session recovery) now
+  works end to end. The client-side gate that authorizes a reconnect is now set
+  from the server's `FEATUREEXTACK` acknowledgment — previously it was only ever
+  set in tests, so reconnect never ran in production despite being negotiated on
+  the wire. The recoverable session-state baseline the server sends in that
+  acknowledgment is now parsed and replayed in the reconnect `LOGIN7`, which the
+  server previously rejected as incomplete (error 17897, state 81).
 
 - `mssql-tds`: reading a fixed-width value that straddles a TDS packet boundary
   could return bytes from the wrong place or panic. The readers checked for

--- a/mssql-odbc/tests/e2e/tests/session_recovery_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/session_recovery_test.cpp
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // session_recovery_test.cpp  –  E2E test for the SQLExecute recovery/epoch gate.
 //
-// STATUS: currently GTEST_SKIP-ped (see SetUp) pending an mssql-tds fix — the
-// reconnection LOGIN7 is still rejected by the server, so it never fails CI.
-// Remove the skip once transparent reconnect works end-to-end.
+// STATUS: enabled. Exercises SQLExecute-after-KILL recovery against a live
+// server that negotiates Idle Connection Resiliency (SESSIONRECOVERY).
 //
 // Requires a configured connection (ODBC_TEST_SERVER / ODBC_TEST_CONNSTR) to a
 // server that negotiates Idle Connection Resiliency (SESSIONRECOVERY) — any
@@ -22,11 +21,6 @@
 class SessionRecoveryLiveTest : public ODBCTest {
 protected:
     void SetUp() override {
-        GTEST_SKIP() << "Disabled pending mssql-tds transparent-reconnect fix: "
-                        "the reconnection LOGIN7 is rejected by the server, so "
-                        "SQLExecute-after-KILL cannot recover yet. Re-enable when "
-                        "transparent reconnect succeeds end-to-end.";
-
         ODBCTest::SetUp();
         ASSERT_TRUE(ODBCTestConfig::Instance().HasConnection())
             << "No connection configured – set ODBC_TEST_SERVER or "
@@ -105,6 +99,10 @@ protected:
 // Prepare + execute (caches a handle), kill the owning session, then execute
 // again: the driver must transparently reconnect, invalidate the stale handle,
 // re-prepare, and return the fresh result.
+//
+// Benefits-from-mock-tds: a mock TDS server could assert the stale prepared
+// handle is not executed and a fresh sp_prepexec fires, which the returned
+// result alone cannot verify.
 TEST_F(SessionRecoveryLiveTest, StaleHandleAfterReconnectIsInvalidatedAndReprepared) {
     // 1. Record the owning session's SPID (the KILL target) and its physical
     //    connect time. A transparent reconnect performs a fresh login with a

--- a/mssql-tds/src/connection/session_recovery.rs
+++ b/mssql-tds/src/connection/session_recovery.rs
@@ -67,20 +67,31 @@ impl RecoveryContext {
 
     /// Initialize recovery context with connection-time settings.
     /// Called after a successful login to capture the original connection parameters
-    /// needed for reconnection validation and orchestration.
+    /// needed for reconnection validation and orchestration, and to seed the
+    /// baseline session state a reconnect's LOGIN7 must replay.
     pub fn initialize(
         &mut self,
         client_context: ClientContext,
-        tds_version: Option<TdsVersion>,
-        server_version: Option<Version>,
-        encryption_level: NegotiatedEncryptionSetting,
-        mars_enabled: bool,
+        negotiated_settings: &crate::handler::handler_factory::NegotiatedSettings,
+        login_session_state_tokens: &[SessionStateToken],
     ) {
         self.client_context = Some(Box::new(client_context));
-        self.original_tds_version = tds_version;
-        self.original_server_version = server_version;
-        self.original_encryption_level = Some(encryption_level);
-        self.original_mars_enabled = mars_enabled;
+        self.original_tds_version = negotiated_settings.login_ack_tds_version;
+        self.original_server_version = negotiated_settings.login_ack_server_version;
+        self.original_encryption_level = Some(
+            negotiated_settings
+                .session_settings
+                .negotiated_encryption_settings,
+        );
+        self.original_mars_enabled = negotiated_settings.session_settings.mars_enabled;
+        self.session_recovery_negotiated = negotiated_settings.is_session_recovery_acknowledged();
+        self.session_state_table.seed_initial_state(
+            negotiated_settings.database.clone(),
+            negotiated_settings.language.clone(),
+            negotiated_settings.database_collation,
+            login_session_state_tokens,
+            negotiated_settings.session_recovery_initial_state(),
+        );
     }
 
     /// Check whether session recovery can be attempted.
@@ -220,8 +231,6 @@ pub(crate) struct SessionStateTable {
     pub initial_language: String,
     /// Collation at connection time.
     pub initial_collation: SqlCollation,
-    /// Count of state entries currently marked as non-recoverable.
-    unrecoverable_state_count: u32,
     /// When true, the server has globally disabled recovery for this session
     /// (signaled by `sequence_number == u32::MAX` in a SESSIONSTATE token).
     pub master_recovery_disabled: bool,
@@ -237,11 +246,16 @@ impl Default for SessionStateTable {
             initial_database: String::new(),
             initial_language: String::new(),
             initial_collation: SqlCollation::default(),
-            unrecoverable_state_count: 0,
             master_recovery_disabled: false,
         }
     }
 }
+
+/// A parsed FEATUREEXTACK entry: `(state_id, value)`.
+type FeatureAckEntry = (u8, Vec<u8>);
+
+/// Where parsing a truncated FEATUREEXTACK payload failed: `(entry_offset, state_id)`.
+type FeatureAckParseError = (usize, u8);
 
 impl SessionStateTable {
     pub fn new() -> Self {
@@ -250,39 +264,145 @@ impl SessionStateTable {
 
     /// Update a session state entry from a SESSIONSTATE token.
     ///
-    /// Follows the JDBC `updateSessionState` pattern:
-    /// - First time a state_id is seen: store data, increment unrecoverable
-    ///   count if the state is not recoverable.
-    /// - Subsequent updates: only adjust unrecoverable count on a recoverable
-    ///   ↔ unrecoverable transition.
+    /// Recoverability is evaluated on demand by [`is_session_recoverable`], so
+    /// this only stores the latest record for the state id.
     pub fn update_state(&mut self, state_id: u8, sequence: u32, recoverable: bool, data: Vec<u8>) {
-        let idx = state_id as usize;
-
-        match &self.delta[idx] {
-            None => {
-                // First time seeing this state_id.
-                if !recoverable {
-                    self.unrecoverable_state_count += 1;
-                }
-            }
-            Some(existing) => {
-                // Subsequent update — adjust count only on transition.
-                if recoverable != existing.recoverable {
-                    if recoverable {
-                        self.unrecoverable_state_count =
-                            self.unrecoverable_state_count.saturating_sub(1);
-                    } else {
-                        self.unrecoverable_state_count += 1;
-                    }
-                }
-            }
-        }
-
-        self.delta[idx] = Some(SessionStateRecord {
+        self.delta[state_id as usize] = Some(SessionStateRecord {
             recoverable,
             sequence,
             data,
         });
+    }
+
+    /// Seed the baseline snapshot captured at login.
+    ///
+    /// Called once, right after a successful login, with the database/language/
+    /// collation negotiated at connect time and any SESSIONSTATE tokens the
+    /// server sent during login. Without this, `initial_*` stays empty and a
+    /// reconnect's LOGIN7 session-recovery block goes out blank, which servers
+    /// reject.
+    pub fn seed_initial_state(
+        &mut self,
+        database: String,
+        language: String,
+        collation: SqlCollation,
+        tokens: &[SessionStateToken],
+        feature_ack_initial_state: Option<&[u8]>,
+    ) {
+        self.initial_database = database;
+        self.initial_language = language;
+        self.initial_collation = collation;
+
+        // The FEATUREEXTACK payload is the recoverable baseline (initial state),
+        // applied before any SESSIONSTATE token so a same-id token (a
+        // post-baseline update) lands in the delta rather than being clobbered.
+        // Without it the reconnect LOGIN7 goes out incomplete and the server
+        // rejects it as semantically invalid (error 17897, state 81).
+        if let Some(data) = feature_ack_initial_state {
+            self.seed_initial_state_from_feature_ack(data);
+        }
+
+        // SESSIONSTATE tokens observed during login are post-baseline updates,
+        // so they belong in the delta — identical to tokens seen mid-session.
+        for token in tokens {
+            if token.sequence_number == u32::MAX {
+                self.master_recovery_disabled = true;
+                continue;
+            }
+            for entry in &token.states {
+                self.update_state(
+                    entry.state_id,
+                    token.sequence_number,
+                    entry.recoverable,
+                    entry.data.clone(),
+                );
+            }
+        }
+    }
+
+    /// Parse the packed FEATUREEXTACK session-recovery payload into
+    /// `(state_id, value)` entries. Entry format matches the reconnect wire
+    /// format: StateId (1 byte), Length (1 byte, or `0xFF` followed by a u32),
+    /// Value. Side-effect-free: returns `Err((entry_offset, state_id))` on a
+    /// truncated payload so the caller can disable recovery and log where the
+    /// parse ran off the end.
+    fn parse_feature_ack(data: &[u8]) -> Result<Vec<FeatureAckEntry>, FeatureAckParseError> {
+        let mut entries = Vec::new();
+        let mut i = 0;
+        while i < data.len() {
+            let entry_start = i;
+            let state_id = data[i];
+            i += 1;
+
+            let Some(&len_byte) = data.get(i) else {
+                return Err((entry_start, state_id));
+            };
+            i += 1;
+
+            let len = if len_byte == 0xFF {
+                let Some(bytes) = i.checked_add(4).and_then(|end| data.get(i..end)) else {
+                    return Err((entry_start, state_id));
+                };
+                i += 4;
+                u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize
+            } else {
+                len_byte as usize
+            };
+
+            let Some(value) = i.checked_add(len).and_then(|end| data.get(i..end)) else {
+                return Err((entry_start, state_id));
+            };
+            i += len;
+            entries.push((state_id, value.to_vec()));
+        }
+        Ok(entries)
+    }
+
+    /// Seed the login baseline (`initial_state`) from the FEATUREEXTACK payload.
+    fn seed_initial_state_from_feature_ack(&mut self, data: &[u8]) {
+        match Self::parse_feature_ack(data) {
+            Ok(entries) => {
+                for (state_id, value) in entries {
+                    self.initial_state[state_id as usize] = Some(SessionStateRecord {
+                        recoverable: true,
+                        sequence: 0,
+                        data: value,
+                    });
+                }
+            }
+            Err((offset, state_id)) => self.abort_partial_baseline(offset, state_id),
+        }
+    }
+
+    /// Apply a recovery-login FEATUREEXTACK payload to the current (`delta`)
+    /// state, mirroring msodbcsql's `ReadUpdatedSessionState(true, 0, ...)`.
+    /// Sequence number 0 marks a feature-ack replace, so the current table is
+    /// reset and repopulated from the payload rather than merged. The login
+    /// baseline is untouched; both blocks serialize on the next reconnect.
+    pub(crate) fn apply_feature_ack_to_delta(&mut self, data: &[u8]) {
+        self.delta = std::array::from_fn(|_| None);
+        match Self::parse_feature_ack(data) {
+            Ok(entries) => {
+                for (state_id, value) in entries {
+                    self.update_state(state_id, 0, true, value);
+                }
+            }
+            Err((offset, state_id)) => self.abort_partial_baseline(offset, state_id),
+        }
+    }
+
+    /// A truncated or malformed FEATUREEXTACK payload means the baseline cannot
+    /// be fully reconstructed. Disable recovery so the next reconnect fails fast
+    /// with a driver error instead of sending a partial baseline the server
+    /// rejects opaquely (error 17897, state 81). `offset` is the start of the
+    /// offending entry, correlating the warning with a wire capture.
+    fn abort_partial_baseline(&mut self, offset: usize, state_id: u8) {
+        tracing::warn!(
+            offset,
+            state_id,
+            "Malformed session-recovery FEATUREEXTACK payload; disabling recovery"
+        );
+        self.master_recovery_disabled = true;
     }
 
     /// Returns `true` if the session can be recovered after a disconnect.
@@ -291,7 +411,13 @@ impl SessionStateTable {
     /// any state entry is marked non-recoverable (e.g., open cursors, certain
     /// temp tables, specific SET options).
     pub fn is_session_recoverable(&self) -> bool {
-        !self.master_recovery_disabled && self.unrecoverable_state_count == 0
+        !self.master_recovery_disabled
+            && !self
+                .initial_state
+                .iter()
+                .chain(self.delta.iter())
+                .flatten()
+                .any(|record| !record.recoverable)
     }
 
     /// Clear accumulated delta state. Called on ENVCHANGE sub-type 18
@@ -299,7 +425,6 @@ impl SessionStateTable {
     /// (ODBC, JDBC, SqlClient) reset state on this event.
     pub fn reset(&mut self) {
         self.delta = std::array::from_fn(|_| None);
-        self.unrecoverable_state_count = 0;
         // master_recovery_disabled is NOT cleared — it persists across resets.
         // initial_state is NOT cleared — it represents the baseline snapshot.
     }
@@ -538,6 +663,158 @@ mod tests {
     }
 
     #[test]
+    fn seed_from_feature_ack_parses_server_baseline() {
+        // The 8-entry baseline the server sent in the SESSIONRECOVERY
+        // FEATUREEXTACK at login (captured from the wire). Dropping any of
+        // these makes the reconnect LOGIN7 fail with error 17897, state 81.
+        let ack = vec![
+            0x00, 0x09, 0x00, 0x60, 0x81, 0x14, 0xFF, 0xE7, 0xFF, 0xFF, 0x00, // id 0, len 9
+            0x02, 0x02, 0x07, 0x01, // id 2, len 2
+            0x04, 0x01, 0x00, // id 4, len 1
+            0x05, 0x04, 0xFF, 0xFF, 0xFF, 0xFF, // id 5, len 4
+            0x06, 0x01, 0x00, // id 6, len 1
+            0x07, 0x01, 0x02, // id 7, len 1
+            0x08, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // id 8, len 8
+            0x09, 0x04, 0xFF, 0xFF, 0xFF, 0xFF, // id 9, len 4
+        ];
+        let mut table = SessionStateTable::new();
+        table.seed_initial_state_from_feature_ack(&ack);
+
+        for (id, expected) in [
+            (
+                0usize,
+                vec![0x00, 0x60, 0x81, 0x14, 0xFF, 0xE7, 0xFF, 0xFF, 0x00],
+            ),
+            (2, vec![0x07, 0x01]),
+            (4, vec![0x00]),
+            (5, vec![0xFF, 0xFF, 0xFF, 0xFF]),
+            (6, vec![0x00]),
+            (7, vec![0x02]),
+            (8, vec![0x00; 8]),
+            (9, vec![0xFF, 0xFF, 0xFF, 0xFF]),
+        ] {
+            let record = table.initial_state[id]
+                .as_ref()
+                .unwrap_or_else(|| panic!("state {id} missing"));
+            assert_eq!(record.data, expected);
+            assert!(record.recoverable);
+            assert_eq!(record.sequence, 0);
+        }
+        // Gaps stay empty and the session remains recoverable.
+        assert!(table.initial_state[1].is_none());
+        assert!(table.initial_state[3].is_none());
+        assert!(table.is_session_recoverable());
+    }
+
+    #[test]
+    fn seed_from_feature_ack_extended_length() {
+        // Values >= 0xFF use the 0xFF marker followed by a u32 length.
+        let mut ack = vec![10u8, 0xFF];
+        ack.extend_from_slice(&300u32.to_le_bytes());
+        ack.extend_from_slice(&[0xAB; 300]);
+
+        let mut table = SessionStateTable::new();
+        table.seed_initial_state_from_feature_ack(&ack);
+
+        let record = table.initial_state[10].as_ref().unwrap();
+        assert_eq!(record.data.len(), 300);
+        assert!(record.data.iter().all(|&b| b == 0xAB));
+    }
+
+    #[test]
+    fn seed_from_feature_ack_truncated_disables_recovery() {
+        // A complete entry followed by one whose declared length runs past the
+        // buffer: the parse aborts all-or-nothing (no entries applied) and
+        // recovery is disabled so the next reconnect fails fast rather than
+        // sending a partial baseline.
+        let ack = vec![3, 1, 0xAA, 5, 10, 0x01];
+        let mut table = SessionStateTable::new();
+        table.seed_initial_state_from_feature_ack(&ack);
+
+        assert!(table.initial_state[3].is_none());
+        assert!(table.initial_state[5].is_none());
+        assert!(table.master_recovery_disabled);
+        assert!(!table.is_session_recoverable());
+    }
+
+    #[test]
+    fn apply_feature_ack_to_delta_resets_then_reloads() {
+        // seq 0 (feature ack) replaces the current table: a stale delta entry is
+        // cleared and only the payload's entries remain; the login baseline is
+        // untouched (msodbcsql ReadUpdatedSessionState parity).
+        let ack = vec![7, 2, 0x01, 0x02];
+        let mut table = SessionStateTable::new();
+        table.update_state(3, 5, true, vec![0xAA]);
+        table.apply_feature_ack_to_delta(&ack);
+
+        assert!(table.delta[3].is_none());
+        assert!(table.initial_state[7].is_none());
+        let record = table.delta[7].as_ref().unwrap();
+        assert_eq!(record.data, vec![0x01, 0x02]);
+        assert!(record.recoverable);
+        assert_eq!(record.sequence, 0);
+    }
+
+    #[test]
+    fn seed_initial_state_forwards_feature_ack() {
+        let ack = vec![7, 2, 0x01, 0x02];
+        let mut table = SessionStateTable::new();
+        table.seed_initial_state(
+            "master".to_string(),
+            "us_english".to_string(),
+            SqlCollation::default(),
+            &[],
+            Some(&ack),
+        );
+
+        assert_eq!(table.initial_database, "master");
+        assert_eq!(
+            table.initial_state[7].as_ref().unwrap().data,
+            vec![0x01, 0x02]
+        );
+    }
+
+    #[test]
+    fn seed_initial_state_from_tokens_tracks_recoverability() {
+        use crate::token::tokens::SessionStateEntry;
+
+        // A non-recoverable login-time SESSIONSTATE entry blocks recovery.
+        let mut table = SessionStateTable::new();
+        table.seed_initial_state(
+            "master".to_string(),
+            "us_english".to_string(),
+            SqlCollation::default(),
+            &[SessionStateToken {
+                sequence_number: 1,
+                status: 0,
+                states: vec![SessionStateEntry {
+                    state_id: 2,
+                    recoverable: false,
+                    data: vec![0x01],
+                }],
+            }],
+            None,
+        );
+        assert!(!table.is_session_recoverable());
+
+        // sequence_number == u32::MAX globally disables recovery.
+        let mut table = SessionStateTable::new();
+        table.seed_initial_state(
+            String::new(),
+            String::new(),
+            SqlCollation::default(),
+            &[SessionStateToken {
+                sequence_number: u32::MAX,
+                status: 0,
+                states: vec![],
+            }],
+            None,
+        );
+        assert!(table.master_recovery_disabled);
+        assert!(!table.is_session_recoverable());
+    }
+
+    #[test]
     fn reset_preserves_master_recovery_disabled() {
         let mut table = SessionStateTable::new();
         table.master_recovery_disabled = true;
@@ -697,18 +974,28 @@ mod tests {
     // ── Recovery eligibility tests ──
 
     fn make_initialized_context() -> RecoveryContext {
+        use crate::message::features::session_recovery::SessionRecoveryFeature;
+        use crate::message::login::Feature;
+
         let mut ctx = RecoveryContext::new();
         let client_ctx = crate::connection::client_context::ClientContext::with_data_source(
             "tcp:localhost,1433",
         );
-        ctx.initialize(
-            client_ctx,
-            Some(TdsVersion::V7_4),
-            Some(Version::new(16, 0, 1000, 0)),
-            NegotiatedEncryptionSetting::Mandatory,
-            false,
-        );
-        ctx.session_recovery_negotiated = true;
+
+        let mut settings =
+            crate::handler::handler_factory::create_test_negotiated_settings_internal();
+        settings.login_ack_tds_version = Some(TdsVersion::V7_4);
+        settings.login_ack_server_version = Some(Version::new(16, 0, 1000, 0));
+        settings.session_settings.negotiated_encryption_settings =
+            NegotiatedEncryptionSetting::Mandatory;
+        let mut feature = SessionRecoveryFeature::new(1);
+        feature.set_acknowledged(true);
+        settings
+            .session_settings
+            .supported_features
+            .push(Box::new(feature));
+
+        ctx.initialize(client_ctx, &settings, &[]);
         ctx
     }
 

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -25,7 +25,7 @@ use crate::message::transaction_management::{
     TransactionManagementType,
 };
 use crate::query::result::ReturnValue;
-use crate::token::tokens::SqlCollation;
+use crate::token::tokens::{SessionStateToken, SqlCollation};
 use crate::{
     connection::execution_context::{ALREADY_EXECUTING_ERROR, ExecutionContext},
     datatypes::column_values::ColumnValues,
@@ -325,16 +325,13 @@ impl TdsClient {
         negotiated_settings: NegotiatedSettings,
         execution_context: ExecutionContext,
         client_context: ClientContext,
+        login_session_state_tokens: Vec<SessionStateToken>,
     ) -> Self {
         let mut recovery_context = RecoveryContext::new();
         recovery_context.initialize(
             client_context,
-            negotiated_settings.login_ack_tds_version,
-            negotiated_settings.login_ack_server_version,
-            negotiated_settings
-                .session_settings
-                .negotiated_encryption_settings,
-            negotiated_settings.session_settings.mars_enabled,
+            &negotiated_settings,
+            &login_session_state_tokens,
         );
 
         Self {
@@ -468,7 +465,13 @@ impl TdsClient {
             )
             .await;
             match connect_result {
-                Ok((new_transport, new_settings, new_exec_ctx, info_messages)) => {
+                Ok((
+                    new_transport,
+                    new_settings,
+                    new_exec_ctx,
+                    info_messages,
+                    session_state_tokens,
+                )) => {
                     // Validate reconnection properties match original
                     if let Err(validation_err) =
                         self.recovery_context.validate_reconnection(&new_settings)
@@ -499,8 +502,24 @@ impl TdsClient {
                     self.remaining_request_timeout = None;
                     self.cancel_handle = None;
 
-                    // Reset session state table for the new session
-                    self.recovery_context.session_state_table.reset();
+                    // Mirror msodbcsql's recovery-login handling
+                    // (ReadUpdatedSessionState, seq 0): the FEATUREEXTACK payload
+                    // REPLACES the current (delta) table (reset-then-reload),
+                    // then any reconnect SESSIONSTATE tokens apply on top. The
+                    // initial baseline is untouched; both blocks serialize on the
+                    // next reconnect.
+                    if let Some(ack) = self
+                        .negotiated_settings
+                        .session_recovery_initial_state()
+                        .map(|s| s.to_vec())
+                    {
+                        self.recovery_context
+                            .session_state_table
+                            .apply_feature_ack_to_delta(&ack);
+                    }
+                    for token in &session_state_tokens {
+                        self.recovery_context.process_session_state(token)?;
+                    }
 
                     // A pending reset is satisfied — more completely than
                     // RESETCONNECTION would — by the fresh login: the new
@@ -4344,6 +4363,9 @@ impl TdsClient {
     /// Close the underlying transport, ending the TDS session.
     #[instrument(skip(self), level = "info")]
     pub async fn close_connection(&mut self) -> TdsResult<()> {
+        // An intentional close is not a recoverable disconnect: disable recovery
+        // so a later call on a lingering handle cannot silently resurrect it.
+        self.recovery_context.session_recovery_negotiated = false;
         self.transport.close_transport().await?;
         Ok(())
     }
@@ -5226,7 +5248,44 @@ mod tests {
             negotiated_settings,
             execution_context,
             client_context,
+            Vec::new(),
         )
+    }
+
+    #[test]
+    fn session_recovery_wiring_from_negotiated_settings() {
+        use crate::message::features::session_recovery::SessionRecoveryFeature;
+        use crate::message::login::Feature;
+
+        let transport = AnyTransport::dynamic(TestTransport::new());
+        let mut negotiated_settings =
+            crate::handler::handler_factory::create_test_negotiated_settings_internal();
+        let mut feature = SessionRecoveryFeature::new(1);
+        feature.set_acknowledged(true);
+        feature.deserialize(&[0x07, 0x02, 0x01, 0x02]).unwrap();
+        negotiated_settings
+            .session_settings
+            .supported_features
+            .push(Box::new(feature));
+
+        let client = TdsClient::new(
+            transport,
+            negotiated_settings,
+            crate::connection::execution_context::ExecutionContext::new(),
+            ClientContext::with_data_source("tcp:localhost,1433"),
+            Vec::new(),
+        );
+
+        // The ack turns session_recovery_negotiated on (previously only ever set
+        // in tests) and seeds the baseline state for replay on reconnect.
+        assert!(client.recovery_context.session_recovery_negotiated);
+        assert_eq!(
+            client.recovery_context.session_state_table.initial_state[7]
+                .as_ref()
+                .unwrap()
+                .data,
+            vec![0x01, 0x02]
+        );
     }
 
     /// Guards the fix for #225: a large local held across an `.await` in
@@ -5340,6 +5399,7 @@ mod tests {
             negotiated_settings,
             execution_context,
             client_context,
+            Vec::new(),
         )
     }
 
@@ -5358,6 +5418,7 @@ mod tests {
             negotiated_settings,
             execution_context,
             client_context,
+            Vec::new(),
         );
         (client, sent)
     }
@@ -6211,6 +6272,19 @@ mod tests {
         assert!(!client.recovery_context.session_recovery_negotiated);
 
         // Should return Ok(Duration::ZERO) even though transport is "dead"
+        let elapsed = client.check_and_reconnect(Some(5), None).await.unwrap();
+        assert_eq!(elapsed, Duration::ZERO);
+    }
+
+    #[tokio::test]
+    async fn check_and_reconnect_is_noop_after_close_connection() {
+        let mut client = create_test_client();
+        client.recovery_context.session_recovery_negotiated = true;
+
+        client.close_connection().await.unwrap();
+        assert!(!client.recovery_context.session_recovery_negotiated);
+
+        // A dead transport must not be resurrected once the caller closed it.
         let elapsed = client.check_and_reconnect(Some(5), None).await.unwrap();
         assert_eq!(elapsed, Duration::ZERO);
     }

--- a/mssql-tds/src/connection/transport/named_pipes.rs
+++ b/mssql-tds/src/connection/transport/named_pipes.rs
@@ -14,8 +14,8 @@ use tracing::{debug, info, warn};
 
 use std::ffi::OsStr;
 use std::os::windows::ffi::OsStrExt;
-use winapi::shared::winerror::ERROR_PIPE_BUSY;
-use winapi::um::namedpipeapi::SetNamedPipeHandleState;
+use winapi::shared::winerror::{ERROR_BROKEN_PIPE, ERROR_PIPE_BUSY, ERROR_PIPE_NOT_CONNECTED};
+use winapi::um::namedpipeapi::{PeekNamedPipe, SetNamedPipeHandleState};
 use winapi::um::winbase::{PIPE_READMODE_BYTE, PIPE_WAIT};
 
 /// Timeout for Named Pipe connection attempts (matching ODBC's NP_OPEN_TIMEOUT)
@@ -222,6 +222,32 @@ impl Stream for NamedPipeClient {
         } else {
             info!("Named Pipe switched to Byte mode for streaming reads");
         }
+    }
+
+    fn is_connection_dead(&self) -> bool {
+        // Non-destructive liveness probe: PeekNamedPipe reports pipe status
+        // without consuming buffered data (unlike a try_read), so it is safe on
+        // an idle connection before issuing a command. A broken or disconnected
+        // pipe surfaces as ERROR_BROKEN_PIPE / ERROR_PIPE_NOT_CONNECTED; success
+        // (with or without buffered bytes) means the pipe is still open.
+        let handle = self.as_raw_handle();
+        let ok = unsafe {
+            PeekNamedPipe(
+                handle as *mut _,
+                std::ptr::null_mut(),
+                0,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        };
+        if ok != 0 {
+            return false;
+        }
+        matches!(
+            std::io::Error::last_os_error().raw_os_error(),
+            Some(code) if code == ERROR_BROKEN_PIPE as i32 || code == ERROR_PIPE_NOT_CONNECTED as i32
+        )
     }
 }
 #[cfg(test)]

--- a/mssql-tds/src/connection_provider/tds_connection_provider.rs
+++ b/mssql-tds/src/connection_provider/tds_connection_provider.rs
@@ -24,6 +24,7 @@ use crate::error::{Error, SqlInfoMessage, TimeoutErrorType};
 use crate::handler::handler_factory::HandlerFactory;
 use crate::io::token_stream::GenericTokenParserRegistry;
 use crate::ssrp;
+use crate::token::tokens::SessionStateToken;
 
 #[cfg(fuzzing)]
 use crate::io::token_stream::TdsTokenStreamReader;
@@ -62,9 +63,20 @@ impl TdsConnectionProvider {
             + crate::io::packet_reader::TdsPacketReader
             + 'static,
     {
-        let (transport, negotiated_settings, execution_context, info_messages) =
-            Self::connect_with_transport(&context, &context.transport_context, transport).await?;
-        let mut client = TdsClient::new(transport, negotiated_settings, execution_context, context);
+        let (
+            transport,
+            negotiated_settings,
+            execution_context,
+            info_messages,
+            session_state_tokens,
+        ) = Self::connect_with_transport(&context, &context.transport_context, transport).await?;
+        let mut client = TdsClient::new(
+            transport,
+            negotiated_settings,
+            execution_context,
+            context,
+            session_state_tokens,
+        );
         client.extend_info_messages(info_messages);
         Ok(client)
     }
@@ -179,13 +191,14 @@ impl TdsConnectionProvider {
                     None => connect_future.await,
                 };
                 match sm_result {
-                    Ok((transport, negotiated_settings, execution_context, info_messages)) => {
+                    Ok((transport, negotiated_settings, execution_context, info_messages, session_state_tokens)) => {
                         debug!("Shared Memory connection succeeded, skipping SSRP");
                         let mut client = TdsClient::new(
                             transport,
                             negotiated_settings,
                             execution_context,
                             context.clone(),
+                            session_state_tokens,
                         );
                         client.extend_info_messages(info_messages);
                         return Ok(client);
@@ -373,13 +386,14 @@ impl TdsConnectionProvider {
                     // Handle redirections
                     loop {
                         match connection_result {
-                            Ok((transport, negotiated_settings, execution_context, info_messages)) => {
+                            Ok((transport, negotiated_settings, execution_context, info_messages, session_state_tokens)) => {
                                 debug!("Connection successful via action chain");
                                 let mut client = TdsClient::new(
                                     transport,
                                     negotiated_settings,
                                     execution_context,
                                     context.clone(),
+                                    session_state_tokens,
                                 );
                                 client.extend_info_messages(info_messages);
                                 return Ok(client);
@@ -546,6 +560,7 @@ impl TdsConnectionProvider {
         crate::handler::handler_factory::NegotiatedSettings,
         crate::connection::execution_context::ExecutionContext,
         Vec<SqlInfoMessage>,
+        Vec<SessionStateToken>,
     )> {
         // Create network transport directly
         // Convert connect_timeout from seconds to milliseconds
@@ -572,7 +587,7 @@ impl TdsConnectionProvider {
             .await;
 
         match session_result {
-            Ok((negotiated_settings, info_messages)) => {
+            Ok((negotiated_settings, info_messages, session_state_tokens)) => {
                 // Create execution context for the new connection
                 let execution_context =
                     crate::connection::execution_context::ExecutionContext::new();
@@ -582,6 +597,7 @@ impl TdsConnectionProvider {
                     negotiated_settings,
                     execution_context,
                     info_messages,
+                    session_state_tokens,
                 ))
             }
             Err(err) => {
@@ -605,6 +621,7 @@ impl TdsConnectionProvider {
         crate::handler::handler_factory::NegotiatedSettings,
         crate::connection::execution_context::ExecutionContext,
         Vec<SqlInfoMessage>,
+        Vec<SessionStateToken>,
     )>
     where
         T: TdsTransport
@@ -623,7 +640,7 @@ impl TdsConnectionProvider {
             .await;
 
         match session_result {
-            Ok((negotiated_settings, info_messages)) => {
+            Ok((negotiated_settings, info_messages, session_state_tokens)) => {
                 // Create execution context for the new connection
                 let execution_context =
                     crate::connection::execution_context::ExecutionContext::new();
@@ -633,6 +650,7 @@ impl TdsConnectionProvider {
                     negotiated_settings,
                     execution_context,
                     info_messages,
+                    session_state_tokens,
                 ))
             }
             Err(err) => {

--- a/mssql-tds/src/fuzz_support.rs
+++ b/mssql-tds/src/fuzz_support.rs
@@ -1111,5 +1111,6 @@ pub fn create_fuzz_tds_client(packet_reader: FuzzPacketReader, packet_size: u32)
         negotiated_settings,
         execution_context,
         client_context,
+        Vec::new(),
     )
 }

--- a/mssql-tds/src/handler/handler_factory.rs
+++ b/mssql-tds/src/handler/handler_factory.rs
@@ -20,7 +20,7 @@ use crate::message::prelogin::{
     EncryptionType, PreloginRequest, PreloginRequestModel, PreloginResponse,
 };
 use crate::token::login_ack::LoginAckToken;
-use crate::token::tokens::SqlCollation;
+use crate::token::tokens::{SessionStateToken, SqlCollation};
 use tracing::{debug, warn};
 use uuid::Uuid;
 
@@ -149,6 +149,16 @@ impl NegotiatedSettings {
             .any(|f| f.feature_identifier() == FeatureExtension::SRecovery && f.is_acknowledged())
     }
 
+    /// Raw FEATUREEXTACK session-recovery baseline the server sent at login,
+    /// which must be echoed back in the reconnect LOGIN7's initial state block.
+    pub(crate) fn session_recovery_initial_state(&self) -> Option<&[u8]> {
+        self.session_settings
+            .supported_features
+            .iter()
+            .find(|f| f.feature_identifier() == FeatureExtension::SRecovery && f.is_acknowledged())
+            .and_then(|f| f.session_recovery_initial_state())
+    }
+
     /// Check if Always Encrypted (column encryption) was acknowledged by the
     /// server in FEATUREEXTACK.
     pub(crate) fn is_column_encryption_supported(&self) -> bool {
@@ -236,7 +246,11 @@ impl<'a, 'b> SessionHandler<'a, 'b> {
     pub(crate) async fn execute<T: NetworkReaderWriter + TdsTokenStreamReader + TdsPacketReader>(
         &mut self,
         reader_writer: &mut T,
-    ) -> TdsResult<(NegotiatedSettings, Vec<SqlInfoMessage>)> {
+    ) -> TdsResult<(
+        NegotiatedSettings,
+        Vec<SqlInfoMessage>,
+        Vec<SessionStateToken>,
+    )> {
         let pre_login_result = self.get_pre_login_result(reader_writer).await?;
         self.validate_prelogin_result(&pre_login_result)?;
 
@@ -252,8 +266,9 @@ impl<'a, 'b> SessionHandler<'a, 'b> {
         let negotiated_settings =
             self.infer_negotiated_settings(&pre_login_result, &mut login_result)?;
         let info_messages = std::mem::take(&mut login_result.diagnostics.info_messages);
+        let session_state_tokens = std::mem::take(&mut login_result.session_state_tokens);
         reader_writer.notify_session_setting_change(&negotiated_settings.session_settings);
-        Ok((negotiated_settings, info_messages))
+        Ok((negotiated_settings, info_messages, session_state_tokens))
     }
 
     async fn get_pre_login_result<T: NetworkReaderWriter + TdsPacketReader>(
@@ -329,10 +344,12 @@ impl<'a, 'b> SessionHandler<'a, 'b> {
             None => (None, None),
         };
 
+        let language = change_props.language.clone().unwrap_or_default();
+
         Ok(NegotiatedSettings::new(
             session_settings,
             database_collation,
-            "".to_string(),
+            language,
             database,
             change_props.char_set.clone(),
             login_ack_tds_version,
@@ -453,6 +470,9 @@ struct LoginResult {
     /// ERROR tokens plus any INFO/warning messages. On success only the
     /// informational messages are populated; on failure the errors explain why.
     diagnostics: SqlServerDiagnostics,
+    /// SESSIONSTATE tokens received during login — the baseline snapshot a
+    /// reconnect's LOGIN7 session-recovery block must replay.
+    session_state_tokens: Vec<SessionStateToken>,
 }
 
 pub struct LoginHandler<'a> {
@@ -594,12 +614,15 @@ impl LoginHandler<'_> {
             .map(|f| f.clone_box())
             .collect();
 
+        let session_state_tokens = std::mem::take(&mut login_response.session_state_tokens);
+
         Ok(LoginResult {
             supported_features,
             change_properties: login_response.change_properties,
             status: response_status,
             login_ack: login_response.success_token,
             diagnostics: SqlServerDiagnostics::new(errors, info_messages),
+            session_state_tokens,
         })
     }
 
@@ -759,5 +782,28 @@ mod tests {
     fn is_session_recovery_acknowledged_false_when_feature_absent() {
         let settings = create_test_negotiated_settings_internal();
         assert!(!settings.is_session_recovery_acknowledged());
+    }
+
+    #[test]
+    fn session_recovery_initial_state_returns_ack_payload() {
+        let mut settings = create_test_negotiated_settings_internal();
+        let mut feature = SessionRecoveryFeature::new(1);
+        feature.set_acknowledged(true);
+        feature.deserialize(&[0x07, 0x02, 0x01, 0x02]).unwrap();
+        settings
+            .session_settings
+            .supported_features
+            .push(Box::new(feature));
+
+        assert_eq!(
+            settings.session_recovery_initial_state(),
+            Some([0x07, 0x02, 0x01, 0x02].as_slice())
+        );
+    }
+
+    #[test]
+    fn session_recovery_initial_state_none_without_feature() {
+        let settings = create_test_negotiated_settings_internal();
+        assert!(settings.session_recovery_initial_state().is_none());
     }
 }

--- a/mssql-tds/src/message/features/session_recovery.rs
+++ b/mssql-tds/src/message/features/session_recovery.rs
@@ -189,6 +189,10 @@ impl Feature for SessionRecoveryFeature {
         Ok(())
     }
 
+    fn session_recovery_initial_state(&self) -> Option<&[u8]> {
+        self.initial_state_data.as_deref()
+    }
+
     fn is_acknowledged(&self) -> bool {
         self.acknowledged
     }
@@ -235,10 +239,15 @@ mod tests {
     fn deserialize_stores_initial_state_data() {
         let mut feature = SessionRecoveryFeature::new(1);
         assert!(feature.initial_state_data.is_none());
+        assert!(feature.session_recovery_initial_state().is_none());
 
         let data = vec![0x01, 0x02, 0x03];
         feature.deserialize(&data).unwrap();
         assert_eq!(feature.initial_state_data.as_ref().unwrap(), &data);
+        assert_eq!(
+            feature.session_recovery_initial_state(),
+            Some(data.as_slice())
+        );
     }
 
     #[test]
@@ -496,6 +505,50 @@ mod tests {
         assert_eq!(fb[16], 0);
         assert_eq!(fb[17], 0);
         assert_eq!(fb[18], 0);
+    }
+
+    #[test]
+    fn feature_ack_round_trips_through_serialize() {
+        use crate::connection::session_recovery::SessionStateTable;
+        use crate::io::packet_writer::tests::MockNetworkWriter;
+        use crate::message::messages::PacketType;
+        use futures::executor::block_on;
+
+        // Ascending state-id entries, matching the server's FEATUREEXTACK order.
+        let ack = vec![
+            0x00, 0x02, 0xAA, 0xBB, // id 0, len 2
+            0x05, 0x01, 0xCC, // id 5, len 1
+            0x09, 0x03, 0x01, 0x02, 0x03, // id 9, len 3
+        ];
+
+        // Seed a table (empty db/lang/default collation) from the ack, snapshot
+        // it, and serialize the reconnect feature.
+        let mut table = SessionStateTable::new();
+        table.seed_initial_state(
+            String::new(),
+            String::new(),
+            SqlCollation::default(),
+            &[],
+            Some(&ack),
+        );
+        let feature =
+            SessionRecoveryFeature::new_for_reconnection(table.snapshot(None, None, None));
+
+        let mut mock_writer = MockNetworkWriter::new(4096);
+        let mut pw = PacketWriter::new(PacketType::Login7, &mut mock_writer, None, None);
+        block_on(feature.serialize(&mut pw)).unwrap();
+        let payload = pw.get_payload();
+        let bytes = payload.get_ref();
+        let fb = &bytes[8..]; // skip packet header
+
+        // fb: [feature_id][total_len:4][initial_len:4][initial block]...
+        let initial_len = u32::from_le_bytes([fb[5], fb[6], fb[7], fb[8]]) as usize;
+        let initial_block = &fb[9..9 + initial_len];
+        // db(0) + collation(0) + language(0), then the state entries.
+        assert_eq!(&initial_block[0..3], &[0, 0, 0]);
+        // The emitted state entries byte-match the original ack blob, pinning
+        // the parser and serializer against each other.
+        assert_eq!(&initial_block[3..], ack.as_slice());
     }
 
     #[test]

--- a/mssql-tds/src/message/login.rs
+++ b/mssql-tds/src/message/login.rs
@@ -117,6 +117,12 @@ pub(crate) trait Feature: Send + Sync + Debug {
     async fn serialize(&self, packet_writer: &mut PacketWriter) -> TdsResult<()>;
     fn deserialize(&mut self, data: &[u8]) -> TdsResult<()>;
 
+    /// Raw FEATUREEXTACK initial session-state payload, if this feature carries
+    /// one. Only SessionRecovery does; it must be echoed in the reconnect LOGIN7.
+    fn session_recovery_initial_state(&self) -> Option<&[u8]> {
+        None
+    }
+
     #[allow(dead_code)]
     // This method is not used currently, and exists for completeness.
     fn is_acknowledged(&self) -> bool;

--- a/mssql-tds/src/test_client_support.rs
+++ b/mssql-tds/src/test_client_support.rs
@@ -213,6 +213,7 @@ pub fn tds_client_from_tokens(tokens: Vec<ScriptedToken>) -> TdsClient {
         negotiated_settings,
         execution_context,
         client_context,
+        Vec::new(),
     )
 }
 
@@ -239,6 +240,7 @@ pub fn tds_client_from_tokens_in_transaction(
         negotiated_settings,
         execution_context,
         client_context,
+        Vec::new(),
     )
 }
 
@@ -504,6 +506,7 @@ pub(crate) mod byte_stream {
             negotiated_settings,
             execution_context,
             client_context,
+            Vec::new(),
         )
     }
 
@@ -530,6 +533,7 @@ pub(crate) mod byte_stream {
             negotiated_settings,
             execution_context,
             client_context,
+            Vec::new(),
         )
     }
 }

--- a/mssql-tds/tests/connectivity.rs
+++ b/mssql-tds/tests/connectivity.rs
@@ -433,13 +433,14 @@ mod connectivity {
 
             tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
-            let new_spid = get_spid(&mut client).await?;
+            // The query succeeding after the KILL proves the connection was
+            // transparently re-established (it would error otherwise). The SPID
+            // is deliberately NOT asserted to change: SQL Server recycles SPID
+            // numbers, so a recovered session frequently reuses the same one.
+            // connection_recovery_count is the reliable signal that a reconnect
+            // actually occurred.
+            let _ = get_spid(&mut client).await?;
 
-            assert_ne!(
-                original_spid, new_spid,
-                "SPID should change after reconnection (was {}, now {})",
-                original_spid, new_spid
-            );
             assert_eq!(
                 client.connection_recovery_count(),
                 1,


### PR DESCRIPTION
<!--
Thank you for your interest in this project!

This repository is not currently accepting external pull requests. If you've found
a bug or have a feature request, please open an issue instead.

If you are a Microsoft team member, please follow the instructions in the internal
contribution guide.
-->

## Description

<!-- Briefly describe the change. -->
This pull request implements critical fixes and enhancements to the SQL Server session recovery feature in the TDS client, ensuring that session state is correctly seeded and replayed during reconnects. The main changes include capturing and forwarding the session state baseline provided by the server at login, updating the session recovery context and table to handle this state, and extending the connection and client initialization code to manage session state tokens throughout the connection lifecycle. This allows transparent reconnects to succeed where they previously failed due to missing or incomplete session state.

**Session Recovery State Handling:**

* Added `SessionStateToken` support throughout the connection stack, ensuring that the baseline session state (including database, language, collation, and server-provided tokens) is captured at login and replayed during reconnects. This includes passing session state tokens from the connection provider to the TdsClient and into the session recovery context. [[1]](diffhunk://#diff-6447dc0ccde8cd634bf2c5908731c366a34fec26a42b1635c1e8ddf9493d7b8dL26-R26) [[2]](diffhunk://#diff-6447dc0ccde8cd634bf2c5908731c366a34fec26a42b1635c1e8ddf9493d7b8dR186) [[3]](diffhunk://#diff-6447dc0ccde8cd634bf2c5908731c366a34fec26a42b1635c1e8ddf9493d7b8dR197-R202) [[4]](diffhunk://#diff-9740887f52fe0bf00a14e663a08521e65e9c1ce4a30d6596e8cf0f71fcac8313R25) [[5]](diffhunk://#diff-9740887f52fe0bf00a14e663a08521e65e9c1ce4a30d6596e8cf0f71fcac8313L63-R77) [[6]](diffhunk://#diff-9740887f52fe0bf00a14e663a08521e65e9c1ce4a30d6596e8cf0f71fcac8313L180-R199) [[7]](diffhunk://#diff-9740887f52fe0bf00a14e663a08521e65e9c1ce4a30d6596e8cf0f71fcac8313L374-R394) [[8]](diffhunk://#diff-9740887f52fe0bf00a14e663a08521e65e9c1ce4a30d6596e8cf0f71fcac8313R561) [[9]](diffhunk://#diff-9740887f52fe0bf00a14e663a08521e65e9c1ce4a30d6596e8cf0f71fcac8313L573-R588) [[10]](diffhunk://#diff-9740887f52fe0bf00a14e663a08521e65e9c1ce4a30d6596e8cf0f71fcac8313R598) [[11]](diffhunk://#diff-9740887f52fe0bf00a14e663a08521e65e9c1ce4a30d6596e8cf0f71fcac8313R622) [[12]](diffhunk://#diff-9740887f52fe0bf00a14e663a08521e65e9c1ce4a30d6596e8cf0f71fcac8313L624-R641) [[13]](diffhunk://#diff-9740887f52fe0bf00a14e663a08521e65e9c1ce4a30d6596e8cf0f71fcac8313R651) [[14]](diffhunk://#diff-6447dc0ccde8cd634bf2c5908731c366a34fec26a42b1635c1e8ddf9493d7b8dR4437) [[15]](diffhunk://#diff-6447dc0ccde8cd634bf2c5908731c366a34fec26a42b1635c1e8ddf9493d7b8dR4482) [[16]](diffhunk://#diff-6447dc0ccde8cd634bf2c5908731c366a34fec26a42b1635c1e8ddf9493d7b8dR4500) [[17]](diffhunk://#diff-8e5ffdbb793ed4c2080b4f2359e6e55348db129238b658a5e981b3708cb7a731R759)

* Enhanced `RecoveryContext::initialize` to take and store all relevant session state information, and to seed the session state table with the baseline provided at login. [[1]](diffhunk://#diff-6812cf686356bb7734b94de2312ef358dee0da8944fde3ae28e4df25f61c8099L70-R99) [[2]](diffhunk://#diff-6812cf686356bb7734b94de2312ef358dee0da8944fde3ae28e4df25f61c8099R894-L711)

**Session State Table Improvements:**

* Added `SessionStateTable::seed_initial_state` and `seed_initial_state_from_feature_ack` to correctly parse and store the session state baseline from server-provided FEATUREEXTACK payloads, ensuring reconnect attempts include all required state and are accepted by the server.

**Testing and Validation:**

* Added comprehensive tests for session state seeding and parsing, covering normal, extended, and truncated FEATUREEXTACK payloads, and verifying that session recovery remains robust and non-panicking in edge cases.

**Test Enablement:**

* Re-enabled the session recovery end-to-end test, which was previously skipped due to reconnect failures, as the reconnect logic now correctly replays the required session state.

These changes collectively ensure that session recovery is robust and compliant with SQL Server requirements, enabling transparent reconnects to succeed in scenarios where they previously failed.
> **Note:** Beyond FEATUREEXTACK seeding, this PR also wires `session_recovery_negotiated`
> from the server's ack. On the base branch that gate was only ever set in tests, so
> `check_and_reconnect` short-circuited everywhere and reconnect never ran in production.
> **This PR is what makes idle connection resiliency functional** — see CHANGELOG.

## Related Issues

<!--
Required: link a GitHub issue OR an Azure DevOps work item. The PR check will
fail without one.

ADO work item: https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47254
https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47099
https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46631
-->

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes
- [x] New/changed functionality has tests
- [x] Public API changes are documented
