### PR TITLE
Extract shared conversion core into src/conversion

### DIFF
--- a/mssql-odbc/docs/parameters_plan.md
+++ b/mssql-odbc/docs/parameters_plan.md
@@ -107,7 +107,8 @@ transparent reconnects.
 
 Goal: support parameters of narrow and wide integer C types and character C
 types, with SQL <-> C conversion among them, on conversion infrastructure shared
-with the fetch path ([`api/fetch_convert.rs`](../src/api/fetch_convert.rs)).
+with the fetch path
+([`conversion/fetch_convert.rs`](../src/conversion/fetch_convert.rs)).
 
 ### Scope
 
@@ -164,7 +165,7 @@ one task per phase.
 
 | Phase | Task | Status | Deliverable |
 | --- | --- | --- | --- |
-| P0 | [47364](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47364) | Not started | Extract shared conversion core from `fetch_convert.rs` |
+| P0 | [47364](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47364) | Code complete | Extract shared conversion core from `fetch_convert.rs` |
 | P1 | [47365](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47365) | Code complete, unmerged | Parameter type model, conversion matrix, `SQL_C_DEFAULT` |
 | P2 | [47366](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47366) | Not started | Safe C-buffer reader and conversion-outcome channel |
 | P3 | [47367](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47367) | Not started | Quadrant A: integer C -> integer SQL |
@@ -175,23 +176,36 @@ one task per phase.
 
 P1 is independent of P0; P3 onward depend on both.
 
-#### P0 - Extract shared conversion core (not started)
+#### P0 - Extract shared conversion core (code complete)
 
-Pure refactor, no behavior change. Create `src/conversion/`:
+Pure refactor, no behavior change. `src/conversion/` now holds the value-level
+conversion for both directions:
 
-- `error.rs` - direction-aware outcome vocabulary lifted from `fetch_convert.rs`:
-  a `ConvDirection`, an outcome (`Exact`, `FractionalTruncation`,
-  `StringTruncation`), and an error kind (`OutOfRange`, `InvalidCharacterValue`,
-  `Restricted`, `StringTruncation`). `NotHandledHere` stays private to fetch
-  dispatch and must never reach an application.
-- `numeric.rs` - move `NumericSource` (exact `Int` / `Scaled` / `Float` model),
-  `parse_decimal_literal`, `to_i128_truncating`, and the checked-narrowing
-  helper. This carries the hardening from the 128-bit shift-overflow guard and
-  the `22003` unrepresentable-value fix into the parameter path.
-- Add `SQLSTATE_22001` and an inbound string-truncation `DiagMsg`;
-  `ERR_STRING_RIGHT_TRUNCATION` (`01004`) stays for the outbound path.
+- `error.rs` - the outcome vocabulary (`ConvOk`, `ConvError`) lifted out of
+  `fetch_convert.rs`. `NotHandledHere` stays a dispatch signal and must never
+  reach an application.
+- `numeric.rs` - `NumericSource` (exact `Int` / `Scaled` / `Float` model),
+  `parse_decimal_literal`, `to_i128_truncating`, and `narrow_i128`, extracted
+  from the `narrow!` macro that was local to `convert_integer_c`. This carries
+  the 128-bit shift-overflow guard and the `22003` unrepresentable-value fix
+  into the parameter path.
+- `fetch_convert.rs` - `api/fetch_convert.rs` moved wholesale. It has no handle
+  or diagnostic coupling, so it never belonged beside the `SQLxxx` entry points
+  in `api/`.
+- `param_convert.rs` - `params/convert.rs` moved, so both direction converters
+  sit together on the shared core. `params/` keeps what is genuinely about
+  bindings: the `BoundParam` record and the bind-time `conversion_matrix`.
 
-#### P1 - Parameter type model and conversion matrix (code complete, unmerged)
+Deferred to the phase that first constructs them, because `sqlstate.rs` carries
+no `allow(dead_code)` and `cargo bclippy` runs `-D warnings` - an unused
+SQLSTATE constant or a never-constructed enum variant fails the lint gate:
+
+- `ConvDirection` and the split of `Truncated` into `FractionalTruncation` /
+  `StringTruncation` - land with P4/P5, which raise inbound truncation.
+- `SQLSTATE_22001` and its `DiagMsg` - same. `ERR_STRING_RIGHT_TRUNCATION`
+  (`01004`) already exists for the outbound path.
+
+#### P1 - Parameter type model and conversion matrix (code complete)
 
 - [`api/type_rules.rs`](../src/api/type_rules.rs) - C-type canonicalization, the
   `HY003` / `HY004` identifier gates, and version-aware `SQL_C_DEFAULT`
@@ -293,7 +307,7 @@ Deviations from msodbcsql, verified against source:
 
 #### P7 - Cleanup and hooks (not started)
 
-- Remove remaining "Phase 1" language from `params/convert.rs` and
+- Remove remaining "Phase 1" language from `conversion/param_convert.rs` and
   `params/bound_param.rs`.
 - Record the deferred blockers: `SqlType` metadata/value separation for decimal
   and temporal typed NULLs, and the hard-coded decimal precision/scale in
@@ -329,7 +343,8 @@ accepting a pairing inbound that is rejected outbound for no principled reason.
   also allow `OUTPUT` and `?=` handling. This is no longer a repeated-parsing
   correctness issue.
 - **Type matrix and TDS type selection:** tracked by the conversion milestone
-  above. `params::convert` still ignores `sql_type` and emits `(n)varchar(max)`,
+  above. `conversion::param_convert` still ignores `sql_type` and emits
+  `(n)varchar(max)`,
   relying on SQL Server implicit conversion; P3 and P4 drive the wire type from
   `ParameterType` instead. Beyond this milestone the same work is needed for
   binary, `uniqueidentifier`, money, decimal, and date/time values.

--- a/mssql-odbc/docs/parameters_plan.md
+++ b/mssql-odbc/docs/parameters_plan.md
@@ -344,10 +344,10 @@ accepting a pairing inbound that is rejected outbound for no principled reason.
   correctness issue.
 - **Type matrix and TDS type selection:** tracked by the conversion milestone
   above. `conversion::param_convert` still ignores `sql_type` and emits
-  `(n)varchar(max)`,
-  relying on SQL Server implicit conversion; P3 and P4 drive the wire type from
-  `ParameterType` instead. Beyond this milestone the same work is needed for
-  binary, `uniqueidentifier`, money, decimal, and date/time values.
+  `(n)varchar(max)`, relying on SQL Server implicit conversion; P3 and P4 drive
+  the wire type from `ParameterType` instead. Beyond this milestone the same
+  work is needed for binary, `uniqueidentifier`, money, decimal, and date/time
+  values.
 - **Deferred features:** output parameters (`SQL_PARAM_OUTPUT`, `SQL_PARAM_INPUT_OUTPUT`), data-at-exec
   (`SQLParamData` / `SQLPutData`), parameter arrays
   (`SQL_ATTR_PARAMSET_SIZE`), and TVPs. Data-at-exec requires an

--- a/mssql-odbc/src/api/exec_common.rs
+++ b/mssql-odbc/src/api/exec_common.rs
@@ -331,7 +331,9 @@ pub(super) fn finish_execute(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::odbc_types::{SQL_C_CHAR, SQL_NTS, SQL_PARAM_INPUT, SQL_VARCHAR, SqlLen};
+    use crate::api::odbc_types::{
+        SQL_C_CHAR, SQL_DEFAULT_PARAM, SQL_NTS, SQL_PARAM_INPUT, SQL_VARCHAR, SqlLen,
+    };
     use crate::handles::handle_from_raw;
     use crate::params::BoundParam;
     use crate::test_support::TestHandles;
@@ -417,5 +419,26 @@ mod tests {
         let ret = unsafe { build_named_params(&mut state, 1, "test") };
         assert_eq!(ret.unwrap_err(), SQL_ERROR);
         assert_eq!(state.diag_records[0].sql_state, SQLSTATE_07002);
+    }
+
+    /// `SQL_DEFAULT_PARAM` is terminal 07S01, not "not yet implemented" —
+    /// asserted through the poster, since the enum-level check cannot catch a
+    /// dropped `post_diag` or the wrong `DiagMsg`.
+    #[test]
+    fn build_named_params_default_param_posts_07s01() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+
+        let mut buf: Vec<u8> = b"x\0".to_vec();
+        let mut ind: SqlLen = SQL_DEFAULT_PARAM;
+
+        let mut state = stmt.inner.lock().unwrap();
+        state
+            .bound_params
+            .push(Some(char_param(&mut buf, &mut ind)));
+
+        let ret = unsafe { build_named_params(&mut state, 1, "test") };
+        assert_eq!(ret.unwrap_err(), SQL_ERROR);
+        assert_eq!(state.diag_records[0].sql_state, SQLSTATE_07S01);
     }
 }

--- a/mssql-odbc/src/api/exec_common.rs
+++ b/mssql-odbc/src/api/exec_common.rs
@@ -17,13 +17,12 @@ use mssql_tds::message::parameters::rpc_parameters::RpcParameter;
 
 use super::sqlstate::*;
 use crate::api::odbc_types::{SQL_ERROR, SQL_SUCCESS, SQL_SUCCESS_WITH_INFO, SqlHandle, SqlReturn};
-use crate::error::post_sql_error;
+use crate::conversion::param_convert::{ParamBuildError, bound_param_to_rpc};
 use crate::handles::dbc::ConnectionState;
 use crate::handles::stmt::{
     STMT_STATE_CURSOR_OPEN, STMT_STATE_EXEC_CONTEXT, STMT_STATE_EXEC_STARTED, StmtState,
 };
 use crate::handles::{DbcHandle, StmtHandle};
-use crate::params::convert::{ParamConvError, bound_param_to_rpc};
 
 /// Clears the in-flight `EXEC_STARTED` flag on an execution failure so the
 /// statement is reusable.
@@ -189,7 +188,7 @@ pub(super) fn flush_pending_unprepare(
 /// Builds the ordered `@P1..@Pn` RPC parameter list from the statement's bound
 /// parameters, reading application value buffers by reference. Posts the
 /// matching diagnostic and returns `Err(SQL_ERROR)` when a marker is unbound
-/// (`07002`) or a value cannot be converted (`HYC00`). Shared by `SQLExecute`
+/// (`07002`) or a parameter cannot be built. Shared by `SQLExecute`
 /// and `SQLExecDirect`; `op` names the entry point for traceable diagnostics.
 ///
 /// # Safety
@@ -210,18 +209,13 @@ pub(super) unsafe fn build_named_params(
         let name = format!("@P{}", i + 1);
         match unsafe { bound_param_to_rpc(name, bound_param) } {
             Ok(param) => named_params.push(param),
-            Err(ParamConvError::InvalidLength(len)) => {
-                error!("{op}: parameter {} has invalid StrLen_or_Ind {len}", i + 1);
-                post_diag(stmt_state, ERR_INVALID_STRING_OR_BUFFER_LENGTH);
-                return Err(SQL_ERROR);
-            }
             Err(e) => {
-                error!(
-                    "{op}: parameter {} conversion failed: {}",
-                    i + 1,
-                    e.message()
-                );
-                post_sql_error(stmt_state, SQLSTATE_HYC00, 0, e.message());
+                if let ParamBuildError::InvalidLength(len) = e {
+                    error!("{op}: parameter {} has invalid StrLen_or_Ind {len}", i + 1);
+                } else {
+                    error!("{op}: parameter {} rejected: {}", i + 1, e.diag().text);
+                }
+                post_diag(stmt_state, e.diag());
                 return Err(SQL_ERROR);
             }
         }

--- a/mssql-odbc/src/api/get_data.rs
+++ b/mssql-odbc/src/api/get_data.rs
@@ -18,10 +18,11 @@ use crate::handles::stmt::{ActivePlpStream, STMT_STATE_CURSOR_OPEN};
 use crate::handles::{HandleType, StmtHandle, handle_from_raw};
 use mssql_tds::connection::tds_client::{CursorColumn, PlpChunk};
 
-use super::fetch_convert::{
-    ConvError, ConvOk, convert_datetime_c, convert_float_c, convert_guid_c, convert_integer_c,
-    extract_datetime_parts, format_datetime_parts, is_datetime_c_target, is_float_c_target,
-    is_integer_c_target, sql_string_to_text,
+use crate::conversion::error::{ConvError, ConvOk};
+use crate::conversion::fetch_convert::{
+    convert_datetime_c, convert_float_c, convert_guid_c, convert_integer_c, extract_datetime_parts,
+    format_datetime_parts, is_datetime_c_target, is_float_c_target, is_integer_c_target,
+    money_scaled, sql_string_to_text,
 };
 use mssql_tds::datatypes::column_values::ColumnValues;
 use mssql_tds::query::metadata::PlpEncoding;
@@ -1055,9 +1056,7 @@ fn column_value_to_text(v: &ColumnValues) -> Result<String, TextError> {
         ColumnValues::Float(x) => Ok(x.to_string()),
         ColumnValues::Bit(x) => Ok(if *x { "1".into() } else { "0".into() }),
         ColumnValues::Decimal(d) | ColumnValues::Numeric(d) => Ok(d.to_string()),
-        ColumnValues::Money(m) => Ok(money_scaled_to_string(super::fetch_convert::money_scaled(
-            m.lsb_part, m.msb_part,
-        ))),
+        ColumnValues::Money(m) => Ok(money_scaled_to_string(money_scaled(m.lsb_part, m.msb_part))),
         ColumnValues::SmallMoney(m) => Ok(money_scaled_to_string(i64::from(m.int_val))),
         // `SqlString::to_utf8_string` unwraps on its UTF-8 branch; decode fallibly.
         ColumnValues::String(s) => sql_string_to_text(s).ok_or(TextError::Malformed),

--- a/mssql-odbc/src/api/mod.rs
+++ b/mssql-odbc/src/api/mod.rs
@@ -14,7 +14,6 @@ mod exec_common;
 mod exec_direct;
 mod execute;
 pub(crate) mod fetch;
-pub(crate) mod fetch_convert;
 pub(crate) mod free_handle;
 pub(crate) mod get_connect_attr;
 mod get_data;

--- a/mssql-odbc/src/api/sqlstate.rs
+++ b/mssql-odbc/src/api/sqlstate.rs
@@ -15,6 +15,7 @@ pub(crate) const SQLSTATE_01S07: [u8; 5] = *b"01S07";
 pub(crate) const SQLSTATE_07002: [u8; 5] = *b"07002";
 pub(crate) const SQLSTATE_07006: [u8; 5] = *b"07006";
 pub(crate) const SQLSTATE_07009: [u8; 5] = *b"07009";
+pub(crate) const SQLSTATE_07S01: [u8; 5] = *b"07S01";
 pub(crate) const SQLSTATE_08001: [u8; 5] = *b"08001";
 pub(crate) const SQLSTATE_08003: [u8; 5] = *b"08003";
 /// Connection failure during a transaction — ODBC's precise state for a
@@ -111,6 +112,21 @@ pub(crate) const ERR_INVALID_C_DATA_TYPE: DiagMsg = DiagMsg {
 pub(crate) const ERR_RESTRICTED_DATA_TYPE: DiagMsg = DiagMsg {
     state: SQLSTATE_07006,
     text: "Restricted data type attribute violation",
+};
+// `SQL_DEFAULT_PARAM` is only legal for a canonical procedure call, which this
+// driver does not support, so the state is terminal rather than "not yet"
+// (msodbcsql `sqlccmd.cpp` -> IDS_07_S01 on a non-canonical call statement).
+pub(crate) const ERR_INVALID_USE_OF_DEFAULT_PARAM: DiagMsg = DiagMsg {
+    state: SQLSTATE_07S01,
+    text: "Invalid use of default parameter",
+};
+pub(crate) const ERR_DATA_AT_EXEC_NOT_IMPLEMENTED: DiagMsg = DiagMsg {
+    state: SQLSTATE_HYC00,
+    text: "Data-at-execution parameters not yet implemented",
+};
+pub(crate) const ERR_PARAM_C_TYPE_NOT_IMPLEMENTED: DiagMsg = DiagMsg {
+    state: SQLSTATE_HYC00,
+    text: "Parameter C type not yet implemented",
 };
 pub(crate) const ERR_NUMERIC_OUT_OF_RANGE: DiagMsg = DiagMsg {
     state: SQLSTATE_22003,

--- a/mssql-odbc/src/conversion/error.rs
+++ b/mssql-odbc/src/conversion/error.rs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Direction-neutral outcome vocabulary for value conversion.
+//!
+//! Converters report through these types instead of posting diagnostics
+//! themselves: they have no handle to post to, and the record a caller builds
+//! differs by path (`SQLGetData` sets a column number; block fetch also sets a
+//! row number and a row-status entry). The caller maps a variant to its
+//! SQLSTATE.
+
+/// Outcome of a successful conversion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ConvOk {
+    /// The value was represented exactly.
+    Exact,
+    /// Precision was lost (e.g. a date/time component the target cannot hold).
+    /// The caller posts `01S07` and returns `SQL_SUCCESS_WITH_INFO`.
+    Truncated,
+}
+
+/// Why a value-level conversion could not be completed. The caller maps each
+/// variant to the appropriate SQLSTATE on its own diagnostic target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ConvError {
+    /// The value does not fit the requested C type (SQLSTATE `22003`).
+    OutOfRange,
+    /// This source/target pairing is not handled by this converter; the caller
+    /// should try another path. Never surfaced to the application directly.
+    NotHandledHere,
+    /// The requested C type is not a legal target for this SQL type
+    /// (SQLSTATE `07006`). Terminal.
+    Restricted,
+    /// A character column's text is not a valid literal for the requested target
+    /// (SQLSTATE `22018`). Terminal.
+    InvalidCharacterValue,
+}

--- a/mssql-odbc/src/conversion/fetch_convert.rs
+++ b/mssql-odbc/src/conversion/fetch_convert.rs
@@ -19,7 +19,7 @@
 //! [`ConvError::NotHandledHere`] so callers can fall back to their existing paths
 //! (e.g. the character conversion in `get_data`).
 
-use super::odbc_types::{
+use crate::api::odbc_types::{
     SQL_C_BIT, SQL_C_DATE, SQL_C_DOUBLE, SQL_C_FLOAT, SQL_C_GUID, SQL_C_LONG, SQL_C_SBIGINT,
     SQL_C_SHORT, SQL_C_SLONG, SQL_C_SS_TIME2, SQL_C_SS_TIMESTAMPOFFSET, SQL_C_SSHORT,
     SQL_C_STINYINT, SQL_C_TIME, SQL_C_TIMESTAMP, SQL_C_TINYINT, SQL_C_TYPE_DATE, SQL_C_TYPE_TIME,
@@ -27,7 +27,9 @@ use super::odbc_types::{
     SqlGuid, SqlLen, SqlPointer, SqlSmallInt, SqlSsTime2Struct, SqlSsTimestampoffsetStruct,
     SqlTimeStruct, SqlTimestampStruct,
 };
-use super::util::write_if_some;
+use crate::api::util::write_if_some;
+use crate::conversion::error::{ConvError, ConvOk};
+use crate::conversion::numeric::{NumericSource, narrow_i128, parse_decimal_literal};
 use mssql_tds::datatypes::column_values::ColumnValues;
 use mssql_tds::datatypes::sql_string::{EncodingType, SqlString};
 
@@ -40,33 +42,6 @@ pub(crate) fn sql_string_to_text(s: &SqlString) -> Option<String> {
         EncodingType::Utf8 => String::from_utf8(s.bytes.clone()).ok(),
         _ => Some(s.to_utf8_string()),
     }
-}
-
-/// Outcome of a successful conversion.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ConvOk {
-    /// The value was represented exactly.
-    Exact,
-    /// Precision was lost (e.g. a date/time component the target cannot hold).
-    /// The caller posts `01S07` and returns `SQL_SUCCESS_WITH_INFO`.
-    Truncated,
-}
-
-/// Why a value-level conversion could not be completed. The caller maps each
-/// variant to the appropriate SQLSTATE on its own diagnostic target.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ConvError {
-    /// The value does not fit the requested C type (SQLSTATE `22003`).
-    OutOfRange,
-    /// This source/target pairing is not handled by this converter; the caller
-    /// should try another path. Never surfaced to the application directly.
-    NotHandledHere,
-    /// The requested C type is not a legal target for this SQL type
-    /// (SQLSTATE `07006`). Terminal.
-    Restricted,
-    /// A character column's text is not a valid literal for the requested target
-    /// (SQLSTATE `22018`). Terminal.
-    InvalidCharacterValue,
 }
 
 /// Returns `true` if `target_type` is one of the fixed-width integer C types
@@ -103,93 +78,6 @@ unsafe fn write_fixed<T: Copy>(ptr: SqlPointer, value: T, ind: *mut SqlLen) -> C
     }
     unsafe { write_if_some(ind, std::mem::size_of::<T>() as SqlLen) };
     ConvOk::Exact
-}
-
-/// A numeric column value in a form that keeps exact sources exact, so an
-/// integer target can report truncation instead of silently dropping a
-/// fraction.
-#[derive(Debug, Clone, Copy, PartialEq)]
-enum NumericSource {
-    Int(i128),
-    /// `mantissa / 10^scale` — the exact decimal types (`decimal`, `numeric`,
-    /// `money`, `smallmoney`) and decimal literals in character columns.
-    Scaled {
-        mantissa: i128,
-        scale: u32,
-    },
-    Float(f64),
-}
-
-impl NumericSource {
-    fn as_f64(&self) -> f64 {
-        match self {
-            NumericSource::Int(v) => *v as f64,
-            NumericSource::Scaled { mantissa, scale } => {
-                *mantissa as f64 / 10f64.powi(*scale as i32)
-            }
-            NumericSource::Float(f) => *f,
-        }
-    }
-
-    /// Sign of the value before any truncation toward zero.
-    fn is_negative(&self) -> bool {
-        match self {
-            NumericSource::Int(v) => *v < 0,
-            NumericSource::Scaled { mantissa, .. } => *mantissa < 0,
-            NumericSource::Float(f) => *f < 0.0,
-        }
-    }
-
-    /// Value truncated toward zero plus whether a fractional part was dropped.
-    /// `None` when the value cannot be represented as an integer at all.
-    fn to_i128_truncating(self) -> Option<(i128, bool)> {
-        match self {
-            NumericSource::Int(v) => Some((v, false)),
-            NumericSource::Scaled { mantissa, scale } => {
-                // Past 10^38 the divisor exceeds every representable mantissa, so
-                // the quotient is zero and the whole value is the dropped fraction.
-                let Some(divisor) = 10i128.checked_pow(scale) else {
-                    return Some((0, mantissa != 0));
-                };
-                Some((mantissa / divisor, mantissa % divisor != 0))
-            }
-            NumericSource::Float(f) => {
-                if !f.is_finite() || !(-1.7e38..=1.7e38).contains(&f) {
-                    return None;
-                }
-                Some((f.trunc() as i128, f.fract() != 0.0))
-            }
-        }
-    }
-}
-
-/// Parses a plain decimal literal (`-12.34`, `+7`, `.5`) into an exact
-/// [`NumericSource::Scaled`]. Exponent forms are left to the `f64` fallback.
-fn parse_decimal_literal(text: &str) -> Option<NumericSource> {
-    let t = text.trim();
-    let (negative, body) = match t.strip_prefix('-') {
-        Some(rest) => (true, rest),
-        None => (false, t.strip_prefix('+').unwrap_or(t)),
-    };
-    let (int_digits, frac_digits) = match body.split_once('.') {
-        Some((i, f)) => (i, f),
-        None => (body, ""),
-    };
-    if int_digits.is_empty() && frac_digits.is_empty() {
-        return None;
-    }
-    if !int_digits
-        .bytes()
-        .chain(frac_digits.bytes())
-        .all(|b| b.is_ascii_digit())
-    {
-        return None;
-    }
-    let mantissa: i128 = format!("{int_digits}{frac_digits}").parse().ok()?;
-    Some(NumericSource::Scaled {
-        mantissa: if negative { -mantissa } else { mantissa },
-        scale: frac_digits.len() as u32,
-    })
 }
 
 /// The `money` / `smallmoney` wire value as an integer scaled by 10^4.
@@ -307,9 +195,8 @@ pub(crate) unsafe fn convert_integer_c(
     let source = numeric_source_or_parse(value)?;
     let (v, truncated) = source.to_i128_truncating().ok_or(ConvError::OutOfRange)?;
 
-    // Helper: narrow `v` to the target's range or fail with OutOfRange.
     macro_rules! narrow {
-        ($ty:ty) => {{ <$ty>::try_from(v).map_err(|_| ConvError::OutOfRange)? }};
+        ($ty:ty) => {{ narrow_i128::<$ty>(v)? }};
     }
 
     match target_type {
@@ -1048,7 +935,7 @@ mod tests {
         let mut ind: SqlLen = 0;
         let err = conv(
             &ColumnValues::Int(1),
-            super::super::odbc_types::SQL_C_DOUBLE,
+            crate::api::odbc_types::SQL_C_DOUBLE,
             out.as_mut_ptr().cast(),
             &mut ind,
         )

--- a/mssql-odbc/src/conversion/fetch_convert.rs
+++ b/mssql-odbc/src/conversion/fetch_convert.rs
@@ -1189,34 +1189,6 @@ mod tests {
     }
 
     #[test]
-    fn parse_decimal_literal_forms() {
-        assert_eq!(
-            parse_decimal_literal("12.34"),
-            Some(NumericSource::Scaled {
-                mantissa: 1234,
-                scale: 2
-            })
-        );
-        assert_eq!(
-            parse_decimal_literal("-0.01"),
-            Some(NumericSource::Scaled {
-                mantissa: -1,
-                scale: 2
-            })
-        );
-        assert_eq!(
-            parse_decimal_literal("+7"),
-            Some(NumericSource::Scaled {
-                mantissa: 7,
-                scale: 0
-            })
-        );
-        assert_eq!(parse_decimal_literal("1e5"), None);
-        assert_eq!(parse_decimal_literal("abc"), None);
-        assert_eq!(parse_decimal_literal(""), None);
-    }
-
-    #[test]
     fn character_source_into_date_target() {
         let mut out = SqlDateStruct::default();
         let mut ind: SqlLen = 0;
@@ -1576,15 +1548,6 @@ mod tests {
     /// rather than reporting the value as out of range.
     #[test]
     fn scale_beyond_i128_truncates_to_zero() {
-        assert_eq!(
-            NumericSource::Scaled {
-                mantissa: 1,
-                scale: 39
-            }
-            .to_i128_truncating(),
-            Some((0, true))
-        );
-
         let mut out: i32 = -1;
         let mut ind: SqlLen = 0;
         let ok = unsafe {

--- a/mssql-odbc/src/conversion/mod.rs
+++ b/mssql-odbc/src/conversion/mod.rs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Value-level conversion for both ODBC data directions.
+//!
+//! [`fetch_convert`] converts a fetched `ColumnValues` into a requested
+//! `SQL_C_*` buffer; [`param_convert`] converts a bound application buffer into
+//! the `SqlType` sent as an RPC parameter. Both sit on the direction-neutral
+//! pieces here: the [`error`] outcome vocabulary and the exact [`numeric`]
+//! value model.
+//!
+//! Only the value model is shared. Each direction keeps its own audited unsafe
+//! pointer I/O — fetch writes caller buffers, parameters read them — and each
+//! decides conversion legality at the moment its types become known: a
+//! bind-time matrix in `crate::params` for parameters, [`error::ConvError`]
+//! returned from inside the converters for fetch.
+
+pub(crate) mod error;
+pub(crate) mod fetch_convert;
+pub(crate) mod numeric;
+pub(crate) mod param_convert;

--- a/mssql-odbc/src/conversion/numeric.rs
+++ b/mssql-odbc/src/conversion/numeric.rs
@@ -129,6 +129,15 @@ mod tests {
                 scale: 1
             })
         );
+        // A leading zero in the fraction is absorbed into the mantissa while
+        // scale still counts both digits.
+        assert_eq!(
+            parse_decimal_literal("-0.01"),
+            Some(NumericSource::Scaled {
+                mantissa: -1,
+                scale: 2
+            })
+        );
     }
 
     #[test]

--- a/mssql-odbc/src/conversion/numeric.rs
+++ b/mssql-odbc/src/conversion/numeric.rs
@@ -1,0 +1,200 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Exact numeric value model shared by both conversion directions.
+//!
+//! Keeping exact sources exact (rather than routing everything through `f64`)
+//! is what lets an integer target report truncation instead of silently
+//! dropping a fraction, and lets a value too wide for the target be reported as
+//! `22003` rather than saturating.
+
+use super::error::ConvError;
+
+/// A numeric value in a form that keeps exact sources exact, so an integer
+/// target can report truncation instead of silently dropping a fraction.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum NumericSource {
+    Int(i128),
+    /// `mantissa / 10^scale` — the exact decimal types (`decimal`, `numeric`,
+    /// `money`, `smallmoney`) and decimal literals in character columns.
+    Scaled {
+        mantissa: i128,
+        scale: u32,
+    },
+    Float(f64),
+}
+
+impl NumericSource {
+    pub(crate) fn as_f64(&self) -> f64 {
+        match self {
+            NumericSource::Int(v) => *v as f64,
+            NumericSource::Scaled { mantissa, scale } => {
+                *mantissa as f64 / 10f64.powi(*scale as i32)
+            }
+            NumericSource::Float(f) => *f,
+        }
+    }
+
+    /// Sign of the value before any truncation toward zero.
+    pub(crate) fn is_negative(&self) -> bool {
+        match self {
+            NumericSource::Int(v) => *v < 0,
+            NumericSource::Scaled { mantissa, .. } => *mantissa < 0,
+            NumericSource::Float(f) => *f < 0.0,
+        }
+    }
+
+    /// Value truncated toward zero plus whether a fractional part was dropped.
+    /// `None` when the value cannot be represented as an integer at all.
+    pub(crate) fn to_i128_truncating(self) -> Option<(i128, bool)> {
+        match self {
+            NumericSource::Int(v) => Some((v, false)),
+            NumericSource::Scaled { mantissa, scale } => {
+                // Past 10^38 the divisor exceeds every representable mantissa, so
+                // the quotient is zero and the whole value is the dropped fraction.
+                let Some(divisor) = 10i128.checked_pow(scale) else {
+                    return Some((0, mantissa != 0));
+                };
+                Some((mantissa / divisor, mantissa % divisor != 0))
+            }
+            NumericSource::Float(f) => {
+                if !f.is_finite() || !(-1.7e38..=1.7e38).contains(&f) {
+                    return None;
+                }
+                Some((f.trunc() as i128, f.fract() != 0.0))
+            }
+        }
+    }
+}
+
+/// Parses a plain decimal literal (`-12.34`, `+7`, `.5`) into an exact
+/// [`NumericSource::Scaled`]. Exponent forms are left to the `f64` fallback.
+pub(crate) fn parse_decimal_literal(text: &str) -> Option<NumericSource> {
+    let t = text.trim();
+    let (negative, body) = match t.strip_prefix('-') {
+        Some(rest) => (true, rest),
+        None => (false, t.strip_prefix('+').unwrap_or(t)),
+    };
+    let (int_digits, frac_digits) = match body.split_once('.') {
+        Some((i, f)) => (i, f),
+        None => (body, ""),
+    };
+    if int_digits.is_empty() && frac_digits.is_empty() {
+        return None;
+    }
+    if !int_digits
+        .bytes()
+        .chain(frac_digits.bytes())
+        .all(|b| b.is_ascii_digit())
+    {
+        return None;
+    }
+    let mantissa: i128 = format!("{int_digits}{frac_digits}").parse().ok()?;
+    Some(NumericSource::Scaled {
+        mantissa: if negative { -mantissa } else { mantissa },
+        scale: frac_digits.len() as u32,
+    })
+}
+
+/// Narrows an `i128` to a target integer type, reporting an out-of-range value
+/// as [`ConvError::OutOfRange`] rather than wrapping.
+pub(crate) fn narrow_i128<T: TryFrom<i128>>(v: i128) -> Result<T, ConvError> {
+    T::try_from(v).map_err(|_| ConvError::OutOfRange)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_decimal_literals_parse_exactly() {
+        assert_eq!(
+            parse_decimal_literal("-12.34"),
+            Some(NumericSource::Scaled {
+                mantissa: -1234,
+                scale: 2
+            })
+        );
+        assert_eq!(
+            parse_decimal_literal("+7"),
+            Some(NumericSource::Scaled {
+                mantissa: 7,
+                scale: 0
+            })
+        );
+        assert_eq!(
+            parse_decimal_literal(" .5 "),
+            Some(NumericSource::Scaled {
+                mantissa: 5,
+                scale: 1
+            })
+        );
+    }
+
+    #[test]
+    fn non_decimal_text_is_rejected() {
+        // Exponent forms are deliberately left to the f64 fallback.
+        assert_eq!(parse_decimal_literal("1e3"), None);
+        assert_eq!(parse_decimal_literal("abc"), None);
+        assert_eq!(parse_decimal_literal(""), None);
+        assert_eq!(parse_decimal_literal("-"), None);
+    }
+
+    #[test]
+    fn truncation_toward_zero_reports_dropped_fraction() {
+        let n = NumericSource::Scaled {
+            mantissa: -1234,
+            scale: 2,
+        };
+        assert_eq!(n.to_i128_truncating(), Some((-12, true)));
+        assert!(n.is_negative());
+
+        let exact = NumericSource::Scaled {
+            mantissa: 1200,
+            scale: 2,
+        };
+        assert_eq!(exact.to_i128_truncating(), Some((12, false)));
+    }
+
+    /// A scale past 10^38 overflows `checked_pow`; the whole value is then the
+    /// dropped fraction rather than a panic.
+    #[test]
+    fn scale_beyond_i128_pow_yields_zero_with_truncation() {
+        let n = NumericSource::Scaled {
+            mantissa: 5,
+            scale: 40,
+        };
+        assert_eq!(n.to_i128_truncating(), Some((0, true)));
+    }
+
+    #[test]
+    fn non_finite_and_oversized_floats_are_unrepresentable() {
+        assert_eq!(NumericSource::Float(f64::NAN).to_i128_truncating(), None);
+        assert_eq!(
+            NumericSource::Float(f64::INFINITY).to_i128_truncating(),
+            None
+        );
+        assert_eq!(NumericSource::Float(1e39).to_i128_truncating(), None);
+    }
+
+    #[test]
+    fn narrowing_out_of_range_is_reported_not_wrapped() {
+        assert_eq!(narrow_i128::<i8>(127), Ok(127i8));
+        assert_eq!(narrow_i128::<i8>(128), Err(ConvError::OutOfRange));
+        assert_eq!(narrow_i128::<u8>(-1), Err(ConvError::OutOfRange));
+    }
+
+    #[test]
+    fn as_f64_covers_every_variant() {
+        assert_eq!(NumericSource::Int(-3).as_f64(), -3.0);
+        assert_eq!(
+            NumericSource::Scaled {
+                mantissa: 1234,
+                scale: 2
+            }
+            .as_f64(),
+            12.34
+        );
+        assert_eq!(NumericSource::Float(1.5).as_f64(), 1.5);
+    }
+}

--- a/mssql-odbc/src/conversion/param_convert.rs
+++ b/mssql-odbc/src/conversion/param_convert.rs
@@ -7,8 +7,8 @@
 //! Which C/SQL pairings reach this module is decided at bind time by
 //! [`crate::api::type_rules`] and [`crate::params::conversion_matrix`];
 //! `SQL_C_DEFAULT` has already been resolved to a concrete C type by then.
-//! Data-at-execution and default parameters are rejected with `HYC00`, and an
-//! invalid negative `StrLen_or_Ind` with `HY090`.
+//! Data-at-execution is rejected with `HYC00`, `SQL_DEFAULT_PARAM` with
+//! `07S01`, and an invalid negative `StrLen_or_Ind` with `HY090`.
 
 use std::slice;
 
@@ -20,35 +20,40 @@ use crate::api::odbc_types::{
     SQL_C_CHAR, SQL_C_WCHAR, SQL_DATA_AT_EXEC, SQL_DEFAULT_PARAM, SQL_LEN_DATA_AT_EXEC_OFFSET,
     SQL_NTS, SQL_NULL_DATA, SqlLen, SqlSmallInt,
 };
-use crate::api::sqlstate::ERR_INVALID_STRING_OR_BUFFER_LENGTH;
+use crate::api::sqlstate::{
+    DiagMsg, ERR_DATA_AT_EXEC_NOT_IMPLEMENTED, ERR_INVALID_STRING_OR_BUFFER_LENGTH,
+    ERR_INVALID_USE_OF_DEFAULT_PARAM, ERR_PARAM_C_TYPE_NOT_IMPLEMENTED,
+};
 use crate::params::BoundParam;
 
-/// Why a bound parameter could not be converted.
+/// Why a bound parameter could not be turned into an RPC parameter.
 ///
-/// The "not yet implemented" variants post `HYC00` via [`message`]; a bad
-/// indicator posts the canonical `HY090` diagnostic
-/// (`ERR_INVALID_STRING_OR_BUFFER_LENGTH`).
+/// Each variant carries its own SQLSTATE through [`diag`]; none of these are
+/// value-conversion failures, which arrive from
+/// [`crate::conversion::error::ConvError`] instead.
 ///
-/// [`message`]: ParamConvError::message
+/// [`diag`]: ParamBuildError::diag
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ParamConvError {
-    /// The application's C type is not supported in Phase 1.
+pub(crate) enum ParamBuildError {
+    /// Backstop only: bind time rejects any C type the conversion matrix does
+    /// not list, so reaching this means the matrix and this module disagree.
     UnsupportedCType(SqlSmallInt),
     /// The parameter uses data-at-execution (`SQLPutData`).
     DataAtExecUnsupported,
-    /// The parameter requested its default value.
-    DefaultParamUnsupported,
+    /// `StrLen_or_Ind` was `SQL_DEFAULT_PARAM` on a statement that is not a
+    /// canonical procedure call.
+    InvalidUseOfDefaultParam,
     /// `StrLen_or_Ind` is a negative value that is not a valid input length.
     InvalidLength(SqlLen),
 }
 
-impl ParamConvError {
-    pub(crate) fn message(self) -> &'static str {
+impl ParamBuildError {
+    pub(crate) fn diag(self) -> DiagMsg {
         match self {
-            Self::UnsupportedCType(_) => "Parameter C type not yet implemented",
-            Self::DataAtExecUnsupported => "Data-at-execution parameters not yet implemented",
-            Self::DefaultParamUnsupported => "Default parameters not yet implemented",
-            Self::InvalidLength(_) => ERR_INVALID_STRING_OR_BUFFER_LENGTH.text,
+            Self::UnsupportedCType(_) => ERR_PARAM_C_TYPE_NOT_IMPLEMENTED,
+            Self::DataAtExecUnsupported => ERR_DATA_AT_EXEC_NOT_IMPLEMENTED,
+            Self::InvalidUseOfDefaultParam => ERR_INVALID_USE_OF_DEFAULT_PARAM,
+            Self::InvalidLength(_) => ERR_INVALID_STRING_OR_BUFFER_LENGTH,
         }
     }
 }
@@ -60,7 +65,7 @@ impl ParamConvError {
 pub(crate) unsafe fn bound_param_to_rpc(
     name: String,
     param: &BoundParam,
-) -> Result<RpcParameter, ParamConvError> {
+) -> Result<RpcParameter, ParamBuildError> {
     let value = unsafe { bound_param_to_value(param) }?;
     Ok(RpcParameter::new(Some(name), StatusFlags::NONE, value))
 }
@@ -72,7 +77,7 @@ pub(crate) unsafe fn bound_param_to_rpc(
 /// `param.parameter_value_ptr` and `param.strlen_or_ind_ptr` must satisfy the
 /// ODBC binding contract: the value buffer is readable for the indicated
 /// length and the indicator pointer, if non-null, points to one valid `SqlLen`.
-pub(crate) unsafe fn bound_param_to_value(param: &BoundParam) -> Result<SqlType, ParamConvError> {
+pub(crate) unsafe fn bound_param_to_value(param: &BoundParam) -> Result<SqlType, ParamBuildError> {
     let indicator = if param.strlen_or_ind_ptr.is_null() {
         None
     } else {
@@ -84,14 +89,14 @@ pub(crate) unsafe fn bound_param_to_value(param: &BoundParam) -> Result<SqlType,
             return null_value(param.c_type);
         }
         if ind == SQL_DEFAULT_PARAM {
-            return Err(ParamConvError::DefaultParamUnsupported);
+            return Err(ParamBuildError::InvalidUseOfDefaultParam);
         }
         if ind == SQL_DATA_AT_EXEC || ind <= SQL_LEN_DATA_AT_EXEC_OFFSET {
-            return Err(ParamConvError::DataAtExecUnsupported);
+            return Err(ParamBuildError::DataAtExecUnsupported);
         }
         // Any remaining negative indicator  is invalid for an input parameter
         if ind < 0 && ind != SQL_NTS as SqlLen {
-            return Err(ParamConvError::InvalidLength(ind));
+            return Err(ParamBuildError::InvalidLength(ind));
         }
     }
 
@@ -110,18 +115,18 @@ pub(crate) unsafe fn bound_param_to_value(param: &BoundParam) -> Result<SqlType,
                 unsafe { read_wchar_bytes(param.parameter_value_ptr as *const u16, len_spec) };
             SqlType::NVarcharMax(Some(SqlString::new(bytes, EncodingType::Utf16)))
         }
-        other => return Err(ParamConvError::UnsupportedCType(other)),
+        other => return Err(ParamBuildError::UnsupportedCType(other)),
     };
 
     Ok(value)
 }
 
 /// Typed NULL for the supported C types.
-fn null_value(c_type: SqlSmallInt) -> Result<SqlType, ParamConvError> {
+fn null_value(c_type: SqlSmallInt) -> Result<SqlType, ParamBuildError> {
     match c_type {
         SQL_C_CHAR => Ok(SqlType::VarcharMax(None)),
         SQL_C_WCHAR => Ok(SqlType::NVarcharMax(None)),
-        other => Err(ParamConvError::UnsupportedCType(other)),
+        other => Err(ParamBuildError::UnsupportedCType(other)),
     }
 }
 
@@ -231,7 +236,7 @@ mod tests {
         let mut val: i32 = 7;
         let p = param(SQL_C_LONG, &mut val as *mut i32 as *mut c_void, &mut ind);
         let err = unsafe { bound_param_to_value(&p) }.unwrap_err();
-        assert_eq!(err, ParamConvError::UnsupportedCType(SQL_C_LONG));
+        assert_eq!(err, ParamBuildError::UnsupportedCType(SQL_C_LONG));
     }
 
     #[test]
@@ -239,7 +244,7 @@ mod tests {
         let mut ind: SqlLen = SQL_DATA_AT_EXEC;
         let p = param(SQL_C_CHAR, std::ptr::null_mut(), &mut ind);
         let err = unsafe { bound_param_to_value(&p) }.unwrap_err();
-        assert_eq!(err, ParamConvError::DataAtExecUnsupported);
+        assert_eq!(err, ParamBuildError::DataAtExecUnsupported);
     }
 
     #[test]
@@ -247,15 +252,19 @@ mod tests {
         let mut ind: SqlLen = SQL_NO_TOTAL;
         let p = param(SQL_C_CHAR, std::ptr::null_mut(), &mut ind);
         let err = unsafe { bound_param_to_value(&p) }.unwrap_err();
-        assert_eq!(err, ParamConvError::InvalidLength(SQL_NO_TOTAL));
+        assert_eq!(err, ParamBuildError::InvalidLength(SQL_NO_TOTAL));
     }
 
+    /// `SQL_DEFAULT_PARAM` is only legal for a canonical procedure call, which
+    /// this driver does not support, so it is 07S01 rather than "not yet
+    /// implemented" (msodbcsql `sqlccmd.cpp` -> IDS_07_S01).
     #[test]
-    fn default_param_indicator_is_rejected() {
+    fn default_param_indicator_is_invalid_use_not_unimplemented() {
         let mut ind: SqlLen = SQL_DEFAULT_PARAM;
         let p = param(SQL_C_CHAR, std::ptr::null_mut(), &mut ind);
         let err = unsafe { bound_param_to_value(&p) }.unwrap_err();
-        assert_eq!(err, ParamConvError::DefaultParamUnsupported);
+        assert_eq!(err, ParamBuildError::InvalidUseOfDefaultParam);
+        assert_eq!(err.diag().state, *b"07S01");
     }
 
     #[test]
@@ -271,7 +280,7 @@ mod tests {
         let mut ind: SqlLen = SQL_NULL_DATA;
         let p = param(SQL_C_LONG, std::ptr::null_mut(), &mut ind);
         let err = unsafe { bound_param_to_value(&p) }.unwrap_err();
-        assert_eq!(err, ParamConvError::UnsupportedCType(SQL_C_LONG));
+        assert_eq!(err, ParamBuildError::UnsupportedCType(SQL_C_LONG));
     }
 
     #[test]

--- a/mssql-odbc/src/lib.rs
+++ b/mssql-odbc/src/lib.rs
@@ -6,6 +6,7 @@ use std::sync::Once;
 pub mod api;
 mod auth;
 mod connection;
+mod conversion;
 mod error;
 mod handles;
 mod params;

--- a/mssql-odbc/src/params/mod.rs
+++ b/mssql-odbc/src/params/mod.rs
@@ -5,6 +5,5 @@
 
 mod bound_param;
 pub(crate) mod conversion_matrix;
-pub(crate) mod convert;
 
 pub(crate) use bound_param::BoundParam;


### PR DESCRIPTION
## Description

P0 of the parameter conversion milestone: move value-level conversion out from under the `SQLxxx` entry points into a shared `conversion/` module.

| File | From |
| --- | --- |
| `conversion/fetch_convert.rs` | `api/fetch_convert.rs` — the only file in `api/` that wasn't an entry point |
| `conversion/param_convert.rs` | `params/convert.rs` — so both direction converters are siblings |
| `conversion/error.rs` | `ConvOk` / `ConvError`, lifted out of `fetch_convert.rs` |
| `conversion/numeric.rs` | `NumericSource`, `parse_decimal_literal`, plus `narrow_i128` extracted from the `narrow!` macro that was inline in `convert_integer_c` |

Both moves are `git mv`, so they read as renames. `params/` keeps the `BoundParam` record and `conversion_matrix.rs` — the matrix never runs during conversion, it's consulted once at bind time and is parameter-direction-only by design.

**Parity:** msodbcsql has one conversion implementation parameterized by direction, declared in the shared `sqlcprot.h` (`XLATDIR` at `:769`, used by `Xlat` `:781`, `Convert` `:987`, `ParseDateTime` `:1004`). This matches that; conversion living beside the entry points did not. No new deviations.

### Also included: `SQL_DEFAULT_PARAM` returns 07S01

A correctness fix, in this PR because it shares files with the move.

`SQL_DEFAULT_PARAM` is only legal for a canonical procedure call, which this driver doesn't support, so it returned `HYC00` / *"not yet implemented"* — telling applications to wait for a feature that would never make their usage legal. It's now the terminal **07S01 "Invalid use of default parameter"**, matching msodbcsql (`sqlccmd.cpp:4104`, `:4513`, `deprecate.cpp:1275`, `sqlcfunc.cpp:2538`, each gated on `(cmdp.status & CANONICAL_CALL) == 0`).

Knock-on changes:
- `ParamConvError` → `ParamBuildError`, `DefaultParamUnsupported` → `InvalidUseOfDefaultParam`. The old name also collided with `SQL_C_DEFAULT`, which #323 now supports.
- `message() -> &'static str` → `diag() -> DiagMsg`. The old shape was the root cause: `build_named_params` forced everything except `InvalidLength` into `HYC00`, so a variant couldn't have its own SQLSTATE.

### Deferred

`ConvDirection`, the `FractionalTruncation` / `StringTruncation` split, and `SQLSTATE_22001` were in P0's original scope but nothing constructs them until P4/P5 — and unused constants fail `bclippy -D warnings`. Noted in `docs/parameters_plan.md`.

## Related Issues

https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47364

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes
- [x] New/changed functionality has tests
- [x] Public API changes are documented

## Testing

623 unit tests pass, re-run after rebasing onto `main`. Every pre-existing test passes unmodified — the main evidence the move is behavior-preserving. 7 new tests in `conversion/numeric.rs` cover the extracted code (literal parsing, truncation toward zero, `10^38` `checked_pow` overflow, non-finite floats, narrowing reports rather than wraps), and the default-param test asserts the SQLSTATE directly so a regression to `HYC00` fails.

Two gaps: `cargo btest` couldn't run locally (no `cargo-nextest` / `cargo-llvm-cov` here) so `cargo test -p mssql-odbc` was substituted, and the **e2e suite has not been run against a live server** — it needs an elevated shell for the HKLM write.
