### PR TITLE
Share result metadata across paused rows

### DIFF
--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -3259,14 +3259,14 @@ impl TdsClient {
         pause_state: RowPauseState,
         target: usize,
     ) -> TdsResult<CursorColumn> {
-        if target >= pause_state.columns().len() {
+        let column_count = pause_state.columns().len();
+        if target >= column_count {
             // Out-of-range: decoding with ColumnPolicy::DecodeOne(target) would skip
             // every remaining column and report RowWritten, silently consuming
             // the row. Reject without touching the transport and keep the
             // cursor positioned so valid pulls still work. ODBC validates the
             // column index first, so this guards the public API against other
             // callers.
-            let column_count = pause_state.columns().len();
             self.active_row_read_state = ActiveRowReadState::RowPaused(Box::new(pause_state));
             return Err(UsageError(format!(
                 "read_row_column target column {target} is out of range (row has {column_count} columns)"

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -3259,14 +3259,14 @@ impl TdsClient {
         pause_state: RowPauseState,
         target: usize,
     ) -> TdsResult<CursorColumn> {
-        if target >= pause_state.columns.len() {
+        if target >= pause_state.columns().len() {
             // Out-of-range: decoding with ColumnPolicy::DecodeOne(target) would skip
             // every remaining column and report RowWritten, silently consuming
             // the row. Reject without touching the transport and keep the
             // cursor positioned so valid pulls still work. ODBC validates the
             // column index first, so this guards the public API against other
             // callers.
-            let column_count = pause_state.columns.len();
+            let column_count = pause_state.columns().len();
             self.active_row_read_state = ActiveRowReadState::RowPaused(Box::new(pause_state));
             return Err(UsageError(format!(
                 "read_row_column target column {target} is out of range (row has {column_count} columns)"
@@ -4739,9 +4739,14 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
+        let row_metadata = Arc::new(ColMetadataToken {
+            column_count: 1,
+            columns: vec![metadata.clone()],
+            cek_table: vec![],
+        });
         let inner_pause_state = RowPauseState {
             next_column_index: 1,
-            columns: vec![metadata.clone()],
+            metadata: Arc::clone(&row_metadata),
             nbc_null_bitmap: None,
             decryptor: None,
         };
@@ -4759,7 +4764,7 @@ mod tests {
         let mut client = create_test_client_with_transport(transport);
         client.active_row_read_state = ActiveRowReadState::RowPaused(Box::new(RowPauseState {
             next_column_index: 0,
-            columns: vec![metadata],
+            metadata: row_metadata,
             nbc_null_bitmap: None,
             decryptor: None,
         }));
@@ -4779,7 +4784,7 @@ mod tests {
         let mut client = create_test_client();
         client.active_row_read_state = ActiveRowReadState::RowPaused(Box::new(RowPauseState {
             next_column_index: 1,
-            columns: Vec::new(),
+            metadata: Arc::new(ColMetadataToken::default()),
             nbc_null_bitmap: None,
             decryptor: None,
         }));
@@ -4798,7 +4803,7 @@ mod tests {
         client.current_result_set_has_been_read_till_end = false;
         client.active_row_read_state = ActiveRowReadState::RowPaused(Box::new(RowPauseState {
             next_column_index: 1,
-            columns: Vec::new(),
+            metadata: Arc::new(ColMetadataToken::default()),
             nbc_null_bitmap: None,
             decryptor: None,
         }));

--- a/mssql-tds/src/io/token_stream.rs
+++ b/mssql-tds/src/io/token_stream.rs
@@ -137,6 +137,7 @@ pub(crate) struct RowPauseState {
 
 #[derive(Debug)]
 #[cfg(fuzzing)]
+#[allow(private_interfaces)]
 pub struct RowPauseState {
     pub next_column_index: usize,
     pub metadata: Arc<ColMetadataToken>,

--- a/mssql-tds/src/io/token_stream.rs
+++ b/mssql-tds/src/io/token_stream.rs
@@ -126,8 +126,8 @@ pub enum RowHeader {
 pub(crate) struct RowPauseState {
     /// Index of the first column that has not yet been decoded.
     pub(crate) next_column_index: usize,
-    /// Full column metadata for the row (shared with the ParserContext).
-    pub(crate) columns: Vec<ColumnMetadata>,
+    /// Column metadata for the row, shared with the ParserContext.
+    pub(crate) metadata: Arc<ColMetadataToken>,
     /// NBCROW null-bitmap (one bit per column, LSB-first).  `None` for plain ROW.
     pub(crate) nbc_null_bitmap: Option<Vec<u8>>,
     /// Optional AE decryptor needed to continue decrypting encrypted columns
@@ -139,9 +139,15 @@ pub(crate) struct RowPauseState {
 #[cfg(fuzzing)]
 pub struct RowPauseState {
     pub next_column_index: usize,
-    pub columns: Vec<ColumnMetadata>,
+    pub metadata: Arc<ColMetadataToken>,
     pub nbc_null_bitmap: Option<Vec<u8>>,
     pub decryptor: Option<Arc<dyn CellDecryptor>>,
+}
+
+impl RowPauseState {
+    pub(crate) fn columns(&self) -> &[ColumnMetadata] {
+        &self.metadata.columns
+    }
 }
 
 /// Active PLP stream state captured when row decoding is paused at a PLP column.
@@ -293,7 +299,10 @@ where
 ///
 /// Returned by [`extract_row_context`] so the ROW/NBCROW decode paths can both
 /// access the column layout and the Always Encrypted decryptor (if any).
-type RowDecodeContext<'a> = (&'a [ColumnMetadata], Option<&'a Arc<dyn CellDecryptor>>);
+type RowDecodeContext<'a> = (
+    &'a Arc<ColMetadataToken>,
+    Option<&'a Arc<dyn CellDecryptor>>,
+);
 
 /// `ParserContext` is used to add additional context, which can be leveraged by the token parsers.
 /// One of the usecase is passing the metadata for the columns, to the row parser and to the
@@ -344,9 +353,7 @@ impl ParserContext {
 
 fn extract_row_context(context: &ParserContext) -> TdsResult<RowDecodeContext<'_>> {
     match context {
-        ParserContext::ColumnMetadata(metadata, decryptor) => {
-            Ok((&metadata.columns, decryptor.as_ref()))
-        }
+        ParserContext::ColumnMetadata(metadata, decryptor) => Ok((metadata, decryptor.as_ref())),
         _ => Err(crate::error::Error::ProtocolError(
             "Expected ColumnMetadata in context for row decoding".to_string(),
         )),
@@ -441,14 +448,14 @@ async fn skip_column<R: TdsPacketReader + Send + Sync>(
 /// [`RowReadResult::RowWritten`] if `col` was the last column.
 fn pause_after_column(
     col: usize,
-    columns: &[ColumnMetadata],
+    metadata: &Arc<ColMetadataToken>,
     bitmap: Option<&[u8]>,
     decryptor: Option<&Arc<dyn CellDecryptor>>,
 ) -> RowReadResult {
-    if col + 1 < columns.len() {
+    if col + 1 < metadata.columns.len() {
         RowReadResult::RowPaused(RowPauseState {
             next_column_index: col + 1,
-            columns: columns.to_vec(),
+            metadata: Arc::clone(metadata),
             nbc_null_bitmap: bitmap.map(|b| b.to_vec()),
             decryptor: decryptor.cloned(),
         })
@@ -466,7 +473,7 @@ fn pause_after_column(
 /// `writer.pause_*` polling.
 async fn drive_row_columns<R: TdsPacketReader + Send + Sync>(
     reader: &mut R,
-    columns: &[ColumnMetadata],
+    metadata: &Arc<ColMetadataToken>,
     decryptor: Option<&Arc<dyn CellDecryptor>>,
     bitmap: Option<&[u8]>,
     start_col: usize,
@@ -474,6 +481,7 @@ async fn drive_row_columns<R: TdsPacketReader + Send + Sync>(
     writer: &mut (dyn RowWriter + Send),
 ) -> TdsResult<RowReadResult> {
     let decoder = GenericDecoder::default();
+    let columns = &metadata.columns;
     for (col, meta) in columns.iter().enumerate().skip(start_col) {
         let stop_here = matches!(plan, ColumnPolicy::DecodeOne(target) if target == col);
         let skip = match plan {
@@ -490,7 +498,7 @@ async fn drive_row_columns<R: TdsPacketReader + Send + Sync>(
                 writer.write_null(col);
             }
             if stop_here {
-                return Ok(pause_after_column(col, columns, bitmap, decryptor));
+                return Ok(pause_after_column(col, metadata, bitmap, decryptor));
             }
             continue;
         }
@@ -517,7 +525,7 @@ async fn drive_row_columns<R: TdsPacketReader + Send + Sync>(
             match PlpColumnStream::begin(meta, reader).await? {
                 None => {
                     writer.write_null(col);
-                    return Ok(pause_after_column(col, columns, bitmap, decryptor));
+                    return Ok(pause_after_column(col, metadata, bitmap, decryptor));
                 }
                 Some(plp_stream) => {
                     // `pause_after_column` reports `RowWritten` when `col` is the
@@ -529,7 +537,7 @@ async fn drive_row_columns<R: TdsPacketReader + Send + Sync>(
                     return Ok(RowReadResult::PlpPaused(PlpPauseState {
                         row_pause_state: RowPauseState {
                             next_column_index: col + 1,
-                            columns: columns.to_vec(),
+                            metadata: Arc::clone(metadata),
                             nbc_null_bitmap: bitmap.map(|b| b.to_vec()),
                             decryptor: decryptor.cloned(),
                         },
@@ -542,7 +550,7 @@ async fn drive_row_columns<R: TdsPacketReader + Send + Sync>(
         decode_or_decrypt_column(&decoder, reader, meta, decryptor, col, writer).await?;
 
         if stop_here {
-            return Ok(pause_after_column(col, columns, bitmap, decryptor));
+            return Ok(pause_after_column(col, metadata, bitmap, decryptor));
         }
     }
     Ok(RowReadResult::RowWritten)
@@ -590,15 +598,15 @@ pub(crate) async fn receive_row_into_internal<R: TdsPacketReader + Send + Sync>(
 
     match token_type {
         TokenType::Row => {
-            let (columns, decryptor) = extract_row_context(context)?;
-            drive_row_columns(reader, columns, decryptor, None, 0, plan, writer).await
+            let (metadata, decryptor) = extract_row_context(context)?;
+            drive_row_columns(reader, metadata, decryptor, None, 0, plan, writer).await
         }
         TokenType::NbcRow => {
-            let (columns, decryptor) = extract_row_context(context)?;
-            let bitmap_len = columns.len().div_ceil(8);
+            let (metadata, decryptor) = extract_row_context(context)?;
+            let bitmap_len = metadata.columns.len().div_ceil(8);
             let mut bitmap = vec![0u8; bitmap_len];
             reader.read_bytes(&mut bitmap).await?;
-            drive_row_columns(reader, columns, decryptor, Some(&bitmap), 0, plan, writer).await
+            drive_row_columns(reader, metadata, decryptor, Some(&bitmap), 0, plan, writer).await
         }
         _ => {
             let token = dispatch_token(reader, registry, token_type, context).await?;
@@ -622,22 +630,22 @@ pub(crate) async fn receive_row_header_internal<R: TdsPacketReader + Send + Sync
 
     match token_type {
         TokenType::Row => {
-            let (columns, decryptor) = extract_row_context(context)?;
+            let (metadata, decryptor) = extract_row_context(context)?;
             Ok(RowHeader::Positioned(RowPauseState {
                 next_column_index: 0,
-                columns: columns.to_vec(),
+                metadata: Arc::clone(metadata),
                 nbc_null_bitmap: None,
                 decryptor: decryptor.cloned(),
             }))
         }
         TokenType::NbcRow => {
-            let (columns, decryptor) = extract_row_context(context)?;
-            let bitmap_len = columns.len().div_ceil(8);
+            let (metadata, decryptor) = extract_row_context(context)?;
+            let bitmap_len = metadata.columns.len().div_ceil(8);
             let mut bitmap = vec![0u8; bitmap_len];
             reader.read_bytes(&mut bitmap).await?;
             Ok(RowHeader::Positioned(RowPauseState {
                 next_column_index: 0,
-                columns: columns.to_vec(),
+                metadata: Arc::clone(metadata),
                 nbc_null_bitmap: Some(bitmap),
                 decryptor: decryptor.cloned(),
             }))
@@ -661,14 +669,14 @@ pub(crate) async fn resume_row_into_internal<R: TdsPacketReader + Send + Sync>(
 ) -> TdsResult<RowReadResult> {
     let RowPauseState {
         next_column_index,
-        columns,
+        metadata,
         nbc_null_bitmap,
         decryptor,
     } = pause_state;
 
     drive_row_columns(
         reader,
-        &columns,
+        &metadata,
         decryptor.as_ref(),
         nbc_null_bitmap.as_deref(),
         next_column_index,
@@ -1309,14 +1317,12 @@ mod tests {
             multi_part_name: None,
             crypto_metadata: None,
         };
-        let context = ParserContext::ColumnMetadata(
-            Arc::new(ColMetadataToken {
-                column_count: 1,
-                columns: vec![metadata],
-                cek_table: vec![],
-            }),
-            None,
-        );
+        let metadata = Arc::new(ColMetadataToken {
+            column_count: 1,
+            columns: vec![metadata],
+            cek_table: vec![],
+        });
+        let context = ParserContext::ColumnMetadata(Arc::clone(&metadata), None);
 
         let mut packet = vec![TokenType::Row as u8];
         packet.extend_from_slice(&(-2_i64).to_le_bytes());
@@ -1338,6 +1344,7 @@ mod tests {
             RowReadResult::PlpPaused(plp_state) => {
                 assert_eq!(plp_state.collation(), Some(collation));
                 assert!(!plp_state.reached_end());
+                assert!(Arc::ptr_eq(&metadata, &plp_state.row_pause_state.metadata));
             }
             _ => panic!("expected PlpPaused"),
         }

--- a/mssql-tds/src/io/token_stream.rs
+++ b/mssql-tds/src/io/token_stream.rs
@@ -19,6 +19,7 @@ use crate::token::tokens::{ColMetadataToken, TokenType, Tokens};
 use async_trait::async_trait;
 use core::convert::From;
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::debug;
@@ -121,7 +122,6 @@ pub enum RowHeader {
 ///
 /// Passed back to [`TdsTokenStreamReader::resume_row_into`] to continue
 /// decoding the rest of the row from where it paused.
-#[derive(Debug)]
 #[cfg(not(fuzzing))]
 pub(crate) struct RowPauseState {
     /// Index of the first column that has not yet been decoded.
@@ -135,7 +135,6 @@ pub(crate) struct RowPauseState {
     pub(crate) decryptor: Option<Arc<dyn CellDecryptor>>,
 }
 
-#[derive(Debug)]
 #[cfg(fuzzing)]
 #[allow(private_interfaces)]
 pub struct RowPauseState {
@@ -146,8 +145,24 @@ pub struct RowPauseState {
 }
 
 impl RowPauseState {
+    /// Borrows just the column layout so callers outside this module don't have
+    /// to reach through the shared token and its CEK table.
     pub(crate) fn columns(&self) -> &[ColumnMetadata] {
         &self.metadata.columns
+    }
+}
+
+impl fmt::Debug for RowPauseState {
+    /// Hand-written so the shared [`ColMetadataToken`] never reaches a log: its
+    /// `cek_table` carries encrypted CEK blobs and key-store paths (e.g. AKV
+    /// URIs), which a stray `{:?}` on this state would otherwise print.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RowPauseState")
+            .field("next_column_index", &self.next_column_index)
+            .field("column_count", &self.metadata.columns.len())
+            .field("nbc_null_bitmap", &self.nbc_null_bitmap)
+            .field("has_decryptor", &self.decryptor.is_some())
+            .finish_non_exhaustive()
     }
 }
 
@@ -1186,7 +1201,8 @@ mod tests {
         }
 
         async fn read_int32(&mut self) -> TdsResult<i32> {
-            unimplemented!("unused in test")
+            let raw = self.take(4)?;
+            Ok(i32::from_le_bytes([raw[0], raw[1], raw[2], raw[3]]))
         }
 
         async fn read_uint32(&mut self) -> TdsResult<u32> {
@@ -1345,10 +1361,172 @@ mod tests {
             RowReadResult::PlpPaused(plp_state) => {
                 assert_eq!(plp_state.collation(), Some(collation));
                 assert!(!plp_state.reached_end());
+            }
+            _ => panic!("expected PlpPaused"),
+        }
+    }
+
+    fn int4_metadata(column_name: &str) -> ColumnMetadata {
+        ColumnMetadata {
+            user_type: 0,
+            flags: 0,
+            data_type: TdsDataType::Int4,
+            type_info: TypeInfo::fixed_len(TdsDataType::Int4).unwrap(),
+            column_name: column_name.to_string(),
+            multi_part_name: None,
+            crypto_metadata: None,
+        }
+    }
+
+    fn two_int4_metadata() -> Arc<ColMetadataToken> {
+        Arc::new(ColMetadataToken {
+            column_count: 2,
+            columns: vec![int4_metadata("c1"), int4_metadata("c2")],
+            cek_table: vec![],
+        })
+    }
+
+    // The pause states below must borrow the ParserContext's metadata rather than
+    // deep-copy it: on the SQLGetData path a row pauses after every column pull,
+    // so a clone here is O(N) metadata allocations per pull.
+    #[tokio::test]
+    async fn row_pause_shares_result_metadata_arc() {
+        let metadata = two_int4_metadata();
+        let context = ParserContext::ColumnMetadata(Arc::clone(&metadata), None);
+
+        let mut packet = vec![TokenType::Row as u8];
+        packet.extend_from_slice(&1_i32.to_le_bytes());
+        let mut reader = TestByteReader::new(packet);
+        let registry = GenericTokenParserRegistry::default();
+        let mut writer = DiscardRowWriter;
+
+        let result = receive_row_into_internal(
+            &mut reader,
+            &registry,
+            &context,
+            ColumnPolicy::DecodeOne(0),
+            &mut writer,
+        )
+        .await
+        .unwrap();
+
+        match result {
+            RowReadResult::RowPaused(state) => {
+                assert!(Arc::ptr_eq(&metadata, &state.metadata));
+                assert_eq!(state.next_column_index, 1);
+            }
+            other => panic!("expected RowPaused, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn row_header_shares_result_metadata_arc() {
+        let metadata = two_int4_metadata();
+        let context = ParserContext::ColumnMetadata(Arc::clone(&metadata), None);
+
+        let mut reader = TestByteReader::new(vec![TokenType::Row as u8]);
+        let registry = GenericTokenParserRegistry::default();
+
+        match receive_row_header_internal(&mut reader, &registry, &context)
+            .await
+            .unwrap()
+        {
+            RowHeader::Positioned(state) => {
+                assert!(Arc::ptr_eq(&metadata, &state.metadata));
+                assert_eq!(state.next_column_index, 0);
+                assert!(state.nbc_null_bitmap.is_none());
+            }
+            RowHeader::Token(_) => panic!("expected Positioned, got Token"),
+        }
+    }
+
+    #[tokio::test]
+    async fn nbcrow_header_shares_result_metadata_arc() {
+        let metadata = two_int4_metadata();
+        let context = ParserContext::ColumnMetadata(Arc::clone(&metadata), None);
+
+        let mut reader = TestByteReader::new(vec![TokenType::NbcRow as u8, 0b0000_0010]);
+        let registry = GenericTokenParserRegistry::default();
+
+        match receive_row_header_internal(&mut reader, &registry, &context)
+            .await
+            .unwrap()
+        {
+            RowHeader::Positioned(state) => {
+                assert!(Arc::ptr_eq(&metadata, &state.metadata));
+                assert_eq!(state.next_column_index, 0);
+                // bitmap_len still derives from the shared token's column count.
+                assert_eq!(state.nbc_null_bitmap.as_deref(), Some(&[0b0000_0010][..]));
+            }
+            RowHeader::Token(_) => panic!("expected Positioned, got Token"),
+        }
+    }
+
+    #[tokio::test]
+    async fn plp_pause_shares_result_metadata_arc() {
+        let metadata = Arc::new(ColMetadataToken {
+            column_count: 1,
+            columns: vec![plp_varbinary_metadata("c1", None)],
+            cek_table: vec![],
+        });
+        let context = ParserContext::ColumnMetadata(Arc::clone(&metadata), None);
+
+        let mut packet = vec![TokenType::Row as u8];
+        packet.extend_from_slice(&(-2_i64).to_le_bytes());
+        let mut reader = TestByteReader::new(packet);
+        let registry = GenericTokenParserRegistry::default();
+        let mut writer = DiscardRowWriter;
+
+        let result = receive_row_into_internal(
+            &mut reader,
+            &registry,
+            &context,
+            ColumnPolicy::DecodeOne(0),
+            &mut writer,
+        )
+        .await
+        .unwrap();
+
+        match result {
+            RowReadResult::PlpPaused(plp_state) => {
                 assert!(Arc::ptr_eq(&metadata, &plp_state.row_pause_state.metadata));
             }
             _ => panic!("expected PlpPaused"),
         }
+    }
+
+    #[test]
+    fn row_pause_state_debug_elides_cek_table() {
+        let metadata = Arc::new(ColMetadataToken {
+            column_count: 1,
+            columns: vec![int4_metadata("c1")],
+            cek_table: vec![crate::query::metadata::CekTableEntry {
+                database_id: 1,
+                cek_id: 2,
+                cek_version: 3,
+                cek_md_version: [0u8; 8],
+                encrypted_cek_values: vec![crate::query::metadata::EncryptedCekValue {
+                    encrypted_key: vec![0xAB; 4],
+                    key_store_name: "AZURE_KEY_VAULT".to_string(),
+                    key_path: "https://vault.example/keys/cmk".to_string(),
+                    algorithm_name: "RSA_OAEP".to_string(),
+                }],
+            }],
+        });
+
+        let rendered = format!(
+            "{:?}",
+            RowPauseState {
+                next_column_index: 0,
+                metadata,
+                nbc_null_bitmap: None,
+                decryptor: None,
+            }
+        );
+
+        assert!(!rendered.contains("vault.example"));
+        assert!(!rendered.contains("AZURE_KEY_VAULT"));
+        assert!(rendered.contains("column_count: 1"));
     }
 
     #[tokio::test]

--- a/mssql-tds/src/io/token_stream.rs
+++ b/mssql-tds/src/io/token_stream.rs
@@ -19,7 +19,6 @@ use crate::token::tokens::{ColMetadataToken, TokenType, Tokens};
 use async_trait::async_trait;
 use core::convert::From;
 use std::collections::HashMap;
-use std::fmt;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::debug;
@@ -122,6 +121,7 @@ pub enum RowHeader {
 ///
 /// Passed back to [`TdsTokenStreamReader::resume_row_into`] to continue
 /// decoding the rest of the row from where it paused.
+#[derive(Debug)]
 #[cfg(not(fuzzing))]
 pub(crate) struct RowPauseState {
     /// Index of the first column that has not yet been decoded.
@@ -135,6 +135,7 @@ pub(crate) struct RowPauseState {
     pub(crate) decryptor: Option<Arc<dyn CellDecryptor>>,
 }
 
+#[derive(Debug)]
 #[cfg(fuzzing)]
 #[allow(private_interfaces)]
 pub struct RowPauseState {
@@ -149,20 +150,6 @@ impl RowPauseState {
     /// to reach through the shared token and its CEK table.
     pub(crate) fn columns(&self) -> &[ColumnMetadata] {
         &self.metadata.columns
-    }
-}
-
-impl fmt::Debug for RowPauseState {
-    /// Hand-written so the shared [`ColMetadataToken`] never reaches a log: its
-    /// `cek_table` carries encrypted CEK blobs and key-store paths (e.g. AKV
-    /// URIs), which a stray `{:?}` on this state would otherwise print.
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RowPauseState")
-            .field("next_column_index", &self.next_column_index)
-            .field("column_count", &self.metadata.columns.len())
-            .field("nbc_null_bitmap", &self.nbc_null_bitmap)
-            .field("has_decryptor", &self.decryptor.is_some())
-            .finish_non_exhaustive()
     }
 }
 
@@ -1496,7 +1483,8 @@ mod tests {
     }
 
     #[test]
-    fn row_pause_state_debug_elides_cek_table() {
+    fn row_pause_state_debug_redacts_cek_secrets() {
+        let encrypted_key = vec![0x2A; 4];
         let metadata = Arc::new(ColMetadataToken {
             column_count: 1,
             columns: vec![int4_metadata("c1")],
@@ -1506,7 +1494,7 @@ mod tests {
                 cek_version: 3,
                 cek_md_version: [0u8; 8],
                 encrypted_cek_values: vec![crate::query::metadata::EncryptedCekValue {
-                    encrypted_key: vec![0xAB; 4],
+                    encrypted_key: encrypted_key.clone(),
                     key_store_name: "AZURE_KEY_VAULT".to_string(),
                     key_path: "https://vault.example/keys/cmk".to_string(),
                     algorithm_name: "RSA_OAEP".to_string(),
@@ -1524,9 +1512,10 @@ mod tests {
             }
         );
 
+        assert!(!rendered.contains(&format!("{encrypted_key:?}")));
         assert!(!rendered.contains("vault.example"));
         assert!(!rendered.contains("AZURE_KEY_VAULT"));
-        assert!(rendered.contains("column_count: 1"));
+        assert!(rendered.contains("c1"));
     }
 
     #[tokio::test]

--- a/mssql-tds/src/query/metadata.rs
+++ b/mssql-tds/src/query/metadata.rs
@@ -240,7 +240,7 @@ impl MultiPartName {
 /// A CEK may have more than one encrypted value (one per column master key that
 /// wraps it) to support key rotation; any one of them can be used to recover the
 /// plaintext CEK.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct EncryptedCekValue {
     /// The encrypted CEK bytes (ciphertext produced by the column master key).
     pub encrypted_key: Vec<u8>,
@@ -250,6 +250,20 @@ pub(crate) struct EncryptedCekValue {
     pub key_path: String,
     /// Name of the asymmetric algorithm used to encrypt the CEK (e.g. `RSA_OAEP`).
     pub algorithm_name: String,
+}
+
+impl fmt::Debug for EncryptedCekValue {
+    /// Redacts here rather than in each holder: this value is reachable by `{:?}`
+    /// from [`CekTableEntry`], `ColMetadataToken`, `Tokens`, and `ParserContext`,
+    /// including the row parsers' TRACE logging of the whole metadata token.
+    /// Deriving `Debug` would print the wrapped-key ciphertext and the column
+    /// master key path (e.g. an Azure Key Vault URI) at every one of those sites.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EncryptedCekValue")
+            .field("encrypted_key_len", &self.encrypted_key.len())
+            .field("algorithm_name", &self.algorithm_name)
+            .finish_non_exhaustive()
+    }
 }
 
 /// One entry in the COLMETADATA CEK table, describing a column encryption key
@@ -706,5 +720,24 @@ mod tests {
         let cloned = metadata.clone();
         assert_eq!(cloned.column_name, "test_column");
         assert_eq!(cloned.flags, 0x01);
+    }
+
+    #[test]
+    fn encrypted_cek_value_debug_redacts_key_material() {
+        let rendered = format!(
+            "{:?}",
+            EncryptedCekValue {
+                encrypted_key: vec![0x2A; 4],
+                key_store_name: "AZURE_KEY_VAULT".to_string(),
+                key_path: "https://vault.example/keys/cmk".to_string(),
+                algorithm_name: "RSA_OAEP".to_string(),
+            }
+        );
+
+        assert!(!rendered.contains("42"));
+        assert!(!rendered.contains("vault.example"));
+        assert!(!rendered.contains("AZURE_KEY_VAULT"));
+        assert!(rendered.contains("encrypted_key_len: 4"));
+        assert!(rendered.contains("RSA_OAEP"));
     }
 }


### PR DESCRIPTION
## Description

Retain the existing `Arc<ColMetadataToken>` in `RowPauseState` instead of cloning the result-set `Vec<ColumnMetadata>` whenever a pull cursor pauses after a row column. Pausing now performs an Arc refcount increment while preserving the same metadata and encryption context.

On the ODBC `SQLGetData` path the cursor pauses after every column pull, so the previous deep copy cost one full metadata clone per pause — O(N) allocations per pause across N columns per row.

Named tests cover all four `RowPauseState` construction sites (`pause_after_column`, the PLP pause, and both `receive_row_header_internal` arms) so a regression back to a deep copy fails under a test name that says what broke.

Because the pause state now carries the whole token, the CEK table came within reach of a stray `{:?}`. Rather than guard the one holder, `EncryptedCekValue` gets a hand-written `Debug` that reports the ciphertext length and algorithm name and drops the wrapped key and column master key path. That covers every holder — `ParserContext`, `Tokens`, `CekTableEntry`, `RowPauseState`, and the row parsers' existing TRACE logging of the whole metadata token, which printed this material verbatim before.

## Related Issues

Fixes #232

Follow-up tracked in #233 (share the NBCROW null bitmap the same way).

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes for `mssql-tds`
- [x] Focused `cargo nextest` regression passes
- [x] New/changed functionality has tests
- [x] Public API changes are documented

Targeted run: 17 tests across the `token_stream` module and the row-cursor tests, all passing.

