### PR TITLE
Stop fuzz jobs from installing JS deps on Linux (fixes fnm-not-found CI failure)

### DIFF
--- a/.pipeline/templates/install-dependencies.yml
+++ b/.pipeline/templates/install-dependencies.yml
@@ -54,9 +54,10 @@ steps:
         .pipeline/scripts/install-rustup.sh
       displayName: "Install Rustup"
 
-    - script: |
-        scripts/install-jsdeps.sh
-      displayName: "Install JS dependencies"
+    - ${{ if eq(parameters.enableJsDeps, true) }}:
+      - script: |
+          scripts/install-jsdeps.sh
+        displayName: "Install JS dependencies"
 
     - script: |
         docker ps

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -428,6 +428,7 @@ stages:
       - template: install-dependencies.yml
         parameters:
           osType: Linux
+          enableJsDeps: false
       - template: fuzz-template.yml
         parameters:
           osType: Linux
@@ -449,6 +450,7 @@ stages:
       - template: install-dependencies.yml
         parameters:
           osType: Linux
+          enableJsDeps: false
       - template: fuzz-template.yml
         parameters:
           osType: Linux
@@ -470,6 +472,7 @@ stages:
       - template: install-dependencies.yml
         parameters:
           osType: Linux
+          enableJsDeps: false
       - template: fuzz-template.yml
         parameters:
           osType: Linux


### PR DESCRIPTION
## Description

The Linux path in `.pipeline/templates/install-dependencies.yml` ran `scripts/install-jsdeps.sh` **unconditionally**, ignoring the `enableJsDeps` parameter that already gates the Windows path. When the agent image lacked `fnm`, the script failed with `fnm: command not found` (exit 127), which aborted the GH-Rust Fuzz Test Linux jobs **before any fuzzing ran** — the subsequent fuzz steps were skipped (`succeeded()` = False).

This change:
- Gates the Linux "Install JS dependencies" step on `enableJsDeps` (matching the existing Windows behavior).
- Passes `enableJsDeps: false` for the three Linux fuzz jobs (`Fuzz_TokenStream_Linux`, `Fuzz_TdsClient_Linux`, `Fuzz_Additional_Targets_Linux`), which do not need a JS/Node toolchain.

Net effect: the fuzz pipeline no longer depends on the JS toolchain and can't be broken by a missing `fnm`. All other consumers keep the default (`enableJsDeps: true`), so their behavior is unchanged.

### Context / triage
Investigated GH-Rust Fuzz Test (definitionId=2207) failures in the last 24h. The only failing run was build **166545**, which failed for this infrastructure reason — **not** a libFuzzer crash. No `crash-*` artifact was produced and no `Found N crash(es)` log issue was emitted. A local corpus + mutation reproduction (401,332 inputs across `fuzz_token_stream` and `fuzz_tds_client`) on `main` produced zero crashes, corroborating CI.

## Related Issues

ADO work item: https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47296

[AB#47296](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47296)

## Checklist

- [ ] `cargo bfmt` passes — N/A (pipeline YAML-only change, no Rust code)
- [ ] `cargo bclippy` passes — N/A (pipeline YAML-only change, no Rust code)
- [ ] `cargo btest` passes — N/A (pipeline YAML-only change, no Rust code)
- [ ] New/changed functionality has tests — N/A (CI pipeline configuration; validated by the Fuzz stage itself)
- [ ] Public API changes are documented — N/A
