### PR TITLE
Stop printing raw AAD access tokens in connectivity tests

### DIFF
--- a/mssql-tds/tests/connectivity.rs
+++ b/mssql-tds/tests/connectivity.rs
@@ -38,7 +38,7 @@ mod connectivity {
         let token_response = credential.unwrap().get_token(&[SCOPE], None).await;
 
         let secret = token_response.as_ref().unwrap().token.secret();
-        print!("{secret}");
+        debug_assert!(!secret.is_empty(), "empty access token");
         secret.to_string()
     }
 
@@ -82,7 +82,7 @@ mod connectivity {
         };
 
         let secret = token_response.as_ref().unwrap().token.secret();
-        print!("{secret}");
+        debug_assert!(!secret.is_empty(), "empty access token");
         secret.to_string()
     }
 


### PR DESCRIPTION
## Description

`mssql-tds/tests/connectivity.rs` unconditionally wrote the raw AAD bearer token to stdout in two helpers (`generate_access_token` and `generate_access_token_with_sts_and_resource`). Since `cargo test` surfaces captured stdout for failing tests, the token showed up exactly when someone was debugging and most likely to paste output into an issue, PR comment, or chat — and `--nocapture` printed it on passing runs too. The scope is `https://database.windows.net/.default`, so the leaked value is a usable Azure SQL credential carrying the developer's identity claims.

Both `print!("{secret}")` calls are replaced with a `debug_assert!(!secret.is_empty(), "empty access token")`. The existing hint below (`"This test expects that az login ... was run to get a token."`) already covers the common failure mode without exposing the secret.

Swept the rest of the repo for the same pattern: the other token-related prints (`test_windows_sspi.rs`, `test_kerberos_gssapi.rs`, `test_mock_server_fedauth.rs`) only log byte counts or mock-server verification messages, so no other changes are needed.

## Related Issues

Fixes #236

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes (`cargo clippy -p mssql-tds --all-features --all-targets -- -D warnings`; `--frozen` skipped because `Cargo.lock` isn't checked in)
- [ ] `cargo btest` passes — these connectivity tests require a live Azure SQL endpoint and `az login`; unchanged test logic, only the print removed
- [ ] New/changed functionality has tests — n/a, test-only change
- [ ] Public API changes are documented — n/a