### PR TITLE
Add ODBC 3.x type rules and SQL_C_DEFAULT resolution to SQLBindParameter

### DIFF
--- a/.github/instructions/mssql-odbc.instructions.md
+++ b/.github/instructions/mssql-odbc.instructions.md
@@ -28,14 +28,36 @@ authoritative parity reference for this crate. Its source lives in the
 - When reporting a parity finding, cite the msodbcsql source (file + what it does),
   and state explicitly whether the decision **matches**, **exceeds**, or **diverges
   from** msodbcsql so the trade-off is visible.
-- **This driver targets ODBC 3.x only.** msodbcsql also serves ODBC 2.x
-  applications, so parts of its source exist purely for backward compatibility:
-  deprecated 2.x entry points, 2.x identifier spellings and attribute values,
-  2.x-era internal representations, and branches keyed on the application's
-  declared version. The Driver Manager maps a 2.x application onto the 3.x
-  interface before the call reaches a 3.x driver, so those paths are out of
-  scope here — a msodbcsql code path that exists solely for 2.x compatibility is
-  not a parity gap. Say so rather than porting it.
+- **This driver targets ODBC 3.x only.** That scopes out support for ODBC 2.x
+  *applications* — deprecated 2.x entry points, 2.x-only attribute values, and
+  the paths msodbcsql keeps for them. The Driver Manager maps a 2.x application
+  onto the 3.x interface before the call reaches a 3.x driver, so a msodbcsql
+  code path that exists solely for 2.x compatibility is not a parity gap. Say so
+  rather than porting it.
+  - **It does not scope out 2.x-era identifiers.** `SQL_C_DATE` / `SQL_C_TIME` /
+    `SQL_C_TIMESTAMP` are deprecated but still defined in the ODBC 3.x headers, so
+    a 3.x application may legally pass them and the DM remaps nothing. Accept
+    them and fold them onto the 3.x form (`api::type_rules::canonical_c_type`).
+    Check each identifier before assuming the rule applies — the SQL side is not
+    symmetric, ODBC 3.x reuses the 2.x date/time SQL values: `9` is both `SQL_DATE`
+    (2.x concise) and `SQL_DATETIME` (3.x verbose), and `10` is both `SQL_TIME` and
+    `SQL_INTERVAL`. A `ParameterType` of `9` is therefore ambiguous, so it is
+    rejected (`HY004`) rather than folded - 3.x applications use `SQL_TYPE_*`
+    (91-93), and the DM remaps a 2.x application's spelling first. msodbcsql
+    accepts both SQL spellings because it also serves 2.x applications and can
+    disambiguate on the declared version.
+  - **It does not cover 3.0/3.5 vs 3.8.** `SQL_OV_ODBC3` and `SQL_OV_ODBC3_80`
+    are both ODBC 3.x and both in scope. msodbcsql branches on this separately —
+    `Sql2CDefault` selects `rgbTRANSTYPE` when `IS351ORLESSAPP(wStatus)` and
+    `rgbTRANSTYPE380` otherwise — so a version-keyed branch is only out of scope
+    once you have checked *which* version boundary it keys on.
+  - Beware that msodbcsql normalizes types to their 2.x values on entry
+    (`SQLBindParameter` in `Sql/Ntdbms/sqlncli/odbc/sqlcdesc.cpp` maps
+    `SQL_TYPE_*` down to `SQL_DATE`/`SQL_TIME`/`SQL_TIMESTAMP`, and `SQL_DOUBLE`
+    to `SQL_FLOAT`, before validating). Downstream code accepting a 2.x spelling
+    therefore does **not** prove it supports 2.x applications, and a branch that
+    looks reachable in a validator may be dead once the caller's normalization is
+    accounted for. Read the caller before concluding either way.
 - Deliberate deviations (exceed-parity) are allowed with product-owner sign-off;
   record the rationale in code comments and the tracking work item.
 - Deliberate deviations are listed below:

--- a/.github/instructions/mssql-odbc.instructions.md
+++ b/.github/instructions/mssql-odbc.instructions.md
@@ -28,6 +28,14 @@ authoritative parity reference for this crate. Its source lives in the
 - When reporting a parity finding, cite the msodbcsql source (file + what it does),
   and state explicitly whether the decision **matches**, **exceeds**, or **diverges
   from** msodbcsql so the trade-off is visible.
+- **This driver targets ODBC 3.x only.** msodbcsql also serves ODBC 2.x
+  applications, so parts of its source exist purely for backward compatibility:
+  deprecated 2.x entry points, 2.x identifier spellings and attribute values,
+  2.x-era internal representations, and branches keyed on the application's
+  declared version. The Driver Manager maps a 2.x application onto the 3.x
+  interface before the call reaches a 3.x driver, so those paths are out of
+  scope here — a msodbcsql code path that exists solely for 2.x compatibility is
+  not a parity gap. Say so rather than porting it.
 - Deliberate deviations (exceed-parity) are allowed with product-owner sign-off;
   record the rationale in code comments and the tracking work item.
 - Deliberate deviations are listed below:
@@ -36,6 +44,13 @@ authoritative parity reference for this crate. Its source lives in the
     (`Sql/Ntdbms/sqlncli/msdart/inc/dlgattr.h` → `OPTIONADMSI L"ActiveDirectoryMSI"`);
     `ActiveDirectoryManagedIdentity` does not appear anywhere in the msodbcsql source.
     Added to match MS Learn and the sibling drivers (JDBC/.NET/go-sqlcmd). Tracked in AB#46066.
+  - `SQL_C_DEFAULT` in SQLBindParameter resolves the wide character SQL types to `SQL_C_WCHAR`, and
+    `SQL_GUID` to `SQL_C_GUID`, following the ODBC 3.x default-C-type table.
+    msodbcsql's `Sql2CDefault` reads `rgbTRANSTYPE380`
+    (`Sql/Ntdbms/sqlncli/odbc/sqlcmisc.cpp`), which resolves both to `SQL_C_CHAR`
+    — an ANSI-transfer default this driver has no equivalent for, since its
+    `SQL_C_CHAR` is UTF-8. Resolving UTF-16 application input to a UTF-8 buffer
+    type would silently corrupt data. Tracked in AB#47365.
 
 ## No panics
 

--- a/mssql-odbc/docs/parameters_plan.md
+++ b/mssql-odbc/docs/parameters_plan.md
@@ -55,17 +55,21 @@ transparent reconnects.
   skipping string literals, quoted identifiers, and comments. It stores the
   rewritten SQL and marker count, so repeated `SQLExecute` calls do not re-scan
   the text.
-- **Bind-time type validation** - `api::type_rules` owns the `HY003` gate (every
-  real ODBC C type, including the SQL Server extensions) and classifies SQL data
-  types three ways, like msodbcsql's `IsValidSqlType`: supported, real but with
-  no SQL Server counterpart (`HYC00` - the interval types), or unknown
-  (`HY004`). `params::conversion_matrix` owns the C -> SQL conversion table,
-  shaped like msodbcsql's `fValidConversion` (one row per C type). A C type that
-  is real but not yet convertible returns `07006`, not `HY003`.
+- **Bind-time type validation** - `api::type_rules` canonicalizes the C type
+  (folding the deprecated `SQL_C_DATE` / `SQL_C_TIME` / `SQL_C_TIMESTAMP`
+  spellings onto the `SQL_C_TYPE_*` forms), then applies the `HY003` gate to that
+  canonical form, and classifies SQL data types three ways, like msodbcsql's
+  `IsValidSqlType`: supported, real but with no SQL Server counterpart (`HYC00` -
+  the interval types), or unknown (`HY004`). `params::conversion_matrix` owns the
+  C -> SQL conversion table, shaped like msodbcsql's `fValidConversion` (one row
+  per C type). A C type that is real but not yet convertible returns `07006`, not
+  `HY003`.
 - **`SQL_C_DEFAULT` resolution** - resolved at bind time to the C type implied
-  by `ParameterType` (msodbcsql `Sql2CDefault`, which reads `rgbTRANSTYPE380`
-  for ODBC 3.8+ applications) and stored resolved in `BoundParam`, so the
-  execute path never sees the placeholder.
+  by `ParameterType` and stored resolved in `BoundParam`, so the execute path
+  never sees the placeholder. Version-aware, like msodbcsql's `Sql2CDefault`,
+  which reads `rgbTRANSTYPE` for a 3.51-or-earlier application and
+  `rgbTRANSTYPE380` otherwise: `SQL_SS_TIME2` and `SQL_SS_TIMESTAMPOFFSET`
+  default to `SQL_C_BINARY` below ODBC 3.8.
 - **Value conversion** - `SQL_C_CHAR` maps to varchar and `SQL_C_WCHAR` to
   nvarchar. Indicators support `SQL_NULL_DATA`, `SQL_NTS`, and explicit byte
   length.
@@ -189,9 +193,9 @@ Pure refactor, no behavior change. Create `src/conversion/`:
 
 #### P1 - Parameter type model and conversion matrix (code complete, unmerged)
 
-- [`api/type_rules.rs`](../src/api/type_rules.rs) - the `HY003` / `HY004`
-  identifier gates and `SQL_C_DEFAULT` resolution. Direction-neutral, so it sits
-  in `api` rather than `params`.
+- [`api/type_rules.rs`](../src/api/type_rules.rs) - C-type canonicalization, the
+  `HY003` / `HY004` identifier gates, and version-aware `SQL_C_DEFAULT`
+  resolution. Direction-neutral, so it sits in `api` rather than `params`.
 - [`params/conversion_matrix.rs`](../src/params/conversion_matrix.rs) - one row
   per C type listing the SQL types it converts to. Rows today: `SQL_C_CHAR` ->
   `CHAR` / `VARCHAR` / `LONGVARCHAR`, `SQL_C_WCHAR` -> `WCHAR` / `WVARCHAR` /
@@ -204,10 +208,16 @@ bind until P3 adds its row.
 
 Deviations from msodbcsql, verified against source:
 
-- The driver is ODBC 3.x only, so the 2.x date/time SQL spellings (`SQL_DATE` /
-  `SQL_TIME` / `SQL_TIMESTAMP`, 9-11) are not accepted; the DM maps them to the
-  `SQL_TYPE_*` forms for a 3.x driver. msodbcsql accepts both because its
-  internal representation is the 2.x form.
+- ODBC 3.x reuses the 2.x date/time SQL values: `9` is both `SQL_DATE` (2.x
+  concise) and `SQL_DATETIME` (3.x verbose), and `10` is both `SQL_TIME` and
+  `SQL_INTERVAL`. A `ParameterType` of `9` is therefore ambiguous, so it is
+  rejected (`HY004`) rather than folded - 3.x applications use `SQL_TYPE_*`
+  (91-93), and the DM remaps a 2.x application's spelling first. The C side has
+  no such collision (`SQL_C_DATE` is only ever 9), so `canonical_c_type` folds
+  9-11 onto the `SQL_C_TYPE_*` forms instead of rejecting them. msodbcsql
+  accepts both SQL spellings because it also serves 2.x applications and can
+  disambiguate on the declared version, and it canonicalizes the C pair in the
+  opposite direction, toward its 2.x internal representation.
 - `SQL_C_DEFAULT` resolves the wide character types to `SQL_C_WCHAR` and
   `SQL_GUID` to `SQL_C_GUID`, following the ODBC 3.x default-C-type table.
   msodbcsql's `rgbTRANSTYPE380` resolves both to `SQL_C_CHAR`, an ANSI-transfer
@@ -216,10 +226,14 @@ Deviations from msodbcsql, verified against source:
   registered in
   [`mssql-odbc.instructions.md`](../../.github/instructions/mssql-odbc.instructions.md)
   and on AB#47365.
-- msodbcsql normalizes ODBC 3.x date/time identifiers to their 2.x values and
-  `SQL_DOUBLE` to `SQL_FLOAT` before validating; this driver accepts both
-  spellings directly. Equivalent today, but the normalization will be needed
-  when descriptors land.
+- msodbcsql normalizes types to its internal representation before validating:
+  ODBC 3.x date/time identifiers down to their 2.x values, the SS types to their
+  `*_MAPPED` ids, and `SQL_DOUBLE` to `SQL_FLOAT`. Those exist because its
+  validators and default-type tables are dense arrays indexed by the internal id;
+  this driver matches on the ODBC 3.x values directly and needs no equivalent.
+  `SQL_DOUBLE` and `SQL_FLOAT` are therefore two distinct `Supported` types here
+  that happen to resolve alike - revisit at P3/P4 if numeric matrix rows start
+  duplicating them.
 
 #### P2 - Buffer reader and outcome channel (not started)
 

--- a/mssql-odbc/docs/parameters_plan.md
+++ b/mssql-odbc/docs/parameters_plan.md
@@ -1,7 +1,7 @@
 # Parameterized execution - `SQLBindParameter` / `SQLExecute` / `SQLExecDirect`
 
 Status, behavior, and known gaps for parameterized prepared-statement execution
-in the ODBC Driver 18 (Rust). Updated 2026-08-11.
+in the ODBC Driver 18 (Rust). Updated 2026-08-18.
 
 ---
 
@@ -55,8 +55,19 @@ transparent reconnects.
   skipping string literals, quoted identifiers, and comments. It stores the
   rewritten SQL and marker count, so repeated `SQLExecute` calls do not re-scan
   the text.
-- **Types** - `SQL_C_CHAR` maps to varchar and `SQL_C_WCHAR` to nvarchar; other
-   Invalid C types return  HY003 ; unsupported C/SQL conversions return  07006. Indicators support `SQL_NULL_DATA`, `SQL_NTS`, and explicit byte length.
+- **Bind-time type validation** - `api::type_rules` owns the `HY003` gate (every
+  real ODBC C type, including the SQL Server extensions) and the `HY004` gate
+  (SQL data types). `params::conversion_matrix` owns the C -> SQL conversion
+  table, shaped like msodbcsql's `fValidConversion` (one row per C type). A C
+  type that is real but not yet convertible returns `07006`, not `HY003`.
+- **`SQL_C_DEFAULT` resolution** - resolved at bind time to the C type implied
+  by `ParameterType` (msodbcsql `Sql2CDefault`, which reads `rgbTRANSTYPE380`
+  for ODBC 3.8+ applications) and stored resolved in `BoundParam`, so the
+  execute path never sees the placeholder. Interval SQL types have no default
+  and return `07006`.
+- **Value conversion** - `SQL_C_CHAR` maps to varchar and `SQL_C_WCHAR` to
+  nvarchar. Indicators support `SQL_NULL_DATA`, `SQL_NTS`, and explicit byte
+  length.
 
 ## `mssql-tds` prepared API
 
@@ -87,6 +98,213 @@ transparent reconnects.
   Enable `StaleHandleAfterReconnectIsInvalidatedAndReprepared` afterward under
   [ADO 47099](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47099).
 
+## Conversion milestone: integers and strings
+
+Goal: support parameters of narrow and wide integer C types and character C
+types, with SQL <-> C conversion among them, on conversion infrastructure shared
+with the fetch path ([`api/fetch_convert.rs`](../src/api/fetch_convert.rs)).
+
+### Scope
+
+| Axis | In scope |
+| --- | --- |
+| Narrow integer C | `SQL_C_STINYINT`, `SQL_C_TINYINT`, `SQL_C_UTINYINT`, `SQL_C_SSHORT`, `SQL_C_SHORT`, `SQL_C_USHORT` |
+| Wide integer C | `SQL_C_SLONG`, `SQL_C_LONG`, `SQL_C_ULONG`, `SQL_C_SBIGINT`, `SQL_C_UBIGINT` |
+| Character C | `SQL_C_CHAR`, `SQL_C_WCHAR` |
+| Special | `SQL_C_DEFAULT` (resolved to a concrete C type) |
+| Integer SQL | `SQL_TINYINT`, `SQL_SMALLINT`, `SQL_INTEGER`, `SQL_BIGINT` |
+| Character SQL | `SQL_CHAR`, `SQL_VARCHAR`, `SQL_LONGVARCHAR`, `SQL_WCHAR`, `SQL_WVARCHAR`, `SQL_WLONGVARCHAR` |
+| Stretch | `SQL_C_BIT` <-> `SQL_BIT` |
+
+Four conversion quadrants:
+
+| | to integer SQL | to character SQL |
+| --- | --- | --- |
+| **integer C** | A: narrow and range-check (`22003`) | C: format as text (`22001`) |
+| **character C** | D: parse (`22018`, `22003`, `01S07`) | B: transcode and length (`22001`) |
+
+Out of scope for this milestone: decimal/numeric, money, temporal, GUID, binary,
+output parameters, data-at-exec, parameter arrays, and TVPs.
+
+### Design rules
+
+- **The matrix lists only implemented pairs.** A pairing accepted at bind time is
+  always one the execute path can convert, so there is no bind-succeeds /
+  execute-fails window. Rows and entries are added as each phase lands.
+- **Legality is decided per direction, at different moments.** msodbcsql consults
+  its shared `fValidConversion` table only where both types are known up front:
+  `SQLBindParameter` (`sqlcdesc.cpp`), output-parameter retrieval
+  (`sqlcdata.cpp`), and BCP. `SQLBindCol` / `SQLGetData` cannot, since a column's
+  SQL type may be unknown until after execute, so the fetch direction returns the
+  same `07006` from inside `Convert()` (`CVT_ILLEGAL`, which is literally
+  `IDS_07_006`). This driver mirrors that split: a bind-time matrix for
+  parameters, `ConvError::Restricted` inside the fetch converters.
+- **Direction changes severity.** Character truncation is benign outbound
+  (`01004`, chunked `SQLGetData`) but an error inbound (`22001`). msodbcsql
+  encodes this with an explicit `XLATDIR` argument
+  (`sqlccnvt.cpp`: `CVT_CHAR_TRUNC && fConversionDirection == TODRIVER`).
+- **Share the value model, not the pointer I/O.** Fetch and parameters share the
+  canonical numeric value, literal parsers, and SQLSTATE vocabulary; each keeps
+  its own audited unsafe edge.
+- **`SqlType` metadata is sufficient for this milestone.** `Int(None)`,
+  `Varchar(None, len)`, and `NVarchar(None, len)` carry type and length
+  independent of the value. Only decimal and temporal typed NULLs need the
+  `mssql-tds` metadata rework, and those are out of scope.
+
+### Phases
+
+Tracked under User Story
+[46373](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46373),
+one task per phase.
+
+| Phase | Task | Status | Deliverable |
+| --- | --- | --- | --- |
+| P0 | [47364](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47364) | Not started | Extract shared conversion core from `fetch_convert.rs` |
+| P1 | [47365](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47365) | Code complete, unmerged | Parameter type model, conversion matrix, `SQL_C_DEFAULT` |
+| P2 | [47366](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47366) | Not started | Safe C-buffer reader and conversion-outcome channel |
+| P3 | [47367](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47367) | Not started | Quadrant A: integer C -> integer SQL |
+| P4 | [47368](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47368) | Not started | Quadrant B: character C -> character SQL |
+| P5 | [47369](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47369) | Not started | Quadrants C and D: cross conversions |
+| P6 | [47370](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47370) | Not started | Parity and e2e hardening |
+| P7 | [47371](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47371) | Not started | Cleanup and follow-up hooks |
+
+P1 is independent of P0; P3 onward depend on both.
+
+#### P0 - Extract shared conversion core (not started)
+
+Pure refactor, no behavior change. Create `src/conversion/`:
+
+- `error.rs` - direction-aware outcome vocabulary lifted from `fetch_convert.rs`:
+  a `ConvDirection`, an outcome (`Exact`, `FractionalTruncation`,
+  `StringTruncation`), and an error kind (`OutOfRange`, `InvalidCharacterValue`,
+  `Restricted`, `StringTruncation`). `NotHandledHere` stays private to fetch
+  dispatch and must never reach an application.
+- `numeric.rs` - move `NumericSource` (exact `Int` / `Scaled` / `Float` model),
+  `parse_decimal_literal`, `to_i128_truncating`, and the checked-narrowing
+  helper. This carries the hardening from the 128-bit shift-overflow guard and
+  the `22003` unrepresentable-value fix into the parameter path.
+- Add `SQLSTATE_22001` and an inbound string-truncation `DiagMsg`;
+  `ERR_STRING_RIGHT_TRUNCATION` (`01004`) stays for the outbound path.
+
+#### P1 - Parameter type model and conversion matrix (code complete, unmerged)
+
+- [`api/type_rules.rs`](../src/api/type_rules.rs) - the `HY003` / `HY004`
+  identifier gates and `SQL_C_DEFAULT` resolution. Direction-neutral, so it sits
+  in `api` rather than `params`.
+- [`params/conversion_matrix.rs`](../src/params/conversion_matrix.rs) - one row
+  per C type listing the SQL types it converts to. Rows today: `SQL_C_CHAR` ->
+  `CHAR` / `VARCHAR` / `LONGVARCHAR`, `SQL_C_WCHAR` -> `WCHAR` / `WVARCHAR` /
+  `WLONGVARCHAR`.
+- [`api/bind_param.rs`](../src/api/bind_param.rs) - runs both checks and stores
+  the resolved C type on the binding.
+
+No value conversion changed here: `SQL_C_SLONG` + `SQL_INTEGER` still fails at
+bind until P3 adds its row.
+
+Deviations from msodbcsql, verified against source:
+
+- The driver is ODBC 3.x only, so the 2.x date/time SQL spellings (`SQL_DATE` /
+  `SQL_TIME` / `SQL_TIMESTAMP`, 9-11) are not accepted; the DM maps them to the
+  `SQL_TYPE_*` forms for a 3.x driver. msodbcsql accepts both because its
+  internal representation is the 2.x form.
+- `SQL_C_DEFAULT` resolves the wide character types to `SQL_C_WCHAR` and
+  `SQL_GUID` to `SQL_C_GUID`, following the ODBC 3.x default-C-type table.
+  msodbcsql's `rgbTRANSTYPE380` resolves both to `SQL_C_CHAR`, an ANSI-transfer
+  artifact with no equivalent here; resolving UTF-16 input to this driver's
+  UTF-8 `SQL_C_CHAR` would silently corrupt data. Accepted deviation, also
+  registered in
+  [`mssql-odbc.instructions.md`](../../.github/instructions/mssql-odbc.instructions.md)
+  and on AB#47365.
+- msodbcsql normalizes ODBC 3.x date/time identifiers to their 2.x values and
+  `SQL_DOUBLE` to `SQL_FLOAT` before validating; this driver accepts both
+  spellings directly. Equivalent today, but the normalization will be needed
+  when descriptors land.
+
+#### P2 - Buffer reader and outcome channel (not started)
+
+- `params/buffer.rs` as the single audited unsafe input site: `read_unaligned`
+  for fixed-width C integers, `SQL_NTS` / explicit length / `buffer_length` for
+  character buffers.
+- Fix indicator handling: for fixed-width C types `StrLen_or_Ind` is not a
+  length. Only `SQL_NULL_DATA`, `SQL_DEFAULT_PARAM`, and data-at-exec values are
+  meaningful; size comes from the C type (msodbcsql `IsFixedCType` /
+  `GetLengthForFixedLengthCType`). Current code treats the indicator as a length
+  for every type.
+- Produce an `AppValue` (`Null`, `Integer`, `Text`) for the milestone subset.
+- Thread a warning channel through `build_named_params` so `SQLExecute` and
+  `SQLExecDirect` can return `SQL_SUCCESS_WITH_INFO`; it returns only
+  `Result<Vec<RpcParameter>, SqlReturn>` today. Landing it here avoids a late
+  signature change in P5.
+
+#### P3 - Integer C to integer SQL (not started)
+
+- Identity fast path for exact pairs (msodbcsql `IsParamConversionNeeded`).
+- Cross-width narrowing through the shared numeric model, `22003` on overflow.
+- Emit `SqlType::TinyInt` / `SmallInt` / `Int` / `BigInt` driven by
+  `ParameterType`, not the C type, including typed NULL. This is the first phase
+  where `@P1` is declared `int` instead of `nvarchar(max)`.
+- `SQL_C_TINYINT` is unsigned, matching the documented fetch decision.
+- `SQL_C_UBIGINT` above `i64::MAX` has no SQL Server target: `22003`.
+
+#### P4 - Character C to character SQL (not started)
+
+- Same-family and cross-family (`SQL_C_CHAR` -> `SQL_WVARCHAR` and the reverse),
+  transcoding UTF-8 <-> UTF-16.
+- Use `ColumnSize` to select `Varchar(_, n)` / `NVarchar(_, n)` / `Char` /
+  `NChar` versus the `Max` variants, applying the existing 8000 / 4000
+  thresholds.
+- Inbound truncation beyond the declared length is `22001`, not the benign
+  outbound `01004`.
+- Highest-risk phase: everything is `(n)varchar(max)` today, so declared lengths
+  have never applied. Verify against msodbcsql: `ColumnSize == 0`, and data
+  longer than `ColumnSize`.
+- Keep the documented UTF-8 `SQL_C_CHAR` divergence; do not add ANSI codepage
+  translation.
+
+#### P5 - Cross conversions (not started)
+
+- Integer C to character SQL: format, then apply P4 length rules.
+- Character C to integer SQL: reuse `parse_decimal_literal`. `"12"` is exact,
+  `"12.7"` yields 12 with `01S07`, `"abc"` is `22018`, and an overflow is
+  `22003`.
+
+#### P6 - Parity and e2e hardening (not started)
+
+- Parameter-numbered diagnostics.
+- Run the e2e suite under `--compare-with-msodbcsql`; mark driver-specific
+  assertions with `SKIP_IF_COMPARING_MSODBCSQL()`.
+- Add `Benefits-from-mock-tds:` notes where only the round-tripped value is
+  observable and the declared RPC type is not.
+
+#### P7 - Cleanup and hooks (not started)
+
+- Remove remaining "Phase 1" language from `params/convert.rs` and
+  `params/bound_param.rs`.
+- Record the deferred blockers: `SqlType` metadata/value separation for decimal
+  and temporal typed NULLs, and the hard-coded decimal precision/scale in
+  `mssql-tds/src/datatypes/sqltypes.rs`.
+
+### Shared with fetch
+
+| Shared | Not shared |
+| --- | --- |
+| Outcome and error vocabulary | Pointer I/O (`write_fixed` vs the buffer reader) |
+| Canonical numeric value, narrowing, overflow guards | Source model (`ColumnValues` vs `AppValue`) |
+| Numeric and temporal literal parsers | Chunking, PLP streaming, cursor state |
+| SQLSTATE mapping helpers | Direction-specific truncation severity |
+
+Fetch is not retrofitted onto the conversion matrix, and should not be:
+msodbcsql does not route its fetch path through `fValidConversion` either,
+because `SQLBindCol` cannot know a column's SQL type at bind time. The
+`is_*_c_target` helpers in `fetch_convert.rs` are converter routing - the same
+role `Convert()`'s dispatch switch plays - not a legality table.
+
+One divergence to watch: this driver's matrix answers "implemented?" while
+msodbcsql's answers "legal?". Both directions currently hold legality knowledge
+in different shapes, so when P5 adds character/numeric cross conversions, check
+that the two agree on what is legal versus merely unimplemented rather than
+accepting a pairing inbound that is rejected outbound for no principled reason.
+
 ## Remaining work
 
 - **Stream marker rewriting without an intermediate SQL string.** `SQLPrepare`
@@ -95,13 +313,10 @@ transparent reconnects.
   `@P{n}` names directly to the TDS writer. Execute-time binding state would
   also allow `OUTPUT` and `?=` handling. This is no longer a repeated-parsing
   correctness issue.
-- **Phase-2 type matrix:** widen beyond `SQL_C_CHAR` / `SQL_C_WCHAR` as
-  `SQLGetData` grows (numeric, binary, and date C types).
-- **Drive the RPC parameter's TDS type from `ParameterType`, not the C type.**
-  `params::convert` currently ignores `sql_type` and emits `(n)varchar(max)`,
-  relying on SQL Server implicit conversion. Map the ODBC SQL type to the wire
-  TDS type; use the C type only to read and convert the application buffer.
-  This avoids incorrect plan declarations and conversion differences for
+- **Type matrix and TDS type selection:** tracked by the conversion milestone
+  above. `params::convert` still ignores `sql_type` and emits `(n)varchar(max)`,
+  relying on SQL Server implicit conversion; P3 and P4 drive the wire type from
+  `ParameterType` instead. Beyond this milestone the same work is needed for
   binary, `uniqueidentifier`, money, decimal, and date/time values.
 - **Deferred features:** output parameters (`SQL_PARAM_OUTPUT`, `SQL_PARAM_INPUT_OUTPUT`), data-at-exec
   (`SQLParamData` / `SQLPutData`), parameter arrays

--- a/mssql-odbc/docs/parameters_plan.md
+++ b/mssql-odbc/docs/parameters_plan.md
@@ -56,15 +56,16 @@ transparent reconnects.
   rewritten SQL and marker count, so repeated `SQLExecute` calls do not re-scan
   the text.
 - **Bind-time type validation** - `api::type_rules` owns the `HY003` gate (every
-  real ODBC C type, including the SQL Server extensions) and the `HY004` gate
-  (SQL data types). `params::conversion_matrix` owns the C -> SQL conversion
-  table, shaped like msodbcsql's `fValidConversion` (one row per C type). A C
-  type that is real but not yet convertible returns `07006`, not `HY003`.
+  real ODBC C type, including the SQL Server extensions) and classifies SQL data
+  types three ways, like msodbcsql's `IsValidSqlType`: supported, real but with
+  no SQL Server counterpart (`HYC00` - the interval types), or unknown
+  (`HY004`). `params::conversion_matrix` owns the C -> SQL conversion table,
+  shaped like msodbcsql's `fValidConversion` (one row per C type). A C type that
+  is real but not yet convertible returns `07006`, not `HY003`.
 - **`SQL_C_DEFAULT` resolution** - resolved at bind time to the C type implied
   by `ParameterType` (msodbcsql `Sql2CDefault`, which reads `rgbTRANSTYPE380`
   for ODBC 3.8+ applications) and stored resolved in `BoundParam`, so the
-  execute path never sees the placeholder. Interval SQL types have no default
-  and return `07006`.
+  execute path never sees the placeholder.
 - **Value conversion** - `SQL_C_CHAR` maps to varchar and `SQL_C_WCHAR` to
   nvarchar. Indicators support `SQL_NULL_DATA`, `SQL_NTS`, and explicit byte
   length.

--- a/mssql-odbc/src/api/bind_param.rs
+++ b/mssql-odbc/src/api/bind_param.rs
@@ -12,7 +12,8 @@ use crate::api::odbc_types::{
     SqlPointer, SqlReturn, SqlSmallInt, SqlULen, SqlUSmallInt,
 };
 use crate::api::type_rules::{
-    SqlTypeSupport, classify_sql_type, is_valid_c_type, resolve_default_c_type,
+    SqlTypeSupport, canonical_c_type, classify_parameter_sql_type, is_valid_c_type,
+    resolve_default_c_type,
 };
 use crate::error::{free_errors, post_sql_error};
 use crate::handles::{HandleType, StmtHandle, handle_from_raw};
@@ -125,11 +126,26 @@ fn sql_bind_parameter_safe(
     buffer_length: SqlLen,
     strlen_or_ind_ptr: *mut SqlLen,
 ) -> SqlReturn {
+    // The declared ODBC version selects the SQL_C_DEFAULT table. Read it before
+    // the stmt lock to preserve parent-before-child lock ordering.
+    let odbc_version = {
+        let env = stmt.parent_dbc().parent_env();
+        let Ok(env_state) = env.inner.lock() else {
+            error!("SQLBindParameter: env mutex poisoned");
+            return SQL_ERROR;
+        };
+        env_state.odbc_version
+    };
+
     let Ok(mut stmt_state) = stmt.inner.lock() else {
         error!("SQLBindParameter: stmt mutex poisoned");
         return SQL_ERROR;
     };
     free_errors(&mut stmt_state);
+
+    // Fold the deprecated 2.x date/time C spellings onto the SQL_C_TYPE_* forms
+    // so only one form per type reaches validation, conversion, and storage.
+    let value_type = canonical_c_type(value_type);
 
     // ValueType (C type) and ParameterType (SQL type) must be known type
     // identifiers (HY003 / HY004).
@@ -141,7 +157,7 @@ fn sql_bind_parameter_safe(
         post_diag(&mut stmt_state, ERR_INVALID_C_DATA_TYPE);
         return SQL_ERROR;
     }
-    match classify_sql_type(parameter_type) {
+    match classify_parameter_sql_type(parameter_type) {
         SqlTypeSupport::Supported => {}
         SqlTypeSupport::NotImplemented => {
             error!(
@@ -161,7 +177,13 @@ fn sql_bind_parameter_safe(
     // Resolve SQL_C_DEFAULT here so the execute path never sees the placeholder,
     // matching msodbcsql, which stores the resolved type in the APD.
     let c_type = if value_type == SQL_C_DEFAULT {
-        let Some(resolved) = resolve_default_c_type(parameter_type) else {
+        let Some(resolved) = resolve_default_c_type(parameter_type, odbc_version) else {
+            // Unreachable: every Supported type has a default C type, pinned by
+            // every_supported_sql_type_has_a_default_c_type.
+            debug_assert!(
+                false,
+                "no default C type for supported SQL type {parameter_type}"
+            );
             error!(
                 parameter_type,
                 "SQLBindParameter: no default C type for this SQL type"
@@ -546,6 +568,32 @@ mod tests {
         let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
         let state = stmt.inner.lock().unwrap();
         assert_eq!(state.diag_records[0].sql_state, SQLSTATE_HYC00);
+    }
+
+    #[test]
+    fn deprecated_c_type_spelling_passes_the_hy003_gate() {
+        // SQL_C_TIMESTAMP is folded to SQL_C_TYPE_TIMESTAMP before validation, so
+        // it must fail on the missing conversion row, not as an unknown C type.
+        let h = TestHandles::with_env_dbc_stmt();
+        let mut ind: SqlLen = 0;
+        let ret = unsafe {
+            sql_bind_parameter(
+                h.stmt,
+                1,
+                SQL_PARAM_INPUT,
+                crate::api::odbc_types::SQL_C_TIMESTAMP,
+                crate::api::odbc_types::SQL_TYPE_TIMESTAMP,
+                0,
+                0,
+                std::ptr::null_mut(),
+                0,
+                &mut ind,
+            )
+        };
+        assert_eq!(ret, SQL_ERROR);
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        let state = stmt.inner.lock().unwrap();
+        assert_eq!(state.diag_records[0].sql_state, SQLSTATE_07006);
     }
 
     #[test]

--- a/mssql-odbc/src/api/bind_param.rs
+++ b/mssql-odbc/src/api/bind_param.rs
@@ -11,7 +11,9 @@ use crate::api::odbc_types::{
     SQL_C_DEFAULT, SQL_ERROR, SQL_INVALID_HANDLE, SQL_PARAM_INPUT, SQL_SUCCESS, SqlHandle, SqlLen,
     SqlPointer, SqlReturn, SqlSmallInt, SqlULen, SqlUSmallInt,
 };
-use crate::api::type_rules::{is_valid_c_type, is_valid_sql_type, resolve_default_c_type};
+use crate::api::type_rules::{
+    SqlTypeSupport, classify_sql_type, is_valid_c_type, resolve_default_c_type,
+};
 use crate::error::{free_errors, post_sql_error};
 use crate::handles::{HandleType, StmtHandle, handle_from_raw};
 use crate::params::BoundParam;
@@ -139,10 +141,21 @@ fn sql_bind_parameter_safe(
         post_diag(&mut stmt_state, ERR_INVALID_C_DATA_TYPE);
         return SQL_ERROR;
     }
-    if !is_valid_sql_type(parameter_type) {
-        error!(parameter_type, "SQLBindParameter: invalid SQL data type");
-        post_diag(&mut stmt_state, ERR_INVALID_SQL_DATA_TYPE);
-        return SQL_ERROR;
+    match classify_sql_type(parameter_type) {
+        SqlTypeSupport::Supported => {}
+        SqlTypeSupport::NotImplemented => {
+            error!(
+                parameter_type,
+                "SQLBindParameter: unsupported SQL data type"
+            );
+            post_diag(&mut stmt_state, ERR_OPTIONAL_FEATURE_NOT_IMPLEMENTED);
+            return SQL_ERROR;
+        }
+        SqlTypeSupport::Invalid => {
+            error!(parameter_type, "SQLBindParameter: invalid SQL data type");
+            post_diag(&mut stmt_state, ERR_INVALID_SQL_DATA_TYPE);
+            return SQL_ERROR;
+        }
     }
 
     // Resolve SQL_C_DEFAULT here so the execute path never sees the placeholder,
@@ -510,8 +523,9 @@ mod tests {
     }
 
     #[test]
-    fn default_c_type_without_a_mapping_returns_07006() {
-        // Interval SQL types are valid identifiers with no default C type.
+    fn interval_sql_type_returns_hyc00() {
+        // SQL Server has no interval type: a real ODBC identifier the driver
+        // cannot implement is HYC00, not a conversion failure.
         let h = TestHandles::with_env_dbc_stmt();
         let mut ind: SqlLen = 0;
         let ret = unsafe {
@@ -531,7 +545,7 @@ mod tests {
         assert_eq!(ret, SQL_ERROR);
         let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
         let state = stmt.inner.lock().unwrap();
-        assert_eq!(state.diag_records[0].sql_state, SQLSTATE_07006);
+        assert_eq!(state.diag_records[0].sql_state, SQLSTATE_HYC00);
     }
 
     #[test]

--- a/mssql-odbc/src/api/bind_param.rs
+++ b/mssql-odbc/src/api/bind_param.rs
@@ -8,13 +8,14 @@ use tracing::{debug, error};
 
 use super::sqlstate::*;
 use crate::api::odbc_types::{
-    SQL_ERROR, SQL_INVALID_HANDLE, SQL_PARAM_INPUT, SQL_SUCCESS, SqlHandle, SqlLen, SqlPointer,
-    SqlReturn, SqlSmallInt, SqlULen, SqlUSmallInt,
+    SQL_C_DEFAULT, SQL_ERROR, SQL_INVALID_HANDLE, SQL_PARAM_INPUT, SQL_SUCCESS, SqlHandle, SqlLen,
+    SqlPointer, SqlReturn, SqlSmallInt, SqlULen, SqlUSmallInt,
 };
+use crate::api::type_rules::{is_valid_c_type, is_valid_sql_type, resolve_default_c_type};
 use crate::error::{free_errors, post_sql_error};
 use crate::handles::{HandleType, StmtHandle, handle_from_raw};
 use crate::params::BoundParam;
-use crate::params::convert::{is_valid_c_type, is_valid_conversion, is_valid_sql_type};
+use crate::params::conversion_matrix::is_supported_conversion;
 
 /// Binds a buffer to a parameter marker in an SQL statement.
 ///
@@ -144,10 +145,26 @@ fn sql_bind_parameter_safe(
         return SQL_ERROR;
     }
 
+    // Resolve SQL_C_DEFAULT here so the execute path never sees the placeholder,
+    // matching msodbcsql, which stores the resolved type in the APD.
+    let c_type = if value_type == SQL_C_DEFAULT {
+        let Some(resolved) = resolve_default_c_type(parameter_type) else {
+            error!(
+                parameter_type,
+                "SQLBindParameter: no default C type for this SQL type"
+            );
+            post_diag(&mut stmt_state, ERR_RESTRICTED_DATA_TYPE);
+            return SQL_ERROR;
+        };
+        resolved
+    } else {
+        value_type
+    };
+
     // The C type → SQL type conversion must be one we support (07006).
-    if !is_valid_conversion(value_type, parameter_type) {
+    if !is_supported_conversion(c_type, parameter_type) {
         error!(
-            value_type,
+            c_type,
             parameter_type, "SQLBindParameter: unsupported C/SQL type conversion"
         );
         post_diag(&mut stmt_state, ERR_RESTRICTED_DATA_TYPE);
@@ -176,7 +193,7 @@ fn sql_bind_parameter_safe(
     }
     stmt_state.bound_params[idx] = Some(BoundParam {
         input_output_type,
-        c_type: value_type,
+        c_type,
         sql_type: parameter_type,
         column_size,
         decimal_digits,
@@ -234,7 +251,8 @@ fn sql_free_stmt_reset_params_safe(stmt: &StmtHandle) -> SqlReturn {
 mod tests {
     use super::*;
     use crate::api::odbc_types::{
-        SQL_C_CHAR, SQL_INTEGER, SQL_NULL_HANDLE, SQL_PARAM_OUTPUT, SQL_VARCHAR,
+        SQL_C_CHAR, SQL_C_SLONG, SQL_GUID, SQL_INTEGER, SQL_NULL_HANDLE, SQL_PARAM_OUTPUT,
+        SQL_VARCHAR,
     };
     use crate::handles::handle_from_raw;
     use crate::test_support::TestHandles;
@@ -404,6 +422,108 @@ mod tests {
                 0,
                 0,
                 &mut val as *mut i32 as SqlPointer,
+                0,
+                &mut ind,
+            )
+        };
+        assert_eq!(ret, SQL_ERROR);
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        let state = stmt.inner.lock().unwrap();
+        assert_eq!(state.diag_records[0].sql_state, SQLSTATE_07006);
+    }
+
+    #[test]
+    fn real_but_unconvertible_c_type_returns_07006() {
+        // SQL_C_SLONG is a legal ODBC C type the driver cannot convert yet, so it
+        // must fail the conversion check rather than the HY003 type check.
+        let h = TestHandles::with_env_dbc_stmt();
+        let mut val: i32 = 0;
+        let mut ind: SqlLen = 0;
+        let ret = unsafe {
+            sql_bind_parameter(
+                h.stmt,
+                1,
+                SQL_PARAM_INPUT,
+                SQL_C_SLONG,
+                SQL_INTEGER,
+                0,
+                0,
+                &mut val as *mut i32 as SqlPointer,
+                0,
+                &mut ind,
+            )
+        };
+        assert_eq!(ret, SQL_ERROR);
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        let state = stmt.inner.lock().unwrap();
+        assert_eq!(state.diag_records[0].sql_state, SQLSTATE_07006);
+    }
+
+    #[test]
+    fn default_c_type_is_resolved_before_storage() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let mut buf: Vec<u8> = b"abc\0".to_vec();
+        let mut ind: SqlLen = crate::api::odbc_types::SQL_NTS as SqlLen;
+        let ret = unsafe {
+            sql_bind_parameter(
+                h.stmt,
+                1,
+                SQL_PARAM_INPUT,
+                SQL_C_DEFAULT,
+                SQL_VARCHAR,
+                0,
+                0,
+                buf.as_mut_ptr() as SqlPointer,
+                buf.len() as SqlLen,
+                &mut ind,
+            )
+        };
+        assert_eq!(ret, SQL_SUCCESS);
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        let state = stmt.inner.lock().unwrap();
+        let bound = state.bound_params[0].expect("parameter 1 should be bound");
+        assert_eq!(bound.c_type, SQL_C_CHAR);
+    }
+
+    #[test]
+    fn default_c_type_resolved_but_unconvertible_returns_07006() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let mut ind: SqlLen = 0;
+        let ret = unsafe {
+            sql_bind_parameter(
+                h.stmt,
+                1,
+                SQL_PARAM_INPUT,
+                SQL_C_DEFAULT,
+                SQL_GUID,
+                0,
+                0,
+                std::ptr::null_mut(),
+                0,
+                &mut ind,
+            )
+        };
+        assert_eq!(ret, SQL_ERROR);
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        let state = stmt.inner.lock().unwrap();
+        assert_eq!(state.diag_records[0].sql_state, SQLSTATE_07006);
+    }
+
+    #[test]
+    fn default_c_type_without_a_mapping_returns_07006() {
+        // Interval SQL types are valid identifiers with no default C type.
+        let h = TestHandles::with_env_dbc_stmt();
+        let mut ind: SqlLen = 0;
+        let ret = unsafe {
+            sql_bind_parameter(
+                h.stmt,
+                1,
+                SQL_PARAM_INPUT,
+                SQL_C_DEFAULT,
+                crate::api::odbc_types::SQL_INTERVAL_YEAR,
+                0,
+                0,
+                std::ptr::null_mut(),
                 0,
                 &mut ind,
             )

--- a/mssql-odbc/src/api/mod.rs
+++ b/mssql-odbc/src/api/mod.rs
@@ -33,6 +33,7 @@ pub(crate) mod set_env_attr;
 pub(crate) mod set_stmt_attr;
 pub(crate) mod sqlstate;
 mod txn;
+pub(crate) mod type_rules;
 pub(crate) mod util;
 
 // Exported ODBC entry points — the driver's public API surface.

--- a/mssql-odbc/src/api/odbc_types.rs
+++ b/mssql-odbc/src/api/odbc_types.rs
@@ -302,6 +302,8 @@ pub const SQL_LEN_DATA_AT_EXEC_OFFSET: SqlLen = -100;
 pub const SQL_SS_VARIANT: SqlSmallInt = -150;
 pub const SQL_SS_UDT: SqlSmallInt = -151;
 pub const SQL_SS_XML: SqlSmallInt = -152;
+pub const SQL_SS_TABLE: SqlSmallInt = -153;
+pub const SQL_SS_VECTOR: SqlSmallInt = -156;
 
 // ---- Additional ODBC C type identifiers (SQLBindCol / SQLGetData) -----------
 // Signed/unsigned integer C types are the base numeric type id plus an offset,
@@ -339,6 +341,15 @@ pub const SQL_C_TYPE_TIMESTAMP: SqlSmallInt = 93;
 pub const SQL_C_TYPES_EXTENDED: SqlSmallInt = 0x4000; // 16384
 pub const SQL_C_SS_TIME2: SqlSmallInt = SQL_C_TYPES_EXTENDED; // 0x4000
 pub const SQL_C_SS_TIMESTAMPOFFSET: SqlSmallInt = SQL_C_TYPES_EXTENDED + 1; // 0x4001
+pub const SQL_C_SS_VECTOR: SqlSmallInt = SQL_C_TYPES_EXTENDED + 2; // 0x4002
+
+// The 13 ODBC 3.x interval C types occupy a contiguous range, 101..=113, and the
+// matching `SQL_INTERVAL_*` SQL types share those values.
+pub const SQL_C_INTERVAL_YEAR: SqlSmallInt = 101;
+pub const SQL_C_INTERVAL_MINUTE_TO_SECOND: SqlSmallInt = 113;
+// The interval SQL types share the C type values above.
+pub const SQL_INTERVAL_YEAR: SqlSmallInt = 101;
+pub const SQL_INTERVAL_MINUTE_TO_SECOND: SqlSmallInt = 113;
 
 // SQLColAttribute field identifier for the underlying type of a `sql_variant`
 // column (msodbcsql: `SQL_CA_SS_BASE + 15`). Required by mssql-python's

--- a/mssql-odbc/src/api/odbc_types.rs
+++ b/mssql-odbc/src/api/odbc_types.rs
@@ -336,8 +336,8 @@ pub const SQL_C_TYPE_DATE: SqlSmallInt = 91;
 pub const SQL_C_TYPE_TIME: SqlSmallInt = 92;
 pub const SQL_C_TYPE_TIMESTAMP: SqlSmallInt = 93;
 
-// SQL Server-specific C types (msodbcsql extensions). `SQL_C_TYPES_EXTENDED`
-// is `0x4000`; the two SS date/time C types are offset from it.
+// SQL Server-specific C types (msodbcsql extensions). Values confirmed against
+// msodbcsql's `msodbcsql.h`: `#define SQL_C_TYPES_EXTENDED 0x04000L`.
 pub const SQL_C_TYPES_EXTENDED: SqlSmallInt = 0x4000; // 16384
 pub const SQL_C_SS_TIME2: SqlSmallInt = SQL_C_TYPES_EXTENDED; // 0x4000
 pub const SQL_C_SS_TIMESTAMPOFFSET: SqlSmallInt = SQL_C_TYPES_EXTENDED + 1; // 0x4001

--- a/mssql-odbc/src/api/type_rules.rs
+++ b/mssql-odbc/src/api/type_rules.rs
@@ -18,7 +18,9 @@
 //! Validity here means only that an identifier names a real ODBC type. Whether a
 //! particular pairing can be converted is decided per direction — for input
 //! parameters by [`crate::params::conversion_matrix`], and for fetch inside the
-//! converters themselves.
+//! converters themselves. SQL types are the exception: a real ODBC identifier
+//! SQL Server has no counterpart for is rejected outright by
+//! [`classify_sql_type`], never reaching a conversion check.
 
 use crate::api::odbc_types::{
     SQL_BIGINT, SQL_BINARY, SQL_BIT, SQL_C_BINARY, SQL_C_BIT, SQL_C_CHAR, SQL_C_DATE,
@@ -77,43 +79,60 @@ pub(crate) fn is_valid_c_type(c_type: SqlSmallInt) -> bool {
     )
 }
 
-/// Known ODBC SQL data type identifiers, plus the SQL Server extensions. This
-/// is the `HY004` gate only; conversion support is checked separately.
-pub(crate) fn is_valid_sql_type(sql_type: SqlSmallInt) -> bool {
-    matches!(
-        sql_type,
+/// How a SQL type identifier is treated at bind time.
+///
+/// Mirrors the tri-state return of msodbcsql's `IsValidSqlType` (`sqlcprot.h`),
+/// which yields `SQL_SUCCESS`, `IDS_S1_C00` (`HYC00`), or `IDS_S1_004`
+/// (`HY004`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SqlTypeSupport {
+    /// A SQL type this driver and SQL Server can carry.
+    Supported,
+    /// A real ODBC identifier with no SQL Server counterpart (`HYC00`).
+    NotImplemented,
+    /// Not a known ODBC SQL type identifier (`HY004`).
+    Invalid,
+}
+
+/// Classifies a `ParameterType` before any conversion check.
+pub(crate) fn classify_sql_type(sql_type: SqlSmallInt) -> SqlTypeSupport {
+    match sql_type {
         SQL_CHAR
-            | SQL_VARCHAR
-            | SQL_LONGVARCHAR
-            | SQL_WCHAR
-            | SQL_WVARCHAR
-            | SQL_WLONGVARCHAR
-            | SQL_BINARY
-            | SQL_VARBINARY
-            | SQL_LONGVARBINARY
-            | SQL_DECIMAL
-            | SQL_NUMERIC
-            | SQL_SMALLINT
-            | SQL_INTEGER
-            | SQL_BIGINT
-            | SQL_TINYINT
-            | SQL_BIT
-            | SQL_REAL
-            | SQL_FLOAT
-            | SQL_DOUBLE
-            | SQL_GUID
-            | SQL_TYPE_DATE
-            | SQL_TYPE_TIME
-            | SQL_TYPE_TIMESTAMP
-            | SQL_SS_TIME2
-            | SQL_SS_TIMESTAMPOFFSET
-            | SQL_SS_VARIANT
-            | SQL_SS_UDT
-            | SQL_SS_XML
-            | SQL_SS_TABLE
-            | SQL_SS_VECTOR
-            | SQL_INTERVAL_YEAR..=SQL_INTERVAL_MINUTE_TO_SECOND
-    )
+        | SQL_VARCHAR
+        | SQL_LONGVARCHAR
+        | SQL_WCHAR
+        | SQL_WVARCHAR
+        | SQL_WLONGVARCHAR
+        | SQL_BINARY
+        | SQL_VARBINARY
+        | SQL_LONGVARBINARY
+        | SQL_DECIMAL
+        | SQL_NUMERIC
+        | SQL_SMALLINT
+        | SQL_INTEGER
+        | SQL_BIGINT
+        | SQL_TINYINT
+        | SQL_BIT
+        | SQL_REAL
+        | SQL_FLOAT
+        | SQL_DOUBLE
+        | SQL_GUID
+        | SQL_TYPE_DATE
+        | SQL_TYPE_TIME
+        | SQL_TYPE_TIMESTAMP
+        | SQL_SS_TIME2
+        | SQL_SS_TIMESTAMPOFFSET
+        | SQL_SS_VARIANT
+        | SQL_SS_UDT
+        | SQL_SS_XML
+        | SQL_SS_TABLE
+        | SQL_SS_VECTOR => SqlTypeSupport::Supported,
+        // SQL Server has no interval type, so no conversion could ever succeed.
+        // msodbcsql returns IDS_S1_C00 for this whole range from IsValidSqlType,
+        // before IsValidSQLConversion is consulted.
+        SQL_INTERVAL_YEAR..=SQL_INTERVAL_MINUTE_TO_SECOND => SqlTypeSupport::NotImplemented,
+        _ => SqlTypeSupport::Invalid,
+    }
 }
 
 /// Resolves `SQL_C_DEFAULT` to the C type implied by `sql_type`.
@@ -126,9 +145,8 @@ pub(crate) fn is_valid_sql_type(sql_type: SqlSmallInt) -> bool {
 /// default is an ANSI-transfer artifact with no equivalent here, and resolving
 /// UTF-16 input to this driver's UTF-8 `SQL_C_CHAR` would silently corrupt data.
 ///
-/// Intervals are deliberately unmapped: the ODBC default is the identity
-/// `SQL_C_INTERVAL_*`, but SQL Server has no interval type so nothing can
-/// convert one. The caller reports the `None` as `07006`.
+/// Every [`SqlTypeSupport::Supported`] type has a mapping; `None` means the
+/// caller passed a type that should already have been rejected.
 pub(crate) fn resolve_default_c_type(sql_type: SqlSmallInt) -> Option<SqlSmallInt> {
     Some(match sql_type {
         SQL_CHAR | SQL_VARCHAR | SQL_LONGVARCHAR => SQL_C_CHAR,
@@ -185,8 +203,8 @@ mod tests {
 
     #[test]
     fn unknown_sql_type_is_invalid() {
-        assert!(is_valid_sql_type(SQL_VARCHAR));
-        assert!(!is_valid_sql_type(9999));
+        assert_eq!(classify_sql_type(SQL_VARCHAR), SqlTypeSupport::Supported);
+        assert_eq!(classify_sql_type(9999), SqlTypeSupport::Invalid);
     }
 
     #[test]
@@ -216,8 +234,17 @@ mod tests {
     }
 
     #[test]
-    fn interval_sql_types_are_valid_but_unresolved() {
-        assert!(is_valid_sql_type(SQL_INTERVAL_YEAR));
-        assert_eq!(resolve_default_c_type(SQL_INTERVAL_YEAR), None);
+    fn interval_sql_types_are_not_implemented() {
+        for sql_type in [
+            SQL_INTERVAL_YEAR,
+            SQL_INTERVAL_MINUTE_TO_SECOND,
+            SQL_INTERVAL_YEAR + 1,
+        ] {
+            assert_eq!(
+                classify_sql_type(sql_type),
+                SqlTypeSupport::NotImplemented,
+                "{sql_type} should be HYC00, not a conversion failure"
+            );
+        }
     }
 }

--- a/mssql-odbc/src/api/type_rules.rs
+++ b/mssql-odbc/src/api/type_rules.rs
@@ -10,40 +10,74 @@
 //! `SQLBindParameter` and `SQLBindCol`) and keeps these predicates in the shared
 //! `sqlcprot.h`.
 //!
-//! This driver targets ODBC 3.x only, so only the 3.x concise identifiers are
-//! accepted: the Driver Manager maps an ODBC 2.x application's `SQL_DATE` /
-//! `SQL_TIME` / `SQL_TIMESTAMP` to the `SQL_TYPE_*` forms before they reach a
-//! 3.x driver.
+//! This driver targets ODBC 3.x only, which scopes out support for ODBC 2.x
+//! *applications* — not the 2.x-era *identifiers*. `SQL_C_DATE` / `SQL_C_TIME` /
+//! `SQL_C_TIMESTAMP` are deprecated but still defined in the ODBC 3.x headers, so
+//! a 3.x application may legally pass them and the Driver Manager remaps nothing.
+//! [`canonical_c_type`] folds them onto the `SQL_C_TYPE_*` forms, and everything
+//! after it — validation, conversion, storage — sees only the canonical form.
+//! msodbcsql is the mirror image: it folds 3.x down to 2.x, and its
+//! `IsValidCType` likewise accepts only its own canonical (2.x) spelling.
 //!
 //! Validity here means only that an identifier names a real ODBC type. Whether a
 //! particular pairing can be converted is decided per direction — for input
 //! parameters by [`crate::params::conversion_matrix`], and for fetch inside the
 //! converters themselves. SQL types are the exception: a real ODBC identifier
 //! SQL Server has no counterpart for is rejected outright by
-//! [`classify_sql_type`], never reaching a conversion check.
+//! [`classify_parameter_sql_type`], never reaching a conversion check.
 
 use crate::api::odbc_types::{
     SQL_BIGINT, SQL_BINARY, SQL_BIT, SQL_C_BINARY, SQL_C_BIT, SQL_C_CHAR, SQL_C_DATE,
     SQL_C_DEFAULT, SQL_C_DOUBLE, SQL_C_FLOAT, SQL_C_GUID, SQL_C_INTERVAL_MINUTE_TO_SECOND,
     SQL_C_INTERVAL_YEAR, SQL_C_LONG, SQL_C_NUMERIC, SQL_C_SBIGINT, SQL_C_SHORT, SQL_C_SLONG,
     SQL_C_SS_TIME2, SQL_C_SS_TIMESTAMPOFFSET, SQL_C_SS_VECTOR, SQL_C_SSHORT, SQL_C_STINYINT,
-    SQL_C_TIME, SQL_C_TIMESTAMP, SQL_C_TINYINT, SQL_C_TYPE_DATE, SQL_C_TYPE_TIME,
-    SQL_C_TYPE_TIMESTAMP, SQL_C_UBIGINT, SQL_C_ULONG, SQL_C_USHORT, SQL_C_UTINYINT, SQL_C_WCHAR,
-    SQL_CHAR, SQL_DECIMAL, SQL_DOUBLE, SQL_FLOAT, SQL_GUID, SQL_INTEGER,
-    SQL_INTERVAL_MINUTE_TO_SECOND, SQL_INTERVAL_YEAR, SQL_LONGVARBINARY, SQL_LONGVARCHAR,
-    SQL_NUMERIC, SQL_REAL, SQL_SMALLINT, SQL_SS_TABLE, SQL_SS_TIME2, SQL_SS_TIMESTAMPOFFSET,
-    SQL_SS_UDT, SQL_SS_VARIANT, SQL_SS_VECTOR, SQL_SS_XML, SQL_TINYINT, SQL_TYPE_DATE,
-    SQL_TYPE_TIME, SQL_TYPE_TIMESTAMP, SQL_VARBINARY, SQL_VARCHAR, SQL_WCHAR, SQL_WLONGVARCHAR,
-    SQL_WVARCHAR, SqlSmallInt,
+    SQL_C_TIMESTAMP, SQL_C_TINYINT, SQL_C_TYPE_DATE, SQL_C_TYPE_TIME, SQL_C_TYPE_TIMESTAMP,
+    SQL_C_UBIGINT, SQL_C_ULONG, SQL_C_USHORT, SQL_C_UTINYINT, SQL_C_WCHAR, SQL_CHAR, SQL_DECIMAL,
+    SQL_DOUBLE, SQL_FLOAT, SQL_GUID, SQL_INTEGER, SQL_INTERVAL_MINUTE_TO_SECOND, SQL_INTERVAL_YEAR,
+    SQL_LONGVARBINARY, SQL_LONGVARCHAR, SQL_NUMERIC, SQL_REAL, SQL_SMALLINT, SQL_SS_TABLE,
+    SQL_SS_TIME2, SQL_SS_TIMESTAMPOFFSET, SQL_SS_UDT, SQL_SS_VARIANT, SQL_SS_VECTOR, SQL_SS_XML,
+    SQL_TINYINT, SQL_TYPE_DATE, SQL_TYPE_TIME, SQL_TYPE_TIMESTAMP, SQL_VARBINARY, SQL_VARCHAR,
+    SQL_WCHAR, SQL_WLONGVARCHAR, SQL_WVARCHAR, SqlSmallInt,
 };
+use crate::handles::OdbcVersion;
 
-/// Known ODBC C type identifiers, including the SQL Server extensions.
+/// Offset between the ODBC 2.x (`9`..`11`) and 3.x (`91`..`93`) date/time ids.
+const ODBC2_DATETIME_OFFSET: SqlSmallInt = SQL_C_TYPE_DATE - SQL_C_DATE;
+
+/// Folds the deprecated 2.x date/time C spellings onto their `SQL_C_TYPE_*`
+/// equivalents so everything downstream sees one form per type.
+///
+/// msodbcsql canonicalizes the same pair in `SQLBindParameter`
+/// (`Sql/Ntdbms/sqlncli/odbc/sqlcdesc.cpp`), just toward the 2.x values, which
+/// are its internal representation.
+pub(crate) fn canonical_c_type(c_type: SqlSmallInt) -> SqlSmallInt {
+    if (SQL_C_DATE..=SQL_C_TIMESTAMP).contains(&c_type) {
+        c_type + ODBC2_DATETIME_OFFSET
+    } else {
+        c_type
+    }
+}
+
+/// Known ODBC C type identifiers in canonical form, including the SQL Server
+/// extensions.
+///
+/// Callers must pass the output of [`canonical_c_type`]: the deprecated
+/// `SQL_C_DATE` / `SQL_C_TIME` / `SQL_C_TIMESTAMP` spellings are **not** accepted
+/// here, so that exactly one form per type reaches everything downstream.
+/// msodbcsql's `IsValidCType` draws the same line in its own canonical form — it
+/// bounds the positive range at `fCType <= 32`, rejecting `SQL_C_TYPE_DATE` and
+/// friends.
 ///
 /// This is the `HY003` gate only. A C type listed here that the driver cannot
 /// yet convert is rejected later with `07006`, matching msodbcsql, which treats
 /// an unconvertible-but-real C type as a restricted conversion rather than an
 /// out-of-range program type.
 pub(crate) fn is_valid_c_type(c_type: SqlSmallInt) -> bool {
+    debug_assert_eq!(
+        c_type,
+        canonical_c_type(c_type),
+        "C type must be canonicalized before validation"
+    );
     matches!(
         c_type,
         SQL_C_CHAR
@@ -65,9 +99,6 @@ pub(crate) fn is_valid_c_type(c_type: SqlSmallInt) -> bool {
             | SQL_C_UBIGINT
             | SQL_C_FLOAT
             | SQL_C_DOUBLE
-            | SQL_C_DATE
-            | SQL_C_TIME
-            | SQL_C_TIMESTAMP
             | SQL_C_TYPE_DATE
             | SQL_C_TYPE_TIME
             | SQL_C_TYPE_TIMESTAMP
@@ -95,7 +126,7 @@ pub(crate) enum SqlTypeSupport {
 }
 
 /// Classifies a `ParameterType` before any conversion check.
-pub(crate) fn classify_sql_type(sql_type: SqlSmallInt) -> SqlTypeSupport {
+pub(crate) fn classify_parameter_sql_type(sql_type: SqlSmallInt) -> SqlTypeSupport {
     match sql_type {
         SQL_CHAR
         | SQL_VARCHAR
@@ -137,7 +168,11 @@ pub(crate) fn classify_sql_type(sql_type: SqlSmallInt) -> SqlTypeSupport {
 
 /// Resolves `SQL_C_DEFAULT` to the C type implied by `sql_type`.
 ///
-/// Mirrors msodbcsql's `Sql2CDefault` (`sqlcprot.h`).
+/// Mirrors msodbcsql's `Sql2CDefault` (`sqlcprot.h`), which selects
+/// `rgbTRANSTYPE` for a 3.51-or-earlier application and `rgbTRANSTYPE380`
+/// otherwise. Per the comment on those tables
+/// (`Sql/Ntdbms/sqlncli/odbc/sqlcmisc.cpp`) they differ only in the two SS
+/// date/time rows, which default to `SQL_C_BINARY` before ODBC 3.8.
 ///
 /// Two deliberate deviations, both following the ODBC 3.x default-C-type table
 /// instead: the wide character types resolve to `SQL_C_WCHAR` and `SQL_GUID` to
@@ -147,7 +182,11 @@ pub(crate) fn classify_sql_type(sql_type: SqlSmallInt) -> SqlTypeSupport {
 ///
 /// Every [`SqlTypeSupport::Supported`] type has a mapping; `None` means the
 /// caller passed a type that should already have been rejected.
-pub(crate) fn resolve_default_c_type(sql_type: SqlSmallInt) -> Option<SqlSmallInt> {
+pub(crate) fn resolve_default_c_type(
+    sql_type: SqlSmallInt,
+    odbc_version: OdbcVersion,
+) -> Option<SqlSmallInt> {
+    let is_3_80 = odbc_version == OdbcVersion::Odbc3_80;
     Some(match sql_type {
         SQL_CHAR | SQL_VARCHAR | SQL_LONGVARCHAR => SQL_C_CHAR,
         SQL_WCHAR | SQL_WVARCHAR | SQL_WLONGVARCHAR => SQL_C_WCHAR,
@@ -164,8 +203,10 @@ pub(crate) fn resolve_default_c_type(sql_type: SqlSmallInt) -> Option<SqlSmallIn
         SQL_TYPE_DATE => SQL_C_TYPE_DATE,
         SQL_TYPE_TIME => SQL_C_TYPE_TIME,
         SQL_TYPE_TIMESTAMP => SQL_C_TYPE_TIMESTAMP,
-        SQL_SS_TIME2 => SQL_C_SS_TIME2,
-        SQL_SS_TIMESTAMPOFFSET => SQL_C_SS_TIMESTAMPOFFSET,
+        SQL_SS_TIME2 if is_3_80 => SQL_C_SS_TIME2,
+        SQL_SS_TIME2 => SQL_C_BINARY,
+        SQL_SS_TIMESTAMPOFFSET if is_3_80 => SQL_C_SS_TIMESTAMPOFFSET,
+        SQL_SS_TIMESTAMPOFFSET => SQL_C_BINARY,
         SQL_SS_VARIANT => SQL_C_CHAR,
         SQL_SS_UDT | SQL_SS_TABLE => SQL_C_BINARY,
         SQL_SS_XML => SQL_C_WCHAR,
@@ -177,6 +218,7 @@ pub(crate) fn resolve_default_c_type(sql_type: SqlSmallInt) -> Option<SqlSmallIn
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::odbc_types::SQL_C_TIME;
 
     #[test]
     fn real_c_types_are_valid_even_when_unconvertible() {
@@ -203,34 +245,102 @@ mod tests {
 
     #[test]
     fn unknown_sql_type_is_invalid() {
-        assert_eq!(classify_sql_type(SQL_VARCHAR), SqlTypeSupport::Supported);
-        assert_eq!(classify_sql_type(9999), SqlTypeSupport::Invalid);
+        assert_eq!(
+            classify_parameter_sql_type(SQL_VARCHAR),
+            SqlTypeSupport::Supported
+        );
+        assert_eq!(classify_parameter_sql_type(9999), SqlTypeSupport::Invalid);
+    }
+
+    /// Keeps the two halves of the type model in step: `bind_param` relies on
+    /// every `Supported` type having a default C type, so a new row in one
+    /// function without the other must fail here rather than at runtime.
+    #[test]
+    fn every_supported_sql_type_has_a_default_c_type() {
+        for version in [
+            OdbcVersion::Unset,
+            OdbcVersion::Odbc2,
+            OdbcVersion::Odbc3,
+            OdbcVersion::Odbc3_80,
+        ] {
+            for sql_type in i16::MIN..=i16::MAX {
+                if classify_parameter_sql_type(sql_type) != SqlTypeSupport::Supported {
+                    continue;
+                }
+                assert!(
+                    resolve_default_c_type(sql_type, version).is_some(),
+                    "SQL type {sql_type} is Supported but has no default C type at {version:?}"
+                );
+            }
+        }
     }
 
     #[test]
     fn default_c_type_follows_the_sql_type() {
-        assert_eq!(resolve_default_c_type(SQL_VARCHAR), Some(SQL_C_CHAR));
-        assert_eq!(resolve_default_c_type(SQL_LONGVARCHAR), Some(SQL_C_CHAR));
-        assert_eq!(resolve_default_c_type(SQL_WVARCHAR), Some(SQL_C_WCHAR));
-        assert_eq!(resolve_default_c_type(SQL_VARBINARY), Some(SQL_C_BINARY));
-        assert_eq!(resolve_default_c_type(SQL_DECIMAL), Some(SQL_C_CHAR));
-        assert_eq!(resolve_default_c_type(SQL_BIT), Some(SQL_C_BIT));
-        assert_eq!(resolve_default_c_type(SQL_TINYINT), Some(SQL_C_UTINYINT));
-        assert_eq!(resolve_default_c_type(SQL_SMALLINT), Some(SQL_C_SSHORT));
-        assert_eq!(resolve_default_c_type(SQL_INTEGER), Some(SQL_C_SLONG));
-        assert_eq!(resolve_default_c_type(SQL_BIGINT), Some(SQL_C_SBIGINT));
-        assert_eq!(resolve_default_c_type(SQL_REAL), Some(SQL_C_FLOAT));
-        assert_eq!(resolve_default_c_type(SQL_DOUBLE), Some(SQL_C_DOUBLE));
-        assert_eq!(resolve_default_c_type(SQL_GUID), Some(SQL_C_GUID));
+        let v = OdbcVersion::Odbc3_80;
+        assert_eq!(resolve_default_c_type(SQL_VARCHAR, v), Some(SQL_C_CHAR));
+        assert_eq!(resolve_default_c_type(SQL_LONGVARCHAR, v), Some(SQL_C_CHAR));
+        assert_eq!(resolve_default_c_type(SQL_WVARCHAR, v), Some(SQL_C_WCHAR));
+        assert_eq!(resolve_default_c_type(SQL_VARBINARY, v), Some(SQL_C_BINARY));
+        assert_eq!(resolve_default_c_type(SQL_DECIMAL, v), Some(SQL_C_CHAR));
+        assert_eq!(resolve_default_c_type(SQL_BIT, v), Some(SQL_C_BIT));
+        assert_eq!(resolve_default_c_type(SQL_TINYINT, v), Some(SQL_C_UTINYINT));
+        assert_eq!(resolve_default_c_type(SQL_SMALLINT, v), Some(SQL_C_SSHORT));
+        assert_eq!(resolve_default_c_type(SQL_INTEGER, v), Some(SQL_C_SLONG));
+        assert_eq!(resolve_default_c_type(SQL_BIGINT, v), Some(SQL_C_SBIGINT));
+        assert_eq!(resolve_default_c_type(SQL_REAL, v), Some(SQL_C_FLOAT));
+        assert_eq!(resolve_default_c_type(SQL_DOUBLE, v), Some(SQL_C_DOUBLE));
+        assert_eq!(resolve_default_c_type(SQL_GUID, v), Some(SQL_C_GUID));
         assert_eq!(
-            resolve_default_c_type(SQL_TYPE_TIMESTAMP),
+            resolve_default_c_type(SQL_TYPE_TIMESTAMP, v),
             Some(SQL_C_TYPE_TIMESTAMP)
         );
         assert_eq!(
-            resolve_default_c_type(SQL_SS_TIMESTAMPOFFSET),
+            resolve_default_c_type(SQL_SS_TIMESTAMPOFFSET, v),
             Some(SQL_C_SS_TIMESTAMPOFFSET)
         );
-        assert_eq!(resolve_default_c_type(SQL_SS_VECTOR), Some(SQL_C_SS_VECTOR));
+        assert_eq!(
+            resolve_default_c_type(SQL_SS_VECTOR, v),
+            Some(SQL_C_SS_VECTOR)
+        );
+    }
+
+    /// msodbcsql's `Sql2CDefault` picks `rgbTRANSTYPE` below ODBC 3.8, whose only
+    /// difference is that the two SS date/time rows default to `SQL_C_BINARY`.
+    #[test]
+    fn ss_datetime_defaults_depend_on_the_odbc_version() {
+        for older in [OdbcVersion::Unset, OdbcVersion::Odbc2, OdbcVersion::Odbc3] {
+            assert_eq!(
+                resolve_default_c_type(SQL_SS_TIME2, older),
+                Some(SQL_C_BINARY)
+            );
+            assert_eq!(
+                resolve_default_c_type(SQL_SS_TIMESTAMPOFFSET, older),
+                Some(SQL_C_BINARY)
+            );
+        }
+        assert_eq!(
+            resolve_default_c_type(SQL_SS_TIME2, OdbcVersion::Odbc3_80),
+            Some(SQL_C_SS_TIME2)
+        );
+        assert_eq!(
+            resolve_default_c_type(SQL_SS_TIMESTAMPOFFSET, OdbcVersion::Odbc3_80),
+            Some(SQL_C_SS_TIMESTAMPOFFSET)
+        );
+    }
+
+    #[test]
+    fn deprecated_datetime_c_types_fold_onto_the_3x_forms() {
+        assert_eq!(canonical_c_type(SQL_C_DATE), SQL_C_TYPE_DATE);
+        assert_eq!(canonical_c_type(SQL_C_TIME), SQL_C_TYPE_TIME);
+        assert_eq!(canonical_c_type(SQL_C_TIMESTAMP), SQL_C_TYPE_TIMESTAMP);
+        // Already canonical, and unrelated types, pass through untouched.
+        assert_eq!(canonical_c_type(SQL_C_TYPE_DATE), SQL_C_TYPE_DATE);
+        assert_eq!(canonical_c_type(SQL_C_CHAR), SQL_C_CHAR);
+        assert_eq!(canonical_c_type(SQL_C_SLONG), SQL_C_SLONG);
+        // Folding is what makes the deprecated spellings pass the HY003 gate;
+        // is_valid_c_type itself only accepts the canonical form.
+        assert!(is_valid_c_type(canonical_c_type(SQL_C_TIMESTAMP)));
     }
 
     #[test]
@@ -241,7 +351,7 @@ mod tests {
             SQL_INTERVAL_YEAR + 1,
         ] {
             assert_eq!(
-                classify_sql_type(sql_type),
+                classify_parameter_sql_type(sql_type),
                 SqlTypeSupport::NotImplemented,
                 "{sql_type} should be HYC00, not a conversion failure"
             );

--- a/mssql-odbc/src/api/type_rules.rs
+++ b/mssql-odbc/src/api/type_rules.rs
@@ -1,0 +1,223 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Static ODBC rules about type identifiers: which `SQL_C_*` / `SQL_*` values
+//! name real ODBC types, and which C type a SQL type defaults to.
+//!
+//! Distinct from [`crate::api::odbc_types`], which defines the identifiers
+//! themselves. Direction-neutral and deliberately outside `params`: msodbcsql
+//! shares `IsValidCType` between its APD and ARD paths (`SetADRec` serves both
+//! `SQLBindParameter` and `SQLBindCol`) and keeps these predicates in the shared
+//! `sqlcprot.h`.
+//!
+//! This driver targets ODBC 3.x only, so only the 3.x concise identifiers are
+//! accepted: the Driver Manager maps an ODBC 2.x application's `SQL_DATE` /
+//! `SQL_TIME` / `SQL_TIMESTAMP` to the `SQL_TYPE_*` forms before they reach a
+//! 3.x driver.
+//!
+//! Validity here means only that an identifier names a real ODBC type. Whether a
+//! particular pairing can be converted is decided per direction — for input
+//! parameters by [`crate::params::conversion_matrix`], and for fetch inside the
+//! converters themselves.
+
+use crate::api::odbc_types::{
+    SQL_BIGINT, SQL_BINARY, SQL_BIT, SQL_C_BINARY, SQL_C_BIT, SQL_C_CHAR, SQL_C_DATE,
+    SQL_C_DEFAULT, SQL_C_DOUBLE, SQL_C_FLOAT, SQL_C_GUID, SQL_C_INTERVAL_MINUTE_TO_SECOND,
+    SQL_C_INTERVAL_YEAR, SQL_C_LONG, SQL_C_NUMERIC, SQL_C_SBIGINT, SQL_C_SHORT, SQL_C_SLONG,
+    SQL_C_SS_TIME2, SQL_C_SS_TIMESTAMPOFFSET, SQL_C_SS_VECTOR, SQL_C_SSHORT, SQL_C_STINYINT,
+    SQL_C_TIME, SQL_C_TIMESTAMP, SQL_C_TINYINT, SQL_C_TYPE_DATE, SQL_C_TYPE_TIME,
+    SQL_C_TYPE_TIMESTAMP, SQL_C_UBIGINT, SQL_C_ULONG, SQL_C_USHORT, SQL_C_UTINYINT, SQL_C_WCHAR,
+    SQL_CHAR, SQL_DECIMAL, SQL_DOUBLE, SQL_FLOAT, SQL_GUID, SQL_INTEGER,
+    SQL_INTERVAL_MINUTE_TO_SECOND, SQL_INTERVAL_YEAR, SQL_LONGVARBINARY, SQL_LONGVARCHAR,
+    SQL_NUMERIC, SQL_REAL, SQL_SMALLINT, SQL_SS_TABLE, SQL_SS_TIME2, SQL_SS_TIMESTAMPOFFSET,
+    SQL_SS_UDT, SQL_SS_VARIANT, SQL_SS_VECTOR, SQL_SS_XML, SQL_TINYINT, SQL_TYPE_DATE,
+    SQL_TYPE_TIME, SQL_TYPE_TIMESTAMP, SQL_VARBINARY, SQL_VARCHAR, SQL_WCHAR, SQL_WLONGVARCHAR,
+    SQL_WVARCHAR, SqlSmallInt,
+};
+
+/// Known ODBC C type identifiers, including the SQL Server extensions.
+///
+/// This is the `HY003` gate only. A C type listed here that the driver cannot
+/// yet convert is rejected later with `07006`, matching msodbcsql, which treats
+/// an unconvertible-but-real C type as a restricted conversion rather than an
+/// out-of-range program type.
+pub(crate) fn is_valid_c_type(c_type: SqlSmallInt) -> bool {
+    matches!(
+        c_type,
+        SQL_C_CHAR
+            | SQL_C_WCHAR
+            | SQL_C_BIT
+            | SQL_C_BINARY
+            | SQL_C_GUID
+            | SQL_C_NUMERIC
+            | SQL_C_STINYINT
+            | SQL_C_TINYINT
+            | SQL_C_UTINYINT
+            | SQL_C_SHORT
+            | SQL_C_SSHORT
+            | SQL_C_USHORT
+            | SQL_C_LONG
+            | SQL_C_SLONG
+            | SQL_C_ULONG
+            | SQL_C_SBIGINT
+            | SQL_C_UBIGINT
+            | SQL_C_FLOAT
+            | SQL_C_DOUBLE
+            | SQL_C_DATE
+            | SQL_C_TIME
+            | SQL_C_TIMESTAMP
+            | SQL_C_TYPE_DATE
+            | SQL_C_TYPE_TIME
+            | SQL_C_TYPE_TIMESTAMP
+            | SQL_C_SS_TIME2
+            | SQL_C_SS_TIMESTAMPOFFSET
+            | SQL_C_SS_VECTOR
+            | SQL_C_DEFAULT
+            | SQL_C_INTERVAL_YEAR..=SQL_C_INTERVAL_MINUTE_TO_SECOND
+    )
+}
+
+/// Known ODBC SQL data type identifiers, plus the SQL Server extensions. This
+/// is the `HY004` gate only; conversion support is checked separately.
+pub(crate) fn is_valid_sql_type(sql_type: SqlSmallInt) -> bool {
+    matches!(
+        sql_type,
+        SQL_CHAR
+            | SQL_VARCHAR
+            | SQL_LONGVARCHAR
+            | SQL_WCHAR
+            | SQL_WVARCHAR
+            | SQL_WLONGVARCHAR
+            | SQL_BINARY
+            | SQL_VARBINARY
+            | SQL_LONGVARBINARY
+            | SQL_DECIMAL
+            | SQL_NUMERIC
+            | SQL_SMALLINT
+            | SQL_INTEGER
+            | SQL_BIGINT
+            | SQL_TINYINT
+            | SQL_BIT
+            | SQL_REAL
+            | SQL_FLOAT
+            | SQL_DOUBLE
+            | SQL_GUID
+            | SQL_TYPE_DATE
+            | SQL_TYPE_TIME
+            | SQL_TYPE_TIMESTAMP
+            | SQL_SS_TIME2
+            | SQL_SS_TIMESTAMPOFFSET
+            | SQL_SS_VARIANT
+            | SQL_SS_UDT
+            | SQL_SS_XML
+            | SQL_SS_TABLE
+            | SQL_SS_VECTOR
+            | SQL_INTERVAL_YEAR..=SQL_INTERVAL_MINUTE_TO_SECOND
+    )
+}
+
+/// Resolves `SQL_C_DEFAULT` to the C type implied by `sql_type`.
+///
+/// Mirrors msodbcsql's `Sql2CDefault` (`sqlcprot.h`).
+///
+/// Two deliberate deviations, both following the ODBC 3.x default-C-type table
+/// instead: the wide character types resolve to `SQL_C_WCHAR` and `SQL_GUID` to
+/// `SQL_C_GUID`, where msodbcsql resolves both to `SQL_C_CHAR`. That narrow
+/// default is an ANSI-transfer artifact with no equivalent here, and resolving
+/// UTF-16 input to this driver's UTF-8 `SQL_C_CHAR` would silently corrupt data.
+///
+/// Intervals are deliberately unmapped: the ODBC default is the identity
+/// `SQL_C_INTERVAL_*`, but SQL Server has no interval type so nothing can
+/// convert one. The caller reports the `None` as `07006`.
+pub(crate) fn resolve_default_c_type(sql_type: SqlSmallInt) -> Option<SqlSmallInt> {
+    Some(match sql_type {
+        SQL_CHAR | SQL_VARCHAR | SQL_LONGVARCHAR => SQL_C_CHAR,
+        SQL_WCHAR | SQL_WVARCHAR | SQL_WLONGVARCHAR => SQL_C_WCHAR,
+        SQL_BINARY | SQL_VARBINARY | SQL_LONGVARBINARY => SQL_C_BINARY,
+        SQL_DECIMAL | SQL_NUMERIC => SQL_C_CHAR,
+        SQL_BIT => SQL_C_BIT,
+        SQL_TINYINT => SQL_C_UTINYINT,
+        SQL_SMALLINT => SQL_C_SSHORT,
+        SQL_INTEGER => SQL_C_SLONG,
+        SQL_BIGINT => SQL_C_SBIGINT,
+        SQL_REAL => SQL_C_FLOAT,
+        SQL_FLOAT | SQL_DOUBLE => SQL_C_DOUBLE,
+        SQL_GUID => SQL_C_GUID,
+        SQL_TYPE_DATE => SQL_C_TYPE_DATE,
+        SQL_TYPE_TIME => SQL_C_TYPE_TIME,
+        SQL_TYPE_TIMESTAMP => SQL_C_TYPE_TIMESTAMP,
+        SQL_SS_TIME2 => SQL_C_SS_TIME2,
+        SQL_SS_TIMESTAMPOFFSET => SQL_C_SS_TIMESTAMPOFFSET,
+        SQL_SS_VARIANT => SQL_C_CHAR,
+        SQL_SS_UDT | SQL_SS_TABLE => SQL_C_BINARY,
+        SQL_SS_XML => SQL_C_WCHAR,
+        SQL_SS_VECTOR => SQL_C_SS_VECTOR,
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn real_c_types_are_valid_even_when_unconvertible() {
+        // These are legal ODBC C types the driver cannot convert yet; they must
+        // pass the HY003 gate so the conversion check can report 07006 instead.
+        for c_type in [
+            SQL_C_SLONG,
+            SQL_C_SBIGINT,
+            SQL_C_UTINYINT,
+            SQL_C_GUID,
+            SQL_C_BINARY,
+            SQL_C_TYPE_TIMESTAMP,
+            SQL_C_INTERVAL_YEAR,
+            SQL_C_INTERVAL_MINUTE_TO_SECOND,
+        ] {
+            assert!(is_valid_c_type(c_type), "{c_type} should be a valid C type");
+        }
+    }
+
+    #[test]
+    fn unknown_c_type_is_invalid() {
+        assert!(!is_valid_c_type(9999));
+    }
+
+    #[test]
+    fn unknown_sql_type_is_invalid() {
+        assert!(is_valid_sql_type(SQL_VARCHAR));
+        assert!(!is_valid_sql_type(9999));
+    }
+
+    #[test]
+    fn default_c_type_follows_the_sql_type() {
+        assert_eq!(resolve_default_c_type(SQL_VARCHAR), Some(SQL_C_CHAR));
+        assert_eq!(resolve_default_c_type(SQL_LONGVARCHAR), Some(SQL_C_CHAR));
+        assert_eq!(resolve_default_c_type(SQL_WVARCHAR), Some(SQL_C_WCHAR));
+        assert_eq!(resolve_default_c_type(SQL_VARBINARY), Some(SQL_C_BINARY));
+        assert_eq!(resolve_default_c_type(SQL_DECIMAL), Some(SQL_C_CHAR));
+        assert_eq!(resolve_default_c_type(SQL_BIT), Some(SQL_C_BIT));
+        assert_eq!(resolve_default_c_type(SQL_TINYINT), Some(SQL_C_UTINYINT));
+        assert_eq!(resolve_default_c_type(SQL_SMALLINT), Some(SQL_C_SSHORT));
+        assert_eq!(resolve_default_c_type(SQL_INTEGER), Some(SQL_C_SLONG));
+        assert_eq!(resolve_default_c_type(SQL_BIGINT), Some(SQL_C_SBIGINT));
+        assert_eq!(resolve_default_c_type(SQL_REAL), Some(SQL_C_FLOAT));
+        assert_eq!(resolve_default_c_type(SQL_DOUBLE), Some(SQL_C_DOUBLE));
+        assert_eq!(resolve_default_c_type(SQL_GUID), Some(SQL_C_GUID));
+        assert_eq!(
+            resolve_default_c_type(SQL_TYPE_TIMESTAMP),
+            Some(SQL_C_TYPE_TIMESTAMP)
+        );
+        assert_eq!(
+            resolve_default_c_type(SQL_SS_TIMESTAMPOFFSET),
+            Some(SQL_C_SS_TIMESTAMPOFFSET)
+        );
+        assert_eq!(resolve_default_c_type(SQL_SS_VECTOR), Some(SQL_C_SS_VECTOR));
+    }
+
+    #[test]
+    fn interval_sql_types_are_valid_but_unresolved() {
+        assert!(is_valid_sql_type(SQL_INTERVAL_YEAR));
+        assert_eq!(resolve_default_c_type(SQL_INTERVAL_YEAR), None);
+    }
+}

--- a/mssql-odbc/src/params/bound_param.rs
+++ b/mssql-odbc/src/params/bound_param.rs
@@ -22,7 +22,8 @@ use crate::api::odbc_types::{SqlLen, SqlSmallInt, SqlULen};
 pub(crate) struct BoundParam {
     /// `SQL_PARAM_INPUT` / `SQL_PARAM_INPUT_OUTPUT` / `SQL_PARAM_OUTPUT`.
     pub(crate) input_output_type: SqlSmallInt,
-    /// C data type of the application buffer (ODBC `ValueType`, `SQL_C_*`).
+    /// C data type of the application buffer (ODBC `ValueType`, `SQL_C_*`),
+    /// with `SQL_C_DEFAULT` already resolved to a concrete type.
     pub(crate) c_type: SqlSmallInt,
     /// SQL data type of the column/expression (ODBC `ParameterType`, `SQL_*`).
     pub(crate) sql_type: SqlSmallInt,

--- a/mssql-odbc/src/params/conversion_matrix.rs
+++ b/mssql-odbc/src/params/conversion_matrix.rs
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Which C type → SQL type parameter conversions the driver can perform.
+//!
+//! Table-driven, mirroring msodbcsql's `fValidConversion` matrix
+//! (`Sql/Ntdbms/sqlncli/odbc/sqlcmisc.cpp`), which is indexed by C type and
+//! yields the set of legal SQL types. The rows here list only the pairings this
+//! driver implements today; rows and entries are added as each conversion
+//! lands, so a pairing accepted at bind time is always one the execute path can
+//! actually convert.
+//!
+//! Anything absent is rejected with `07006` at bind time rather than failing
+//! later at execute.
+//!
+//! Parameter-side only, matching msodbcsql: it consults `IsValidSQLConversion`
+//! where both types are known up front (`SQLBindParameter`, output-parameter
+//! retrieval, BCP), but `SQLBindCol` / `SQLGetData` cannot — a column's SQL type
+//! may be unknown until after execute — so the fetch direction reports the same
+//! `07006` from inside its converters (`ConvError::Restricted`) instead.
+
+use crate::api::odbc_types::{
+    SQL_C_CHAR, SQL_C_WCHAR, SQL_CHAR, SQL_LONGVARCHAR, SQL_VARCHAR, SQL_WCHAR, SQL_WLONGVARCHAR,
+    SQL_WVARCHAR, SqlSmallInt,
+};
+
+/// SQL types a `SQL_C_CHAR` buffer can be converted to.
+const CHAR_C_TARGETS: &[SqlSmallInt] = &[SQL_CHAR, SQL_VARCHAR, SQL_LONGVARCHAR];
+
+/// SQL types a `SQL_C_WCHAR` buffer can be converted to.
+const WCHAR_C_TARGETS: &[SqlSmallInt] = &[SQL_WCHAR, SQL_WVARCHAR, SQL_WLONGVARCHAR];
+
+/// Whether the driver can convert a `c_type` application buffer into `sql_type`
+/// for an input parameter.
+pub(crate) fn is_supported_conversion(c_type: SqlSmallInt, sql_type: SqlSmallInt) -> bool {
+    let targets: &[SqlSmallInt] = match c_type {
+        SQL_C_CHAR => CHAR_C_TARGETS,
+        SQL_C_WCHAR => WCHAR_C_TARGETS,
+        _ => return false,
+    };
+    targets.contains(&sql_type)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::odbc_types::{SQL_C_SLONG, SQL_GUID, SQL_INTEGER};
+
+    #[test]
+    fn narrow_character_conversions_are_supported() {
+        for sql_type in [SQL_CHAR, SQL_VARCHAR, SQL_LONGVARCHAR] {
+            assert!(is_supported_conversion(SQL_C_CHAR, sql_type));
+        }
+    }
+
+    #[test]
+    fn wide_character_conversions_are_supported() {
+        for sql_type in [SQL_WCHAR, SQL_WVARCHAR, SQL_WLONGVARCHAR] {
+            assert!(is_supported_conversion(SQL_C_WCHAR, sql_type));
+        }
+    }
+
+    #[test]
+    fn cross_family_character_conversions_are_unsupported() {
+        assert!(!is_supported_conversion(SQL_C_CHAR, SQL_WVARCHAR));
+        assert!(!is_supported_conversion(SQL_C_WCHAR, SQL_VARCHAR));
+    }
+
+    #[test]
+    fn numeric_conversions_are_unsupported() {
+        assert!(!is_supported_conversion(SQL_C_CHAR, SQL_INTEGER));
+        assert!(!is_supported_conversion(SQL_C_SLONG, SQL_INTEGER));
+    }
+
+    #[test]
+    fn c_types_without_a_row_are_unsupported() {
+        assert!(!is_supported_conversion(SQL_C_SLONG, SQL_GUID));
+    }
+}

--- a/mssql-odbc/src/params/conversion_matrix.rs
+++ b/mssql-odbc/src/params/conversion_matrix.rs
@@ -3,12 +3,13 @@
 
 //! Which C type → SQL type parameter conversions the driver can perform.
 //!
-//! Table-driven, mirroring msodbcsql's `fValidConversion` matrix
+//! Table-driven, in the same shape as msodbcsql's `fValidConversion` matrix
 //! (`Sql/Ntdbms/sqlncli/odbc/sqlcmisc.cpp`), which is indexed by C type and
-//! yields the set of legal SQL types. The rows here list only the pairings this
-//! driver implements today; rows and entries are added as each conversion
-//! lands, so a pairing accepted at bind time is always one the execute path can
-//! actually convert.
+//! yields the set of legal SQL types. The semantics differ: that matrix answers
+//! "is this pairing legal?", this one answers "is this pairing implemented?".
+//! The rows here list only the pairings this driver implements today; rows and
+//! entries are added as each conversion lands, so a pairing accepted at bind
+//! time is always one the execute path can actually convert.
 //!
 //! Anything absent is rejected with `07006` at bind time rather than failing
 //! later at execute.
@@ -20,8 +21,8 @@
 //! `07006` from inside its converters (`ConvError::Restricted`) instead.
 
 use crate::api::odbc_types::{
-    SQL_C_CHAR, SQL_C_WCHAR, SQL_CHAR, SQL_LONGVARCHAR, SQL_VARCHAR, SQL_WCHAR, SQL_WLONGVARCHAR,
-    SQL_WVARCHAR, SqlSmallInt,
+    SQL_C_CHAR, SQL_C_DEFAULT, SQL_C_WCHAR, SQL_CHAR, SQL_LONGVARCHAR, SQL_VARCHAR, SQL_WCHAR,
+    SQL_WLONGVARCHAR, SQL_WVARCHAR, SqlSmallInt,
 };
 
 /// SQL types a `SQL_C_CHAR` buffer can be converted to.
@@ -33,6 +34,10 @@ const WCHAR_C_TARGETS: &[SqlSmallInt] = &[SQL_WCHAR, SQL_WVARCHAR, SQL_WLONGVARC
 /// Whether the driver can convert a `c_type` application buffer into `sql_type`
 /// for an input parameter.
 pub(crate) fn is_supported_conversion(c_type: SqlSmallInt, sql_type: SqlSmallInt) -> bool {
+    debug_assert_ne!(
+        c_type, SQL_C_DEFAULT,
+        "SQL_C_DEFAULT must be resolved before consulting the conversion matrix"
+    );
     let targets: &[SqlSmallInt] = match c_type {
         SQL_C_CHAR => CHAR_C_TARGETS,
         SQL_C_WCHAR => WCHAR_C_TARGETS,

--- a/mssql-odbc/src/params/convert.rs
+++ b/mssql-odbc/src/params/convert.rs
@@ -5,10 +5,10 @@
 //! TDS RPC parameter (`RpcParameter`).
 //!
 //! Which C/SQL pairings reach this module is decided at bind time by
-//! [`crate::params::conversion_matrix`]; `SQL_C_DEFAULT` has already been
-//! resolved to a
-//! concrete C type by then. Data-at-execution and default parameters are
-//! rejected with `HYC00`, and an invalid negative `StrLen_or_Ind` with `HY090`.
+//! [`crate::api::type_rules`] and [`crate::params::conversion_matrix`];
+//! `SQL_C_DEFAULT` has already been resolved to a concrete C type by then.
+//! Data-at-execution and default parameters are rejected with `HYC00`, and an
+//! invalid negative `StrLen_or_Ind` with `HY090`.
 
 use std::slice;
 

--- a/mssql-odbc/src/params/convert.rs
+++ b/mssql-odbc/src/params/convert.rs
@@ -4,10 +4,11 @@
 //! Conversion from a bound application parameter buffer (`BoundParam`) to a
 //! TDS RPC parameter (`RpcParameter`).
 //!
-//! Phase 1 mirrors `SQLGetData`'s supported C types: only `SQL_C_CHAR`
-//! (→ `varchar`) and `SQL_C_WCHAR` (→ `nvarchar`). Every other C type, plus
-//! data-at-execution and default parameters, is rejected with `HYC00`; an
-//! invalid negative `StrLen_or_Ind` is rejected with `HY090`.
+//! Which C/SQL pairings reach this module is decided at bind time by
+//! [`crate::params::conversion_matrix`]; `SQL_C_DEFAULT` has already been
+//! resolved to a
+//! concrete C type by then. Data-at-execution and default parameters are
+//! rejected with `HYC00`, and an invalid negative `StrLen_or_Ind` with `HY090`.
 
 use std::slice;
 
@@ -16,12 +17,8 @@ use mssql_tds::datatypes::sqltypes::SqlType;
 use mssql_tds::message::parameters::rpc_parameters::{RpcParameter, StatusFlags};
 
 use crate::api::odbc_types::{
-    SQL_BIGINT, SQL_BINARY, SQL_BIT, SQL_C_CHAR, SQL_C_DEFAULT, SQL_C_LONG, SQL_C_WCHAR, SQL_CHAR,
-    SQL_DATA_AT_EXEC, SQL_DECIMAL, SQL_DEFAULT_PARAM, SQL_DOUBLE, SQL_FLOAT, SQL_GUID, SQL_INTEGER,
-    SQL_LEN_DATA_AT_EXEC_OFFSET, SQL_LONGVARBINARY, SQL_LONGVARCHAR, SQL_NTS, SQL_NULL_DATA,
-    SQL_NUMERIC, SQL_REAL, SQL_SMALLINT, SQL_SS_TIME2, SQL_SS_TIMESTAMPOFFSET, SQL_TINYINT,
-    SQL_TYPE_DATE, SQL_TYPE_TIME, SQL_TYPE_TIMESTAMP, SQL_VARBINARY, SQL_VARCHAR, SQL_WCHAR,
-    SQL_WLONGVARCHAR, SQL_WVARCHAR, SqlLen, SqlSmallInt,
+    SQL_C_CHAR, SQL_C_WCHAR, SQL_DATA_AT_EXEC, SQL_DEFAULT_PARAM, SQL_LEN_DATA_AT_EXEC_OFFSET,
+    SQL_NTS, SQL_NULL_DATA, SqlLen, SqlSmallInt,
 };
 use crate::api::sqlstate::ERR_INVALID_STRING_OR_BUFFER_LENGTH;
 use crate::params::BoundParam;
@@ -125,60 +122,6 @@ fn null_value(c_type: SqlSmallInt) -> Result<SqlType, ParamConvError> {
         SQL_C_CHAR => Ok(SqlType::VarcharMax(None)),
         SQL_C_WCHAR => Ok(SqlType::NVarcharMax(None)),
         other => Err(ParamConvError::UnsupportedCType(other)),
-    }
-}
-
-/// Known ODBC SQL data type identifiers (plus SQL Server extensions) accepted
-/// at bind time. Conversion support is checked separately.
-pub(crate) fn is_valid_sql_type(sql_type: SqlSmallInt) -> bool {
-    matches!(
-        sql_type,
-        SQL_CHAR
-            | SQL_VARCHAR
-            | SQL_LONGVARCHAR
-            | SQL_WCHAR
-            | SQL_WVARCHAR
-            | SQL_WLONGVARCHAR
-            | SQL_BINARY
-            | SQL_VARBINARY
-            | SQL_LONGVARBINARY
-            | SQL_DECIMAL
-            | SQL_NUMERIC
-            | SQL_SMALLINT
-            | SQL_INTEGER
-            | SQL_BIGINT
-            | SQL_TINYINT
-            | SQL_BIT
-            | SQL_REAL
-            | SQL_FLOAT
-            | SQL_DOUBLE
-            | SQL_GUID
-            | SQL_TYPE_DATE
-            | SQL_TYPE_TIME
-            | SQL_TYPE_TIMESTAMP
-            | SQL_SS_TIME2
-            | SQL_SS_TIMESTAMPOFFSET
-    )
-}
-
-/// Known ODBC C type identifiers accepted at bind time.
-pub(crate) fn is_valid_c_type(c_type: SqlSmallInt) -> bool {
-    matches!(
-        c_type,
-        SQL_C_CHAR | SQL_C_WCHAR | SQL_C_LONG | SQL_C_DEFAULT
-    )
-}
-
-/// Whether the C type → SQL type conversion is supported. Phase 1 only allows
-/// same-family character conversions: `SQL_C_CHAR` → narrow character SQL types
-/// (`CHAR`/`VARCHAR`/`LONGVARCHAR`) and `SQL_C_WCHAR` → the wide character SQL
-/// types (`WCHAR`/`WVARCHAR`/`WLONGVARCHAR`). Every other pairing is rejected
-/// (`07006`).
-pub(crate) fn is_valid_conversion(c_type: SqlSmallInt, sql_type: SqlSmallInt) -> bool {
-    match c_type {
-        SQL_C_CHAR => matches!(sql_type, SQL_CHAR | SQL_VARCHAR | SQL_LONGVARCHAR),
-        SQL_C_WCHAR => matches!(sql_type, SQL_WCHAR | SQL_WVARCHAR | SQL_WLONGVARCHAR),
-        _ => false,
     }
 }
 
@@ -305,17 +248,6 @@ mod tests {
         let p = param(SQL_C_CHAR, std::ptr::null_mut(), &mut ind);
         let err = unsafe { bound_param_to_value(&p) }.unwrap_err();
         assert_eq!(err, ParamConvError::InvalidLength(SQL_NO_TOTAL));
-    }
-
-    #[test]
-    fn conversion_allows_same_family_only() {
-        assert!(is_valid_conversion(SQL_C_CHAR, SQL_VARCHAR));
-        assert!(is_valid_conversion(SQL_C_WCHAR, SQL_WVARCHAR));
-        // Cross-family, non-character, and unsupported C types are rejected.
-        assert!(!is_valid_conversion(SQL_C_CHAR, SQL_WVARCHAR));
-        assert!(!is_valid_conversion(SQL_C_WCHAR, SQL_VARCHAR));
-        assert!(!is_valid_conversion(SQL_C_CHAR, SQL_INTEGER));
-        assert!(!is_valid_conversion(SQL_C_LONG, SQL_INTEGER));
     }
 
     #[test]

--- a/mssql-odbc/src/params/mod.rs
+++ b/mssql-odbc/src/params/mod.rs
@@ -4,6 +4,7 @@
 //! Statement parameter binding and value conversion.
 
 mod bound_param;
+pub(crate) mod conversion_matrix;
 pub(crate) mod convert;
 
 pub(crate) use bound_param::BoundParam;

--- a/mssql-odbc/tests/e2e/tests/execute_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/execute_test.cpp
@@ -150,6 +150,63 @@ TEST_F(PrepareExecuteLiveTest, ExplicitLengthWideCharParam) {
     EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
 }
 
+// SQL_C_DEFAULT reaches the driver unresolved (the Driver Manager does not
+// substitute it), and the driver resolves it from ParameterType. SQL_VARCHAR
+// yields SQL_C_CHAR on both drivers.
+TEST_F(PrepareExecuteLiveTest, DefaultCTypeNarrowCharParam) {
+    ASSERT_SQL_OK(Prepare("SELECT ? AS v"), SQL_HANDLE_STMT, stmt_);
+
+    std::vector<SQLCHAR> value = {'p', 'l', 'a', 'i', 'n', '\0'};
+    SQLLEN ind = SQL_NTS;
+    SQLRETURN rc = SQLBindParameter(stmt_, 1, SQL_PARAM_INPUT, SQL_C_DEFAULT,
+                                    SQL_VARCHAR, value.size(), 0, value.data(),
+                                    static_cast<SQLLEN>(value.size()), &ind);
+    ASSERT_SQL_OK(rc, SQL_HANDLE_STMT, stmt_);
+
+    ASSERT_SQL_OK(SQLExecute(stmt_), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ("plain", GetColumnChar(1));
+
+    EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
+}
+
+// Accepted parity deviation (AB#47365): SQL_C_DEFAULT resolves the wide
+// character SQL types to SQL_C_WCHAR, per the ODBC 3.x default-C-type table.
+// msodbcsql's rgbTRANSTYPE380 resolves them to SQL_C_CHAR and would read this
+// UTF-16 buffer as narrow text, so the round trip differs there.
+TEST_F(PrepareExecuteLiveTest, DefaultCTypeWideCharParam) {
+    SKIP_IF_COMPARING_MSODBCSQL();
+
+    ASSERT_SQL_OK(Prepare("SELECT ? AS v"), SQL_HANDLE_STMT, stmt_);
+
+    SQLWCHAR value[] = {'w', 'i', 'd', 'e', 0};
+    SQLLEN ind = SQL_NTS;
+    SQLRETURN rc = SQLBindParameter(stmt_, 1, SQL_PARAM_INPUT, SQL_C_DEFAULT,
+                                    SQL_WVARCHAR, 4, 0, value, sizeof(value), &ind);
+    ASSERT_SQL_OK(rc, SQL_HANDLE_STMT, stmt_);
+
+    ASSERT_SQL_OK(SQLExecute(stmt_), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ("wide", GetColumnChar(1));
+
+    EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
+}
+
+// SQL_C_DEFAULT + SQL_INTEGER resolves to SQL_C_SLONG, which has no conversion
+// row yet, so the bind is rejected up front instead of failing at execute.
+// msodbcsql supports the pairing, hence the skip. The skip will be removed soon
+// when we implement the conversion.
+TEST_F(PrepareExecuteLiveTest, DefaultCTypeUnsupportedConversionIsRejected) {
+    SKIP_IF_COMPARING_MSODBCSQL();
+
+    SQLINTEGER value = 42;
+    SQLLEN ind = 0;
+    SQLRETURN rc = SQLBindParameter(stmt_, 1, SQL_PARAM_INPUT, SQL_C_DEFAULT,
+                                    SQL_INTEGER, 0, 0, &value, 0, &ind);
+    EXPECT_EQ(SQL_ERROR, rc);
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "07006");
+}
+
 // A NULL-indicator parameter produces a SQL NULL result.
 TEST_F(PrepareExecuteLiveTest, NullParam) {
     ASSERT_SQL_OK(Prepare("SELECT ? AS v"), SQL_HANDLE_STMT, stmt_);

--- a/mssql-odbc/tests/e2e/tests/execute_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/execute_test.cpp
@@ -215,6 +215,20 @@ TEST_F(PrepareExecuteLiveTest, DefaultCTypeUnsupportedConversionIsRejected) {
     EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "07006");
 }
 
+// SQL Server has no interval type, so a real-but-unsupported ParameterType is
+// HYC00 ("optional feature not implemented") rather than a conversion failure.
+// msodbcsql's IsValidSqlType returns IDS_S1_C00 for the whole interval range
+// before IsValidSQLConversion is reached, so both drivers agree here.
+TEST_F(PrepareExecuteLiveTest, IntervalSqlTypeIsRejectedWithHyc00) {
+    SQL_INTERVAL_STRUCT value = {};
+    SQLLEN ind = 0;
+    SQLRETURN rc = SQLBindParameter(stmt_, 1, SQL_PARAM_INPUT, SQL_C_DEFAULT,
+                                    SQL_INTERVAL_YEAR, 0, 0, &value,
+                                    sizeof(value), &ind);
+    EXPECT_EQ(SQL_ERROR, rc);
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "HYC00");
+}
+
 // A NULL-indicator parameter produces a SQL NULL result.
 TEST_F(PrepareExecuteLiveTest, NullParam) {
     ASSERT_SQL_OK(Prepare("SELECT ? AS v"), SQL_HANDLE_STMT, stmt_);

--- a/mssql-odbc/tests/e2e/tests/execute_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/execute_test.cpp
@@ -202,8 +202,9 @@ TEST_F(PrepareExecuteLiveTest, DefaultCTypeWideCharParam) {
 
 // SQL_C_DEFAULT + SQL_INTEGER resolves to SQL_C_SLONG, which has no conversion
 // row yet, so the bind is rejected up front instead of failing at execute.
-// msodbcsql supports the pairing, hence the skip. The skip will be removed soon
-// when we implement the conversion.
+// msodbcsql supports the pairing, hence the skip. The skip goes away when P3
+// (integer C to integer SQL) adds the conversion row - see
+// docs/parameters_plan.md.
 TEST_F(PrepareExecuteLiveTest, DefaultCTypeUnsupportedConversionIsRejected) {
     SKIP_IF_COMPARING_MSODBCSQL();
 
@@ -227,6 +228,21 @@ TEST_F(PrepareExecuteLiveTest, IntervalSqlTypeIsRejectedWithHyc00) {
                                     sizeof(value), &ind);
     EXPECT_EQ(SQL_ERROR, rc);
     EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "HYC00");
+}
+
+// Accepted parity deviation (AB#47365): SQL_C_DEFAULT resolves SQL_GUID to
+// SQL_C_GUID per the ODBC 3.x default-C-type table, which has no conversion row
+// yet, so the bind is rejected. msodbcsql's rgbTRANSTYPE380 resolves it to
+// SQL_C_CHAR, which it supports, so the bind succeeds there.
+TEST_F(PrepareExecuteLiveTest, DefaultCTypeGuidIsRejected) {
+    SKIP_IF_COMPARING_MSODBCSQL();
+
+    SQLGUID value = {};
+    SQLLEN ind = 0;
+    SQLRETURN rc = SQLBindParameter(stmt_, 1, SQL_PARAM_INPUT, SQL_C_DEFAULT,
+                                    SQL_GUID, 0, 0, &value, sizeof(value), &ind);
+    EXPECT_EQ(SQL_ERROR, rc);
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "07006");
 }
 
 // A NULL-indicator parameter produces a SQL NULL result.

--- a/mssql-odbc/tests/e2e/tests/execute_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/execute_test.cpp
@@ -153,6 +153,10 @@ TEST_F(PrepareExecuteLiveTest, ExplicitLengthWideCharParam) {
 // SQL_C_DEFAULT reaches the driver unresolved (the Driver Manager does not
 // substitute it), and the driver resolves it from ParameterType. SQL_VARCHAR
 // yields SQL_C_CHAR on both drivers.
+//
+// Benefits-from-mock-tds: a mock TDS server could assert the RPC parameter was
+// declared varchar with a single-byte payload; the round-tripped text alone
+// cannot show which C type the driver resolved.
 TEST_F(PrepareExecuteLiveTest, DefaultCTypeNarrowCharParam) {
     ASSERT_SQL_OK(Prepare("SELECT ? AS v"), SQL_HANDLE_STMT, stmt_);
 
@@ -174,6 +178,10 @@ TEST_F(PrepareExecuteLiveTest, DefaultCTypeNarrowCharParam) {
 // character SQL types to SQL_C_WCHAR, per the ODBC 3.x default-C-type table.
 // msodbcsql's rgbTRANSTYPE380 resolves them to SQL_C_CHAR and would read this
 // UTF-16 buffer as narrow text, so the round trip differs there.
+//
+// Benefits-from-mock-tds: a mock TDS server could assert the RPC parameter was
+// declared nvarchar carrying the full UTF-16 payload, which is the deviation
+// itself; the round-tripped ASCII text alone cannot show it.
 TEST_F(PrepareExecuteLiveTest, DefaultCTypeWideCharParam) {
     SKIP_IF_COMPARING_MSODBCSQL();
 


### PR DESCRIPTION
## Description

First phase (P1) of the parameter conversion milestone: a re-usable type model for `SQLBindParameter`, split so the pieces that are direction-neutral can be shared with the fetch path.

- **`api/type_rules.rs` (new)** — direction-neutral ODBC type-identifier rules: `is_valid_c_type` (HY003), `is_valid_sql_type` (HY004), and `resolve_default_c_type`. Placed under `api/` rather than `params/` because msodbcsql keeps the equivalent `IsValidCType` / `IsValidSqlType` / `Sql2CDefault` in the shared `sqlcprot.h`, where `SetADRec` serves both `SQLBindCol` and `SQLBindParameter`.
- **`params/conversion_matrix.rs` (new)** — table-driven parameter-direction C→SQL conversion check, mirroring msodbcsql's `fValidConversion`. Returns `07006` for a real-but-unsupported pairing. Parameter-side only: msodbcsql's fetch path does not consult `fValidConversion` either.
- **`api/bind_param.rs`** — validation order is now C type (HY003) → SQL type (HY004) → `SQL_C_DEFAULT` resolution → supported-conversion check (07006) → input-only check (HYC00). The resolved C type is what gets stored on the `BoundParam`, so nothing downstream sees `SQL_C_DEFAULT`.
- **`params/convert.rs`** — type validation removed; it is now purely value conversion.
- **`api/odbc_types.rs`** — added the identifiers the rules need (`SQL_SS_TABLE`, `SQL_SS_VECTOR`, `SQL_C_SS_VECTOR`, and the interval C/SQL type range bounds).

The phased plan and the per-phase breakdown are in `mssql-odbc/docs/parameters_plan.md`.

### Accepted parity deviation

`SQL_C_DEFAULT` resolves the wide character SQL types to `SQL_C_WCHAR` and `SQL_GUID` to `SQL_C_GUID`. msodbcsql's `Sql2CDefault` reads `rgbTRANSTYPE380` (`Sql/Ntdbms/sqlncli/odbc/sqlcmisc.cpp`) and resolves both to `SQL_C_CHAR` — an ANSI-transfer default this driver has no equivalent for, since its `SQL_C_CHAR` is UTF-8. Resolving UTF-16 application input to a UTF-8 buffer type would silently corrupt data (`read_char_bytes` with `SQL_NTS` stops at the first `0x00`, the high half of the first code unit). Recorded in the instructions file, the plan doc, and as a comment on [AB#47365](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47365).

This crate also targets ODBC 3.x only, so msodbcsql paths that exist solely for 2.x compatibility (the `rgbTRANSTYPE` selection for 3.51-or-earlier apps, `IsValidSqlType` accepting the 2.x `SQL_DATE` / `SQL_TIME` / `SQL_TIMESTAMP` spellings) are deliberately not ported. That rule is now written down in `.github/instructions/mssql-odbc.instructions.md`.

## Related Issues

https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47365

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes
- [x] New/changed functionality has tests
- [x] Public API changes are documented

`cargo btest` could not be run locally — neither `cargo-nextest` nor `cargo-llvm-cov` is installed on this machine. Substituted `cargo test -p mssql-odbc --lib`: **612 passed, 0 failed**. Relying on PR validation for the real `btest` run.

## Testing

- 612 unit tests pass, including new coverage for: a real-but-unconvertible C type returning `07006`, `SQL_C_DEFAULT` being resolved before storage, a resolved-but-unconvertible default returning `07006`, and a default with no mapping (`SQL_INTERVAL_YEAR`) returning `07006`.
- Three e2e cases added to `mssql-odbc/tests/e2e/tests/execute_test.cpp`: `DefaultCTypeNarrowCharParam`, `DefaultCTypeWideCharParam`, and `DefaultCTypeUnsupportedConversionIsRejected`. The latter two carry `SKIP_IF_COMPARING_MSODBCSQL()` — the first for the deviation above, the second because msodbcsql supports `SQL_C_SLONG` → `SQL_INTEGER` and this driver does not yet (P2).
- **The e2e suite has not been executed against a live server.** The binary compiles and all three tests are registered; running them needs an elevated shell (the runner writes to HKLM) and a reachable SQL Server. Please treat that as outstanding.
