### PR TITLE
Route pipeline jobs to the split public/trusted agent pools

### DIFF
--- a/.pipeline/OneBranch/PublishFeeds-Sandbox.yml
+++ b/.pipeline/OneBranch/PublishFeeds-Sandbox.yml
@@ -110,9 +110,9 @@ extends:
         pool:
           type: windows
           isCustom: true
-          name: RUST-1ES-POOL-WUS3
+          name: RUST-X64-WUS3
           demands:
-            - imageOverride -equals RUST-Win22-Sql25-1P
+            - imageOverride -equals RUST-W22-SQL25
         variables:
           ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
         steps:
@@ -144,9 +144,9 @@ extends:
         pool:
           type: linux
           isCustom: true
-          name: RUST-1ES-POOL-WUS3
+          name: RUST-X64-WUS3
           demands:
-            - imageOverride -equals RUST-1ES-UBUSLIM
+            - imageOverride -equals RUST-UBUSLIM
         variables:
           ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
           ob_artifactSuffix: '_mock_linux_x64'
@@ -195,7 +195,7 @@ extends:
         pool:
           type: linux
           isCustom: true
-          name: RUST-1ES-POOL-ARM-WUS3
+          name: RUST-ARM64-WUS3
           demands:
             - imageOverride -equals RUST-UBUNTU-ARM64
         variables:
@@ -248,9 +248,9 @@ extends:
         pool:
           type: linux
           isCustom: true
-          name: RUST-1ES-POOL-WUS3
+          name: RUST-X64-WUS3
           demands:
-            - imageOverride -equals RUST-1ES-UBUSLIM
+            - imageOverride -equals RUST-UBUSLIM
         variables:
           ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
           ob_artifactSuffix: '_mock_linux_musl_x64'
@@ -301,7 +301,7 @@ extends:
         pool:
           type: linux
           isCustom: true
-          name: RUST-1ES-POOL-ARM-WUS3
+          name: RUST-ARM64-WUS3
           demands:
             - imageOverride -equals RUST-UBUNTU-ARM64
         variables:
@@ -353,9 +353,9 @@ extends:
         pool:
           type: windows
           isCustom: true
-          name: RUST-1ES-POOL-WUS3
+          name: RUST-X64-WUS3
           demands:
-            - imageOverride -equals RUST-Win22-Sql25-1P
+            - imageOverride -equals RUST-W22-SQL25
         variables:
           ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
           ob_artifactSuffix: '_mock_windows_x64'
@@ -400,7 +400,7 @@ extends:
         pool:
           type: windows
           isCustom: true
-          name: RUST-1ES-POOL-ARM-WUS3
+          name: RUST-ARM64-WUS3
           demands:
             - imageOverride -equals RUST-WINSRV-ARM
         variables:
@@ -522,9 +522,9 @@ extends:
         pool:
           type: windows
           isCustom: true
-          name: RUST-1ES-POOL-WUS3
+          name: RUST-X64-WUS3
           demands:
-            - imageOverride -equals RUST-Win22-Sql25-1P
+            - imageOverride -equals RUST-W22-SQL25
         variables:
           ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
         steps:
@@ -576,9 +576,9 @@ extends:
         pool:
           type: windows
           isCustom: true
-          name: RUST-1ES-POOL-WUS3
+          name: RUST-X64-WUS3
           demands:
-            - imageOverride -equals RUST-Win22-Sql25-1P
+            - imageOverride -equals RUST-W22-SQL25
         variables:
           ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
           CARGO_TARGET_DIR: C:\cargo_target_dir

--- a/.pipeline/OneBranch/stages.yml
+++ b/.pipeline/OneBranch/stages.yml
@@ -48,9 +48,9 @@ stages:
     pool:
       type: windows
       isCustom: true
-      name: RUST-1ES-POOL-WUS3
+      name: RUST-X64-WUS3
       demands:
-        - imageOverride -equals RUST-Win22-Sql25-1P
+        - imageOverride -equals RUST-W22-SQL25
     variables:
     - ${{ if eq(parameters.isOfficial, true) }}:
       - group: 'ESRP Federated Creds (AME)'
@@ -93,7 +93,7 @@ stages:
       pool:
         type: windows
         isCustom: true
-        name: RUST-1ES-POOL-ARM-WUS3
+        name: RUST-ARM64-WUS3
         demands:
           - imageOverride -equals RUST-WINSRV-ARM
       variables:
@@ -148,9 +148,9 @@ stages:
     pool:
       type: linux
       isCustom: true
-      name: RUST-1ES-POOL-WUS3
+      name: RUST-X64-WUS3
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-UBUSLIM
     variables:
       ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
       ob_artifactSuffix: '_linux_x64'
@@ -195,7 +195,7 @@ stages:
       pool:
         type: linux
         isCustom: true
-        name: RUST-1ES-POOL-ARM-WUS3
+        name: RUST-ARM64-WUS3
         demands:
           - imageOverride -equals RUST-UBUNTU-ARM64
       variables:

--- a/.pipeline/benchmark-pipeline.yml
+++ b/.pipeline/benchmark-pipeline.yml
@@ -25,9 +25,9 @@ stages:
         displayName: 'Criterion Benchmark'
         timeoutInMinutes: 30
         pool:
-          name: RUST-1ES-POOL-WUS3
+          name: RUST-X64-WUS3
           demands:
-            - imageOverride -equals RUST-1ES-UBUSLIM
+            - imageOverride -equals RUST-UBUSLIM
         variables:
           ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
 

--- a/.pipeline/docs/arm-sql-host-design.md
+++ b/.pipeline/docs/arm-sql-host-design.md
@@ -341,15 +341,15 @@ unchanged.
 
 ## Open assumptions
 
-- Cross-pool reachability between `RUST-1ES-POOL-WUS3` (x64) and
-  `RUST-1ES-POOL-ARM-WUS3` (ARM) on the SQL host's private IPv4 and the
+- Cross-pool reachability between `RUST-X64-WUS3` (x64) and
+  `RUST-ARM64-WUS3` (ARM) on the SQL host's private IPv4 and the
   published port. Confirmed at design time; a connectivity regression here
   would surface as `poll-for-endpoint.sh` succeeds (the test job sees the
   endpoint) but the subsequent test connect times out.
 - `mcr.microsoft.com/mssql/server:<sqlImageTag>` ships
   `/opt/mssql-tools18/bin/sqlcmd`, which `start.sh` uses for the readiness
   probe. The current default tag (`2025-latest`) does.
-- The ubuntu image used by the x64 SQL host (`RUST-1ES-UBUSLIM`) provides
+- The ubuntu image used by the x64 SQL host (`RUST-UBUSLIM`) provides
   `curl` and `docker`. The latter is enforced by `DockerInstaller@0` and
   `install-ubuntu-dependency.yaml`; the former is standard in the image.
 - Both ARM and x64 1ES pool agents have `python3` available (used by

--- a/.pipeline/docs/arm-sql-host-design.md
+++ b/.pipeline/docs/arm-sql-host-design.md
@@ -341,8 +341,9 @@ unchanged.
 
 ## Open assumptions
 
-- Cross-pool reachability between `RUST-X64-WUS3` (x64) and
-  `RUST-ARM64-WUS3` (ARM) on the SQL host's private IPv4 and the
+- Cross-pool reachability within both pool sets: `RUST-X64-WUS3` (x64) to
+  `RUST-ARM64-WUS3` (ARM), and `RUST-PUBLIC-X64-WUS3` (x64) to
+  `RUST-PUBLIC-ARM64-WUS3` (ARM), on the SQL host's private IPv4 and the
   published port. Confirmed at design time; a connectivity regression here
   would surface as `poll-for-endpoint.sh` succeeds (the test job sees the
   endpoint) but the subsequent test connect times out.

--- a/.pipeline/scripts/containerized-python-test.sh
+++ b/.pipeline/scripts/containerized-python-test.sh
@@ -14,6 +14,40 @@ export PATH="/usr/local/bin:$PATH"
 # Pass through any arguments (e.g., --skip-integration)
 echo "Running Python tests for mssql-py-core..."
 cd /workspace
+
+# rust-toolchain.toml pins the channel and rustup materialises it on first use,
+# deep inside `maturin develop`. When that fetch lands incomplete the toolchain
+# stays registered but without rustc, and the only symptom is maturin reporting
+# "Failed to run rustc to get the host target" with no indication of which
+# download failed. Materialise it here instead, with retries, and dump enough
+# state to explain a failure that survives them.
+RUST_CHANNEL="$(sed -n 's/^channel[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' rust-toolchain.toml | head -1)"
+echo "=== Rust toolchain state (rust-toolchain.toml channel: ${RUST_CHANNEL:-unknown}) ==="
+rustup show || true
+rustup toolchain list --verbose || true
+
+for attempt in 1 2 3; do
+    if rustc --version >/dev/null 2>&1; then
+        break
+    fi
+    echo "rustc not usable (attempt ${attempt}/3); installing toolchain ${RUST_CHANNEL}..."
+    # --force because the failure mode is a half-installed toolchain: without it
+    # rustup considers the channel present and skips the repair.
+    rustup toolchain install "${RUST_CHANNEL}" --force --no-self-update || true
+done
+
+if ! rustc --version; then
+    echo "ERROR: rustc still unavailable after 3 attempts."
+    echo "=== toolchain CDN reachability ==="
+    curl -sS -o /dev/null \
+        -w '  channel manifest: http=%{http_code} dns=%{time_namelookup}s connect=%{time_connect}s total=%{time_total}s bytes=%{size_download} speed=%{speed_download}B/s\n' \
+        "https://static.rust-lang.org/dist/channel-rust-${RUST_CHANNEL}.toml" \
+        || echo "  probe failed to complete"
+    echo "=== toolchains after retries ==="
+    rustup toolchain list --verbose || true
+    exit 1
+fi
+
 ./dev/test-python.sh "$@"
 
 echo "Python tests completed successfully"

--- a/.pipeline/sync-container-images.yml
+++ b/.pipeline/sync-container-images.yml
@@ -147,9 +147,9 @@ stages:
     displayName: 'Import manylinux x64 & arm64'
     condition: eq('${{ parameters.syncManylinux }}', 'true')
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: RUST-X64-WUS3
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-UBUSLIM
     steps:
     - checkout: none
     - task: AzureCLI@2
@@ -210,9 +210,9 @@ stages:
     displayName: 'Import musllinux x64 & arm64'
     condition: eq('${{ parameters.syncMusllinux }}', 'true')
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: RUST-X64-WUS3
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-UBUSLIM
     steps:
     - checkout: none
     - task: AzureCLI@2
@@ -247,9 +247,9 @@ stages:
     displayName: 'Import Ubuntu 22.04 & 24.04'
     condition: eq('${{ parameters.syncUbuntu }}', 'true')
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: RUST-X64-WUS3
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-UBUSLIM
     steps:
     - checkout: none
     - task: AzureCLI@2
@@ -306,9 +306,9 @@ stages:
     displayName: 'Import Alpine 3.18 & 3.19'
     condition: eq('${{ parameters.syncAlpine1 }}', 'true')
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: RUST-X64-WUS3
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-UBUSLIM
     steps:
     - checkout: none
     - task: AzureCLI@2
@@ -365,9 +365,9 @@ stages:
     displayName: 'Import Alpine 3.20 & 3.21'
     condition: eq('${{ parameters.syncAlpine2 }}', 'true')
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: RUST-X64-WUS3
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-UBUSLIM
     steps:
     - checkout: none
     - task: AzureCLI@2
@@ -424,9 +424,9 @@ stages:
     displayName: 'Import Alpine 3.22 & 3.23'
     condition: eq('${{ parameters.syncAlpine3 }}', 'true')
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: RUST-X64-WUS3
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-UBUSLIM
     steps:
     - checkout: none
     - task: AzureCLI@2
@@ -483,9 +483,9 @@ stages:
     displayName: 'Import Debian & RHEL UBI'
     condition: eq('${{ parameters.syncDebianRHEL }}', 'true')
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: RUST-X64-WUS3
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-UBUSLIM
     steps:
     - checkout: none
     - task: AzureCLI@2
@@ -629,9 +629,9 @@ stages:
     displayName: 'Import Oracle Linux 9'
     condition: eq('${{ parameters.syncOracle }}', 'true')
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: RUST-X64-WUS3
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-UBUSLIM
     steps:
     - checkout: none
     - task: AzureCLI@2
@@ -664,9 +664,9 @@ stages:
     displayName: 'Import CentOS Stream 9'
     condition: eq('${{ parameters.syncCentOS }}', 'true')
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: RUST-X64-WUS3
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-UBUSLIM
     steps:
     - checkout: none
     - task: AzureCLI@2
@@ -688,9 +688,9 @@ stages:
     displayName: 'Import openSUSE Leap 15.6'
     condition: eq('${{ parameters.syncSUSE }}', 'true')
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: RUST-X64-WUS3
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-UBUSLIM
     steps:
     - checkout: none
     - task: AzureCLI@2
@@ -735,9 +735,9 @@ stages:
     displayName: Build x64 Images
     condition: or(eq('${{ parameters.buildPythonImages }}', 'true'), eq('${{ parameters.buildUbuntuImages }}', 'true'))
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: RUST-X64-WUS3
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-UBUSLIM
     steps:
     - checkout: self
       displayName: Checkout repository
@@ -858,9 +858,9 @@ stages:
     timeoutInMinutes: 120
     condition: eq('${{ parameters.buildKerberosImages }}', 'true')
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: RUST-X64-WUS3
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-UBUSLIM
     steps:
     - checkout: self
       displayName: Checkout repository
@@ -936,7 +936,7 @@ stages:
     # x64 failure.
     condition: and(succeeded(), or(eq('${{ parameters.buildPythonImages }}', 'true'), eq('${{ parameters.buildUbuntuImages }}', 'true')))
     pool:
-      name: RUST-1ES-POOL-ARM-WUS3
+      name: RUST-ARM64-WUS3
       demands:
         - imageOverride -equals RUST-UBUNTU-ARM64
     steps:
@@ -1071,9 +1071,9 @@ stages:
     - BuildARM64Images
     condition: eq('${{ parameters.buildUbuntuImages }}', 'true')
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: RUST-X64-WUS3
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-UBUSLIM
     steps:
     - checkout: none
 
@@ -1132,9 +1132,9 @@ stages:
     - CreateMultiArchManifests
     condition: always()
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: RUST-X64-WUS3
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-UBUSLIM
     steps:
     - checkout: none
 
@@ -1268,9 +1268,9 @@ stages:
     displayName: 'Mirror ACR -> GHCR'
     timeoutInMinutes: 60
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: RUST-X64-WUS3
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-UBUSLIM
     steps:
     - checkout: none
 

--- a/.pipeline/sync-github-main-to-stable.yml
+++ b/.pipeline/sync-github-main-to-stable.yml
@@ -35,9 +35,9 @@ resources:
     ref: refs/heads/stable
 
 pool:
-  name: RUST-1ES-POOL-WUS3
+  name: RUST-X64-WUS3
   demands:
-    - imageOverride -equals RUST-1ES-UBUSLIM
+    - imageOverride -equals RUST-UBUSLIM
 
 steps:
 # GitHub main (self): the source we are syncing from.

--- a/.pipeline/templates/kerberos-test-template.yml
+++ b/.pipeline/templates/kerberos-test-template.yml
@@ -33,10 +33,10 @@ parameters:
       - alpine318
   - name: poolName
     type: string
-    default: 'RUST-1ES-POOL-WUS3'
+    default: 'RUST-X64-WUS3'
   - name: poolImageOverride
     type: string
-    default: 'imageOverride -equals RUST-1ES-UBUSLIM'
+    default: 'imageOverride -equals RUST-UBUSLIM'
   - name: testTimeout
     type: number
     default: 60

--- a/.pipeline/templates/odbc-e2e-windows-remote-sql-template.yml
+++ b/.pipeline/templates/odbc-e2e-windows-remote-sql-template.yml
@@ -3,7 +3,7 @@
 # Runs the mssql-odbc C++ gtest e2e suite on a Windows agent that has no local
 # SQL Server, against the cross-pool x64 SQL host booted by sql-host-template.yml.
 #
-# The Windows ARM agent image ships no SQL Server (unlike RUST-Win22-Sql25-1P used
+# The Windows ARM agent image ships no SQL Server (unlike RUST-W22-SQL25 used
 # by Build_Windows), so the ARM job joins the same artifact-sentinel rendezvous the
 # Linux ARM jobs use: derive the shared SA password, poll for the sql-ready
 # endpoint sentinel, run the suite, then publish a teardown sentinel to release

--- a/.pipeline/templates/private-link-smoke-template.yml
+++ b/.pipeline/templates/private-link-smoke-template.yml
@@ -41,11 +41,11 @@ parameters:
 
 - name: vnet
   type: string
-  default: vnet-sqldrivers-trusted-westus3
+  default: vnet-sqldrivers-trusted-westus3-01
 
 - name: subnet
   type: string
-  default: default2
+  default: snet-aci-01
 
 - name: miName
   type: string
@@ -70,9 +70,9 @@ jobs:
 - job: PrivateLink_Smoke
   displayName: Private Link Smoke Test (ACI)
   pool:
-    name: RUST-1ES-POOL-WUS3
+    name: RUST-X64-WUS3
     demands:
-      - imageOverride -equals RUST-1ES-UBUSLIM
+      - imageOverride -equals RUST-UBUSLIM
   timeoutInMinutes: 30
   steps:
   # --- Login ---

--- a/.pipeline/templates/private-link-smoke-template.yml
+++ b/.pipeline/templates/private-link-smoke-template.yml
@@ -8,6 +8,10 @@
 # This ties each ACR image and ACI instance back to the pipeline run.
 
 parameters:
+- name: poolName
+  type: string
+  default: 'RUST-X64-WUS3'
+
 - name: wheelArtifact
   displayName: Name of the published wheel artifact
   type: string
@@ -70,7 +74,7 @@ jobs:
 - job: PrivateLink_Smoke
   displayName: Private Link Smoke Test (ACI)
   pool:
-    name: RUST-X64-WUS3
+    name: ${{ parameters.poolName }}
     demands:
       - imageOverride -equals RUST-UBUSLIM
   timeoutInMinutes: 30

--- a/.pipeline/templates/sql-host-template.yml
+++ b/.pipeline/templates/sql-host-template.yml
@@ -51,10 +51,10 @@ parameters:
     default: 120
   - name: poolName
     type: string
-    default: 'RUST-1ES-POOL-WUS3'
+    default: 'RUST-X64-WUS3'
   - name: poolImageOverride
     type: string
-    default: 'imageOverride -equals RUST-1ES-UBUSLIM'
+    default: 'imageOverride -equals RUST-UBUSLIM'
   - name: jobCondition
     # Job-level condition. Defaults to succeeded(); callers that only need the
     # SQL host on PRs (e.g. the Build stage) pass a Build.Reason check.

--- a/.pipeline/templates/test-matrix-odbc-template-arm64.yml
+++ b/.pipeline/templates/test-matrix-odbc-template-arm64.yml
@@ -11,6 +11,9 @@
 # sql-ready artifact in, teardown sentinel out, derived SA password).
 
 parameters:
+  - name: poolName
+    type: string
+    default: 'RUST-ARM64-WUS3'
   - name: targets
     # Each entry: { name, container, entry }
     type: object
@@ -79,7 +82,7 @@ jobs:
               entry: ${{ target.entry }}
               sentinelName: ${{ parameters.sentinelPrefix }}${{ target.name }}
       pool:
-        name: RUST-ARM64-WUS3
+        name: ${{ parameters.poolName }}
         demands:
           - imageOverride -equals RUST-UBUNTU-ARM64
       steps:
@@ -191,7 +194,7 @@ jobs:
         displayName: 'ODBC e2e Linux arm64 ${{ target.name }}'
         # Intentionally no `dependsOn`: see sql-host-template.yml header.
         pool:
-          name: RUST-ARM64-WUS3
+          name: ${{ parameters.poolName }}
           demands:
             - imageOverride -equals RUST-UBUNTU-ARM64
         steps:

--- a/.pipeline/templates/test-matrix-odbc-template-arm64.yml
+++ b/.pipeline/templates/test-matrix-odbc-template-arm64.yml
@@ -79,7 +79,7 @@ jobs:
               entry: ${{ target.entry }}
               sentinelName: ${{ parameters.sentinelPrefix }}${{ target.name }}
       pool:
-        name: RUST-1ES-POOL-ARM-WUS3
+        name: RUST-ARM64-WUS3
         demands:
           - imageOverride -equals RUST-UBUNTU-ARM64
       steps:
@@ -191,7 +191,7 @@ jobs:
         displayName: 'ODBC e2e Linux arm64 ${{ target.name }}'
         # Intentionally no `dependsOn`: see sql-host-template.yml header.
         pool:
-          name: RUST-1ES-POOL-ARM-WUS3
+          name: RUST-ARM64-WUS3
           demands:
             - imageOverride -equals RUST-UBUNTU-ARM64
         steps:

--- a/.pipeline/templates/test-matrix-odbc-template.yml
+++ b/.pipeline/templates/test-matrix-odbc-template.yml
@@ -17,9 +17,9 @@ jobs:
     strategy:
       matrix: ${{ parameters.matrix }}
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: RUST-X64-WUS3
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-UBUSLIM
     steps:
       - template: generate-sql-password-template.yml
         parameters:

--- a/.pipeline/templates/test-matrix-odbc-template.yml
+++ b/.pipeline/templates/test-matrix-odbc-template.yml
@@ -10,6 +10,7 @@ parameters:
   matrix: {}
   artifactName: 'Odbc_Linux_x64'
   nameSuffix: ''
+  poolName: 'RUST-X64-WUS3'
 
 jobs:
   - job: Test_Odbc_Matrix${{ parameters.nameSuffix }}
@@ -17,7 +18,7 @@ jobs:
     strategy:
       matrix: ${{ parameters.matrix }}
     pool:
-      name: RUST-X64-WUS3
+      name: ${{ parameters.poolName }}
       demands:
         - imageOverride -equals RUST-UBUSLIM
     steps:

--- a/.pipeline/templates/test-matrix-template-alpine.yml
+++ b/.pipeline/templates/test-matrix-template-alpine.yml
@@ -2,8 +2,8 @@
 parameters:
   matrix: {}
   artifactName: 'Build_Linux'
-  poolName: 'RUST-1ES-POOL-WUS3'
-  poolImageOverride: 'imageOverride -equals RUST-1ES-UBUSLIM'
+  poolName: 'RUST-X64-WUS3'
+  poolImageOverride: 'imageOverride -equals RUST-UBUSLIM'
 
 jobs:
   - job: Test_Matrix

--- a/.pipeline/templates/test-matrix-template-alpine_arm64.yml
+++ b/.pipeline/templates/test-matrix-template-alpine_arm64.yml
@@ -14,7 +14,7 @@ parameters:
     default: 'Build_Linux_ARM'
   - name: poolName
     type: string
-    default: 'RUST-1ES-POOL-ARM-WUS3'
+    default: 'RUST-ARM64-WUS3'
   - name: poolImageOverride
     type: string
     default: 'imageOverride -equals RUST-UBUNTU-ARM64'

--- a/.pipeline/templates/test-matrix-template-arm64.yml
+++ b/.pipeline/templates/test-matrix-template-arm64.yml
@@ -75,7 +75,7 @@ jobs:
               entry: ${{ target.entry }}
               sentinelName: ${{ target.name }}
       pool:
-        name: RUST-1ES-POOL-ARM-WUS3
+        name: RUST-ARM64-WUS3
         demands:
           - imageOverride -equals RUST-UBUNTU-ARM64
       steps:
@@ -190,7 +190,7 @@ jobs:
         displayName: 'Linux arm64 ${{ target.name }}'
         # Intentionally no `dependsOn`: see sql-host-template.yml header.
         pool:
-          name: RUST-1ES-POOL-ARM-WUS3
+          name: RUST-ARM64-WUS3
           demands:
             - imageOverride -equals RUST-UBUNTU-ARM64
         steps:

--- a/.pipeline/templates/test-matrix-template-arm64.yml
+++ b/.pipeline/templates/test-matrix-template-arm64.yml
@@ -48,6 +48,9 @@ parameters:
     # this template then only emits the test job, which consumes sql-ready-shared.
     type: boolean
     default: true
+  - name: poolName
+    type: string
+    default: 'RUST-ARM64-WUS3'
 
 jobs:
   # ------------------------------------------------------------------
@@ -75,7 +78,7 @@ jobs:
               entry: ${{ target.entry }}
               sentinelName: ${{ target.name }}
       pool:
-        name: RUST-ARM64-WUS3
+        name: ${{ parameters.poolName }}
         demands:
           - imageOverride -equals RUST-UBUNTU-ARM64
       steps:
@@ -190,7 +193,7 @@ jobs:
         displayName: 'Linux arm64 ${{ target.name }}'
         # Intentionally no `dependsOn`: see sql-host-template.yml header.
         pool:
-          name: RUST-ARM64-WUS3
+          name: ${{ parameters.poolName }}
           demands:
             - imageOverride -equals RUST-UBUNTU-ARM64
         steps:

--- a/.pipeline/templates/test-matrix-template.yml
+++ b/.pipeline/templates/test-matrix-template.yml
@@ -8,9 +8,9 @@ jobs:
     strategy:
       matrix: ${{ parameters.matrix }}
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: RUST-X64-WUS3
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-UBUSLIM
     steps:
       - template: generate-sql-password-template.yml
         parameters:

--- a/.pipeline/templates/test-matrix-template.yml
+++ b/.pipeline/templates/test-matrix-template.yml
@@ -1,6 +1,7 @@
 # filepath: .pipeline/templates/test-matrix-template.yml
 parameters:
   matrix: {}
+  poolName: 'RUST-X64-WUS3'
 
 jobs:
   - job: Test_Matrix
@@ -8,7 +9,7 @@ jobs:
     strategy:
       matrix: ${{ parameters.matrix }}
     pool:
-      name: RUST-X64-WUS3
+      name: ${{ parameters.poolName }}
       demands:
         - imageOverride -equals RUST-UBUSLIM
     steps:

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -601,6 +601,7 @@ stages:
   jobs:
     - template: test-matrix-template-alpine.yml
       parameters:
+        poolName: ${{ parameters.poolName }}
         artifactName: 'Build_Linux'
         matrix:
           Alpine3_18:
@@ -620,6 +621,7 @@ stages:
     # build image and rerun on every listed tag (all ship libssl.so.3 + unixODBC).
     - template: test-matrix-odbc-template.yml
       parameters:
+        poolName: ${{ parameters.poolName }}
         artifactName: 'Odbc_Musl_x64'
         nameSuffix: _musl
         matrix:
@@ -677,6 +679,7 @@ stages:
               entry: alpine.sh
       - template: test-matrix-odbc-template-arm64.yml
         parameters:
+          poolName: ${{ parameters.armPoolName }}
           manageSqlHost: false
           sqlReadyInstanceId: shared_musl
           sentinelPrefix: 'odbc_'
@@ -721,6 +724,7 @@ stages:
               entry: alpine.sh
       - template: test-matrix-odbc-template-arm64.yml
         parameters:
+          poolName: ${{ parameters.armPoolName }}
           sqlInstanceMode: per-job
           sentinelPrefix: 'odbc_'
           sqlImageTag: ${{ parameters.sqlImageTag }}
@@ -747,6 +751,7 @@ stages:
   jobs:
     - template: test-matrix-template.yml
       parameters:
+        poolName: ${{ parameters.poolName }}
         matrix:
           DebianBookworm:
             container: ghcr.io/microsoft/mssql-rs/import/debian:bookworm
@@ -777,6 +782,7 @@ stages:
     # excluded; RHEL 8 is covered by the glibc-2.28 track below.
     - template: test-matrix-odbc-template.yml
       parameters:
+        poolName: ${{ parameters.poolName }}
         artifactName: 'Odbc_Linux_x64'
         matrix:
           DebianBookworm:
@@ -796,6 +802,7 @@ stages:
     # (libssl.so.1.1), where the modern glibc 2.35 / OpenSSL 3 binaries would not.
     - template: test-matrix-odbc-template.yml
       parameters:
+        poolName: ${{ parameters.poolName }}
         artifactName: 'Odbc_glibc228_x64'
         nameSuffix: _glibc228
         matrix:
@@ -824,6 +831,7 @@ stages:
           expectedSentinels: 'DebianBookworm,AzLinux3,RHEL9,OracleLinux9,SLES15,Ubuntu22,Ubuntu24,odbc_DebianBookworm,odbc_Ubuntu22,odbc_Ubuntu24,odbc_AzLinux3,odbc_RHEL8'
       - template: test-matrix-template-arm64.yml
         parameters:
+          poolName: ${{ parameters.armPoolName }}
           manageSqlHost: false
           sqlInstanceMode: shared
           sqlImageTag: ${{ parameters.sqlImageTag }}
@@ -851,6 +859,7 @@ stages:
               entry: deb-bookworm.sh
       - template: test-matrix-odbc-template-arm64.yml
         parameters:
+          poolName: ${{ parameters.armPoolName }}
           manageSqlHost: false
           sqlReadyInstanceId: shared
           sentinelPrefix: 'odbc_'
@@ -876,6 +885,7 @@ stages:
       # in the shared host's expectedSentinels above.
       - template: test-matrix-odbc-template-arm64.yml
         parameters:
+          poolName: ${{ parameters.armPoolName }}
           manageSqlHost: false
           sqlReadyInstanceId: shared
           sentinelPrefix: 'odbc_'
@@ -892,6 +902,7 @@ stages:
     - ${{ if eq(parameters.sqlInstanceMode, 'per-job') }}:
       - template: test-matrix-template-arm64.yml
         parameters:
+          poolName: ${{ parameters.armPoolName }}
           sqlInstanceMode: per-job
           sqlImageTag: ${{ parameters.sqlImageTag }}
           targets:
@@ -918,6 +929,7 @@ stages:
               entry: deb-bookworm.sh
       - template: test-matrix-odbc-template-arm64.yml
         parameters:
+          poolName: ${{ parameters.armPoolName }}
           sqlInstanceMode: per-job
           sentinelPrefix: 'odbc_'
           sqlImageTag: ${{ parameters.sqlImageTag }}
@@ -939,6 +951,7 @@ stages:
       # manylinux_2_28 aarch64 so it loads on RHEL 8 / UBI 8 arm64.
       - template: test-matrix-odbc-template-arm64.yml
         parameters:
+          poolName: ${{ parameters.armPoolName }}
           sqlInstanceMode: per-job
           sentinelPrefix: 'odbc_'
           nameSuffix: _glibc228
@@ -1131,3 +1144,5 @@ stages:
     condition: and(succeeded('Build'), ne(variables['Build.Reason'], 'PullRequest'), eq('${{ parameters.RunFuzz }}', 'false'), eq('${{ parameters.RunLongHaul }}', 'false'))
     jobs:
       - template: private-link-smoke-template.yml
+        parameters:
+          poolName: ${{ parameters.poolName }}

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -39,6 +39,25 @@ parameters:
   type: string
   default: '2025-latest'
 
+# Pool names are supplied by the entry pipeline, which picks them from
+# System.TeamProject. Defaults are the TRUSTED pools so a missed argument fails
+# closed: the public project cannot see those pools, so a misrouted run gets a
+# "pool not found" error instead of running unreviewed code on a trusted agent.
+- name: poolName
+  displayName: x64 agent pool
+  type: string
+  default: RUST-X64-WUS3
+
+- name: armPoolName
+  displayName: ARM64 agent pool
+  type: string
+  default: RUST-ARM64-WUS3
+
+- name: utilPoolName
+  displayName: Small agent pool for short jobs that must not queue behind builds
+  type: string
+  default: RUST-UTIL-WUS3
+
 stages:
 - stage: EvaluateDuplicate
   displayName: Evaluate PR duplicate
@@ -47,9 +66,9 @@ stages:
   - job: Evaluate
     displayName: Check prior successful PR validation
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ parameters.utilPoolName }}
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-UBUSLIM
     steps:
     - bash: |
         set -euo pipefail
@@ -81,6 +100,7 @@ stages:
   # idle an x64 agent on every merge.
   - template: sql-host-template.yml
     parameters:
+      poolName: ${{ parameters.poolName }}
       instanceId: build_arm
       expectedSentinels: build_arm,build_win_arm
       sqlImageTag: ${{ parameters.sqlImageTag }}
@@ -88,9 +108,9 @@ stages:
   - job: Build_Windows
     displayName: Build Windows
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ parameters.poolName }}
       demands:
-        - imageOverride -equals RUST-Win22-Sql25-1P
+        - imageOverride -equals RUST-W22-SQL25
     variables:
       # For details on this CARGO_TARGET_DIR setting, see https://eng.ms/docs/more/rust/topics/onebranch-workaround
       CARGO_TARGET_DIR: C:\cargo_target_dir
@@ -170,7 +190,7 @@ stages:
   - job: Build_Windows_Arm
     displayName: Build Windows ARM
     pool:
-      name: RUST-1ES-POOL-ARM-WUS3
+      name: ${{ parameters.armPoolName }}
       demands:
         - imageOverride -equals RUST-WINSRV-ARM
     variables:
@@ -221,9 +241,9 @@ stages:
   - job: Build_Linux
     displayName: Build Linux
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ parameters.poolName }}
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-UBUSLIM
     variables:
       CARGO_TARGET_DIR: $(Build.SourcesDirectory)
       ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
@@ -273,7 +293,7 @@ stages:
   - job: Build_Linux_ARM
     displayName: Build Linux ARM
     pool:
-      name: RUST-1ES-POOL-ARM-WUS3
+      name: ${{ parameters.armPoolName }}
       demands:
         - imageOverride -equals RUST-UBUNTU-ARM64
     variables:
@@ -388,6 +408,7 @@ stages:
   jobs:
     - template: kerberos-test-template.yml
       parameters:
+        poolName: ${{ parameters.poolName }}
         profiles:
           - ubuntu22
           - alpine318
@@ -406,6 +427,7 @@ stages:
   jobs:
     - template: kerberos-test-template.yml
       parameters:
+        poolName: ${{ parameters.poolName }}
         profiles:
           - ubuntu22
           - ubuntu24
@@ -427,9 +449,9 @@ stages:
   - job: Fuzz_TokenStream_Linux
     displayName: Fuzz Test Token Stream Linux (30 min)
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ parameters.poolName }}
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-UBUSLIM
     variables:
       CARGO_TARGET_DIR: $(Build.SourcesDirectory)
     steps:
@@ -449,9 +471,9 @@ stages:
   - job: Fuzz_TdsClient_Linux
     displayName: Fuzz Test TdsClient Linux (30 min)
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ parameters.poolName }}
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-UBUSLIM
     variables:
       CARGO_TARGET_DIR: $(Build.SourcesDirectory)
     steps:
@@ -471,9 +493,9 @@ stages:
   - job: Fuzz_Additional_Targets_Linux
     displayName: Fuzz Additional Targets Linux (Serial - 5 min each)
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ parameters.poolName }}
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-UBUSLIM
     variables:
       CARGO_TARGET_DIR: $(Build.SourcesDirectory)
     steps:
@@ -524,9 +546,9 @@ stages:
   - job: Build_mssql_python_Linux
     displayName: Build mssql-python (cross-repo)
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ parameters.poolName }}
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-UBUSLIM
     variables:
       CARGO_TARGET_DIR: $(Build.SourcesDirectory)
     steps:
@@ -565,9 +587,9 @@ stages:
     displayName: mssql-python suite on mssql-odbc driver (cross-repo)
     timeoutInMinutes: 150
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ parameters.poolName }}
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-UBUSLIM
     steps:
       - template: test-mssql-python-odbc-template.yml
 
@@ -628,6 +650,7 @@ stages:
     - ${{ if eq(parameters.sqlInstanceMode, 'shared') }}:
       - template: sql-host-template.yml
         parameters:
+          poolName: ${{ parameters.poolName }}
           instanceId: shared_musl
           sqlImageTag: ${{ parameters.sqlImageTag }}
           expectedSentinels: 'Alpine3_18,Alpine3_19,Alpine3_20,Alpine3_21,odbc_Alpine3_18,odbc_Alpine3_19,odbc_Alpine3_20,odbc_Alpine3_21'
@@ -635,7 +658,7 @@ stages:
         parameters:
           manageSqlHost: false
           artifactName: 'Build_Linux_ARM'
-          poolName: RUST-1ES-POOL-ARM-WUS3
+          poolName: ${{ parameters.armPoolName }}
           poolImageOverride: imageOverride -equals RUST-UBUNTU-ARM64
           sqlInstanceMode: shared
           sqlImageTag: ${{ parameters.sqlImageTag }}
@@ -679,7 +702,7 @@ stages:
       - template: test-matrix-template-alpine_arm64.yml
         parameters:
           artifactName: 'Build_Linux_ARM'
-          poolName: RUST-1ES-POOL-ARM-WUS3
+          poolName: ${{ parameters.armPoolName }}
           poolImageOverride: imageOverride -equals RUST-UBUNTU-ARM64
           sqlInstanceMode: per-job
           sqlImageTag: ${{ parameters.sqlImageTag }}
@@ -795,6 +818,7 @@ stages:
     - ${{ if eq(parameters.sqlInstanceMode, 'shared') }}:
       - template: sql-host-template.yml
         parameters:
+          poolName: ${{ parameters.poolName }}
           instanceId: shared
           sqlImageTag: ${{ parameters.sqlImageTag }}
           expectedSentinels: 'DebianBookworm,AzLinux3,RHEL9,OracleLinux9,SLES15,Ubuntu22,Ubuntu24,odbc_DebianBookworm,odbc_Ubuntu22,odbc_Ubuntu24,odbc_AzLinux3,odbc_RHEL8'
@@ -941,9 +965,9 @@ stages:
   - job: Merge_Coverage
     displayName: Merge Rust and Python coverage
     pool:
-      name: RUST-1ES-POOL-WUS3
+      name: ${{ parameters.utilPoolName }}
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-UBUSLIM
     steps:
       - checkout: self
       - task: DownloadPipelineArtifact@2
@@ -1062,9 +1086,9 @@ stages:
     - job: LongHaul_BCP_Test
       displayName: Long-Haul BCP Test Ubuntu
       pool:
-        name: RUST-1ES-POOL-WUS3
+        name: ${{ parameters.poolName }}
         demands:
-          - imageOverride -equals RUST-1ES-UBUSLIM
+          - imageOverride -equals RUST-UBUSLIM
       variables:
         CARGO_TARGET_DIR: $(Build.SourcesDirectory)
       steps:
@@ -1081,9 +1105,9 @@ stages:
     - job: LongHaul_BCP_Arrow_Test
       displayName: Long-Haul BCP Arrow Test Ubuntu
       pool:
-        name: RUST-1ES-POOL-WUS3
+        name: ${{ parameters.poolName }}
         demands:
-          - imageOverride -equals RUST-1ES-UBUSLIM
+          - imageOverride -equals RUST-UBUSLIM
       variables:
         CARGO_TARGET_DIR: $(Build.SourcesDirectory)
       steps:

--- a/.pipeline/validation-pipeline-ci.yml
+++ b/.pipeline/validation-pipeline-ci.yml
@@ -54,5 +54,10 @@ stages:
     RunLongHaul: ${{ parameters.RunLongHaul }}
     sqlInstanceMode: ${{ parameters.sqlInstanceMode }}
     sqlImageTag: ${{ parameters.sqlImageTag }}
+    # This pipeline only ever runs in the mssql-rs project, so it names the
+    # trusted pools outright rather than deriving them from System.TeamProject.
+    poolName: RUST-X64-WUS3
+    armPoolName: RUST-ARM64-WUS3
+    utilPoolName: RUST-UTIL-WUS3
     # Runs with internal resource access, so keep the infra stages.
     includeInfraStages: true

--- a/.pipeline/validation-pipeline.yml
+++ b/.pipeline/validation-pipeline.yml
@@ -51,6 +51,20 @@ stages:
     RunLongHaul: ${{ parameters.RunLongHaul }}
     sqlInstanceMode: ${{ parameters.sqlInstanceMode }}
     sqlImageTag: ${{ parameters.sqlImageTag }}
+    # This file is shared by TWO pipeline definitions: 2267 in the `public`
+    # project (GitHub PRs, i.e. unreviewed code) and 2204 in `mssql-rs` (the ADO
+    # mirror). Pool names must resolve at compile time, so this is a template
+    # rather than a runtime variable. The pools are project-scoped, so a wrong
+    # branch here fails with "pool not found" rather than putting unreviewed
+    # code on a trusted agent.
+    ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      poolName: RUST-PUBLIC-X64-WUS3
+      armPoolName: RUST-PUBLIC-ARM64-WUS3
+      utilPoolName: RUST-PUBLIC-UTIL-WUS3
+    ${{ else }}:
+      poolName: RUST-X64-WUS3
+      armPoolName: RUST-ARM64-WUS3
+      utilPoolName: RUST-UTIL-WUS3
     # PR validation for internal ADO and GitHub PRs. GitHub PRs run in the public
     # project, which lacks 'Magnitude Test', so exclude the infra stages here.
     includeInfraStages: false


### PR DESCRIPTION
## Summary

Repoints every pipeline job at the new split agent pools, so that unreviewed pull request code and trusted CI no longer share agents.

Until now both ran on `RUST-1ES-POOL-WUS3` / `RUST-1ES-POOL-ARM-WUS3`, which sit in a vnet with private endpoints to the ACR, SQL server and Key Vault. A GitHub PR from a fork therefore executed on an agent that could reach internal resources. The new pools are split by trust boundary and project scope: the `RUST-PUBLIC-*` pools are visible only to the `public` project and have no private endpoints, while the `RUST-*` pools are visible only to `mssql-rs`.

The pool infrastructure (two vnets, images, six pools, queue authorization) is already deployed. This change is the pipeline half.

### How the routing works

`validation-stages.yml` now takes `poolName`, `armPoolName` and `utilPoolName` instead of naming pools inline. The entry file `validation-pipeline.yml` is consumed by two definitions — 2267 in the `public` project for GitHub PRs, and 2204 in `mssql-rs` for the ADO mirror — so it selects pools from `System.TeamProject`. Pool names must resolve at compile time, so this is a template expression rather than a runtime variable.

The parameter defaults are the **trusted** pools, which makes a mistake fail closed: the `public` project cannot see those pools, so a misrouted run fails with "pool not found" instead of putting unreviewed code on an agent with private endpoint access.

Pipelines that only ever run in `mssql-rs` (container image sync, OneBranch publish, benchmark, branch sync) name the trusted pools outright rather than taking a parameter. The same applies to templates used exclusively by CI-only stages (`test-matrix-*`, `private-link-smoke`), since those stages are gated off for PR runs and can never need a public pool.

### Utility pools

The `Evaluate` gate job and `Merge_Coverage` move to small dedicated pools. Both are short — the gate job does about 0.4 minutes of real work — but on real PR runs it waited a median of **4.4 minutes** for an agent (samples: 0.6, 4.0, 4.1, 4.4, 4.4, 6.5, 8.6). The Build stage depends on it, so that wait is dead time on the critical path of every PR. The cause is contention rather than provisioning speed: the pool it ran on already uses automatic provisioning, but a 0.4-minute job was queued behind 40-minute builds.

The SQL host job deliberately stays on the full-size pool; it serves real query load from the ARM tests.

### Image rename

`RUST-1ES-UBUSLIM` → `RUST-UBUSLIM` (36 references) and `RUST-Win22-Sql25-1P` → `RUST-W22-SQL25` (6). The ARM image demands (`RUST-UBUNTU-ARM64`, `RUST-WINSRV-ARM`) are unchanged — those images are reused as-is.

The private link smoke test moves to the new trusted vnet and its dedicated ACI subnet (`snet-aci-01`, previously `default2`).

## Linked work item

[AB#46593](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46593)

## Testing

Not yet exercised by a pipeline run — that is the point of opening this as a draft. What has been verified:

- All 35 pipeline YAML files parse.
- No stale references remain: `RUST-1ES-POOL*`, `RUST-1ES-UBUSLIM` and `RUST-Win22-Sql25*` all return zero matches under `.pipeline/`.
- Every job's pool assignment was checked individually against its architecture, and the two utility-pool jobs against their job names.
- On the infrastructure side, all six pools report `Succeeded`, both images published version 1.0.0, and queue authorization was confirmed to be least-privilege: no blanket `allPipelines` authorization on any queue, public queues authorized for definition 2267 only, and an org-wide check confirming only `public` can see the public queues and only `mssql-rs` the trusted ones.

Suggested validation order:

1. Run definition 2204 (`mssql-rs` project) to exercise the trusted path first.
2. Then let a GitHub PR exercise the public path.
3. Compare the `Evaluate` job's queue-to-start wait against the ~4.4 minute baseline.

Treat the first public run's wall-clock time as unrepresentative: the pools start cold and the Windows image is at its first version.

## Breaking changes / migration notes

No source or API changes; this is pipeline configuration only.

Operationally it does repoint all CI and PR jobs onto new pools at once. Two things must be true before merge, and both currently are:

- The six pools exist and are authorized for the right pipeline definitions.
- The renamed images exist, since `imageOverride` demands are matched by name.

The old pools are intentionally left in place, so reverting this commit restores the previous routing. They should only be retired after a soak period, along with the old vnet and its private endpoints.
