### PR TITLE
[DRAFT/DO NOT MERGE] x64 SKU A/B: D4ads_v6 arm (replaces #240)

### DIFF
--- a/.pipeline/scripts/Generate-SqlCertificates.ps1
+++ b/.pipeline/scripts/Generate-SqlCertificates.ps1
@@ -23,6 +23,39 @@ function Copy-To-Root-Store($cert) {
     }
 }
 
+function Restart-SqlServiceSafely($serviceName) {
+    # Freshly-provisioned images can leave SQL Server briefly in a start-pending /
+    # not-yet-stoppable state (startup database recovery), which makes a plain
+    # Restart-Service fail intermittently with "cannot be stopped"
+    # (CouldNotStopService). Wait for a steady state, then stop/start with retries.
+    $svc = Get-Service -Name $serviceName -ErrorAction Stop
+
+    for ($i = 1; $i -le 30; $i++) {
+        $svc.Refresh()
+        if ($svc.Status -eq 'Running' -or $svc.Status -eq 'Stopped') { break }
+        Write-Host "Waiting for $serviceName to reach a steady state (current: $($svc.Status))..."
+        Start-Sleep -Seconds 5
+    }
+
+    for ($attempt = 1; $attempt -le 5; $attempt++) {
+        try {
+            $svc.Refresh()
+            if ($svc.Status -ne 'Stopped') {
+                Stop-Service -Name $serviceName -Force -ErrorAction Stop
+                $svc.WaitForStatus('Stopped', [TimeSpan]::FromSeconds(120))
+            }
+            Start-Service -Name $serviceName -ErrorAction Stop
+            $svc.WaitForStatus('Running', [TimeSpan]::FromSeconds(120))
+            Write-Host "SQL service '$serviceName' restarted (attempt $attempt)."
+            return
+        } catch {
+            Write-Host "Restart attempt $attempt for '$serviceName' failed: $($_.Exception.Message)"
+            Start-Sleep -Seconds 10
+        }
+    }
+    throw "Failed to restart SQL service '$serviceName' after multiple attempts."
+}
+
 function New-And-Install-Certificates($instanceName) {
     Write-Output "Instance name received is " + $instanceName
     $certStorePath  = "Cert:\LocalMachine\My"
@@ -70,7 +103,7 @@ function New-And-Install-Certificates($instanceName) {
 
     Set-ItemProperty -Path $registryPath -Name "Certificate" -Value $thumbprint
 
-    Restart-Service -Name "MSSQLSERVER"
+    Restart-SqlServiceSafely -serviceName $instanceName
     Copy-To-Root-Store -cert $cert
 }
 

--- a/.pipeline/validation-pipeline.yml
+++ b/.pipeline/validation-pipeline.yml
@@ -1,9 +1,38 @@
-# CI trigger only on development. Main-branch builds are produced by the
-# Official pipeline (OneBranch/OfficialPythonWheelsBuild.yml) on merge.
-trigger:
-- development
+# =============================================================================
+# TEMPORARY - x64 SKU A/B experiment (D4ads_v6 vs D8ads_v6). DO NOT MERGE.
+#
+# Runs ONLY Build Windows + Build Linux, against the single pool named by the
+# x64Pool parameter. Both pools are identical except sku.name, so the job
+# duration difference isolates the SKU. Flip the x64Pool default, push, and
+# compare median job durations across interleaved runs.
+#
+# One variant per run (not both in one run) because the coverage/wheel publish
+# steps are gated on Build.Reason == PullRequest and their artifact names are
+# hardcoded - duplicating the jobs in a single PR run would collide on artifact
+# names. Interleaving runs + taking medians controls for drift instead.
+#
+# The original entry point is preserved at the bottom of this file.
+# =============================================================================
+
+trigger: none
 
 parameters:
+- name: x64Pool
+  displayName: x64 agent pool under test
+  type: string
+  default: RUST-SKUTEST-X64-D4
+  values:
+  - RUST-SKUTEST-X64-D4
+  - RUST-SKUTEST-X64-D8
+
+- name: windowsImage
+  type: string
+  default: RUST-Win22-Sql25-1P-NVME
+
+- name: linuxImage
+  type: string
+  default: RUST-1ES-UBUSLIM-NVME
+
 - name: buildType
   displayName: Type of the build to produce
   type: string
@@ -13,44 +42,193 @@ parameters:
   - Release
   default: Both
 
-- name: RunFuzz
-  displayName: Run Fuzz Tests (30 min)
-  type: boolean
-  default: false
-
-- name: RunLongHaul
-  displayName: Run Long-Haul BCP Test (30 min)
-  type: boolean
-  default: false
-
-- name: sqlInstanceMode
-  displayName: SQL host cardinality for ARM test stages
-  type: string
-  values:
-  - shared
-  - per-job
-  default: shared
-
-- name: sqlImageTag
-  displayName: SQL Server docker image tag for ARM test stages
-  type: string
-  default: '2025-latest'
-
-variables:
-  # msodbcsql18 reference-driver version for the ODBC C++ e2e parity comparison.
-  # Pinned so an upstream release can't silently change what the parity table
-  # compares against. Consumed on Windows by install-msodbcsql.ps1 and on Linux
-  # by containerized-odbc-e2e.sh (which appends the Debian package revision).
-  msodbcsqlVersion: '18.6.2.1'
-
 stages:
-- template: templates/validation-stages.yml
-  parameters:
-    buildType: ${{ parameters.buildType }}
-    RunFuzz: ${{ parameters.RunFuzz }}
-    RunLongHaul: ${{ parameters.RunLongHaul }}
-    sqlInstanceMode: ${{ parameters.sqlInstanceMode }}
-    sqlImageTag: ${{ parameters.sqlImageTag }}
-    # PR validation for internal ADO and GitHub PRs. GitHub PRs run in the public
-    # project, which lacks 'Magnitude Test', so exclude the infra stages here.
-    includeInfraStages: false
+- stage: Build
+  displayName: SKU A/B Build (${{ parameters.x64Pool }})
+  jobs:
+  - job: Build_Windows
+    displayName: Build Windows
+    pool:
+      name: ${{ parameters.x64Pool }}
+      demands:
+        - imageOverride -equals ${{ parameters.windowsImage }}
+    variables:
+      # For details on this CARGO_TARGET_DIR setting, see https://eng.ms/docs/more/rust/topics/onebranch-workaround
+      CARGO_TARGET_DIR: C:\cargo_target_dir
+      ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
+    steps:
+      - template: sql-setup-template.yml
+        parameters:
+          buildTarget: Windows
+      - template: cargo-authenticate-template.yml
+        parameters:
+          osType: Windows
+      - template: install-dependencies.yml
+        parameters:
+          osType: Windows
+      - template: build-template.yml
+        parameters:
+          osType: Windows
+          buildType: ${{ parameters.buildType }}
+          testFilter: -E "not (test(connectivity))"
+          enableOdbcE2E: true
+      # Extended Protection (EPA) channel-binding test.
+      # Runs AFTER the main test pass. Runs the same integrated-auth encrypted
+      # login test under two server configurations, expecting success in both:
+      #   1. EPA = Off      -- baseline (channel binding not enforced).
+      #   2. EPA = Required -- the server rejects any login lacking a valid
+      #      channel binding, so a successful login proves we send a real,
+      #      server-validated tls-unique token.
+      # Reverts EPA to Off in `finally` so a failure still restores the
+      # instance. Each registry change requires a SQL service restart, handled
+      # by the script.
+      - pwsh: |
+          $ErrorActionPreference = 'Stop'
+          $spns = @("MSSQLSvc/localhost:1433", "MSSQLSvc/$($env:COMPUTERNAME):1433")
+          $configured = $false
+          try {
+            foreach ($level in @('Off', 'Required')) {
+              ./.pipeline/scripts/Configure-ExtendedProtection.ps1 `
+                -InstanceName 'MSSQLSERVER' -Level $level -ForceEncryption 'Yes' `
+                -AcceptedNtlmSpns $spns -RestartService $true
+              $configured = $true
+
+              Write-Host "Running EPA channel-binding test with Extended Protection = $level"
+              cargo nextest run --frozen --package mssql-tds `
+                -E 'test(epa_channel_binding)' --no-fail-fast --profile ci
+              if ($LASTEXITCODE -ne 0) { throw "EPA channel-binding test failed with EPA=$level (exit $LASTEXITCODE)" }
+            }
+          }
+          finally {
+            if ($configured) {
+              Write-Host 'Reverting Extended Protection to Off...'
+              ./.pipeline/scripts/Configure-ExtendedProtection.ps1 `
+                -InstanceName 'MSSQLSERVER' -Level 'Off' -ForceEncryption 'No' -RestartService $true
+            }
+          }
+        displayName: 'Extended Protection (EPA) channel-binding test'
+        condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+        env:
+          EPA_TEST: '1'
+          SSPI_TEST: '1'
+          SQL_PASSWORD: $(SQL_PASSWORD)
+          RUST_BACKTRACE: full
+      - task: PublishTestResults@2
+        condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
+        displayName: 'Publish EPA test results'
+        inputs:
+          testResultsFormat: 'JUnit'
+          testResultsFiles: $(Build.SourcesDirectory)/target/nextest/ci/junit.xml
+          testRunTitle: 'Extended Protection (EPA)'
+      - template: build-python-wheels-template.yml
+        parameters:
+          osType: Windows
+          architecture: x64
+  - job: Build_Linux
+    displayName: Build Linux
+    pool:
+      name: ${{ parameters.x64Pool }}
+      demands:
+        - imageOverride -equals ${{ parameters.linuxImage }}
+    variables:
+      CARGO_TARGET_DIR: $(Build.SourcesDirectory)
+      ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
+    steps:
+      - template: cargo-authenticate-template.yml
+        parameters:
+          osType: Linux
+      - template: build-template-container.yml
+        parameters:
+          architecture: x64
+          buildType: ${{ parameters.buildType }}
+          testFilter: -E 'not (test(connectivity))'
+          enableJsBuild: true
+          enableJsTest: true
+          additionalPythonTestArgs: '--coverage'
+          collectPythonCoverage: true
+          collectRustCoverage: true
+      - template: build-template-alpine.yml
+        parameters:
+          osType: Linux
+          buildType: ${{ parameters.buildType }}
+          testFilter: -E 'not (test(connectivity))'
+      - template: build-python-wheels-template.yml
+        parameters:
+          osType: Linux
+          architecture: x64
+      - template: build-python-wheels-template.yml
+        parameters:
+          osType: Alpine
+          architecture: x64
+      - template: build-odbc-template.yml
+        parameters:
+          architecture: x64
+          artifactName: 'Odbc_Linux_x64'
+      - template: build-odbc-alpine-template.yml
+        parameters:
+          architecture: x64
+          artifactName: 'Odbc_Musl_x64'
+      - template: build-odbc-glibc228-template.yml
+        parameters:
+          architecture: x64
+          artifactName: 'Odbc_glibc228_x64'
+
+# =============================================================================
+# ORIGINAL ENTRY POINT (restore this file from origin/main to un-hijack):
+#
+# # CI trigger only on development. Main-branch builds are produced by the
+# # Official pipeline (OneBranch/OfficialPythonWheelsBuild.yml) on merge.
+# trigger:
+# - development
+# 
+# parameters:
+# - name: buildType
+#   displayName: Type of the build to produce
+#   type: string
+#   values:
+#   - Both
+#   - Debug
+#   - Release
+#   default: Both
+# 
+# - name: RunFuzz
+#   displayName: Run Fuzz Tests (30 min)
+#   type: boolean
+#   default: false
+# 
+# - name: RunLongHaul
+#   displayName: Run Long-Haul BCP Test (30 min)
+#   type: boolean
+#   default: false
+# 
+# - name: sqlInstanceMode
+#   displayName: SQL host cardinality for ARM test stages
+#   type: string
+#   values:
+#   - shared
+#   - per-job
+#   default: shared
+# 
+# - name: sqlImageTag
+#   displayName: SQL Server docker image tag for ARM test stages
+#   type: string
+#   default: '2025-latest'
+# 
+# variables:
+#   # msodbcsql18 reference-driver version for the ODBC C++ e2e parity comparison.
+#   # Pinned so an upstream release can't silently change what the parity table
+#   # compares against. Consumed on Windows by install-msodbcsql.ps1 and on Linux
+#   # by containerized-odbc-e2e.sh (which appends the Debian package revision).
+#   msodbcsqlVersion: '18.6.2.1'
+# 
+# stages:
+# - template: templates/validation-stages.yml
+#   parameters:
+#     buildType: ${{ parameters.buildType }}
+#     RunFuzz: ${{ parameters.RunFuzz }}
+#     RunLongHaul: ${{ parameters.RunLongHaul }}
+#     sqlInstanceMode: ${{ parameters.sqlInstanceMode }}
+#     sqlImageTag: ${{ parameters.sqlImageTag }}
+#     # PR validation for internal ADO and GitHub PRs. GitHub PRs run in the public
+#     # project, which lacks 'Magnitude Test', so exclude the infra stages here.
+#     includeInfraStages: false# =============================================================================

--- a/.pipeline/validation-pipeline.yml
+++ b/.pipeline/validation-pipeline.yml
@@ -42,6 +42,12 @@ parameters:
   - Release
   default: Both
 
+variables:
+  # msodbcsql18 reference-driver version for the ODBC C++ e2e parity comparison.
+  # Defined by the real entry files; the copied jobs consume it via
+  # install-msodbcsql.ps1 (Windows) and containerized-odbc-e2e.sh (Linux).
+  msodbcsqlVersion: '18.6.2.1'
+
 stages:
 - stage: Build
   displayName: SKU A/B Build (${{ parameters.x64Pool }})

--- a/.pipeline/validation-pipeline.yml
+++ b/.pipeline/validation-pipeline.yml
@@ -1,37 +1,54 @@
 # =============================================================================
-# TEMPORARY - x64 SKU A/B experiment (D4ads_v6 vs D8ads_v6). DO NOT MERGE.
+# TEMPORARY - ARM64 SKU A/B experiment (D4pds_v5 vs D8pds_v5). DO NOT MERGE.
 #
-# Runs ONLY Build Windows + Build Linux, against the single pool named by the
-# x64Pool parameter. Both pools are identical except sku.name, so the job
-# duration difference isolates the SKU. Flip the x64Pool default, push, and
-# compare median job durations across interleaved runs.
+# Phase 2 of the SKU study. Phase 1 compared the x64 pair; this compares the ARM
+# pair. Stays on the v5 generation deliberately: the existing ARM images were
+# built against a SKU with a resource disk and every ARM v6 SKU reports
+# MaxResourceVolumeMB=0, so comparing v5 sizes keeps the images unchanged.
 #
-# One variant per run (not both in one run) because the coverage/wheel publish
-# steps are gated on Build.Reason == PullRequest and their artifact names are
-# hardcoded - duplicating the jobs in a single PR run would collide on artifact
-# names. Interleaving runs + taking medians controls for drift instead.
+# Runs ONLY the two ARM build jobs plus the cross-pool x64 SQL host they depend
+# on. The SQL host is pinned to the SAME x64 pool for both variants so it cannot
+# bias the comparison - only armPool differs between this branch and its twin.
 #
-# The original entry point is preserved at the bottom of this file.
+# One variant per run (not both in one run): the heavy steps and artifact
+# publishes are gated on Build.Reason == PullRequest and artifact names are
+# hardcoded, so both variants in a single PR run would collide. The twin branches
+# run concurrently on different pools instead, giving matched pairs.
+#
+# The original entry point is preserved as comments at the bottom of this file.
 # =============================================================================
 
 trigger: none
 
 parameters:
-- name: x64Pool
-  displayName: x64 agent pool under test
+- name: armPool
+  displayName: ARM64 agent pool under test
   type: string
-  default: RUST-SKUTEST-X64-D4
+  default: RUST-SKUTEST-ARM-D4
   values:
-  - RUST-SKUTEST-X64-D4
-  - RUST-SKUTEST-X64-D8
+  - RUST-SKUTEST-ARM-D4
+  - RUST-SKUTEST-ARM-D8
 
-- name: windowsImage
+- name: armLinuxImage
   type: string
-  default: RUST-Win22-Sql25-1P-NVME
+  default: RUST-UBUNTU-ARM64
 
-- name: linuxImage
+- name: armWindowsImage
+  type: string
+  default: RUST-WINSRV-ARM
+
+# Fixed for both variants - the SQL host is infrastructure, not under test.
+- name: sqlHostPool
+  type: string
+  default: RUST-SKUTEST-X64-D8
+
+- name: sqlHostImage
   type: string
   default: RUST-1ES-UBUSLIM-NVME
+
+- name: sqlImageTag
+  type: string
+  default: '2025-latest'
 
 - name: buildType
   displayName: Type of the build to produce
@@ -43,116 +60,94 @@ parameters:
   default: Both
 
 variables:
-  # msodbcsql18 reference-driver version for the ODBC C++ e2e parity comparison.
-  # Defined by the real entry files; the copied jobs consume it via
-  # install-msodbcsql.ps1 (Windows) and containerized-odbc-e2e.sh (Linux).
+  # msodbcsql18 reference-driver version, normally supplied by the real entry
+  # files and consumed by install-msodbcsql.ps1 / containerized-odbc-e2e.sh.
   msodbcsqlVersion: '18.6.2.1'
 
 stages:
 - stage: Build
-  displayName: SKU A/B Build (${{ parameters.x64Pool }})
+  displayName: ARM SKU A/B Build (${{ parameters.armPool }})
   jobs:
-  - job: Build_Windows
-    displayName: Build Windows
+  # Cross-pool x64 SQL host. Build_Windows_Arm polls for its endpoint and
+  # fail-fasts without it; Build_Linux_ARM publishes the release sentinel.
+  - template: templates/sql-host-template.yml
+    parameters:
+      instanceId: build_arm
+      expectedSentinels: build_arm,build_win_arm
+      sqlImageTag: ${{ parameters.sqlImageTag }}
+      poolName: ${{ parameters.sqlHostPool }}
+      poolImageOverride: 'imageOverride -equals ${{ parameters.sqlHostImage }}'
+      jobCondition: eq(variables['Build.Reason'], 'PullRequest')
+  - job: Build_Windows_Arm
+    displayName: Build Windows ARM
     pool:
-      name: ${{ parameters.x64Pool }}
+      name: ${{ parameters.armPool }}
       demands:
-        - imageOverride -equals ${{ parameters.windowsImage }}
+        - imageOverride -equals ${{ parameters.armWindowsImage }}
     variables:
       # For details on this CARGO_TARGET_DIR setting, see https://eng.ms/docs/more/rust/topics/onebranch-workaround
       CARGO_TARGET_DIR: C:\cargo_target_dir
       ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
     steps:
-      - template: templates/sql-setup-template.yml
-        parameters:
-          buildTarget: Windows
+      # Add Node.js to PATH for Azure DevOps tasks
+      # Using x64 Node.js via Windows ARM64 emulation since ARM64 Node isn't available
+      - pwsh: ./scripts/setup-nodejs-path.ps1
+        displayName: 'Add Node.js to PATH for ADO tasks'
+
+      # Create Node.js in the agent's externals folder where ADO tasks expect it
+      - pwsh: ./scripts/install-nodejs-to-agent.ps1
+        displayName: 'Install Node.js to agent externals folder'
+
       - template: templates/cargo-authenticate-template.yml
         parameters:
           osType: Windows
+
       - template: templates/install-dependencies.yml
         parameters:
           osType: Windows
-      - template: templates/build-template.yml
-        parameters:
-          osType: Windows
-          buildType: ${{ parameters.buildType }}
-          testFilter: -E "not (test(connectivity))"
-          enableOdbcE2E: true
-      # Extended Protection (EPA) channel-binding test.
-      # Runs AFTER the main test pass. Runs the same integrated-auth encrypted
-      # login test under two server configurations, expecting success in both:
-      #   1. EPA = Off      -- baseline (channel binding not enforced).
-      #   2. EPA = Required -- the server rejects any login lacking a valid
-      #      channel binding, so a successful login proves we send a real,
-      #      server-validated tls-unique token.
-      # Reverts EPA to Off in `finally` so a failure still restores the
-      # instance. Each registry change requires a SQL service restart, handled
-      # by the script.
-      - pwsh: |
-          $ErrorActionPreference = 'Stop'
-          $spns = @("MSSQLSvc/localhost:1433", "MSSQLSvc/$($env:COMPUTERNAME):1433")
-          $configured = $false
-          try {
-            foreach ($level in @('Off', 'Required')) {
-              ./.pipeline/scripts/Configure-ExtendedProtection.ps1 `
-                -InstanceName 'MSSQLSERVER' -Level $level -ForceEncryption 'Yes' `
-                -AcceptedNtlmSpns $spns -RestartService $true
-              $configured = $true
-
-              Write-Host "Running EPA channel-binding test with Extended Protection = $level"
-              cargo nextest run --frozen --package mssql-tds `
-                -E 'test(epa_channel_binding)' --no-fail-fast --profile ci
-              if ($LASTEXITCODE -ne 0) { throw "EPA channel-binding test failed with EPA=$level (exit $LASTEXITCODE)" }
-            }
-          }
-          finally {
-            if ($configured) {
-              Write-Host 'Reverting Extended Protection to Off...'
-              ./.pipeline/scripts/Configure-ExtendedProtection.ps1 `
-                -InstanceName 'MSSQLSERVER' -Level 'Off' -ForceEncryption 'No' -RestartService $true
-            }
-          }
-        displayName: 'Extended Protection (EPA) channel-binding test'
-        condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
-        env:
-          EPA_TEST: '1'
-          SSPI_TEST: '1'
-          SQL_PASSWORD: $(SQL_PASSWORD)
-          RUST_BACKTRACE: full
-      - task: PublishTestResults@2
-        condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
-        displayName: 'Publish EPA test results'
-        inputs:
-          testResultsFormat: 'JUnit'
-          testResultsFiles: $(Build.SourcesDirectory)/target/nextest/ci/junit.xml
-          testRunTitle: 'Extended Protection (EPA)'
+          enableJsDeps: false
       - template: templates/build-python-wheels-template.yml
         parameters:
           osType: Windows
-          architecture: x64
-  - job: Build_Linux
-    displayName: Build Linux
+          architecture: arm64
+          # Python 3.10 excluded - limited ARM64 support
+          pythonVersions:
+          - '3.11'
+          - '3.12'
+          - '3.13'
+          - '3.14'
+
+      # ODBC C++ e2e against the cross-pool x64 SQL host booted above. This image
+      # has no local SQL Server, so it joins the same artifact-sentinel rendezvous
+      # Build_Linux_ARM uses. Intentionally no `dependsOn` on the SQL host job.
+      - template: templates/odbc-e2e-windows-remote-sql-template.yml
+        parameters:
+          sqlReadyInstanceId: build_arm
+          sentinelName: build_win_arm
+          testRunTitle: 'ODBC e2e (Windows ARM)'
+  - job: Build_Linux_ARM
+    displayName: Build Linux ARM
     pool:
-      name: ${{ parameters.x64Pool }}
+      name: ${{ parameters.armPool }}
       demands:
-        - imageOverride -equals ${{ parameters.linuxImage }}
+        - imageOverride -equals ${{ parameters.armLinuxImage }}
     variables:
       CARGO_TARGET_DIR: $(Build.SourcesDirectory)
       ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
     steps:
+      - script: |
+          .pipeline/scripts/print-disk-info.sh
+        displayName: 'Print debug information about agent'
+
       - template: templates/cargo-authenticate-template.yml
         parameters:
           osType: Linux
       - template: templates/build-template-container.yml
         parameters:
-          architecture: x64
+          architecture: ARM64
           buildType: ${{ parameters.buildType }}
           testFilter: -E 'not (test(connectivity))'
-          enableJsBuild: true
-          enableJsTest: true
-          additionalPythonTestArgs: '--coverage'
-          collectPythonCoverage: true
-          collectRustCoverage: true
+          additionalPythonTestArgs: '--skip-integration'
       - template: templates/build-template-alpine.yml
         parameters:
           osType: Linux
@@ -161,23 +156,24 @@ stages:
       - template: templates/build-python-wheels-template.yml
         parameters:
           osType: Linux
-          architecture: x64
+          architecture: ARM64
       - template: templates/build-python-wheels-template.yml
         parameters:
           osType: Alpine
-          architecture: x64
+          architecture: ARM64
       - template: templates/build-odbc-template.yml
         parameters:
-          architecture: x64
-          artifactName: 'Odbc_Linux_x64'
+          architecture: ARM64
+          artifactName: 'Odbc_Linux_arm64'
       - template: templates/build-odbc-alpine-template.yml
         parameters:
-          architecture: x64
-          artifactName: 'Odbc_Musl_x64'
+          architecture: ARM64
+          artifactName: 'Odbc_Musl_arm64'
       - template: templates/build-odbc-glibc228-template.yml
         parameters:
-          architecture: x64
-          artifactName: 'Odbc_glibc228_x64'
+          architecture: ARM64
+          buildImage: 'ghcr.io/microsoft/mssql-rs/python-build/manylinux_2_28_aarch64_rust:latest'
+          artifactName: 'Odbc_glibc228_arm64'
 
 # =============================================================================
 # ORIGINAL ENTRY POINT (restore this file from origin/main to un-hijack):
@@ -237,4 +233,5 @@ stages:
 #     sqlImageTag: ${{ parameters.sqlImageTag }}
 #     # PR validation for internal ADO and GitHub PRs. GitHub PRs run in the public
 #     # project, which lacks 'Magnitude Test', so exclude the infra stages here.
-#     includeInfraStages: false# =============================================================================
+#     includeInfraStages: false
+# =============================================================================

--- a/.pipeline/validation-pipeline.yml
+++ b/.pipeline/validation-pipeline.yml
@@ -57,16 +57,16 @@ stages:
       CARGO_TARGET_DIR: C:\cargo_target_dir
       ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
     steps:
-      - template: sql-setup-template.yml
+      - template: templates/sql-setup-template.yml
         parameters:
           buildTarget: Windows
-      - template: cargo-authenticate-template.yml
+      - template: templates/cargo-authenticate-template.yml
         parameters:
           osType: Windows
-      - template: install-dependencies.yml
+      - template: templates/install-dependencies.yml
         parameters:
           osType: Windows
-      - template: build-template.yml
+      - template: templates/build-template.yml
         parameters:
           osType: Windows
           buildType: ${{ parameters.buildType }}
@@ -120,7 +120,7 @@ stages:
           testResultsFormat: 'JUnit'
           testResultsFiles: $(Build.SourcesDirectory)/target/nextest/ci/junit.xml
           testRunTitle: 'Extended Protection (EPA)'
-      - template: build-python-wheels-template.yml
+      - template: templates/build-python-wheels-template.yml
         parameters:
           osType: Windows
           architecture: x64
@@ -134,10 +134,10 @@ stages:
       CARGO_TARGET_DIR: $(Build.SourcesDirectory)
       ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
     steps:
-      - template: cargo-authenticate-template.yml
+      - template: templates/cargo-authenticate-template.yml
         parameters:
           osType: Linux
-      - template: build-template-container.yml
+      - template: templates/build-template-container.yml
         parameters:
           architecture: x64
           buildType: ${{ parameters.buildType }}
@@ -147,28 +147,28 @@ stages:
           additionalPythonTestArgs: '--coverage'
           collectPythonCoverage: true
           collectRustCoverage: true
-      - template: build-template-alpine.yml
+      - template: templates/build-template-alpine.yml
         parameters:
           osType: Linux
           buildType: ${{ parameters.buildType }}
           testFilter: -E 'not (test(connectivity))'
-      - template: build-python-wheels-template.yml
+      - template: templates/build-python-wheels-template.yml
         parameters:
           osType: Linux
           architecture: x64
-      - template: build-python-wheels-template.yml
+      - template: templates/build-python-wheels-template.yml
         parameters:
           osType: Alpine
           architecture: x64
-      - template: build-odbc-template.yml
+      - template: templates/build-odbc-template.yml
         parameters:
           architecture: x64
           artifactName: 'Odbc_Linux_x64'
-      - template: build-odbc-alpine-template.yml
+      - template: templates/build-odbc-alpine-template.yml
         parameters:
           architecture: x64
           artifactName: 'Odbc_Musl_x64'
-      - template: build-odbc-glibc228-template.yml
+      - template: templates/build-odbc-glibc228-template.yml
         parameters:
           architecture: x64
           artifactName: 'Odbc_glibc228_x64'


### PR DESCRIPTION
Replaces #240, which ADO silently stopped creating builds for (the branch and PR are healthy and pushes land, but no new runs are queued). Same commit, same content: pinned to `RUST-SKUTEST-X64-D4`.

Twin of #243 (`RUST-SKUTEST-X64-D8`); the two branches differ by exactly one line. See #240 for the full method write-up. **Do not merge.**