### PR TITLE
Optimize TDS cursor hot paths

### DIFF
--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -609,6 +609,11 @@ impl TdsClient {
         });
     }
 
+    #[inline]
+    fn request_timeout_start(&self) -> Option<Instant> {
+        self.remaining_request_timeout.map(|_| Instant::now())
+    }
+
     /// Pre-execution check: detect a dead connection and attempt session recovery.
     ///
     /// Call this at the top of any operation that sends a TDS request (SQL
@@ -3715,7 +3720,7 @@ impl TdsClient {
         let decryptor = self.resolve_cell_decryptor(&metadata).await?;
         let parser_context = ParserContext::ColumnMetadata(metadata, decryptor);
         loop {
-            let start = Instant::now();
+            let start = self.request_timeout_start();
             let header = self
                 .transport
                 .receive_row_header(
@@ -3724,7 +3729,9 @@ impl TdsClient {
                     self.cancel_handle.as_ref(),
                 )
                 .await?;
-            self.update_remaining_timeout(start);
+            if let Some(start) = start {
+                self.update_remaining_timeout(start);
+            }
 
             match header {
                 RowHeader::Positioned(pause_state) => {
@@ -3776,7 +3783,7 @@ impl TdsClient {
     /// guarantee `read_row_column(0)` yields a value: a zero-column row is
     /// positioned with a column count of 0, so `read_row_column(0)` is
     /// out-of-range and returns `UsageError`.
-    #[instrument(skip(self), level = "info")]
+    // Avoid a span for every SQLGetData column; row and token events retain observability.
     pub async fn read_row_column(&mut self, target: usize) -> TdsResult<CursorColumn> {
         match std::mem::replace(&mut self.active_row_read_state, ActiveRowReadState::Idle) {
             ActiveRowReadState::Idle => Ok(CursorColumn::RowEnded),
@@ -3818,7 +3825,7 @@ impl TdsClient {
         }
 
         let mut capture = DefaultRowWriter::new(1);
-        let start = Instant::now();
+        let start = self.request_timeout_start();
         let result = self
             .transport
             .resume_row_into(
@@ -3829,7 +3836,9 @@ impl TdsClient {
                 &mut capture,
             )
             .await?;
-        self.update_remaining_timeout(start);
+        if let Some(start) = start {
+            self.update_remaining_timeout(start);
+        }
 
         match result {
             RowReadResult::RowPaused(next_pause) => {
@@ -6085,6 +6094,25 @@ mod tests {
     }
 
     // ── deduct_timeout tests ──
+
+    #[test]
+    fn request_timeout_clock_is_skipped_without_budget() {
+        let client = create_test_client();
+        assert!(client.request_timeout_start().is_none());
+    }
+
+    #[test]
+    fn request_timeout_clock_is_kept_for_exhausted_budget() {
+        let mut client = create_test_client();
+        client.remaining_request_timeout = Some(Duration::ZERO);
+
+        let start = client
+            .request_timeout_start()
+            .expect("an explicit zero budget must still be measured");
+        client.update_remaining_timeout(start);
+
+        assert_eq!(client.remaining_request_timeout, Some(Duration::ZERO));
+    }
 
     #[test]
     fn deduct_timeout_subtracts_elapsed() {


### PR DESCRIPTION
## Description

Layer 2 of a separate experimental performance stack.

Removes the per-column `read_row_column` info span and avoids reading the monotonic clock in the cursor row/column paths when no request timeout is active. Explicit timeout budgets, including `Duration::ZERO`, retain the existing accounting behavior.

This preserves strict row-at-a-time and column-at-a-time cursor semantics. It does not batch, prefetch, or materialize whole rows.

Stack parent: #303

### Measurement context

In the strict-streaming ODBC prototype, removing per-column instrumentation moved throughput from about 435K to 577K rows/s. Adding timeout clock gating later raised the combined prototype to about 624K rows/s. These are combined experimental measurements, not isolated claims for this PR alone.

## Related Issues

Related to #303.

## Validation

- `cargo fmt --all -- --check`
- `cargo nextest run -p mssql-tds --lib request_timeout_clock --no-fail-fast`
- `cargo nextest run -p mssql-tds --lib read_row_column --no-fail-fast`
- `cargo clippy -p mssql-tds --frozen --all-features --all-targets -- -D warnings`

## Checklist

- [x] Formatting passes
- [x] Clippy passes with warnings denied
- [x] Focused tests pass
- [x] Strict per-row/per-column streaming is preserved