### PR TITLE
Vendor OpenSSL for the fuzz build to survive apt outages

### DIFF
--- a/mssql-tds/fuzz/Cargo.toml
+++ b/mssql-tds/fuzz/Cargo.toml
@@ -14,6 +14,16 @@ tokio = { version = "1.45.1", features = ["full"] }
 arbitrary = { version = "1.3", features = ["derive"] }
 async-trait = "0.1"
 
+# Build OpenSSL from vendored source on the targets where mssql-tds links it
+# (every non-Windows, non-macOS target — see mssql-tds/Cargo.toml). The fuzz CI
+# agents intermittently fail to `apt install libssl-dev`/`pkg-config` from the
+# Ubuntu mirror, which leaves `openssl-sys` unable to locate OpenSSL and breaks
+# the entire fuzz stage. Enabling the vendored feature compiles OpenSSL from
+# source (shared openssl-sys also backs native-tls here), so the fuzz build no
+# longer depends on those apt-provided system packages.
+[target.'cfg(all(not(windows), not(target_os = "macos")))'.dependencies]
+openssl = { version = "0.10.66", features = ["vendored"] }
+
 # Prevent this from interfering with workspaces
 [workspace]
 members = ["."]


### PR DESCRIPTION
## Summary

The **GH-Rust Fuzz Test** pipeline (`sqlclientdrivers/mssql-rs`, definitionId=2207) has been failing on `main`. This PR fixes the real cause of those failures.

> **This is not a fuzz crash.** Investigation of the last 24h of failing runs (168173, 168079, 167989) found **no libFuzzer crash** and **no `fuzz-crashes-*` artifact** was published by any run. Wherever the fuzzers actually built and ran, they reported `oom/timeout/crash: 0/0/0`. The failures are a **CI/build breakage** that stops the fuzz targets from building at all.

## Root cause

The fuzz jobs run `scripts/install-deps.sh` → `apt install libssl-dev pkg-config`. On the failing agents, apt could not reach the Ubuntu mirror:

```
E: Failed to fetch http://azure.archive.ubuntu.com/.../libssl-dev_3.0.2-0ubuntu1.26_amd64.deb  Unable to connect to azure.archive.ubuntu.com:http
apt install failed, retrying in 5 seconds... (attempt 1/5)
... (attempt 5/5)
```

All retries were exhausted, so `libssl-dev`/`pkg-config` were never installed. The build then reached `openssl-sys` (pulled in on Linux via `native-tls` and the `openssl 0.10.66` dependency in `mssql-tds`) and failed with `Could not find openssl via pkg-config` → `Bash exited with code '1'`.

## Fix

Enable the `openssl` **`vendored`** feature in `mssql-tds/fuzz/Cargo.toml`, target-gated to non-Windows/non-macOS (matching where `mssql-tds` links OpenSSL). This compiles OpenSSL from bundled source, so the shared `openssl-sys` (which also backs `native-tls`) no longer needs the apt-provided system OpenSSL. The fuzz stage becomes resilient to the transient apt-mirror outage.

Notes:
- Change is scoped to the fuzz crate only — no effect on the shipped `mssql-tds` build or on Windows/macOS.
- The fuzz crate has no committed lockfile and the pipeline's `cargo fuzz run` uses no `--frozen`/`--locked`, so no lockfile conflict.
- Vendored OpenSSL requires a C toolchain + perl on the build agent (standard on the Rust CI image).

## Testing

- `cargo metadata` confirms the manifest parses and the `vendored` feature is registered on the target-gated `openssl` dependency.
- Full validation happens in the fuzz pipeline itself, since the vendored build is Linux-only and can't be exercised on the Windows dev host.

Fixes [AB#47446](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47446)