### PR TITLE
perf(lab): advance baseline to c0c4c9e7 to lock in the row-decode gains

### DIFF
--- a/mssql-tds-bench/perf-lab/baseline-commit.txt
+++ b/mssql-tds-bench/perf-lab/baseline-commit.txt
@@ -7,4 +7,4 @@
 #
 # Exactly one full 40-character commit SHA on its own line. Lines starting with
 # '#' and blank lines are ignored.
-30e4d2d521bc452ae449b8eceb78d17be2a15b03
+c0c4c9e7ad1ab6c4eaf1d6943b09cde5a44b32c6


### PR DESCRIPTION
## Description

Advances the perf baseline to `c0c4c9e7`, locking in the substantial row-decode gains landed since the previous baseline (`30e4d2d5`).

Both perf-lab pipelines were run manually against `main` @ `c0c4c9e7` and passed on both platforms, with **no benchmark slower than the 10% gate** in either. The measured wins are large and consistent across Linux and Windows — on Windows `temporal/decode` is **3.01x** faster and `select_n_rows/10000` **2.90x**; on Linux `row_iteration_throughput/next_row` is **2.42x** faster and `select_n_rows/10000` **2.33x**. Every row-decode benchmark improved on both platforms.

Advancing the baseline makes those numbers the new floor: any future PR that gives the gains back trips the gate instead of silently regressing to the old level.

- Linux: [168480](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build/results?buildId=168480)
- Windows: [168481](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build/results?buildId=168481)

## Changes

`mssql-tds-bench/perf-lab/baseline-commit.txt`: `30e4d2d5` -> `c0c4c9e7`.

## Validation

- Both lab runs above completed green against the outgoing baseline.
- Verified locally by replicating the exact swap the harness performs (`mssql-tds` replaced with a worktree checkout of `c0c4c9e7`): all seven bench binaries compile.

---

# Linux — build 168480

### Change vs baseline

_🟩 faster · 🟥 slower · 1 square ≈ 1% (drawn only for |Δ| ≥ 1%) · ⟳ re-measured (median of re-runs)_

| Benchmark | faster ◄ | Δ% | ► slower |
|---|--:|:--:|:--|
| `row_iteration_throughput/next_row` ⟳ | 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 | -58.8 |  |
| `select_n_rows/10000` ⟳ | 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 | -56.5 |  |
| `temporal/decode` | 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 | -51.0 |  |
| `select_n_rows/1000` ⟳ | 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 | -50.6 |  |
| `primitives/decode` | 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 | -48.5 |  |
| `scalars/decode` | 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 | -47.4 |  |
| `select_n_rows/100` | 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 | -21.9 |  |
| `simple_select_one_row` | 🟩🟩🟩🟩🟩🟩 | -5.7 |  |
| `batched_statements` | 🟩🟩🟩🟩 | -3.8 |  |
| `packet_size_sensitivity/4096` | 🟩🟩🟩🟩 | -3.8 |  |
| `stored_procedure_output` | 🟩🟩🟩 | -2.9 |  |
| `prepared_prepexec` | 🟩🟩🟩 | -2.9 |  |
| `prepared_execute` | 🟩🟩 | -2.0 |  |
| `packet_size_sensitivity/8192` |  | -1.0 |  |
| `single_insert` |  | -1.0 |  |
| `packet_size_sensitivity/32768` |  | ±0.0 |  |
| `bulk_insert/500` |  | ±0.0 |  |
| `connect_close` |  | ±0.0 |  |
| `parameterized_sp_executesql` |  | ±0.0 |  |
| `bulk_insert/5000` |  | +1.0 | 🟥 |
| `lob/20971520` |  | +1.0 | 🟥 |
| `concurrent_connects/100` |  | +1.0 | 🟥 |
| `stored_procedure` |  | +2.0 | 🟥🟥 |
| `lob/1048576` |  | +2.0 | 🟥🟥 |
| `concurrent_connects/50` |  | +2.0 | 🟥🟥 |
| `strings` |  | +5.0 | 🟥🟥🟥🟥🟥 |

Baseline commit: `30e4d2d521bc452ae449b8eceb78d17be2a15b03`

### Raw first-pass measurements

_Full critcmp table from the initial run. Benchmarks marked ⟳ above were re-measured; the chart shows the median and the re-runs are detailed below._

```
group                                base                                     candidate
-----                                ----                                     ---------
batched_statements                   1.04    253.4±6.95µs        ? ?/sec      1.00    243.8±8.51µs        ? ?/sec
bulk_insert/500                      1.00     37.8±0.49ms 258.2 KElem/sec     1.00     38.0±0.50ms 257.1 KElem/sec
bulk_insert/5000                     1.00     10.0±0.07ms 975.3 KElem/sec     1.01     10.1±0.13ms 964.7 KElem/sec
concurrent_connects/100              1.00     76.2±3.10ms  1312 Elem/sec      1.01     76.6±2.70ms  1304 Elem/sec
concurrent_connects/50               1.00     40.5±0.91ms  1235 Elem/sec      1.02     41.3±1.82ms  1211 Elem/sec
connect_close                        1.00      5.7±0.11ms        ? ?/sec      1.00      5.7±0.10ms        ? ?/sec
lob/1048576                          1.00      2.9±0.02ms   345.3 MB/sec      1.02      2.9±0.04ms   339.2 MB/sec
lob/20971520                         1.00     53.9±0.28ms   370.9 MB/sec      1.01     54.4±0.31ms   367.3 MB/sec
packet_size_sensitivity/32768        1.00     27.4±0.40ms   583.9 MB/sec      1.00     27.4±0.12ms   583.1 MB/sec
packet_size_sensitivity/4096         1.04     77.4±1.04ms   206.7 MB/sec      1.00     74.6±0.95ms   214.5 MB/sec
packet_size_sensitivity/8192         1.01     43.4±0.31ms   368.3 MB/sec      1.00     43.0±0.20ms   372.2 MB/sec
parameterized_sp_executesql          1.00   152.0±10.04µs        ? ?/sec      1.00    151.3±9.97µs        ? ?/sec
prepared_execute                     1.02    140.5±5.02µs        ? ?/sec      1.00    138.4±4.49µs        ? ?/sec
prepared_prepexec                    1.03    290.5±8.40µs        ? ?/sec      1.00    281.8±8.35µs        ? ?/sec
primitives/decode                    1.94  1533.6±28.79µs 636.8 KElem/sec     1.00    791.9±9.97µs 1233.2 KElem/sec
row_iteration_throughput/next_row    2.42     47.3±0.68ms 1032.9 KElem/sec    1.00     19.5±0.23ms  2.4 MElem/sec
scalars/decode                       1.90  1443.9±74.37µs 676.4 KElem/sec     1.00   757.9±26.99µs 1288.4 KElem/sec
select_n_rows/100                    1.28    393.7±9.28µs 248.1 KElem/sec     1.00    306.8±8.47µs 318.3 KElem/sec
select_n_rows/1000                   2.11  1711.4±48.98µs 570.6 KElem/sec     1.00   811.3±16.06µs 1203.7 KElem/sec
select_n_rows/10000                  2.33     13.8±0.21ms 708.7 KElem/sec     1.00      5.9±0.05ms 1651.8 KElem/sec
simple_select_one_row                1.06   212.2±10.60µs        ? ?/sec      1.00    199.4±3.21µs        ? ?/sec
single_insert                        1.01   312.6±12.82µs        ? ?/sec      1.00   310.0±10.73µs        ? ?/sec
stored_procedure                     1.00    151.9±2.15µs        ? ?/sec      1.02    155.6±4.13µs        ? ?/sec
stored_procedure_output              1.03    161.5±4.67µs        ? ?/sec      1.00    156.5±4.12µs        ? ?/sec
strings                              1.00    309.8±2.34µs        ? ?/sec      1.05   324.1±13.27µs        ? ?/sec
temporal/decode                      2.04  1428.7±33.76µs 683.6 KElem/sec     1.00    701.6±9.30µs 1391.9 KElem/sec
```

---

# Windows — build 168481

### Change vs baseline

_🟩 faster, 🟥 slower; 1 square ~ 1% (drawn only for changes of at least 1%); ⟳ re-measured (median of re-runs)_

| Benchmark | faster ◄ | Δ% | ► slower |
|---|--:|:--:|:--|
| `temporal/decode` ⟳ | 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 | -66.0 |  |
| `select_n_rows/10000` ⟳ | 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 | -65.2 |  |
| `row_iteration_throughput/next_row` | 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 | -63.0 |  |
| `scalars/decode` ⟳ | 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 | -61.4 |  |
| `select_n_rows/1000` | 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 | -61.2 |  |
| `primitives/decode` | 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 | -56.1 |  |
| `select_n_rows/100` | 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 | -35.5 |  |
| `packet_size_sensitivity/4096` | 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 | -9.9 |  |
| `parameterized_sp_executesql` | 🟩🟩🟩🟩🟩🟩 | -5.7 |  |
| `batched_statements` | 🟩🟩🟩🟩🟩 | -4.8 |  |
| `stored_procedure` | 🟩🟩🟩🟩 | -3.8 |  |
| `lob/1048576` | 🟩🟩 | -2.0 |  |
| `prepared_prepexec` | 🟩🟩 | -2.0 |  |
| `packet_size_sensitivity/8192` | 🟩🟩 | -2.0 |  |
| `packet_size_sensitivity/32768` | 🟩🟩 | -2.0 |  |
| `prepared_execute` |  | -1.0 |  |
| `single_insert` |  | -1.0 |  |
| `lob/20971520` |  | -1.0 |  |
| `concurrent_connects/50` |  | -1.0 |  |
| `stored_procedure_output` |  | ±0.0 |  |
| `bulk_insert/500` |  | ±0.0 |  |
| `bulk_insert/5000` |  | ±0.0 |  |
| `strings` |  | ±0.0 |  |
| `simple_select_one_row` |  | +1.0 | 🟥 |
| `connect_close` |  | +1.0 | 🟥 |
| `concurrent_connects/100` |  | +2.0 | 🟥🟥 |

Baseline commit: `30e4d2d521bc452ae449b8eceb78d17be2a15b03`

### Raw first-pass measurements

_Full critcmp table from the initial run. Benchmarks marked ⟳ above were re-measured; the chart shows the median and the re-runs are detailed below._

```
group                                base                                    candidate
-----                                ----                                    ---------
batched_statements                   1.05    240.2±4.81µs        ? ?/sec     1.00    228.4±4.03µs        ? ?/sec
bulk_insert/500                      1.00     38.5±0.15ms 253.4 KElem/sec    1.00     38.3±0.18ms 254.7 KElem/sec
bulk_insert/5000                     1.00     11.4±0.08ms 856.8 KElem/sec    1.00     11.4±0.08ms 859.1 KElem/sec
concurrent_connects/100              1.00       2.4±0.09s    41 Elem/sec     1.02       2.4±0.13s    40 Elem/sec
concurrent_connects/50               1.01  1394.5±130.40ms    35 Elem/sec    1.00  1380.7±124.66ms    36 Elem/sec
connect_close                        1.00    158.7±4.38ms        ? ?/sec     1.01    159.6±2.95ms        ? ?/sec
lob/1048576                          1.02  1633.2±30.54µs   612.3 MB/sec     1.00  1604.1±23.09µs   623.4 MB/sec
lob/20971520                         1.01     29.6±1.04ms   675.9 MB/sec     1.00     29.3±0.74ms   681.5 MB/sec
packet_size_sensitivity/32768        1.02     19.8±0.42ms   807.3 MB/sec     1.00     19.5±0.51ms   821.8 MB/sec
packet_size_sensitivity/4096         1.11     43.6±0.84ms   366.7 MB/sec     1.00     39.3±2.02ms   407.2 MB/sec
packet_size_sensitivity/8192         1.02     27.1±0.48ms   590.3 MB/sec     1.00     26.6±0.33ms   600.8 MB/sec
parameterized_sp_executesql          1.06    130.0±2.87µs        ? ?/sec     1.00    122.9±2.09µs        ? ?/sec
prepared_execute                     1.01    119.5±4.70µs        ? ?/sec     1.00    118.3±5.68µs        ? ?/sec
prepared_prepexec                    1.02    239.3±3.26µs        ? ?/sec     1.00    234.1±4.91µs        ? ?/sec
primitives/decode                    2.28      2.2±0.02ms 442.0 KElem/sec    1.00   968.7±12.74µs 1008.2 KElem/sec
row_iteration_throughput/next_row    2.70     70.2±0.43ms 695.9 KElem/sec    1.00     26.0±0.05ms 1876.7 KElem/sec
scalars/decode                       2.74      2.0±0.03ms 482.4 KElem/sec    1.00    738.2±9.58µs 1322.9 KElem/sec
select_n_rows/100                    1.55    444.8±7.89µs 219.6 KElem/sec    1.00    286.4±3.89µs 341.0 KElem/sec
select_n_rows/1000                   2.58      2.4±0.03ms 403.4 KElem/sec    1.00   938.1±17.00µs 1041.1 KElem/sec
select_n_rows/10000                  2.90     21.5±0.16ms 455.0 KElem/sec    1.00      7.4±0.05ms 1319.8 KElem/sec
simple_select_one_row                1.00    182.8±4.26µs        ? ?/sec     1.01    185.1±4.54µs        ? ?/sec
single_insert                        1.01    284.8±5.58µs        ? ?/sec     1.00    282.8±3.55µs        ? ?/sec
stored_procedure                     1.04    133.5±1.52µs        ? ?/sec     1.00    128.5±1.71µs        ? ?/sec
stored_procedure_output              1.00    135.7±5.12µs        ? ?/sec     1.00    135.5±1.95µs        ? ?/sec
strings                              1.00    285.8±7.69µs        ? ?/sec     1.00    286.3±3.43µs        ? ?/sec
temporal/decode                      3.01      2.3±0.02ms 433.3 KElem/sec    1.00    749.2±9.69µs 1303.5 KElem/sec
```

---

## Related Issues

[AB#46061](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46061)

## Checklist

- [x] New/changed functionality has tests — N/A: baseline pointer change; validated by the two lab runs above and a local compile against the new baseline
- [x] Public API changes are documented — N/A: no public API changes
