### PR TITLE
Use sync-first TDS cursor reads in ODBC

### DIFF
--- a/mssql-odbc/src/api/fetch.rs
+++ b/mssql-odbc/src/api/fetch.rs
@@ -10,6 +10,7 @@ use crate::api::odbc_types::{
     SQL_ERROR, SQL_INVALID_HANDLE, SQL_NO_DATA, SQL_SUCCESS, SQL_SUCCESS_WITH_INFO, SqlHandle,
     SqlReturn,
 };
+use crate::api::util::resolve_cursor_poll;
 use crate::error::free_errors;
 use crate::handles::stmt::STMT_STATE_CURSOR_OPEN;
 use crate::handles::{HandleType, StmtHandle, handle_from_raw};
@@ -135,7 +136,10 @@ fn fetch_rows_next(statement_handle: SqlHandle, stmt: &StmtHandle) -> SqlReturn 
     // `drain_active_row` in tds_client), so a failure here may originate from
     // the prior row rather than the new one. Columns of the new row are pulled
     // lazily by subsequent SQLGetData calls via `read_row_column`.
-    let fetch_result = dbc.runtime.block_on(client.next_row_cursor());
+    let cursor_poll = client.try_next_row_cursor();
+    let fetch_result = resolve_cursor_poll(cursor_poll, || {
+        dbc.runtime.block_on(client.next_row_cursor())
+    });
 
     match fetch_result {
         Ok(true) => {

--- a/mssql-odbc/src/api/get_data.rs
+++ b/mssql-odbc/src/api/get_data.rs
@@ -12,7 +12,7 @@ use super::odbc_types::{
 };
 use super::sqlstate::*;
 use crate::api::odbc_types::SqlWChar;
-use crate::api::util::{copy_with_nul, write_if_some};
+use crate::api::util::{copy_with_nul, resolve_cursor_poll, write_if_some};
 use crate::error::{free_errors, post_sql_error};
 use crate::handles::stmt::{ActivePlpStream, STMT_STATE_CURSOR_OPEN};
 use crate::handles::{HandleType, StmtHandle, handle_from_raw};
@@ -427,7 +427,10 @@ fn resume_row_to_column(
     };
 
     let target = column_number - 1; // 0-based
-    let cursor_result = dbc.runtime.block_on(client.read_row_column(target));
+    let cursor_poll = client.try_read_row_column(target);
+    let cursor_result = resolve_cursor_poll(cursor_poll, || {
+        dbc.runtime.block_on(client.read_row_column(target))
+    });
 
     let Ok(mut dbc_state) = dbc.inner.lock() else {
         error!("SQLGetData: dbc mutex poisoned after row resume");

--- a/mssql-odbc/src/api/util.rs
+++ b/mssql-odbc/src/api/util.rs
@@ -4,6 +4,17 @@
 use std::slice;
 
 use crate::api::odbc_types::{SQL_NTS, SqlSmallInt, SqlWChar};
+use mssql_tds::connection::tds_client::CursorPoll;
+
+pub(crate) fn resolve_cursor_poll<T, E>(
+    poll: Result<CursorPoll<T>, E>,
+    fallback: impl FnOnce() -> Result<T, E>,
+) -> Result<T, E> {
+    match poll? {
+        CursorPoll::Ready(value) => Ok(value),
+        CursorPoll::Pending => fallback(),
+    }
+}
 
 /// Write `value` to `ptr` if non-null. Every ODBC out-parameter pointer may
 /// legitimately be null (caller opting out of that value), so the
@@ -231,8 +242,47 @@ pub(crate) fn rewrite_param_markers(sql: &str) -> (String, usize) {
 
 #[cfg(test)]
 mod tests {
-    use super::{copy_with_nul, read_utf16, rewrite_param_markers, write_if_some};
+    use super::{
+        copy_with_nul, read_utf16, resolve_cursor_poll, rewrite_param_markers, write_if_some,
+    };
     use crate::api::odbc_types::{SQL_NTS, SqlWChar};
+    use mssql_tds::connection::tds_client::CursorPoll;
+
+    #[test]
+    fn cursor_ready_skips_fallback() {
+        let mut calls = 0;
+        let value = resolve_cursor_poll(Ok::<_, ()>(CursorPoll::Ready(7)), || {
+            calls += 1;
+            Ok(9)
+        });
+
+        assert_eq!(value, Ok(7));
+        assert_eq!(calls, 0);
+    }
+
+    #[test]
+    fn cursor_pending_calls_fallback_once() {
+        let mut calls = 0;
+        let value = resolve_cursor_poll(Ok::<_, ()>(CursorPoll::Pending), || {
+            calls += 1;
+            Ok(9)
+        });
+
+        assert_eq!(value, Ok(9));
+        assert_eq!(calls, 1);
+    }
+
+    #[test]
+    fn cursor_error_skips_fallback() {
+        let mut calls = 0;
+        let value = resolve_cursor_poll::<u8, _>(Err("cursor failed"), || {
+            calls += 1;
+            Ok(9)
+        });
+
+        assert_eq!(value, Err("cursor failed"));
+        assert_eq!(calls, 0);
+    }
 
     #[test]
     fn rewrite_no_markers_is_unchanged() {


### PR DESCRIPTION
## Description

Layer 4 (top) of a separate experimental performance stack.

Updates the existing row-at-a-time / column-at-a-time ODBC paths to use layer 3's explicit sync-first TDS cursor APIs:

- `SQLFetch` calls `try_next_row_cursor` before the async fallback.
- `SQLGetData` calls `try_read_row_column` before the async fallback.
- `CursorPoll::Ready` bypasses Tokio; `CursorPoll::Pending` invokes the existing async method exactly once.

All existing client ownership, DBC/statement locking, diagnostics, INFO handling, active-statement state, PLP behavior, timeout/cancellation behavior, and error recovery remain unchanged. This does not batch, prefetch, or materialize whole rows.

Stack parent: #306

## Linux benchmark

SQL Server 2022 in Podman, unixODBC, `Encrypt=No`, `TrustServerCertificate=Yes`, CPUs 8-15. Each process used two warmups and seven measured passes over 200,000 rows with `SQLExecDirect + SQLFetch + four sequential SQLGetData` calls (`INT`, `BIGINT`, `NVARCHAR`, `BIT`). Runs were counterbalanced parent/candidate/candidate/parent.

| Revision | Aggregate median | Throughput |
| --- | ---: | ---: |
| Parent #306 | 602.788 ms | 331,792 rows/s |
| This PR | 198.371 ms | 1,008,212 rows/s |

- Throughput: **+203.87%**
- Latency: **-67.09%**
- Paired process gains: **+206.65%** and **+198.50%**
- Identical checksum on every run
- Approximately 39.9% of the previously measured patched raw-TDS throughput (2.528M rows/s)

Raw result data is retained in the authoring session artifacts.

## Correctness coverage

The `resolve_cursor_poll` tests prove:

- Ready skips fallback entirely.
- Pending invokes fallback exactly once.
- A sync-attempt error does not invoke fallback.

The full loadable-driver e2e suite passes against SQL Server, covering SQLFetch, SQLGetData, PLP, result navigation, transactions, and recovery through unixODBC.

## Validation

- `cargo fmt --all -- --check`
- `cargo nextest run -p mssql-odbc --no-fail-fast` — 551 passed
- `cargo clippy -p mssql-odbc --frozen --all-features --all-targets -- -D warnings`
- `mssql-odbc/tests/e2e/run_e2e.sh --release --driver=...` — 19/19 test binaries passed

## Limitations

The sync-first coverage is defined by layer 3. PLP, encrypted, skipped, unsupported, incomplete, and control-token paths continue through the existing async implementation.

## Related Issues

Related to #306.

## Checklist

- [x] Formatting passes
- [x] Clippy passes with warnings denied
- [x] Unit and loadable-driver e2e tests pass
- [x] Strict per-row/per-column streaming is preserved
- [x] No batching, prefetch, or whole-row materialization