### PR TITLE
Fail install-deps.sh when apt retries are exhausted

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -57,19 +57,29 @@ fi
 #     sleep $((5 * i))
 # done
 
+apt_update_ok=false
 for i in {1..5}; do
-    sudo apt update && break
+    sudo apt update && { apt_update_ok=true; break; }
     echo "apt update failed, retrying in 5 seconds... (attempt $i/5)"
     sleep $((30 * i))
 done
+if [ "$apt_update_ok" != true ]; then
+    echo "ERROR: apt update failed after 5 attempts"
+    exit 1
+fi
 
 # Needed for msrustup download and essentials for building rust binaries.
 # Try installing dependencies up to 5 times if it fails
+apt_install_ok=false
 for i in {1..5}; do
-    sudo apt install $DEPS -y && break
+    sudo apt install $DEPS -y && { apt_install_ok=true; break; }
     echo "apt install failed, retrying in 5 seconds... (attempt $i/5)"
     sleep $((30 * i))
 done
+if [ "$apt_install_ok" != true ]; then
+    echo "ERROR: apt install failed after 5 attempts"
+    exit 1
+fi
 
 pip --version && pip install pipenv
 


### PR DESCRIPTION
## Description

The `apt update` and `apt install` retry loops in `scripts/install-deps.sh` `break` on success but did **not** fail the script after exhausting all 5 attempts, so a fully-failed dependency install still exited `0`. When this happens, `pkg-config`/`libssl-dev` are never installed and the failure only surfaces much later as a **fuzz build failure**, masking the real (transient) infrastructure problem and preventing 1ES from retrying the install step.

This was hit by the **GH-Rust Fuzz Test** run [build 167989](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build/results?buildId=167989) (`Fuzz Test TdsClient Linux` job): all 5 `apt install` attempts failed, the install step went green, then `cargo fuzz run` failed with `The pkg-config command could not be found`. This was **not** a fuzz crash — no crash artifact was produced.

Change: track success in each retry loop and `exit 1` when all attempts are exhausted, so a dependency-install failure surfaces at the install step.

## Related Issues

ADO work item: https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47399

## Checklist

- [ ] `cargo bfmt` passes — N/A, shell-only change (no Rust sources touched)
- [ ] `cargo bclippy` passes — N/A, shell-only change
- [ ] `cargo btest` passes — N/A, shell-only change
- [ ] New/changed functionality has tests — N/A, CI infra script; validated with `bash -n`
- [ ] Public API changes are documented — N/A

<sub>Validated the script with `bash -n scripts/install-deps.sh` (syntax OK).</sub>