### PR TITLE
Guard decimal magnitude reassembly against 128-bit shift overflow

### DIFF
--- a/mssql-odbc/src/api/fetch_convert.rs
+++ b/mssql-odbc/src/api/fetch_convert.rs
@@ -1397,7 +1397,8 @@ mod tests {
 
     /// The limbs are reassembled directly, and a payload with more limbs than
     /// 128 bits can hold is refused instead of shifting past the width. The wire
-    /// decoder admits up to 64 limbs, so this is reachable from a bad payload.
+    /// decoder now caps the count at 4, so the oversized case below is reachable
+    /// only through FFI or a hand-built `DecimalParts`.
     #[test]
     fn decimal_limbs_are_reassembled_and_bounded() {
         use mssql_tds::datatypes::decoder::DecimalParts;
@@ -1462,6 +1463,20 @@ mod tests {
         }
         .unwrap_err();
         assert_eq!(err, ConvError::Restricted);
+
+        // Zero-padded limbs past the fourth carry no magnitude, so this path
+        // agrees with the string rendering instead of refusing the value.
+        let ok = unsafe {
+            convert_integer_c(
+                &decimal(true, 2, vec![12345, 0, 0, 0, 0, 0]),
+                SQL_C_SLONG,
+                (&mut out as *mut i32).cast(),
+                &mut ind,
+            )
+        }
+        .unwrap();
+        assert_eq!(ok, ConvOk::Truncated);
+        assert_eq!(out, 123);
     }
 
     /// Multi-byte input must not panic while probing for a trailing UTC offset:

--- a/mssql-odbc/src/api/fetch_convert.rs
+++ b/mssql-odbc/src/api/fetch_convert.rs
@@ -208,17 +208,11 @@ fn numeric_source(value: &ColumnValues) -> Option<NumericSource> {
         ColumnValues::Bit(b) => Some(NumericSource::Int(i128::from(*b))),
         ColumnValues::Real(x) => Some(NumericSource::Float(f64::from(*x))),
         ColumnValues::Float(x) => Some(NumericSource::Float(*x)),
-        // `DecimalParts` stores a base-2^32 little-endian magnitude; reassemble
-        // it directly. 38 digits fit in 4 limbs, and the wire decoder admits up
-        // to 64, so reject longer payloads rather than shifting past 128 bits.
+        // `DecimalParts` stores a base-2^32 little-endian magnitude. 38 digits
+        // fit in 4 words, and `magnitude` returns `None` for a wider (malformed)
+        // value rather than shifting past 128 bits.
         ColumnValues::Decimal(d) | ColumnValues::Numeric(d) => {
-            if d.int_parts.len() > 4 {
-                return None;
-            }
-            let mag = d.int_parts.iter().enumerate().fold(0u128, |acc, (i, &p)| {
-                acc | (u128::from(p as u32) << (i * 32))
-            });
-            let m = i128::try_from(mag).ok()?;
+            let m = i128::try_from(d.magnitude()?).ok()?;
             Some(NumericSource::Scaled {
                 mantissa: if d.is_positive { m } else { -m },
                 scale: u32::from(d.scale),

--- a/mssql-tds/src/datatypes/decoder.rs
+++ b/mssql-tds/src/datatypes/decoder.rs
@@ -90,7 +90,7 @@ const MAX_PLP_SIZE: usize = i32::MAX as usize;
 /// magnitude. SQL Server's maximum precision of 38 digits fits in 128 bits, and
 /// the widest value the TDS wire format carries is 17 bytes (sign byte plus four
 /// words), so anything longer is malformed.
-const MAX_DECIMAL_INT_PARTS: u8 = 4;
+const MAX_DECIMAL_INT_PARTS: usize = 4;
 
 // Helper function to validate allocation size before allocating
 #[inline]
@@ -667,7 +667,12 @@ impl GenericDecoder {
         let sign = reader.read_byte().await?;
         let is_positive = sign == 1;
 
-        let number_of_int_parts = (length - 1) >> 2;
+        // Round up: a declared length that does not cover whole 32-bit words
+        // still has to be consumed, or the leftover bytes desynchronize the
+        // stream for the next field. A trailing partial word is zero-padded,
+        // which matches the length-tolerant reader on the Always Encrypted path.
+        let magnitude_len = (length - 1) as usize;
+        let number_of_int_parts = magnitude_len.div_ceil(4);
 
         if number_of_int_parts > MAX_DECIMAL_INT_PARTS {
             return Err(crate::error::Error::ProtocolError(format!(
@@ -675,12 +680,18 @@ impl GenericDecoder {
             )));
         }
 
-        let int_parts_len = number_of_int_parts as usize;
-        validate_alloc_size(int_parts_len * 4, "read_decimal int_parts")?;
-        let mut int_parts = vec![0i32; int_parts_len];
-        for part_index in 0..number_of_int_parts {
-            int_parts[part_index as usize] = reader.read_int32().await?;
-        }
+        validate_alloc_size(number_of_int_parts * 4, "read_decimal int_parts")?;
+        let mut magnitude = vec![0u8; number_of_int_parts * 4];
+        reader.read_bytes(&mut magnitude[..magnitude_len]).await?;
+
+        let int_parts = magnitude
+            .chunks_exact(4)
+            .map(|chunk| {
+                let mut word = [0u8; 4];
+                word.copy_from_slice(chunk);
+                i32::from_le_bytes(word)
+            })
+            .collect();
 
         Ok(Some(DecimalParts {
             is_positive,
@@ -2055,7 +2066,7 @@ impl DecimalParts {
     /// payload or a hand-built [`DecimalParts`] can do; callers fall back to
     /// [`Self::magnitude_big`] instead of shifting past the accumulator width.
     fn magnitude(&self) -> Option<u128> {
-        if self.int_parts.len() > MAX_DECIMAL_INT_PARTS as usize {
+        if self.int_parts.len() > MAX_DECIMAL_INT_PARTS {
             return None;
         }
         Some(
@@ -4343,7 +4354,7 @@ mod test {
         #[tokio::test]
         async fn decimal_large_valid() {
             let md = precision_scale_metadata(TdsDataType::DecimalN, 17, 38, 0);
-            // length=17 → (17-1)>>2 = 4 int parts, the widest valid decimal
+            // length=17 → 16 magnitude bytes = 4 int parts, the widest valid decimal
             let mut buf = vec![17u8, 1u8]; // length=17, sign=positive
             for _ in 0..4 {
                 buf.extend_from_slice(&1i32.to_le_bytes());
@@ -4355,12 +4366,45 @@ mod test {
         #[tokio::test]
         async fn decimal_too_many_int_parts_rejected() {
             let md = precision_scale_metadata(TdsDataType::DecimalN, 21, 38, 0);
-            // length=21 → (21-1)>>2 = 5 int parts, which no valid decimal produces
+            // length=21 → 20 magnitude bytes = 5 int parts, which no valid decimal produces
             let mut buf = vec![21u8, 1u8];
             for _ in 0..5 {
                 buf.extend_from_slice(&1i32.to_le_bytes());
             }
             assert_decode_err(buf, &md).await;
+        }
+
+        #[tokio::test]
+        async fn decimal_oversized_partial_word_length_rejected() {
+            let md = precision_scale_metadata(TdsDataType::DecimalN, 18, 38, 0);
+            // length=18 → 17 magnitude bytes, one byte past the 128-bit limit.
+            // Rounding down would have accepted this as 4 parts and left the
+            // trailing byte unread.
+            let mut buf = vec![18u8, 1u8];
+            buf.extend_from_slice(&[1u8; 17]);
+            assert_decode_err(buf, &md).await;
+        }
+
+        #[tokio::test]
+        async fn decimal_partial_trailing_word_is_fully_consumed() {
+            let md = precision_scale_metadata(TdsDataType::DecimalN, 9, 18, 2);
+            // length=7 → 6 magnitude bytes: a full word plus a 2-byte partial
+            // word that must be zero-padded and consumed, leaving the reader
+            // positioned on the following field rather than mid-value.
+            let mut buf = vec![7u8, 1u8];
+            buf.extend_from_slice(&12345i32.to_le_bytes());
+            buf.extend_from_slice(&[0u8, 0u8]);
+            let trailing = 0x5A5A_5A5Ai32;
+            buf.extend_from_slice(&trailing.to_le_bytes());
+
+            let decoder = GenericDecoder::default();
+            let mut reader = ByteReader::new(buf);
+            let val = decoder.decode(&mut reader, &md).await.unwrap();
+            match val {
+                ColumnValues::Decimal(parts) => assert_eq!(parts.to_string(), "123.45"),
+                other => panic!("expected Decimal, got {other:?}"),
+            }
+            assert_eq!(reader.read_int32().await.unwrap(), trailing);
         }
 
         // ── Time scale branches ────────────────────────────────────────

--- a/mssql-tds/src/datatypes/decoder.rs
+++ b/mssql-tds/src/datatypes/decoder.rs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 use async_trait::async_trait;
+use bigdecimal::num_bigint::BigUint;
+use bigdecimal::num_traits::ToPrimitive;
 use core::fmt;
 use std::sync::Arc;
 use std::{fmt::Debug, io::Error, vec};
@@ -83,6 +85,12 @@ const MAX_ALLOC_SIZE: usize = 100 * 1024 * 1024;
 const MAX_PLP_SIZE: usize = 64 * 1024; // 64KB for fuzzing
 #[cfg(not(fuzzing))]
 const MAX_PLP_SIZE: usize = i32::MAX as usize;
+
+/// Maximum number of little-endian 32-bit words in a `decimal`/`numeric`
+/// magnitude. SQL Server's maximum precision of 38 digits fits in 128 bits, and
+/// the widest value the TDS wire format carries is 17 bytes (sign byte plus four
+/// words), so anything longer is malformed.
+const MAX_DECIMAL_INT_PARTS: u8 = 4;
 
 // Helper function to validate allocation size before allocating
 #[inline]
@@ -660,12 +668,6 @@ impl GenericDecoder {
         let is_positive = sign == 1;
 
         let number_of_int_parts = (length - 1) >> 2;
-
-        // Limit decimal parts allocation for fuzzing
-        #[cfg(fuzzing)]
-        const MAX_DECIMAL_INT_PARTS: u8 = 10; // Maximum 10 int parts = 40 bytes
-        #[cfg(not(fuzzing))]
-        const MAX_DECIMAL_INT_PARTS: u8 = 64; // SQL Server max precision is 38, which needs max ~17 int parts
 
         if number_of_int_parts > MAX_DECIMAL_INT_PARTS {
             return Err(crate::error::Error::ProtocolError(format!(
@@ -2009,17 +2011,10 @@ impl DecimalParts {
     /// Convert DecimalParts to a string representation suitable for Python Decimal.
     /// Returns a string like "123.45", "-0.01", etc.
     fn to_decimal_string(&self) -> String {
-        // Convert int_parts to u128
-        // int_parts[0] is the least significant, int_parts[n-1] is most significant
-        let u128_value = self
-            .int_parts
-            .iter()
-            .enumerate()
-            .fold(0u128, |acc, (i, &part)| {
-                acc + ((part as u32 as u128) << (i * 32))
-            });
-
-        let value_str = u128_value.to_string();
+        let value_str = match self.magnitude() {
+            Some(magnitude) => magnitude.to_string(),
+            None => self.magnitude_big().to_string(),
+        };
 
         // Insert decimal point at the correct position
         let result = if self.scale == 0 {
@@ -2043,19 +2038,40 @@ impl DecimalParts {
     }
 
     fn to_f64(&self) -> f64 {
-        let u128_value = self
-            .int_parts
-            .iter()
-            .enumerate()
-            .fold(0u128, |acc, (i, &part)| {
-                acc + ((part as u32 as u128) << (i * 32))
-            });
+        let magnitude = match self.magnitude() {
+            Some(magnitude) => magnitude as f64,
+            None => self.magnitude_big().to_f64().unwrap_or(f64::INFINITY),
+        };
 
-        let mut d_ret: f64 = u128_value as f64;
-
-        d_ret /= 10.0_f64.powi(self.scale as i32);
+        let d_ret = magnitude / 10.0_f64.powi(self.scale as i32);
 
         if self.is_positive { d_ret } else { -d_ret }
+    }
+
+    /// Reassembles `int_parts` into the unsigned magnitude.
+    ///
+    /// `int_parts[0]` is the least significant word. Returns `None` when the
+    /// value carries more words than a `u128` holds, which only a malformed
+    /// payload or a hand-built [`DecimalParts`] can do; callers fall back to
+    /// [`Self::magnitude_big`] instead of shifting past the accumulator width.
+    fn magnitude(&self) -> Option<u128> {
+        if self.int_parts.len() > MAX_DECIMAL_INT_PARTS as usize {
+            return None;
+        }
+        Some(
+            self.int_parts
+                .iter()
+                .enumerate()
+                .fold(0u128, |acc, (i, &part)| {
+                    acc | ((part as u32 as u128) << (i * 32))
+                }),
+        )
+    }
+
+    /// Reassembles `int_parts` into an arbitrary-precision magnitude, for values
+    /// too wide for [`Self::magnitude`].
+    fn magnitude_big(&self) -> BigUint {
+        BigUint::new(self.int_parts.iter().map(|&part| part as u32).collect())
     }
 }
 
@@ -2980,6 +2996,48 @@ mod test {
         assert!(result.is_ok());
         let parts = result.unwrap();
         assert_eq!(parts.to_decimal_string(), "123.45");
+    }
+
+    #[test]
+    fn test_decimal_parts_max_width_magnitude() {
+        // Four words of all-ones is the widest magnitude a u128 holds.
+        let parts = DecimalParts {
+            is_positive: true,
+            scale: 0,
+            precision: 38,
+            int_parts: vec![-1, -1, -1, -1],
+        };
+        assert_eq!(parts.to_decimal_string(), u128::MAX.to_string());
+    }
+
+    #[test]
+    fn test_decimal_parts_oversized_magnitude_does_not_overflow() {
+        // A malformed 5-word magnitude used to shift a u128 by 128 bits: a panic
+        // in debug builds and a wrapped, wrong value in release builds.
+        let parts = DecimalParts {
+            is_positive: true,
+            scale: 0,
+            precision: 38,
+            int_parts: vec![1, 0, 0, 0, 1],
+        };
+        // 2^128 + 1, rendered exactly rather than wrapping onto the low word.
+        assert_eq!(
+            parts.to_decimal_string(),
+            "340282366920938463463374607431768211457"
+        );
+        assert!((parts.to_f64() - 3.402_823_669_209_385e38).abs() < 1e23);
+    }
+
+    #[test]
+    fn test_decimal_parts_oversized_magnitude_with_trailing_zero_words() {
+        // Zero-padded words past the fourth carry no magnitude.
+        let parts = DecimalParts {
+            is_positive: false,
+            scale: 2,
+            precision: 38,
+            int_parts: vec![12345, 0, 0, 0, 0, 0],
+        };
+        assert_eq!(parts.to_decimal_string(), "-123.45");
     }
 
     // Vector deserialization tests
@@ -4285,13 +4343,24 @@ mod test {
         #[tokio::test]
         async fn decimal_large_valid() {
             let md = precision_scale_metadata(TdsDataType::DecimalN, 17, 38, 0);
-            // length=17 → (17-1)>>2 = 4 int parts, which is well under the 64 limit
+            // length=17 → (17-1)>>2 = 4 int parts, the widest valid decimal
             let mut buf = vec![17u8, 1u8]; // length=17, sign=positive
             for _ in 0..4 {
                 buf.extend_from_slice(&1i32.to_le_bytes());
             }
             let val = assert_decode_equivalence(buf, &md).await;
             assert!(matches!(val, ColumnValues::Decimal(_)));
+        }
+
+        #[tokio::test]
+        async fn decimal_too_many_int_parts_rejected() {
+            let md = precision_scale_metadata(TdsDataType::DecimalN, 21, 38, 0);
+            // length=21 → (21-1)>>2 = 5 int parts, which no valid decimal produces
+            let mut buf = vec![21u8, 1u8];
+            for _ in 0..5 {
+                buf.extend_from_slice(&1i32.to_le_bytes());
+            }
+            assert_decode_err(buf, &md).await;
         }
 
         // ── Time scale branches ────────────────────────────────────────

--- a/mssql-tds/src/datatypes/decoder.rs
+++ b/mssql-tds/src/datatypes/decoder.rs
@@ -2062,10 +2062,11 @@ impl DecimalParts {
     /// Reassembles `int_parts` into the unsigned magnitude.
     ///
     /// `int_parts[0]` is the least significant word. Returns `None` when the
-    /// value carries more words than a `u128` holds, which only a malformed
-    /// payload or a hand-built [`DecimalParts`] can do; callers fall back to
-    /// [`Self::magnitude_big`] instead of shifting past the accumulator width.
-    fn magnitude(&self) -> Option<u128> {
+    /// value carries more words than a `u128` holds. A valid `decimal`/`numeric`
+    /// (precision <= 38) fits in four words, so only a malformed payload or a
+    /// hand-built [`DecimalParts`] can exceed that; the alternative would be to
+    /// shift past the width of the accumulator.
+    pub fn magnitude(&self) -> Option<u128> {
         if self.int_parts.len() > MAX_DECIMAL_INT_PARTS {
             return None;
         }

--- a/mssql-tds/src/datatypes/decoder.rs
+++ b/mssql-tds/src/datatypes/decoder.rs
@@ -2062,16 +2062,21 @@ impl DecimalParts {
     /// Reassembles `int_parts` into the unsigned magnitude.
     ///
     /// `int_parts[0]` is the least significant word. Returns `None` when the
-    /// value carries more words than a `u128` holds. A valid `decimal`/`numeric`
+    /// value does not fit in a `u128`. A valid `decimal`/`numeric`
     /// (precision <= 38) fits in four words, so only a malformed payload or a
     /// hand-built [`DecimalParts`] can exceed that; the alternative would be to
     /// shift past the width of the accumulator.
     pub fn magnitude(&self) -> Option<u128> {
-        if self.int_parts.len() > MAX_DECIMAL_INT_PARTS {
+        let significant = self
+            .int_parts
+            .iter()
+            .rposition(|&part| part != 0)
+            .map_or(0, |i| i + 1);
+        if significant > MAX_DECIMAL_INT_PARTS {
             return None;
         }
         Some(
-            self.int_parts
+            self.int_parts[..significant]
                 .iter()
                 .enumerate()
                 .fold(0u128, |acc, (i, &part)| {
@@ -3020,6 +3025,7 @@ mod test {
             int_parts: vec![-1, -1, -1, -1],
         };
         assert_eq!(parts.to_decimal_string(), u128::MAX.to_string());
+        assert_eq!(parts.magnitude(), Some(u128::MAX));
     }
 
     #[test]
@@ -3038,11 +3044,13 @@ mod test {
             "340282366920938463463374607431768211457"
         );
         assert!((parts.to_f64() - 3.402_823_669_209_385e38).abs() < 1e23);
+        assert_eq!(parts.magnitude(), None);
     }
 
     #[test]
     fn test_decimal_parts_oversized_magnitude_with_trailing_zero_words() {
-        // Zero-padded words past the fourth carry no magnitude.
+        // Zero-padded words past the fourth carry no magnitude, so the value
+        // still fits a u128 and both the string and typed paths agree on it.
         let parts = DecimalParts {
             is_positive: false,
             scale: 2,
@@ -3050,6 +3058,19 @@ mod test {
             int_parts: vec![12345, 0, 0, 0, 0, 0],
         };
         assert_eq!(parts.to_decimal_string(), "-123.45");
+        assert_eq!(parts.magnitude(), Some(12345));
+    }
+
+    #[test]
+    fn test_decimal_parts_empty_magnitude_is_zero() {
+        let parts = DecimalParts {
+            is_positive: true,
+            scale: 0,
+            precision: 38,
+            int_parts: vec![],
+        };
+        assert_eq!(parts.magnitude(), Some(0));
+        assert_eq!(parts.to_decimal_string(), "0");
     }
 
     // Vector deserialization tests

--- a/mssql-tds/src/security/encryption/cell.rs
+++ b/mssql-tds/src/security/encryption/cell.rs
@@ -350,9 +350,8 @@ fn read_decimal(bytes: &[u8], base_type_info: &TypeInfo) -> TdsResult<DecimalPar
 
     // A valid decimal/numeric magnitude (precision <= 38) fits in 128 bits, so
     // it is at most 16 bytes (four 32-bit words). Reject anything longer: it
-    // signals wire-format drift or corrupted plaintext, would allocate an
-    // unbounded `int_parts`, and would break the downstream `DecimalParts`
-    // formatting, which folds `int_parts` into a `u128` (only four words wide).
+    // signals wire-format drift or corrupted plaintext, and would allocate an
+    // unbounded `int_parts`.
     if magnitude.len() > DECIMAL_MAGNITUDE_BYTES {
         return Err(Error::ColumnEncryptionError(format!(
             "Invalid decimal magnitude length {} (max {DECIMAL_MAGNITUDE_BYTES} bytes for \
@@ -1385,7 +1384,7 @@ mod tests {
     fn read_decimal_rejects_oversized_magnitude() {
         // A valid decimal magnitude is at most 16 bytes (128 bits). A longer
         // magnitude must be rejected rather than allocating an unbounded
-        // `int_parts` or overflowing the downstream `u128` fold.
+        // `int_parts`.
         let info = type_info(
             TdsDataType::DecimalN,
             5,


### PR DESCRIPTION
## Description

`DecimalParts::to_decimal_string` and `to_f64` reassembled the little-endian 32-bit words with `acc + ((part as u32 as u128) << (i * 32))`. At `i == 4` the shift amount equals the full width of the accumulator: debug builds panic with `attempt to shift left with overflow` (which aborts the process when it unwinds through `mssql-odbc`'s `extern "C"` boundary), and release builds mask the shift to `amount % 128` and silently return a wrong value.

The input was reachable because `read_decimal_data` capped the word count at 64 rather than 4, so a malformed server payload with 5+ words was accepted at the wire and reached the fold.

Changes:

- Tighten `MAX_DECIMAL_INT_PARTS` from 64 to 4 and hoist it to a module-level constant. SQL Server's maximum precision of 38 digits fits in 128 bits, and the widest decimal the TDS wire format carries is 17 bytes, so a longer payload is malformed and is now rejected with a `ProtocolError`. The fuzzing-only cap of 10 is dropped since 4 is stricter.
- Round the word count up rather than down when deriving it from the declared length. `(length - 1) >> 2` truncated, so a length of 18–20 still resolved to 4 words and was accepted while leaving 1–3 unread bytes to desynchronize the following field; the same truncation left bytes on the stream for any length whose magnitude did not cover whole words (a length of 7 read one word and dropped 2 bytes). The magnitude is now read as a single zero-padded buffer, so every declared byte is consumed and a trailing partial word is preserved — matching the length-tolerant reader on the Always Encrypted path.
- Replace both folds with a shared `DecimalParts::magnitude()` that returns `None` only when the value genuinely does not fit a `u128`, and uses `|` instead of `+` (the words are disjoint, so `+` was an overflow candidate in its own right). Significance is measured rather than word count, so a zero-padded value like `[12345, 0, 0, 0, 0, 0]` still converts.
- Fall back to a `BigUint` over the same words when the value does not fit a `u128`. `DecimalParts` has public fields and is constructible from FFI (`NapiDecimalParts`), so the formatting paths render an oversized value exactly instead of panicking or truncating.
- Reuse `magnitude()` in `mssql-odbc`'s `numeric_source`, replacing the duplicate `> 4` guard #217 added on the typed `SQLGetData` path (whose comment still referred to the 64-word cap this PR removes). With one shared implementation, `SQL_C_CHAR` and `SQL_C_SLONG` can no longer disagree about whether a given value has a numeric interpretation.
- Update the comments in `security/encryption/cell.rs` and in the `fetch_convert.rs` test that cited the now-guarded `u128` fold, or the old 64-word cap, as their justification. The checks themselves are unchanged and still valid.

Tests added: the widest valid 4-word magnitude; an oversized 5-word magnitude through both `to_decimal_string` and `to_f64`; an oversized magnitude whose extra words are zero, asserted through both the string and typed ODBC paths; an empty `int_parts`; a wire-level 5-word payload that must be rejected; a length-18 payload (one byte past the limit, the boundary that rounding down used to accept); and a length-7 payload asserting the partial trailing word is consumed and the next field reads back intact.

## Related Issues

Fixes #234

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes — 1710 `mssql-tds` and 539 `mssql-odbc` lib tests pass. The 7 failures in `certificate_validator` / `win_tls::validate` are pre-existing and unrelated: they need TLS fixtures that are deliberately not tracked in git (see `mssql-tds/tests/test_certificates/README.md`).
- [x] New/changed functionality has tests
- [x] Public API changes are documented — `DecimalParts::magnitude` is newly public, with doc comments explaining the `None` case
