### PR TITLE
odbc: cache Entra ID credentials process-wide across connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,3 +91,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   payload nor terminates a message — but was previously consumed as a
   zero-length packet. Empty end-of-message packets remain legal.
 
+- `mssql-odbc`: Entra ID credentials for service-principal and managed-identity
+  authentication are now cached process-wide (keyed by tenant/authority,
+  client id, and a digest of the secret, or by client id alone for managed
+  identity) instead of being rebuilt for every connection. A burst of new
+  connections for the same identity now triggers a single token acquisition,
+  reused until near expiry, instead of one AAD/IMDS round-trip per connection —
+  avoiding Managed Identity (IMDS) throttling and added login latency during
+  connection-pool warm-up.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   server's `DONE_COUNT`. Fixes a doubled count on distributed engines that
   acknowledge one load with multiple `DONE_COUNT` tokens (issue #209).
 
+- `mssql-odbc`: Entra ID credentials for service-principal and managed-identity
+  authentication are now cached process-wide (keyed by tenant/authority,
+  client id, and a digest of the secret, or by client id alone for managed
+  identity) instead of being rebuilt for every connection. A burst of new
+  connections for the same identity now triggers a single token acquisition,
+  reused until near expiry, instead of one AAD/IMDS round-trip per connection —
+  avoiding Managed Identity (IMDS) throttling and added login latency during
+  connection-pool warm-up. A cached credential retains the secret it was built
+  from for the life of the process; a rotated secret creates a new cache entry
+  rather than replacing the old one.
+
 ### Removed
 
 - `mssql-tds`: the public `connection::odbc_authentication_transformer`,
@@ -90,13 +101,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   rejected as a protocol error. Such a packet is malformed — it neither carries
   payload nor terminates a message — but was previously consumed as a
   zero-length packet. Empty end-of-message packets remain legal.
-
-- `mssql-odbc`: Entra ID credentials for service-principal and managed-identity
-  authentication are now cached process-wide (keyed by tenant/authority,
-  client id, and a digest of the secret, or by client id alone for managed
-  identity) instead of being rebuilt for every connection. A burst of new
-  connections for the same identity now triggers a single token acquisition,
-  reused until near expiry, instead of one AAD/IMDS round-trip per connection —
-  avoiding Managed Identity (IMDS) throttling and added login latency during
-  connection-pool warm-up.
 

--- a/mssql-odbc/Cargo.toml
+++ b/mssql-odbc/Cargo.toml
@@ -26,6 +26,12 @@ azure_core = { version = "1.1", default-features = false, features = [
 ] }
 reqwest = { version = "0.13", default-features = false, features = ["native-tls", "stream"] }
 url = "2"
+# Collision-resistant digest for the Entra credential cache key (AB#46409) —
+# a plain SipHash/DefaultHasher digest is only DoS-resistant, not designed to
+# make two different secrets un-collidable, and a collision would let a new
+# connection silently reuse a stale cached credential built from a different
+# secret.
+sha2 = "0.11.0"
 
 # `ActiveDirectoryInteractive` delegates the sign-in UI to `mssql-auth.dll`
 # (OneAuth), the same library msodbcsql loads. The `windows` crate supplies the

--- a/mssql-odbc/src/auth/entra.rs
+++ b/mssql-odbc/src/auth/entra.rs
@@ -21,8 +21,16 @@
 //!   service-principal auth.
 //! - The service-principal secret travels in the Azure SDK token-request body;
 //!   do not enable `azure_*` trace-level logging in production.
+//! - Credentials (including the service-principal secret) are cached
+//!   process-wide, keyed by identity (see `CREDENTIAL_CACHE`), so a secret can
+//!   now outlive the connection that first supplied it for as long as the
+//!   process runs — the standard trade-off for avoiding a per-connection AAD
+//!   round-trip. Never `Debug`-format a `CredentialConfig` or log a cache key's
+//!   inputs; the cache key itself carries only a digest of the secret.
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use async_trait::async_trait;
 use azure_core::cloud::{CloudConfiguration, CustomConfiguration};
@@ -32,7 +40,7 @@ use azure_identity::{
     ClientSecretCredential, ClientSecretCredentialOptions, ManagedIdentityCredential,
     ManagedIdentityCredentialOptions, UserAssignedId,
 };
-use tokio::sync::OnceCell;
+use tracing::debug;
 use url::{Position, Url};
 
 #[cfg(windows)]
@@ -61,18 +69,37 @@ pub(crate) enum CredentialConfig {
 #[derive(Clone)]
 pub(crate) struct EntraTokenFactory {
     config: CredentialConfig,
-    /// The Azure SDK credential, built lazily on the first token request and
-    /// reused for the remaining requests on this connection so the credential's
-    /// in-memory token cache is shared across repeated logins (e.g. session
-    /// recovery). Cross-connection reuse is tracked in AB#46409.
-    credential: Arc<OnceCell<Arc<dyn TokenCredential>>>,
 }
 
 impl EntraTokenFactory {
     pub(crate) fn new(config: CredentialConfig) -> Self {
-        Self {
-            config,
-            credential: Arc::new(OnceCell::new()),
+        Self { config }
+    }
+
+    /// Derives the process-wide cache key for this factory's identity. For a
+    /// service principal this is the authority/tenant (from the server-provided
+    /// STS URL), client id, and a digest of the secret — never the secret
+    /// itself, so a hash collision can only merge two different secrets for
+    /// the *same* client, which just fails cleanly at the STS. Managed
+    /// identity keys on client id alone (empty for the system-assigned
+    /// identity): IMDS is scoped to the local machine, so no authority/tenant
+    /// applies.
+    fn cache_key(&self, sts_url: &str) -> TdsResult<CredentialCacheKey> {
+        match &self.config {
+            CredentialConfig::ServicePrincipalSecret { client_id, secret } => {
+                let (authority_host, tenant_id) = split_sts_url(sts_url)?;
+                Ok(CredentialCacheKey::ServicePrincipal {
+                    authority_host,
+                    tenant_id,
+                    client_id: client_id.clone(),
+                    secret_digest: digest(secret.secret()),
+                })
+            }
+            CredentialConfig::ManagedIdentity { client_id } => {
+                Ok(CredentialCacheKey::ManagedIdentity {
+                    client_id: client_id.clone().unwrap_or_default(),
+                })
+            }
         }
     }
 
@@ -139,13 +166,10 @@ impl EntraIdTokenFactory for EntraTokenFactory {
         let scope = normalize_scope(&spn);
         let scopes: &[&str] = &[scope.as_str()];
 
-        // Build the credential once per connection and reuse it, so the Azure
-        // SDK credential's own token cache is shared across this connection's
-        // token requests instead of re-authenticating every login.
-        let credential = self
-            .credential
-            .get_or_try_init(|| async { self.build_credential(&sts_url) })
-            .await?;
+        // Reuse the process-wide credential for this identity instead of
+        // building a new one (and re-authenticating) on every connection.
+        let key = self.cache_key(&sts_url)?;
+        let credential = cached_credential(key, || self.build_credential(&sts_url))?;
 
         let access_token = credential.get_token(scopes, None).await.map_err(|e| {
             Error::ConnectionError(format!("Entra ID token acquisition failed: {e}"))
@@ -153,6 +177,103 @@ impl EntraIdTokenFactory for EntraTokenFactory {
 
         Ok(encode_utf16le(access_token.token.secret()))
     }
+}
+
+/// Identifies a distinct Entra ID identity for the process-wide credential
+/// cache ([`CREDENTIAL_CACHE`]). Two factories that produce equal keys are
+/// guaranteed to represent the same tenant/client/secret (or the same managed
+/// identity) and may safely share one credential instance.
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+enum CredentialCacheKey {
+    ServicePrincipal {
+        authority_host: String,
+        tenant_id: String,
+        client_id: String,
+        secret_digest: u64,
+    },
+    ManagedIdentity {
+        /// Empty for the system-assigned identity.
+        client_id: String,
+    },
+}
+
+impl CredentialCacheKey {
+    /// A static, identifier-free label for tracing: enough to tell which
+    /// auth method a cache hit/miss was for without logging any part of the
+    /// identity itself (tenant, client id, or secret digest).
+    fn label(&self) -> &'static str {
+        match self {
+            CredentialCacheKey::ServicePrincipal { .. } => "service principal",
+            CredentialCacheKey::ManagedIdentity { .. } => "managed identity",
+        }
+    }
+}
+
+/// Non-cryptographic digest used only as a process-local cache-key
+/// discriminator — never persisted, logged, or compared against
+/// attacker-controlled input.
+fn digest(secret: &str) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    secret.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Entra ID credentials, shared process-wide so a burst of new connections for
+/// the same identity triggers one token acquisition instead of one per
+/// connection (AB#46409). Each `azure_identity` credential already carries its
+/// own per-scope, expiry-aware token cache internally, so sharing the
+/// credential *instance* is enough to share tokens too — this map never
+/// stores raw tokens itself, which keeps expiry/refresh entirely in the
+/// already-tested Azure SDK code path.
+///
+/// This is a deliberate improvement beyond msodbcsql parity, not a gap versus
+/// it: the classic C++ driver's `AzureADAuth` has no equivalent cache either —
+/// `Parse.cpp:3655` constructs a stack-local `AzureADAuth auth;` and
+/// re-authenticates on every connection for service principal and managed
+/// identity. Only its interactive/WAM path caches (`MSQAAuthContextCache`),
+/// mirrored here by the interactive path's own process-wide cache in
+/// `msqa.rs`.
+///
+/// Unbounded like that interactive cache: entries are never evicted, so a
+/// process that cycles through many distinct identities (e.g. a multi-tenant
+/// service impersonating many different service principals) or rotates a
+/// secret repeatedly retains one entry per identity/secret it has ever seen
+/// for the life of the process. Acceptable for the same reason as the
+/// interactive cache — realistic deployments use a small, stable set of
+/// identities — but a candidate for follow-up if that stops holding.
+static CREDENTIAL_CACHE: OnceLock<Mutex<HashMap<CredentialCacheKey, Arc<dyn TokenCredential>>>> =
+    OnceLock::new();
+
+/// Returns the cached credential for `key`, building and caching one via
+/// `build` on a miss. Held across `build` deliberately: constructing a
+/// credential is local config assembly (no I/O, no `.await`), so the lock is
+/// never held across a blocking or network operation — the token request
+/// itself always runs after this returns.
+///
+/// Logs a hit/miss at `debug` (identity kind only — never the tenant, client
+/// id, or secret digest) so a connection storm's throttling behavior can be
+/// correlated against actual cache effectiveness in production traces.
+fn cached_credential(
+    key: CredentialCacheKey,
+    build: impl FnOnce() -> TdsResult<Arc<dyn TokenCredential>>,
+) -> TdsResult<Arc<dyn TokenCredential>> {
+    let cache = CREDENTIAL_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut cache = cache
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    if let Some(existing) = cache.get(&key) {
+        debug!(kind = key.label(), "entra: reusing cached credential");
+        return Ok(Arc::clone(existing));
+    }
+
+    debug!(
+        kind = key.label(),
+        "entra: credential cache miss, acquiring a new credential"
+    );
+    let credential = build()?;
+    cache.insert(key, Arc::clone(&credential));
+    Ok(credential)
 }
 
 /// Normalizes an SPN/resource into a v2 scope by ensuring a single `/.default`
@@ -580,6 +701,192 @@ mod tests {
                 TdsAuthenticationMethod::ActiveDirectoryDeviceCodeFlow
             )),
             "a method that resolves to itself reports itself"
+        );
+    }
+
+    // --- Process-wide credential cache (AB#46409) ---
+
+    use azure_core::credentials::{AccessToken, TokenRequestOptions};
+    use azure_core::time::{Duration, OffsetDateTime};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// A [`TokenCredential`] that counts calls and mints a distinct token each
+    /// time, so a test can prove whether it was reused or rebuilt, and whether
+    /// `get_token` was actually invoked (vs. a stale value cached above it).
+    #[derive(Debug, Default)]
+    struct CountingCredential {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl TokenCredential for CountingCredential {
+        async fn get_token(
+            &self,
+            _scopes: &[&str],
+            _options: Option<TokenRequestOptions<'_>>,
+        ) -> azure_core::Result<AccessToken> {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst) + 1;
+            Ok(AccessToken::new(
+                format!("token-{call}"),
+                OffsetDateTime::now_utc() + Duration::seconds(3600),
+            ))
+        }
+    }
+
+    fn counting_credential() -> TdsResult<Arc<dyn TokenCredential>> {
+        Ok(Arc::new(CountingCredential::default()))
+    }
+
+    #[test]
+    fn service_principal_key_differs_by_tenant_client_and_secret() {
+        let sts = "https://login.microsoftonline.com/tenant-a";
+        let base = EntraTokenFactory::new(CredentialConfig::ServicePrincipalSecret {
+            client_id: "cache-key-client".to_string(),
+            secret: Secret::from("cache-key-secret-1".to_string()),
+        });
+        let same_again = EntraTokenFactory::new(CredentialConfig::ServicePrincipalSecret {
+            client_id: "cache-key-client".to_string(),
+            secret: Secret::from("cache-key-secret-1".to_string()),
+        });
+        let different_secret = EntraTokenFactory::new(CredentialConfig::ServicePrincipalSecret {
+            client_id: "cache-key-client".to_string(),
+            secret: Secret::from("cache-key-secret-2".to_string()),
+        });
+        let different_client = EntraTokenFactory::new(CredentialConfig::ServicePrincipalSecret {
+            client_id: "cache-key-client-2".to_string(),
+            secret: Secret::from("cache-key-secret-1".to_string()),
+        });
+        let different_tenant_sts = "https://login.microsoftonline.com/tenant-b";
+
+        let base_key = base.cache_key(sts).unwrap();
+        assert_eq!(base_key, same_again.cache_key(sts).unwrap());
+        assert_ne!(
+            base_key,
+            different_secret.cache_key(sts).unwrap(),
+            "different secrets must not share a cache entry"
+        );
+        assert_ne!(
+            base_key,
+            different_client.cache_key(sts).unwrap(),
+            "different client ids must not share a cache entry"
+        );
+        assert_ne!(
+            base_key,
+            base.cache_key(different_tenant_sts).unwrap(),
+            "different tenants must not share a cache entry"
+        );
+    }
+
+    #[test]
+    fn managed_identity_key_distinguishes_system_and_user_assigned() {
+        let system = EntraTokenFactory::new(CredentialConfig::ManagedIdentity { client_id: None });
+        let user_a = EntraTokenFactory::new(CredentialConfig::ManagedIdentity {
+            client_id: Some("uid-cache-key-a".to_string()),
+        });
+        let user_b = EntraTokenFactory::new(CredentialConfig::ManagedIdentity {
+            client_id: Some("uid-cache-key-b".to_string()),
+        });
+
+        let system_key = system.cache_key("unused").unwrap();
+        let user_a_key = user_a.cache_key("unused").unwrap();
+        assert_ne!(system_key, user_a_key);
+        assert_ne!(user_a_key, user_b.cache_key("unused").unwrap());
+        // The STS URL is ignored for managed identity: IMDS is machine-local.
+        assert_eq!(
+            system_key,
+            system.cache_key("https://any.example/tenant").unwrap()
+        );
+    }
+
+    #[test]
+    fn cache_key_label_is_identity_free() {
+        // The label feeds a `debug!` trace: it must say which auth method a
+        // cache hit/miss was for without ever including the tenant, client
+        // id, or secret digest.
+        let sp = CredentialCacheKey::ServicePrincipal {
+            authority_host: "https://login.microsoftonline.com".to_string(),
+            tenant_id: "some-tenant".to_string(),
+            client_id: "some-client".to_string(),
+            secret_digest: 0xdead_beef,
+        };
+        let mi = CredentialCacheKey::ManagedIdentity {
+            client_id: "some-client".to_string(),
+        };
+        assert_eq!(sp.label(), "service principal");
+        assert_eq!(mi.label(), "managed identity");
+        assert!(!sp.label().contains("some-tenant"));
+        assert!(!sp.label().contains("some-client"));
+    }
+
+    #[test]
+    fn cached_credential_reuses_the_same_instance_on_a_hit() {
+        let key = CredentialCacheKey::ManagedIdentity {
+            client_id: "cached-credential-hit".to_string(),
+        };
+        let build_calls = AtomicUsize::new(0);
+        let build = || {
+            build_calls.fetch_add(1, Ordering::SeqCst);
+            counting_credential()
+        };
+
+        let first = cached_credential(key.clone(), build).unwrap();
+        let second = cached_credential(key, build).unwrap();
+
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "a cache hit must return the same credential instance"
+        );
+        assert_eq!(build_calls.load(Ordering::SeqCst), 1, "build must run once");
+    }
+
+    #[test]
+    fn cached_credential_never_shares_across_distinct_identities() {
+        let key_a = CredentialCacheKey::ManagedIdentity {
+            client_id: "cached-credential-distinct-a".to_string(),
+        };
+        let key_b = CredentialCacheKey::ManagedIdentity {
+            client_id: "cached-credential-distinct-b".to_string(),
+        };
+
+        let a = cached_credential(key_a, counting_credential).unwrap();
+        let b = cached_credential(key_b, counting_credential).unwrap();
+
+        assert!(
+            !Arc::ptr_eq(&a, &b),
+            "distinct identities must never share a credential"
+        );
+    }
+
+    #[test]
+    fn cached_credential_does_not_freeze_the_token_it_returns() {
+        // Caching the *credential* must not accidentally cache the *token*:
+        // each call through the shared instance should still reach the
+        // delegate, which is what lets it refresh an expiring token. This is
+        // the property that stands in for expiry here — actual expiry/refresh
+        // timing is delegated to azure_identity's own tested token cache
+        // (`azure_identity::cache::TokenCache`), not reimplemented locally.
+        let key = CredentialCacheKey::ManagedIdentity {
+            client_id: "cached-credential-refresh".to_string(),
+        };
+        let credential = cached_credential(key.clone(), counting_credential).unwrap();
+        let same_credential =
+            cached_credential(key, || panic!("must be a cache hit, not a rebuild")).unwrap();
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("a current-thread runtime");
+        let scopes = ["https://database.windows.net/.default"];
+        let token1 = runtime
+            .block_on(same_credential.get_token(&scopes, None))
+            .expect("first token request succeeds");
+        let token2 = runtime
+            .block_on(credential.get_token(&scopes, None))
+            .expect("second token request succeeds");
+
+        assert_ne!(
+            token1.token.secret(),
+            token2.token.secret(),
+            "each call must reach the shared credential rather than a frozen cached token"
         );
     }
 }

--- a/mssql-odbc/src/auth/entra.rs
+++ b/mssql-odbc/src/auth/entra.rs
@@ -186,7 +186,13 @@ impl EntraIdTokenFactory for EntraTokenFactory {
 /// cache ([`CREDENTIAL_CACHE`]). Two factories that produce equal keys are
 /// guaranteed to represent the same tenant/client/secret (or the same managed
 /// identity) and may safely share one credential instance.
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+///
+/// `Debug` is gated to `cfg(test)` rather than derived unconditionally: the
+/// module never logs a cache key's contents (tenant, client id, secret
+/// digest), and gating this makes a future `debug!(?key, ...)` a compile
+/// error in production code instead of a convention someone has to remember.
+#[derive(Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(test, derive(Debug))]
 enum CredentialCacheKey {
     ServicePrincipal {
         authority_host: String,
@@ -228,22 +234,15 @@ fn digest(secret: &str) -> [u8; 32] {
 /// own per-scope, expiry-aware token cache internally, so sharing the
 /// credential *instance* is enough to share tokens too — this map never
 /// stores raw tokens itself, which keeps expiry/refresh entirely in the
-/// already-tested Azure SDK code path.
+/// already-tested Azure SDK code path. Exceeds msodbcsql parity rather than
+/// closing a gap — see the PR description and AB#46409 for the C++ driver
+/// comparison.
 ///
-/// This is a deliberate improvement beyond msodbcsql parity, not a gap versus
-/// it: the classic C++ driver's `AzureADAuth` has no equivalent cache either —
-/// `Parse.cpp:3655` constructs a stack-local `AzureADAuth auth;` and
-/// re-authenticates on every connection for service principal and managed
-/// identity. Only its interactive/WAM path caches (`MSQAAuthContextCache`),
-/// mirrored here by the interactive path's own process-wide cache in
-/// `msqa.rs`.
-///
-/// Unbounded like that interactive cache: entries are never evicted, so a
-/// process that cycles through many distinct identities (e.g. a multi-tenant
-/// service impersonating many different service principals) or rotates a
-/// secret repeatedly retains one entry per identity/secret it has ever seen
-/// for the life of the process. Acceptable for the same reason as the
-/// interactive cache — realistic deployments use a small, stable set of
+/// Unbounded like the interactive path's cache in `msqa.rs`: entries are
+/// never evicted, so a process that cycles through many distinct identities
+/// or rotates a secret repeatedly retains one entry per identity/secret it
+/// has ever seen for the life of the process. Acceptable for the same reason
+/// as that cache — realistic deployments use a small, stable set of
 /// identities — but a candidate for follow-up if that stops holding.
 static CREDENTIAL_CACHE: OnceLock<Mutex<HashMap<CredentialCacheKey, Arc<dyn TokenCredential>>>> =
     OnceLock::new();
@@ -258,18 +257,11 @@ static CREDENTIAL_CACHE: OnceLock<Mutex<HashMap<CredentialCacheKey, Arc<dyn Toke
 /// id, or secret digest) so a connection storm's throttling behavior can be
 /// correlated against actual cache effectiveness in production traces.
 ///
-/// Recovers from a poisoned lock rather than propagating an error, unlike an
-/// ODBC handle's `*.inner` mutex. That rule exists because a poisoned handle
-/// mutex might guard a torn domain object, and erroring out affects only the
-/// one handle that panicked — the application frees it and gets a fresh,
-/// unpoisoned mutex on its next allocation. `CREDENTIAL_CACHE` is a `static`:
-/// once poisoned it never recovers on its own, so treating poison as fatal
-/// here would permanently fail every future connection's Entra auth for the
-/// rest of the process from a single transient panic, instead of just the one
-/// call in flight when it happened. The recovered map cannot be torn in a way
-/// that matters either — the lock is never held across `build()`'s fallible
-/// work in a way that leaves a partial insert (see above), so the worst case
-/// is a missing entry, which is exactly a cache miss.
+/// Recovers from a poisoned lock rather than propagating an error: unlike an
+/// ODBC handle's `*.inner` mutex, `CREDENTIAL_CACHE` is a `static` that never
+/// un-poisons itself, so treating poison as fatal here would fail Entra auth
+/// for the rest of the process instead of just the one call in flight (see
+/// `cached_credential_recovers_from_a_poisoned_lock` for the full case).
 fn cached_credential(
     key: CredentialCacheKey,
     build: impl FnOnce() -> TdsResult<Arc<dyn TokenCredential>>,

--- a/mssql-odbc/src/auth/entra.rs
+++ b/mssql-odbc/src/auth/entra.rs
@@ -29,7 +29,6 @@
 //!   inputs; the cache key itself carries only a digest of the secret.
 
 use std::collections::HashMap;
-use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use async_trait::async_trait;
@@ -40,7 +39,8 @@ use azure_identity::{
     ClientSecretCredential, ClientSecretCredentialOptions, ManagedIdentityCredential,
     ManagedIdentityCredentialOptions, UserAssignedId,
 };
-use tracing::debug;
+use sha2::{Digest, Sha256};
+use tracing::{debug, warn};
 use url::{Position, Url};
 
 #[cfg(windows)]
@@ -78,12 +78,15 @@ impl EntraTokenFactory {
 
     /// Derives the process-wide cache key for this factory's identity. For a
     /// service principal this is the authority/tenant (from the server-provided
-    /// STS URL), client id, and a digest of the secret — never the secret
-    /// itself, so a hash collision can only merge two different secrets for
-    /// the *same* client, which just fails cleanly at the STS. Managed
-    /// identity keys on client id alone (empty for the system-assigned
-    /// identity): IMDS is scoped to the local machine, so no authority/tenant
-    /// applies.
+    /// STS URL), client id, and a SHA-256 digest of the secret — never the
+    /// secret itself. The digest must be collision-resistant: unlike a
+    /// `DefaultHasher`/SipHash digest, which is only DoS-resistant and would
+    /// let two different secrets alias into the same cache entry, SHA-256
+    /// makes that practically impossible, so a secret rotation always misses
+    /// the old entry instead of silently continuing to authenticate with a
+    /// stale (possibly revoked) secret. Managed identity keys on client id
+    /// alone (empty for the system-assigned identity): IMDS is scoped to the
+    /// local machine, so no authority/tenant applies.
     fn cache_key(&self, sts_url: &str) -> TdsResult<CredentialCacheKey> {
         match &self.config {
             CredentialConfig::ServicePrincipalSecret { client_id, secret } => {
@@ -189,7 +192,7 @@ enum CredentialCacheKey {
         authority_host: String,
         tenant_id: String,
         client_id: String,
-        secret_digest: u64,
+        secret_digest: [u8; 32],
     },
     ManagedIdentity {
         /// Empty for the system-assigned identity.
@@ -209,13 +212,14 @@ impl CredentialCacheKey {
     }
 }
 
-/// Non-cryptographic digest used only as a process-local cache-key
+/// Collision-resistant digest used only as a process-local cache-key
 /// discriminator — never persisted, logged, or compared against
-/// attacker-controlled input.
-fn digest(secret: &str) -> u64 {
-    let mut hasher = DefaultHasher::new();
-    secret.hash(&mut hasher);
-    hasher.finish()
+/// attacker-controlled input. SHA-256 (rather than a `DefaultHasher`/SipHash
+/// digest) is what makes two different secrets practically un-collidable, so
+/// a rotated secret always misses the old cache entry instead of an attacker
+/// — or bad luck — being able to alias a new secret onto a stale credential.
+fn digest(secret: &str) -> [u8; 32] {
+    Sha256::digest(secret.as_bytes()).into()
 }
 
 /// Entra ID credentials, shared process-wide so a burst of new connections for
@@ -253,14 +257,28 @@ static CREDENTIAL_CACHE: OnceLock<Mutex<HashMap<CredentialCacheKey, Arc<dyn Toke
 /// Logs a hit/miss at `debug` (identity kind only — never the tenant, client
 /// id, or secret digest) so a connection storm's throttling behavior can be
 /// correlated against actual cache effectiveness in production traces.
+///
+/// Recovers from a poisoned lock rather than propagating an error, unlike an
+/// ODBC handle's `*.inner` mutex. That rule exists because a poisoned handle
+/// mutex might guard a torn domain object, and erroring out affects only the
+/// one handle that panicked — the application frees it and gets a fresh,
+/// unpoisoned mutex on its next allocation. `CREDENTIAL_CACHE` is a `static`:
+/// once poisoned it never recovers on its own, so treating poison as fatal
+/// here would permanently fail every future connection's Entra auth for the
+/// rest of the process from a single transient panic, instead of just the one
+/// call in flight when it happened. The recovered map cannot be torn in a way
+/// that matters either — the lock is never held across `build()`'s fallible
+/// work in a way that leaves a partial insert (see above), so the worst case
+/// is a missing entry, which is exactly a cache miss.
 fn cached_credential(
     key: CredentialCacheKey,
     build: impl FnOnce() -> TdsResult<Arc<dyn TokenCredential>>,
 ) -> TdsResult<Arc<dyn TokenCredential>> {
     let cache = CREDENTIAL_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
-    let mut cache = cache
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let mut cache = cache.lock().unwrap_or_else(|poisoned| {
+        warn!("entra: credential cache mutex was poisoned by a prior panic; recovering its state rather than failing Entra auth process-wide");
+        poisoned.into_inner()
+    });
 
     if let Some(existing) = cache.get(&key) {
         debug!(kind = key.label(), "entra: reusing cached credential");
@@ -778,6 +796,23 @@ mod tests {
     }
 
     #[test]
+    fn digest_is_deterministic_sha256_not_a_weak_hash() {
+        // Pins the fix for a real review finding: a `DefaultHasher`/SipHash
+        // digest is only DoS-resistant, not collision-resistant, so a
+        // rotated secret could alias onto a stale cached credential. SHA-256
+        // (32 bytes, deterministic, and distinguishing secrets that differ by
+        // a single character) is what makes that practically impossible.
+        assert_eq!(digest("same-secret"), digest("same-secret"));
+        assert_ne!(digest("secret-a"), digest("secret-b"));
+        assert_ne!(
+            digest("secret"),
+            digest("Secret"),
+            "digest must be case-sensitive over the raw secret bytes"
+        );
+        assert_eq!(digest("x").len(), 32, "SHA-256 output is 32 bytes");
+    }
+
+    #[test]
     fn managed_identity_key_distinguishes_system_and_user_assigned() {
         let system = EntraTokenFactory::new(CredentialConfig::ManagedIdentity { client_id: None });
         let user_a = EntraTokenFactory::new(CredentialConfig::ManagedIdentity {
@@ -807,7 +842,7 @@ mod tests {
             authority_host: "https://login.microsoftonline.com".to_string(),
             tenant_id: "some-tenant".to_string(),
             client_id: "some-client".to_string(),
-            secret_digest: 0xdead_beef,
+            secret_digest: digest("some-secret"),
         };
         let mi = CredentialCacheKey::ManagedIdentity {
             client_id: "some-client".to_string(),
@@ -854,6 +889,33 @@ mod tests {
         assert!(
             !Arc::ptr_eq(&a, &b),
             "distinct identities must never share a credential"
+        );
+    }
+
+    #[test]
+    fn cached_credential_recovers_from_a_poisoned_lock() {
+        // Runs in its own process under nextest, so poisoning the static
+        // cache here cannot affect any other test.
+        let key = CredentialCacheKey::ManagedIdentity {
+            client_id: "cached-credential-poison-recovery".to_string(),
+        };
+
+        let cache = CREDENTIAL_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+        let poisoned = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = cache.lock().unwrap();
+            panic!("deliberately poisoning the credential cache lock for this test");
+        }));
+        assert!(poisoned.is_err());
+        assert!(cache.is_poisoned());
+
+        // The reasoning on `cached_credential`: recovering here (instead of
+        // propagating an error, as an ODBC handle mutex would) is what keeps
+        // one unrelated panic from permanently failing Entra auth for the
+        // rest of the process.
+        let credential = cached_credential(key, counting_credential);
+        assert!(
+            credential.is_ok(),
+            "poison recovery must not fail Entra auth process-wide"
         );
     }
 


### PR DESCRIPTION
## Description

`EntraTokenFactory` (Service Principal + Managed Identity) built a fresh `azure_identity` credential — and re-authenticated — on every connection's FedAuth handshake. A connection-pool warm-up or app restart therefore fired one IMDS/AAD token request per physical connection instead of one per identity, risking IMDS throttling and added login latency under a connection storm.

Credentials are now cached process-wide, keyed by identity: tenant + authority + client id + a SHA-256 digest of the secret for service principal, client id alone for managed identity (never the raw secret). Caching the credential *instance* rather than the token means `azure_identity`'s own per-scope, expiry-aware `TokenCache` is what actually gets shared, so expiry/refresh stays in the already-tested SDK code path instead of being reimplemented here.

**Difference from msodbcsql**: this exceeds parity rather than closing a gap. The classic C++ driver has no equivalent cache for these two methods either — `Parse.cpp:3655` constructs a stack-local `AzureADAuth` and re-authenticates every connection, and `AzureADAuth.cpp`'s `AKVCFG_AUTHMODE_CLIENTKEY`/`MSI` branches hit the STS/IMDS directly. Only its interactive/WAM path caches (`MSQAAuthContextCache`), mirrored here by the pre-existing `msqa.rs::CONTEXT_CACHE`. Verified against a local msodbcsql checkout: both auth modes are explicitly excluded from the WAM/cache branch at `Parse.cpp:3598-3600`.

Also adds `debug!`-level tracing on cache hit/miss (identity kind only, never the tenant/client id/secret) so a connection storm's throttling can be correlated against actual cache behavior in production traces.

### Addressed in review

Copilot code review found two real issues, both fixed:
- The cache key originally hashed the secret with `DefaultHasher`/SipHash, which is collision-resistant only against random noise, not a deliberate or unlucky collision — a colliding rotated secret could have silently kept authenticating with the old one. Switched to a full SHA-256 digest.
- Poisoned-lock recovery (`into_inner()`) looked like it broke the crate's "return `SQL_ERROR` on poison" convention. That rule is scoped to per-handle mutexes (verified against all of `api/*.rs`); `CREDENTIAL_CACHE` is a `static`, where erroring on poison would permanently fail Entra auth process-wide from one transient panic instead of recovering. Kept the recovery, added a `warn!` trace for visibility and a test proving it.

## Related Issues

[AB#46409](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46409): https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46409

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes (607/607 mssql-odbc tests)
- [x] New/changed functionality has tests (10 new unit tests: cache-key derivation, digest properties, hit/miss, cross-identity isolation, poisoned-lock recovery, token-freshness-through-shared-credential)
- [x] Public API changes are documented (none — internal-only change, `entra.rs` module doc updated)
