### PR TITLE
Add PR description refresh step to PR workflow instructions

### DIFF
--- a/.github/instructions/pr-workflow.instructions.md
+++ b/.github/instructions/pr-workflow.instructions.md
@@ -18,6 +18,7 @@ Follow this workflow for pull requests in `microsoft/mssql-rs`.
 - Address Copilot feedback before requesting human review.
 - Watch PR validation pipelines and fix any failures.
 - Iterate until all feedback is addressed and validation passes on the latest commit.
+- Update the PR description to reflect the latest changes.
 - Mark the PR as ready for review only after the latest commit has passing validation and the author has completed a self-review.
 - Request human review after the PR is ready for review.
 


### PR DESCRIPTION
## Description

Adds one step to the PR workflow instructions: refresh the PR description to reflect the latest changes before marking a PR ready for review.

The surrounding list already covers iterating on feedback and validating the latest commit, but nothing prompted the author to revisit the description after it drifts. Draft-phase changes routinely make the original description stale, so a reviewer coming in at "ready for review" reads a summary that no longer matches the diff. The step is placed after the iterate-on-feedback item and before the mark-ready item, which is the point where the description should be accurate.

Documentation only — no code, build, or test behavior changes.

## Related Issues

[AB#42707](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/42707)

## Checklist

- [x] `cargo bfmt` passes — N/A, no Rust changes
- [x] `cargo bclippy` passes — N/A, no Rust changes
- [x] `cargo btest` passes — N/A, no Rust changes
- [x] New/changed functionality has tests — N/A, documentation only
- [x] Public API changes are documented — N/A, no public API change
