### PR TITLE
Add a measured msodbcsql attribute recognition table

### DIFF
--- a/mssql-odbc/docs/attributes_plan.md
+++ b/mssql-odbc/docs/attributes_plan.md
@@ -143,15 +143,15 @@ completeness.
 
 ---
 
-### S1 — Attribute dispatch spine, string I/O, and defensive rejection
+### S1 — Attribute dispatch spine, string I/O, and defensive rejection — **delivered**
 
-> `mssql-odbc | Attribute dispatch & pass-through hardening`
+> `mssql-odbc | Attribute dispatch & pass-through hardening` (AB#47453)
 
 **Why first:** every other slice needs the table, the string plumbing, and the
 rejection policy. Alone it discharges the §4.10 "never crash on unexpected input"
 requirement.
 
-**Already landed with S2/S3** (the parts those two could not proceed without):
+**Landed with S2/S3** (the parts those two could not proceed without):
 
 - Character-attribute I/O in `util.rs`: `read_utf16_attr` (byte-count input,
   `SQL_NTS` passthrough) and `write_wide_attr` (honors `buffer_length`, writes
@@ -163,27 +163,75 @@ requirement.
 - `post_tds_error_as` in `sqlstate.rs`, for paths where msodbcsql forces a
   SQLSTATE over the error-number map.
 
-**Still open**
+**Landed here**
 
-- Single source-of-truth attribute table: `id → { scope, value kind (int / pointer /
-  wide string), settable phase (pre-connect / post-connect / either), disposition
-  (honored / accepted-no-op / not-implemented / invalid) }`. Replaces four
-  hand-rolled `match` arms.
-- Build the **msodbcsql truth table** systematically: table-driven e2e sweep over
-  the attribute id space against the real driver, recording
-  `(attr, phase, value) → (SQLRETURN, SQLSTATE)`. Everything downstream
-  implements against measured behavior, not a guess. `attributes_test.cpp` is the
-  hand-written seed of this.
-- Finish reconciling rejection SQLSTATEs with msodbcsql: `HY092` invalid
-  identifier, `HYC00` recognized-but-not-implemented, `HY024` invalid value,
-  `HY011` wrong phase, `HY010` function sequence. Promote to `ERR_*` `DiagMsg`
-  constants in `sqlstate.rs` per repo convention.
-- Property/fuzz test sweeping the full `i32` identifier space × representative
-  values, asserting no panic and a diagnostic record on every failure path.
+- **The msodbcsql truth table, measured rather than guessed.** A ctypes sweep
+  drove 135 attribute identifiers through `SQLSetConnectAttrW` /
+  `SQLGetConnectAttrW` / `SQLSetStmtAttrW` / `SQLGetStmtAttrW` on a live
+  msodbcsql 18, pre- and post-connect, recording
+  `(scope, phase, op, id) → (SQLRETURN, SQLSTATE)`. 321 units, 513 rows. See §8
+  for how to reproduce it.
+- `src/api/attributes.rs`, generated from that CSV: `DBC_ATTRS` (90 ids) and
+  `STMT_ATTRS` (46 ids), each row carrying an `OP_SET` / `OP_GET` flag mask.
+  `native_attr_name(scope, op, id)` answers "does msodbcsql know this
+  identifier, in this scope, on this operation?"; `unimplemented_attr_diag`
+  turns that into the right `DiagMsg`.
+- All four attribute catch-alls now consult it: **recognized → `HYC00`**
+  (not implemented), **unrecognized → `HY092`** (not an attribute). A caller
+  probing for, say, MARS can now tell "unavailable" from "no such thing"
+  instead of getting one undifferentiated error.
+- Property test sweeping the identifier space (boundaries plus stride 7 across
+  0–12000, both scopes, both operations) asserting classification never panics.
+- e2e Variations 23–30 in `attributes_test.cpp`. 23–27 are pure parity and pass
+  unmodified on both drivers; 28–30 assert behavior that is deliberately ours.
 
-**Acceptance:** no input to `SQLSet/GetConnectAttrW` or `SQLSet/GetStmtAttrW`
-panics or returns `SQL_ERROR` without a retrievable `SQLGetDiagRec`; parity sweep
-green; string round-trip covered by unit + e2e tests.
+**Two findings that shaped the design** — both measured, neither obvious:
+
+1. **Recognition is scope-keyed.** The vendor ranges collide.
+   `SQL_COPT_SS_*` and `SQL_SOPT_SS_*` both occupy 1225–1238, so
+   `SQL_COPT_SS_FAILOVER_PARTNER` and `SQL_SOPT_SS_TEXTPTR_LOGGING` are both
+   1225; `SQL_ATTR_OUTPUT_NTS` (env) and `SQL_ATTR_AUTO_IPD` (dbc) are both
+   10001. A flat id → name map answers for the wrong scope.
+2. **Recognition is *also* operation-keyed.** msodbcsql accepts the ODBC 2.x
+   statement options (ids 0–12, 29) on a **connection** handle and fans them out
+   to every statement (`sqlcmisc.cpp:2879`), but `SQLGetConnectAttrW` returns
+   `HY092` for those same ids:
+
+   ```
+   post_connect set SQL_ATTR_QUERY_TIMEOUT -> SUCCESS_WITH_INFO 01S02
+   post_connect get SQL_ATTR_QUERY_TIMEOUT -> SQL_ERROR         HY092
+   ```
+
+   A scope-only table would have softened
+   `SQLGetConnectAttrW(SQL_ATTR_QUERY_TIMEOUT)` from `HY092` to `HYC00` and
+   broken the contract S2 already shipped. Hence the per-operation flag column.
+
+**Three further measured facts, recorded so nobody re-derives them:**
+
+- **Pre-connect `SQLSetConnectAttrW` returns `SUCCESS` for every identifier**,
+  including garbage — the Driver Manager buffers the call and replays it after
+  connect, so the driver never sees it. Pre-connect rows prove nothing about the
+  driver and are excluded from the table.
+- **Environment attributes (200–202) answer `HY092` on both dbc and stmt.** The
+  DM handles them; they are absent from both tables by construction.
+- **Three identifiers hard-fault msodbcsql** when handed a plain 256-byte
+  buffer on the connection set path: `SQL_ATTR_ENLIST_IN_DTC` (1207),
+  `SQL_COPT_SS_ENLIST_IN_DTC` (1207) and `SQL_COPT_SS_CEKEYSTOREDATA` (1252).
+  They dereference the pointer as a struct with no validation. Routing
+  unimplemented identifiers through a table lookup rather than a pointer read
+  is what makes this driver immune; Variation 30 pins that down.
+
+**Deferred to the slice that implements each attribute:** the value-kind and
+phase columns (`int` / `pointer` / `wide string`; pre-connect / post-connect /
+either). Recognition is the part every other slice needs, and the hand-written
+`match` arms remain the place a *supported* attribute is defined — the table
+sits behind the catch-all, so S4–S6 shrink it as they land rather than rewriting
+it.
+
+**Acceptance:** met. No input to `SQLSet/GetConnectAttrW` or
+`SQLSet/GetStmtAttrW` panics or returns `SQL_ERROR` without a retrievable
+`SQLGetDiagRec`; parity sweep green on both drivers; string round-trip covered
+by unit + e2e tests.
 
 **Size:** M–L. **Depends on:** nothing.
 
@@ -461,12 +509,19 @@ $env:ODBC_TEST_TRUST_CERT = 'Yes'
 
 # baseline
 $env:ODBC_TEST_DRIVER = 'ODBC Driver 18 for SQL Server'
+$env:ODBC_TEST_TARGET = 'msodbcsql'
 .\build\attributes_test.exe
 
 # this driver
 $env:ODBC_TEST_DRIVER = 'mssql-odbc dev'
+$env:ODBC_TEST_TARGET = 'rust'
 .\build\attributes_test.exe
 ```
+
+`ODBC_TEST_TARGET` drives `SKIP_IF_COMPARING_MSODBCSQL()`. Use it only where the
+two drivers diverge *by design* — an attribute msodbcsql implements and we do
+not, or input that faults it. Everything else must pass on both legs unchanged;
+that is what makes the file a parity contract rather than a regression suite.
 
 Two constraints worth knowing before adding cases:
 
@@ -476,3 +531,36 @@ Two constraints worth knowing before adding cases:
 - A fixture helper that runs its own query fails with a Driver-Manager `24000`
   if a cursor is already open on the shared statement. Resolve every value the
   assertion needs *before* opening the cursor under test.
+
+### 8.1 Re-measuring the msodbcsql recognition table
+
+`src/api/attributes.rs` is generated, not authored. Its rows come from a ctypes
+sweep that calls the four attribute entry points directly against msodbcsql for
+every known identifier and records what comes back. Regenerate it when the
+identifier list grows or a new msodbcsql version ships:
+
+1. **Collect identifiers.** Grep `#define SQL_(ATTR|COPT_SS|SOPT_SS)_\w+` out of
+   the Windows SDK `sqlext.h` / `sql.h` and msodbcsql's `msodbcsql.h`, resolving
+   each to its numeric value. Keep the aliases — `SQL_COPT_SS_ENLIST_IN_DTC` and
+   `SQL_ATTR_ENLIST_IN_DTC` share id 1207, and confirming both behave alike is
+   the point.
+2. **Sweep.** For each `(scope, phase, op, id)` issue the call with a **zeroed
+   256-byte buffer**, not a small integer: several attributes are read as
+   structs and a short buffer turns a recognition probe into a heap overrun.
+   Record `SQLRETURN` plus the SQLSTATE from `SQLGetDiagRec`.
+3. **Isolate.** Use a fresh connection per post-connect probe — a probe that
+   leaves the connection in a bad state otherwise contaminates its successors —
+   and flush results to CSV incrementally, keyed by unit index, so a hard fault
+   can be resumed rather than restarted.
+4. **Expect faults.** Three identifiers take the process down (§S1). Drive the
+   sweep from a wrapper that restarts it at `index + 1` after a crash and logs
+   which unit died; a fault *is* a measurement — it proves msodbcsql recognized
+   the identifier in that scope and operation.
+5. **Classify.** Drop `phase == "pre_connect"` rows: the Driver Manager buffers
+   those and returns `SUCCESS` for anything, so they say nothing about the
+   driver. Treat `HY092` as "not an attribute here" and everything else —
+   success, `HYC00`, `HY011`, `HY024`, a fault — as "recognized".
+6. **Emit and verify.** Generate the two tables sorted by id with the
+   `OP_SET` / `OP_GET` mask per row. `tables_are_sorted_unique_and_flagged`
+   enforces the invariant the binary search depends on, so a bad generation
+   fails the build rather than silently mis-answering.

--- a/mssql-odbc/docs/attributes_plan.md
+++ b/mssql-odbc/docs/attributes_plan.md
@@ -219,7 +219,11 @@ requirement.
   `SQL_COPT_SS_ENLIST_IN_DTC` (1207) and `SQL_COPT_SS_CEKEYSTOREDATA` (1252).
   They dereference the pointer as a struct with no validation. Routing
   unimplemented identifiers through a table lookup rather than a pointer read
-  is what makes this driver immune; Variation 30 pins that down.
+  is what makes this driver immune; Variation 31 pins that down.
+- **The fault hides the get side of those ids**, which had to be measured
+  separately (§8.1 step 5). The two are not alike: 1252 answers `HY010` on get,
+  so it is recognized for both operations, while 1207 answers `HY092` and is
+  genuinely set-only. Variation 32 asserts the 1252 get path on both drivers.
 
 **Deferred to the slice that implements each attribute:** the value-kind and
 phase columns (`int` / `pointer` / `wide string`; pre-connect / post-connect /
@@ -556,11 +560,19 @@ identifier list grows or a new msodbcsql version ships:
    sweep from a wrapper that restarts it at `index + 1` after a crash and logs
    which unit died; a fault *is* a measurement — it proves msodbcsql recognized
    the identifier in that scope and operation.
-5. **Classify.** Drop `phase == "pre_connect"` rows: the Driver Manager buffers
+5. **Re-probe what the fault skipped.** Restarting at `index + 1` resumes past
+   the *remaining operations for that same id*, so a crasher arrives with only
+   the op that killed it measured. Do not infer the others. Re-run each such id
+   one per process (`probe_get_crashers.py`) and append the rows to the CSV.
+   This is not hypothetical: `SQL_COPT_SS_CEKEYSTOREDATA` (1252) was first
+   recorded set-only, but its get path answers `HY010` — recognized — while
+   `SQL_ATTR_ENLIST_IN_DTC` (1207), which faults identically, really does
+   answer `HY092` on get. Same symptom, opposite conclusion.
+6. **Classify.** Drop `phase == "pre_connect"` rows: the Driver Manager buffers
    those and returns `SUCCESS` for anything, so they say nothing about the
    driver. Treat `HY092` as "not an attribute here" and everything else —
-   success, `HYC00`, `HY011`, `HY024`, a fault — as "recognized".
-6. **Emit and verify.** Generate the two tables sorted by id with the
+   success, `HYC00`, `HY010`, `HY011`, `HY024`, a fault — as "recognized".
+7. **Emit and verify.** Generate the two tables sorted by id with the
    `OP_SET` / `OP_GET` mask per row. `tables_are_sorted_unique_and_flagged`
    enforces the invariant the binary search depends on, so a bad generation
    fails the build rather than silently mis-answering.

--- a/mssql-odbc/src/api/attributes.rs
+++ b/mssql-odbc/src/api/attributes.rs
@@ -1,0 +1,521 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Attribute identifier metadata shared by the `SQLSet*Attr` / `SQLGet*Attr`
+//! entry points.
+//!
+//! ODBC draws a sharp line between two failures that callers handle very
+//! differently:
+//!
+//! * `HY092` - *Invalid attribute/option identifier.* The identifier is not an
+//!   attribute at all. A caller probing for capabilities reads this as "this
+//!   driver has never heard of it".
+//! * `HYC00` - *Optional feature not implemented.* The identifier is a real
+//!   attribute this driver understands but does not act on. Callers may retry
+//!   without it, or fall back to a connection-string keyword.
+//!
+//! Answering `HY092` for a recognized-but-unimplemented attribute is a parity
+//! break: `mssql-python` forwards arbitrary identifiers through `attrs_before`
+//! and `set_attr` with no filtering, so a caller probing
+//! `SQL_COPT_SS_MARS_ENABLED` would conclude the identifier is bogus rather
+//! than merely unavailable.
+//!
+//! The tables below record which identifiers msodbcsql recognizes. They are not
+//! transcribed from the headers - a header defines far more constants than any
+//! switch handles, and several of those constants are attribute *values* rather
+//! than identifiers. Each identifier was instead probed against a live `ODBC
+//! Driver 18 for SQL Server`, and counts as recognized when the probe returned
+//! anything other than `HY092`. `docs/attributes_plan.md` §8 documents the
+//! harness and how to reproduce the measurement.
+//!
+//! Two properties of the measured data drive the shape of this table:
+//!
+//! * **Lookup is scope-keyed**, because the vendor ranges overlap.
+//!   `SQL_COPT_SS_*` and `SQL_SOPT_SS_*` share 1225-1238
+//!   (`SQL_COPT_SS_FAILOVER_PARTNER` and `SQL_SOPT_SS_TEXTPTR_LOGGING` are both
+//!   1225), and `SQL_ATTR_OUTPUT_NTS` (environment) collides with
+//!   `SQL_ATTR_AUTO_IPD` (connection) at 10001. A flat identifier map would
+//!   answer for the wrong scope.
+//! * **Lookup is also operation-keyed**, because recognition is not symmetric.
+//!   msodbcsql accepts the ODBC 2.x statement options on a *connection* handle
+//!   and fans them out to every statement (`sqlcmisc.cpp:2879`,
+//!   `IsSetStmtOptionValid`), yet `SQLGetConnectAttrW` rejects those same
+//!   identifiers with `HY092`. `SQL_ATTR_QUERY_TIMEOUT` on a connection is
+//!   settable but not readable.
+//!
+//! Environment attributes are absent from both tables. The Driver Manager
+//! resolves `SQL_ATTR_ODBC_VERSION`, `SQL_ATTR_CONNECTION_POOLING` and
+//! `SQL_ATTR_CP_MATCH` itself and never dispatches them, which the sweep
+//! confirmed: all three answer `HY092` when aimed at a connection or statement.
+
+use crate::api::odbc_types::SqlInteger;
+use crate::api::sqlstate::{
+    DiagMsg, ERR_INVALID_ATTRIBUTE_IDENTIFIER, ERR_OPTIONAL_FEATURE_NOT_IMPLEMENTED,
+};
+
+/// Handle scope an attribute identifier is interpreted against.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AttrScope {
+    /// Connection attributes (`SQLSetConnectAttrW` / `SQLGetConnectAttrW`).
+    Dbc,
+    /// Statement attributes (`SQLSetStmtAttrW` / `SQLGetStmtAttrW`).
+    Stmt,
+}
+
+/// Which half of the attribute API an identifier is being used through.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AttrOp {
+    Set,
+    Get,
+}
+
+const OP_SET: u8 = 1 << 0;
+const OP_GET: u8 = 1 << 1;
+
+/// `(identifier, msodbcsql name, operations msodbcsql recognizes it for)`,
+/// sorted by identifier so lookup can binary search.
+type AttrRow = (SqlInteger, &'static str, u8);
+
+/// Connection-scope identifiers msodbcsql recognizes.
+///
+/// The 0-29 band is the ODBC 2.x statement-option fan-out: msodbcsql accepts
+/// statement options on a connection handle and applies them to every statement
+/// on that connection, but refuses to read them back. This driver implements
+/// the fan-out only for `SQL_ATTR_QUERY_TIMEOUT`; the rest are listed so they
+/// report `HYC00` rather than `HY092`.
+static DBC_ATTRS: &[AttrRow] = &[
+    (0, "SQL_ATTR_QUERY_TIMEOUT", OP_SET),
+    (1, "SQL_ATTR_MAX_ROWS", OP_SET),
+    (2, "SQL_ATTR_NOSCAN", OP_SET),
+    (3, "SQL_ATTR_MAX_LENGTH", OP_SET),
+    (4, "SQL_ATTR_ASYNC_ENABLE", OP_SET | OP_GET),
+    (5, "SQL_ATTR_ROW_BIND_TYPE", OP_SET),
+    (6, "SQL_ATTR_CURSOR_TYPE", OP_SET),
+    (7, "SQL_ATTR_CONCURRENCY", OP_SET),
+    (8, "SQL_ATTR_KEYSET_SIZE", OP_SET),
+    (10, "SQL_ATTR_SIMULATE_CURSOR", OP_SET),
+    (11, "SQL_ATTR_RETRIEVE_DATA", OP_SET),
+    (12, "SQL_ATTR_USE_BOOKMARKS", OP_SET),
+    (29, "SQL_ATTR_ASYNC_STMT_EVENT", OP_SET),
+    (101, "SQL_ATTR_ACCESS_MODE", OP_SET | OP_GET),
+    (102, "SQL_ATTR_AUTOCOMMIT", OP_SET | OP_GET),
+    (103, "SQL_ATTR_LOGIN_TIMEOUT", OP_SET | OP_GET),
+    (104, "SQL_ATTR_TRACE", OP_SET | OP_GET),
+    (105, "SQL_ATTR_TRACEFILE", OP_SET | OP_GET),
+    (106, "SQL_ATTR_TRANSLATE_LIB", OP_SET | OP_GET),
+    (107, "SQL_ATTR_TRANSLATE_OPTION", OP_SET | OP_GET),
+    (108, "SQL_ATTR_TXN_ISOLATION", OP_SET | OP_GET),
+    (109, "SQL_ATTR_CURRENT_CATALOG", OP_SET | OP_GET),
+    (110, "SQL_ATTR_ODBC_CURSORS", OP_SET | OP_GET),
+    (112, "SQL_ATTR_PACKET_SIZE", OP_SET | OP_GET),
+    (113, "SQL_ATTR_CONNECTION_TIMEOUT", OP_SET | OP_GET),
+    (114, "SQL_ATTR_DISCONNECT_BEHAVIOR", OP_SET),
+    (117, "SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE", OP_SET | OP_GET),
+    (119, "SQL_ATTR_ASYNC_DBC_EVENT", OP_SET | OP_GET),
+    (1202, "SQL_COPT_SS_USE_PROC_FOR_PREP", OP_SET | OP_GET),
+    (1203, "SQL_COPT_SS_INTEGRATED_SECURITY", OP_SET | OP_GET),
+    (1204, "SQL_COPT_SS_PRESERVE_CURSORS", OP_SET | OP_GET),
+    (1205, "SQL_COPT_SS_USER_DATA", OP_SET | OP_GET),
+    (1206, "SQL_COPT_SS_ANSI_OEM", OP_SET | OP_GET),
+    (1207, "SQL_ATTR_ENLIST_IN_DTC", OP_SET),
+    (1208, "SQL_ATTR_ENLIST_IN_XA", OP_SET),
+    (1209, "SQL_ATTR_CONNECTION_DEAD", OP_GET),
+    (1210, "SQL_COPT_SS_FALLBACK_CONNECT", OP_SET | OP_GET),
+    (1211, "SQL_COPT_SS_PERF_DATA", OP_SET | OP_GET),
+    (1212, "SQL_COPT_SS_PERF_DATA_LOG", OP_SET | OP_GET),
+    (1213, "SQL_COPT_SS_PERF_QUERY_INTERVAL", OP_SET | OP_GET),
+    (1214, "SQL_COPT_SS_PERF_QUERY_LOG", OP_SET | OP_GET),
+    (1215, "SQL_COPT_SS_PERF_QUERY", OP_SET | OP_GET),
+    (1216, "SQL_COPT_SS_PERF_DATA_LOG_NOW", OP_SET),
+    (1217, "SQL_COPT_SS_QUOTED_IDENT", OP_SET | OP_GET),
+    (1218, "SQL_COPT_SS_ANSI_NPW", OP_SET | OP_GET),
+    (1219, "SQL_COPT_SS_BCP", OP_SET | OP_GET),
+    (1220, "SQL_COPT_SS_TRANSLATE", OP_SET | OP_GET),
+    (1221, "SQL_COPT_SS_ATTACHDBFILENAME", OP_SET | OP_GET),
+    (1222, "SQL_COPT_SS_CONCAT_NULL", OP_SET | OP_GET),
+    (1223, "SQL_COPT_SS_ENCRYPT", OP_SET | OP_GET),
+    (1224, "SQL_COPT_SS_MARS_ENABLED", OP_SET | OP_GET),
+    (1225, "SQL_COPT_SS_FAILOVER_PARTNER", OP_SET | OP_GET),
+    (1226, "SQL_COPT_SS_OLDPWD", OP_SET),
+    (1227, "SQL_COPT_SS_TXN_ISOLATION", OP_SET | OP_GET),
+    (
+        1228,
+        "SQL_COPT_SS_TRUST_SERVER_CERTIFICATE",
+        OP_SET | OP_GET,
+    ),
+    (1229, "SQL_COPT_SS_SERVER_SPN", OP_SET | OP_GET),
+    (1230, "SQL_COPT_SS_FAILOVER_PARTNER_SPN", OP_SET | OP_GET),
+    (1231, "SQL_COPT_SS_INTEGRATED_AUTHENTICATION_METHOD", OP_GET),
+    (1232, "SQL_COPT_SS_MUTUALLY_AUTHENTICATED", OP_GET),
+    (1233, "SQL_COPT_SS_CLIENT_CONNECTION_ID", OP_GET),
+    (1234, "SQL_COPT_SS_CONNECT_RETRY_COUNT", OP_GET),
+    (1235, "SQL_COPT_SS_CONNECT_RETRY_INTERVAL", OP_GET),
+    (1236, "SQL_COPT_SS_CLIENT_CERTIFICATE", OP_SET | OP_GET),
+    (
+        1237,
+        "SQL_COPT_SS_CLIENT_CERTIFICATE_FALLBACK",
+        OP_SET | OP_GET,
+    ),
+    (1238, "SQL_COPT_SS_CLIENT_CONNECTION_ID_POINTER", OP_SET),
+    (
+        1239,
+        "SQL_COPT_SS_CLIENT_CONNECTION_ID_REDIRECTED_POINTER",
+        OP_SET,
+    ),
+    (
+        1240,
+        "SQL_COPT_SS_SERVER_CERTIFICATE_VALIDATION_CALLBACK",
+        OP_SET,
+    ),
+    (1241, "SQL_COPT_SS_BROWSE_CONNECT", OP_SET | OP_GET),
+    (1242, "SQL_COPT_SS_BROWSE_SERVER", OP_SET | OP_GET),
+    (1243, "SQL_COPT_SS_WARN_ON_CP_ERROR", OP_SET | OP_GET),
+    (1244, "SQL_COPT_SS_CONNECTION_DEAD", OP_GET),
+    (1245, "SQL_COPT_SS_BROWSE_CACHE_DATA", OP_SET | OP_GET),
+    (1246, "SQL_COPT_SS_RESET_CONNECTION", OP_SET),
+    (1247, "SQL_COPT_SS_APPLICATION_INTENT", OP_SET | OP_GET),
+    (1248, "SQL_COPT_SS_MULTISUBNET_FAILOVER", OP_SET | OP_GET),
+    (1249, "SQL_COPT_SS_TNIR", OP_SET | OP_GET),
+    (1250, "SQL_COPT_SS_COLUMN_ENCRYPTION", OP_SET | OP_GET),
+    (1251, "SQL_COPT_SS_CEKEYSTOREPROVIDER", OP_SET | OP_GET),
+    (1252, "SQL_COPT_SS_CEKEYSTOREDATA", OP_SET),
+    (1253, "SQL_COPT_SS_TRUSTEDCMKPATHS", OP_SET | OP_GET),
+    (1254, "SQL_COPT_SS_CEKCACHETTL", OP_SET | OP_GET),
+    (1255, "SQL_COPT_SS_AUTHENTICATION", OP_SET | OP_GET),
+    (1256, "SQL_COPT_SS_ACCESS_TOKEN", OP_SET | OP_GET),
+    (
+        1400,
+        "SQL_COPT_SS_DATACLASSIFICATION_VERSION",
+        OP_SET | OP_GET,
+    ),
+    (1401, "SQL_COPT_SS_SPID", OP_GET),
+    (1402, "SQL_COPT_SS_AUTOBEGINTXN", OP_SET),
+    (1403, "SQL_COPT_SS_LONGASMAX", OP_SET | OP_GET),
+    (1404, "SQL_COPT_SS_GETDATA_EXTENSIONS", OP_SET | OP_GET),
+    (10001, "SQL_ATTR_AUTO_IPD", OP_GET),
+    (10014, "SQL_ATTR_METADATA_ID", OP_SET | OP_GET),
+];
+
+/// Statement-scope identifiers msodbcsql recognizes.
+///
+/// `SQL_ATTR_ENLIST_IN_DTC` (1207) is deliberately absent: it is a connection
+/// attribute, and the sweep confirmed msodbcsql answers `HY092` for it on a
+/// statement handle even though the identifier sits in the shared vendor range.
+static STMT_ATTRS: &[AttrRow] = &[
+    (0, "SQL_ATTR_QUERY_TIMEOUT", OP_SET | OP_GET),
+    (1, "SQL_ATTR_MAX_ROWS", OP_SET | OP_GET),
+    (2, "SQL_ATTR_NOSCAN", OP_SET | OP_GET),
+    (3, "SQL_ATTR_MAX_LENGTH", OP_SET | OP_GET),
+    (4, "SQL_ATTR_ASYNC_ENABLE", OP_SET | OP_GET),
+    (5, "SQL_ATTR_ROW_BIND_TYPE", OP_SET | OP_GET),
+    (6, "SQL_ATTR_CURSOR_TYPE", OP_SET | OP_GET),
+    (7, "SQL_ATTR_CONCURRENCY", OP_SET | OP_GET),
+    (8, "SQL_ATTR_KEYSET_SIZE", OP_SET | OP_GET),
+    (10, "SQL_ATTR_SIMULATE_CURSOR", OP_SET | OP_GET),
+    (11, "SQL_ATTR_RETRIEVE_DATA", OP_SET | OP_GET),
+    (12, "SQL_ATTR_USE_BOOKMARKS", OP_SET | OP_GET),
+    (14, "SQL_ATTR_ROW_NUMBER", OP_GET),
+    (15, "SQL_ATTR_ENABLE_AUTO_IPD", OP_SET | OP_GET),
+    (16, "SQL_ATTR_FETCH_BOOKMARK_PTR", OP_SET | OP_GET),
+    (17, "SQL_ATTR_PARAM_BIND_OFFSET_PTR", OP_SET | OP_GET),
+    (18, "SQL_ATTR_PARAM_BIND_TYPE", OP_SET | OP_GET),
+    (19, "SQL_ATTR_PARAM_OPERATION_PTR", OP_SET | OP_GET),
+    (20, "SQL_ATTR_PARAM_STATUS_PTR", OP_SET | OP_GET),
+    (21, "SQL_ATTR_PARAMS_PROCESSED_PTR", OP_SET | OP_GET),
+    (22, "SQL_ATTR_PARAMSET_SIZE", OP_SET | OP_GET),
+    (23, "SQL_ATTR_ROW_BIND_OFFSET_PTR", OP_SET | OP_GET),
+    (24, "SQL_ATTR_ROW_OPERATION_PTR", OP_SET | OP_GET),
+    (25, "SQL_ATTR_ROW_STATUS_PTR", OP_SET | OP_GET),
+    (26, "SQL_ATTR_ROWS_FETCHED_PTR", OP_SET | OP_GET),
+    (27, "SQL_ATTR_ROW_ARRAY_SIZE", OP_SET | OP_GET),
+    (29, "SQL_ATTR_ASYNC_STMT_EVENT", OP_SET),
+    (1225, "SQL_SOPT_SS_TEXTPTR_LOGGING", OP_SET | OP_GET),
+    (1226, "SQL_SOPT_SS_CURRENT_COMMAND", OP_GET),
+    (1227, "SQL_SOPT_SS_HIDDEN_COLUMNS", OP_SET | OP_GET),
+    (1228, "SQL_SOPT_SS_NOBROWSETABLE", OP_SET | OP_GET),
+    (1229, "SQL_SOPT_SS_REGIONALIZE", OP_SET | OP_GET),
+    (1230, "SQL_SOPT_SS_CURSOR_OPTIONS", OP_SET | OP_GET),
+    (1231, "SQL_SOPT_SS_NOCOUNT_STATUS", OP_GET),
+    (1232, "SQL_SOPT_SS_DEFER_PREPARE", OP_SET | OP_GET),
+    (
+        1233,
+        "SQL_SOPT_SS_QUERYNOTIFICATION_TIMEOUT",
+        OP_SET | OP_GET,
+    ),
+    (
+        1234,
+        "SQL_SOPT_SS_QUERYNOTIFICATION_MSGTEXT",
+        OP_SET | OP_GET,
+    ),
+    (
+        1235,
+        "SQL_SOPT_SS_QUERYNOTIFICATION_OPTIONS",
+        OP_SET | OP_GET,
+    ),
+    (1236, "SQL_SOPT_SS_PARAM_FOCUS", OP_SET | OP_GET),
+    (1237, "SQL_SOPT_SS_NAME_SCOPE", OP_SET | OP_GET),
+    (1238, "SQL_SOPT_SS_COLUMN_ENCRYPTION", OP_SET | OP_GET),
+    (10010, "SQL_ATTR_APP_ROW_DESC", OP_SET | OP_GET),
+    (10011, "SQL_ATTR_APP_PARAM_DESC", OP_SET | OP_GET),
+    (10012, "SQL_ATTR_IMP_ROW_DESC", OP_SET | OP_GET),
+    (10013, "SQL_ATTR_IMP_PARAM_DESC", OP_SET | OP_GET),
+    (10014, "SQL_ATTR_METADATA_ID", OP_SET | OP_GET),
+];
+
+/// Returns the msodbcsql name for `attribute`, when the native driver
+/// recognizes it for this exact scope and operation.
+pub(crate) fn native_attr_name(
+    scope: AttrScope,
+    op: AttrOp,
+    attribute: SqlInteger,
+) -> Option<&'static str> {
+    let table = match scope {
+        AttrScope::Dbc => DBC_ATTRS,
+        AttrScope::Stmt => STMT_ATTRS,
+    };
+    let wanted = match op {
+        AttrOp::Set => OP_SET,
+        AttrOp::Get => OP_GET,
+    };
+    let i = table
+        .binary_search_by_key(&attribute, |&(id, _, _)| id)
+        .ok()?;
+    let (_, name, ops) = table[i];
+    (ops & wanted != 0).then_some(name)
+}
+
+/// Picks the diagnostic for an attribute this driver does not implement.
+///
+/// `HYC00` when msodbcsql knows the identifier for this scope and operation,
+/// `HY092` when neither driver does. The caller posts the diagnostic and
+/// returns `SQL_ERROR`.
+pub(crate) fn unimplemented_attr_diag(
+    scope: AttrScope,
+    op: AttrOp,
+    attribute: SqlInteger,
+) -> DiagMsg {
+    match native_attr_name(scope, op, attribute) {
+        Some(name) => {
+            tracing::debug!(
+                attribute,
+                name,
+                ?scope,
+                ?op,
+                "attribute recognized by msodbcsql but not implemented"
+            );
+            ERR_OPTIONAL_FEATURE_NOT_IMPLEMENTED
+        }
+        None => {
+            tracing::error!(attribute, ?scope, ?op, "unrecognized attribute identifier");
+            ERR_INVALID_ATTRIBUTE_IDENTIFIER
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::sqlstate::{SQLSTATE_HY092, SQLSTATE_HYC00};
+
+    const SCOPES: [AttrScope; 2] = [AttrScope::Dbc, AttrScope::Stmt];
+    const OPS: [AttrOp; 2] = [AttrOp::Set, AttrOp::Get];
+
+    fn table_of(scope: AttrScope) -> &'static [AttrRow] {
+        match scope {
+            AttrScope::Dbc => DBC_ATTRS,
+            AttrScope::Stmt => STMT_ATTRS,
+        }
+    }
+
+    /// `binary_search_by_key` returns arbitrary answers on an unsorted slice,
+    /// so guard the invariant the lookup depends on. A regenerated table that
+    /// came out unsorted fails here rather than silently mis-answering. An
+    /// entry with no operation flags would be unreachable dead data.
+    #[test]
+    fn tables_are_sorted_unique_and_flagged() {
+        for scope in SCOPES {
+            let table = table_of(scope);
+            for pair in table.windows(2) {
+                assert!(
+                    pair[0].0 < pair[1].0,
+                    "{scope:?} table not strictly ascending at {} -> {}",
+                    pair[0].0,
+                    pair[1].0
+                );
+            }
+            for &(id, name, ops) in table {
+                assert!(ops & (OP_SET | OP_GET) != 0, "{name} ({id}) has no ops");
+                assert!(ops & !(OP_SET | OP_GET) == 0, "{name} ({id}) has junk ops");
+            }
+        }
+    }
+
+    /// Every entry must resolve to its own name for at least one operation, and
+    /// must not resolve for an operation it is not flagged for.
+    #[test]
+    fn every_table_entry_round_trips() {
+        for scope in SCOPES {
+            for &(id, name, ops) in table_of(scope) {
+                for (op, bit) in [(AttrOp::Set, OP_SET), (AttrOp::Get, OP_GET)] {
+                    let got = native_attr_name(scope, op, id);
+                    if ops & bit != 0 {
+                        assert_eq!(got, Some(name), "{name} ({id}) {op:?}");
+                    } else {
+                        assert_eq!(got, None, "{name} ({id}) {op:?}");
+                    }
+                }
+            }
+        }
+    }
+
+    /// The overlapping vendor ranges are the reason lookup is scope-keyed.
+    #[test]
+    fn vendor_ranges_resolve_per_scope() {
+        assert_eq!(
+            native_attr_name(AttrScope::Dbc, AttrOp::Set, 1225),
+            Some("SQL_COPT_SS_FAILOVER_PARTNER")
+        );
+        assert_eq!(
+            native_attr_name(AttrScope::Stmt, AttrOp::Set, 1225),
+            Some("SQL_SOPT_SS_TEXTPTR_LOGGING")
+        );
+        assert_eq!(
+            native_attr_name(AttrScope::Dbc, AttrOp::Get, 10001),
+            Some("SQL_ATTR_AUTO_IPD")
+        );
+        assert_eq!(native_attr_name(AttrScope::Stmt, AttrOp::Get, 10001), None);
+    }
+
+    /// The ODBC 2.x statement options are settable on a connection but not
+    /// readable back - the asymmetry that forced the per-operation flag.
+    #[test]
+    fn statement_options_on_a_connection_are_set_only() {
+        for id in [0, 1, 2, 3, 5, 6, 7, 8, 10, 11, 12, 29] {
+            assert!(
+                native_attr_name(AttrScope::Dbc, AttrOp::Set, id).is_some(),
+                "id {id} should be settable on a connection"
+            );
+            assert_eq!(
+                native_attr_name(AttrScope::Dbc, AttrOp::Get, id),
+                None,
+                "id {id} should not be readable from a connection"
+            );
+        }
+    }
+
+    /// Connection attributes on a statement, and vice versa, are `HY092` in
+    /// msodbcsql. Measured, not assumed.
+    #[test]
+    fn cross_scope_identifiers_are_unknown() {
+        for op in OPS {
+            // SQL_ATTR_CURRENT_CATALOG / SQL_ATTR_TXN_ISOLATION are dbc-only.
+            assert!(native_attr_name(AttrScope::Stmt, op, 109).is_none());
+            assert!(native_attr_name(AttrScope::Stmt, op, 108).is_none());
+            // The descriptor handles and rowset controls are stmt-only.
+            assert!(native_attr_name(AttrScope::Dbc, op, 10010).is_none());
+            assert!(native_attr_name(AttrScope::Dbc, op, 27).is_none());
+            // SQL_ATTR_ENLIST_IN_DTC is dbc-only despite the shared range.
+            assert!(native_attr_name(AttrScope::Stmt, op, 1207).is_none());
+        }
+        assert!(native_attr_name(AttrScope::Dbc, AttrOp::Set, 1207).is_some());
+    }
+
+    /// Environment attributes never reach the driver, so neither table claims
+    /// them: SQL_ATTR_ODBC_VERSION (200), SQL_ATTR_CONNECTION_POOLING (201),
+    /// SQL_ATTR_CP_MATCH (202).
+    #[test]
+    fn environment_attributes_are_absent_from_both_tables() {
+        for id in [200, 201, 202] {
+            for scope in SCOPES {
+                for op in OPS {
+                    assert!(native_attr_name(scope, op, id).is_none(), "id {id}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn known_identifier_maps_to_hyc00() {
+        // SQL_COPT_SS_MARS_ENABLED: recognized by msodbcsql either way.
+        assert_eq!(
+            unimplemented_attr_diag(AttrScope::Dbc, AttrOp::Set, 1224).state,
+            SQLSTATE_HYC00
+        );
+        assert_eq!(
+            unimplemented_attr_diag(AttrScope::Dbc, AttrOp::Get, 1224).state,
+            SQLSTATE_HYC00
+        );
+        // SQL_SOPT_SS_DEFER_PREPARE on a statement.
+        assert_eq!(
+            unimplemented_attr_diag(AttrScope::Stmt, AttrOp::Set, 1232).state,
+            SQLSTATE_HYC00
+        );
+    }
+
+    #[test]
+    fn unknown_identifier_maps_to_hy092() {
+        for scope in SCOPES {
+            for op in OPS {
+                assert_eq!(
+                    unimplemented_attr_diag(scope, op, 99999).state,
+                    SQLSTATE_HY092
+                );
+            }
+        }
+    }
+
+    /// A set-only identifier must still report `HY092` on the get path, so the
+    /// diagnostic follows the flag rather than mere table membership.
+    #[test]
+    fn set_only_identifier_maps_to_hy092_on_get() {
+        assert_eq!(
+            unimplemented_attr_diag(AttrScope::Dbc, AttrOp::Set, 1).state,
+            SQLSTATE_HYC00
+        );
+        assert_eq!(
+            unimplemented_attr_diag(AttrScope::Dbc, AttrOp::Get, 1).state,
+            SQLSTATE_HY092
+        );
+    }
+
+    /// `attrs_before` forwards arbitrary integers, so no identifier may panic
+    /// and every one must classify. A full `i32` sweep is too slow for a unit
+    /// test; the boundaries plus a stride over the populated region cover the
+    /// interesting shape.
+    #[test]
+    fn every_identifier_classifies_without_panicking() {
+        let probes = [SqlInteger::MIN, SqlInteger::MIN + 1, -1, 0]
+            .into_iter()
+            .chain((0..12_000).step_by(7))
+            .chain([SqlInteger::MAX - 1, SqlInteger::MAX]);
+        for id in probes {
+            for scope in SCOPES {
+                for op in OPS {
+                    let expected = if native_attr_name(scope, op, id).is_some() {
+                        SQLSTATE_HYC00
+                    } else {
+                        SQLSTATE_HY092
+                    };
+                    assert_eq!(
+                        unimplemented_attr_diag(scope, op, id).state,
+                        expected,
+                        "id {id} {scope:?} {op:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Negative identifiers are reachable from Python, whose `attrs_before`
+    /// keys are unbounded ints, and must never be treated as recognized.
+    #[test]
+    fn negative_identifiers_are_unknown() {
+        for id in [-1, -1000, SqlInteger::MIN] {
+            for scope in SCOPES {
+                for op in OPS {
+                    assert!(native_attr_name(scope, op, id).is_none(), "id {id}");
+                }
+            }
+        }
+    }
+}

--- a/mssql-odbc/src/api/attributes.rs
+++ b/mssql-odbc/src/api/attributes.rs
@@ -178,7 +178,7 @@ static DBC_ATTRS: &[AttrRow] = &[
     (1249, "SQL_COPT_SS_TNIR", OP_SET | OP_GET),
     (1250, "SQL_COPT_SS_COLUMN_ENCRYPTION", OP_SET | OP_GET),
     (1251, "SQL_COPT_SS_CEKEYSTOREPROVIDER", OP_SET | OP_GET),
-    (1252, "SQL_COPT_SS_CEKEYSTOREDATA", OP_SET),
+    (1252, "SQL_COPT_SS_CEKEYSTOREDATA", OP_SET | OP_GET),
     (1253, "SQL_COPT_SS_TRUSTEDCMKPATHS", OP_SET | OP_GET),
     (1254, "SQL_COPT_SS_CEKCACHETTL", OP_SET | OP_GET),
     (1255, "SQL_COPT_SS_AUTHENTICATION", OP_SET | OP_GET),
@@ -403,6 +403,34 @@ mod tests {
         }
     }
 
+    /// Both halves of `SQL_COPT_SS_CEKEYSTOREDATA` are recognized. The sweep
+    /// could not measure this pair: the set probe faults msodbcsql, so the
+    /// process died before reaching the get probe and the id was first recorded
+    /// as set-only. Measured afterwards one id per process - set faults (which
+    /// is itself proof of recognition) and get answers `HY010`, "no keystore
+    /// provider selected". Neither is `HY092`, so both flags belong here and a
+    /// caller probing for Always Encrypted gets `HYC00` on both paths.
+    #[test]
+    fn keystore_data_is_recognized_for_both_operations() {
+        for op in OPS {
+            assert_eq!(
+                native_attr_name(AttrScope::Dbc, op, 1252),
+                Some("SQL_COPT_SS_CEKEYSTOREDATA"),
+                "1252 must be recognized for {op:?}"
+            );
+        }
+    }
+
+    /// The sibling crasher, for contrast: `SQL_ATTR_ENLIST_IN_DTC` faults the
+    /// same way on set but genuinely answers `HY092` on get, so its set-only
+    /// flag survived re-measurement. Guards against "flag every crasher for
+    /// both operations" as an over-correction.
+    #[test]
+    fn enlist_in_dtc_stays_set_only() {
+        assert!(native_attr_name(AttrScope::Dbc, AttrOp::Set, 1207).is_some());
+        assert_eq!(native_attr_name(AttrScope::Dbc, AttrOp::Get, 1207), None);
+    }
+
     /// Connection attributes on a statement, and vice versa, are `HY092` in
     /// msodbcsql. Measured, not assumed.
     #[test]
@@ -417,7 +445,6 @@ mod tests {
             // SQL_ATTR_ENLIST_IN_DTC is dbc-only despite the shared range.
             assert!(native_attr_name(AttrScope::Stmt, op, 1207).is_none());
         }
-        assert!(native_attr_name(AttrScope::Dbc, AttrOp::Set, 1207).is_some());
     }
 
     /// Environment attributes never reach the driver, so neither table claims

--- a/mssql-odbc/src/api/get_connect_attr.rs
+++ b/mssql-odbc/src/api/get_connect_attr.rs
@@ -15,6 +15,7 @@ use tracing::{debug, error};
 
 use super::current_catalog::get_current_catalog;
 use super::sqlstate::*;
+use crate::api::attributes::{AttrOp, AttrScope, unimplemented_attr_diag};
 use crate::api::odbc_types::{
     SQL_ATTR_ACCESS_MODE, SQL_ATTR_AUTOCOMMIT, SQL_ATTR_CONNECTION_DEAD,
     SQL_ATTR_CONNECTION_TIMEOUT, SQL_ATTR_CURRENT_CATALOG, SQL_ATTR_LOGIN_TIMEOUT,
@@ -194,18 +195,19 @@ fn sql_get_connect_attr_w_safe(
             debug!(value, "SQLGetConnectAttrW: connection-dead returned");
             SQL_SUCCESS
         }
-        // Any other attribute identifier is not one this driver knows: surface
-        // HY092 instead of claiming success while leaving the caller's buffer
-        // untouched. `SQL_ATTR_ANSI_APP` lands here deliberately — the Driver
-        // Manager sets it and ODBC defines no way to read it back, and so does
+        // Any other identifier is not one this driver reports: surface a
+        // diagnostic rather than claiming success while leaving the caller's
+        // buffer untouched. Which diagnostic depends on whether msodbcsql
+        // recognizes the identifier *on the get path* — recognition is not
+        // symmetric. `SQL_ATTR_ANSI_APP` lands here deliberately (the Driver
+        // Manager sets it and ODBC defines no way to read it back), and so does
         // `SQL_ATTR_QUERY_TIMEOUT`, which msodbcsql accepts on a connection but
-        // refuses to report back.
+        // refuses to report back; both stay `HY092`. See `attributes.rs`.
         _ => {
-            error!(
-                attribute,
-                "SQLGetConnectAttrW: unsupported connection attribute"
+            post_diag(
+                &mut state,
+                unimplemented_attr_diag(AttrScope::Dbc, AttrOp::Get, attribute),
             );
-            post_diag(&mut state, ERR_INVALID_ATTRIBUTE_IDENTIFIER);
             SQL_ERROR
         }
     }
@@ -397,6 +399,30 @@ mod tests {
             )
         };
         assert_eq!(get, SQL_ERROR);
+    }
+
+    /// `SQL_COPT_SS_MARS_ENABLED` (1224) is readable from msodbcsql, so a
+    /// caller probing for MARS must get `HYC00` here rather than `HY092`.
+    /// Contrast `query_timeout_is_write_only_on_a_connection`: msodbcsql's
+    /// recognized set is not the same for the set and get paths, so the lookup
+    /// is keyed by operation as well as scope.
+    #[test]
+    fn attribute_known_to_msodbcsql_reports_not_implemented() {
+        let h = TestHandles::with_env_dbc();
+        let mut out: u32 = 0;
+        let get = unsafe {
+            sql_get_connect_attr_w(
+                h.dbc,
+                1224,
+                &mut out as *mut u32 as SqlPointer,
+                0,
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(get, SQL_ERROR);
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        let state = dbc.inner.lock().unwrap();
+        assert_eq!(state.diag_records[0].sql_state, SQLSTATE_HYC00);
     }
 
     #[test]

--- a/mssql-odbc/src/api/mod.rs
+++ b/mssql-odbc/src/api/mod.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 pub(crate) mod alloc_handle;
+mod attributes;
 mod bind_col;
 mod bind_param;
 mod catalog;

--- a/mssql-odbc/src/api/set_connect_attr.rs
+++ b/mssql-odbc/src/api/set_connect_attr.rs
@@ -16,6 +16,7 @@ use super::current_catalog::set_current_catalog;
 use super::set_stmt_attr::clamp_query_timeout;
 use super::sqlstate::*;
 use super::txn::{reset_connection, set_autocommit, set_txn_isolation};
+use crate::api::attributes::{AttrOp, AttrScope, unimplemented_attr_diag};
 use crate::api::odbc_types::{
     SQL_ATTR_ACCESS_MODE, SQL_ATTR_ANSI_APP, SQL_ATTR_AUTOCOMMIT, SQL_ATTR_CONNECTION_TIMEOUT,
     SQL_ATTR_CURRENT_CATALOG, SQL_ATTR_LOGIN_TIMEOUT, SQL_ATTR_PACKET_SIZE, SQL_ATTR_QUERY_TIMEOUT,
@@ -224,17 +225,15 @@ unsafe fn sql_set_connect_attr_w_impl(
         // Set by the Driver Manager only, and not retrievable, so nothing to
         // store.
         SQL_ATTR_ANSI_APP => SQL_SUCCESS,
-        // Any other attribute identifier is not one this driver knows. msodbcsql
-        // answers HY092 ("invalid attribute/option identifier") here rather than
-        // HYC00, and the Driver Manager relies on that to tell "you named
-        // something that isn't an attribute" apart from "that attribute exists
-        // but I can't do it".
+        // Any other identifier is one this driver does not act on. Which
+        // diagnostic that earns depends on whether msodbcsql recognizes it:
+        // `HYC00` when it does, so a caller can tell "unavailable here" from
+        // "not an attribute", and `HY092` when it does not. See `attributes.rs`.
         _ => {
-            error!(
-                attribute,
-                "SQLSetConnectAttrW: unsupported connection attribute"
+            post_diag(
+                &mut state,
+                unimplemented_attr_diag(AttrScope::Dbc, AttrOp::Set, attribute),
             );
-            post_diag(&mut state, ERR_INVALID_ATTRIBUTE_IDENTIFIER);
             SQL_ERROR
         }
     }
@@ -454,6 +453,46 @@ mod tests {
         // attribute/option identifier") here, not HYC00. (1234 would be a poor
         // choice: it is a real undocumented SQL_COPT_SS_* id msodbcsql accepts.)
         let ret = unsafe { sql_set_connect_attr_w(h.dbc, 99999, std::ptr::null_mut(), 0) };
+        assert_eq!(ret, SQL_ERROR);
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        let state = dbc.inner.lock().unwrap();
+        assert_eq!(state.diag_records[0].sql_state, SQLSTATE_HY092);
+    }
+
+    /// `SQL_COPT_SS_MARS_ENABLED` (1224) is a real msodbcsql connection
+    /// attribute this driver does not implement, so it must report `HYC00`.
+    /// `attrs_before` forwards identifiers unfiltered, and a caller probing for
+    /// MARS has to be able to tell "not available" from "not an attribute".
+    #[test]
+    fn attribute_known_to_msodbcsql_reports_not_implemented() {
+        let h = TestHandles::with_env_dbc();
+        let ret = unsafe { sql_set_connect_attr_w(h.dbc, 1224, std::ptr::null_mut(), 0) };
+        assert_eq!(ret, SQL_ERROR);
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        let state = dbc.inner.lock().unwrap();
+        assert_eq!(state.diag_records[0].sql_state, SQLSTATE_HYC00);
+    }
+
+    /// A statement attribute aimed at a connection is `HYC00`, not `HY092`:
+    /// msodbcsql accepts the ODBC 2.x statement options here and fans them out
+    /// to every statement (`SQL_ATTR_MAX_ROWS` = 1). This driver implements the
+    /// fan-out only for `SQL_ATTR_QUERY_TIMEOUT`.
+    #[test]
+    fn statement_option_on_a_connection_reports_not_implemented() {
+        let h = TestHandles::with_env_dbc();
+        let ret = unsafe { sql_set_connect_attr_w(h.dbc, 1, 10 as SqlPointer, 0) };
+        assert_eq!(ret, SQL_ERROR);
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        let state = dbc.inner.lock().unwrap();
+        assert_eq!(state.diag_records[0].sql_state, SQLSTATE_HYC00);
+    }
+
+    /// A statement-only identifier msodbcsql rejects on a connection stays
+    /// `HY092`. `SQL_ATTR_ROW_ARRAY_SIZE` (27) is outside the fan-out band.
+    #[test]
+    fn statement_only_attribute_on_a_connection_stays_invalid() {
+        let h = TestHandles::with_env_dbc();
+        let ret = unsafe { sql_set_connect_attr_w(h.dbc, 27, 10 as SqlPointer, 0) };
         assert_eq!(ret, SQL_ERROR);
         let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
         let state = dbc.inner.lock().unwrap();

--- a/mssql-odbc/src/api/set_stmt_attr.rs
+++ b/mssql-odbc/src/api/set_stmt_attr.rs
@@ -24,6 +24,7 @@
 
 use tracing::{debug, error};
 
+use crate::api::attributes::{AttrOp, AttrScope, unimplemented_attr_diag};
 use crate::api::odbc_types::{
     MAX_QUERY_TIMEOUT, SQL_ATTR_APP_PARAM_DESC, SQL_ATTR_APP_ROW_DESC, SQL_ATTR_CONCURRENCY,
     SQL_ATTR_CURSOR_TYPE, SQL_ATTR_IMP_PARAM_DESC, SQL_ATTR_IMP_ROW_DESC, SQL_ATTR_PARAM_BIND_TYPE,
@@ -34,8 +35,8 @@ use crate::api::odbc_types::{
     SQL_SUCCESS_WITH_INFO, SqlHandle, SqlInteger, SqlPointer, SqlReturn, SqlULen, SqlUSmallInt,
 };
 use crate::api::sqlstate::{
-    ERR_FUNCTION_SEQUENCE, ERR_INVALID_ATTRIBUTE_IDENTIFIER, ERR_INVALID_ATTRIBUTE_VALUE,
-    SQLSTATE_01S02, SQLSTATE_HYC00, WARN_OPTION_VALUE_CHANGED, post_diag,
+    ERR_FUNCTION_SEQUENCE, ERR_INVALID_ATTRIBUTE_VALUE, SQLSTATE_01S02, SQLSTATE_HYC00,
+    WARN_OPTION_VALUE_CHANGED, post_diag,
 };
 use crate::api::util::write_if_some;
 use crate::error::{free_errors, post_sql_error};
@@ -254,11 +255,10 @@ fn sql_set_stmt_attr_w_safe(
             SQL_SUCCESS
         }
         _ => {
-            error!(
-                attribute,
-                "SQLSetStmtAttrW: unrecognized attribute identifier"
+            post_diag(
+                &mut state,
+                unimplemented_attr_diag(AttrScope::Stmt, AttrOp::Set, attribute),
             );
-            post_diag(&mut state, ERR_INVALID_ATTRIBUTE_IDENTIFIER);
             SQL_ERROR
         }
     }
@@ -371,11 +371,10 @@ fn sql_get_stmt_attr_w_safe(
             write_if_some(value_ptr as *mut SqlHandle, stmt.ipd);
         },
         _ => {
-            error!(
-                attribute,
-                "SQLGetStmtAttrW: unrecognized attribute identifier"
+            post_diag(
+                &mut state,
+                unimplemented_attr_diag(AttrScope::Stmt, AttrOp::Get, attribute),
             );
-            post_diag(&mut state, ERR_INVALID_ATTRIBUTE_IDENTIFIER);
             return SQL_ERROR;
         }
     }
@@ -387,6 +386,7 @@ fn sql_get_stmt_attr_w_safe(
 mod tests {
     use super::*;
     use crate::api::odbc_types::{SQL_BIND_BY_COLUMN, SQL_NULL_HANDLE};
+    use crate::api::sqlstate::SQLSTATE_HY092;
     use crate::handles::handle_from_raw;
     use crate::test_support::TestHandles;
 
@@ -401,6 +401,15 @@ mod tests {
             )
         };
         assert_eq!(ret, SQL_INVALID_HANDLE);
+    }
+
+    /// Reads the SQLSTATE of the newest diagnostic on a statement. Must be
+    /// called before any `sql_get_stmt_attr_w` helper, which frees diagnostics
+    /// on entry.
+    fn stmt_sql_state(stmt: SqlHandle) -> [u8; 5] {
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(stmt) };
+        let state = stmt.inner.lock().unwrap();
+        state.diag_records[0].sql_state
     }
 
     /// Reads `SQL_ATTR_QUERY_TIMEOUT` back off a statement.
@@ -610,6 +619,47 @@ mod tests {
         let h = TestHandles::with_env_dbc_stmt();
         let ret = unsafe { sql_set_stmt_attr_w(h.stmt, 9999, 0 as SqlPointer, 0) };
         assert_eq!(ret, SQL_ERROR);
+        assert_eq!(stmt_sql_state(h.stmt), SQLSTATE_HY092);
+    }
+
+    /// An identifier msodbcsql implements but this driver does not must report
+    /// `HYC00`, not `HY092`: a caller probing for the feature has to be able to
+    /// tell "unavailable" from "not an attribute". `SQL_SOPT_SS_DEFER_PREPARE`
+    /// (1232) is a statement attribute msodbcsql honors.
+    #[test]
+    fn set_attribute_known_to_msodbcsql_reports_not_implemented() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let ret = unsafe { sql_set_stmt_attr_w(h.stmt, 1232, 0 as SqlPointer, 0) };
+        assert_eq!(ret, SQL_ERROR);
+        assert_eq!(stmt_sql_state(h.stmt), SQLSTATE_HYC00);
+    }
+
+    #[test]
+    fn get_attribute_known_to_msodbcsql_reports_not_implemented() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let mut out: SqlULen = 7;
+        let ret = unsafe {
+            sql_get_stmt_attr_w(
+                h.stmt,
+                1232,
+                (&mut out as *mut SqlULen).cast(),
+                0,
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(ret, SQL_ERROR);
+        assert_eq!(stmt_sql_state(h.stmt), SQLSTATE_HYC00);
+    }
+
+    /// A connection attribute aimed at a statement stays `HY092`; the tables are
+    /// scope-keyed precisely so this does not soften to `HYC00`.
+    /// `SQL_ATTR_CURRENT_CATALOG` (109) is connection-only.
+    #[test]
+    fn connection_attribute_on_a_statement_stays_invalid() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let ret = unsafe { sql_set_stmt_attr_w(h.stmt, 109, 0 as SqlPointer, 0) };
+        assert_eq!(ret, SQL_ERROR);
+        assert_eq!(stmt_sql_state(h.stmt), SQLSTATE_HY092);
     }
 
     #[test]

--- a/mssql-odbc/tests/e2e/tests/attributes_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/attributes_test.cpp
@@ -35,6 +35,16 @@
 //   22. SetCurrentCatalogQuotesIdentifier  - injection attempt stays one name
 //   23. PreConnectDefaultCatalogIsNotASentinel - "(Default)" only means
 //                                            "no change" once connected
+//
+// Attribute rejection policy:
+//   24. UnknownStatementAttributeIsInvalidIdentifier   - HY092
+//   25. UnknownConnectionAttributeIsInvalidIdentifier  - HY092
+//   26. StatementOnlyAttributeIsRejectedOnAConnection  - scope-keyed HY092
+//   27. ConnectionOnlyAttributeIsRejectedOnAStatement  - the mirror image
+//   28. RowNumberIsNotSettable                         - operation-keyed HY092
+//   29. UnimplementedStatementAttributeIsNotImplemented- HYC00, not HY092
+//   30. UnimplementedConnectionAttributeIsNotImplemented - HYC00 on the get path
+//   31. HostileAttributePayloadDoesNotFault            - HYC00, session survives
 
 #include "odbc_test_fixture.h"
 
@@ -52,6 +62,40 @@ constexpr SQLULEN kMaxQueryTimeout = 0xfffe;
 
 // SQL Server's sysname limit; longer catalog names are rejected outright.
 constexpr size_t kSysnameLen = 128;
+
+// -- attribute identifiers used only to exercise the rejection policy --------
+//
+// Values measured against msodbcsql 18 rather than assumed; see
+// `docs/attributes_plan.md` §8 for the sweep that produced them.
+
+// Not an attribute in any scope. Both drivers must answer HY092.
+constexpr SQLINTEGER kUnknownAttribute = 99999;
+
+// Statement-only. msodbcsql's connection switch has no arm for it, because it
+// falls outside the ODBC 2.x statement-option fan-out band (0-12, 29).
+constexpr SQLINTEGER kRowArraySizeAttr = 27;
+
+// Connection-only (SQL_ATTR_ENLIST_IN_DTC). Rejected on a statement handle.
+constexpr SQLINTEGER kEnlistInDtcAttr = 1207;
+
+// SQL_ATTR_NOSCAN - a real statement attribute msodbcsql implements and this
+// driver does not yet, so the two legs diverge by design.
+constexpr SQLINTEGER kNoScanAttr = 2;
+
+// SQL_ATTR_ROW_NUMBER - readable but not settable on msodbcsql, which makes it
+// the statement-side mirror of the connection-side SQL_ATTR_QUERY_TIMEOUT
+// asymmetry that Variation 13 pins down.
+constexpr SQLINTEGER kRowNumberAttr = 14;
+
+// SQL_COPT_SS_MARS_ENABLED - readable on msodbcsql. MARS is a deferred feature
+// here (plan §4.12), and "is MARS available?" is exactly the question a caller
+// needs a distinguishable answer to.
+constexpr SQLINTEGER kMarsEnabledAttr = 1224;
+
+// SQL_COPT_SS_CEKEYSTOREDATA - msodbcsql dereferences the pointer as a struct
+// without validating it, so a caller passing a plain buffer faults the process.
+// This driver must refuse it cleanly instead.
+constexpr SQLINTEGER kCekeystoreDataAttr = 1252;
 
 } // namespace
 
@@ -499,4 +543,133 @@ TEST_F(AttributesTest, PreConnectDefaultCatalogIsNotASentinel) {
         SQLDisconnect(dbc);
     }
     SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+}
+
+// ===========================================================================
+// Attribute rejection policy (§4.10 pass-through hardening)
+//
+// mssql-python forwards arbitrary identifiers through `attrs_before` and
+// `set_attr` without filtering, so the answer to "is this an attribute at all?"
+// is part of the contract. Variations 24-28 are pure parity: both drivers must
+// agree. Variations 29-31 assert behavior that is deliberately this driver's
+// own, because msodbcsql implements the attribute (or faults on it).
+// ===========================================================================
+
+// -------------------------------------------------------------------
+// Variation 24 - an identifier that is not an attribute in any scope is
+// HY092 on a statement, on both drivers.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, UnknownStatementAttributeIsInvalidIdentifier) {
+    EXPECT_EQ(SQL_ERROR,
+              SQLSetStmtAttr(stmt_, kUnknownAttribute,
+                             reinterpret_cast<SQLPOINTER>(1), 0));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "HY092");
+
+    SQLULEN out = 0;
+    EXPECT_EQ(SQL_ERROR, SQLGetStmtAttr(stmt_, kUnknownAttribute, &out,
+                                        sizeof(out), nullptr));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "HY092");
+}
+
+// -------------------------------------------------------------------
+// Variation 25 - the same identifier on a connection. Asserted after
+// connect: before connect the Driver Manager buffers the call and the
+// driver never sees it, so pre-connect proves nothing about either.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, UnknownConnectionAttributeIsInvalidIdentifier) {
+    EXPECT_EQ(SQL_ERROR,
+              SQLSetConnectAttr(dbc_, kUnknownAttribute,
+                                reinterpret_cast<SQLPOINTER>(1), 0));
+    EXPECT_SQLSTATE(SQL_HANDLE_DBC, dbc_, "HY092");
+
+    SQLULEN out = 0;
+    EXPECT_EQ(SQL_ERROR, SQLGetConnectAttr(dbc_, kUnknownAttribute, &out,
+                                           sizeof(out), nullptr));
+    EXPECT_SQLSTATE(SQL_HANDLE_DBC, dbc_, "HY092");
+}
+
+// -------------------------------------------------------------------
+// Variation 26 - recognition is scoped. SQL_ATTR_ROW_ARRAY_SIZE is a real
+// statement attribute, but it sits outside the ODBC 2.x statement-option
+// band that msodbcsql fans out from a connection, so on a connection it is
+// as unknown as garbage.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, StatementOnlyAttributeIsRejectedOnAConnection) {
+    EXPECT_EQ(SQL_ERROR,
+              SQLSetConnectAttr(dbc_, kRowArraySizeAttr,
+                                reinterpret_cast<SQLPOINTER>(10), 0));
+    EXPECT_SQLSTATE(SQL_HANDLE_DBC, dbc_, "HY092");
+}
+
+// -------------------------------------------------------------------
+// Variation 27 - the mirror image: a connection-only attribute on a
+// statement handle. Vendor ranges overlap between the two scopes, so this
+// is the case a flat identifier table would get wrong.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, ConnectionOnlyAttributeIsRejectedOnAStatement) {
+    EXPECT_EQ(SQL_ERROR,
+              SQLSetStmtAttr(stmt_, kEnlistInDtcAttr,
+                             reinterpret_cast<SQLPOINTER>(0), 0));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "HY092");
+}
+
+// -------------------------------------------------------------------
+// Variation 28 - recognition is keyed by operation as well as scope.
+// SQL_ATTR_ROW_NUMBER is readable but not settable, so the set path
+// rejects an identifier the get path accepts.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, RowNumberIsNotSettable) {
+    EXPECT_EQ(SQL_ERROR,
+              SQLSetStmtAttr(stmt_, kRowNumberAttr,
+                             reinterpret_cast<SQLPOINTER>(1), 0));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "HY092");
+}
+
+// -------------------------------------------------------------------
+// Variation 29 - a statement attribute msodbcsql implements and this
+// driver does not: HYC00, so a caller can tell "unavailable here" from
+// "never an attribute". msodbcsql returns success, hence the skip.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, UnimplementedStatementAttributeIsNotImplemented) {
+    SKIP_IF_COMPARING_MSODBCSQL();
+
+    EXPECT_EQ(SQL_ERROR,
+              SQLSetStmtAttr(stmt_, kNoScanAttr,
+                             reinterpret_cast<SQLPOINTER>(0), 0));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "HYC00");
+}
+
+// -------------------------------------------------------------------
+// Variation 30 - the connection-side equivalent, on the get path. MARS is
+// deferred here, so a caller probing for it gets "not implemented" rather
+// than "no such attribute" and can fall back deliberately.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, UnimplementedConnectionAttributeIsNotImplemented) {
+    SKIP_IF_COMPARING_MSODBCSQL();
+
+    SQLULEN out = 0;
+    EXPECT_EQ(SQL_ERROR, SQLGetConnectAttr(dbc_, kMarsEnabledAttr, &out,
+                                           sizeof(out), nullptr));
+    EXPECT_SQLSTATE(SQL_HANDLE_DBC, dbc_, "HYC00");
+}
+
+// -------------------------------------------------------------------
+// Variation 31 - msodbcsql reads SQL_COPT_SS_CEKEYSTOREDATA as a struct
+// with no validation and faults on a plain buffer. Refusing it is the
+// whole point of routing unimplemented identifiers through a table
+// instead of a pointer read, so this runs on this driver only - the
+// msodbcsql leg would take down the test binary.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, HostileAttributePayloadDoesNotFault) {
+    SKIP_IF_COMPARING_MSODBCSQL();
+
+    unsigned char payload[8] = {};
+    EXPECT_EQ(SQL_ERROR,
+              SQLSetConnectAttr(dbc_, kCekeystoreDataAttr, payload,
+                                sizeof(payload)));
+    EXPECT_SQLSTATE(SQL_HANDLE_DBC, dbc_, "HYC00");
+
+    // Still usable afterwards: a rejected attribute must not disturb the
+    // session.
+    EXPECT_FALSE(DbName().empty());
 }

--- a/mssql-odbc/tests/e2e/tests/attributes_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/attributes_test.cpp
@@ -45,6 +45,7 @@
 //   29. UnimplementedStatementAttributeIsNotImplemented- HYC00, not HY092
 //   30. UnimplementedConnectionAttributeIsNotImplemented - HYC00 on the get path
 //   31. HostileAttributePayloadDoesNotFault            - HYC00, session survives
+//   32. KeystoreDataGetIsRecognizedNotUnknown          - recognized on both, never HY092
 
 #include "odbc_test_fixture.h"
 
@@ -92,9 +93,10 @@ constexpr SQLINTEGER kRowNumberAttr = 14;
 // needs a distinguishable answer to.
 constexpr SQLINTEGER kMarsEnabledAttr = 1224;
 
-// SQL_COPT_SS_CEKEYSTOREDATA - msodbcsql dereferences the pointer as a struct
-// without validating it, so a caller passing a plain buffer faults the process.
-// This driver must refuse it cleanly instead.
+// SQL_COPT_SS_CEKEYSTOREDATA - on the set path msodbcsql dereferences the
+// pointer as a struct without validating it, so a caller passing a plain buffer
+// faults the process. This driver must refuse it cleanly instead. The get path
+// is safe on both and answers HY010 there, so it is asserted on both drivers.
 constexpr SQLINTEGER kCekeystoreDataAttr = 1252;
 
 } // namespace
@@ -552,7 +554,9 @@ TEST_F(AttributesTest, PreConnectDefaultCatalogIsNotASentinel) {
 // `set_attr` without filtering, so the answer to "is this an attribute at all?"
 // is part of the contract. Variations 24-28 are pure parity: both drivers must
 // agree. Variations 29-31 assert behavior that is deliberately this driver's
-// own, because msodbcsql implements the attribute (or faults on it).
+// own, because msodbcsql implements the attribute (or faults on it). Variation
+// 32 runs on both but expects a different SQLSTATE from each, asserting only
+// the shared half of the contract: a recognized id is never HY092.
 // ===========================================================================
 
 // -------------------------------------------------------------------
@@ -671,5 +675,36 @@ TEST_F(AttributesTest, HostileAttributePayloadDoesNotFault) {
 
     // Still usable afterwards: a rejected attribute must not disturb the
     // session.
+    EXPECT_FALSE(DbName().empty());
+}
+
+// -------------------------------------------------------------------
+// Variation 32 - the get half of the same identifier. This one does run
+// on both drivers: msodbcsql only faults on the set path, and answers the
+// get with HY010 ("function sequence error" - no keystore provider has
+// been selected). The states differ, but the contract this table exists
+// to enforce is the one both must satisfy: 1252 is a real attribute, so
+// neither driver may claim it does not exist.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, KeystoreDataGetIsRecognizedNotUnknown) {
+    unsigned char out[64] = {};
+    SQLINTEGER written = 0;
+    EXPECT_EQ(SQL_ERROR, SQLGetConnectAttr(dbc_, kCekeystoreDataAttr, out,
+                                           sizeof(out), &written));
+
+    // The shared assertion: recognized, therefore not HY092.
+    const std::string state =
+        ODBCTestUtils::GetDiagState(SQL_HANDLE_DBC, dbc_);
+    EXPECT_NE("HY092", state);
+
+    const char* target = std::getenv("ODBC_TEST_TARGET");
+    if (target && std::string(target) == "msodbcsql") {
+        // No keystore provider selected, so the sequence is wrong.
+        EXPECT_EQ("HY010", state);
+    } else {
+        // Always Encrypted is deferred, so the feature is what is missing.
+        EXPECT_EQ("HYC00", state);
+    }
+
     EXPECT_FALSE(DbName().empty());
 }


### PR DESCRIPTION
Stacked on #348. Base is `dev/saurabh/odbc-attrs-timeout-catalog` — review that one first.

Implements **[AB#47453](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47453)**, part of [AB#46377](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46377).

## Problem

All four attribute entry points answered every unrecognized identifier with `HY092`. That conflates two different answers:

- *this driver does not implement that attribute* — try something else
- *that is not an attribute* — you have a bug

`mssql-python` forwards arbitrary identifiers straight through `attrs_before` and `set_attr` with no filtering (spec §4.10), so a caller probing for a feature has no way to tell those apart.

## Change

`src/api/attributes.rs` records which identifiers msodbcsql recognizes, keyed by **handle scope** and by **operation**. The catch-alls consult it:

| lookup | answer |
|---|---|
| msodbcsql knows it, in this scope, on this op | `HYC00` — not implemented |
| otherwise | `HY092` — not an attribute |

Supported attributes keep their existing `match` arms. The table sits *behind* them, so the later PRs in the stack shrink it as they implement attributes rather than rewriting dispatch.

## The rows are measured, not transcribed

A ctypes sweep drove 135 identifiers through all four entry points against a live msodbcsql 18, pre- and post-connect: **321 units, 513 rows**. Two results forced the shape of the table.

**Recognition is scope-keyed**, because the vendor ranges collide. `SQL_COPT_SS_*` and `SQL_SOPT_SS_*` both occupy 1225–1238, so `SQL_COPT_SS_FAILOVER_PARTNER` and `SQL_SOPT_SS_TEXTPTR_LOGGING` are both 1225; `SQL_ATTR_OUTPUT_NTS` and `SQL_ATTR_AUTO_IPD` are both 10001. A flat id map answers for the wrong scope.

**Recognition is also operation-keyed.** msodbcsql accepts the ODBC 2.x statement options on a *connection* and fans them out to every statement, but `SQLGetConnectAttrW` rejects those same ids:

```
post_connect set SQL_ATTR_QUERY_TIMEOUT -> SUCCESS_WITH_INFO 01S02
post_connect get SQL_ATTR_QUERY_TIMEOUT -> SQL_ERROR         HY092
```

A scope-only table would have softened `SQLGetConnectAttrW(SQL_ATTR_QUERY_TIMEOUT)` from `HY092` to `HYC00` and broken the contract #348 shipped. Hence the per-operation flag column rather than four tables.

Three further facts worth recording, all measured:

- **Pre-connect `SQLSetConnectAttrW` returns `SUCCESS` for any identifier**, garbage included — the Driver Manager buffers and replays it, so the driver never sees the call. Pre-connect rows prove nothing and are excluded.
- **Env attributes (200–202) answer `HY092` on both dbc and stmt.** The DM handles them; absent from both tables by construction.
- **Three identifiers hard-fault msodbcsql** — `SQL_ATTR_ENLIST_IN_DTC` / `SQL_COPT_SS_ENLIST_IN_DTC` (1207) and `SQL_COPT_SS_CEKEYSTOREDATA` (1252) on the connection set path. It reads them as structs with no validation, so a plain buffer takes the process down. Answering from a table instead of a pointer read is exactly what makes this driver immune; Variation 30 pins that down.

## Verification

Both legs run the same unmodified binary against a live SQL Server 2022.

| leg | result |
|---|---|
| `mssql-odbc dev` | **30/30 passed** |
| `ODBC Driver 18 for SQL Server` | **27/27 passed**, 3 skipped |

Variations 23–27 are pure parity and pass on **real msodbcsql** — that is what confirms the table rather than just confirming itself. 28–30 assert behavior that is deliberately ours (an attribute msodbcsql implements and we do not; input that faults it) and skip the comparison leg via `SKIP_IF_COMPARING_MSODBCSQL()`.

- `cargo bfmt` clean
- `cargo bclippy` clean
- **756 unit tests pass**
- **Diff coverage 99.02% (202/204)** — the two uncovered lines are `assert!` failure-message arguments, only evaluated when the assertion fails

## Scope note

The value-kind and phase columns from the original sketch are deferred to the PR that implements each attribute. Recognition is the part everything else depends on; how a given attribute parses its value belongs with that attribute.

`docs/attributes_plan.md` §8.1 documents how to re-measure the table when msodbcsql ships a new version.


