### PR TITLE
[DRAFT/DO NOT MERGE] x64 SKU A/B: D4ads_v6 vs D8ads_v6

### DIFF
--- a/.pipeline/scripts/Generate-SqlCertificates.ps1
+++ b/.pipeline/scripts/Generate-SqlCertificates.ps1
@@ -23,6 +23,39 @@ function Copy-To-Root-Store($cert) {
     }
 }
 
+function Restart-SqlServiceSafely($serviceName) {
+    # Freshly-provisioned images can leave SQL Server briefly in a start-pending /
+    # not-yet-stoppable state (startup database recovery), which makes a plain
+    # Restart-Service fail intermittently with "cannot be stopped"
+    # (CouldNotStopService). Wait for a steady state, then stop/start with retries.
+    $svc = Get-Service -Name $serviceName -ErrorAction Stop
+
+    for ($i = 1; $i -le 30; $i++) {
+        $svc.Refresh()
+        if ($svc.Status -eq 'Running' -or $svc.Status -eq 'Stopped') { break }
+        Write-Host "Waiting for $serviceName to reach a steady state (current: $($svc.Status))..."
+        Start-Sleep -Seconds 5
+    }
+
+    for ($attempt = 1; $attempt -le 5; $attempt++) {
+        try {
+            $svc.Refresh()
+            if ($svc.Status -ne 'Stopped') {
+                Stop-Service -Name $serviceName -Force -ErrorAction Stop
+                $svc.WaitForStatus('Stopped', [TimeSpan]::FromSeconds(120))
+            }
+            Start-Service -Name $serviceName -ErrorAction Stop
+            $svc.WaitForStatus('Running', [TimeSpan]::FromSeconds(120))
+            Write-Host "SQL service '$serviceName' restarted (attempt $attempt)."
+            return
+        } catch {
+            Write-Host "Restart attempt $attempt for '$serviceName' failed: $($_.Exception.Message)"
+            Start-Sleep -Seconds 10
+        }
+    }
+    throw "Failed to restart SQL service '$serviceName' after multiple attempts."
+}
+
 function New-And-Install-Certificates($instanceName) {
     Write-Output "Instance name received is " + $instanceName
     $certStorePath  = "Cert:\LocalMachine\My"
@@ -70,7 +103,7 @@ function New-And-Install-Certificates($instanceName) {
 
     Set-ItemProperty -Path $registryPath -Name "Certificate" -Value $thumbprint
 
-    Restart-Service -Name "MSSQLSERVER"
+    Restart-SqlServiceSafely -serviceName $instanceName
     Copy-To-Root-Store -cert $cert
 }
 

--- a/.pipeline/validation-pipeline.yml
+++ b/.pipeline/validation-pipeline.yml
@@ -1,9 +1,38 @@
-# CI trigger only on development. Main-branch builds are produced by the
-# Official pipeline (OneBranch/OfficialPythonWheelsBuild.yml) on merge.
-trigger:
-- development
+# =============================================================================
+# TEMPORARY - x64 SKU A/B experiment (D4ads_v6 vs D8ads_v6). DO NOT MERGE.
+#
+# Runs ONLY Build Windows + Build Linux, against the single pool named by the
+# x64Pool parameter. Both pools are identical except sku.name, so the job
+# duration difference isolates the SKU. Flip the x64Pool default, push, and
+# compare median job durations across interleaved runs.
+#
+# One variant per run (not both in one run) because the coverage/wheel publish
+# steps are gated on Build.Reason == PullRequest and their artifact names are
+# hardcoded - duplicating the jobs in a single PR run would collide on artifact
+# names. Interleaving runs + taking medians controls for drift instead.
+#
+# The original entry point is preserved at the bottom of this file.
+# =============================================================================
+
+trigger: none
 
 parameters:
+- name: x64Pool
+  displayName: x64 agent pool under test
+  type: string
+  default: RUST-SKUTEST-X64-D4
+  values:
+  - RUST-SKUTEST-X64-D4
+  - RUST-SKUTEST-X64-D8
+
+- name: windowsImage
+  type: string
+  default: RUST-Win22-Sql25-1P-NVME
+
+- name: linuxImage
+  type: string
+  default: RUST-1ES-UBUSLIM-NVME
+
 - name: buildType
   displayName: Type of the build to produce
   type: string
@@ -13,44 +42,193 @@ parameters:
   - Release
   default: Both
 
-- name: RunFuzz
-  displayName: Run Fuzz Tests (30 min)
-  type: boolean
-  default: false
-
-- name: RunLongHaul
-  displayName: Run Long-Haul BCP Test (30 min)
-  type: boolean
-  default: false
-
-- name: sqlInstanceMode
-  displayName: SQL host cardinality for ARM test stages
-  type: string
-  values:
-  - shared
-  - per-job
-  default: shared
-
-- name: sqlImageTag
-  displayName: SQL Server docker image tag for ARM test stages
-  type: string
-  default: '2025-latest'
-
-variables:
-  # msodbcsql18 reference-driver version for the ODBC C++ e2e parity comparison.
-  # Pinned so an upstream release can't silently change what the parity table
-  # compares against. Consumed on Windows by install-msodbcsql.ps1 and on Linux
-  # by containerized-odbc-e2e.sh (which appends the Debian package revision).
-  msodbcsqlVersion: '18.6.2.1'
-
 stages:
-- template: templates/validation-stages.yml
-  parameters:
-    buildType: ${{ parameters.buildType }}
-    RunFuzz: ${{ parameters.RunFuzz }}
-    RunLongHaul: ${{ parameters.RunLongHaul }}
-    sqlInstanceMode: ${{ parameters.sqlInstanceMode }}
-    sqlImageTag: ${{ parameters.sqlImageTag }}
-    # PR validation for internal ADO and GitHub PRs. GitHub PRs run in the public
-    # project, which lacks 'Magnitude Test', so exclude the infra stages here.
-    includeInfraStages: false
+- stage: Build
+  displayName: SKU A/B Build (${{ parameters.x64Pool }})
+  jobs:
+  - job: Build_Windows
+    displayName: Build Windows
+    pool:
+      name: ${{ parameters.x64Pool }}
+      demands:
+        - imageOverride -equals ${{ parameters.windowsImage }}
+    variables:
+      # For details on this CARGO_TARGET_DIR setting, see https://eng.ms/docs/more/rust/topics/onebranch-workaround
+      CARGO_TARGET_DIR: C:\cargo_target_dir
+      ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
+    steps:
+      - template: sql-setup-template.yml
+        parameters:
+          buildTarget: Windows
+      - template: cargo-authenticate-template.yml
+        parameters:
+          osType: Windows
+      - template: install-dependencies.yml
+        parameters:
+          osType: Windows
+      - template: build-template.yml
+        parameters:
+          osType: Windows
+          buildType: ${{ parameters.buildType }}
+          testFilter: -E "not (test(connectivity))"
+          enableOdbcE2E: true
+      # Extended Protection (EPA) channel-binding test.
+      # Runs AFTER the main test pass. Runs the same integrated-auth encrypted
+      # login test under two server configurations, expecting success in both:
+      #   1. EPA = Off      -- baseline (channel binding not enforced).
+      #   2. EPA = Required -- the server rejects any login lacking a valid
+      #      channel binding, so a successful login proves we send a real,
+      #      server-validated tls-unique token.
+      # Reverts EPA to Off in `finally` so a failure still restores the
+      # instance. Each registry change requires a SQL service restart, handled
+      # by the script.
+      - pwsh: |
+          $ErrorActionPreference = 'Stop'
+          $spns = @("MSSQLSvc/localhost:1433", "MSSQLSvc/$($env:COMPUTERNAME):1433")
+          $configured = $false
+          try {
+            foreach ($level in @('Off', 'Required')) {
+              ./.pipeline/scripts/Configure-ExtendedProtection.ps1 `
+                -InstanceName 'MSSQLSERVER' -Level $level -ForceEncryption 'Yes' `
+                -AcceptedNtlmSpns $spns -RestartService $true
+              $configured = $true
+
+              Write-Host "Running EPA channel-binding test with Extended Protection = $level"
+              cargo nextest run --frozen --package mssql-tds `
+                -E 'test(epa_channel_binding)' --no-fail-fast --profile ci
+              if ($LASTEXITCODE -ne 0) { throw "EPA channel-binding test failed with EPA=$level (exit $LASTEXITCODE)" }
+            }
+          }
+          finally {
+            if ($configured) {
+              Write-Host 'Reverting Extended Protection to Off...'
+              ./.pipeline/scripts/Configure-ExtendedProtection.ps1 `
+                -InstanceName 'MSSQLSERVER' -Level 'Off' -ForceEncryption 'No' -RestartService $true
+            }
+          }
+        displayName: 'Extended Protection (EPA) channel-binding test'
+        condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+        env:
+          EPA_TEST: '1'
+          SSPI_TEST: '1'
+          SQL_PASSWORD: $(SQL_PASSWORD)
+          RUST_BACKTRACE: full
+      - task: PublishTestResults@2
+        condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
+        displayName: 'Publish EPA test results'
+        inputs:
+          testResultsFormat: 'JUnit'
+          testResultsFiles: $(Build.SourcesDirectory)/target/nextest/ci/junit.xml
+          testRunTitle: 'Extended Protection (EPA)'
+      - template: build-python-wheels-template.yml
+        parameters:
+          osType: Windows
+          architecture: x64
+  - job: Build_Linux
+    displayName: Build Linux
+    pool:
+      name: ${{ parameters.x64Pool }}
+      demands:
+        - imageOverride -equals ${{ parameters.linuxImage }}
+    variables:
+      CARGO_TARGET_DIR: $(Build.SourcesDirectory)
+      ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
+    steps:
+      - template: cargo-authenticate-template.yml
+        parameters:
+          osType: Linux
+      - template: build-template-container.yml
+        parameters:
+          architecture: x64
+          buildType: ${{ parameters.buildType }}
+          testFilter: -E 'not (test(connectivity))'
+          enableJsBuild: true
+          enableJsTest: true
+          additionalPythonTestArgs: '--coverage'
+          collectPythonCoverage: true
+          collectRustCoverage: true
+      - template: build-template-alpine.yml
+        parameters:
+          osType: Linux
+          buildType: ${{ parameters.buildType }}
+          testFilter: -E 'not (test(connectivity))'
+      - template: build-python-wheels-template.yml
+        parameters:
+          osType: Linux
+          architecture: x64
+      - template: build-python-wheels-template.yml
+        parameters:
+          osType: Alpine
+          architecture: x64
+      - template: build-odbc-template.yml
+        parameters:
+          architecture: x64
+          artifactName: 'Odbc_Linux_x64'
+      - template: build-odbc-alpine-template.yml
+        parameters:
+          architecture: x64
+          artifactName: 'Odbc_Musl_x64'
+      - template: build-odbc-glibc228-template.yml
+        parameters:
+          architecture: x64
+          artifactName: 'Odbc_glibc228_x64'
+
+# =============================================================================
+# ORIGINAL ENTRY POINT (restore this file from origin/main to un-hijack):
+#
+# # CI trigger only on development. Main-branch builds are produced by the
+# # Official pipeline (OneBranch/OfficialPythonWheelsBuild.yml) on merge.
+# trigger:
+# - development
+# 
+# parameters:
+# - name: buildType
+#   displayName: Type of the build to produce
+#   type: string
+#   values:
+#   - Both
+#   - Debug
+#   - Release
+#   default: Both
+# 
+# - name: RunFuzz
+#   displayName: Run Fuzz Tests (30 min)
+#   type: boolean
+#   default: false
+# 
+# - name: RunLongHaul
+#   displayName: Run Long-Haul BCP Test (30 min)
+#   type: boolean
+#   default: false
+# 
+# - name: sqlInstanceMode
+#   displayName: SQL host cardinality for ARM test stages
+#   type: string
+#   values:
+#   - shared
+#   - per-job
+#   default: shared
+# 
+# - name: sqlImageTag
+#   displayName: SQL Server docker image tag for ARM test stages
+#   type: string
+#   default: '2025-latest'
+# 
+# variables:
+#   # msodbcsql18 reference-driver version for the ODBC C++ e2e parity comparison.
+#   # Pinned so an upstream release can't silently change what the parity table
+#   # compares against. Consumed on Windows by install-msodbcsql.ps1 and on Linux
+#   # by containerized-odbc-e2e.sh (which appends the Debian package revision).
+#   msodbcsqlVersion: '18.6.2.1'
+# 
+# stages:
+# - template: templates/validation-stages.yml
+#   parameters:
+#     buildType: ${{ parameters.buildType }}
+#     RunFuzz: ${{ parameters.RunFuzz }}
+#     RunLongHaul: ${{ parameters.RunLongHaul }}
+#     sqlInstanceMode: ${{ parameters.sqlInstanceMode }}
+#     sqlImageTag: ${{ parameters.sqlImageTag }}
+#     # PR validation for internal ADO and GitHub PRs. GitHub PRs run in the public
+#     # project, which lacks 'Magnitude Test', so exclude the infra stages here.
+#     includeInfraStages: false# =============================================================================

--- a/.pipeline/validation-pipeline.yml
+++ b/.pipeline/validation-pipeline.yml
@@ -42,6 +42,12 @@ parameters:
   - Release
   default: Both
 
+variables:
+  # msodbcsql18 reference-driver version for the ODBC C++ e2e parity comparison.
+  # Defined by the real entry files; the copied jobs consume it via
+  # install-msodbcsql.ps1 (Windows) and containerized-odbc-e2e.sh (Linux).
+  msodbcsqlVersion: '18.6.2.1'
+
 stages:
 - stage: Build
   displayName: SKU A/B Build (${{ parameters.x64Pool }})

--- a/.pipeline/validation-pipeline.yml
+++ b/.pipeline/validation-pipeline.yml
@@ -57,16 +57,16 @@ stages:
       CARGO_TARGET_DIR: C:\cargo_target_dir
       ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
     steps:
-      - template: sql-setup-template.yml
+      - template: templates/sql-setup-template.yml
         parameters:
           buildTarget: Windows
-      - template: cargo-authenticate-template.yml
+      - template: templates/cargo-authenticate-template.yml
         parameters:
           osType: Windows
-      - template: install-dependencies.yml
+      - template: templates/install-dependencies.yml
         parameters:
           osType: Windows
-      - template: build-template.yml
+      - template: templates/build-template.yml
         parameters:
           osType: Windows
           buildType: ${{ parameters.buildType }}
@@ -120,7 +120,7 @@ stages:
           testResultsFormat: 'JUnit'
           testResultsFiles: $(Build.SourcesDirectory)/target/nextest/ci/junit.xml
           testRunTitle: 'Extended Protection (EPA)'
-      - template: build-python-wheels-template.yml
+      - template: templates/build-python-wheels-template.yml
         parameters:
           osType: Windows
           architecture: x64
@@ -134,10 +134,10 @@ stages:
       CARGO_TARGET_DIR: $(Build.SourcesDirectory)
       ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
     steps:
-      - template: cargo-authenticate-template.yml
+      - template: templates/cargo-authenticate-template.yml
         parameters:
           osType: Linux
-      - template: build-template-container.yml
+      - template: templates/build-template-container.yml
         parameters:
           architecture: x64
           buildType: ${{ parameters.buildType }}
@@ -147,28 +147,28 @@ stages:
           additionalPythonTestArgs: '--coverage'
           collectPythonCoverage: true
           collectRustCoverage: true
-      - template: build-template-alpine.yml
+      - template: templates/build-template-alpine.yml
         parameters:
           osType: Linux
           buildType: ${{ parameters.buildType }}
           testFilter: -E 'not (test(connectivity))'
-      - template: build-python-wheels-template.yml
+      - template: templates/build-python-wheels-template.yml
         parameters:
           osType: Linux
           architecture: x64
-      - template: build-python-wheels-template.yml
+      - template: templates/build-python-wheels-template.yml
         parameters:
           osType: Alpine
           architecture: x64
-      - template: build-odbc-template.yml
+      - template: templates/build-odbc-template.yml
         parameters:
           architecture: x64
           artifactName: 'Odbc_Linux_x64'
-      - template: build-odbc-alpine-template.yml
+      - template: templates/build-odbc-alpine-template.yml
         parameters:
           architecture: x64
           artifactName: 'Odbc_Musl_x64'
-      - template: build-odbc-glibc228-template.yml
+      - template: templates/build-odbc-glibc228-template.yml
         parameters:
           architecture: x64
           artifactName: 'Odbc_glibc228_x64'


### PR DESCRIPTION
## Purpose (temporary experiment)

Decides the x64 agent SKU for the upcoming pool split: **Standard_D4ads_v6** (4 vCPU / 16 GB) vs **Standard_D8ads_v6** (8 vCPU / 32 GB). Both are NVMe v6 SKUs with no resource disk, so the ephemeral OS disk lands on local NVMe either way.

This PR hijacks `.pipeline/validation-pipeline.yml` to run **only `Build Windows` and `Build Linux`** against a single pool, chosen by the `x64Pool` parameter.

## Method

Two throwaway pools, identical in every respect except `sku.name`:

| Pool | SKU | Subnet |
|---|---|---|
| `RUST-SKUTEST-X64-D4` | `Standard_D4ads_v6` | `snet-skutest-d4` |
| `RUST-SKUTEST-X64-D8` | `Standard_D8ads_v6` | `snet-skutest-d8` |

Same images (`RUST-Win22-Sql25-1P-NVME`, `RUST-1ES-UBUSLIM-NVME`), same vnet, `maxPoolSize` 3, standby off.

**One variant per run**, not both in one run: the coverage and wheel publish steps are gated on `Build.Reason == PullRequest` and their artifact names are hardcoded, so duplicating the jobs in a single PR run would collide on artifact names. Runs are **interleaved** (D4, D8, D4, D8, ...) within a short window and compared on **median job duration**, which controls for drift without touching shared templates.

Measuring **job** duration (agent start to finish) excludes queue and agent-acquisition time.

## Why repetitions matter

Two runs of an identical configuration earlier in this workstream came in at 40.2m and 37.1m - roughly 8% spread, the same order as the effect being measured. A single run per SKU would not be conclusive.

## Decision framework

1ES bills VM time and D8 costs about 2x D4 per hour, so the question is not only which is faster:

| D8 speedup | Cost per run vs D4 |
|---|---|
| 30% faster | 1.40x |
| 50% faster | 1.00x (break-even) |
| >50% faster | cheaper *and* faster |

Rust builds are Amdahl-limited (serial link step, single-threaded rustc front-end, dependency critical path), so >50% is unlikely.

## Notes

- **Do not merge.** The original entry point is preserved as comments at the bottom of the file.
- The two pools and their subnets are temporary and will be deleted once the experiment concludes.