### PR TITLE
perf(lab): advance baseline to 30e4d2d5 to fix the failing scheduled runs (#148 API rename)

### DIFF
--- a/mssql-tds-bench/perf-lab/baseline-commit.txt
+++ b/mssql-tds-bench/perf-lab/baseline-commit.txt
@@ -7,4 +7,4 @@
 #
 # Exactly one full 40-character commit SHA on its own line. Lines starting with
 # '#' and blank lines are ignored.
-bb02ba65254536bcef44c0a5bf682bd761ac51ee
+30e4d2d521bc452ae449b8eceb78d17be2a15b03


### PR DESCRIPTION
## Description

The scheduled 2026-08-17 perf runs failed on **both** platforms — Linux [167567](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build/results?buildId=167567) and Windows [167581](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build/results?buildId=167581) — with the **baseline** bench compile failing:

```
error[E0599]: no method named `execute_sp_prepexec_for_test` found for struct `TdsClient`
error: could not compile `mssql-tds-bench` (bench "query_prepared") due to 5 previous errors
ERROR: baseline bench compilation failed — see the cargo errors above.
```

This is not a perf regression. [#148](https://github.com/microsoft/mssql-rs/pull/148) (*Prepared-handle invalidation after transparent reconnect*, merged 2026-08-13) renamed the prepared-statement entry points to `execute_sp_{prepare,execute,prepexec,unprepare}_for_test` and updated the benches accordingly. The harness compiles **one** bench source — the candidate's — against **both** libraries, which is what makes a measured delta attributable to `mssql-tds` alone; the corollary is that the benches can no longer build against a baseline predating the rename. The baseline was still pinned to `bb02ba65` (2026-08-05).

Timeline: 08-10 runs green → #148 merged 08-13 → 08-17 runs failed.

## Changes

`mssql-tds-bench/perf-lab/baseline-commit.txt`: `bb02ba65` → **`30e4d2d5`**, the commit that *introduced* the API — i.e. the earliest library that compiles the current benches, which preserves the longest comparison window.

## Validation

Verified locally by replicating the exact swap the harness performs (`mssql-tds` replaced with a worktree checkout of `30e4d2d5`):

- All **seven** bench binaries compile.
- `query_prepared` runs **end to end** against a local SQL 2022 — `prepared_execute`, `prepared_prepexec`, and `batched_statements` all complete with no panic.

The runtime check is deliberate, not ceremonial: the previous baseline bump compiled cleanly and then panicked at run time (`prepared handle not found in return values`) because the `sp_prepexec` handle had moved out of the generic return-value buffer. A compile-only check would not have caught that.

Perf-lab validation runs on this branch are queued; results will be posted below.

## Note on coverage

Advancing the baseline moves #148 *inside* the baseline, so the gate can no longer see its own perf impact — and it is the largest change in the window (~1600 lines in `tds_client.rs`, reworking the prepared-statement path and adding reconnect logic). Two companion streams cover the gap:

- `david/perf-prebreak-148` — candidate `7c5168a6` (`30e4d2d5^`) against the **old** baseline `bb02ba65`, validating the 11 `mssql-tds` commits merged *before* #148 (including #231 shared result metadata, #226 PLP drain scratch, #153 column-wise fetch).
- A `cfg`-gated one-off to measure #148 itself, using the escape hatch [`docs/perf-testing-plan.md`](docs/perf-testing-plan.md) reserves for exactly this case.

## Related Issues

[AB#46061](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46061)

## Checklist

- [x] New/changed functionality has tests — N/A: baseline pointer change; validated by the compile + runtime swap check above and the queued lab runs
- [x] Public API changes are documented — N/A: no public API changes
