### PR TITLE
Make SQL service restart in cert generation resilient to start-pending state

### DIFF
--- a/.pipeline/scripts/Generate-SqlCertificates.ps1
+++ b/.pipeline/scripts/Generate-SqlCertificates.ps1
@@ -23,6 +23,39 @@ function Copy-To-Root-Store($cert) {
     }
 }
 
+function Restart-SqlServiceSafely($serviceName) {
+    # Freshly-provisioned images can leave SQL Server briefly in a start-pending /
+    # not-yet-stoppable state (startup database recovery), which makes a plain
+    # Restart-Service fail intermittently with "cannot be stopped"
+    # (CouldNotStopService). Wait for a steady state, then stop/start with retries.
+    $svc = Get-Service -Name $serviceName -ErrorAction Stop
+
+    for ($i = 1; $i -le 30; $i++) {
+        $svc.Refresh()
+        if ($svc.Status -eq 'Running' -or $svc.Status -eq 'Stopped') { break }
+        Write-Host "Waiting for $serviceName to reach a steady state (current: $($svc.Status))..."
+        Start-Sleep -Seconds 5
+    }
+
+    for ($attempt = 1; $attempt -le 5; $attempt++) {
+        try {
+            $svc.Refresh()
+            if ($svc.Status -ne 'Stopped') {
+                Stop-Service -Name $serviceName -Force -ErrorAction Stop
+                $svc.WaitForStatus('Stopped', [TimeSpan]::FromSeconds(120))
+            }
+            Start-Service -Name $serviceName -ErrorAction Stop
+            $svc.WaitForStatus('Running', [TimeSpan]::FromSeconds(120))
+            Write-Host "SQL service '$serviceName' restarted (attempt $attempt)."
+            return
+        } catch {
+            Write-Host "Restart attempt $attempt for '$serviceName' failed: $($_.Exception.Message)"
+            Start-Sleep -Seconds 10
+        }
+    }
+    throw "Failed to restart SQL service '$serviceName' after multiple attempts."
+}
+
 function New-And-Install-Certificates($instanceName) {
     Write-Output "Instance name received is " + $instanceName
     $certStorePath  = "Cert:\LocalMachine\My"
@@ -70,7 +103,7 @@ function New-And-Install-Certificates($instanceName) {
 
     Set-ItemProperty -Path $registryPath -Name "Certificate" -Value $thumbprint
 
-    Restart-Service -Name "MSSQLSERVER"
+    Restart-SqlServiceSafely -serviceName $instanceName
     Copy-To-Root-Store -cert $cert
 }
 

--- a/.pipeline/scripts/Generate-SqlCertificates.ps1
+++ b/.pipeline/scripts/Generate-SqlCertificates.ps1
@@ -103,7 +103,14 @@ function New-And-Install-Certificates($instanceName) {
 
     Set-ItemProperty -Path $registryPath -Name "Certificate" -Value $thumbprint
 
-    Restart-SqlServiceSafely -serviceName $instanceName
+    # Named instances register as MSSQL$<instance>; the default instance is MSSQLSERVER.
+    if ($instanceName -eq "MSSQLSERVER") {
+        $serviceName = "MSSQLSERVER"
+    } else {
+        $serviceName = "MSSQL`$$instanceName"
+    }
+
+    Restart-SqlServiceSafely -serviceName $serviceName
     Copy-To-Root-Store -cert $cert
 }
 


### PR DESCRIPTION
## Summary

Fixes an intermittent CI failure in the Windows SQL setup step where `Generate-SqlCertificates.ps1` fails with `CouldNotStopService` ("service cannot be stopped"). On freshly-provisioned images SQL Server can still be in a start-pending state (startup database recovery) when the script tries to restart it to pick up the new TLS certificate thumbprint, and a plain `Restart-Service` fails outright.

Adds `Restart-SqlServiceSafely`, which:
- waits (up to ~150s) for the service to settle into `Running` or `Stopped` before touching it,
- then stops/starts with explicit `WaitForStatus` and up to 5 retries,
- throws a clear error if all attempts fail.

Also stops hardcoding `MSSQLSERVER` as the service name: the service is now derived from the `$instanceName` already passed into `New-And-Install-Certificates`, mapping named instances to `MSSQL$<instance>` the same way `Enable-SqlProtocols.ps1` and `Configure-ExtendedProtection.ps1` do. Behavior is unchanged for the default instance.

This change was split out of #142 so the flake fix can merge independently of the NVMe pool retarget.

## Linked work item

None.

## Testing

No local test run — this only executes on Windows CI agents with a real SQL Server service. Verification is a green Windows validation run; the failure mode it addresses is intermittent, so the signal is the absence of `CouldNotStopService` in the "Generate SQL certificates" step across runs.

## Breaking changes / migration notes

None. Script parameters and outputs are unchanged.

