### PR TITLE
Honor DB_PORT in connectivity integration tests

### DIFF
--- a/mssql-tds/tests/TRANSPORT_TESTS_README.md
+++ b/mssql-tds/tests/TRANSPORT_TESTS_README.md
@@ -33,6 +33,11 @@ This directory contains integration tests for different SQL Server transport pro
 
 The tests require the following environment variables (typically set in `.env` file):
 
+> Note: nextest runs each test binary with its crate directory as the working directory, so
+> `mssql-tds/.env` takes precedence over a workspace-root `.env`. Real environment variables
+> always win over `dotenv`, so exporting them in the shell is the most reliable way to point a
+> run at a specific endpoint.
+
 ```bash
 # Required for all tests
 DB_USERNAME=your_username

--- a/mssql-tds/tests/connectivity.rs
+++ b/mssql-tds/tests/connectivity.rs
@@ -13,7 +13,7 @@ mod connectivity {
     use azure_core::http::ClientOptions;
     use mssql_tds::connection::client_context::CloneableEntraIdTokenFactory;
 
-    use crate::common::{create_context, get_scalar_value, init_tracing};
+    use crate::common::{build_tcp_datasource, create_context, get_scalar_value, init_tracing};
     use azure_identity::{
         DeveloperToolsCredential, ManagedIdentityCredential, ManagedIdentityCredentialOptions,
     };
@@ -142,8 +142,7 @@ mod connectivity {
     pub async fn select_1() {
         let access_token = generate_access_token().await;
         let context = create_context_with_accesstoken(access_token);
-        let host = env::var("DB_HOST").expect("DB_HOST environment variable not set");
-        let datasource = format!("tcp:{},1433", host);
+        let datasource = build_tcp_datasource();
         let provider = TdsConnectionProvider {};
         let connection_result = provider.create_client(context, &datasource, None).await;
         let mut connection = connection_result.unwrap();
@@ -164,8 +163,7 @@ mod connectivity {
     pub async fn test_authentication_provider() {
         let context =
             create_context_with_auth_method(TdsAuthenticationMethod::ActiveDirectoryDefault);
-        let host = env::var("DB_HOST").expect("DB_HOST environment variable not set");
-        let datasource = format!("tcp:{},1433", host);
+        let datasource = build_tcp_datasource();
         let provider = TdsConnectionProvider {};
         let connection_result = provider.create_client(context, &datasource, None).await;
         let mut connection = connection_result.unwrap();
@@ -215,8 +213,7 @@ mod connectivity {
         let access_token = generate_access_token().await;
         let mut context = create_context_with_accesstoken(access_token);
         context.encryption_options.trust_server_certificate = true;
-        let host = env::var("DB_HOST").expect("DB_HOST environment variable not set");
-        let datasource = format!("tcp:{},1433", host);
+        let datasource = build_tcp_datasource();
         let provider = TdsConnectionProvider {};
         let connection_result = provider.create_client(context, &datasource, None).await;
         let mut connection = connection_result.unwrap();


### PR DESCRIPTION
## Description

Three tests in `mssql-tds/tests/connectivity.rs` (`select_1`, `test_authentication_provider`, `trust_server_cert`) built their datasource as `tcp:{DB_HOST},1433`, ignoring `DB_PORT`. That made them unusable against a SQL Server published on an alternate host port (e.g. a local container on `-p 14333:1433`), while the rest of the same file and the shared helpers in `tests/common/mod.rs` already honor `DB_PORT`.

These now use the existing `common::build_tcp_datasource()` helper, which reads `DB_HOST` and `DB_PORT` (defaulting to 1433) — same behavior as the other TCP tests, with less duplication.

Also added a short note to `tests/TRANSPORT_TESTS_README.md` explaining that nextest runs each test binary with its crate directory as the cwd, so `mssql-tds/.env` shadows a workspace-root `.env`, and that real environment variables take precedence over `dotenv`.

Out of scope (called out in the issue as judgment calls, not part of the bug): gating the Entra-only / Windows-only / cert-fixture tests behind env guards. Those remain as-is.

## Related Issues

Fixes #316

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes (`cargo clippy -p mssql-tds --all-features --all-targets -- -D warnings`; note the repo has no checked-in `Cargo.lock`, so `--frozen` cannot be used)
- [ ] `cargo btest` — the changed tests are live-server integration tests excluded from CI by the `not (test(connectivity))` nextest filter; they compile clean under `--all-targets`
- [x] New/changed functionality has tests (this change *is* test-only)
- [x] Public API changes are documented (none)