### PR TITLE
Enhancing macOS SQL diagnostics

### DIFF
--- a/.pipeline/templates/sql-setup-template.yml
+++ b/.pipeline/templates/sql-setup-template.yml
@@ -292,6 +292,7 @@ steps:
 
       if [ "$ready" != true ]; then
         echo "SQL Server failed readiness checks"
+        set +e
         docker ps -a
         docker inspect sqlserver --format \
           'status={{.State.Status}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}} error={{.State.Error}}'

--- a/.pipeline/templates/sql-setup-template.yml
+++ b/.pipeline/templates/sql-setup-template.yml
@@ -272,19 +272,32 @@ steps:
       docker run \
         --name sqlserver \
         -e ACCEPT_EULA=Y \
-        -e "MSSQL_SA_PASSWORD=$(SQL_PASSWORD)" \
+        -e "MSSQL_SA_PASSWORD=$SQL_PASSWORD" \
         -p 1433:1433 \
         -d mcr.microsoft.com/mssql/server:2025-latest
 
       echo "Waiting for SQL Server to start..."
+      ready=false
       for i in $(seq 1 30); do
-        docker exec sqlserver \
+        if docker exec sqlserver \
           /opt/mssql-tools18/bin/sqlcmd \
-          -S localhost -U SA -P "$(SQL_PASSWORD)" \
-          -C -Q "SELECT 1" 2>/dev/null && break
+          -S localhost -U SA -P "$SQL_PASSWORD" \
+          -C -b -Q "SELECT 1" 2>/dev/null; then
+          ready=true
+          break
+        fi
         echo "  attempt $i/30..."
         sleep 2
       done
+
+      if [ "$ready" != true ]; then
+        echo "SQL Server failed readiness checks"
+        docker ps -a
+        docker inspect sqlserver --format \
+          'status={{.State.Status}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}} error={{.State.Error}}'
+        docker logs --tail 500 sqlserver
+        exit 1
+      fi
     displayName: 'Start SQL Server (Docker, no TLS certs)'
     env:
       SQL_PASSWORD: $(SQL_PASSWORD)

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -382,7 +382,7 @@ stages:
             /opt/mssql-tools18/bin/sqlcmd \
             -S localhost -U SA -P "$SQL_PASSWORD" \
             -C -b -Q "SELECT 1"
-          nc -zv localhost 1433
+          nc -z -v 127.0.0.1 1433
         displayName: 'Verify macOS SQL Server before tests'
         env:
           SQL_PASSWORD: $(SQL_PASSWORD)

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -383,7 +383,7 @@ stages:
             -S localhost -U SA -P "$SQL_PASSWORD" \
             -C -b -Q "SELECT 1"
           nc -zv localhost 1433
-        displayName: 'Temporary: verify macOS SQL Server before tests'
+        displayName: 'Verify macOS SQL Server before tests'
         env:
           SQL_PASSWORD: $(SQL_PASSWORD)
       - template: build-template.yml
@@ -405,7 +405,7 @@ stages:
           docker logs --tail 500 sqlserver
           echo "=== Host port 1433 ==="
           lsof -nP -iTCP:1433 -sTCP:LISTEN
-        displayName: 'Temporary: diagnose macOS SQL Server failure'
+        displayName: 'Diagnose macOS SQL Server failure'
         condition: failed()
 
 # Kerberos tests for PRs (fast - 2 distros: ubuntu22 + alpine318)

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -395,16 +395,17 @@ stages:
       - script: |
           set +e
           echo "=== Colima status ==="
-          colima status
+          colima status || true
           echo "=== Docker containers ==="
-          docker ps -a
+          docker ps -a || true
           echo "=== SQL Server state ==="
           docker inspect sqlserver --format \
-            'status={{.State.Status}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}} error={{.State.Error}}'
+            'status={{.State.Status}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}} error={{.State.Error}}' || true
           echo "=== SQL Server logs ==="
-          docker logs --tail 500 sqlserver
+          docker logs --tail 500 sqlserver || true
           echo "=== Host port 1433 ==="
-          lsof -nP -iTCP:1433 -sTCP:LISTEN
+          lsof -nP -iTCP:1433 -sTCP:LISTEN || true
+          exit 0
         displayName: 'Diagnose macOS SQL Server failure'
         condition: or(failed(), canceled())
 

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -406,7 +406,7 @@ stages:
           echo "=== Host port 1433 ==="
           lsof -nP -iTCP:1433 -sTCP:LISTEN
         displayName: 'Diagnose macOS SQL Server failure'
-        condition: failed()
+        condition: or(failed(), canceled())
 
 # Kerberos tests for PRs (fast - 2 distros: ubuntu22 + alpine318)
 - stage: Kerberos_Test_PR

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -372,12 +372,41 @@ stages:
       - template: install-dependencies.yml
         parameters:
           osType: MacOS
+      - script: |
+          set -euo pipefail
+          colima status
+          docker ps -a
+          docker inspect sqlserver --format \
+            'status={{.State.Status}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}} error={{.State.Error}}'
+          docker exec sqlserver \
+            /opt/mssql-tools18/bin/sqlcmd \
+            -S localhost -U SA -P "$SQL_PASSWORD" \
+            -C -b -Q "SELECT 1"
+          nc -zv localhost 1433
+        displayName: 'Temporary: verify macOS SQL Server before tests'
+        env:
+          SQL_PASSWORD: $(SQL_PASSWORD)
       - template: build-template.yml
         parameters:
           osType: MacOS
           buildType: ${{ parameters.buildType }}
           testFilter: -E 'not (test(connectivity))'
           enableClippy: false
+      - script: |
+          set +e
+          echo "=== Colima status ==="
+          colima status
+          echo "=== Docker containers ==="
+          docker ps -a
+          echo "=== SQL Server state ==="
+          docker inspect sqlserver --format \
+            'status={{.State.Status}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}} error={{.State.Error}}'
+          echo "=== SQL Server logs ==="
+          docker logs --tail 500 sqlserver
+          echo "=== Host port 1433 ==="
+          lsof -nP -iTCP:1433 -sTCP:LISTEN
+        displayName: 'Temporary: diagnose macOS SQL Server failure'
+        condition: failed()
 
 # Kerberos tests for PRs (fast - 2 distros: ubuntu22 + alpine318)
 - stage: Kerberos_Test_PR


### PR DESCRIPTION
<!--
Thank you for your interest in this project!

This repository is not currently accepting external pull requests. If you've found
a bug or have a feature request, please open an issue instead.

If you are a Microsoft team member, please follow the instructions in the internal
contribution guide.
-->

## Description
This pull request improves the reliability and debuggability of the SQL Server setup and validation steps in the CI pipeline, particularly for macOS environments. The main changes include fixing environment variable usage, enhancing readiness checks, and adding diagnostic scripts to help troubleshoot SQL Server startup issues on macOS.

**Improvements to SQL Server Docker setup:**

* Fixed environment variable syntax for `MSSQL_SA_PASSWORD` and improved readiness check logic in `.pipeline/templates/sql-setup-template.yml` to better handle SQL Server startup failures and provide detailed diagnostics if the server fails to become ready.
* The readiness change in [sql-setup-template.yml:280] fixes a real bug: previously, 30 failed attempts could still let setup succeed.
* sqlcmd -b, explicit readiness state, safe environment-variable usage, and startup logs are solid improvements.
* The pre-test probe catches Colima/SQL dying during dependency installation.
* Failure-only container logs are useful and do not expose the password.

**Enhancements for macOS validation and diagnostics:**

* Added a script before tests in `.pipeline/templates/validation-stages.yml` to verify the SQL Server container is running and accessible on macOS, including checks for container status, SQL command execution, and port availability.
* Added a diagnostic script after the build step (conditional on failure) to output detailed information about Colima, Docker containers, SQL Server state, logs, and host port usage to aid in troubleshooting failures on macOS.
<!-- Briefly describe the change. -->

## Related Issues

<!--
Required: link a GitHub issue OR an Azure DevOps work item. The PR check will
fail without one.
GitHub issue: Fixes #123 (or https://github.com/microsoft/mssql-rs/issues/123)
ADO work item: https://sqlclientdrivers.visualstudio.com/<...>/_workitems/edit/<ID>
  (any project/collection path is accepted, e.g. .../<project>/_workitems/edit/123
  or .../DefaultCollection/<project>/_workitems/edit/123)
-->
ADO work item: https://dev.azure.com/sqlclientdrivers/mssql-python/_sprints/taskboard/mssql-python%20Team/mssql-python/Rubidium/Aug%202026?workitem=47383
## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes
- [ ] New/changed functionality has tests
- [ ] Public API changes are documented
