### PR TITLE
Stage 3: reset acking + isolation carrier (ADO #47339)

### DIFF
--- a/mssql-odbc/src/api/sqlstate.rs
+++ b/mssql-odbc/src/api/sqlstate.rs
@@ -20,6 +20,9 @@ pub(crate) const SQLSTATE_08003: [u8; 5] = *b"08003";
 /// Connection failure during a transaction — ODBC's precise state for a
 /// commit or rollback that could not reach the server.
 pub(crate) const SQLSTATE_08007: [u8; 5] = *b"08007";
+/// Communication link failure — the connection to the server broke, so a
+/// connection pool must discard the connection rather than reuse it.
+pub(crate) const SQLSTATE_08S01: [u8; 5] = *b"08S01";
 pub(crate) const SQLSTATE_22003: [u8; 5] = *b"22003";
 pub(crate) const SQLSTATE_22018: [u8; 5] = *b"22018";
 pub(crate) const SQLSTATE_24000: [u8; 5] = *b"24000";

--- a/mssql-odbc/src/api/txn.rs
+++ b/mssql-odbc/src/api/txn.rs
@@ -24,8 +24,8 @@ use super::odbc_types::{
 use super::sqlstate::{
     ERR_ATTRIBUTE_CANNOT_BE_SET_NOW, ERR_CONNECTION_BUSY, ERR_CONNECTION_DOES_NOT_EXIST,
     ERR_INVALID_ATTRIBUTE_VALUE, ERR_NO_ACTIVE_TDS_CLIENT, ERR_OPTIONAL_FEATURE_NOT_IMPLEMENTED,
-    SQLSTATE_01000, SQLSTATE_08007, SQLSTATE_HY000, WARN_TRANSACTION_COMMITTED, post_diag,
-    post_tds_error,
+    SQLSTATE_08S01, SQLSTATE_01000, SQLSTATE_08007, SQLSTATE_HY000, WARN_TRANSACTION_COMMITTED,
+    post_diag, post_tds_error,
 };
 use crate::error::{HasDiagnostics, free_errors, post_sql_error};
 use crate::handles::DbcHandle;
@@ -362,13 +362,18 @@ pub(super) fn set_autocommit(dbc: &DbcHandle, value: u64) -> SqlReturn {
 ///
 /// Mirrors msodbcsql's `SQL_COPT_SS_RESET_CONNECTION` handler
 /// (`sqlcmisc.cpp:2373-2461`): reject any value but `SQL_RESET_CONNECTION_YES`
-/// with HY024 (D7), roll back a live local transaction first (D4), then arm the
-/// full RESETCONNECTION bit so the next request resets the session to its login
-/// defaults. Pool checkout does not preserve transactions, so this never uses
-/// RESETCONNECTIONSKIPTRAN.
+/// with HY024 (D7), roll back a live local transaction first (D4), then reset
+/// the session to its login defaults. Pool checkout does not preserve
+/// transactions, so this never uses RESETCONNECTIONSKIPTRAN.
 ///
-/// The bit only rides the next request here; making the reset self-acking with
-/// its own round trip is a later stage.
+/// The reset is driven eagerly (A2): rather than only arming the bit for the
+/// next request, it drives a minimal round trip so the server processes the
+/// reset and acknowledges it before this call returns. That way a failed reset
+/// is caught at pool checkout — the connection is poisoned and surfaces `08S01`
+/// so `mssql-python` discards it — instead of failing the next borrower's first
+/// query. The acknowledging round trip also clears the client's session-bound
+/// caches (`on_reset_connection_ack`), so a later short-circuited isolation SET
+/// cannot leave the reset unacknowledged.
 pub(super) fn reset_connection(dbc: &DbcHandle, value: u64) -> SqlReturn {
     const OP: &str = "SQLSetConnectAttrW(SQL_ATTR_RESET_CONNECTION)";
 
@@ -395,7 +400,10 @@ pub(super) fn reset_connection(dbc: &DbcHandle, value: u64) -> SqlReturn {
 
     // D4: roll back a live local transaction before the reset so the next
     // borrower cannot inherit it. Guard on the server actually having one, the
-    // same way `end_transaction` does — the flag can be stale.
+    // same way `end_transaction` does — the flag can be stale. A full
+    // RESETCONNECTION would discard the transaction server-side regardless, but
+    // rolling back explicitly keeps the client's own transaction tracking in
+    // step with the server.
     let started = match dbc.inner.lock() {
         Ok(state) => state.local_tran_started,
         Err(_) => false,
@@ -408,7 +416,16 @@ pub(super) fn reset_connection(dbc: &DbcHandle, value: u64) -> SqlReturn {
         Ok(())
     };
 
-    client.prepare_reset_connection(false);
+    // A2: drive the reset to completion so it is acknowledged before checkout.
+    // The mutex is not held across this I/O — the client is owned here.
+    let result = result.and_then(|()| dbc.runtime.block_on(client.reset_connection()));
+
+    // A failed reset leaves the session in an unknown state; poison the client
+    // so a subsequent SQL_ATTR_CONNECTION_DEAD read reports it dead and the pool
+    // discards it, then restore it so SQLDisconnect can still tear it down.
+    if result.is_err() {
+        client.mark_connection_dead();
+    }
     release_dbc_client(dbc, client);
 
     let Ok(mut state) = dbc.inner.lock() else {
@@ -417,11 +434,11 @@ pub(super) fn reset_connection(dbc: &DbcHandle, value: u64) -> SqlReturn {
     };
     state.local_tran_started = false;
     if let Err(e) = result {
-        error!(%e, "{OP}: rollback before reset failed");
-        post_tds_error(&mut state, &e, SQLSTATE_HY000);
+        error!(%e, "{OP}: connection reset failed");
+        post_tds_error(&mut state, &e, SQLSTATE_08S01);
         return SQL_ERROR;
     }
-    debug!("{OP}: reset armed for next request");
+    debug!("{OP}: reset processed and acknowledged");
     SQL_SUCCESS
 }
 
@@ -551,6 +568,16 @@ pub(super) fn set_txn_isolation(dbc: &DbcHandle, value: u64) -> SqlReturn {
         // explicitly selects the default READ COMMITTED at startup pays neither
         // an error inside a transaction nor a cursor sweep and round trip
         // outside one.
+        //
+        // D9 caveat: this cache tracks only isolation set through this attribute.
+        // A borrower that ran `SET TRANSACTION ISOLATION LEVEL ...` as raw T-SQL
+        // leaves the cache stale, so a pool checkout re-applying READ COMMITTED
+        // can short-circuit here and leak the borrower's level. This mirrors
+        // mssql-python's own coverage gap (#343 only tracks the attribute path);
+        // `sp_reset_connection` does not reset isolation, so it is a shared,
+        // documented limitation (see the plan's Non-goals), not fixed here. The
+        // eager reset does not paper over it: it clears session-bound caches, not
+        // the server's isolation level.
         if level == state.txn_isolation {
             debug!(value, "{OP}: already at this isolation level");
             return SQL_SUCCESS;
@@ -903,9 +930,44 @@ mod tests {
 
     #[test]
     fn reset_connection_arms_and_clears_local_tran() {
-        // A successful reset leaves the idle client in place and clears the
-        // driver-side transaction flag (D4). The RESETCONNECTION bit riding the
-        // next request is covered by the mssql-tds transport test.
+        // A successful reset drives the acknowledging round trip, leaves the idle
+        // client in place, and clears the driver-side transaction flag (D4).
+        use crate::error::HasDiagnostics;
+        use crate::test_support::TestHandles;
+        use mssql_tds::test_client_support::{
+            done_no_more, env_change_reset_connection, tds_client_from_tokens,
+        };
+
+        let h = TestHandles::with_env_dbc();
+        h.mark_dbc_connected();
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        {
+            let mut state = dbc.inner.lock().unwrap();
+            state.client = Some(tds_client_from_tokens(vec![
+                env_change_reset_connection(),
+                done_no_more(),
+            ]));
+            state.local_tran_started = true;
+        }
+
+        assert_eq!(reset_connection(dbc, 1), SQL_SUCCESS);
+        let state = dbc.inner.lock().unwrap();
+        assert!(!state.local_tran_started);
+        let client = state.client.as_ref().expect("client restored after reset");
+        assert!(
+            !client.is_connection_dead(),
+            "a reset that was acknowledged must leave the connection reusable"
+        );
+        assert!(state.diag_records().is_empty());
+    }
+
+    #[test]
+    fn reset_connection_poisons_client_on_failure() {
+        // A reset whose round trip fails (the server never acknowledges) leaves
+        // the session in an unknown state: surface 08S01 so the pool discards it
+        // and poison the client so a later SQL_ATTR_CONNECTION_DEAD read reports
+        // dead, while restoring it so SQLDisconnect can still tear it down.
+        use crate::api::sqlstate::SQLSTATE_08S01;
         use crate::error::HasDiagnostics;
         use crate::test_support::TestHandles;
         use mssql_tds::test_client_support::tds_client_from_tokens;
@@ -915,14 +977,122 @@ mod tests {
         let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
         {
             let mut state = dbc.inner.lock().unwrap();
+            // No tokens: the reset round trip runs dry and fails.
             state.client = Some(tds_client_from_tokens(vec![]));
-            state.local_tran_started = true;
+        }
+
+        assert_eq!(reset_connection(dbc, 1), SQL_ERROR);
+        let state = dbc.inner.lock().unwrap();
+        assert_eq!(state.diag_records()[0].sql_state, SQLSTATE_08S01);
+        let client = state.client.as_ref().expect("client restored for teardown");
+        assert!(
+            client.is_connection_dead(),
+            "a failed reset must poison the client so the pool discards it"
+        );
+    }
+
+    #[test]
+    fn reset_then_checkout_isolation_reapplies_read_committed() {
+        // D9/B4: a borrower raised isolation to SERIALIZABLE via the attribute.
+        // At checkout the pool resets (acked eagerly here) and re-applies READ
+        // COMMITTED, which `sp_reset_connection` does not restore. The isolation
+        // SET differs from the cached SERIALIZABLE, so it emits a real batch and
+        // the cached level lands back at READ COMMITTED.
+        use crate::api::odbc_types::SQL_TXN_READ_COMMITTED as READ_COMMITTED;
+        use crate::error::HasDiagnostics;
+        use crate::test_support::TestHandles;
+        use mssql_tds::test_client_support::{
+            done_no_more, env_change_reset_connection, tds_client_from_tokens,
+        };
+
+        let h = TestHandles::with_env_dbc();
+        h.mark_dbc_connected();
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        {
+            let mut state = dbc.inner.lock().unwrap();
+            state.client = Some(tds_client_from_tokens(vec![
+                // SET TRANSACTION ISOLATION LEVEL SERIALIZABLE
+                done_no_more(),
+                // reset round trip
+                env_change_reset_connection(),
+                done_no_more(),
+                // SET TRANSACTION ISOLATION LEVEL READ COMMITTED
+                done_no_more(),
+            ]));
+        }
+
+        assert_eq!(
+            set_txn_isolation(dbc, u64::from(SQL_TXN_SERIALIZABLE)),
+            SQL_SUCCESS
+        );
+        assert_eq!(reset_connection(dbc, 1), SQL_SUCCESS);
+        assert_eq!(
+            set_txn_isolation(dbc, u64::from(READ_COMMITTED)),
+            SQL_SUCCESS
+        );
+
+        let state = dbc.inner.lock().unwrap();
+        assert_eq!(
+            state.txn_isolation, READ_COMMITTED,
+            "checkout must re-apply READ COMMITTED after the reset"
+        );
+        assert!(
+            !state.client.as_ref().unwrap().is_connection_dead(),
+            "the connection stays reusable across reset + isolation re-apply"
+        );
+        assert!(state.diag_records().is_empty());
+    }
+
+    #[test]
+    fn checkout_cycle_reuses_one_physical_connection() {
+        // B5: the mssql-python checkout lifecycle on a single physical client —
+        // acquire (reset, eagerly acked) → setautocommit(False) (begin-txn) →
+        // check-in → next acquire (reset again). One scripted client services the
+        // whole sequence, proving the same physical connection is reused and stays
+        // reusable rather than being reconnected underneath.
+        use crate::error::HasDiagnostics;
+        use crate::test_support::TestHandles;
+        use mssql_tds::test_client_support::{
+            done_no_more, env_change_reset_connection, tds_client_from_tokens,
+        };
+
+        let h = TestHandles::with_env_dbc();
+        h.mark_dbc_connected();
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        {
+            let mut state = dbc.inner.lock().unwrap();
+            state.client = Some(tds_client_from_tokens(vec![
+                // acquire: reset round trip
+                env_change_reset_connection(),
+                done_no_more(),
+                // setautocommit(False): begin transaction
+                done_no_more(),
+                // setautocommit(True) on the way back: no active txn, no I/O
+                // next acquire: reset round trip
+                env_change_reset_connection(),
+                done_no_more(),
+            ]));
         }
 
         assert_eq!(reset_connection(dbc, 1), SQL_SUCCESS);
+        assert_eq!(
+            set_autocommit(dbc, u64::from(SQL_AUTOCOMMIT_OFF)),
+            SQL_SUCCESS
+        );
+        assert!(!dbc.inner.lock().unwrap().autocommit);
+        assert_eq!(
+            set_autocommit(dbc, u64::from(SQL_AUTOCOMMIT_ON)),
+            SQL_SUCCESS
+        );
+        assert!(dbc.inner.lock().unwrap().autocommit);
+        assert_eq!(reset_connection(dbc, 1), SQL_SUCCESS);
+
         let state = dbc.inner.lock().unwrap();
-        assert!(!state.local_tran_started);
-        assert!(state.client.is_some());
+        let client = state
+            .client
+            .as_ref()
+            .expect("same client reused across cycle");
+        assert!(!client.is_connection_dead());
         assert!(state.diag_records().is_empty());
     }
 }

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -621,6 +621,17 @@ impl TdsClient {
         self.transport.connection_known_dead()
     }
 
+    /// Marks the connection known-dead so [`is_connection_dead`] reports it
+    /// without touching the socket. A caller that observes the session in an
+    /// unrecoverable state — e.g. a connection-pool reset that failed partway —
+    /// uses this so a later liveness check discards the connection instead of
+    /// handing back a session left in an unknown state.
+    ///
+    /// [`is_connection_dead`]: Self::is_connection_dead
+    pub fn mark_connection_dead(&mut self) {
+        self.transport.mark_known_dead();
+    }
+
     pub(crate) fn get_current_metadata(&self) -> Option<&ColMetadataToken> {
         self.current_metadata.as_deref()
     }
@@ -823,6 +834,27 @@ impl TdsClient {
             false => ResetConnectionMode::Reset,
         };
         self.transport.as_writer().set_reset_mode(mode);
+    }
+
+    /// Arms the full RESETCONNECTION bit and drives a minimal round trip so the
+    /// server processes the reset and returns its `ResetConnection` ENVCHANGE
+    /// within this call — the eager, self-acking counterpart to
+    /// [`prepare_reset_connection`](Self::prepare_reset_connection).
+    ///
+    /// A connection pool uses this at checkout so the reset is processed and its
+    /// session-bound caches cleared (via
+    /// [`on_reset_connection_ack`](Self::on_reset_connection_ack)) *before* the
+    /// connection is handed out, instead of riding whatever request the borrower
+    /// issues next. A failed round trip surfaces as an error so the caller can
+    /// discard the connection rather than leak stale session state to the next
+    /// borrower.
+    ///
+    /// `SELECT 1` is the cheapest batch that reliably carries the reset bit and
+    /// forces the acknowledging ENVCHANGE.
+    pub async fn reset_connection(&mut self) -> TdsResult<()> {
+        self.prepare_reset_connection(false);
+        self.execute("SELECT 1".to_string(), ()).await?;
+        self.close_query().await
     }
 
     /// Executes a SQL batch and positions on its **first navigable result**,
@@ -7887,6 +7919,41 @@ mod tests {
             client.get_collation().lcid_language_id,
             0x0409,
             "collation reverts to login"
+        );
+    }
+
+    /// A2: `reset_connection()` arms the RESETCONNECTION bit on the wire and
+    /// drives the round trip whose `ResetConnection` ENVCHANGE clears the
+    /// session-bound caches, so the reset is acknowledged before the call
+    /// returns rather than riding a later request.
+    #[tokio::test]
+    async fn reset_connection_arms_bit_and_acks_within_the_call() {
+        use crate::message::messages::PacketStatusFlags;
+        use crate::token::tokens::{EnvChangeContainer, EnvChangeToken, EnvChangeTokenSubType};
+
+        let (mut client, sent) = create_capturing_client(vec![
+            Tokens::EnvChange(EnvChangeToken {
+                sub_type: EnvChangeTokenSubType::ResetConnection,
+                change_type: EnvChangeContainer::from((0u32, 0u32)),
+            }),
+            done_no_more(),
+        ]);
+        client.prepared_handles.insert(sid(1), 55);
+
+        client
+            .reset_connection()
+            .await
+            .expect("reset round trip should succeed against the queued ack");
+
+        let sent = sent.lock().unwrap();
+        assert_eq!(
+            sent[1] & PacketStatusFlags::ResetConnection as u8,
+            PacketStatusFlags::ResetConnection as u8,
+            "the round trip must carry the RESETCONNECTION bit in its first packet"
+        );
+        assert!(
+            client.prepared_handles.is_empty(),
+            "the ResetConnection ack must clear session-bound caches within the call"
         );
     }
 

--- a/mssql-tds/src/test_client_support.rs
+++ b/mssql-tds/src/test_client_support.rs
@@ -36,7 +36,8 @@ use crate::io::token_stream::{
 use crate::message::messages::ResetConnectionMode;
 use crate::query::metadata::ColumnMetadata;
 use crate::token::tokens::{
-    ColMetadataToken, CurrentCommand, DoneStatus, DoneToken, InfoToken, Tokens,
+    ColMetadataToken, CurrentCommand, DoneStatus, DoneToken, EnvChangeContainer, EnvChangeToken,
+    EnvChangeTokenSubType, InfoToken, Tokens,
 };
 
 /// An opaque, scripted TDS token produced by the constructor helpers in this
@@ -51,6 +52,7 @@ pub struct ScriptedToken(Tokens);
 struct TokenReplayTransport {
     pending_tokens: VecDeque<Tokens>,
     reset_mode: ResetConnectionMode,
+    known_dead: bool,
 }
 
 impl TokenReplayTransport {
@@ -58,6 +60,7 @@ impl TokenReplayTransport {
         Self {
             pending_tokens: VecDeque::from(tokens),
             reset_mode: ResetConnectionMode::None,
+            known_dead: false,
         }
     }
 }
@@ -184,6 +187,12 @@ impl TdsTransport for TokenReplayTransport {
     fn is_connection_dead(&self) -> bool {
         true
     }
+    fn connection_known_dead(&self) -> bool {
+        self.known_dead
+    }
+    fn mark_known_dead(&mut self) {
+        self.known_dead = true;
+    }
 }
 
 /// Builds a [`TdsClient`] whose transport replays `tokens`. Combine with the
@@ -245,6 +254,17 @@ pub fn done_no_more() -> ScriptedToken {
         status: DoneStatus::FINAL,
         cur_cmd: CurrentCommand::Insert,
         row_count: 0,
+    }))
+}
+
+/// A `ResetConnection` ENVCHANGE token — the acknowledgement the server emits
+/// when it processes a RESETCONNECTION request. Script it ahead of a terminal
+/// DONE to drive [`TdsClient::reset_connection`](crate::connection::tds_client::TdsClient::reset_connection)
+/// to completion in a consumer test.
+pub fn env_change_reset_connection() -> ScriptedToken {
+    ScriptedToken(Tokens::EnvChange(EnvChangeToken {
+        sub_type: EnvChangeTokenSubType::ResetConnection,
+        change_type: EnvChangeContainer::from((0u32, 0u32)),
     }))
 }
 


### PR DESCRIPTION
## Summary

Stage 3 of the mssql-odbc connection pooling effort (ADO User Story #47317, Task `[AB#47339](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47339)`). Makes the connection reset **self-acking at pool checkout** so a borrower never inherits a session whose reset has not yet been processed, and confirms the isolation/autocommit checkout lifecycle carries and survives the reset.

Stacked on **Stage 2 PR #296** (→ #294 → #293). **Base branch: `saurabh500-stage-2-odbc-pooling-primitives`, not `main`.**

## A2 — reset is self-acking (`mssql-tds`)
- New `TdsClient::reset_connection()`: arms the full RESETCONNECTION bit and drives a minimal `SELECT 1` round trip so the server processes the reset and returns its `ResetConnection` ENVCHANGE within the call. The ack flows through Stage 1's `on_reset_connection_ack()`, clearing session-bound caches before checkout. A failed round trip returns an error so the caller can discard the connection.
- `prepare_reset_connection(bool)` is unchanged (the deferred-piggyback path); `reset_connection()` is the eager variant.
- New `TdsClient::mark_connection_dead()` lets the ODBC layer deterministically poison a client whose reset failed.
- Unit test proves the round trip carries the RESETCONNECTION bit and the ack clears session-bound caches.

## B4 — wire eager reset + isolation carrier (`mssql-odbc`)
- `SQLSetConnectAttr(SQL_ATTR_RESET_CONNECTION)` now calls `reset_connection()` after arming, so the reset is processed+acked before the set-attr returns. The DBC mutex is never held across the round-trip I/O (claim → drop lock → I/O → restore). On failure it poisons the client and surfaces **`08S01`** so mssql-python discards it at checkout.
- Confirmed the `SQL_ATTR_TXN_ISOLATION` handler still emits a real `SET TRANSACTION ISOLATION LEVEL` batch; because the reset now acks eagerly, a later short-circuited isolation SET can't leave the reset unacknowledged. Test covers a borrower raising isolation to SERIALIZABLE, resetting, then re-applying READ COMMITTED at checkout.
- Documented the **D9 raw-T-SQL isolation caveat** (stale cache → possible leak; shared, documented limitation, not fixed here) as a code comment at the same-value short-circuit.

## B5 — autocommit / EndTran lifecycle confirmation
- Added a checkout-cycle test: acquire (reset, eagerly acked) → `setautocommit(False)` (begin-txn) → check-in → next acquire (reset) reuses the same physical connection and leaves it reusable. No autocommit/EndTran plumbing rebuilt.

## Tests
- New/updated unit + mock tests in `mssql-tds` and `mssql-odbc`: eager-ack round trip, failure poison → `08S01`, reset+isolation re-apply, and the full checkout lifecycle. Extended `test_client_support` with a `ResetConnection` ENVCHANGE token helper and `mark_known_dead` support on the replay transport.

## Validation
- `cargo bfmt` ✅ (workspace + `mssql-py-core`)
- `cargo bclippy` ✅ (warnings-as-errors, clean)
- `mssql-tds` / `mssql-odbc` lib unit tests ✅ — the only failures are the pre-existing cert/TLS-fixture tests on the base, unrelated to this change.

References `[AB#47339](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47339)`.