### PR TITLE
Skip macOS wheels and JS build in PR validation

### DIFF
--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -331,12 +331,15 @@ stages:
           osType: MacOS
           buildType: ${{ parameters.buildType }}
           testFilter: -E 'not (test(connectivity))'
-          enableJsBuild: true
+          # JS build and macOS wheels dominate this job's runtime and nothing in a
+          # PR run consumes their output, so they only run on CI (non-PR) builds.
+          enableJsBuild: ${{ ne(variables['Build.Reason'], 'PullRequest') }}
           enableTests: false
-      - template: build-python-wheels-template.yml
-        parameters:
-          osType: MacOS
-          architecture: x64
+      - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+        - template: build-python-wheels-template.yml
+          parameters:
+            osType: MacOS
+            architecture: x64
 
   - job: Test_MacOS
     displayName: Test MacOS


### PR DESCRIPTION
## Description

`Build MacOS` no longer builds Python wheels or runs `Build JS Integration` on PR runs; both still run on CI (non-PR) builds.

- `enableJsBuild: ${{ ne(variables['Build.Reason'], 'PullRequest') }}`
- macOS `build-python-wheels-template.yml` include gated behind the same condition

Nothing in a PR run consumes these artifacts — only `wheels_Linux_x64` is downloaded downstream (private-link smoke). `Build_MacOS` already runs with `enableTests: false`, so coverage is unaffected (macOS Rust coverage comes from `Test_MacOS`).

## Related Issues

Fixes #241

## Checklist

- [x] `cargo bfmt` passes (no Rust changes)
- [x] `cargo bclippy` passes (no Rust changes)
- [x] `cargo btest` passes (no Rust changes)
- [ ] New/changed functionality has tests — n/a, pipeline config
- [ ] Public API changes are documented — n/a