### PR TITLE
Report 22003 for an unrepresentable numeric column value

### DIFF
--- a/mssql-odbc/src/api/fetch_convert.rs
+++ b/mssql-odbc/src/api/fetch_convert.rs
@@ -211,17 +211,31 @@ fn numeric_source(value: &ColumnValues) -> Result<NumericSource, ConvError> {
         ColumnValues::Bit(b) => Ok(NumericSource::Int(i128::from(*b))),
         ColumnValues::Real(x) => Ok(NumericSource::Float(f64::from(*x))),
         ColumnValues::Float(x) => Ok(NumericSource::Float(*x)),
-        // `DecimalParts` stores a base-2^32 little-endian magnitude. 38 digits
-        // fit in 4 words; a wider magnitude, or one past `i128::MAX`, is a
-        // numeric value this converter cannot represent, not an illegal cast.
+        // `DecimalParts` stores a base-2^32 little-endian magnitude. A legal
+        // 38-digit value fits in 4 words and in `i128`, so it keeps its exact
+        // scaled form. A non-conforming server can still send 4 words above
+        // `i128::MAX`; that has no exact form here but is a real number, so it
+        // degrades to the `f64` reading rather than an error. Only a magnitude
+        // wider than 4 words has no reading at all.
+        //
+        // Matches msodbcsql: `sqlccnvt.cpp` `ConvertToFixed` returns `CVT_PREC`
+        // (`IDS_22_003`) for an out-of-range numeric and reserves `CVT_ILLEGAL`
+        // (`IDS_07_006`) for a source with no numeric reading, and
+        // `ConvertToFloat` accumulates all four words into a double. Four words
+        // is also all `SQL_NUMERIC_STRUCT` can hold, so a wider magnitude has no
+        // msodbcsql counterpart to diverge from.
         ColumnValues::Decimal(d) | ColumnValues::Numeric(d) => {
-            let m = d
-                .magnitude()
-                .and_then(|mag| i128::try_from(mag).ok())
-                .ok_or(ConvError::OutOfRange)?;
-            Ok(NumericSource::Scaled {
-                mantissa: if d.is_positive { m } else { -m },
-                scale: u32::from(d.scale),
+            let mag = d.magnitude().ok_or(ConvError::OutOfRange)?;
+            let scale = u32::from(d.scale);
+            Ok(match i128::try_from(mag) {
+                Ok(m) => NumericSource::Scaled {
+                    mantissa: if d.is_positive { m } else { -m },
+                    scale,
+                },
+                Err(_) => {
+                    let v = mag as f64 / 10f64.powi(scale as i32);
+                    NumericSource::Float(if d.is_positive { v } else { -v })
+                }
             })
         }
         ColumnValues::Money(m) => Ok(NumericSource::Scaled {
@@ -350,8 +364,11 @@ pub(crate) fn is_float_c_target(target_type: SqlSmallInt) -> bool {
 
 /// Converts a numeric column value to a floating-point C target.
 ///
-/// Returns [`ConvError::NotHandledHere`] when the source is not numeric or the
-/// target is not a floating-point C type.
+/// Returns [`ConvError::NotHandledHere`] only when the target is not a
+/// floating-point C type. A column with no numeric interpretation is
+/// [`ConvError::Restricted`], a numeric value too wide to represent is
+/// [`ConvError::OutOfRange`], and text that is not a valid number is
+/// [`ConvError::InvalidCharacterValue`].
 ///
 /// # Safety
 /// Same pointer contract as [`convert_integer_c`].
@@ -1471,8 +1488,9 @@ mod tests {
         .unwrap_err();
         assert_eq!(err, ConvError::OutOfRange);
 
-        // A magnitude filling all four limbs exceeds `i128::MAX`: also a
-        // representability failure, not an illegal cast.
+        // A magnitude filling all four limbs exceeds `i128::MAX`. It has no
+        // exact scaled form, so it reads as `f64` and lands far outside a
+        // 32-bit target: out of range, not an illegal cast.
         let err = unsafe {
             convert_integer_c(
                 &decimal(true, 0, vec![-1, -1, -1, -1]),
@@ -1483,6 +1501,25 @@ mod tests {
         }
         .unwrap_err();
         assert_eq!(err, ConvError::OutOfRange);
+
+        // The largest legal `decimal(38, 38)` magnitude (10^38 - 1) still fits
+        // in `i128`, so it must keep its exact form rather than trip either the
+        // range check above or the `f64` fallback.
+        let ok = unsafe {
+            convert_integer_c(
+                &decimal(
+                    true,
+                    38,
+                    vec![-1, 160_047_679, 1_518_781_562, 1_262_177_448],
+                ),
+                SQL_C_SLONG,
+                (&mut out as *mut i32).cast(),
+                &mut ind,
+            )
+        }
+        .unwrap();
+        assert_eq!(ok, ConvOk::Truncated);
+        assert_eq!(out, 0);
 
         // Zero-padded limbs past the fourth carry no magnitude, so this path
         // agrees with the string rendering instead of refusing the value.
@@ -1794,6 +1831,36 @@ mod tests {
         assert_eq!(err, ConvError::Restricted);
     }
 
+    /// The reachable wide-decimal case: the decoder validates limb count but
+    /// never the magnitude against `precision`, so 16 bytes of `0xFF` arrives
+    /// intact from a non-conforming server. It exceeds `i128::MAX`, so there is
+    /// no exact scaled form — but msodbcsql's `ConvertToFloat` accumulates all
+    /// four words into a double and succeeds, so a float target must too.
+    #[test]
+    fn wide_decimal_into_float_target_matches_msodbcsql() {
+        use mssql_tds::datatypes::decoder::DecimalParts;
+
+        let mut out: f64 = 0.0;
+        let mut ind: SqlLen = 0;
+        let ret = conv_f(
+            &ColumnValues::Decimal(DecimalParts {
+                is_positive: true,
+                scale: 0,
+                precision: 38,
+                int_parts: vec![-1, -1, -1, -1],
+            }),
+            SQL_C_DOUBLE,
+            (&mut out as *mut f64).cast(),
+            &mut ind,
+        )
+        .unwrap();
+        assert_eq!(ret, ConvOk::Exact);
+        assert_eq!(out, u128::MAX as f64);
+    }
+
+    /// A magnitude wider than four words has no `SQL_NUMERIC_STRUCT` (or wire)
+    /// counterpart, so there is no msodbcsql behavior to match. It is still a
+    /// numeric value we cannot represent, which is `22003`, not `07006`.
     #[test]
     fn oversized_decimal_into_float_target_is_out_of_range() {
         use mssql_tds::datatypes::decoder::DecimalParts;

--- a/mssql-odbc/src/api/fetch_convert.rs
+++ b/mssql-odbc/src/api/fetch_convert.rs
@@ -197,38 +197,44 @@ pub(crate) fn money_scaled(lsb: i32, msb: i32) -> i64 {
     (i64::from(lsb) & 0xFFFF_FFFF) | (i64::from(msb) << 32)
 }
 
-/// Interprets a column as a number, or `None` when the column type has no
-/// numeric interpretation.
-fn numeric_source(value: &ColumnValues) -> Option<NumericSource> {
+/// Interprets a column as a number.
+///
+/// [`ConvError::Restricted`] (`07006`) means the column type has no numeric
+/// interpretation at all; [`ConvError::OutOfRange`] (`22003`) means the column
+/// is numeric but the value cannot be represented here.
+fn numeric_source(value: &ColumnValues) -> Result<NumericSource, ConvError> {
     match value {
-        ColumnValues::TinyInt(x) => Some(NumericSource::Int(i128::from(*x))),
-        ColumnValues::SmallInt(x) => Some(NumericSource::Int(i128::from(*x))),
-        ColumnValues::Int(x) => Some(NumericSource::Int(i128::from(*x))),
-        ColumnValues::BigInt(x) => Some(NumericSource::Int(i128::from(*x))),
-        ColumnValues::Bit(b) => Some(NumericSource::Int(i128::from(*b))),
-        ColumnValues::Real(x) => Some(NumericSource::Float(f64::from(*x))),
-        ColumnValues::Float(x) => Some(NumericSource::Float(*x)),
+        ColumnValues::TinyInt(x) => Ok(NumericSource::Int(i128::from(*x))),
+        ColumnValues::SmallInt(x) => Ok(NumericSource::Int(i128::from(*x))),
+        ColumnValues::Int(x) => Ok(NumericSource::Int(i128::from(*x))),
+        ColumnValues::BigInt(x) => Ok(NumericSource::Int(i128::from(*x))),
+        ColumnValues::Bit(b) => Ok(NumericSource::Int(i128::from(*b))),
+        ColumnValues::Real(x) => Ok(NumericSource::Float(f64::from(*x))),
+        ColumnValues::Float(x) => Ok(NumericSource::Float(*x)),
         // `DecimalParts` stores a base-2^32 little-endian magnitude. 38 digits
-        // fit in 4 words, and `magnitude` returns `None` for a wider (malformed)
-        // value rather than shifting past 128 bits.
+        // fit in 4 words; a wider magnitude, or one past `i128::MAX`, is a
+        // numeric value this converter cannot represent, not an illegal cast.
         ColumnValues::Decimal(d) | ColumnValues::Numeric(d) => {
-            let m = i128::try_from(d.magnitude()?).ok()?;
-            Some(NumericSource::Scaled {
+            let m = d
+                .magnitude()
+                .and_then(|mag| i128::try_from(mag).ok())
+                .ok_or(ConvError::OutOfRange)?;
+            Ok(NumericSource::Scaled {
                 mantissa: if d.is_positive { m } else { -m },
                 scale: u32::from(d.scale),
             })
         }
-        ColumnValues::Money(m) => Some(NumericSource::Scaled {
+        ColumnValues::Money(m) => Ok(NumericSource::Scaled {
             mantissa: i128::from(money_scaled(m.lsb_part, m.msb_part)),
             scale: 4,
         }),
-        ColumnValues::SmallMoney(m) => Some(NumericSource::Scaled {
+        ColumnValues::SmallMoney(m) => Ok(NumericSource::Scaled {
             mantissa: i128::from(m.int_val),
             scale: 4,
         }),
         // Character columns are handled by `numeric_source_or_parse`, which can
         // distinguish bad text (22018) from a non-numeric column (07006).
-        _ => None,
+        _ => Err(ConvError::Restricted),
     }
 }
 
@@ -252,7 +258,7 @@ fn numeric_source_or_parse(value: &ColumnValues) -> Result<NumericSource, ConvEr
             _ => Err(ConvError::InvalidCharacterValue),
         };
     }
-    numeric_source(value).ok_or(ConvError::Restricted)
+    numeric_source(value)
 }
 
 /// Converts a numeric column value to a fixed-width integer C target,
@@ -262,8 +268,9 @@ fn numeric_source_or_parse(value: &ColumnValues) -> Result<NumericSource, ConvEr
 /// `numeric`, `money`, `smallmoney`), the floating-point columns, and character
 /// columns holding a numeric literal. A dropped fractional part is reported as
 /// [`ConvOk::Truncated`], text that is not a valid number as
-/// [`ConvError::InvalidCharacterValue`], and a column with no numeric
-/// interpretation as [`ConvError::Restricted`].
+/// [`ConvError::InvalidCharacterValue`], a numeric value too wide to represent
+/// as [`ConvError::OutOfRange`], and a column with no numeric interpretation as
+/// [`ConvError::Restricted`].
 ///
 /// Returns [`ConvError::NotHandledHere`] when the target is not a fixed-width
 /// integer C type, letting the caller fall back to another conversion path.
@@ -1462,7 +1469,20 @@ mod tests {
             )
         }
         .unwrap_err();
-        assert_eq!(err, ConvError::Restricted);
+        assert_eq!(err, ConvError::OutOfRange);
+
+        // A magnitude filling all four limbs exceeds `i128::MAX`: also a
+        // representability failure, not an illegal cast.
+        let err = unsafe {
+            convert_integer_c(
+                &decimal(true, 0, vec![-1, -1, -1, -1]),
+                SQL_C_SLONG,
+                (&mut out as *mut i32).cast(),
+                &mut ind,
+            )
+        }
+        .unwrap_err();
+        assert_eq!(err, ConvError::OutOfRange);
 
         // Zero-padded limbs past the fourth carry no magnitude, so this path
         // agrees with the string rendering instead of refusing the value.
@@ -1772,6 +1792,27 @@ mod tests {
         )
         .unwrap_err();
         assert_eq!(err, ConvError::Restricted);
+    }
+
+    #[test]
+    fn oversized_decimal_into_float_target_is_out_of_range() {
+        use mssql_tds::datatypes::decoder::DecimalParts;
+
+        let mut out: f64 = 0.0;
+        let mut ind: SqlLen = 0;
+        let err = conv_f(
+            &ColumnValues::Decimal(DecimalParts {
+                is_positive: true,
+                scale: 0,
+                precision: 38,
+                int_parts: vec![1, 0, 0, 0, 1],
+            }),
+            SQL_C_DOUBLE,
+            (&mut out as *mut f64).cast(),
+            &mut ind,
+        )
+        .unwrap_err();
+        assert_eq!(err, ConvError::OutOfRange);
     }
 
     #[test]


### PR DESCRIPTION
## Description

`numeric_source` in `mssql-odbc/src/api/fetch_convert.rs` returned `Option<NumericSource>`, so every failure collapsed into a single `None`. The caller turned that into `ConvError::Restricted`, which `finish_typed_conv` posts as **07006** ("restricted data type attribute violation").

That is right for a column with no numeric interpretation (binary, guid, a date/time column into an integer target). It is wrong for a value that *is* numeric but cannot be represented, which is **22003** ("numeric value out of range").

`numeric_source` now returns `Result<NumericSource, ConvError>`, and `numeric_source_or_parse` propagates instead of re-wrapping, so its character-column arms (22018 / 22003) are unchanged. Both `ConvError` variants already existed and were already mapped to the right SQLSTATEs by `finish_typed_conv`, so there is no new diagnostic plumbing. Both callers (`convert_integer_c`, `convert_float_c`) get the corrected SQLSTATE.

### Wide decimals

Review raised that the decimal arm was conflating two different failures, so they are now split:

- **Magnitude above `i128::MAX`, still within 4 words.** Reachable: the decoder validates limb count but never the magnitude against `precision`, so 16 bytes of `0xFF` arrives intact from a non-conforming server. There is no exact scaled form, so it degrades to the `f64` reading. A float target then succeeds — matching msodbcsql's `ConvertToFloat`, which accumulates all four words into a double — while an integer target still reports 22003 because the value falls outside the integer range.
- **Magnitude wider than 4 words.** Defensive only, rejected by both decode paths. Reports 22003. `SQL_NUMERIC_STRUCT` is four words as well, so there is no msodbcsql counterpart here to diverge from.

Parity statement: **matches** msodbcsql. `sqlcprot.h` maps `CVT_PREC` → `IDS_22_003` and `CVT_ILLEGAL` → `IDS_07_006`; `sqlccnvt.cpp` `ConvertToFixed` returns `CVT_PREC` from its range checks and reserves `CVT_ILLEGAL` for its `default:` arm — the same split drawn here. Cited in code. No new row in the known-divergences table, since the one reachable divergence is now gone rather than documented.

Reaching parity needed no `mssql-tds` change: `DecimalParts::to_f64` and `magnitude_big` are private, but `magnitude()` is `pub` and returns `u128`, which already covers the reachable case.

### Tests

- `decimal_limbs_are_reassembled_and_bounded` — asserts `OutOfRange` for the 5-word payload and for a 4-word magnitude above `i128::MAX`, plus a new boundary case that the largest legal `decimal(38, 38)` magnitude (10^38 - 1, ≈9.99e37 vs `i128::MAX` ≈1.70e38) still keeps its exact form.
- `wide_decimal_into_float_target_matches_msodbcsql` — the reachable 4-word case converts on a float target.
- `oversized_decimal_into_float_target_is_out_of_range` — the defensive >4-word case still reports 22003.

## Related Issues

Fixes #235

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes (567 `mssql-odbc` lib tests pass locally via `cargo test -p mssql-odbc --all-features --lib`; `cargo-nextest` is not installed in this environment, so the full workspace nextest run is left to CI)
- [x] New/changed functionality has tests
- [x] Public API changes are documented (none — `numeric_source` is private to the module)
