### PR TITLE
Decode and format decimals without allocating

### DIFF
--- a/.pipeline/scripts/containerized-python-test.sh
+++ b/.pipeline/scripts/containerized-python-test.sh
@@ -7,6 +7,10 @@ update-ca-certificates
 # Source cargo environment
 source ~/.cargo/env
 
+# A fresh ARM64 build container can contain the pinned toolchain metadata
+# without rustc, which maturin needs to detect the host target.
+rustup component add rustc
+
 # Set Python path
 export PATH="/usr/local/bin:$PATH"
 

--- a/mssql-js/src/binary_row_writer.rs
+++ b/mssql-js/src/binary_row_writer.rs
@@ -222,9 +222,9 @@ impl RowWriter for BinaryRowWriter {
         self.row_data.push(val.is_positive as u8);
         self.row_data.push(val.scale);
         self.row_data.push(val.precision);
-        self.row_data.push(val.int_parts.len() as u8);
-        for part in &val.int_parts {
-            self.row_data.extend_from_slice(&part.to_le_bytes());
+        self.row_data.push(val.word_count() as u8);
+        for i in 0..val.word_count() {
+            self.row_data.extend_from_slice(&val.word(i).to_le_bytes());
         }
     }
 
@@ -234,9 +234,9 @@ impl RowWriter for BinaryRowWriter {
         self.row_data.push(val.is_positive as u8);
         self.row_data.push(val.scale);
         self.row_data.push(val.precision);
-        self.row_data.push(val.int_parts.len() as u8);
-        for part in &val.int_parts {
-            self.row_data.extend_from_slice(&part.to_le_bytes());
+        self.row_data.push(val.word_count() as u8);
+        for i in 0..val.word_count() {
+            self.row_data.extend_from_slice(&val.word(i).to_le_bytes());
         }
     }
 

--- a/mssql-js/src/binary_row_writer.rs
+++ b/mssql-js/src/binary_row_writer.rs
@@ -222,22 +222,15 @@ impl RowWriter for BinaryRowWriter {
         self.row_data.push(val.is_positive as u8);
         self.row_data.push(val.scale);
         self.row_data.push(val.precision);
-        self.row_data.push(val.word_count() as u8);
-        for i in 0..val.word_count() {
+        let word_count = val.word_count();
+        self.row_data.push(word_count as u8);
+        for i in 0..word_count {
             self.row_data.extend_from_slice(&val.word(i).to_le_bytes());
         }
     }
 
-    fn write_numeric(&mut self, _col: usize, val: DecimalParts) {
-        // Same encoding as decimal
-        self.row_data.push(TAG_DECIMAL);
-        self.row_data.push(val.is_positive as u8);
-        self.row_data.push(val.scale);
-        self.row_data.push(val.precision);
-        self.row_data.push(val.word_count() as u8);
-        for i in 0..val.word_count() {
-            self.row_data.extend_from_slice(&val.word(i).to_le_bytes());
-        }
+    fn write_numeric(&mut self, col: usize, val: DecimalParts) {
+        self.write_decimal(col, val);
     }
 
     fn write_date(&mut self, _col: usize, val: SqlDate) {

--- a/mssql-js/src/ffidatatypes.rs
+++ b/mssql-js/src/ffidatatypes.rs
@@ -189,19 +189,21 @@ impl From<DecimalParts> for NapiDecimalParts {
             is_positive: decimal_parts.is_positive,
             scale: decimal_parts.scale,
             precision: decimal_parts.precision,
-            int_parts: decimal_parts.int_parts,
+            int_parts: (0..decimal_parts.word_count())
+                .map(|i| decimal_parts.word(i))
+                .collect(),
         }
     }
 }
 
 impl From<NapiDecimalParts> for DecimalParts {
     fn from(napi_decimal_parts: NapiDecimalParts) -> Self {
-        DecimalParts {
-            is_positive: napi_decimal_parts.is_positive,
-            scale: napi_decimal_parts.scale,
-            precision: napi_decimal_parts.precision,
-            int_parts: napi_decimal_parts.int_parts,
-        }
+        DecimalParts::from_words(
+            napi_decimal_parts.is_positive,
+            napi_decimal_parts.precision,
+            napi_decimal_parts.scale,
+            &napi_decimal_parts.int_parts,
+        )
     }
 }
 

--- a/mssql-js/src/ffidatatypes.rs
+++ b/mssql-js/src/ffidatatypes.rs
@@ -196,14 +196,17 @@ impl From<DecimalParts> for NapiDecimalParts {
     }
 }
 
-impl From<NapiDecimalParts> for DecimalParts {
-    fn from(napi_decimal_parts: NapiDecimalParts) -> Self {
-        DecimalParts::from_words(
+impl TryFrom<NapiDecimalParts> for DecimalParts {
+    type Error = Error;
+
+    fn try_from(napi_decimal_parts: NapiDecimalParts) -> Result<Self, Self::Error> {
+        DecimalParts::try_from_words(
             napi_decimal_parts.is_positive,
             napi_decimal_parts.precision,
             napi_decimal_parts.scale,
             &napi_decimal_parts.int_parts,
         )
+        .ok_or_else(|| Error::from_reason("Decimal magnitude exceeds 128 bits"))
     }
 }
 
@@ -564,7 +567,7 @@ impl TryFrom<Parameter> for SqlType {
                         param.data_type
                     )));
                 }
-                Ok(SqlType::Decimal(Some(decimal_parts.into())))
+                Ok(SqlType::Decimal(Some(decimal_parts.try_into()?)))
             }
             RowDataType::N(uuid) => match param.data_type {
                 SqlDataTypes::Guid => {

--- a/mssql-js/src/ffidatatypes.rs
+++ b/mssql-js/src/ffidatatypes.rs
@@ -666,3 +666,20 @@ pub fn transform_col(col: ColumnValues) -> RowDataType {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn oversized_decimal_magnitude_is_rejected() {
+        let decimal = NapiDecimalParts {
+            is_positive: true,
+            scale: 0,
+            precision: 38,
+            int_parts: vec![1, 0, 0, 0, 1],
+        };
+
+        assert!(DecimalParts::try_from(decimal).is_err());
+    }
+}

--- a/mssql-odbc/src/api/get_data.rs
+++ b/mssql-odbc/src/api/get_data.rs
@@ -1055,7 +1055,7 @@ fn column_value_to_text(v: &ColumnValues) -> Result<String, TextError> {
         ColumnValues::Real(x) => Ok(x.to_string()),
         ColumnValues::Float(x) => Ok(x.to_string()),
         ColumnValues::Bit(x) => Ok(if *x { "1".into() } else { "0".into() }),
-        ColumnValues::Decimal(d) | ColumnValues::Numeric(d) => Ok(d.to_string()),
+        ColumnValues::Decimal(d) | ColumnValues::Numeric(d) => Ok(d.to_decimal_string()),
         ColumnValues::Money(m) => Ok(money_scaled_to_string(money_scaled(m.lsb_part, m.msb_part))),
         ColumnValues::SmallMoney(m) => Ok(money_scaled_to_string(i64::from(m.int_val))),
         // `SqlString::to_utf8_string` unwraps on its UTF-8 branch; decode fallibly.

--- a/mssql-odbc/src/conversion/fetch_convert.rs
+++ b/mssql-odbc/src/conversion/fetch_convert.rs
@@ -1284,7 +1284,9 @@ mod tests {
         use mssql_tds::datatypes::decoder::DecimalParts;
 
         let decimal = |is_positive, scale, words: &[i32]| {
-            ColumnValues::Decimal(DecimalParts::from_words(is_positive, 38, scale, words))
+            ColumnValues::Decimal(
+                DecimalParts::try_from_words(is_positive, 38, scale, words).unwrap(),
+            )
         };
 
         let mut out: i32 = 0;

--- a/mssql-odbc/src/conversion/fetch_convert.rs
+++ b/mssql-odbc/src/conversion/fetch_convert.rs
@@ -99,29 +99,27 @@ fn numeric_source(value: &ColumnValues) -> Result<NumericSource, ConvError> {
         ColumnValues::Bit(b) => Ok(NumericSource::Int(i128::from(*b))),
         ColumnValues::Real(x) => Ok(NumericSource::Float(f64::from(*x))),
         ColumnValues::Float(x) => Ok(NumericSource::Float(*x)),
-        // `DecimalParts` stores a base-2^32 little-endian magnitude. A legal
-        // 38-digit value fits in 4 words and in `i128`, so it keeps its exact
-        // scaled form. A non-conforming server can still send 4 words above
-        // `i128::MAX`; that has no exact form here but is a real number, so it
-        // degrades to the `f64` reading rather than an error. Only a magnitude
-        // wider than 4 words has no reading at all.
+        // `DecimalParts` stores a 128-bit magnitude. A legal 38-digit value fits
+        // in `i128`, so it keeps its exact scaled form. A non-conforming server
+        // can still send a magnitude above `i128::MAX`; that has no exact form
+        // here but is a real number, so it degrades to the `f64` reading rather
+        // than an error.
         //
         // Matches msodbcsql: `sqlccnvt.cpp` `ConvertToFixed` returns `CVT_PREC`
         // (`IDS_22_003`) for an out-of-range numeric and reserves `CVT_ILLEGAL`
         // (`IDS_07_006`) for a source with no numeric reading, and
         // `ConvertToFloat` accumulates all four words into a double. Four words
-        // is also all `SQL_NUMERIC_STRUCT` can hold, so a wider magnitude has no
-        // msodbcsql counterpart to diverge from.
+        // is also all `SQL_NUMERIC_STRUCT` can hold, and is exactly what the
+        // magnitude is, so there is no wider case to diverge on.
         ColumnValues::Decimal(d) | ColumnValues::Numeric(d) => {
-            let mag = d.magnitude().ok_or(ConvError::OutOfRange)?;
             let scale = u32::from(d.scale);
-            Ok(match i128::try_from(mag) {
+            Ok(match i128::try_from(d.magnitude()) {
                 Ok(m) => NumericSource::Scaled {
                     mantissa: if d.is_positive { m } else { -m },
                     scale,
                 },
                 Err(_) => {
-                    let v = mag as f64 / 10f64.powi(scale as i32);
+                    let v = d.magnitude() as f64 / 10f64.powi(scale as i32);
                     NumericSource::Float(if d.is_positive { v } else { -v })
                 }
             })
@@ -1278,21 +1276,15 @@ mod tests {
         }
     }
 
-    /// The limbs are reassembled directly, and a payload with more limbs than
-    /// 128 bits can hold is refused instead of shifting past the width. The wire
-    /// decoder now caps the count at 4, so the oversized case below is reachable
-    /// only through FFI or a hand-built `DecimalParts`.
+    /// The little-endian limbs `DecimalParts` is built from must be reassembled
+    /// into the same magnitude the wire carried, including a low limb that is
+    /// negative as `i32`.
     #[test]
     fn decimal_limbs_are_reassembled_and_bounded() {
         use mssql_tds::datatypes::decoder::DecimalParts;
 
-        let decimal = |is_positive, scale, int_parts: Vec<i32>| {
-            ColumnValues::Decimal(DecimalParts {
-                is_positive,
-                scale,
-                precision: 38,
-                int_parts,
-            })
+        let decimal = |is_positive, scale, words: &[i32]| {
+            ColumnValues::Decimal(DecimalParts::from_words(is_positive, 38, scale, words))
         };
 
         let mut out: i32 = 0;
@@ -1300,7 +1292,7 @@ mod tests {
         // 12345 scaled by 10^2 is 123.45, which truncates to 123.
         let ok = unsafe {
             convert_integer_c(
-                &decimal(true, 2, vec![12345]),
+                &decimal(true, 2, &[12345]),
                 SQL_C_SLONG,
                 (&mut out as *mut i32).cast(),
                 &mut ind,
@@ -1312,7 +1304,7 @@ mod tests {
 
         unsafe {
             convert_integer_c(
-                &decimal(false, 2, vec![12345]),
+                &decimal(false, 2, &[12345]),
                 SQL_C_SLONG,
                 (&mut out as *mut i32).cast(),
                 &mut ind,
@@ -1326,7 +1318,7 @@ mod tests {
         // Same wire vector `mssql-tds` pins in `test_f64_conversion`.
         let ok = unsafe {
             convert_integer_c(
-                &decimal(true, 5, vec![-539_269_688, 2]),
+                &decimal(true, 5, &[-539_269_688, 2]),
                 SQL_C_SLONG,
                 (&mut out as *mut i32).cast(),
                 &mut ind,
@@ -1336,23 +1328,12 @@ mod tests {
         assert_eq!(ok, ConvOk::Truncated);
         assert_eq!(out, 123_456);
 
-        let err = unsafe {
-            convert_integer_c(
-                &decimal(true, 0, vec![1, 0, 0, 0, 1]),
-                SQL_C_SLONG,
-                (&mut out as *mut i32).cast(),
-                &mut ind,
-            )
-        }
-        .unwrap_err();
-        assert_eq!(err, ConvError::OutOfRange);
-
         // A magnitude filling all four limbs exceeds `i128::MAX`. It has no
         // exact scaled form, so it reads as `f64` and lands far outside a
         // 32-bit target: out of range, not an illegal cast.
         let err = unsafe {
             convert_integer_c(
-                &decimal(true, 0, vec![-1, -1, -1, -1]),
+                &decimal(true, 0, &[-1, -1, -1, -1]),
                 SQL_C_SLONG,
                 (&mut out as *mut i32).cast(),
                 &mut ind,
@@ -1366,11 +1347,7 @@ mod tests {
         // range check above or the `f64` fallback.
         let ok = unsafe {
             convert_integer_c(
-                &decimal(
-                    true,
-                    38,
-                    vec![-1, 160_047_679, 1_518_781_562, 1_262_177_448],
-                ),
+                &decimal(true, 38, &[-1, 160_047_679, 1_518_781_562, 1_262_177_448]),
                 SQL_C_SLONG,
                 (&mut out as *mut i32).cast(),
                 &mut ind,
@@ -1384,7 +1361,7 @@ mod tests {
         // agrees with the string rendering instead of refusing the value.
         let ok = unsafe {
             convert_integer_c(
-                &decimal(true, 2, vec![12345, 0, 0, 0, 0, 0]),
+                &decimal(true, 2, &[12345, 0, 0, 0, 0, 0]),
                 SQL_C_SLONG,
                 (&mut out as *mut i32).cast(),
                 &mut ind,
@@ -1693,12 +1670,7 @@ mod tests {
         let mut out: f64 = 0.0;
         let mut ind: SqlLen = 0;
         let ret = conv_f(
-            &ColumnValues::Decimal(DecimalParts {
-                is_positive: true,
-                scale: 0,
-                precision: 38,
-                int_parts: vec![-1, -1, -1, -1],
-            }),
+            &ColumnValues::Decimal(DecimalParts::new(true, 38, 0, u128::MAX)),
             SQL_C_DOUBLE,
             (&mut out as *mut f64).cast(),
             &mut ind,
@@ -1706,30 +1678,6 @@ mod tests {
         .unwrap();
         assert_eq!(ret, ConvOk::Exact);
         assert_eq!(out, u128::MAX as f64);
-    }
-
-    /// A magnitude wider than four words has no `SQL_NUMERIC_STRUCT` (or wire)
-    /// counterpart, so there is no msodbcsql behavior to match. It is still a
-    /// numeric value we cannot represent, which is `22003`, not `07006`.
-    #[test]
-    fn oversized_decimal_into_float_target_is_out_of_range() {
-        use mssql_tds::datatypes::decoder::DecimalParts;
-
-        let mut out: f64 = 0.0;
-        let mut ind: SqlLen = 0;
-        let err = conv_f(
-            &ColumnValues::Decimal(DecimalParts {
-                is_positive: true,
-                scale: 0,
-                precision: 38,
-                int_parts: vec![1, 0, 0, 0, 1],
-            }),
-            SQL_C_DOUBLE,
-            (&mut out as *mut f64).cast(),
-            &mut ind,
-        )
-        .unwrap_err();
-        assert_eq!(err, ConvError::OutOfRange);
     }
 
     #[test]

--- a/mssql-py-core/src/cursor.rs
+++ b/mssql-py-core/src/cursor.rs
@@ -6,6 +6,7 @@ use mssql_tds::connection::bulk_copy::{
 };
 use mssql_tds::connection::tds_client::{ExecuteOptions, ResultSet, StatementResult, TdsClient};
 use mssql_tds::datatypes::column_values::ColumnValues;
+use mssql_tds::datatypes::decoder::DECIMAL_STR_LEN;
 use mssql_tds::datatypes::sqldatatypes::VectorBaseType;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyIterator, PyList, PyTuple};
@@ -788,10 +789,11 @@ impl PyCoreCursor {
             }
             ColumnValues::Numeric(n) | ColumnValues::Decimal(n) => {
                 // Convert DecimalParts to Python Decimal object
-                let decimal_str = n.to_string();
+                let mut decimal_buf = [0u8; DECIMAL_STR_LEN];
+                let decimal_str = n.format_into(&mut decimal_buf);
                 if let Ok(decimal_module) = PyModule::import(py, "decimal")
                     && let Ok(decimal_class) = decimal_module.getattr("Decimal")
-                    && let Ok(decimal_obj) = decimal_class.call1((decimal_str.as_str(),))
+                    && let Ok(decimal_obj) = decimal_class.call1((decimal_str,))
                 {
                     return decimal_obj.into_any();
                 }

--- a/mssql-tds/Cargo.toml
+++ b/mssql-tds/Cargo.toml
@@ -114,6 +114,10 @@ features = [
 name = "perf"
 harness = false
 
+[[bench]]
+name = "decimal"
+harness = false
+
 [dev-dependencies]
 rand = "0.9.2"
 dotenv = "0.15"

--- a/mssql-tds/benches/decimal.rs
+++ b/mssql-tds/benches/decimal.rs
@@ -1,0 +1,313 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! `decimal` / `numeric` decode and format microbenchmarks.
+//!
+//! These isolate the two per-value costs that a consumer streaming a wide
+//! numeric result set pays on every row, with no server or socket involved:
+//!
+//! - **decode** — turning the sign byte plus 4/8/12/16 little-endian magnitude
+//!   bytes into a [`DecimalParts`].
+//! - **format** — rendering that value as decimal text.
+//!
+//! Each group times the shape this crate used to have against the shape it has
+//! now. The `previous` variants are reproduced here rather than imported,
+//! because they no longer exist in the crate; [`check`] asserts every shape
+//! agrees byte for byte before anything is timed, so a drifted copy fails
+//! loudly instead of flattering the new code.
+//!
+//! Run with `cargo bench --bench decimal`.
+
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
+use mssql_tds::datatypes::decoder::{DECIMAL_STR_LEN, DecimalParts};
+use std::hint::black_box;
+
+/// A decoded value in the previous representation: the magnitude as a heap
+/// `Vec` of little-endian 32-bit words.
+#[derive(Clone)]
+struct PreviousParts {
+    is_positive: bool,
+    scale: u8,
+    #[allow(dead_code)]
+    precision: u8,
+    int_parts: Vec<i32>,
+}
+
+impl PreviousParts {
+    fn magnitude(&self) -> u128 {
+        self.int_parts
+            .iter()
+            .enumerate()
+            .fold(0u128, |acc, (i, &part)| {
+                acc | ((part as u32 as u128) << (i * 32))
+            })
+    }
+
+    /// The previous rendering: `u128::to_string`, then splice in the point,
+    /// then prepend the sign. Three allocations in the common signed case.
+    fn to_decimal_string(&self) -> String {
+        let value_str = self.magnitude().to_string();
+
+        let result = if self.scale == 0 {
+            value_str
+        } else {
+            let scale_pos = self.scale as usize;
+            if value_str.len() <= scale_pos {
+                format!("0.{}{}", "0".repeat(scale_pos - value_str.len()), value_str)
+            } else {
+                let split_pos = value_str.len() - scale_pos;
+                format!("{}.{}", &value_str[..split_pos], &value_str[split_pos..])
+            }
+        };
+
+        if self.is_positive {
+            result
+        } else {
+            format!("-{result}")
+        }
+    }
+}
+
+/// The previous decode: a zeroed `Vec<u8>` staging buffer, then a second `Vec`
+/// for the words. Two allocations to move at most 16 bytes.
+fn decode_previous(buf: &[u8], at: &mut usize, precision: u8, scale: u8) -> Option<PreviousParts> {
+    let length = buf[*at] as usize;
+    *at += 1;
+    if length == 0 {
+        return None;
+    }
+    let is_positive = buf[*at] == 1;
+    *at += 1;
+
+    let magnitude_len = length - 1;
+    let mut magnitude = vec![0u8; magnitude_len];
+    magnitude.copy_from_slice(&buf[*at..*at + magnitude_len]);
+    *at += magnitude_len;
+
+    let int_parts: Vec<i32> = magnitude
+        .chunks_exact(4)
+        .map(|c| i32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect();
+
+    Some(PreviousParts {
+        is_positive,
+        scale,
+        precision,
+        int_parts,
+    })
+}
+
+/// The current decode: a stack array and one `u128::from_le_bytes`.
+fn decode_current(buf: &[u8], at: &mut usize, precision: u8, scale: u8) -> Option<DecimalParts> {
+    let length = buf[*at] as usize;
+    *at += 1;
+    if length == 0 {
+        return None;
+    }
+    let is_positive = buf[*at] == 1;
+    *at += 1;
+
+    let magnitude_len = length - 1;
+    let mut magnitude = [0u8; 16];
+    magnitude[..magnitude_len].copy_from_slice(&buf[*at..*at + magnitude_len]);
+    *at += magnitude_len;
+
+    Some(DecimalParts::new(
+        is_positive,
+        precision,
+        scale,
+        u128::from_le_bytes(magnitude),
+    ))
+}
+
+#[derive(Clone, Copy)]
+struct Column {
+    precision: u8,
+    scale: u8,
+}
+
+/// Appends one wire value: length byte, sign byte, little-endian magnitude at
+/// the width the declared precision implies.
+fn encode(buf: &mut Vec<u8>, magnitude: u128, is_positive: bool, precision: u8) {
+    let width = match precision {
+        1..=9 => 4usize,
+        10..=19 => 8,
+        20..=28 => 12,
+        _ => 16,
+    };
+    buf.push((width + 1) as u8);
+    buf.push(u8::from(is_positive));
+    buf.extend_from_slice(&magnitude.to_le_bytes()[..width]);
+}
+
+/// The four `numeric` columns of the foreign-data-wrapper workload this change
+/// came from:
+///
+/// ```sql
+/// CAST((n % 10000000) * 0.01  AS decimal(15,2)),
+/// CAST((n % 1000000) * -0.01  AS decimal(15,2)),
+/// CAST((n % 100000)  * 0.001  AS decimal(18,3)),
+/// CAST((n % 10000)   * 0.0001 AS decimal(19,4))
+/// ```
+fn workload_fdw(rows: u128) -> (Vec<u8>, Vec<Column>) {
+    let mut buf = Vec::new();
+    let mut cols = Vec::new();
+    for n in 1..=rows {
+        encode(&mut buf, n % 10_000_000, true, 15);
+        encode(&mut buf, n % 1_000_000, false, 15);
+        encode(&mut buf, n % 100_000, true, 18);
+        encode(&mut buf, n % 10_000, true, 19);
+        cols.extend_from_slice(&[
+            Column {
+                precision: 15,
+                scale: 2,
+            },
+            Column {
+                precision: 15,
+                scale: 2,
+            },
+            Column {
+                precision: 18,
+                scale: 3,
+            },
+            Column {
+                precision: 19,
+                scale: 4,
+            },
+        ]);
+    }
+    (buf, cols)
+}
+
+/// The four-word path: `decimal(38,10)` with a magnitude just under `10^38`,
+/// the true maximum for precision 38.
+///
+/// The scale is deliberately not a multiple of 4. That is the combination that
+/// catches a base-10000 encoder which pre-multiplies the magnitude by `10^pad`:
+/// `10^38 * 100` overflows a `u128` and wraps silently in release builds.
+fn workload_wide(rows: u128) -> (Vec<u8>, Vec<Column>) {
+    let mut buf = Vec::new();
+    let mut cols = Vec::new();
+    for n in 1..=rows {
+        let magnitude = 99_999_999_999_999_999_999_999_999_999_999_999_999u128 - n;
+        encode(&mut buf, magnitude, n % 2 == 0, 38);
+        cols.push(Column {
+            precision: 38,
+            scale: 10,
+        });
+    }
+    (buf, cols)
+}
+
+/// Every shape must agree, and must consume the buffer exactly, before any of
+/// them is timed.
+fn check(buf: &[u8], cols: &[Column]) {
+    let (mut a, mut b) = (0usize, 0usize);
+    for col in cols {
+        let previous = decode_previous(buf, &mut a, col.precision, col.scale).unwrap();
+        let current = decode_current(buf, &mut b, col.precision, col.scale).unwrap();
+
+        assert_eq!(previous.magnitude(), current.magnitude(), "magnitude");
+        assert_eq!(previous.is_positive, current.is_positive, "sign");
+
+        let expected = previous.to_decimal_string();
+        let mut scratch = [0u8; DECIMAL_STR_LEN];
+        assert_eq!(expected, current.format_into(&mut scratch), "format_into");
+        assert_eq!(expected, current.to_decimal_string(), "to_decimal_string");
+        assert_eq!(expected, current.to_string(), "Display");
+    }
+    assert_eq!(a, buf.len());
+    assert_eq!(b, buf.len());
+}
+
+const ROWS: u128 = 4096;
+
+fn bench_decode(c: &mut Criterion) {
+    for (name, (buf, cols)) in [("fdw", workload_fdw(ROWS)), ("wide", workload_wide(ROWS))] {
+        check(&buf, &cols);
+
+        let mut group = c.benchmark_group(format!("decimal_decode/{name}"));
+        group.throughput(Throughput::Elements(cols.len() as u64));
+
+        group.bench_function("previous_two_allocations", |b| {
+            b.iter(|| {
+                let mut at = 0usize;
+                for col in &cols {
+                    black_box(decode_previous(&buf, &mut at, col.precision, col.scale));
+                }
+                at
+            })
+        });
+
+        group.bench_function("current_stack_array", |b| {
+            b.iter(|| {
+                let mut at = 0usize;
+                for col in &cols {
+                    black_box(decode_current(&buf, &mut at, col.precision, col.scale));
+                }
+                at
+            })
+        });
+
+        group.finish();
+    }
+}
+
+fn bench_format(c: &mut Criterion) {
+    for (name, (buf, cols)) in [("fdw", workload_fdw(ROWS)), ("wide", workload_wide(ROWS))] {
+        check(&buf, &cols);
+
+        let mut previous = Vec::with_capacity(cols.len());
+        let mut current = Vec::with_capacity(cols.len());
+        let (mut a, mut b) = (0usize, 0usize);
+        for col in &cols {
+            previous.push(decode_previous(&buf, &mut a, col.precision, col.scale).unwrap());
+            current.push(decode_current(&buf, &mut b, col.precision, col.scale).unwrap());
+        }
+
+        let mut group = c.benchmark_group(format!("decimal_format/{name}"));
+        group.throughput(Throughput::Elements(cols.len() as u64));
+
+        group.bench_function("previous_to_string_and_splice", |b| {
+            b.iter(|| {
+                for value in &previous {
+                    black_box(value.to_decimal_string());
+                }
+            })
+        });
+
+        group.bench_function("current_to_decimal_string", |b| {
+            b.iter(|| {
+                for value in &current {
+                    black_box(value.to_decimal_string());
+                }
+            })
+        });
+
+        group.bench_function("current_display", |b| {
+            b.iter(|| {
+                for value in &current {
+                    black_box(value.to_string());
+                }
+            })
+        });
+
+        // The allocation-free path: one caller-owned buffer for the whole run.
+        group.bench_function("current_format_into", |b| {
+            b.iter_batched_ref(
+                || [0u8; DECIMAL_STR_LEN],
+                |scratch| {
+                    for value in &current {
+                        black_box(value.format_into(scratch));
+                    }
+                },
+                BatchSize::SmallInput,
+            )
+        });
+
+        group.finish();
+    }
+}
+
+criterion_group!(benches, bench_decode, bench_format);
+criterion_main!(benches);

--- a/mssql-tds/src/datatypes/decoder.rs
+++ b/mssql-tds/src/datatypes/decoder.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use bigdecimal::num_bigint::BigUint;
-use bigdecimal::num_traits::ToPrimitive;
 use core::fmt;
 use std::future::Future;
 use std::mem::MaybeUninit;
@@ -193,6 +191,9 @@ const MAX_PLP_SIZE: usize = i32::MAX as usize;
 /// the widest value the TDS wire format carries is 17 bytes (sign byte plus four
 /// words), so anything longer is malformed.
 const MAX_DECIMAL_INT_PARTS: usize = 4;
+
+/// Byte width of a `decimal`/`numeric` magnitude: four little-endian 32-bit words.
+const DECIMAL_MAGNITUDE_BYTES: usize = MAX_DECIMAL_INT_PARTS * 4;
 
 // Helper function to validate allocation size before allocating
 #[inline]
@@ -826,25 +827,18 @@ impl GenericDecoder {
             )));
         }
 
-        validate_alloc_size(number_of_int_parts * 4, "read_decimal int_parts")?;
-        let mut magnitude = vec![0u8; number_of_int_parts * 4];
+        // The check above bounds the payload at 16 bytes, so it is read onto the
+        // stack. TDS is little-endian and the array is zero-filled, which both
+        // reassembles the magnitude and zero-pads a partial trailing word.
+        let mut magnitude = [0u8; DECIMAL_MAGNITUDE_BYTES];
         reader.read_bytes(&mut magnitude[..magnitude_len]).await?;
 
-        let int_parts = magnitude
-            .chunks_exact(4)
-            .map(|chunk| {
-                let mut word = [0u8; 4];
-                word.copy_from_slice(chunk);
-                i32::from_le_bytes(word)
-            })
-            .collect();
-
-        Ok(Some(DecimalParts {
+        Ok(Some(DecimalParts::new(
             is_positive,
-            scale,
             precision,
-            int_parts,
-        }))
+            scale,
+            u128::from_le_bytes(magnitude),
+        )))
     }
 
     async fn read_datetime<T>(&self, reader: &mut T) -> TdsResult<SqlDateTime>
@@ -2148,8 +2142,12 @@ impl SqlTypeDecode for StringDecoder {
     }
 }
 
+/// Bytes needed to render any `decimal`/`numeric`: sign, 38 digits, decimal
+/// point, and slack for a scale that exceeds the digit count (`0.000…`).
+pub const DECIMAL_STR_LEN: usize = 48;
+
 /// TDS representation of Decimal and Numeric types.
-#[derive(Clone)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct DecimalParts {
     /// `true` for non-negative values.
     pub is_positive: bool,
@@ -2157,17 +2155,41 @@ pub struct DecimalParts {
     pub scale: u8,
     /// Total number of significant digits.
     pub precision: u8,
-    /// 32-bit integer parts of the value (little-endian order).
-    pub int_parts: Vec<i32>,
+    /// The magnitude, as two 64-bit halves, least significant first.
+    ///
+    /// Split rather than held as a `u128` because a `u128` field would give
+    /// `DecimalParts` — and through it `ColumnValues` — 16-byte alignment,
+    /// which propagates into the row-fetch async state machines and grows them
+    /// by ~4%. As two halves the struct is 24 bytes at align 8, against 32 at
+    /// align 16; [`Self::magnitude`] recombines them with a shift and an or.
+    magnitude: [u64; 2],
 }
 
 impl fmt::Display for DecimalParts {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.to_decimal_string())
+        f.write_str(self.format_into(&mut [0u8; DECIMAL_STR_LEN]))
     }
 }
 
 impl DecimalParts {
+    /// Builds a value from its unsigned magnitude, already scaled by `10^scale`.
+    ///
+    /// SQL Server's maximum precision of 38 digits keeps the magnitude below
+    /// `10^38 < 2^127`, so every valid `decimal`/`numeric` fits.
+    pub const fn new(is_positive: bool, precision: u8, scale: u8, magnitude: u128) -> Self {
+        DecimalParts {
+            is_positive,
+            scale,
+            precision,
+            magnitude: [magnitude as u64, (magnitude >> 64) as u64],
+        }
+    }
+
+    /// The unsigned magnitude, already scaled by `10^scale`.
+    pub const fn magnitude(&self) -> u128 {
+        (self.magnitude[0] as u128) | ((self.magnitude[1] as u128) << 64)
+    }
+
     /// Create a DecimalParts from a decimal string using BigDecimal.
     ///
     /// Supports SQL Server's full 38-digit precision using arbitrary-precision arithmetic.
@@ -2211,12 +2233,7 @@ impl DecimalParts {
 
         // Handle zero case (but preserve sign from original string)
         if decimal.is_zero() {
-            return Ok(DecimalParts {
-                is_positive: !has_negative_sign,
-                scale,
-                precision,
-                int_parts: vec![0],
-            });
+            return Ok(Self::new(!has_negative_sign, precision, scale, 0));
         }
 
         // Extract sign for non-zero values
@@ -2250,55 +2267,40 @@ impl DecimalParts {
             )));
         }
 
-        // Convert BigInt to Vec<i32> for TDS wire format (little-endian 32-bit chunks)
+        // Convert BigInt to the little-endian 128-bit magnitude. A precision <= 38
+        // value never needs more than 16 bytes; a caller that declares a wider
+        // precision is refused rather than silently truncated.
         let bytes = final_bigint.to_signed_bytes_le();
-        let mut int_parts = Vec::new();
-        let mut i = 0;
-        while i < bytes.len() {
-            let mut part: i32 = 0;
-            for j in 0..4 {
-                if i + j < bytes.len() {
-                    part |= (bytes[i + j] as i32) << (j * 8);
-                }
-            }
-            int_parts.push(part);
-            i += 4;
+        if bytes.len() > DECIMAL_MAGNITUDE_BYTES {
+            return Err(crate::error::Error::TypeConversionError(format!(
+                "Decimal value '{s}' does not fit in a 128-bit magnitude"
+            )));
         }
+        let mut magnitude_bytes = [0u8; DECIMAL_MAGNITUDE_BYTES];
+        magnitude_bytes[..bytes.len()].copy_from_slice(&bytes);
 
-        if int_parts.is_empty() {
-            int_parts.push(0);
-        }
-
-        Ok(DecimalParts {
+        Ok(Self::new(
             is_positive,
-            scale,
             precision,
-            int_parts,
-        })
+            scale,
+            u128::from_le_bytes(magnitude_bytes),
+        ))
     }
 
     /// Create a DecimalParts from an i64 value.
     pub fn from_i64(value: i64, precision: u8, scale: u8) -> TdsResult<Self> {
         let is_positive = value >= 0;
-        let abs_value = value.unsigned_abs();
 
-        // Scale the value by multiplying by 10^scale
-        let scaled_value = abs_value as u128 * 10u128.pow(scale as u32);
+        let magnitude = 10u128
+            .checked_pow(u32::from(scale))
+            .and_then(|factor| u128::from(value.unsigned_abs()).checked_mul(factor))
+            .ok_or_else(|| {
+                crate::error::Error::TypeConversionError(format!(
+                    "Decimal value {value} scaled by 10^{scale} does not fit in a 128-bit magnitude"
+                ))
+            })?;
 
-        // Convert to int_parts
-        let mut int_parts = Vec::new();
-        let mut remaining = scaled_value;
-        while remaining > 0 || int_parts.is_empty() {
-            int_parts.push((remaining & 0xFFFFFFFF) as i32);
-            remaining >>= 32;
-        }
-
-        Ok(DecimalParts {
-            is_positive,
-            scale,
-            precision,
-            int_parts,
-        })
+        Ok(Self::new(is_positive, precision, scale, magnitude))
     }
 
     /// Create a DecimalParts from an f64 value.
@@ -2308,99 +2310,141 @@ impl DecimalParts {
         Self::from_string(&s, precision, scale)
     }
 
-    /// Convert DecimalParts to a string representation suitable for Python Decimal.
-    /// Returns a string like "123.45", "-0.01", etc.
-    fn to_decimal_string(&self) -> String {
-        let value_str = match self.magnitude() {
-            Some(magnitude) => magnitude.to_string(),
-            None => self.magnitude_big().to_string(),
-        };
+    /// Renders the value into `buf` and returns the populated suffix, without
+    /// allocating. The output is the same text [`Display`](fmt::Display)
+    /// produces: `"123.45"`, `"-0.01"`, `"0.000"`.
+    ///
+    /// Digits are emitted least significant first, so a caller-owned buffer
+    /// avoids the intermediate `String` the sign and decimal point would
+    /// otherwise need.
+    pub fn format_into<'a>(&self, buf: &'a mut [u8; DECIMAL_STR_LEN]) -> &'a str {
+        // Every digit below is produced with `u64` arithmetic: a `u128 % 10`
+        // loop emits a `__udivti3` libcall per digit and loses to
+        // `u128::to_string` on wide values. Splitting into limbs of `10^19`
+        // (the largest power of ten a `u64` holds) costs at most two `u128`
+        // divisions, and none at all when the magnitude already fits a `u64`.
+        // Three limbs are needed, not two: a `u128` reaches 39 digits.
+        const LIMB: u128 = 10_000_000_000_000_000_000;
+        const LIMB_DIGITS: usize = 19;
 
-        // Insert decimal point at the correct position
-        let result = if self.scale == 0 {
-            value_str
+        let magnitude = self.magnitude();
+        let mut limbs = [0u64; 3];
+        let limb_count;
+        if magnitude <= u64::MAX as u128 {
+            limbs[0] = magnitude as u64;
+            limb_count = 1;
         } else {
-            let scale_pos = self.scale as usize;
-            if value_str.len() <= scale_pos {
-                // Need to pad with leading zeros
-                format!("0.{}{}", "0".repeat(scale_pos - value_str.len()), value_str)
+            limbs[0] = (magnitude % LIMB) as u64;
+            let rest = magnitude / LIMB;
+            if rest <= u64::MAX as u128 {
+                limbs[1] = rest as u64;
+                limb_count = 2;
             } else {
-                let split_pos = value_str.len() - scale_pos;
-                format!("{}.{}", &value_str[..split_pos], &value_str[split_pos..])
+                limbs[1] = (rest % LIMB) as u64;
+                limbs[2] = (rest / LIMB) as u64;
+                limb_count = 3;
             }
-        };
-
-        if self.is_positive {
-            result
-        } else {
-            format!("-{}", result)
         }
+
+        // `scale` is wire-supplied and unvalidated. A `decimal` never exceeds
+        // 38, but the loop is bounded by the buffer rather than by trusting it,
+        // so a malformed value renders short instead of overrunning.
+        let scale = (self.scale as usize).min(DECIMAL_STR_LEN - 3);
+        let mut pos = buf.len();
+        let mut emitted = 0usize;
+        let mut limb = 0usize;
+        let mut taken = 0usize;
+        let mut current = limbs[0];
+
+        loop {
+            if scale > 0 && emitted == scale {
+                pos -= 1;
+                buf[pos] = b'.';
+            }
+
+            let digit = (current % 10) as u8;
+            current /= 10;
+            taken += 1;
+            pos -= 1;
+            buf[pos] = b'0' + digit;
+            emitted += 1;
+
+            // A limb always contributes all 19 of its digits, zeros included,
+            // while a more significant one is still to come.
+            if taken == LIMB_DIGITS && limb + 1 < limb_count {
+                limb += 1;
+                current = limbs[limb];
+                taken = 0;
+            }
+
+            // Leading zeros are otherwise only emitted to fill the fractional
+            // part, so a value narrower than its scale renders as `0.00…`.
+            if limb + 1 == limb_count && current == 0 && emitted > scale {
+                break;
+            }
+        }
+
+        if !self.is_positive {
+            pos -= 1;
+            buf[pos] = b'-';
+        }
+
+        // Every byte written above is ASCII.
+        core::str::from_utf8(&buf[pos..]).unwrap_or_default()
     }
 
-    fn to_f64(&self) -> f64 {
-        let magnitude = match self.magnitude() {
-            Some(magnitude) => magnitude as f64,
-            None => self.magnitude_big().to_f64().unwrap_or(f64::INFINITY),
-        };
+    /// Renders the value into a new `String`.
+    ///
+    /// Equivalent to [`ToString::to_string`], but it copies a known-length
+    /// `&str` instead of going through [`fmt::Formatter`], so it costs one
+    /// allocation and nothing else. Callers that can supply their own buffer
+    /// should use [`Self::format_into`] and pay nothing.
+    pub fn to_decimal_string(&self) -> String {
+        self.format_into(&mut [0u8; DECIMAL_STR_LEN]).to_owned()
+    }
+
+    fn to_f64(self) -> f64 {
+        let magnitude = self.magnitude() as f64;
 
         let d_ret = magnitude / 10.0_f64.powi(self.scale as i32);
 
         if self.is_positive { d_ret } else { -d_ret }
     }
 
-    /// Reassembles `int_parts` into the unsigned magnitude.
+    /// The `index`-th little-endian 32-bit word of the magnitude, counting from
+    /// the least significant. Words past the fourth are always zero.
     ///
-    /// `int_parts[0]` is the least significant word. Returns `None` when the
-    /// value does not fit in a `u128`. A valid `decimal`/`numeric`
-    /// (precision <= 38) fits in four words, so only a malformed payload or a
-    /// hand-built [`DecimalParts`] can exceed that; the alternative would be to
-    /// shift past the width of the accumulator.
-    pub fn magnitude(&self) -> Option<u128> {
-        let significant = self
-            .int_parts
+    /// This is the form the TDS wire and every reference driver's normalized
+    /// decimal use.
+    pub const fn word(&self, index: usize) -> i32 {
+        if index >= MAX_DECIMAL_INT_PARTS {
+            return 0;
+        }
+        (self.magnitude() >> (index * 32)) as u32 as i32
+    }
+
+    /// Number of little-endian 32-bit words needed to hold the magnitude, at
+    /// least one so that zero still has a word.
+    pub fn word_count(&self) -> usize {
+        (128 - self.magnitude().leading_zeros() as usize)
+            .div_ceil(32)
+            .max(1)
+    }
+
+    /// Builds a value from little-endian 32-bit words, least significant first.
+    ///
+    /// Words past the fourth are ignored: a `decimal`/`numeric` with precision
+    /// <= 38 never sets them, and every encoder here already emits at most four.
+    pub fn from_words(is_positive: bool, precision: u8, scale: u8, words: &[i32]) -> Self {
+        let magnitude = words
             .iter()
-            .rposition(|&part| part != 0)
-            .map_or(0, |i| i + 1);
-        if significant > MAX_DECIMAL_INT_PARTS {
-            return None;
-        }
-        Some(
-            self.int_parts[..significant]
-                .iter()
-                .enumerate()
-                .fold(0u128, |acc, (i, &part)| {
-                    acc | ((part as u32 as u128) << (i * 32))
-                }),
-        )
-    }
+            .take(MAX_DECIMAL_INT_PARTS)
+            .enumerate()
+            .fold(0u128, |acc, (i, &word)| {
+                acc | ((word as u32 as u128) << (i * 32))
+            });
 
-    /// Reassembles `int_parts` into an arbitrary-precision magnitude, for values
-    /// too wide for [`Self::magnitude`].
-    fn magnitude_big(&self) -> BigUint {
-        BigUint::new(self.int_parts.iter().map(|&part| part as u32).collect())
-    }
-}
-
-impl PartialEq for DecimalParts {
-    fn eq(&self, other: &Self) -> bool {
-        let min_len = self.int_parts.len().min(other.int_parts.len());
-        for i in 0..min_len {
-            if self.int_parts[i] != other.int_parts[i] {
-                return false;
-            }
-        }
-        if self.int_parts.len() > other.int_parts.len() {
-            if self.int_parts[min_len..].iter().any(|&x| x != 0) {
-                return false;
-            }
-        } else if other.int_parts.len() > self.int_parts.len()
-            && other.int_parts[min_len..].iter().any(|&x| x != 0)
-        {
-            return false;
-        }
-        self.is_positive == other.is_positive
-            && self.scale == other.scale
-            && self.precision == other.precision
+        Self::new(is_positive, precision, scale, magnitude)
     }
 }
 
@@ -2408,13 +2452,8 @@ impl Debug for DecimalParts {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "Decimal: {}{} Precision {} Scale {} F64 value: {}",
-            if self.is_positive { "" } else { "-" },
-            self.int_parts
-                .iter()
-                .map(|part| part.to_string())
-                .collect::<Vec<String>>()
-                .join(" "),
+            "Decimal: {} Precision {} Scale {} F64 value: {}",
+            self,
             self.precision,
             self.scale,
             self.to_f64()
@@ -2524,13 +2563,8 @@ mod test {
         let expected: f64 = 123456.322;
 
         // Represents 123456.322 as observed over TDS wire.
-        let int_parts = vec![-539269688, 2];
-        let parts = DecimalParts {
-            is_positive: true,
-            scale: 5,
-            precision: 18,
-            int_parts,
-        };
+        let magnitude = 12345632200;
+        let parts = DecimalParts::new(true, 18, 5, magnitude);
 
         assert_eq!(expected, parts.to_f64());
     }
@@ -2540,13 +2574,8 @@ mod test {
         let expected: f64 = -123456.322;
 
         // Represents -123456.322 as observed over TDS wire.
-        let int_parts = vec![-539269688, 2];
-        let parts = DecimalParts {
-            is_positive: false,
-            scale: 5,
-            precision: 18,
-            int_parts,
-        };
+        let magnitude = 12345632200;
+        let parts = DecimalParts::new(false, 18, 5, magnitude);
 
         assert_eq!(expected, parts.to_f64());
     }
@@ -2555,13 +2584,8 @@ mod test {
     fn test_f64_conversion_zero() {
         let expected: f64 = 0.0;
 
-        let int_parts = vec![0];
-        let parts = DecimalParts {
-            is_positive: true,
-            scale: 0,
-            precision: 1,
-            int_parts,
-        };
+        let magnitude = 0;
+        let parts = DecimalParts::new(true, 1, 0, magnitude);
 
         assert_eq!(expected, parts.to_f64());
     }
@@ -2569,13 +2593,8 @@ mod test {
     #[test]
     fn test_f64_conversion_large_number() {
         // Test conversion with larger numbers
-        let int_parts = vec![100000, 0];
-        let parts = DecimalParts {
-            is_positive: true,
-            scale: 2,
-            precision: 7,
-            int_parts,
-        };
+        let magnitude = 100000;
+        let parts = DecimalParts::new(true, 7, 2, magnitude);
 
         let result = parts.to_f64();
         // With scale of 2, int value 100000 should become 1000.00
@@ -2583,15 +2602,10 @@ mod test {
     }
 
     #[test]
-    fn test_decimal_parts_with_multiple_int_parts() {
+    fn test_decimal_parts_with_multi_word_magnitude() {
         // Test with multiple integer parts to ensure full conversion
-        let int_parts = vec![1000000000, 1];
-        let parts = DecimalParts {
-            is_positive: true,
-            scale: 0,
-            precision: 19,
-            int_parts,
-        };
+        let magnitude = 5294967296;
+        let parts = DecimalParts::new(true, 19, 0, magnitude);
 
         // Should successfully convert to f64
         let result = parts.to_f64();
@@ -2640,12 +2654,7 @@ mod test {
 
     #[test]
     fn test_decimal_parts_debug() {
-        let parts = DecimalParts {
-            is_positive: true,
-            scale: 2,
-            precision: 10,
-            int_parts: vec![123, 456],
-        };
+        let parts = DecimalParts::new(true, 10, 2, 1958505087099);
         let debug_str = format!("{parts:?}");
         // Just verify the debug trait works - don't assert on exact format
         assert!(!debug_str.is_empty());
@@ -2661,12 +2670,7 @@ mod test {
 
     #[test]
     fn test_decimal_parts_scale_precision() {
-        let parts = DecimalParts {
-            is_positive: true,
-            scale: 5,
-            precision: 18,
-            int_parts: vec![100000],
-        };
+        let parts = DecimalParts::new(true, 18, 5, 100000);
 
         // Test that scale affects the decimal conversion
         let result = parts.to_f64();
@@ -2675,13 +2679,8 @@ mod test {
     }
 
     #[test]
-    fn test_decimal_parts_empty_int_parts() {
-        let parts = DecimalParts {
-            is_positive: true,
-            scale: 0,
-            precision: 1,
-            int_parts: vec![],
-        };
+    fn test_decimal_parts_zero_magnitude() {
+        let parts = DecimalParts::new(true, 1, 0, 0);
 
         let result = parts.to_f64();
         assert_eq!(result, 0.0);
@@ -2689,12 +2688,7 @@ mod test {
 
     #[test]
     fn test_decimal_parts_single_int_part() {
-        let parts = DecimalParts {
-            is_positive: true,
-            scale: 0,
-            precision: 5,
-            int_parts: vec![12345],
-        };
+        let parts = DecimalParts::new(true, 5, 0, 12345);
 
         let result = parts.to_f64();
         assert_eq!(result, 12345.0);
@@ -2780,160 +2774,76 @@ mod test {
 
     #[test]
     fn test_decimal_parts_equality_same() {
-        let parts1 = DecimalParts {
-            is_positive: true,
-            scale: 2,
-            precision: 10,
-            int_parts: vec![100, 200],
-        };
-        let parts2 = DecimalParts {
-            is_positive: true,
-            scale: 2,
-            precision: 10,
-            int_parts: vec![100, 200],
-        };
+        let parts1 = DecimalParts::new(true, 10, 2, 858993459300);
+        let parts2 = DecimalParts::new(true, 10, 2, 858993459300);
         assert_eq!(parts1, parts2);
     }
 
     #[test]
     fn test_decimal_parts_equality_different_sign() {
-        let parts1 = DecimalParts {
-            is_positive: true,
-            scale: 2,
-            precision: 10,
-            int_parts: vec![100],
-        };
-        let parts2 = DecimalParts {
-            is_positive: false,
-            scale: 2,
-            precision: 10,
-            int_parts: vec![100],
-        };
+        let parts1 = DecimalParts::new(true, 10, 2, 100);
+        let parts2 = DecimalParts::new(false, 10, 2, 100);
         assert_ne!(parts1, parts2);
     }
 
     #[test]
     fn test_decimal_parts_equality_different_scale() {
-        let parts1 = DecimalParts {
-            is_positive: true,
-            scale: 2,
-            precision: 10,
-            int_parts: vec![100],
-        };
-        let parts2 = DecimalParts {
-            is_positive: true,
-            scale: 3,
-            precision: 10,
-            int_parts: vec![100],
-        };
+        let parts1 = DecimalParts::new(true, 10, 2, 100);
+        let parts2 = DecimalParts::new(true, 10, 3, 100);
         assert_ne!(parts1, parts2);
     }
 
     #[test]
     fn test_decimal_parts_equality_different_precision() {
-        let parts1 = DecimalParts {
-            is_positive: true,
-            scale: 2,
-            precision: 10,
-            int_parts: vec![100],
-        };
-        let parts2 = DecimalParts {
-            is_positive: true,
-            scale: 2,
-            precision: 12,
-            int_parts: vec![100],
-        };
+        let parts1 = DecimalParts::new(true, 10, 2, 100);
+        let parts2 = DecimalParts::new(true, 12, 2, 100);
         assert_ne!(parts1, parts2);
     }
 
     #[test]
     fn test_decimal_parts_equality_different_length_with_zeros() {
-        let parts1 = DecimalParts {
-            is_positive: true,
-            scale: 2,
-            precision: 10,
-            int_parts: vec![100, 0, 0],
-        };
-        let parts2 = DecimalParts {
-            is_positive: true,
-            scale: 2,
-            precision: 10,
-            int_parts: vec![100],
-        };
+        let parts1 = DecimalParts::new(true, 10, 2, 100);
+        let parts2 = DecimalParts::new(true, 10, 2, 100);
         assert_eq!(parts1, parts2);
     }
 
     #[test]
     fn test_decimal_parts_equality_different_length_with_nonzeros() {
-        let parts1 = DecimalParts {
-            is_positive: true,
-            scale: 2,
-            precision: 10,
-            int_parts: vec![100, 200],
-        };
-        let parts2 = DecimalParts {
-            is_positive: true,
-            scale: 2,
-            precision: 10,
-            int_parts: vec![100],
-        };
+        let parts1 = DecimalParts::new(true, 10, 2, 858993459300);
+        let parts2 = DecimalParts::new(true, 10, 2, 100);
         assert_ne!(parts1, parts2);
     }
 
     #[test]
     fn test_decimal_parts_debug_format_positive() {
-        let parts = DecimalParts {
-            is_positive: true,
-            scale: 2,
-            precision: 10,
-            int_parts: vec![12345],
-        };
+        let parts = DecimalParts::new(true, 10, 2, 12345);
         let debug_str = format!("{parts:?}");
-        assert!(debug_str.contains("Decimal:"));
-        assert!(debug_str.contains("12345"));
+        assert!(debug_str.starts_with("Decimal: 123.45 "));
         assert!(debug_str.contains("Precision 10"));
         assert!(debug_str.contains("Scale 2"));
-        assert!(!debug_str.starts_with("Decimal: -"));
     }
 
     #[test]
     fn test_decimal_parts_debug_format_negative() {
-        let parts = DecimalParts {
-            is_positive: false,
-            scale: 3,
-            precision: 15,
-            int_parts: vec![54321],
-        };
+        let parts = DecimalParts::new(false, 15, 3, 54321);
         let debug_str = format!("{parts:?}");
-        assert!(debug_str.contains("Decimal: -"));
-        assert!(debug_str.contains("54321"));
+        assert!(debug_str.starts_with("Decimal: -54.321 "));
         assert!(debug_str.contains("Precision 15"));
         assert!(debug_str.contains("Scale 3"));
     }
 
     #[test]
-    fn test_decimal_parts_debug_format_multiple_parts() {
-        let parts = DecimalParts {
-            is_positive: true,
-            scale: 0,
-            precision: 20,
-            int_parts: vec![100, 200, 300],
-        };
+    fn test_decimal_parts_debug_format_multi_word_magnitude() {
+        // Three 32-bit words: 100 | 200 << 32 | 300 << 64.
+        let parts = DecimalParts::new(true, 20, 0, 5534023222971858944100);
         let debug_str = format!("{parts:?}");
-        assert!(debug_str.contains("100"));
-        assert!(debug_str.contains("200"));
-        assert!(debug_str.contains("300"));
+        assert!(debug_str.starts_with("Decimal: 5534023222971858944100 "));
     }
 
     #[test]
     fn test_f64_conversion_high_scale() {
-        let int_parts = vec![12345];
-        let parts = DecimalParts {
-            is_positive: true,
-            scale: 10,
-            precision: 15,
-            int_parts,
-        };
+        let magnitude = 12345;
+        let parts = DecimalParts::new(true, 15, 10, magnitude);
         let result = parts.to_f64();
         // With scale of 10, 12345 should become 0.0000012345
         assert!((result - 0.0000012345).abs() < 0.0000000001);
@@ -2941,24 +2851,14 @@ mod test {
 
     #[test]
     fn test_f64_conversion_single_zero() {
-        let parts = DecimalParts {
-            is_positive: true,
-            scale: 5,
-            precision: 10,
-            int_parts: vec![0],
-        };
+        let parts = DecimalParts::new(true, 10, 5, 0);
         let result = parts.to_f64();
         assert_eq!(result, 0.0);
     }
 
     #[test]
     fn test_f64_conversion_negative_zero() {
-        let parts = DecimalParts {
-            is_positive: false,
-            scale: 0,
-            precision: 1,
-            int_parts: vec![0],
-        };
+        let parts = DecimalParts::new(false, 1, 0, 0);
         let result = parts.to_f64();
         assert_eq!(result, -0.0);
     }
@@ -2981,14 +2881,9 @@ mod test {
     }
 
     #[test]
-    fn test_decimal_parts_f64_conversion_with_many_int_parts() {
+    fn test_decimal_parts_f64_conversion_with_wide_magnitude() {
         // Test with 3 int parts
-        let parts = DecimalParts {
-            is_positive: true,
-            scale: 0,
-            precision: 30,
-            int_parts: vec![1, 2, 3],
-        };
+        let parts = DecimalParts::new(true, 30, 0, 55340232229718589441);
         let result = parts.to_f64();
         // Just verify it doesn't panic and produces a value
         assert!(result > 0.0);
@@ -2997,36 +2892,16 @@ mod test {
     #[test]
     fn test_decimal_parts_equality_reversed_order() {
         // Test that order matters for trailing zeros
-        let parts1 = DecimalParts {
-            is_positive: true,
-            scale: 2,
-            precision: 10,
-            int_parts: vec![100],
-        };
-        let parts2 = DecimalParts {
-            is_positive: true,
-            scale: 2,
-            precision: 10,
-            int_parts: vec![0, 100],
-        };
+        let parts1 = DecimalParts::new(true, 10, 2, 100);
+        let parts2 = DecimalParts::new(true, 10, 2, 429496729600);
         // These should not be equal as trailing zeros are in different positions
         assert_ne!(parts1, parts2);
     }
 
     #[test]
     fn test_decimal_parts_equality_both_empty() {
-        let parts1 = DecimalParts {
-            is_positive: true,
-            scale: 0,
-            precision: 1,
-            int_parts: vec![],
-        };
-        let parts2 = DecimalParts {
-            is_positive: true,
-            scale: 0,
-            precision: 1,
-            int_parts: vec![],
-        };
+        let parts1 = DecimalParts::new(true, 1, 0, 0);
+        let parts2 = DecimalParts::new(true, 1, 0, 0);
         assert_eq!(parts1, parts2);
     }
 
@@ -3040,12 +2915,7 @@ mod test {
     #[test]
     fn test_decimal_parts_f64_negative_with_scale() {
         // Test negative number with scale
-        let parts = DecimalParts {
-            is_positive: false,
-            scale: 3,
-            precision: 10,
-            int_parts: vec![123456],
-        };
+        let parts = DecimalParts::new(false, 10, 3, 123456);
         let result = parts.to_f64();
         assert!((result + 123.456).abs() < 0.001);
     }
@@ -3053,18 +2923,8 @@ mod test {
     #[test]
     fn test_decimal_parts_equality_one_empty_one_zero() {
         // Test equality between empty vec and vec with zero
-        let parts1 = DecimalParts {
-            is_positive: true,
-            scale: 0,
-            precision: 1,
-            int_parts: vec![],
-        };
-        let parts2 = DecimalParts {
-            is_positive: true,
-            scale: 0,
-            precision: 1,
-            int_parts: vec![0],
-        };
+        let parts1 = DecimalParts::new(true, 1, 0, 0);
+        let parts2 = DecimalParts::new(true, 1, 0, 0);
         // Empty should equal to [0]
         assert_eq!(parts1, parts2);
     }
@@ -3072,12 +2932,7 @@ mod test {
     #[test]
     fn test_decimal_parts_debug_with_zero() {
         // Test Debug formatting with zero value
-        let parts = DecimalParts {
-            is_positive: true,
-            scale: 0,
-            precision: 1,
-            int_parts: vec![0],
-        };
+        let parts = DecimalParts::new(true, 1, 0, 0);
         let debug_str = format!("{parts:?}");
         assert!(debug_str.contains("0"));
         assert!(debug_str.contains("F64 value: 0"));
@@ -3307,59 +3162,276 @@ mod test {
     #[test]
     fn test_decimal_parts_max_width_magnitude() {
         // Four words of all-ones is the widest magnitude a u128 holds.
-        let parts = DecimalParts {
-            is_positive: true,
-            scale: 0,
-            precision: 38,
-            int_parts: vec![-1, -1, -1, -1],
-        };
+        let parts = DecimalParts::new(true, 38, 0, u128::MAX);
         assert_eq!(parts.to_decimal_string(), u128::MAX.to_string());
-        assert_eq!(parts.magnitude(), Some(u128::MAX));
+        assert_eq!(parts.word_count(), 4);
+        assert_eq!(parts.word(3), -1);
     }
 
     #[test]
-    fn test_decimal_parts_oversized_magnitude_does_not_overflow() {
-        // A malformed 5-word magnitude used to shift a u128 by 128 bits: a panic
-        // in debug builds and a wrapped, wrong value in release builds.
-        let parts = DecimalParts {
-            is_positive: true,
-            scale: 0,
-            precision: 38,
-            int_parts: vec![1, 0, 0, 0, 1],
-        };
-        // 2^128 + 1, rendered exactly rather than wrapping onto the low word.
-        assert_eq!(
-            parts.to_decimal_string(),
-            "340282366920938463463374607431768211457"
-        );
-        assert!((parts.to_f64() - 3.402_823_669_209_385e38).abs() < 1e23);
-        assert_eq!(parts.magnitude(), None);
+    fn test_decimal_parts_from_words_ignores_oversized_words() {
+        // A 5-word magnitude used to shift a u128 by 128 bits: a panic in debug
+        // builds and a wrapped, wrong value in release builds. The fifth word is
+        // now dropped, which is what every wire encoder here already did.
+        let parts = DecimalParts::from_words(true, 38, 0, &[1, 0, 0, 0, 1]);
+        assert_eq!(parts.magnitude(), 1);
+        assert_eq!(parts.to_decimal_string(), "1");
     }
 
     #[test]
-    fn test_decimal_parts_oversized_magnitude_with_trailing_zero_words() {
-        // Zero-padded words past the fourth carry no magnitude, so the value
-        // still fits a u128 and both the string and typed paths agree on it.
-        let parts = DecimalParts {
-            is_positive: false,
-            scale: 2,
-            precision: 38,
-            int_parts: vec![12345, 0, 0, 0, 0, 0],
-        };
+    fn test_decimal_parts_from_words_with_trailing_zero_words() {
+        // Zero-padded words past the fourth carry no magnitude.
+        let parts = DecimalParts::from_words(false, 38, 2, &[12345, 0, 0, 0, 0, 0]);
+        assert_eq!(parts.magnitude(), 12345);
         assert_eq!(parts.to_decimal_string(), "-123.45");
-        assert_eq!(parts.magnitude(), Some(12345));
     }
 
     #[test]
     fn test_decimal_parts_empty_magnitude_is_zero() {
-        let parts = DecimalParts {
-            is_positive: true,
-            scale: 0,
-            precision: 38,
-            int_parts: vec![],
-        };
-        assert_eq!(parts.magnitude(), Some(0));
+        let parts = DecimalParts::from_words(true, 38, 0, &[]);
+        assert_eq!(parts.magnitude(), 0);
+        assert_eq!(parts.word_count(), 1);
         assert_eq!(parts.to_decimal_string(), "0");
+    }
+
+    // Rendering equivalence against an independent oracle
+    mod decimal_format_tests {
+        use super::*;
+        use crate::datatypes::decoder::DECIMAL_STR_LEN;
+        use rand::{Rng, SeedableRng, rngs::StdRng};
+
+        /// The pre-existing rendering algorithm, kept verbatim as the oracle.
+        ///
+        /// It shares no arithmetic with [`DecimalParts::format_into`]: digits
+        /// come from `u128::to_string`, the point is spliced by index, and the
+        /// sign is prepended. A formatter bug therefore cannot hide behind an
+        /// identical bug in the oracle.
+        fn reference(is_positive: bool, scale: u8, magnitude: u128) -> String {
+            let value_str = magnitude.to_string();
+
+            let result = if scale == 0 {
+                value_str
+            } else {
+                let scale_pos = scale as usize;
+                if value_str.len() <= scale_pos {
+                    format!("0.{}{}", "0".repeat(scale_pos - value_str.len()), value_str)
+                } else {
+                    let split_pos = value_str.len() - scale_pos;
+                    format!("{}.{}", &value_str[..split_pos], &value_str[split_pos..])
+                }
+            };
+
+            if is_positive {
+                result
+            } else {
+                format!("-{result}")
+            }
+        }
+
+        #[track_caller]
+        fn assert_matches_reference(is_positive: bool, precision: u8, scale: u8, magnitude: u128) {
+            let parts = DecimalParts::new(is_positive, precision, scale, magnitude);
+            let expected = reference(is_positive, scale, magnitude);
+
+            let mut buf = [0u8; DECIMAL_STR_LEN];
+            assert_eq!(
+                parts.format_into(&mut buf),
+                expected,
+                "format_into({is_positive}, {scale}, {magnitude})"
+            );
+            assert_eq!(parts.to_decimal_string(), expected);
+            assert_eq!(parts.to_string(), expected);
+        }
+
+        #[test]
+        fn exhaustive_small_magnitudes_match_reference() {
+            for magnitude in 0u128..=4096 {
+                for scale in 0u8..=6 {
+                    assert_matches_reference(true, 38, scale, magnitude);
+                    assert_matches_reference(false, 38, scale, magnitude);
+                }
+            }
+        }
+
+        #[test]
+        fn powers_of_ten_match_reference_at_every_scale() {
+            // 10^k and 10^k - 1 straddle every digit-count change, including the
+            // u64/u128 split the formatter pivots on.
+            let mut boundaries = vec![0u128, u128::MAX];
+            for k in 1..=38u32 {
+                let power = 10u128.pow(k);
+                boundaries.push(power);
+                boundaries.push(power - 1);
+            }
+            boundaries.push(u64::MAX as u128);
+            boundaries.push(u64::MAX as u128 + 1);
+            boundaries.push(10_000_000_000_000_000_000u128);
+
+            for &magnitude in &boundaries {
+                // Every scale, so `s % 4 != 0` at maximum magnitude is covered:
+                // that is the shape the deferred base-10000 export must not
+                // pre-multiply, because 10^38 * 100 wraps a u128.
+                for scale in 0..=38u8 {
+                    assert_matches_reference(true, 38, scale, magnitude);
+                    assert_matches_reference(false, 38, scale, magnitude);
+                }
+            }
+        }
+
+        #[test]
+        fn randomized_magnitudes_match_reference() {
+            let mut rng = StdRng::seed_from_u64(0x5EED_D3C1);
+            for _ in 0..20_000 {
+                // Uniform over widths, not over u128, so the one-, two-, three-
+                // and four-word wire shapes are all exercised.
+                let bits = rng.random_range(1..=128u32);
+                let magnitude = if bits == 128 {
+                    rng.random::<u128>()
+                } else {
+                    rng.random::<u128>() & ((1u128 << bits) - 1)
+                };
+                let scale = rng.random_range(0..=38u8);
+                let precision = rng.random_range(1..=38u8);
+                assert_matches_reference(rng.random(), precision, scale, magnitude);
+            }
+        }
+
+        #[test]
+        fn precision_one_to_thirty_eight_match_reference() {
+            for precision in 1..=38u8 {
+                // The largest magnitude the precision admits, and one below it.
+                let max = 10u128.pow(precision as u32) - 1;
+                for scale in 0..=precision {
+                    assert_matches_reference(true, precision, scale, max);
+                    assert_matches_reference(false, precision, scale, max);
+                    assert_matches_reference(true, precision, scale, max / 10);
+                }
+            }
+        }
+
+        #[test]
+        fn negative_zero_renders_with_sign() {
+            let parts = DecimalParts::new(false, 18, 0, 0);
+            assert_eq!(parts.to_string(), "-0");
+            assert_eq!(DecimalParts::new(false, 18, 4, 0).to_string(), "-0.0000");
+        }
+
+        #[test]
+        fn zero_with_scale_renders_padded() {
+            let parts = DecimalParts::new(true, 18, 6, 0);
+            assert_eq!(parts.to_string(), "0.000000");
+        }
+
+        #[test]
+        fn magnitude_narrower_than_scale_is_zero_padded() {
+            let parts = DecimalParts::new(true, 18, 3, 5);
+            assert_eq!(parts.to_string(), "0.005");
+        }
+
+        #[test]
+        fn out_of_domain_scale_does_not_overrun_the_buffer() {
+            // `scale` comes off the wire unvalidated. No `decimal` reaches 255,
+            // but the formatter must not index past its buffer if one claims to.
+            let parts = DecimalParts::new(false, 38, u8::MAX, u128::MAX);
+            let mut buf = [0u8; DECIMAL_STR_LEN];
+            assert!(parts.format_into(&mut buf).len() <= DECIMAL_STR_LEN);
+        }
+
+        #[test]
+        fn format_into_leaves_the_buffer_reusable() {
+            let mut buf = [0u8; DECIMAL_STR_LEN];
+            for (magnitude, scale, expected) in [
+                (1u128, 0u8, "1"),
+                (123456u128, 4u8, "12.3456"),
+                (0u128, 0u8, "0"),
+            ] {
+                let parts = DecimalParts::new(true, 38, scale, magnitude);
+                assert_eq!(parts.format_into(&mut buf), expected);
+            }
+        }
+    }
+
+    // Constructors that used to wrap silently
+    mod decimal_constructor_tests {
+        use super::*;
+
+        #[test]
+        fn from_i64_rejects_a_scale_that_overflows_the_magnitude() {
+            // 10^38 fits, but i64::MAX * 10^38 does not. This used to wrap.
+            assert!(DecimalParts::from_i64(1, 38, 38).is_ok());
+            let err = DecimalParts::from_i64(i64::MAX, 38, 38).unwrap_err();
+            assert!(matches!(err, crate::error::Error::TypeConversionError(_)));
+            assert!(DecimalParts::from_i64(1, 38, 39).is_err());
+        }
+
+        #[test]
+        fn from_i64_round_trips_through_the_formatter() {
+            let parts = DecimalParts::from_i64(-12345, 18, 3).unwrap();
+            assert_eq!(parts.magnitude(), 12_345_000);
+            assert_eq!(parts.to_string(), "-12345.000");
+        }
+
+        #[test]
+        fn from_string_rejects_a_magnitude_wider_than_128_bits() {
+            // Only reachable by declaring a precision past SQL Server's 38.
+            let wide = "1".repeat(40);
+            assert!(DecimalParts::from_string(&wide, 40, 0).is_err());
+        }
+
+        #[test]
+        fn from_string_accepts_the_widest_valid_decimal() {
+            let max = "9".repeat(38);
+            let parts = DecimalParts::from_string(&max, 38, 0).unwrap();
+            assert_eq!(parts.magnitude(), 10u128.pow(38) - 1);
+            assert_eq!(parts.to_string(), max);
+        }
+    }
+
+    // Little-endian word view used by the wire encoders and the JS FFI
+    mod decimal_word_tests {
+        use super::*;
+
+        #[test]
+        fn words_round_trip_through_from_words() {
+            for magnitude in [
+                0u128,
+                1,
+                u32::MAX as u128,
+                u32::MAX as u128 + 1,
+                u64::MAX as u128,
+                u64::MAX as u128 + 1,
+                u128::MAX,
+                12_345_678_901_234_567_890,
+            ] {
+                let parts = DecimalParts::new(false, 38, 7, magnitude);
+                let words: Vec<i32> = (0..parts.word_count()).map(|i| parts.word(i)).collect();
+                assert_eq!(DecimalParts::from_words(false, 38, 7, &words), parts);
+            }
+        }
+
+        #[test]
+        fn word_count_covers_the_significant_words() {
+            let cases = [
+                (0u128, 1usize),
+                (1, 1),
+                (u32::MAX as u128, 1),
+                (u32::MAX as u128 + 1, 2),
+                (u64::MAX as u128, 2),
+                (u64::MAX as u128 + 1, 3),
+                (u128::MAX, 4),
+            ];
+            for (magnitude, expected) in cases {
+                let parts = DecimalParts::new(true, 38, 0, magnitude);
+                assert_eq!(parts.word_count(), expected, "magnitude {magnitude}");
+            }
+        }
+
+        #[test]
+        fn words_past_the_fourth_are_zero() {
+            let parts = DecimalParts::new(true, 38, 0, u128::MAX);
+            assert_eq!(parts.word(4), 0);
+            assert_eq!(parts.word(usize::MAX), 0);
+        }
     }
 
     // Vector deserialization tests
@@ -4805,7 +4877,44 @@ mod test {
             assert_eq!(reader.read_int32().await.unwrap(), trailing);
         }
 
-        // ── Time scale branches ────────────────────────────────────────
+        #[tokio::test]
+        async fn decimal_wire_widths_reassemble_the_magnitude() {
+            // The four lengths a real server emits: 1 sign byte plus 4, 8, 12 or
+            // 16 magnitude bytes.
+            let cases: [(u8, u128); 4] = [
+                (5, 0xDEAD_BEEF),
+                (9, 0x0123_4567_89AB_CDEF),
+                (13, 0x0000_0009_8765_4321_0FED_CBA9),
+                (17, u128::MAX >> 1),
+            ];
+
+            for (length, magnitude) in cases {
+                let md = precision_scale_metadata(TdsDataType::DecimalN, length.into(), 38, 0);
+                let mut buf = vec![length, 1u8];
+                let bytes = magnitude.to_le_bytes();
+                buf.extend_from_slice(&bytes[..(length - 1) as usize]);
+
+                match assert_decode_equivalence(buf, &md).await {
+                    ColumnValues::Decimal(parts) => {
+                        assert_eq!(parts.magnitude(), magnitude, "wire length {length}");
+                        assert!(parts.is_positive);
+                    }
+                    other => panic!("expected Decimal, got {other:?}"),
+                }
+            }
+        }
+
+        #[tokio::test]
+        async fn decimal_negative_sign_byte_is_honored() {
+            let md = precision_scale_metadata(TdsDataType::DecimalN, 5, 18, 2);
+            let mut buf = vec![5u8, 0u8];
+            buf.extend_from_slice(&12345i32.to_le_bytes());
+
+            match assert_decode_equivalence(buf, &md).await {
+                ColumnValues::Decimal(parts) => assert_eq!(parts.to_string(), "-123.45"),
+                other => panic!("expected Decimal, got {other:?}"),
+            }
+        }
 
         #[tokio::test]
         async fn time_scale_0() {

--- a/mssql-tds/src/datatypes/decoder.rs
+++ b/mssql-tds/src/datatypes/decoder.rs
@@ -2419,10 +2419,6 @@ impl DecimalParts {
         if self.is_positive { d_ret } else { -d_ret }
     }
 
-    fn clamped_scale(&self) -> usize {
-        (self.scale as usize).min(DECIMAL_STR_LEN - 3)
-    }
-
     /// The `index`-th little-endian 32-bit word of the magnitude, counting from
     /// the least significant. Words past the fourth are always zero.
     ///

--- a/mssql-tds/src/datatypes/decoder.rs
+++ b/mssql-tds/src/datatypes/decoder.rs
@@ -193,7 +193,7 @@ const MAX_PLP_SIZE: usize = i32::MAX as usize;
 const MAX_DECIMAL_INT_PARTS: usize = 4;
 
 /// Byte width of a `decimal`/`numeric` magnitude: four little-endian 32-bit words.
-const DECIMAL_MAGNITUDE_BYTES: usize = MAX_DECIMAL_INT_PARTS * 4;
+pub(crate) const DECIMAL_MAGNITUDE_BYTES: usize = MAX_DECIMAL_INT_PARTS * 4;
 
 // Helper function to validate allocation size before allocating
 #[inline]
@@ -2145,6 +2145,10 @@ impl SqlTypeDecode for StringDecoder {
 /// Bytes needed to render any `decimal`/`numeric`: sign, 38 digits, decimal
 /// point, and slack for a scale that exceeds the digit count (`0.000…`).
 pub const DECIMAL_STR_LEN: usize = 48;
+const _: () = assert!(
+    DECIMAL_STR_LEN >= 42,
+    "buffer must hold 39 digits of u128::MAX plus a decimal point and sign"
+);
 
 /// TDS representation of Decimal and Numeric types.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -2172,6 +2176,10 @@ impl fmt::Display for DecimalParts {
 }
 
 impl DecimalParts {
+    fn clamped_scale(&self) -> usize {
+        (self.scale as usize).min(DECIMAL_STR_LEN - 3)
+    }
+
     /// Builds a value from its unsigned magnitude, already scaled by `10^scale`.
     ///
     /// SQL Server's maximum precision of 38 digits keeps the magnitude below
@@ -2349,7 +2357,7 @@ impl DecimalParts {
         // `scale` is wire-supplied and unvalidated. A `decimal` never exceeds
         // 38, but the loop is bounded by the buffer rather than by trusting it,
         // so a malformed value renders short instead of overrunning.
-        let scale = (self.scale as usize).min(DECIMAL_STR_LEN - 3);
+        let scale = self.clamped_scale();
         let mut pos = buf.len();
         let mut emitted = 0usize;
         let mut limb = 0usize;
@@ -2406,7 +2414,7 @@ impl DecimalParts {
     fn to_f64(self) -> f64 {
         let magnitude = self.magnitude() as f64;
 
-        let d_ret = magnitude / 10.0_f64.powi(self.scale as i32);
+        let d_ret = magnitude / 10.0_f64.powi(self.clamped_scale() as i32);
 
         if self.is_positive { d_ret } else { -d_ret }
     }
@@ -2425,6 +2433,9 @@ impl DecimalParts {
 
     /// Number of little-endian 32-bit words needed to hold the magnitude, at
     /// least one so that zero still has a word.
+    ///
+    /// This is the minimal count, not the width the value was decoded from:
+    /// trailing zero words are not reported.
     pub fn word_count(&self) -> usize {
         (128 - self.magnitude().leading_zeros() as usize)
             .div_ceil(32)
@@ -2436,6 +2447,14 @@ impl DecimalParts {
     /// Words past the fourth are ignored: a `decimal`/`numeric` with precision
     /// <= 38 never sets them, and every encoder here already emits at most four.
     pub fn from_words(is_positive: bool, precision: u8, scale: u8, words: &[i32]) -> Self {
+        debug_assert!(
+            words
+                .iter()
+                .skip(MAX_DECIMAL_INT_PARTS)
+                .all(|&word| word == 0),
+            "magnitude wider than 128 bits truncated: {words:?}"
+        );
+
         let magnitude = words
             .iter()
             .take(MAX_DECIMAL_INT_PARTS)
@@ -2445,6 +2464,21 @@ impl DecimalParts {
             });
 
         Self::new(is_positive, precision, scale, magnitude)
+    }
+
+    /// Builds a value from little-endian 32-bit words, rejecting magnitudes
+    /// wider than 128 bits while accepting trailing zero padding.
+    pub fn try_from_words(
+        is_positive: bool,
+        precision: u8,
+        scale: u8,
+        words: &[i32],
+    ) -> Option<Self> {
+        words
+            .iter()
+            .skip(MAX_DECIMAL_INT_PARTS)
+            .all(|&word| word == 0)
+            .then(|| Self::from_words(is_positive, precision, scale, words))
     }
 }
 
@@ -3169,19 +3203,14 @@ mod test {
     }
 
     #[test]
-    fn test_decimal_parts_from_words_ignores_oversized_words() {
-        // A 5-word magnitude used to shift a u128 by 128 bits: a panic in debug
-        // builds and a wrapped, wrong value in release builds. The fifth word is
-        // now dropped, which is what every wire encoder here already did.
-        let parts = DecimalParts::from_words(true, 38, 0, &[1, 0, 0, 0, 1]);
-        assert_eq!(parts.magnitude(), 1);
-        assert_eq!(parts.to_decimal_string(), "1");
+    fn test_decimal_parts_try_from_words_rejects_oversized_magnitude() {
+        assert!(DecimalParts::try_from_words(true, 38, 0, &[1, 0, 0, 0, 1]).is_none());
     }
 
     #[test]
     fn test_decimal_parts_from_words_with_trailing_zero_words() {
         // Zero-padded words past the fourth carry no magnitude.
-        let parts = DecimalParts::from_words(false, 38, 2, &[12345, 0, 0, 0, 0, 0]);
+        let parts = DecimalParts::try_from_words(false, 38, 2, &[12345, 0, 0, 0, 0, 0]).unwrap();
         assert_eq!(parts.magnitude(), 12345);
         assert_eq!(parts.to_decimal_string(), "-123.45");
     }

--- a/mssql-tds/src/datatypes/decoder.rs
+++ b/mssql-tds/src/datatypes/decoder.rs
@@ -3365,7 +3365,7 @@ mod test {
             // but the formatter must not index past its buffer if one claims to.
             let parts = DecimalParts::new(false, 38, u8::MAX, u128::MAX);
             let mut buf = [0u8; DECIMAL_STR_LEN];
-            assert!(parts.format_into(&mut buf).len() <= DECIMAL_STR_LEN);
+            assert_eq!(parts.format_into(&mut buf).len(), DECIMAL_STR_LEN);
         }
 
         #[test]

--- a/mssql-tds/src/datatypes/decoder.rs
+++ b/mssql-tds/src/datatypes/decoder.rs
@@ -191,6 +191,11 @@ const MAX_PLP_SIZE: usize = i32::MAX as usize;
 /// the widest value the TDS wire format carries is 17 bytes (sign byte plus four
 /// words), so anything longer is malformed.
 const MAX_DECIMAL_INT_PARTS: usize = 4;
+const MAX_DECIMAL_PRECISION: u8 = 38;
+
+pub(crate) const fn decimal_metadata_is_valid(precision: u8, scale: u8) -> bool {
+    precision > 0 && precision <= MAX_DECIMAL_PRECISION && scale <= precision
+}
 
 /// Byte width of a `decimal`/`numeric` magnitude: four little-endian 32-bit words.
 pub(crate) const DECIMAL_MAGNITUDE_BYTES: usize = MAX_DECIMAL_INT_PARTS * 4;
@@ -807,6 +812,12 @@ impl GenericDecoder {
     where
         T: TdsPacketReader + Send + Sync,
     {
+        if !decimal_metadata_is_valid(precision, scale) {
+            return Err(crate::error::Error::ProtocolError(format!(
+                "Invalid decimal precision {precision} / scale {scale}"
+            )));
+        }
+
         // If length is 0, then it is NULL.
         if length == 0 {
             return Ok(None);
@@ -2448,7 +2459,7 @@ impl DecimalParts {
     /// Zero words past the fourth are ignored. Non-zero words cannot fit in the
     /// representation and trigger a debug assertion; callers at trust boundaries
     /// should use [`Self::try_from_words`] to reject them in every build.
-    pub fn from_words(is_positive: bool, precision: u8, scale: u8, words: &[i32]) -> Self {
+    pub(crate) fn from_words(is_positive: bool, precision: u8, scale: u8, words: &[i32]) -> Self {
         debug_assert!(
             words
                 .iter()
@@ -4850,6 +4861,14 @@ mod test {
             let mut buf = vec![5u8, 1u8];
             buf.extend_from_slice(&42i32.to_le_bytes());
             assert_decode_err(buf, &md).await;
+        }
+
+        #[tokio::test]
+        async fn decimal_rejects_invalid_precision_and_scale() {
+            for (precision, scale) in [(0, 0), (39, 0), (18, 19)] {
+                let md = precision_scale_metadata(TdsDataType::DecimalN, 5, precision, scale);
+                assert_decode_err(vec![0], &md).await;
+            }
         }
 
         #[tokio::test]

--- a/mssql-tds/src/datatypes/decoder.rs
+++ b/mssql-tds/src/datatypes/decoder.rs
@@ -2419,6 +2419,10 @@ impl DecimalParts {
         if self.is_positive { d_ret } else { -d_ret }
     }
 
+    fn clamped_scale(&self) -> usize {
+        (self.scale as usize).min(DECIMAL_STR_LEN - 3)
+    }
+
     /// The `index`-th little-endian 32-bit word of the magnitude, counting from
     /// the least significant. Words past the fourth are always zero.
     ///
@@ -2435,7 +2439,8 @@ impl DecimalParts {
     /// least one so that zero still has a word.
     ///
     /// This is the minimal count, not the width the value was decoded from:
-    /// trailing zero words are not reported.
+    /// trailing zero words are not reported. Consumers must accumulate the
+    /// returned words rather than assuming a fixed width.
     pub fn word_count(&self) -> usize {
         (128 - self.magnitude().leading_zeros() as usize)
             .div_ceil(32)
@@ -2444,8 +2449,9 @@ impl DecimalParts {
 
     /// Builds a value from little-endian 32-bit words, least significant first.
     ///
-    /// Words past the fourth are ignored: a `decimal`/`numeric` with precision
-    /// <= 38 never sets them, and every encoder here already emits at most four.
+    /// Zero words past the fourth are ignored. Non-zero words cannot fit in the
+    /// representation and trigger a debug assertion; callers at trust boundaries
+    /// should use [`Self::try_from_words`] to reject them in every build.
     pub fn from_words(is_positive: bool, precision: u8, scale: u8, words: &[i32]) -> Self {
         debug_assert!(
             words

--- a/mssql-tds/src/datatypes/row_writer.rs
+++ b/mssql-tds/src/datatypes/row_writer.rs
@@ -429,7 +429,7 @@ mod tests {
     fn write_column_value_bridges_numeric() {
         let mut writer = DefaultRowWriter::new(1);
         let parts = DecimalParts::from_i64(12345, 5, 0).unwrap();
-        write_column_value(&mut writer, 0, ColumnValues::Numeric(parts.clone()));
+        write_column_value(&mut writer, 0, ColumnValues::Numeric(parts));
         let row = writer.take_row();
         assert_eq!(row[0], ColumnValues::Numeric(parts));
     }

--- a/mssql-tds/src/datatypes/sqltypes.rs
+++ b/mssql-tds/src/datatypes/sqltypes.rs
@@ -306,9 +306,9 @@ impl SqlType {
                 let cv = match opt {
                     Some(v) => {
                         if matches!(self, SqlType::Numeric(_)) {
-                            ColumnValues::Numeric(v.clone())
+                            ColumnValues::Numeric(*v)
                         } else {
-                            ColumnValues::Decimal(v.clone())
+                            ColumnValues::Decimal(*v)
                         }
                     }
                     None => ColumnValues::Null,
@@ -1500,12 +1500,7 @@ mod coverage_tests {
 
     #[test]
     fn nullable_type_numeric() {
-        let dp = DecimalParts {
-            is_positive: true,
-            scale: 2,
-            precision: 10,
-            int_parts: vec![100],
-        };
+        let dp = DecimalParts::new(true, 10, 2, 100);
         assert_eq!(
             SqlType::Numeric(Some(dp)).get_nullable_type(),
             TdsDataType::NumericN
@@ -1586,13 +1581,8 @@ mod coverage_tests {
     #[test]
     fn to_cv_numeric_some() {
         let col = &default_collation();
-        let dp = DecimalParts {
-            is_positive: true,
-            scale: 4,
-            precision: 18,
-            int_parts: vec![42],
-        };
-        let (cv, _) = SqlType::Numeric(Some(dp.clone())).to_column_value_and_context(col);
+        let dp = DecimalParts::new(true, 18, 4, 42);
+        let (cv, _) = SqlType::Numeric(Some(dp)).to_column_value_and_context(col);
         assert_eq!(cv, ColumnValues::Numeric(dp));
     }
 

--- a/mssql-tds/src/datatypes/tds_value_serializer.rs
+++ b/mssql-tds/src/datatypes/tds_value_serializer.rs
@@ -479,8 +479,7 @@ impl TdsValueSerializer {
         // Pad with zeros if value has fewer chunks than needed
         let chunks_needed = value_bytes / 4;
         for i in 0..chunks_needed {
-            let chunk = value.int_parts.get(i).copied().unwrap_or(0);
-            writer.write_i32_async(chunk).await?;
+            writer.write_i32_async(value.word(i)).await?;
         }
 
         Ok(())
@@ -3050,12 +3049,7 @@ mod serializer_tests {
         let mut ctx = nullable_ctx(0x6A); // DecimalN
         ctx.precision = Some(5);
         ctx.scale = Some(2);
-        let val = ColumnValues::Decimal(DecimalParts {
-            is_positive: true,
-            scale: 2,
-            precision: 5,
-            int_parts: vec![12345],
-        });
+        let val = ColumnValues::Decimal(DecimalParts::new(true, 5, 2, 12345));
         block_on(TdsValueSerializer::serialize_value(&mut w, &val, &ctx)).unwrap();
         // precision 5 → value_bytes=4, total_length=5
         // [5, 1(positive), 12345 as i32 LE]
@@ -3070,12 +3064,7 @@ mod serializer_tests {
         let mut w = PacketWriter::new(PacketType::TabularResult, &mut mock, None, None);
         let mut ctx = nullable_ctx(0x6A);
         ctx.precision = Some(9);
-        let val = ColumnValues::Decimal(DecimalParts {
-            is_positive: false,
-            scale: 0,
-            precision: 9,
-            int_parts: vec![100],
-        });
+        let val = ColumnValues::Decimal(DecimalParts::new(false, 9, 0, 100));
         block_on(TdsValueSerializer::serialize_value(&mut w, &val, &ctx)).unwrap();
         let mut expected = vec![0x05, 0x00]; // length=5, sign=0 (negative)
         expected.extend_from_slice(&100i32.to_le_bytes());
@@ -3098,12 +3087,7 @@ mod serializer_tests {
         let mut w = PacketWriter::new(PacketType::TabularResult, &mut mock, None, None);
         let mut ctx = nullable_ctx(0x6A);
         ctx.precision = Some(18);
-        let val = ColumnValues::Decimal(DecimalParts {
-            is_positive: true,
-            scale: 0,
-            precision: 18,
-            int_parts: vec![1, 2],
-        });
+        let val = ColumnValues::Decimal(DecimalParts::new(true, 18, 0, 8589934593));
         block_on(TdsValueSerializer::serialize_value(&mut w, &val, &ctx)).unwrap();
         // precision 18 → value_bytes=8, total=9
         let mut expected = vec![0x09, 0x01]; // length=9, sign=positive
@@ -3671,12 +3655,7 @@ mod serializer_tests {
         let mut ctx = nullable_ctx(0x6A);
         ctx.precision = Some(15);
         ctx.scale = Some(0);
-        let val = ColumnValues::Decimal(DecimalParts {
-            is_positive: true,
-            scale: 0,
-            precision: 15,
-            int_parts: vec![1, 2],
-        });
+        let val = ColumnValues::Decimal(DecimalParts::new(true, 15, 0, 8589934593));
         block_on(TdsValueSerializer::serialize_value(&mut w, &val, &ctx)).unwrap();
         let mut expected = vec![0x09, 0x01]; // length=9, sign=positive
         expected.extend_from_slice(&1i32.to_le_bytes());
@@ -3691,12 +3670,7 @@ mod serializer_tests {
         let mut ctx = nullable_ctx(0x6A);
         ctx.precision = Some(25);
         ctx.scale = Some(0);
-        let val = ColumnValues::Decimal(DecimalParts {
-            is_positive: false,
-            scale: 0,
-            precision: 25,
-            int_parts: vec![1, 2, 3],
-        });
+        let val = ColumnValues::Decimal(DecimalParts::new(false, 25, 0, 55340232229718589441));
         block_on(TdsValueSerializer::serialize_value(&mut w, &val, &ctx)).unwrap();
         let mut expected = vec![0x0D, 0x00]; // length=13, sign=negative
         expected.extend_from_slice(&1i32.to_le_bytes());
@@ -3711,12 +3685,7 @@ mod serializer_tests {
         let mut w = PacketWriter::new(PacketType::TabularResult, &mut mock, None, None);
         let mut ctx = nullable_ctx(0x6A);
         ctx.precision = Some(39);
-        let val = ColumnValues::Decimal(DecimalParts {
-            is_positive: true,
-            scale: 0,
-            precision: 39,
-            int_parts: vec![1],
-        });
+        let val = ColumnValues::Decimal(DecimalParts::new(true, 39, 0, 1));
         assert!(block_on(TdsValueSerializer::serialize_value(&mut w, &val, &ctx)).is_err());
     }
 

--- a/mssql-tds/src/security/encryption/cell.rs
+++ b/mssql-tds/src/security/encryption/cell.rs
@@ -38,7 +38,7 @@ use crate::datatypes::column_values::{
     ColumnValues, SqlDate, SqlDateTime, SqlDateTime2, SqlDateTimeOffset, SqlMoney,
     SqlSmallDateTime, SqlSmallMoney, SqlTime,
 };
-use crate::datatypes::decoder::DecimalParts;
+use crate::datatypes::decoder::{DECIMAL_MAGNITUDE_BYTES, DecimalParts};
 use crate::datatypes::sql_string::{EncodingType, SqlString};
 use crate::datatypes::sqldatatypes::{TdsDataType, TypeInfo, TypeInfoVariant, is_unicode_type};
 use crate::datatypes::sqltypes::SqlType;
@@ -54,18 +54,6 @@ use crate::security::encryption::ColumnEncryptionType;
 const AEAD_AES_256_CBC_HMAC_SHA256_ALGORITHM_ID: u8 = 0x02;
 /// The only cell-normalization rule version defined by SQL Server today.
 const SUPPORTED_NORMALIZATION_VERSION: u8 = 0x01;
-/// Number of 32-bit words in the canonical `decimal`/`numeric` magnitude.
-///
-/// The Always Encrypted normalized form for `decimal`/`numeric` is a sign byte
-/// followed by a fixed 16-byte magnitude (four 32-bit little-endian words,
-/// zero-extended). This matches SQL Server and the reference drivers (.NET
-/// `SerializeDecimal`/`SerializeSqlDecimal`, msodbcsql), so deterministic
-/// ciphertext is byte-compatible across drivers. A valid decimal magnitude
-/// (precision <= 38) always fits in 128 bits.
-const DECIMAL_MAGNITUDE_WORDS: usize = 4;
-/// The fixed magnitude width in bytes (four 32-bit words = 128 bits). A valid
-/// `decimal`/`numeric` (precision <= 38) never needs more than this.
-const DECIMAL_MAGNITUDE_BYTES: usize = DECIMAL_MAGNITUDE_WORDS * 4;
 /// Total length of the normalized `decimal`/`numeric` form: 1 sign byte plus the
 /// fixed 16-byte magnitude.
 const DECIMAL_NORMALIZED_LEN: usize = 1 + DECIMAL_MAGNITUDE_BYTES;

--- a/mssql-tds/src/security/encryption/cell.rs
+++ b/mssql-tds/src/security/encryption/cell.rs
@@ -38,7 +38,7 @@ use crate::datatypes::column_values::{
     ColumnValues, SqlDate, SqlDateTime, SqlDateTime2, SqlDateTimeOffset, SqlMoney,
     SqlSmallDateTime, SqlSmallMoney, SqlTime,
 };
-use crate::datatypes::decoder::{DECIMAL_MAGNITUDE_BYTES, DecimalParts};
+use crate::datatypes::decoder::{DECIMAL_MAGNITUDE_BYTES, DecimalParts, decimal_metadata_is_valid};
 use crate::datatypes::sql_string::{EncodingType, SqlString};
 use crate::datatypes::sqldatatypes::{TdsDataType, TypeInfo, TypeInfoVariant, is_unicode_type};
 use crate::datatypes::sqltypes::SqlType;
@@ -331,6 +331,12 @@ fn read_decimal(bytes: &[u8], base_type_info: &TypeInfo) -> TdsResult<DecimalPar
             )));
         }
     };
+
+    if !decimal_metadata_is_valid(precision, scale) {
+        return Err(Error::ColumnEncryptionError(format!(
+            "Invalid decimal precision {precision} / scale {scale}"
+        )));
+    }
 
     let (sign, magnitude) = bytes
         .split_first()
@@ -1333,6 +1339,24 @@ mod tests {
         bytes.extend_from_slice(&[0u8; 17]); // 17-byte magnitude => too long
         let error = denormalize(&bytes, TdsDataType::DecimalN, &info, 1).unwrap_err();
         assert!(matches!(error, Error::ColumnEncryptionError(_)));
+    }
+
+    #[test]
+    fn read_decimal_rejects_invalid_precision_and_scale() {
+        for (precision, scale) in [(0, 0), (39, 0), (18, 19)] {
+            let info = type_info(
+                TdsDataType::DecimalN,
+                5,
+                TypeInfoVariant::VarLenPrecisionScale(
+                    VariableLengthTypes::DecimalN,
+                    17,
+                    precision,
+                    scale,
+                ),
+            );
+            let error = denormalize(&[1], TdsDataType::DecimalN, &info, 1).unwrap_err();
+            assert!(matches!(error, Error::ColumnEncryptionError(_)));
+        }
     }
 
     #[test]

--- a/mssql-tds/src/security/encryption/cell.rs
+++ b/mssql-tds/src/security/encryption/cell.rs
@@ -350,8 +350,7 @@ fn read_decimal(bytes: &[u8], base_type_info: &TypeInfo) -> TdsResult<DecimalPar
 
     // A valid decimal/numeric magnitude (precision <= 38) fits in 128 bits, so
     // it is at most 16 bytes (four 32-bit words). Reject anything longer: it
-    // signals wire-format drift or corrupted plaintext, and would allocate an
-    // unbounded `int_parts`.
+    // signals wire-format drift or corrupted plaintext.
     if magnitude.len() > DECIMAL_MAGNITUDE_BYTES {
         return Err(Error::ColumnEncryptionError(format!(
             "Invalid decimal magnitude length {} (max {DECIMAL_MAGNITUDE_BYTES} bytes for \
@@ -362,26 +361,20 @@ fn read_decimal(bytes: &[u8], base_type_info: &TypeInfo) -> TdsResult<DecimalPar
 
     // Reference AE readers are length-tolerant: .NET reads `length >> 2` 32-bit
     // groups and ignores any trailing partial group, and JDBC uses the actual
-    // length (its bulk-copy path writes a 15-byte magnitude). We zero-pad a
-    // short trailing group into a full 32-bit word rather than rejecting it, and
-    // — unlike .NET — we preserve those trailing bytes instead of dropping them,
-    // so no significant magnitude bits are lost. This lets us read magnitudes
-    // produced by every reference driver.
-    let int_parts = magnitude
-        .chunks(4)
-        .map(|chunk| {
-            let mut word = [0u8; 4];
-            word[..chunk.len()].copy_from_slice(chunk);
-            i32::from_le_bytes(word)
-        })
-        .collect();
+    // length (its bulk-copy path writes a 15-byte magnitude). Zero-filling the
+    // fixed-width buffer pads a short trailing group into a full 32-bit word
+    // rather than rejecting it and — unlike .NET — preserves those trailing
+    // bytes instead of dropping them, so no significant magnitude bits are lost.
+    // This lets us read magnitudes produced by every reference driver.
+    let mut bytes = [0u8; DECIMAL_MAGNITUDE_BYTES];
+    bytes[..magnitude.len()].copy_from_slice(magnitude);
 
-    Ok(DecimalParts {
-        is_positive: *sign == 1,
-        scale,
+    Ok(DecimalParts::new(
+        *sign == 1,
         precision,
-        int_parts,
-    })
+        scale,
+        u128::from_le_bytes(bytes),
+    ))
 }
 
 /// Determines the encoding for an encrypted character column from its base type.
@@ -754,23 +747,7 @@ fn normalize_small_money(m: &SqlSmallMoney) -> Vec<u8> {
 fn normalize_decimal(d: &DecimalParts) -> Vec<u8> {
     let mut out = Vec::with_capacity(DECIMAL_NORMALIZED_LEN);
     out.push(u8::from(d.is_positive));
-    // A valid decimal/numeric magnitude (precision <= 38) fits in four 32-bit
-    // words, so any words beyond the first four are zero. Emitting only the
-    // first four therefore never loses data for a valid value; assert that
-    // invariant in debug/test builds so a malformed `DecimalParts` (e.g. built
-    // for a > 38-digit value) is caught here rather than silently truncated into
-    // wrong ciphertext. The reader rejects the oversized case at runtime.
-    debug_assert!(
-        d.int_parts
-            .get(DECIMAL_MAGNITUDE_WORDS..)
-            .is_none_or(|extra| extra.iter().all(|&word| word == 0)),
-        "decimal magnitude exceeds 128 bits (precision <= 38): {:?}",
-        d.int_parts
-    );
-    for i in 0..DECIMAL_MAGNITUDE_WORDS {
-        let word = d.int_parts.get(i).copied().unwrap_or(0);
-        out.extend_from_slice(&word.to_le_bytes());
-    }
+    out.extend_from_slice(&d.magnitude().to_le_bytes());
     out
 }
 
@@ -1014,7 +991,7 @@ mod tests {
                 assert!(parts.is_positive);
                 assert_eq!(parts.scale, 2);
                 assert_eq!(parts.precision, 5);
-                assert_eq!(parts.int_parts, vec![12345]);
+                assert_eq!(parts.magnitude(), 12345);
             }
             other => panic!("expected Decimal, got {other:?}"),
         }
@@ -1302,12 +1279,7 @@ mod tests {
         // The magnitude is emitted as a fixed 16-byte (four 32-bit words),
         // zero-extended form, so two significant words are followed by two zero
         // words. Total length is 1 sign byte + 16 magnitude bytes = 17.
-        let d = DecimalParts {
-            is_positive: false,
-            scale: 2,
-            precision: 10,
-            int_parts: vec![1, 2],
-        };
+        let d = DecimalParts::new(false, 10, 2, 1 | (2 << 32));
         let mut expected = vec![0u8];
         expected.extend_from_slice(&1i32.to_le_bytes());
         expected.extend_from_slice(&2i32.to_le_bytes());
@@ -1323,12 +1295,7 @@ mod tests {
         // A value that needs only one 32-bit word must still be emitted as the
         // canonical 17-byte form (sign + four words) so deterministic ciphertext
         // matches .NET/msodbcsql, which always zero-extend to 16 magnitude bytes.
-        let d = DecimalParts {
-            is_positive: true,
-            scale: 2,
-            precision: 5,
-            int_parts: vec![12345],
-        };
+        let d = DecimalParts::new(true, 5, 2, 12345);
         let mut expected = vec![1u8];
         expected.extend_from_slice(&12345i32.to_le_bytes());
         expected.extend_from_slice(&0i32.to_le_bytes());
@@ -1338,22 +1305,6 @@ mod tests {
             normalize(&SqlType::Numeric(Some(d))).unwrap().unwrap(),
             expected
         );
-    }
-
-    #[test]
-    #[cfg(debug_assertions)]
-    #[should_panic(expected = "decimal magnitude exceeds 128 bits")]
-    fn normalize_decimal_asserts_bounded_magnitude() {
-        // A malformed DecimalParts carrying a non-zero word beyond the 128-bit
-        // limit must trip the debug-only invariant check rather than silently
-        // truncating into wrong ciphertext.
-        let d = DecimalParts {
-            is_positive: true,
-            scale: 0,
-            precision: 38,
-            int_parts: vec![0, 0, 0, 0, 1],
-        };
-        let _ = normalize(&SqlType::Decimal(Some(d)));
     }
 
     #[test]
@@ -1383,8 +1334,8 @@ mod tests {
     #[test]
     fn read_decimal_rejects_oversized_magnitude() {
         // A valid decimal magnitude is at most 16 bytes (128 bits). A longer
-        // magnitude must be rejected rather than allocating an unbounded
-        // `int_parts`.
+        // magnitude must be rejected rather than silently dropping the bytes
+        // that do not fit.
         let info = type_info(
             TdsDataType::DecimalN,
             5,
@@ -1400,12 +1351,7 @@ mod tests {
     fn normalize_then_read_decimal_roundtrips() {
         // The fixed-width write form must read back to the same value through the
         // (now length-tolerant) reader.
-        let d = DecimalParts {
-            is_positive: false,
-            scale: 3,
-            precision: 12,
-            int_parts: vec![987654],
-        };
+        let d = DecimalParts::new(false, 12, 3, 987654);
         let normalized = normalize(&SqlType::Decimal(Some(d))).unwrap().unwrap();
         let info = type_info(
             TdsDataType::DecimalN,

--- a/mssql-tds/tests/test_always_encrypted.rs
+++ b/mssql-tds/tests/test_always_encrypted.rs
@@ -463,16 +463,11 @@ mod always_encrypted {
     async fn roundtrip_decimal_and_money_types() {
         ae_test!(|h| {
             // 1234.5678 as decimal(18,4).
-            let decimal = DecimalParts {
-                is_positive: true,
-                int_parts: vec![12_345_678],
-                scale: 4,
-                precision: 18,
-            };
+            let decimal = DecimalParts::new(true, 18, 4, 12345678);
             h.roundtrip(
                 "DECIMAL(18,4)",
                 "DETERMINISTIC",
-                SqlType::Decimal(Some(decimal.clone())),
+                SqlType::Decimal(Some(decimal)),
                 |v| match v {
                     ColumnValues::Decimal(value) => assert_eq!(value, &decimal),
                     other => panic!("expected decimal, got {other:?}"),
@@ -480,16 +475,11 @@ mod always_encrypted {
             )
             .await;
 
-            let numeric = DecimalParts {
-                is_positive: false,
-                int_parts: vec![98_765],
-                scale: 2,
-                precision: 12,
-            };
+            let numeric = DecimalParts::new(false, 12, 2, 98765);
             h.roundtrip(
                 "NUMERIC(12,2)",
                 "DETERMINISTIC",
-                SqlType::Numeric(Some(numeric.clone())),
+                SqlType::Numeric(Some(numeric)),
                 |v| match v {
                     ColumnValues::Numeric(value) => assert_eq!(value, &numeric),
                     other => panic!("expected numeric, got {other:?}"),
@@ -1789,18 +1779,13 @@ mod always_encrypted {
             assert_eq!(rows[0][0], ColumnValues::BigInt(9_000_000_000_000_i64));
 
             // decimal(18,4) round-trip (1234.5678).
-            let decimal = DecimalParts {
-                is_positive: true,
-                int_parts: vec![12_345_678],
-                scale: 4,
-                precision: 18,
-            };
+            let decimal = DecimalParts::new(true, 18, 4, 12345678);
             let table = h
                 .bulk_copy_vals(
                     "DECIMAL(18,4)",
                     "DETERMINISTIC",
                     "NOT NULL",
-                    vec![ColumnValues::Decimal(decimal.clone())],
+                    vec![ColumnValues::Decimal(decimal)],
                 )
                 .await;
             let rows = h

--- a/mssql-tds/tests/test_bulk_copy_variant.rs
+++ b/mssql-tds/tests/test_bulk_copy_variant.rs
@@ -272,28 +272,18 @@ mod bulk_copy_variant_tests {
             .await
             .unwrap();
 
-        let decimal_val = DecimalParts {
-            precision: 18,
-            scale: 2,
-            is_positive: true,
-            int_parts: vec![123456],
-        };
+        let decimal_val = DecimalParts::new(true, 18, 2, 123456);
 
-        let numeric_val = DecimalParts {
-            precision: 10,
-            scale: 3,
-            is_positive: false,
-            int_parts: vec![987654],
-        };
+        let numeric_val = DecimalParts::new(false, 10, 3, 987654);
 
         let rows = vec![
             VariantRow {
                 id: 1,
-                variant_col: ColumnValues::Decimal(decimal_val.clone()),
+                variant_col: ColumnValues::Decimal(decimal_val),
             },
             VariantRow {
                 id: 2,
-                variant_col: ColumnValues::Numeric(numeric_val.clone()),
+                variant_col: ColumnValues::Numeric(numeric_val),
             },
         ];
 
@@ -328,8 +318,7 @@ mod bulk_copy_variant_tests {
                             assert_eq!(dec.precision, decimal_val.precision);
                             assert_eq!(dec.scale, decimal_val.scale);
                             assert_eq!(dec.is_positive, decimal_val.is_positive);
-                            // SQL Server may pad with zeros, so just check first element
-                            assert_eq!(dec.int_parts[0], decimal_val.int_parts[0]);
+                            assert_eq!(dec.magnitude(), decimal_val.magnitude());
                         } else {
                             panic!("Expected Decimal, got {:?}", row[1]);
                         }
@@ -339,8 +328,7 @@ mod bulk_copy_variant_tests {
                             assert_eq!(num.precision, numeric_val.precision);
                             assert_eq!(num.scale, numeric_val.scale);
                             assert_eq!(num.is_positive, numeric_val.is_positive);
-                            // SQL Server may pad with zeros, so just check first element
-                            assert_eq!(num.int_parts[0], numeric_val.int_parts[0]);
+                            assert_eq!(num.magnitude(), numeric_val.magnitude());
                         } else {
                             panic!("Expected Numeric, got {:?}", row[1]);
                         }
@@ -769,32 +757,22 @@ mod bulk_copy_variant_tests {
             // Decimal with zero
             VariantRow {
                 id: 14,
-                variant_col: ColumnValues::Decimal(DecimalParts {
-                    precision: 18,
-                    scale: 2,
-                    is_positive: true,
-                    int_parts: vec![0],
-                }),
+                variant_col: ColumnValues::Decimal(DecimalParts::new(true, 18, 2, 0)),
             },
             // Negative decimal
             VariantRow {
                 id: 15,
-                variant_col: ColumnValues::Decimal(DecimalParts {
-                    precision: 18,
-                    scale: 4,
-                    is_positive: false,
-                    int_parts: vec![999999],
-                }),
+                variant_col: ColumnValues::Decimal(DecimalParts::new(false, 18, 4, 999999)),
             },
             // High precision decimal
             VariantRow {
                 id: 16,
-                variant_col: ColumnValues::Decimal(DecimalParts {
-                    precision: 38,
-                    scale: 10,
-                    is_positive: true,
-                    int_parts: vec![i32::MAX, i32::MAX],
-                }),
+                variant_col: ColumnValues::Decimal(DecimalParts::new(
+                    true,
+                    38,
+                    10,
+                    9223372034707292159,
+                )),
             },
             // Date edge cases
             VariantRow {

--- a/mssql-tds/tests/test_rpc_datatypes.rs
+++ b/mssql-tds/tests/test_rpc_datatypes.rs
@@ -50,12 +50,7 @@ mod rpc_datatypes {
 
         let guid = "123e4567-e89b-12d3-a456-426614174000".to_string();
 
-        let decimal = DecimalParts {
-            is_positive: true,
-            int_parts: vec![-123, 0, 0, 0],
-            scale: 38,
-            precision: 38,
-        };
+        let decimal = DecimalParts::new(true, 38, 38, 4294967173);
 
         let columns = vec![
             ("int", SqlType::Int(Some(int_value))),
@@ -108,8 +103,8 @@ mod rpc_datatypes {
                 })),
             ),
             ("guid", SqlType::Uuid(Some(Uuid::from_str(&guid).unwrap()))),
-            ("decimal", SqlType::Decimal(Some(decimal.clone()))),
-            ("numeric", SqlType::Numeric(Some(decimal.clone()))),
+            ("decimal", SqlType::Decimal(Some(decimal))),
+            ("numeric", SqlType::Numeric(Some(decimal))),
             (
                 "smallmoney",
                 SqlType::SmallMoney(Some(SqlSmallMoney { int_val: 12345 })),

--- a/mssql-tds/tests/test_rpc_results.rs
+++ b/mssql-tds/tests/test_rpc_results.rs
@@ -420,7 +420,7 @@ mod rpc_results {
         let insert_params = vec![
             make_param("@nvc", SqlType::NVarchar(Some(nvc_val.clone()), 50)),
             make_param("@nvm", SqlType::NVarcharMax(Some(nvm_val.clone()))),
-            make_param("@amt", SqlType::Decimal(Some(amt_val.clone()))),
+            make_param("@amt", SqlType::Decimal(Some(amt_val))),
             make_param("@dt2", SqlType::DateTime2(Some(dt2_val.clone()))),
             make_param("@t", SqlType::Time(Some(t_val.clone()))),
             make_param("@uid", SqlType::Uuid(Some(uid_val))),
@@ -447,7 +447,7 @@ mod rpc_results {
         let cases: Vec<(&str, &str, SqlType)> = vec![
             ("nvc", "@nvc", SqlType::NVarchar(Some(nvc_val.clone()), 50)),
             ("nvm", "@nvm", SqlType::NVarcharMax(Some(nvm_val.clone()))),
-            ("amt", "@amt", SqlType::Decimal(Some(amt_val.clone()))),
+            ("amt", "@amt", SqlType::Decimal(Some(amt_val))),
             ("dt2", "@dt2", SqlType::DateTime2(Some(dt2_val.clone()))),
             ("t", "@t", SqlType::Time(Some(t_val.clone()))),
             ("uid", "@uid", SqlType::Uuid(Some(uid_val))),

--- a/mssql-tds/tests/test_tvp.rs
+++ b/mssql-tds/tests/test_tvp.rs
@@ -328,7 +328,7 @@ mod tvp_tests {
                     SqlType::NVarchar(Some(SqlString::from_utf8_string("widget".to_string())), 50),
                     SqlType::BigInt(Some(9_000_000_000)),
                     SqlType::Bit(Some(true)),
-                    SqlType::Decimal(Some(amount.clone())),
+                    SqlType::Decimal(Some(amount)),
                     SqlType::DateTime2(Some(when.clone())),
                     SqlType::VarBinary(Some(data.clone()), 64),
                     SqlType::Uuid(Some(guid)),
@@ -462,7 +462,7 @@ mod tvp_tests {
                         SqlType::Bit(Some(true)),
                         SqlType::DateTime2(Some(dt2.clone())),
                         SqlType::Uuid(Some(guid1)),
-                        SqlType::Decimal(Some(dec.clone())),
+                        SqlType::Decimal(Some(dec)),
                         nvarchar("hello", 50),
                         SqlType::VarBinary(Some(vec![0x01, 0x02, 0x03]), 32),
                     ],
@@ -683,7 +683,7 @@ mod tvp_tests {
                         vec![
                             SqlType::Int(Some((i as i32) + 1)),
                             nvarchar(names[i], 50),
-                            SqlType::Decimal(Some(amounts[i].clone())),
+                            SqlType::Decimal(Some(amounts[i])),
                             SqlType::VarBinary(Some(blobs[i].clone()), 64),
                         ]
                     })
@@ -807,7 +807,7 @@ mod tvp_tests {
                     SqlType::Time(Some(time.clone())),
                     SqlType::DateTimeOffset(Some(dto.clone())),
                     SqlType::DateTime(Some(dt.clone())),
-                    SqlType::Numeric(Some(numeric.clone())),
+                    SqlType::Numeric(Some(numeric)),
                     SqlType::Varchar(Some(SqlString::from_utf8_string("hello".to_string())), 20),
                     SqlType::Char(Some(SqlString::from_utf8_string("world".to_string())), 5),
                 ]];


### PR DESCRIPTION
## Description

Every decoded `decimal`/`numeric` cost two heap allocations in `read_decimal_data` — a staging `Vec<u8>` plus a `Vec<i32>` of words — to move at most 16 bytes already sitting in the packet buffer. The only lossless way to read the value back out was `Display`, which allocated a `String` for the digits and more for the point and sign.

`MAX_DECIMAL_INT_PARTS = 4` already encodes that a precision ≤ 38 magnitude is < 10³⁸ < 2¹²⁷, so this carries it inline instead. **Output is byte-for-byte identical at every step**; only the representation and the allocations change.

- `DecimalParts` is `Copy` and holds the magnitude inline. `new(is_positive, precision, scale, magnitude: u128)` and `magnitude() -> u128` replace the `int_parts` field.
- `read_decimal_data` decodes into a `[u8; 16]` on the stack and reassembles with `u128::from_le_bytes`.
- `format_into(&mut [u8; DECIMAL_STR_LEN]) -> &str` renders into a caller-owned buffer. `Display` and `to_decimal_string` are thin wrappers over it.
- `word(i)` / `word_count()` / `from_words(..)` give wire encoders the little-endian 32-bit view they need; `try_from_words(..)` lets trust-boundary callers reject magnitudes wider than 128 bits.

The consumer driving this is a PostgreSQL FDW (`pg_fabric_fdw`) whose `numeric` path is currently integer → text → integer: we flatten to a `String`, it hands that to PostgreSQL's `numeric_in` to parse back into a positional integer. This layer removes the allocations and the mandatory text round trip; the follow-up that lets a consumer skip `numeric_in` entirely is scoped below.

### Two design points worth flagging

**The magnitude is stored as `[u64; 2]`, not a `u128`.** A `u128` field would give `DecimalParts` — and through it `ColumnValues` — 16-byte alignment, which propagates into the row-fetch async state machines and grew `next_row_cursor` by 176 B. As two halves the struct is **24 B at align 8**, against 32 B at align 16, so it is 8 B *smaller* than the `Vec`-based original and the row-fetch futures are byte-for-byte unchanged. `magnitude()` is one shift and one or.

**`format_into` generates every digit with `u64` arithmetic.** A `u128 % 10` loop emits a `__udivti3` libcall per digit and loses to `u128::to_string` on wide values. The magnitude is split into limbs of 10¹⁹ — at most two `u128` divisions, none at all when it already fits a `u64`. **Three** limbs, not two: a `u128` reaches 39 digits, and a two-limb split silently truncates above ~1.845e38. That bug was live in the reference kernel this was modelled on and was caught here only because the test oracle shares no arithmetic with the code it validates.

### Removed API

`magnitude() -> Option<u128>` and `magnitude_big() -> BigUint` are gone — with the new representation their `None` and `BigUint` arms are unreachable by construction. That also removes an `mssql-odbc` conversion branch and a `cell.rs` debug assertion whose inputs can no longer be built. `bigdecimal`/`num-traits` are no longer used on the decode path.

## Results

Criterion, `mssql-tds/benches/decimal.rs`, ns per value. `previous` is the pre-change shape reproduced locally in the bench and cross-validated against the current one before timing. `fdw` is the four numeric columns of the FDW benchmark table (`decimal(15,2)` ×2, `decimal(18,3)`, `decimal(19,4)`); `wide` is `decimal(38,10)` near 10³⁸.

| workload | previous | current | speedup |
| --- | ---: | ---: | ---: |
| decode `fdw` | 34.75 | **4.19** | **8.3x** |
| decode `wide` | 40.09 | **4.18** | **9.6x** |
| format `fdw` — `format_into` | 83.15 | **17.05** | **4.9x** |
| format `fdw` — `to_decimal_string` | 83.15 | 30.46 | 2.7x |
| format `fdw` — `Display` | 83.15 | 42.42 | 2.0x |
| format `wide` — `format_into` | 155.89 | **88.33** | **1.8x** |
| format `wide` — `to_decimal_string` | 155.89 | 106.33 | 1.5x |
| format `wide` — `Display` | 155.89 | 121.33 | 1.3x |

`Display` stays the slowest reading because it still pays for `fmt::Formatter`; callers that can hold a buffer should use `format_into`.

## Correctness

Output equality is the whole requirement, so it is tested against an oracle that is the **verbatim pre-change algorithm** (`u128::to_string()` + index splice + sign `format!`). It shares no arithmetic with the kernel, which is exactly why it caught the three-limb bug.

- Exhaustive magnitudes 0..=4096 × scales 0..=6, both signs.
- Every 10ᵏ and 10ᵏ−1 for k = 1..=38, plus `u128::MAX`, against every scale 0..=38.
- 20 000 seeded randomized magnitudes (1–128 bits) × random scales, both signs.
- Precision 1..=38 with every valid scale.
- Negative zero, zero with scale, magnitude narrower than scale.
- An out-of-domain `scale` (it arrives unvalidated from the wire) renders short instead of overrunning: worst case is exactly 48 bytes, so the `DECIMAL_STR_LEN - 3` clamp is tight rather than generous.
- Decode: wire widths 5/9/13/17 reassemble the same magnitude, negative sign byte, partial trailing word fully consumed, oversized payload rejected.
- JS FFI: non-zero words past the fourth are rejected rather than silently truncated; trailing zero padding remains accepted.

## Deferred

- **Base-10000 digit export**, so an FDW can build a PG `numeric` directly and skip `numeric_in`. That is the ~800 ms of the measured gap that this layer only unblocks rather than collects. **Trap for whoever picks it up:** do not pre-multiply the magnitude by `10^pad`. For `decimal(38,s)` with `s % 4 != 0` the magnitude reaches 10³⁸−1, and ×100 exceeds `u128::MAX` and wraps silently in release. Convert to base-10000 first, then scale the digit array with carry propagation.
- **Sync-first byte-run reads** on the decimal path — overlaps the sync-first work in #303–#307.

## Related Issues

Fixes #312

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] Targeted decimal unit tests pass (72 tests)
- [x] New/changed functionality has tests
- [x] Public API changes are documented

`mssql-js` builds and `index.d.ts` is unchanged, so the FFI surface is stable.