### PR TITLE
Allow re-execute after SQLFetch reaches SQL_NO_DATA

### DIFF
--- a/mssql-odbc/src/api/close_cursor.rs
+++ b/mssql-odbc/src/api/close_cursor.rs
@@ -14,7 +14,9 @@ use crate::api::odbc_types::{
     SQL_ERROR, SQL_INVALID_HANDLE, SQL_SUCCESS, SQL_SUCCESS_WITH_INFO, SqlHandle, SqlReturn,
 };
 use crate::error::free_errors;
-use crate::handles::stmt::{STMT_STATE_CURSOR_OPEN, STMT_STATE_EXEC_CONTEXT};
+use crate::handles::stmt::{
+    STMT_STATE_CURSOR_EXHAUSTED, STMT_STATE_CURSOR_OPEN, STMT_STATE_EXEC_CONTEXT,
+};
 use crate::handles::{HandleType, StmtHandle, handle_from_raw};
 
 /// Closes the cursor on `statement_handle` and discards any pending rows.
@@ -58,21 +60,20 @@ unsafe fn sql_close_cursor_impl(statement_handle: SqlHandle) -> SqlReturn {
 }
 
 fn sql_close_cursor_safe(statement_handle: SqlHandle, stmt: &StmtHandle) -> SqlReturn {
-    let Ok(mut stmt_state) = stmt.inner.lock() else {
-        error!("SQLCloseCursor: stmt mutex poisoned");
-        return SQL_ERROR;
-    };
-    free_errors(&mut stmt_state);
-    if !stmt_state.has_state(STMT_STATE_CURSOR_OPEN) {
-        error!("SQLCloseCursor: no cursor is open — SQLSTATE 24000");
-        post_diag(&mut stmt_state, ERR_INVALID_CURSOR_STATE);
-        return SQL_ERROR;
+    {
+        let Ok(mut stmt_state) = stmt.inner.lock() else {
+            error!("SQLCloseCursor: stmt mutex poisoned");
+            return SQL_ERROR;
+        };
+        free_errors(&mut stmt_state);
+        if !stmt_state.has_state(STMT_STATE_CURSOR_OPEN) {
+            error!("SQLCloseCursor: no cursor is open — SQLSTATE 24000");
+            post_diag(&mut stmt_state, ERR_INVALID_CURSOR_STATE);
+            return SQL_ERROR;
+        }
     }
 
-    reset_cursor_state(&mut stmt_state);
-    drop(stmt_state);
-
-    match drain_and_release(stmt, statement_handle) {
+    match close_open_cursor(stmt, statement_handle) {
         DrainOutcome::Failed => {
             error!("SQLCloseCursor: failed to drain TDS stream on close");
             SQL_ERROR
@@ -99,20 +100,19 @@ unsafe fn sql_free_stmt_close_impl(statement_handle: SqlHandle) -> SqlReturn {
 }
 
 fn sql_free_stmt_close_safe(statement_handle: SqlHandle, stmt: &StmtHandle) -> SqlReturn {
-    let Ok(mut stmt_state) = stmt.inner.lock() else {
-        error!("SQLFreeStmt(SQL_CLOSE): stmt mutex poisoned");
-        return SQL_ERROR;
-    };
-    free_errors(&mut stmt_state);
-    // No-op if cursor is already closed.
-    if !stmt_state.has_state(STMT_STATE_CURSOR_OPEN) {
-        return SQL_SUCCESS;
+    {
+        let Ok(mut stmt_state) = stmt.inner.lock() else {
+            error!("SQLFreeStmt(SQL_CLOSE): stmt mutex poisoned");
+            return SQL_ERROR;
+        };
+        free_errors(&mut stmt_state);
+        // No-op if cursor is already closed.
+        if !stmt_state.has_state(STMT_STATE_CURSOR_OPEN) {
+            return SQL_SUCCESS;
+        }
     }
 
-    reset_cursor_state(&mut stmt_state);
-    drop(stmt_state);
-
-    match drain_and_release(stmt, statement_handle) {
+    match close_open_cursor(stmt, statement_handle) {
         DrainOutcome::Failed => {
             error!("SQLFreeStmt(SQL_CLOSE): failed to drain TDS stream on close");
             SQL_ERROR
@@ -166,10 +166,43 @@ pub(super) fn close_cursor_for_connection_op(stmt: &StmtHandle, handle: SqlHandl
 
 /// Resets cursor state on the statement (cursor is no longer open, metadata cleared).
 pub(super) fn reset_cursor_state(stmt_state: &mut crate::handles::stmt::StmtState) {
-    stmt_state.clear_state(STMT_STATE_CURSOR_OPEN | STMT_STATE_EXEC_CONTEXT);
+    stmt_state.clear_state(
+        STMT_STATE_CURSOR_OPEN | STMT_STATE_EXEC_CONTEXT | STMT_STATE_CURSOR_EXHAUSTED,
+    );
     stmt_state.reset_row_stream();
     stmt_state.column_metadata.clear();
     stmt_state.pending_row_counts.clear();
+}
+
+/// Shared tail of every cursor close: reset the statement's cursor state, then
+/// drain the TDS stream and release the connection. Used by `SQLCloseCursor`,
+/// `SQLFreeStmt(SQL_CLOSE)`, and the implicit close on re-execute; each caller
+/// keeps its own "no cursor open" handling and `DrainOutcome` → `SqlReturn`
+/// mapping.
+pub(super) fn close_open_cursor(stmt: &StmtHandle, statement_handle: SqlHandle) -> DrainOutcome {
+    if let Ok(mut stmt_state) = stmt.inner.lock() {
+        reset_cursor_state(&mut stmt_state);
+    }
+    drain_and_release(stmt, statement_handle)
+}
+
+/// If the statement's cursor is open but its whole batch has been consumed
+/// (`SQLFetch` returned `SQL_NO_DATA` on the final result set), implicitly close
+/// it via the shared close path so a re-execute (`SQLExecute` / `SQLExecDirect`)
+/// starts from a clean cursor state. A cursor with un-read rows or still-pending
+/// result sets is left untouched, so the caller's 24000 guard still rejects that
+/// re-execute — msodbcsql only allows re-execute once the batch is fully read.
+pub(super) fn implicit_cursor_close_if_exhausted(stmt: &StmtHandle, statement_handle: SqlHandle) {
+    {
+        let Ok(stmt_state) = stmt.inner.lock() else {
+            error!("implicit cursor close: stmt mutex poisoned checking cursor state");
+            return;
+        };
+        if !stmt_state.cursor_is_exhausted() {
+            return;
+        }
+    }
+    close_open_cursor(stmt, statement_handle);
 }
 
 /// Outcome of draining the TDS stream and releasing the connection on cursor close.
@@ -295,5 +328,86 @@ mod tests {
         // No execute has been called — cursor_open is false; SQL_CLOSE is a no-op.
         let ret = unsafe { sql_free_stmt_close(h.stmt) };
         assert_eq!(ret, SQL_SUCCESS);
+    }
+
+    // A cursor that fetched to end-of-batch (CURSOR_OPEN + CURSOR_EXHAUSTED) is
+    // implicitly closed: state cleared, wire drained, connection released — the
+    // precondition that lets SQLExecute / SQLExecDirect re-run without 24000.
+    #[test]
+    fn implicit_close_closes_exhausted_cursor() {
+        use crate::handles::dbc::DbcHandle;
+        use mssql_tds::test_client_support::{done_no_more, tds_client_from_tokens};
+
+        let h = TestHandles::with_env_dbc_stmt();
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        {
+            let mut ss = stmt.inner.lock().unwrap();
+            ss.set_state(STMT_STATE_CURSOR_OPEN | STMT_STATE_CURSOR_EXHAUSTED);
+        }
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        {
+            let mut ds = dbc.inner.lock().unwrap();
+            ds.client = Some(tds_client_from_tokens(vec![done_no_more()]));
+            ds.active_stmt = Some(h.stmt);
+        }
+
+        implicit_cursor_close_if_exhausted(stmt, h.stmt);
+
+        let ss = stmt.inner.lock().unwrap();
+        assert!(!ss.has_state(STMT_STATE_CURSOR_OPEN));
+        assert!(!ss.has_state(STMT_STATE_CURSOR_EXHAUSTED));
+        drop(ss);
+        let ds = dbc.inner.lock().unwrap();
+        assert!(ds.client.is_some(), "client restored after drain");
+        assert_eq!(ds.active_stmt, None, "busy claim released");
+    }
+
+    // A cursor that is open but NOT exhausted (rows or result sets still pending)
+    // is left untouched, so the caller's 24000 guard still fires.
+    #[test]
+    fn implicit_close_noop_when_not_exhausted() {
+        use crate::handles::dbc::DbcHandle;
+        use mssql_tds::test_client_support::{done_no_more, tds_client_from_tokens};
+
+        let h = TestHandles::with_env_dbc_stmt();
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        {
+            let mut ss = stmt.inner.lock().unwrap();
+            ss.set_state(STMT_STATE_CURSOR_OPEN);
+        }
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        {
+            let mut ds = dbc.inner.lock().unwrap();
+            ds.client = Some(tds_client_from_tokens(vec![done_no_more()]));
+            ds.active_stmt = Some(h.stmt);
+        }
+
+        implicit_cursor_close_if_exhausted(stmt, h.stmt);
+
+        let ss = stmt.inner.lock().unwrap();
+        assert!(ss.has_state(STMT_STATE_CURSOR_OPEN), "cursor left open");
+        drop(ss);
+        let ds = dbc.inner.lock().unwrap();
+        assert_eq!(ds.active_stmt, Some(h.stmt), "connection still busy");
+    }
+
+    #[test]
+    fn cursor_is_exhausted_requires_both_open_and_exhausted() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        let mut ss = stmt.inner.lock().unwrap();
+
+        ss.set_state(STMT_STATE_CURSOR_OPEN);
+        assert!(!ss.cursor_is_exhausted(), "open alone is not exhausted");
+
+        ss.clear_state(STMT_STATE_CURSOR_OPEN);
+        ss.set_state(STMT_STATE_CURSOR_EXHAUSTED);
+        assert!(
+            !ss.cursor_is_exhausted(),
+            "exhausted flag without open is not exhausted"
+        );
+
+        ss.set_state(STMT_STATE_CURSOR_OPEN);
+        assert!(ss.cursor_is_exhausted(), "both bits set");
     }
 }

--- a/mssql-odbc/src/api/exec_direct.rs
+++ b/mssql-odbc/src/api/exec_direct.rs
@@ -82,6 +82,10 @@ fn sql_exec_direct_w_safe(
 
     let dbc = stmt.parent_dbc();
 
+    // msodbcsql parity: implicitly close a fully-consumed cursor so a re-execute
+    // on this handle is allowed instead of hitting the 24000 guard below.
+    super::close_cursor::implicit_cursor_close_if_exhausted(stmt, statement_handle);
+
     // Check STMT state, gather parameter values, and reset prior context.
     let (named_params, rewritten_sql, marker_count) = {
         let Ok(mut stmt_state) = stmt.inner.lock() else {

--- a/mssql-odbc/src/api/execute.rs
+++ b/mssql-odbc/src/api/execute.rs
@@ -58,6 +58,10 @@ struct Execution {
 fn sql_execute_safe(statement_handle: SqlHandle, stmt: &StmtHandle) -> SqlReturn {
     let dbc = stmt.parent_dbc();
 
+    // msodbcsql parity: implicitly close a fully-consumed cursor so a re-execute
+    // on this handle is allowed instead of hitting the 24000 guard below.
+    super::close_cursor::implicit_cursor_close_if_exhausted(stmt, statement_handle);
+
     let Execution {
         named_params,
         mut prepared,

--- a/mssql-odbc/src/api/fetch.rs
+++ b/mssql-odbc/src/api/fetch.rs
@@ -11,7 +11,7 @@ use crate::api::odbc_types::{
     SqlReturn,
 };
 use crate::error::free_errors;
-use crate::handles::stmt::STMT_STATE_CURSOR_OPEN;
+use crate::handles::stmt::{STMT_STATE_CURSOR_EXHAUSTED, STMT_STATE_CURSOR_OPEN};
 use crate::handles::{HandleType, StmtHandle, handle_from_raw};
 
 /// Implements SQLFetch for the current forward-only result set.
@@ -169,35 +169,20 @@ fn fetch_rows_next(statement_handle: SqlHandle, stmt: &StmtHandle) -> SqlReturn 
             }
         }
         Ok(false) => {
-            // End of current rowset. SQLFetch must return SQL_NO_DATA here per the
-            // cursor contract, and SQL_NO_DATA cannot be upgraded to
-            // SQL_SUCCESS_WITH_INFO — so this call has no way to signal "there are
-            // diagnostic records worth reading", and many applications only pump
-            // diagnostics after SQL_SUCCESS_WITH_INFO or SQL_ERROR.
+            // End of current rowset — return SQL_NO_DATA. That code can't be
+            // upgraded to SQL_SUCCESS_WITH_INFO, so any INFO captured reaching
+            // this DONE is left on the client's buffer (nothing resets it) and
+            // surfaced by the next call that can carry it — SQLMoreResults or
+            // SQLCloseCursor/SQLFreeStmt(SQL_CLOSE); nothing is lost.
             //
-            // Therefore any INFO captured while reaching this DONE (e.g. a warning
-            // emitted after the last row but before the result set's DONE) is
-            // intentionally LEFT on the client's info buffer instead of being
-            // posted here under SQL_NO_DATA. It is surfaced — with a return-code
-            // hint — by whichever call the application makes next:
-            //   * SQLMoreResults advancing to a further result set returns
-            //     SQL_SUCCESS_WITH_INFO (its Ok(true) arm), or
-            //   * SQLCloseCursor / SQLFreeStmt(SQL_CLOSE) returns
-            //     SQL_SUCCESS_WITH_INFO (DrainOutcome::InfoPosted).
-            // Neither `move_to_column_metadata`/`move_to_next` nor `close_query`
-            // resets the info buffer, so nothing is lost by deferring; the
-            // messages are simply attributed to the call that reports on the
-            // batch boundary, mirroring msodbcsql's between-result surfacing.
+            // Don't drain the rest of the batch: the cursor stays open (and
+            // active_stmt set) so the app can advance with SQLMoreResults.
             //
-            // (If the batch has no further result set and the application calls
-            // SQLMoreResults rather than closing the cursor, that call also
-            // returns SQL_NO_DATA — an unavoidable consequence of the ODBC
-            // contract, not message loss: the records are still posted there.)
-            //
-            // Do NOT drain the rest of the batch here either: the application may
-            // call SQLMoreResults to advance to a subsequent result set. Cursor
-            // stays open; active_stmt stays set so the connection remains "busy"
-            // with this statement.
+            // If this was the batch's final result set (terminating DONE had no
+            // more-results flag), mark the cursor exhausted so a re-execute can
+            // implicitly close it (msodbcsql parity); if result sets are still
+            // pending, leave it unset so a re-execute returns 24000.
+            let batch_done = !client.has_open_batch();
             let Ok(mut stmt_state) = stmt.inner.lock() else {
                 error!("SQLFetch: stmt mutex poisoned at end of rowset");
                 if let Ok(mut ds) = dbc.inner.lock() {
@@ -208,6 +193,9 @@ fn fetch_rows_next(statement_handle: SqlHandle, stmt: &StmtHandle) -> SqlReturn 
             stmt_state.reset_row_stream();
             // Don't clear CURSOR_OPEN here: the cursor stays open until
             // SQLMoreResults / SQLCloseCursor / SQLFreeStmt(SQL_CLOSE).
+            if batch_done {
+                stmt_state.set_state(STMT_STATE_CURSOR_EXHAUSTED);
+            }
             drop(stmt_state);
             if let Ok(mut dbc_state) = dbc.inner.lock() {
                 dbc_state.client = Some(client);

--- a/mssql-odbc/src/handles/stmt.rs
+++ b/mssql-odbc/src/handles/stmt.rs
@@ -37,6 +37,14 @@ pub(crate) const STMT_STATE_EXEC_STARTED: u32 = 0x0000_0100;
 pub(crate) const STMT_STATE_PREPARED: u32 = 0x0000_0200;
 pub(crate) const STMT_STATE_CURSOR_OPEN: u32 = 0x0000_0800;
 pub(crate) const STMT_STATE_EXEC_CONTEXT: u32 = 0x0000_1000;
+/// Set once `SQLFetch` has returned `SQL_NO_DATA` for the current result set
+/// AND the whole batch has been drained (the terminating DONE carried no
+/// more-results flag). Distinguishes "cursor open, more to read" (un-fetched
+/// rows or pending result sets) from "cursor open, batch fully consumed", so a
+/// re-execute can implicitly close a finished cursor (msodbcsql parity) while a
+/// re-execute with un-read results still returns 24000. Always set together
+/// with `STMT_STATE_CURSOR_OPEN` and cleared with it in `reset_cursor_state`.
+pub(crate) const STMT_STATE_CURSOR_EXHAUSTED: u32 = 0x0000_2000;
 
 /// Statement handle
 ///
@@ -159,6 +167,14 @@ impl StmtState {
 
     pub(crate) fn clear_state(&mut self, mask: u32) {
         self.state_flags &= !mask;
+    }
+
+    /// True when the cursor is open but its whole batch has been consumed
+    /// (`STMT_STATE_CURSOR_EXHAUSTED`, only ever set alongside
+    /// `STMT_STATE_CURSOR_OPEN`) — the precondition for implicitly closing it on
+    /// re-execute.
+    pub(crate) fn cursor_is_exhausted(&self) -> bool {
+        self.has_state(STMT_STATE_CURSOR_OPEN) && self.has_state(STMT_STATE_CURSOR_EXHAUSTED)
     }
 
     /// Clears all row-stream state (cursor invalidated, no PLP in progress).

--- a/mssql-odbc/tests/e2e/tests/execute_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/execute_test.cpp
@@ -384,6 +384,59 @@ TEST_F(PrepareExecuteLiveTest, ReExecuteWhileCursorOpenReturns24000) {
     EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
 }
 
+// Reaching end-of-data via SQLFetch (SQL_NO_DATA) fully consumes a single-result
+// batch, so the next SQLExecute is allowed WITHOUT an intervening SQLCloseCursor:
+// the driver implicitly closes the finished cursor. This mirrors msodbcsql, whose
+// re-execute precondition blocks (24000) only while results are still un-read on
+// the wire — contrast ReExecuteWhileCursorOpenReturns24000, which re-executes
+// while positioned mid-rowset and gets 24000.
+TEST_F(PrepareExecuteLiveTest, ReExecuteAfterFetchToEndSucceedsWithoutClose) {
+    ASSERT_SQL_OK(Prepare("SELECT 1 AS v"), SQL_HANDLE_STMT, stmt_);
+
+    ASSERT_SQL_OK(SQLExecute(stmt_), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ("1", GetColumnChar(1));
+    // Fetch to end — SQL_NO_DATA fully consumes the result set.
+    EXPECT_EQ(SQL_NO_DATA, SQLFetch(stmt_));
+
+    // Re-execute with NO intervening SQLCloseCursor — must succeed.
+    ASSERT_SQL_OK(SQLExecute(stmt_), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ("1", GetColumnChar(1));
+    EXPECT_EQ(SQL_NO_DATA, SQLFetch(stmt_));
+
+    EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
+}
+
+// A multi-statement batch is NOT fully consumed after fetching only the first
+// result set to SQL_NO_DATA — the second result set is still pending on the wire.
+// msodbcsql stays "busy" in that state, so re-executing before the rest of the
+// batch is drained is a cursor-state error (24000). Closing the cursor drains the
+// remainder and makes the statement reusable again. Counterpart to
+// ReExecuteAfterFetchToEndSucceedsWithoutClose (single result set, fully consumed
+// at SQL_NO_DATA).
+TEST_F(PrepareExecuteLiveTest, ReExecuteWithPendingResultSetReturns24000) {
+    ASSERT_SQL_OK(Prepare("SELECT 1 AS v; SELECT 2 AS v"), SQL_HANDLE_STMT, stmt_);
+
+    ASSERT_SQL_OK(SQLExecute(stmt_), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ("1", GetColumnChar(1));
+    // Fetch the FIRST result set to end — the second is still pending.
+    EXPECT_EQ(SQL_NO_DATA, SQLFetch(stmt_));
+
+    // Re-execute with a result set still pending — cursor-state error.
+    SQLRETURN rc = SQLExecute(stmt_);
+    EXPECT_EQ(SQL_ERROR, rc);
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "24000");
+
+    // Closing the cursor drains the rest of the batch; the statement is reusable.
+    EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLExecute(stmt_), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ("1", GetColumnChar(1));
+    EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
+}
+
 // SQLExecDirect with a bound parameter executes directly (sp_executesql) and
 // substitutes the value, with no persistent prepared handle.
 TEST_F(PrepareExecuteLiveTest, ExecDirectWithParam) {
@@ -396,6 +449,59 @@ TEST_F(PrepareExecuteLiveTest, ExecDirectWithParam) {
                   SQL_HANDLE_STMT, stmt_);
     ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
     EXPECT_EQ("direct", GetColumnChar(1));
+    EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
+}
+
+// A direct (unprepared) statement is also re-runnable after fetching its single
+// result set to end without an intervening SQLCloseCursor: the driver implicitly
+// closes the exhausted cursor. Counterpart to
+// ReExecuteAfterFetchToEndSucceedsWithoutClose for the SQLExecDirect entry point
+TEST_F(PrepareExecuteLiveTest, ExecDirectReExecuteAfterFetchToEndSucceeds) {
+    SqlTString sql = ODBCTestUtils::ToSqlTStr("SELECT 1 AS v");
+
+    ASSERT_SQL_OK(SQLExecDirect(stmt_, const_cast<SQLTCHAR*>(sql.c_str()), SQL_NTS),
+                  SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ("1", GetColumnChar(1));
+    // Fetch to end — SQL_NO_DATA fully consumes the result set.
+    EXPECT_EQ(SQL_NO_DATA, SQLFetch(stmt_));
+
+    // Re-execute directly with NO intervening SQLCloseCursor — must succeed.
+    ASSERT_SQL_OK(SQLExecDirect(stmt_, const_cast<SQLTCHAR*>(sql.c_str()), SQL_NTS),
+                  SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ("1", GetColumnChar(1));
+    EXPECT_EQ(SQL_NO_DATA, SQLFetch(stmt_));
+
+    EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
+}
+
+// SQLExecDirect counterpart of ReExecuteWithPendingResultSetReturns24000: a
+// multi-statement batch is not fully consumed after fetching only the first
+// result set to end, so a direct re-execute before the rest is drained is a
+// cursor-state error (24000). Closing the cursor drains the remainder and makes
+// the statement reusable.
+TEST_F(PrepareExecuteLiveTest, ExecDirectReExecuteWithPendingResultSetReturns24000) {
+    SqlTString sql = ODBCTestUtils::ToSqlTStr("SELECT 1 AS v; SELECT 2 AS v");
+
+    ASSERT_SQL_OK(SQLExecDirect(stmt_, const_cast<SQLTCHAR*>(sql.c_str()), SQL_NTS),
+                  SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ("1", GetColumnChar(1));
+    // Fetch the FIRST result set to end — the second is still pending.
+    EXPECT_EQ(SQL_NO_DATA, SQLFetch(stmt_));
+
+    // Re-execute with a result set still pending — cursor-state error.
+    SQLRETURN rc = SQLExecDirect(stmt_, const_cast<SQLTCHAR*>(sql.c_str()), SQL_NTS);
+    EXPECT_EQ(SQL_ERROR, rc);
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "24000");
+
+    // Closing the cursor drains the rest of the batch; the statement is reusable.
+    EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLExecDirect(stmt_, const_cast<SQLTCHAR*>(sql.c_str()), SQL_NTS),
+                  SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ("1", GetColumnChar(1));
     EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
 }
 


### PR DESCRIPTION
## Description

Re-running a statement (`SQLExecute` / `SQLExecDirect`) after its result set had been fetched to `SQL_NO_DATA` returned SQLSTATE `24000`, because the cursor stayed open until an explicit `SQLCloseCursor`. msodbcsql allows the re-execute once the whole batch is drained. This restores that parity.

- Add `STMT_STATE_CURSOR_EXHAUSTED`, set on `SQLFetch` end-of-batch only when the terminating DONE carries no more-results flag (gated on `TdsClient::has_open_batch()`), so the driver can tell "cursor open, still busy" from "cursor open, batch fully consumed".
- Before staging a re-execute, `SQLExecute` and `SQLExecDirect` implicitly close an open-and-exhausted cursor via a shared `close_open_cursor` (also used by `SQLCloseCursor` / `SQLFreeStmt(SQL_CLOSE)`); a cursor with un-read rows or a still-pending result set is left open, so a re-execute with results still on the wire correctly stays `24000` (mirrors msodbcsql `CheckBusy` / `FIsBusyReadingData`).

Tests: unit (token-mock) for the implicit-close decision + drain and the `cursor_is_exhausted` predicate; e2e for both entry points — single result set re-executes without an intervening close, pending result set returns `24000`. Rebased on latest `main`.

## Related Issues

https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47348

[AB#47348](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47348)

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes (scoped to `mssql-odbc`, the only changed crate; 551 unit tests green — full workspace coverage runs in PR validation)
- [x] New/changed functionality has tests
- [x] Public API changes are documented (n/a — no public API surface change; the FFI entry points behave more permissively but signatures are unchanged)
