### PR TITLE
Add missing crates to the issue template "Affected crate" dropdowns

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
         - mssql-mock-tds
         - mssql-mock-tds-py
         - mssql-tds-bench
-        - Not sure / Multiple
+        - Not applicable / Multiple
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -59,10 +59,14 @@ body:
       label: Affected crate
       options:
         - mssql-tds
+        - mssql-odbc
         - mssql-js
+        - mssql-py-core
         - mssql-tds-cli
         - mssql-mock-tds
-        - mssql-py-core
+        - mssql-mock-tds-py
+        - mssql-tds-bench
+        - Not sure / Multiple
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -29,10 +29,13 @@ body:
       label: Affected crate
       options:
         - mssql-tds
+        - mssql-odbc
         - mssql-js
+        - mssql-py-core
         - mssql-tds-cli
         - mssql-mock-tds
-        - mssql-py-core
+        - mssql-mock-tds-py
+        - mssql-tds-bench
         - Not sure / Multiple
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -36,7 +36,7 @@ body:
         - mssql-mock-tds
         - mssql-mock-tds-py
         - mssql-tds-bench
-        - Not sure / Multiple
+        - Not applicable / Multiple
     validations:
       required: false
 


### PR DESCRIPTION
## Description

The `Affected crate` dropdown in both issue templates listed five crates and had not tracked the workspace. Three of the eight crates in the repo were missing from both templates:

| Crate | `Cargo.toml` | Before | After |
|---|---|---|---|
| `mssql-tds` | member | yes | yes |
| `mssql-odbc` | member | **no** | yes |
| `mssql-js` | member | yes | yes |
| `mssql-py-core` | `exclude` | yes | yes |
| `mssql-tds-cli` | member | yes | yes |
| `mssql-mock-tds` | member | yes | yes |
| `mssql-mock-tds-py` | `exclude` | **no** | yes |
| `mssql-tds-bench` | member | **no** | yes |

This is drift, not a deliberate list. Both templates arrived in `9be35c46` ("Add GitHub open-source community files and clean up README"); `mssql-odbc` landed later in #146 and the dropdown was never revisited. `mssql-py-core` being listed despite being in `exclude` shows workspace membership was not the selection criterion, so the other two excluded/internal crates were not omitted on that basis either.

`mssql-odbc` is the one that matters in practice — it is actively developed and the subject of a good share of recent issues, so the dropdown was wrong for a meaningful fraction of reports. #281 hit this and had to note the gap in prose instead of selecting anything accurate.

### Two judgement calls

**1. `bug_report.yml` gains `Not applicable / Multiple`.** `feature_request.yml` already had an option here; `bug_report.yml` did not, *and* its dropdown is `required: true`, so a reporter with no applicable crate could not submit without naming one falsely. That happens whenever an issue has no owning crate — pipeline maintenance, repo-wide cleanup, or #317 itself, where I had to type "Not applicable" into the crate field by hand. It also absorbs the cross-crate case, where a symptom surfaces in `mssql-js` but the defect is in `mssql-tds`.

Per review, the wording is `Not applicable / Multiple` rather than the `Not sure / Multiple` this PR first proposed: "not sure" framed the option as reporter uncertainty, when the more common case is that no single crate applies at all. Applied to `feature_request.yml` too, which carried the older wording, so the two templates do not diverge again. `required: true` is unchanged; the escape hatch is enough.

**2. The options are reordered.** Grouped core → drivers/bindings → tools → test infra, applied identically to both files so they no longer differ in ordering. Purely cosmetic and the reason the diff is larger than three added lines. Happy to restack as pure insertions if you prefer minimal churn.

Whether `mssql-tds-bench` and `mssql-mock-tds-py` belong in a user-facing dropdown at all is a fair question — both are internal (a benchmark harness and a test double). I included them because `mssql-mock-tds` was already listed, so excluding them would leave the list drawn on no consistent line. If the preference is to hide internal crates, the consistent version of that is dropping all three mock/bench entries, which I am glad to do instead.

### Verification

Both files parse as YAML and their option lists are now byte-identical:

```
bug_report.yml      ['mssql-tds', 'mssql-odbc', 'mssql-js', 'mssql-py-core', 'mssql-tds-cli',
                     'mssql-mock-tds', 'mssql-mock-tds-py', 'mssql-tds-bench', 'Not applicable / Multiple']
feature_request.yml [ ...identical... ]
```

Only `required` differs between them — `true` for bugs, `false` for features — which was already the case before this PR.

Every entry cross-checked against the `name =` field of each crate's `Cargo.toml`, not just directory names — all eight match, and all eight are present.

## Related Issues

Fixes #317

Split out of #281, where it was an aside on an unrelated SQLSTATE bug.

## Checklist

- [x] `cargo bfmt` passes — not applicable, no Rust changed; unaffected by this diff
- [x] `cargo bclippy` passes — not applicable, no Rust changed; unaffected by this diff
- [x] `cargo btest` passes — not applicable, no Rust changed; unaffected by this diff
- [x] New/changed functionality has tests — no test hook exists for issue-form YAML; validated by parsing both files and diffing the option lists against `Cargo.toml`, shown above
- [x] Public API changes are documented — none; repository metadata only
