### PR TITLE
Implement remaining ODBC statement attributes (AB#47456)

### DIFF
--- a/mssql-odbc/docs/attributes_plan.md
+++ b/mssql-odbc/docs/attributes_plan.md
@@ -348,11 +348,11 @@ rejection and the `HY024`/native-911 mapping for a nonexistent database.
 
 ---
 
-### S4 — Remaining ODBC-standard statement attributes
+### S4 — Remaining ODBC-standard statement attributes — **shipped**
 
-> `mssql-odbc | Remaining ODBC statement attributes`
+> `mssql-odbc | Remaining ODBC statement attributes` (AB#47456)
 
-**Scope** — for each, either honor it or reject with msodbcsql's exact SQLSTATE;
+**Scope** — for each, either honor it or answer with msodbcsql's exact SQLSTATE;
 no silent success. Derived from `sqlcmisc.cpp:3508` case labels minus what already
 works and minus S2:
 
@@ -367,11 +367,66 @@ works and minus S2:
 
 Also closes the asymmetry where four attributes accept a set but reject the get
 (`PARAM_BIND_TYPE`, `PARAM_STATUS_PTR`, `PARAMS_PROCESSED_PTR`,
-`ROW_BIND_OFFSET_PTR`) — an app that writes then reads currently gets `HY092`.
+`ROW_BIND_OFFSET_PTR`) — an app that writes then reads previously got `HY092`.
 
-**Cross-story notes:** `SQL_ATTR_NOSCAN` must be readable by AB#46384;
-`SQL_ATTR_METADATA_ID` contradicts `catalog.rs:767`, which hardcodes "never TRUE"
-— either wire it through or document the divergence there.
+#### Measured contract
+
+Every row was measured against msodbcsql 18 with the §8 sweep plus targeted
+value probes; none of it was read out of `sqlext.h`, which documents the ODBC
+ideal rather than what this driver does.
+
+| id | attribute | default | behavior |
+|---|---|---|---|
+| 1 | `MAX_ROWS` | 0 | **enforced**: bounds each result set; 0 is unlimited |
+| 2 | `NOSCAN` | 0 | stored, round-trips |
+| 3 | `MAX_LENGTH` | 0 | 0 → success; non-zero → `01S02`, stored value becomes 8000 |
+| 4 | `ASYNC_ENABLE` | 0 | stored |
+| 8 | `KEYSET_SIZE` | 0 | 0 → success; non-zero → `01S02`, stays 0 |
+| 9 | `SQL_ROWSET_SIZE` | 1 | stored, **independent of `ROW_ARRAY_SIZE`** |
+| 10 | `SIMULATE_CURSOR` | `SQL_SC_UNIQUE` | only unique; otherwise `01S02`, unchanged |
+| 11 | `RETRIEVE_DATA` | `SQL_RD_ON` | stored |
+| 12 | `USE_BOOKMARKS` | 0 | stored |
+| 14 | `ROW_NUMBER` | — | get-only; `24000` unless positioned on a row, else 0 |
+| 15 | `ENABLE_AUTO_IPD` | 0 | stored |
+| 16–24 | bind/offset/status pointers | 0 | stored |
+| 10014 | `METADATA_ID` | 0 | stored |
+| -1 | `CURSOR_SCROLLABLE` | `SQL_NONSCROLLABLE` | the boolean face of `CURSOR_TYPE` |
+| -2 | `CURSOR_SENSITIVITY` | `SQL_INSENSITIVE` | `SQL_UNSPECIFIED` normalises to insensitive, silently |
+
+Four findings changed the implementation:
+
+- **The `MAX_ROWS` cutoff has to invalidate the row stream, not just return
+  `SQL_NO_DATA`.** Measured on msodbcsql, stopping at the cap leaves the cursor
+  in exactly the state it reaches at the natural end of a result set:
+  `SQL_ATTR_ROW_NUMBER` and `SQLGetData` both answer `24000`. Short-circuiting
+  the fetch before the row stream is reset would keep the previous row readable
+  past `SQL_NO_DATA`, so an application that loops on `SQLFetch` and then reads
+  columns would see one phantom row here and none on msodbcsql.
+- **`SQL_ATTR_ROW_NUMBER` is not unconditionally 0.** An earlier probe only read
+  it mid-fetch and saw 0. A full cursor-lifecycle probe showed `24000` with no
+  cursor, `24000` after execute but before the first fetch, 0 while positioned,
+  and `24000` again once the cursor is exhausted or closed. Returning a flat 0
+  would make "no cursor" indistinguishable from a real position.
+- **Four defaults are not 0** (`SQL_ROWSET_SIZE`, `SIMULATE_CURSOR`,
+  `RETRIEVE_DATA`, `CURSOR_SENSITIVITY`). An application that reads an attribute
+  to decide whether to change it takes a different branch on a driver that
+  answers a blanket 0.
+- **`HY024` on out-of-range values comes from the Driver Manager, not the
+  driver.** The DM range-checks the documented booleans and enums before
+  dispatch, so a driver-side rejection for those values is unreachable. Range
+  validation is therefore deliberately absent; the identifiers themselves do
+  reach the driver, which is also how `CURSOR_SCROLLABLE` is shown to alias
+  `CURSOR_TYPE` driver-side.
+
+**Known divergence:** `SQL_ATTR_CURSOR_SCROLLABLE = SQL_SCROLLABLE` succeeds on
+msodbcsql and reports `01S02` here, because scrollable cursors are a deferred
+feature. It is the same single divergence already recorded for
+`SQL_ATTR_CURSOR_TYPE`, since the two are one setting. Variation 40 asserts the
+shared invariant on both drivers and the per-driver state separately.
+
+**Cross-story notes:** `SQL_ATTR_NOSCAN` is now readable for AB#46384;
+`SQL_ATTR_METADATA_ID` is stored and round-trips, but `catalog.rs:767` still
+hardcodes "never TRUE" — wiring it into catalog-function matching is S5 work.
 
 **Size:** M. **Depends on:** S1.
 

--- a/mssql-odbc/docs/attributes_plan.md
+++ b/mssql-odbc/docs/attributes_plan.md
@@ -379,7 +379,7 @@ ideal rather than what this driver does.
 |---|---|---|---|
 | 1 | `MAX_ROWS` | 0 | **enforced**: bounds each result set; 0 is unlimited |
 | 2 | `NOSCAN` | 0 | stored, round-trips |
-| 3 | `MAX_LENGTH` | 0 | 0 → success; non-zero → `01S02`, stored value becomes 8000 |
+| 3 | `MAX_LENGTH` | 0 | 0 and 8000 → success; any other non-zero → `01S02` and the stored value is substituted with 8000 |
 | 4 | `ASYNC_ENABLE` | 0 | stored |
 | 8 | `KEYSET_SIZE` | 0 | 0 → success; non-zero → `01S02`, stays 0 |
 | 9 | `SQL_ROWSET_SIZE` | 1 | stored, **independent of `ROW_ARRAY_SIZE`** |
@@ -388,7 +388,9 @@ ideal rather than what this driver does.
 | 12 | `USE_BOOKMARKS` | 0 | stored |
 | 14 | `ROW_NUMBER` | — | get-only; `24000` unless positioned on a row, else 0 |
 | 15 | `ENABLE_AUTO_IPD` | 0 | stored |
-| 16–24 | bind/offset/status pointers | 0 | stored |
+| 17 | `PARAM_BIND_OFFSET_PTR` | 0 (null) | **enforced**: dereferenced at execute and added to both bound pointers |
+| 16, 18–21, 23–24 | bind/offset/status pointers | 0 | stored |
+| 22 | `PARAMSET_SIZE` | 1 | 1 → success; above 1 → `HYC00` (array binding is a deferred feature) |
 | 10014 | `METADATA_ID` | 0 | stored |
 | -1 | `CURSOR_SCROLLABLE` | `SQL_NONSCROLLABLE` | the boolean face of `CURSOR_TYPE` |
 | -2 | `CURSOR_SENSITIVITY` | `SQL_INSENSITIVE` | `SQL_UNSPECIFIED` normalises to insensitive, silently |
@@ -417,6 +419,18 @@ Four findings changed the implementation:
   validation is therefore deliberately absent; the identifiers themselves do
   reach the driver, which is also how `CURSOR_SCROLLABLE` is shown to alias
   `CURSOR_TYPE` driver-side.
+- **`MAX_ROWS` bounds catalog result sets too.** Measured: with the cap at 2,
+  `SQLTables`, `SQLColumns` and `SQLGetTypeInfo` all return exactly 2 rows on
+  msodbcsql. Because catalog functions run through `finish_execute` and then the
+  same `SQLFetch` path, this driver matches without special-casing — the shared
+  path is the correct implementation, not an accident.
+- **`PARAM_BIND_OFFSET_PTR` is honored, not inert.** msodbcsql dereferences the
+  pointer at execute and adds the byte offset to the bound value pointer *and*
+  the length/indicator pointer. Storing it without applying it would accept the
+  set and then read the wrong application buffer, which is worse than rejecting
+  it: an offset binding would silently send the wrong parameter value. The
+  offset is read once per execution, so an application can walk a buffer by
+  writing one `SQLLEN` between executes.
 
 **Known divergence:** `SQL_ATTR_CURSOR_SCROLLABLE = SQL_SCROLLABLE` succeeds on
 msodbcsql and reports `01S02` here, because scrollable cursors are a deferred

--- a/mssql-odbc/src/api/attributes.rs
+++ b/mssql-odbc/src/api/attributes.rs
@@ -202,6 +202,8 @@ static DBC_ATTRS: &[AttrRow] = &[
 /// attribute, and the sweep confirmed msodbcsql answers `HY092` for it on a
 /// statement handle even though the identifier sits in the shared vendor range.
 static STMT_ATTRS: &[AttrRow] = &[
+    (-2, "SQL_ATTR_CURSOR_SENSITIVITY", OP_SET | OP_GET),
+    (-1, "SQL_ATTR_CURSOR_SCROLLABLE", OP_SET | OP_GET),
     (0, "SQL_ATTR_QUERY_TIMEOUT", OP_SET | OP_GET),
     (1, "SQL_ATTR_MAX_ROWS", OP_SET | OP_GET),
     (2, "SQL_ATTR_NOSCAN", OP_SET | OP_GET),
@@ -211,6 +213,7 @@ static STMT_ATTRS: &[AttrRow] = &[
     (6, "SQL_ATTR_CURSOR_TYPE", OP_SET | OP_GET),
     (7, "SQL_ATTR_CONCURRENCY", OP_SET | OP_GET),
     (8, "SQL_ATTR_KEYSET_SIZE", OP_SET | OP_GET),
+    (9, "SQL_ROWSET_SIZE", OP_SET | OP_GET),
     (10, "SQL_ATTR_SIMULATE_CURSOR", OP_SET | OP_GET),
     (11, "SQL_ATTR_RETRIEVE_DATA", OP_SET | OP_GET),
     (12, "SQL_ATTR_USE_BOOKMARKS", OP_SET | OP_GET),
@@ -534,14 +537,28 @@ mod tests {
     }
 
     /// Negative identifiers are reachable from Python, whose `attrs_before`
-    /// keys are unbounded ints, and must never be treated as recognized.
+    /// keys are unbounded ints. Only the two ODBC 3.x cursor attributes are
+    /// genuinely negative; every other negative value must stay unknown so it
+    /// is rejected rather than silently accepted.
     #[test]
-    fn negative_identifiers_are_unknown() {
-        for id in [-1, -1000, SqlInteger::MIN] {
+    fn only_the_cursor_attributes_are_negative() {
+        for id in [-3, -1000, SqlInteger::MIN] {
             for scope in SCOPES {
                 for op in OPS {
                     assert!(native_attr_name(scope, op, id).is_none(), "id {id}");
                 }
+            }
+        }
+        for id in [-1, -2] {
+            for op in OPS {
+                assert!(
+                    native_attr_name(AttrScope::Stmt, op, id).is_some(),
+                    "stmt id {id}"
+                );
+                assert!(
+                    native_attr_name(AttrScope::Dbc, op, id).is_none(),
+                    "dbc id {id}"
+                );
             }
         }
     }

--- a/mssql-odbc/src/api/exec_common.rs
+++ b/mssql-odbc/src/api/exec_common.rs
@@ -255,7 +255,7 @@ pub(super) fn finish_execute(
             return_client_busy(dbc, client);
             return SQL_ERROR;
         };
-        stmt_state.column_metadata = metadata; // empty (0 columns)
+        stmt_state.begin_result_set(metadata); // empty (0 columns)
         // Statement-wise: report this no-row (DML/PRINT/RAISERROR) statement's
         // own affected-row count for SQLRowCount. Later statements' counts are
         // surfaced as SQLMoreResults advances onto each in turn (not pre-queued).
@@ -291,7 +291,7 @@ pub(super) fn finish_execute(
             return_client_idle(dbc, statement_handle, client);
             return SQL_ERROR;
         };
-        stmt_state.column_metadata = metadata; // empty
+        stmt_state.begin_result_set(metadata); // empty
         stmt_state.row_count = first_count;
         stmt_state.pending_row_counts = dml_counts;
         stmt_state.set_state(STMT_STATE_EXEC_CONTEXT);
@@ -313,7 +313,7 @@ pub(super) fn finish_execute(
         return_client_busy(dbc, client);
         return SQL_ERROR;
     };
-    stmt_state.column_metadata = metadata;
+    stmt_state.begin_result_set(metadata);
     stmt_state.row_count = client.last_rows_affected();
     stmt_state.pending_row_counts.clear();
     stmt_state.set_state(STMT_STATE_EXEC_CONTEXT | STMT_STATE_CURSOR_OPEN);

--- a/mssql-odbc/src/api/exec_common.rs
+++ b/mssql-odbc/src/api/exec_common.rs
@@ -200,14 +200,18 @@ pub(super) unsafe fn build_named_params(
     op: &str,
 ) -> Result<Vec<RpcParameter>, SqlReturn> {
     let mut named_params = Vec::with_capacity(marker_count);
+    // Read once per execution: the attribute holds a pointer, and every
+    // binding shifts by the same amount.
+    let bind_offset = unsafe { stmt_state.inert_attrs.param_bind_offset() };
     for i in 0..marker_count {
         let Some(Some(bound_param)) = stmt_state.bound_params.get(i) else {
             error!("{op}: parameter {} has no bound value", i + 1);
             post_diag(stmt_state, ERR_UNBOUND_PARAMETER);
             return Err(SQL_ERROR);
         };
+        let bound_param = bound_param.with_bind_offset(bind_offset);
         let name = format!("@P{}", i + 1);
-        match unsafe { bound_param_to_rpc(name, bound_param) } {
+        match unsafe { bound_param_to_rpc(name, &bound_param) } {
             Ok(param) => named_params.push(param),
             Err(e) => {
                 if let ParamBuildError::InvalidLength(len) = e {

--- a/mssql-odbc/src/api/fetch_scroll.rs
+++ b/mssql-odbc/src/api/fetch_scroll.rs
@@ -276,11 +276,11 @@ fn fill_rowset(
             debug!("SQLFetchScroll: SQL_ATTR_MAX_ROWS reached; returning SQL_NO_DATA");
             return SQL_NO_DATA;
         }
-        if stmt_state.max_rows == 0 {
-            row_array_size
-        } else {
-            row_array_size.min(stmt_state.max_rows - stmt_state.rows_returned)
-        }
+        row_budget(
+            stmt_state.max_rows,
+            stmt_state.rows_returned,
+            row_array_size,
+        )
     };
 
     let dbc = stmt.parent_dbc();
@@ -499,6 +499,19 @@ fn fill_rowset(
         return SQL_SUCCESS_WITH_INFO;
     }
     SQL_SUCCESS
+}
+
+/// How many rows this fetch may deliver.
+///
+/// `SQL_ATTR_MAX_ROWS = 0` is the ODBC default and means unlimited, so the whole
+/// rowset is available. Otherwise the cap is a row budget rather than a rowset
+/// boundary: measured against msodbcsql, a cap of 5 under a rowset of 4 yields
+/// 4 rows and then a *partial* rowset of 1, not two full rowsets or one.
+fn row_budget(max_rows: SqlULen, rows_returned: SqlULen, row_array_size: SqlULen) -> SqlULen {
+    if max_rows == 0 {
+        return row_array_size;
+    }
+    row_array_size.min(max_rows.saturating_sub(rows_returned))
 }
 
 /// Writes `SQL_ROW_NOROW` into the unused tail of the row status array.
@@ -808,6 +821,27 @@ mod tests {
             dbc_state.active_stmt, None,
             "the fetch reached the client rather than being cut off"
         );
+    }
+
+    /// The cap truncates a rowset rather than rounding to a rowset boundary.
+    /// Measured against msodbcsql: a cap of 5 with `SQL_ATTR_ROW_ARRAY_SIZE = 4`
+    /// over a 20-row result yields 4 rows, then 1, then SQL_NO_DATA.
+    #[test]
+    fn the_cap_truncates_a_rowset_rather_than_rounding_it() {
+        // Unlimited leaves the whole rowset available however many rows have
+        // already gone out.
+        assert_eq!(row_budget(0, 1000, 4), 4);
+        // Well inside the cap the rowset is untouched.
+        assert_eq!(row_budget(20, 0, 4), 4);
+        assert_eq!(row_budget(8, 4, 4), 4);
+        // The cap lands inside the rowset, so the fetch is cut short.
+        assert_eq!(row_budget(5, 4, 4), 1);
+        assert_eq!(row_budget(6, 4, 4), 2);
+        assert_eq!(row_budget(3, 0, 4), 3);
+        // A cap already spent yields nothing; `max_rows_reached` short-circuits
+        // before this, so the budget only has to stay total, not underflow.
+        assert_eq!(row_budget(5, 5, 4), 0);
+        assert_eq!(row_budget(5, 9, 4), 0);
     }
 
     /// The cap is per result set, so advancing onto a new one must restart the

--- a/mssql-odbc/src/api/fetch_scroll.rs
+++ b/mssql-odbc/src/api/fetch_scroll.rs
@@ -253,6 +253,36 @@ fn fill_rowset(
     row_status_ptr: *mut SqlUSmallInt,
     row_bind_offset_ptr: *mut SqlULen,
 ) -> SqlReturn {
+    // The application asked for at most `SQL_ATTR_MAX_ROWS` rows from this
+    // result set. Once that many have been returned the cursor stops without
+    // pulling another row, matching msodbcsql. The cursor deliberately stays
+    // open and the connection stays busy on this statement: the rest of the
+    // result set is still on the wire and SQLMoreResults / SQLCloseCursor
+    // drain it as usual.
+    let row_budget = {
+        let Ok(mut stmt_state) = stmt.inner.lock() else {
+            error!("SQLFetchScroll: stmt mutex poisoned checking SQL_ATTR_MAX_ROWS");
+            return SQL_ERROR;
+        };
+        if stmt_state.max_rows_reached() {
+            // Measured: past the cap msodbcsql answers 24000 to both
+            // SQL_ATTR_ROW_NUMBER and SQLGetData, exactly as it does at the
+            // natural end of a result set, so the previous row has to stop
+            // being readable here rather than linger.
+            stmt_state.reset_row_stream();
+            drop(stmt_state);
+            unsafe { write_if_some(rows_fetched_ptr, 0) };
+            mark_no_rows(row_status_ptr, 0, row_array_size);
+            debug!("SQLFetchScroll: SQL_ATTR_MAX_ROWS reached; returning SQL_NO_DATA");
+            return SQL_NO_DATA;
+        }
+        if stmt_state.max_rows == 0 {
+            row_array_size
+        } else {
+            row_array_size.min(stmt_state.max_rows - stmt_state.rows_returned)
+        }
+    };
+
     let dbc = stmt.parent_dbc();
 
     let mut client = {
@@ -314,7 +344,7 @@ fn fill_rowset(
     // whole rowset between calls by updating the pointed-to value.
     let bind_offset = unsafe { read_bind_offset(row_bind_offset_ptr) };
 
-    while rows_filled < row_array_size {
+    while rows_filled < row_budget {
         match dbc.runtime.block_on(client.next_row_cursor()) {
             Ok(true) => {}
             Ok(false) => break,
@@ -408,6 +438,10 @@ fn fill_rowset(
         error!("SQLFetchScroll: stmt mutex poisoned recording rowset");
         return SQL_ERROR;
     };
+
+    // Charged even when the rowset ended in an error: the rows before it were
+    // still delivered to the application, so they count against the cap.
+    stmt_state.rows_returned += rows_filled;
 
     unsafe { write_if_some(rows_fetched_ptr, rows_filled) };
     mark_no_rows(row_status_ptr, rows_filled, row_array_size);
@@ -672,6 +706,128 @@ mod tests {
     fn null_handle_returns_invalid_handle() {
         let rc = unsafe { sql_fetch_scroll(ptr::null_mut(), SQL_FETCH_NEXT, 0) };
         assert_eq!(rc, SQL_INVALID_HANDLE);
+    }
+
+    // ---- SQL_ATTR_MAX_ROWS ------------------------------------------------
+
+    /// Builds a statement whose cursor is open on a one-column result set that
+    /// has already yielded `rows_returned` rows under a `max_rows` cap.
+    fn stmt_at_max_rows(h: &TestHandles, max_rows: SqlULen, rows_returned: SqlULen) {
+        use mssql_tds::test_client_support::{done_no_more, tds_client_from_tokens};
+
+        let stmt_handle = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        {
+            let mut stmt_state = stmt_handle.inner.lock().unwrap();
+            stmt_state.set_state(STMT_STATE_CURSOR_OPEN);
+            stmt_state.begin_result_set(int_columns(1));
+            stmt_state.max_rows = max_rows;
+            stmt_state.rows_returned = rows_returned;
+            // A statement that has already returned rows is positioned on the
+            // last one, which is what makes the cutoff's row-stream reset
+            // observable rather than vacuously true.
+            stmt_state.row_positioned = rows_returned > 0;
+        }
+
+        let dbc_handle = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        let mut dbc_state = dbc_handle.inner.lock().unwrap();
+        dbc_state.client = Some(tds_client_from_tokens(vec![done_no_more()]));
+        dbc_state.active_stmt = Some(h.stmt);
+    }
+
+    /// The cap is reached, so the fetch must report end-of-data *without*
+    /// pulling a row — the scripted client holds no rows, so a fetch that got
+    /// past the cutoff would fail rather than silently pass.
+    #[test]
+    fn fetch_at_max_rows_returns_no_data_without_pulling() {
+        let h = TestHandles::with_env_dbc_stmt();
+        stmt_at_max_rows(&h, 3, 3);
+
+        let mut rows_fetched: SqlULen = 99;
+        {
+            let stmt_handle = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+            let mut s = stmt_handle.inner.lock().unwrap();
+            s.rows_fetched_ptr = &mut rows_fetched;
+        }
+
+        assert_eq!(
+            unsafe { sql_fetch_scroll(h.stmt, SQL_FETCH_NEXT, 0) },
+            SQL_NO_DATA
+        );
+        assert_eq!(rows_fetched, 0, "the cutoff still reports its rowset size");
+
+        let stmt_handle = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        let stmt_state = stmt_handle.inner.lock().unwrap();
+        assert!(stmt_state.diag_records.is_empty(), "cap is not an error");
+        // The cursor stays open and the connection stays busy on this statement
+        // so the rest of the result set can still be drained.
+        assert!(stmt_state.has_state(STMT_STATE_CURSOR_OPEN));
+        // Measured on msodbcsql: past the cap the previous row stops being
+        // readable, so SQL_ATTR_ROW_NUMBER and SQLGetData both answer 24000 —
+        // the same state as the natural end of a result set.
+        assert!(!stmt_state.row_positioned);
+        drop(stmt_state);
+
+        let dbc_handle = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        let dbc_state = dbc_handle.inner.lock().unwrap();
+        assert!(dbc_state.client.is_some());
+        assert_eq!(dbc_state.active_stmt, Some(h.stmt));
+    }
+
+    /// One row below the cap the cutoff must not fire, so the fetch reaches the
+    /// wire. Asserted through the connection hand-back rather than the return
+    /// code: the cap path is the only one that leaves the statement owning the
+    /// connection, so `active_stmt` distinguishes the two paths without
+    /// depending on what the scripted result happens to answer.
+    #[test]
+    fn fetch_below_max_rows_is_not_cut_off() {
+        let h = TestHandles::with_env_dbc_stmt();
+        stmt_at_max_rows(&h, 3, 2);
+
+        unsafe { sql_fetch_scroll(h.stmt, SQL_FETCH_NEXT, 0) };
+
+        let dbc_handle = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        let dbc_state = dbc_handle.inner.lock().unwrap();
+        assert_eq!(
+            dbc_state.active_stmt, None,
+            "the fetch reached the client rather than being cut off"
+        );
+    }
+
+    /// `SQL_ATTR_MAX_ROWS = 0` is the ODBC default and means unlimited, so a
+    /// row count far above it must not be treated as having reached a cap.
+    #[test]
+    fn fetch_with_max_rows_zero_is_unlimited() {
+        let h = TestHandles::with_env_dbc_stmt();
+        stmt_at_max_rows(&h, 0, 1000);
+
+        unsafe { sql_fetch_scroll(h.stmt, SQL_FETCH_NEXT, 0) };
+
+        let dbc_handle = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        let dbc_state = dbc_handle.inner.lock().unwrap();
+        assert_eq!(
+            dbc_state.active_stmt, None,
+            "the fetch reached the client rather than being cut off"
+        );
+    }
+
+    /// The cap is per result set, so advancing onto a new one must restart the
+    /// budget; otherwise a spent cap would truncate every later result set.
+    #[test]
+    fn begin_result_set_restarts_the_max_rows_budget() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let stmt_handle = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        let mut stmt_state = stmt_handle.inner.lock().unwrap();
+
+        stmt_state.max_rows = 3;
+        stmt_state.rows_returned = 3;
+        assert!(stmt_state.max_rows_reached());
+
+        stmt_state.begin_result_set(int_columns(2));
+        assert_eq!(stmt_state.rows_returned, 0);
+        assert!(!stmt_state.max_rows_reached());
+        // The cap itself is a statement attribute and survives the new result
+        // set — only the count restarts.
+        assert_eq!(stmt_state.max_rows, 3);
     }
 
     /// The cursor is forward-only, so every other orientation is rejected

--- a/mssql-odbc/src/api/more_results.rs
+++ b/mssql-odbc/src/api/more_results.rs
@@ -111,7 +111,7 @@ fn sql_more_results_safe(statement_handle: SqlHandle, stmt: &StmtHandle) -> SqlR
                 }
                 return SQL_ERROR;
             };
-            stmt_state.column_metadata = metadata;
+            stmt_state.begin_result_set(metadata);
             stmt_state.reset_row_stream();
             // Refresh the count for the newly-positioned result set (-1 for a SELECT).
             stmt_state.row_count = client.last_rows_affected();

--- a/mssql-odbc/src/api/odbc_types.rs
+++ b/mssql-odbc/src/api/odbc_types.rs
@@ -489,18 +489,41 @@ pub const SQL_ATTR_READONLY: SqlLen = 0;
 pub const SQL_ATTR_READWRITE_UNKNOWN: SqlLen = 2;
 
 // ---- Statement attribute identifiers (SQLSetStmtAttr / SQLGetStmtAttr) ------
+pub const SQL_ATTR_CURSOR_SCROLLABLE: SqlInteger = -1;
+pub const SQL_ATTR_CURSOR_SENSITIVITY: SqlInteger = -2;
 pub const SQL_ATTR_QUERY_TIMEOUT: SqlInteger = 0;
+pub const SQL_ATTR_MAX_ROWS: SqlInteger = 1;
+pub const SQL_ATTR_NOSCAN: SqlInteger = 2;
+pub const SQL_ATTR_MAX_LENGTH: SqlInteger = 3;
+pub const SQL_ATTR_ASYNC_ENABLE: SqlInteger = 4;
 pub const SQL_ATTR_ROW_BIND_TYPE: SqlInteger = 5;
 pub const SQL_ATTR_CURSOR_TYPE: SqlInteger = 6;
 pub const SQL_ATTR_CONCURRENCY: SqlInteger = 7;
+pub const SQL_ATTR_KEYSET_SIZE: SqlInteger = 8;
+/// ODBC 2.x `SQL_ROWSET_SIZE`. Despite the name overlap it is *not* an alias of
+/// [`SQL_ATTR_ROW_ARRAY_SIZE`]: msodbcsql keeps the two in separate slots, so
+/// setting one leaves the other untouched.
+pub const SQL_ROWSET_SIZE: SqlInteger = 9;
+pub const SQL_ATTR_SIMULATE_CURSOR: SqlInteger = 10;
+pub const SQL_ATTR_RETRIEVE_DATA: SqlInteger = 11;
+pub const SQL_ATTR_USE_BOOKMARKS: SqlInteger = 12;
+pub const SQL_ATTR_ROW_NUMBER: SqlInteger = 14;
+pub const SQL_ATTR_ENABLE_AUTO_IPD: SqlInteger = 15;
+pub const SQL_ATTR_FETCH_BOOKMARK_PTR: SqlInteger = 16;
+pub const SQL_ATTR_PARAM_BIND_OFFSET_PTR: SqlInteger = 17;
 pub const SQL_ATTR_PARAM_BIND_TYPE: SqlInteger = 18;
+pub const SQL_ATTR_PARAM_OPERATION_PTR: SqlInteger = 19;
 pub const SQL_ATTR_PARAM_STATUS_PTR: SqlInteger = 20;
 pub const SQL_ATTR_PARAMS_PROCESSED_PTR: SqlInteger = 21;
 pub const SQL_ATTR_PARAMSET_SIZE: SqlInteger = 22;
 pub const SQL_ATTR_ROW_BIND_OFFSET_PTR: SqlInteger = 23;
+pub const SQL_ATTR_ROW_OPERATION_PTR: SqlInteger = 24;
 pub const SQL_ATTR_ROW_STATUS_PTR: SqlInteger = 25;
 pub const SQL_ATTR_ROWS_FETCHED_PTR: SqlInteger = 26;
 pub const SQL_ATTR_ROW_ARRAY_SIZE: SqlInteger = 27;
+/// Shared between the connection and statement scopes; only the statement form
+/// is recognized here.
+pub const SQL_ATTR_METADATA_ID: SqlInteger = 10014;
 
 /// `SQL_ATTR_ROW_BIND_TYPE` value selecting column-wise (array-of-columns)
 /// binding — the mode mssql-python uses.
@@ -513,6 +536,23 @@ pub const SQL_ROWSET_SIZE_DEFAULT: SqlULen = 1;
 pub const SQL_CURSOR_FORWARD_ONLY: SqlULen = 0;
 /// `SQL_ATTR_CONCURRENCY` value: read-only.
 pub const SQL_CONCUR_READ_ONLY: SqlULen = 1;
+/// `SQL_ATTR_CURSOR_SCROLLABLE` value: the cursor cannot scroll. Implied by
+/// [`SQL_CURSOR_FORWARD_ONLY`] — msodbcsql keeps the two in step, flipping the
+/// cursor type when scrollability is requested and vice versa.
+pub const SQL_NONSCROLLABLE: SqlULen = 0;
+/// `SQL_ATTR_CURSOR_SENSITIVITY` value reported for this driver's cursor.
+/// A request for `SQL_UNSPECIFIED` (0) resolves to this, matching msodbcsql,
+/// which answers `1` after a caller sets `0`.
+pub const SQL_INSENSITIVE: SqlULen = 1;
+/// `SQL_ATTR_SIMULATE_CURSOR` value msodbcsql reports and accepts; any other
+/// request is substituted for it and reported with `01S02`.
+pub const SQL_SC_UNIQUE: SqlULen = 2;
+/// `SQL_ATTR_RETRIEVE_DATA` default: data is retrieved on fetch.
+pub const SQL_RD_ON: SqlULen = 1;
+/// Value msodbcsql substitutes for any non-zero `SQL_ATTR_MAX_LENGTH` request,
+/// reporting `01S02`. The cap is cosmetic on both drivers: a value longer than
+/// this is still returned whole.
+pub const MSODBCSQL_MAX_LENGTH: SqlULen = 8000;
 /// Largest `SQL_ATTR_QUERY_TIMEOUT` msodbcsql accepts; larger requests are
 /// clamped to it and reported with `01S02` (`MAX_QUERY_TIMEOUT`,
 /// msodbcsql `sqlcmisc.cpp:3988`).

--- a/mssql-odbc/src/api/set_stmt_attr.rs
+++ b/mssql-odbc/src/api/set_stmt_attr.rs
@@ -44,8 +44,7 @@ use crate::api::odbc_types::{
 };
 use crate::api::sqlstate::{
     ERR_FUNCTION_SEQUENCE, ERR_INVALID_ATTRIBUTE_VALUE, ERR_INVALID_CURSOR_STATE, SQLSTATE_01S02,
-    SQLSTATE_HYC00,
-    WARN_OPTION_VALUE_CHANGED, post_diag,
+    SQLSTATE_HYC00, WARN_OPTION_VALUE_CHANGED, post_diag,
 };
 use crate::api::util::write_if_some;
 use crate::error::{free_errors, post_sql_error};
@@ -521,7 +520,7 @@ mod tests {
         SQL_ATTR_PARAM_BIND_TYPE, SQL_ATTR_PARAM_OPERATION_PTR, SQL_ATTR_PARAM_STATUS_PTR,
         SQL_ATTR_PARAMS_PROCESSED_PTR, SQL_ATTR_RETRIEVE_DATA, SQL_ATTR_ROW_BIND_OFFSET_PTR,
         SQL_ATTR_ROW_OPERATION_PTR, SQL_ATTR_USE_BOOKMARKS, SQL_BIND_BY_COLUMN, SQL_NULL_HANDLE,
-        SQL_RD_ON, SQL_ROWSET_SIZE,
+        SQL_RD_ON, SQL_ROWSET_SIZE, SqlLen,
     };
     use crate::api::sqlstate::{SQLSTATE_24000, SQLSTATE_HY092};
     use crate::handles::handle_from_raw;
@@ -1233,6 +1232,30 @@ mod tests {
             );
             assert_eq!(get_attr(h.stmt, attribute), value, "readback {attribute}");
         }
+    }
+
+    /// `SQL_ATTR_PARAM_BIND_OFFSET_PTR` holds a *pointer to* the offset, so it
+    /// is dereferenced at execute time rather than read at set time. An
+    /// application can therefore step a binding across a buffer by writing one
+    /// `SQLLEN` between executions.
+    #[test]
+    fn param_bind_offset_is_read_through_the_stored_pointer() {
+        let mut attrs = InertStmtAttrs::default();
+        assert_eq!(
+            unsafe { attrs.param_bind_offset() },
+            0,
+            "unset is no offset"
+        );
+
+        let mut offset: SqlLen = 24;
+        let slot = &raw mut offset;
+        attrs.set(SQL_ATTR_PARAM_BIND_OFFSET_PTR, slot as SqlULen);
+        assert_eq!(unsafe { attrs.param_bind_offset() }, 24);
+
+        // Written after the set: the value is read at execute time, not
+        // captured when the attribute was assigned.
+        unsafe { slot.write(-8) };
+        assert_eq!(unsafe { attrs.param_bind_offset() }, -8);
     }
 
     /// `SQL_ROWSET_SIZE` shares a name with `SQL_ATTR_ROW_ARRAY_SIZE` but not a

--- a/mssql-odbc/src/api/set_stmt_attr.rs
+++ b/mssql-odbc/src/api/set_stmt_attr.rs
@@ -9,11 +9,17 @@
 //! fetch path. `SQL_ATTR_CURSOR_TYPE` and `SQL_ATTR_CONCURRENCY` accept only the
 //! supported forward-only / read-only values; any other request is substituted
 //! and reported with `01S02` (option value changed) rather than silently
-//! succeeding. `SQL_ATTR_QUERY_TIMEOUT` is stored and clamped to
-//! [`MAX_QUERY_TIMEOUT`], matching msodbcsql, which reports `01S02` rather than
-//! rejecting an over-large request; enforcing the stored timeout against a
-//! running statement is tracked separately. Other recognized statement
-//! attributes (param / descriptor controls) are accepted without effect.
+//! succeeding; `SQL_ATTR_CURSOR_SCROLLABLE` is the same setting seen from the
+//! other side and behaves identically. `SQL_ATTR_QUERY_TIMEOUT` is stored and
+//! clamped to [`MAX_QUERY_TIMEOUT`], matching msodbcsql, which reports `01S02`
+//! rather than rejecting an over-large request; enforcing the stored timeout
+//! against a running statement is tracked separately. `SQL_ATTR_MAX_ROWS` is
+//! stored and genuinely enforced by the fetch path. Other recognized statement
+//! attributes (param / cursor / descriptor controls) are stored and
+//! round-tripped without effect, because msodbcsql reports back whatever was
+//! written; the handful whose reported value msodbcsql pins regardless of the
+//! request (`SQL_ATTR_MAX_LENGTH`, `SQL_ATTR_KEYSET_SIZE`,
+//! `SQL_ATTR_SIMULATE_CURSOR`) substitute and warn with `01S02`.
 //! `SQL_ATTR_PARAMSET_SIZE` accepts the ODBC default of 1 but rejects larger
 //! batches, since parameter arrays are not yet consumed and a silent success
 //! would execute only the first row. Unrecognized attribute identifiers fail
@@ -26,16 +32,19 @@ use tracing::{debug, error};
 
 use crate::api::attributes::{AttrOp, AttrScope, unimplemented_attr_diag};
 use crate::api::odbc_types::{
-    MAX_QUERY_TIMEOUT, SQL_ATTR_APP_PARAM_DESC, SQL_ATTR_APP_ROW_DESC, SQL_ATTR_CONCURRENCY,
-    SQL_ATTR_CURSOR_TYPE, SQL_ATTR_IMP_PARAM_DESC, SQL_ATTR_IMP_ROW_DESC, SQL_ATTR_PARAM_BIND_TYPE,
-    SQL_ATTR_PARAM_STATUS_PTR, SQL_ATTR_PARAMS_PROCESSED_PTR, SQL_ATTR_PARAMSET_SIZE,
-    SQL_ATTR_QUERY_TIMEOUT, SQL_ATTR_ROW_ARRAY_SIZE, SQL_ATTR_ROW_BIND_OFFSET_PTR,
-    SQL_ATTR_ROW_BIND_TYPE, SQL_ATTR_ROW_STATUS_PTR, SQL_ATTR_ROWS_FETCHED_PTR,
-    SQL_CONCUR_READ_ONLY, SQL_CURSOR_FORWARD_ONLY, SQL_ERROR, SQL_INVALID_HANDLE, SQL_SUCCESS,
+    MAX_QUERY_TIMEOUT, MSODBCSQL_MAX_LENGTH, SQL_ATTR_APP_PARAM_DESC, SQL_ATTR_APP_ROW_DESC,
+    SQL_ATTR_CONCURRENCY, SQL_ATTR_CURSOR_SCROLLABLE, SQL_ATTR_CURSOR_SENSITIVITY,
+    SQL_ATTR_CURSOR_TYPE, SQL_ATTR_IMP_PARAM_DESC, SQL_ATTR_IMP_ROW_DESC, SQL_ATTR_KEYSET_SIZE,
+    SQL_ATTR_MAX_LENGTH, SQL_ATTR_MAX_ROWS, SQL_ATTR_PARAMSET_SIZE, SQL_ATTR_QUERY_TIMEOUT,
+    SQL_ATTR_ROW_ARRAY_SIZE, SQL_ATTR_ROW_BIND_OFFSET_PTR, SQL_ATTR_ROW_BIND_TYPE,
+    SQL_ATTR_ROW_NUMBER, SQL_ATTR_ROW_STATUS_PTR, SQL_ATTR_ROWS_FETCHED_PTR,
+    SQL_ATTR_SIMULATE_CURSOR, SQL_CONCUR_READ_ONLY, SQL_CURSOR_FORWARD_ONLY, SQL_ERROR,
+    SQL_INSENSITIVE, SQL_INVALID_HANDLE, SQL_NONSCROLLABLE, SQL_SC_UNIQUE, SQL_SUCCESS,
     SQL_SUCCESS_WITH_INFO, SqlHandle, SqlInteger, SqlPointer, SqlReturn, SqlULen, SqlUSmallInt,
 };
 use crate::api::sqlstate::{
-    ERR_FUNCTION_SEQUENCE, ERR_INVALID_ATTRIBUTE_VALUE, SQLSTATE_01S02, SQLSTATE_HYC00,
+    ERR_FUNCTION_SEQUENCE, ERR_INVALID_ATTRIBUTE_VALUE, ERR_INVALID_CURSOR_STATE, SQLSTATE_01S02,
+    SQLSTATE_HYC00,
     WARN_OPTION_VALUE_CHANGED, post_diag,
 };
 use crate::api::util::write_if_some;
@@ -243,14 +252,104 @@ fn sql_set_stmt_attr_w_safe(
             }
             SQL_SUCCESS
         }
-        // Recognized attributes accepted without tracking: these param /
-        // descriptor controls have no effect on the implemented forward-only,
-        // read-only behavior.
-        SQL_ATTR_PARAM_BIND_TYPE
-        | SQL_ATTR_PARAM_STATUS_PTR
-        | SQL_ATTR_PARAMS_PROCESSED_PTR
-        | SQL_ATTR_APP_ROW_DESC
-        | SQL_ATTR_APP_PARAM_DESC => {
+        SQL_ATTR_MAX_ROWS => {
+            // Enforced, not merely stored: `fetch_rows_next` stops the cursor
+            // once this many rows have been returned from the current result
+            // set, matching msodbcsql.
+            state.max_rows = value_ptr as SqlULen;
+            debug!(
+                max_rows = state.max_rows,
+                "SQLSetStmtAttrW: SQL_ATTR_MAX_ROWS set"
+            );
+            SQL_SUCCESS
+        }
+        SQL_ATTR_MAX_LENGTH => {
+            // msodbcsql substitutes MSODBCSQL_MAX_LENGTH for any non-zero
+            // request and reports 01S02; the cap is then never applied, and a
+            // longer value still comes back whole. Mirror the reported value
+            // and the warning so an application that inspects either sees the
+            // same thing from both drivers.
+            let requested = value_ptr as SqlULen;
+            let effective = if requested == 0 {
+                0
+            } else {
+                MSODBCSQL_MAX_LENGTH
+            };
+            state.inert_attrs.set(SQL_ATTR_MAX_LENGTH, effective);
+            if requested == effective {
+                SQL_SUCCESS
+            } else {
+                post_diag(&mut state, WARN_OPTION_VALUE_CHANGED);
+                SQL_SUCCESS_WITH_INFO
+            }
+        }
+        SQL_ATTR_KEYSET_SIZE => {
+            // Keyset-driven cursors are not implemented, so any non-zero keyset
+            // is refused the same way msodbcsql refuses it: the stored value
+            // stays 0 and the caller is told with 01S02.
+            if value_ptr as SqlULen == 0 {
+                SQL_SUCCESS
+            } else {
+                post_diag(&mut state, WARN_OPTION_VALUE_CHANGED);
+                SQL_SUCCESS_WITH_INFO
+            }
+        }
+        SQL_ATTR_SIMULATE_CURSOR => {
+            // msodbcsql reports SQL_SC_UNIQUE and accepts only that value.
+            if value_ptr as SqlULen == SQL_SC_UNIQUE {
+                SQL_SUCCESS
+            } else {
+                post_diag(&mut state, WARN_OPTION_VALUE_CHANGED);
+                SQL_SUCCESS_WITH_INFO
+            }
+        }
+        SQL_ATTR_CURSOR_SCROLLABLE => {
+            // Scrollability is the cursor type seen from the other side:
+            // msodbcsql moves SQL_ATTR_CURSOR_TYPE off forward-only when a
+            // caller asks for a scrollable cursor. This driver has no scrollable
+            // cursor, so a request is substituted and reported exactly as
+            // SQL_ATTR_CURSOR_TYPE already does.
+            if value_ptr as SqlULen == SQL_NONSCROLLABLE {
+                SQL_SUCCESS
+            } else {
+                post_sql_error(
+                    &mut state,
+                    SQLSTATE_01S02,
+                    0,
+                    "Scrollable cursors not supported; substituted SQL_NONSCROLLABLE",
+                );
+                SQL_SUCCESS_WITH_INFO
+            }
+        }
+        SQL_ATTR_CURSOR_SENSITIVITY => {
+            // SQL_UNSPECIFIED (0) means "whatever the driver does", so the get
+            // path must answer with the driver's actual sensitivity rather than
+            // the request. msodbcsql resolves it to SQL_INSENSITIVE silently —
+            // no 01S02 — and stores any other value verbatim.
+            let requested = value_ptr as SqlULen;
+            let effective = if requested == 0 {
+                SQL_INSENSITIVE
+            } else {
+                requested
+            };
+            state
+                .inert_attrs
+                .set(SQL_ATTR_CURSOR_SENSITIVITY, effective);
+            SQL_SUCCESS
+        }
+        // Recognized attributes stored and round-tripped without effect: these
+        // param / cursor / descriptor controls do not change the implemented
+        // forward-only, read-only behavior, but msodbcsql reports back whatever
+        // was written, so silently discarding the value would diverge on the
+        // very next get.
+        attribute if state.inert_attrs.set(attribute, value_ptr as SqlULen) => {
+            debug!(
+                attribute,
+                "SQLSetStmtAttrW: attribute stored without effect"
+            );
+            SQL_SUCCESS
+        }
+        SQL_ATTR_APP_ROW_DESC | SQL_ATTR_APP_PARAM_DESC => {
             debug!(attribute, "SQLSetStmtAttrW: attribute accepted as no-op");
             SQL_SUCCESS
         }
@@ -341,6 +440,29 @@ fn sql_get_stmt_attr_w_safe(
         SQL_ATTR_QUERY_TIMEOUT => unsafe {
             write_if_some(value_ptr as *mut SqlULen, state.query_timeout as SqlULen);
         },
+        SQL_ATTR_MAX_ROWS => unsafe {
+            write_if_some(value_ptr as *mut SqlULen, state.max_rows);
+        },
+        SQL_ATTR_ROW_NUMBER => {
+            // Get-only, and only answerable while the cursor sits on a row:
+            // msodbcsql returns 24000 on a statement with no cursor, on an
+            // executed-but-not-yet-fetched cursor, and again once the rowset is
+            // exhausted or closed. Positioned, it answers 0 rather than an
+            // ordinal, because a forward-only cursor keeps no rowset origin to
+            // number rows against.
+            if !state.row_positioned {
+                post_diag(&mut state, ERR_INVALID_CURSOR_STATE);
+                return SQL_ERROR;
+            }
+            unsafe {
+                write_if_some(value_ptr as *mut SqlULen, 0);
+            }
+        }
+        SQL_ATTR_CURSOR_SCROLLABLE => unsafe {
+            // Derived from the cursor type rather than stored, so the pair can
+            // never disagree.
+            write_if_some(value_ptr as *mut SqlULen, SQL_NONSCROLLABLE);
+        },
         // Recognized attributes we don't store: report their effective ODBC
         // defaults for this forward-only, read-only, single-paramset driver.
         SQL_ATTR_CURSOR_TYPE => unsafe {
@@ -370,13 +492,21 @@ fn sql_get_stmt_attr_w_safe(
         SQL_ATTR_IMP_PARAM_DESC => unsafe {
             write_if_some(value_ptr as *mut SqlHandle, stmt.ipd);
         },
-        _ => {
-            post_diag(
-                &mut state,
-                unimplemented_attr_diag(AttrScope::Stmt, AttrOp::Get, attribute),
-            );
-            return SQL_ERROR;
-        }
+        // Attributes the set path stores without effect share the table that
+        // holds their measured defaults, so a get before any set answers what
+        // msodbcsql answers. Anything not in it is genuinely unhandled.
+        _ => match state.inert_attrs.get(attribute) {
+            Some(value) => unsafe {
+                write_if_some(value_ptr as *mut SqlULen, value);
+            },
+            None => {
+                post_diag(
+                    &mut state,
+                    unimplemented_attr_diag(AttrScope::Stmt, AttrOp::Get, attribute),
+                );
+                return SQL_ERROR;
+            }
+        },
     }
 
     SQL_SUCCESS
@@ -385,9 +515,17 @@ fn sql_get_stmt_attr_w_safe(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::odbc_types::{SQL_BIND_BY_COLUMN, SQL_NULL_HANDLE};
-    use crate::api::sqlstate::SQLSTATE_HY092;
+    use crate::api::odbc_types::{
+        SQL_ATTR_ASYNC_ENABLE, SQL_ATTR_ENABLE_AUTO_IPD, SQL_ATTR_FETCH_BOOKMARK_PTR,
+        SQL_ATTR_METADATA_ID, SQL_ATTR_NOSCAN, SQL_ATTR_PARAM_BIND_OFFSET_PTR,
+        SQL_ATTR_PARAM_BIND_TYPE, SQL_ATTR_PARAM_OPERATION_PTR, SQL_ATTR_PARAM_STATUS_PTR,
+        SQL_ATTR_PARAMS_PROCESSED_PTR, SQL_ATTR_RETRIEVE_DATA, SQL_ATTR_ROW_BIND_OFFSET_PTR,
+        SQL_ATTR_ROW_OPERATION_PTR, SQL_ATTR_USE_BOOKMARKS, SQL_BIND_BY_COLUMN, SQL_NULL_HANDLE,
+        SQL_RD_ON, SQL_ROWSET_SIZE,
+    };
+    use crate::api::sqlstate::{SQLSTATE_24000, SQLSTATE_HY092};
     use crate::handles::handle_from_raw;
+    use crate::handles::stmt::InertStmtAttrs;
     use crate::test_support::TestHandles;
 
     #[test]
@@ -575,6 +713,58 @@ mod tests {
         assert_eq!(ret, SQL_SUCCESS);
         let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
         assert_eq!(stmt.inner.lock().unwrap().row_status_ptr, ptr);
+    }
+
+    /// The rowset pointers are the only statement attributes whose value *is* a
+    /// pointer, so the get path has to write a pointer-width slot rather than
+    /// the `SqlULen` every other attribute uses. Round-tripped through the
+    /// public entry points because an application that sets a rowset pointer
+    /// and reads it back must get the same address, not a truncated one.
+    #[test]
+    fn rowset_pointers_round_trip_through_the_get_path() {
+        let h = TestHandles::with_env_dbc_stmt();
+
+        let mut rows_fetched: SqlULen = 0;
+        let fetched_ptr = &mut rows_fetched as *mut SqlULen;
+        let mut status: SqlUSmallInt = 0;
+        let status_ptr = &mut status as *mut SqlUSmallInt;
+
+        unsafe {
+            assert_eq!(
+                sql_set_stmt_attr_w(h.stmt, SQL_ATTR_ROWS_FETCHED_PTR, fetched_ptr.cast(), 0),
+                SQL_SUCCESS
+            );
+            assert_eq!(
+                sql_set_stmt_attr_w(h.stmt, SQL_ATTR_ROW_STATUS_PTR, status_ptr.cast(), 0),
+                SQL_SUCCESS
+            );
+
+            let mut out_fetched: *mut SqlULen = std::ptr::null_mut();
+            assert_eq!(
+                sql_get_stmt_attr_w(
+                    h.stmt,
+                    SQL_ATTR_ROWS_FETCHED_PTR,
+                    (&raw mut out_fetched).cast(),
+                    0,
+                    std::ptr::null_mut(),
+                ),
+                SQL_SUCCESS
+            );
+            assert_eq!(out_fetched, fetched_ptr);
+
+            let mut out_status: *mut SqlUSmallInt = std::ptr::null_mut();
+            assert_eq!(
+                sql_get_stmt_attr_w(
+                    h.stmt,
+                    SQL_ATTR_ROW_STATUS_PTR,
+                    (&raw mut out_status).cast(),
+                    0,
+                    std::ptr::null_mut(),
+                ),
+                SQL_SUCCESS
+            );
+            assert_eq!(out_status, status_ptr);
+        }
     }
 
     #[test]
@@ -937,5 +1127,326 @@ mod tests {
             stmt.inner.lock().unwrap().diag_records.is_empty(),
             "stale diagnostic from the prior failure was not cleared"
         );
+    }
+
+    // ---- S4: remaining statement attributes -------------------------------
+    //
+    // Every expectation below was measured against msodbcsql 18 rather than
+    // read out of the ODBC headers; see `docs/attributes_plan.md` §8.
+
+    /// Sets an attribute and returns the return code.
+    fn set_attr(stmt: SqlHandle, attribute: SqlInteger, value: SqlULen) -> SqlReturn {
+        unsafe { sql_set_stmt_attr_w(stmt, attribute, value as SqlPointer, 0) }
+    }
+
+    /// Reads an attribute back, asserting the get itself succeeded.
+    fn get_attr(stmt: SqlHandle, attribute: SqlInteger) -> SqlULen {
+        let mut out: SqlULen = 0;
+        let rc = unsafe {
+            sql_get_stmt_attr_w(
+                stmt,
+                attribute,
+                (&mut out as *mut SqlULen).cast(),
+                0,
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(rc, SQL_SUCCESS, "get of attribute {attribute} failed");
+        out
+    }
+
+    /// The msodbcsql defaults, restated independently of the table the driver
+    /// reads them from so the two can be compared rather than agreeing by
+    /// construction.
+    const MEASURED_DEFAULTS: &[(SqlInteger, SqlULen)] = &[
+        (SQL_ATTR_NOSCAN, 0),
+        (SQL_ATTR_MAX_LENGTH, 0),
+        (SQL_ATTR_ASYNC_ENABLE, 0),
+        (SQL_ATTR_KEYSET_SIZE, 0),
+        (SQL_ROWSET_SIZE, 1),
+        (SQL_ATTR_SIMULATE_CURSOR, SQL_SC_UNIQUE),
+        (SQL_ATTR_RETRIEVE_DATA, SQL_RD_ON),
+        (SQL_ATTR_USE_BOOKMARKS, 0),
+        (SQL_ATTR_ENABLE_AUTO_IPD, 0),
+        (SQL_ATTR_FETCH_BOOKMARK_PTR, 0),
+        (SQL_ATTR_PARAM_BIND_OFFSET_PTR, 0),
+        (SQL_ATTR_PARAM_BIND_TYPE, 0),
+        (SQL_ATTR_PARAM_OPERATION_PTR, 0),
+        (SQL_ATTR_PARAM_STATUS_PTR, 0),
+        (SQL_ATTR_PARAMS_PROCESSED_PTR, 0),
+        (SQL_ATTR_ROW_BIND_OFFSET_PTR, 0),
+        (SQL_ATTR_ROW_OPERATION_PTR, 0),
+        (SQL_ATTR_METADATA_ID, 0),
+        (SQL_ATTR_CURSOR_SENSITIVITY, SQL_INSENSITIVE),
+    ];
+
+    /// A get before any set must answer the measured default, because an
+    /// application that reads an attribute to decide whether to change it would
+    /// otherwise take a different branch on each driver.
+    #[test]
+    fn inert_attribute_defaults_match_msodbcsql() {
+        let h = TestHandles::with_env_dbc_stmt();
+        for &(attribute, expected) in MEASURED_DEFAULTS {
+            assert_eq!(get_attr(h.stmt, attribute), expected, "attr {attribute}");
+        }
+    }
+
+    /// Guards [`MEASURED_DEFAULTS`] against drift: adding an identifier to the
+    /// store without measuring its msodbcsql default would otherwise ship an
+    /// invented value that no test ever looks at.
+    #[test]
+    fn every_inert_identifier_has_a_measured_default() {
+        for attribute in InertStmtAttrs::identifiers() {
+            assert!(
+                MEASURED_DEFAULTS.iter().any(|&(id, _)| id == attribute),
+                "attribute {attribute} is stored but has no asserted default"
+            );
+        }
+    }
+
+    /// The set/get asymmetry this slice closes: these were previously accepted
+    /// and discarded, so a read-back reported a stale default.
+    #[test]
+    fn inert_attributes_round_trip_the_written_value() {
+        let h = TestHandles::with_env_dbc_stmt();
+        for (attribute, value) in [
+            (SQL_ATTR_NOSCAN, 1),
+            (SQL_ATTR_ASYNC_ENABLE, 1),
+            (SQL_ROWSET_SIZE, 10),
+            (SQL_ATTR_RETRIEVE_DATA, 0),
+            (SQL_ATTR_USE_BOOKMARKS, 2),
+            (SQL_ATTR_ENABLE_AUTO_IPD, 1),
+            (SQL_ATTR_FETCH_BOOKMARK_PTR, 0x1234),
+            (SQL_ATTR_PARAM_BIND_OFFSET_PTR, 0x2345),
+            (SQL_ATTR_PARAM_BIND_TYPE, 16),
+            (SQL_ATTR_PARAM_OPERATION_PTR, 0x3456),
+            (SQL_ATTR_PARAM_STATUS_PTR, 0x4567),
+            (SQL_ATTR_PARAMS_PROCESSED_PTR, 0x5678),
+            (SQL_ATTR_ROW_BIND_OFFSET_PTR, 0x6789),
+            (SQL_ATTR_ROW_OPERATION_PTR, 0x789a),
+            (SQL_ATTR_METADATA_ID, 1),
+        ] {
+            assert_eq!(
+                set_attr(h.stmt, attribute, value),
+                SQL_SUCCESS,
+                "set {attribute}"
+            );
+            assert_eq!(get_attr(h.stmt, attribute), value, "readback {attribute}");
+        }
+    }
+
+    /// `SQL_ROWSET_SIZE` shares a name with `SQL_ATTR_ROW_ARRAY_SIZE` but not a
+    /// slot: msodbcsql keeps them independent, so treating one as an alias of
+    /// the other would silently resize an application's rowset.
+    #[test]
+    fn rowset_size_is_independent_of_row_array_size() {
+        let h = TestHandles::with_env_dbc_stmt();
+        assert_eq!(set_attr(h.stmt, SQL_ROWSET_SIZE, 7), SQL_SUCCESS);
+        assert_eq!(get_attr(h.stmt, SQL_ROWSET_SIZE), 7);
+        assert_eq!(get_attr(h.stmt, SQL_ATTR_ROW_ARRAY_SIZE), 1);
+
+        assert_eq!(set_attr(h.stmt, SQL_ATTR_ROW_ARRAY_SIZE, 5), SQL_SUCCESS);
+        assert_eq!(get_attr(h.stmt, SQL_ATTR_ROW_ARRAY_SIZE), 5);
+        assert_eq!(get_attr(h.stmt, SQL_ROWSET_SIZE), 7);
+    }
+
+    /// A non-zero `SQL_ATTR_MAX_LENGTH` is substituted rather than honored, and
+    /// the substitution is announced. The cap is cosmetic on msodbcsql too — a
+    /// longer value still comes back whole — so only the reported state matters.
+    #[test]
+    fn max_length_substitutes_and_warns() {
+        let h = TestHandles::with_env_dbc_stmt();
+        assert_eq!(
+            set_attr(h.stmt, SQL_ATTR_MAX_LENGTH, 10),
+            SQL_SUCCESS_WITH_INFO
+        );
+        assert_eq!(stmt_sql_state(h.stmt), SQLSTATE_01S02);
+        assert_eq!(get_attr(h.stmt, SQL_ATTR_MAX_LENGTH), MSODBCSQL_MAX_LENGTH);
+    }
+
+    #[test]
+    fn max_length_zero_is_accepted_silently() {
+        let h = TestHandles::with_env_dbc_stmt();
+        assert_eq!(set_attr(h.stmt, SQL_ATTR_MAX_LENGTH, 0), SQL_SUCCESS);
+        assert_eq!(get_attr(h.stmt, SQL_ATTR_MAX_LENGTH), 0);
+    }
+
+    /// Setting the already-substituted value is not itself a change, so it must
+    /// not warn a second time.
+    #[test]
+    fn max_length_at_the_substituted_value_is_accepted_silently() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let rc = set_attr(h.stmt, SQL_ATTR_MAX_LENGTH, MSODBCSQL_MAX_LENGTH);
+        assert_eq!(rc, SQL_SUCCESS);
+        assert_eq!(get_attr(h.stmt, SQL_ATTR_MAX_LENGTH), MSODBCSQL_MAX_LENGTH);
+    }
+
+    #[test]
+    fn keyset_size_zero_accepted_nonzero_warns_and_stays_zero() {
+        let h = TestHandles::with_env_dbc_stmt();
+        assert_eq!(set_attr(h.stmt, SQL_ATTR_KEYSET_SIZE, 0), SQL_SUCCESS);
+
+        let rc = set_attr(h.stmt, SQL_ATTR_KEYSET_SIZE, 100);
+        assert_eq!(rc, SQL_SUCCESS_WITH_INFO);
+        assert_eq!(stmt_sql_state(h.stmt), SQLSTATE_01S02);
+        assert_eq!(get_attr(h.stmt, SQL_ATTR_KEYSET_SIZE), 0);
+    }
+
+    #[test]
+    fn simulate_cursor_accepts_only_unique() {
+        let h = TestHandles::with_env_dbc_stmt();
+        assert_eq!(
+            set_attr(h.stmt, SQL_ATTR_SIMULATE_CURSOR, SQL_SC_UNIQUE),
+            SQL_SUCCESS
+        );
+
+        let rc = set_attr(h.stmt, SQL_ATTR_SIMULATE_CURSOR, 0);
+        assert_eq!(rc, SQL_SUCCESS_WITH_INFO);
+        assert_eq!(stmt_sql_state(h.stmt), SQLSTATE_01S02);
+        assert_eq!(get_attr(h.stmt, SQL_ATTR_SIMULATE_CURSOR), SQL_SC_UNIQUE);
+    }
+
+    /// `SQL_UNSPECIFIED` means "whatever the driver does", so the get must
+    /// resolve it to the driver's actual sensitivity instead of echoing the
+    /// request. msodbcsql resolves it silently, with no `01S02`.
+    #[test]
+    fn cursor_sensitivity_unspecified_resolves_to_insensitive() {
+        let h = TestHandles::with_env_dbc_stmt();
+        assert_eq!(
+            set_attr(h.stmt, SQL_ATTR_CURSOR_SENSITIVITY, 0),
+            SQL_SUCCESS
+        );
+        assert_eq!(
+            get_attr(h.stmt, SQL_ATTR_CURSOR_SENSITIVITY),
+            SQL_INSENSITIVE
+        );
+    }
+
+    #[test]
+    fn cursor_sensitivity_explicit_values_round_trip() {
+        let h = TestHandles::with_env_dbc_stmt();
+        for value in [1, 2] {
+            assert_eq!(
+                set_attr(h.stmt, SQL_ATTR_CURSOR_SENSITIVITY, value),
+                SQL_SUCCESS
+            );
+            assert_eq!(get_attr(h.stmt, SQL_ATTR_CURSOR_SENSITIVITY), value);
+        }
+    }
+
+    #[test]
+    fn cursor_scrollable_nonscrollable_accepted() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let rc = set_attr(h.stmt, SQL_ATTR_CURSOR_SCROLLABLE, SQL_NONSCROLLABLE);
+        assert_eq!(rc, SQL_SUCCESS);
+        assert_eq!(
+            get_attr(h.stmt, SQL_ATTR_CURSOR_SCROLLABLE),
+            SQL_NONSCROLLABLE
+        );
+    }
+
+    /// Scrollability is the cursor type seen from the other side, so a request
+    /// for a scrollable cursor is refused exactly as `SQL_ATTR_CURSOR_TYPE`
+    /// refuses a non-forward-only type: substituted, and announced.
+    #[test]
+    fn cursor_scrollable_request_is_substituted_like_cursor_type() {
+        let h = TestHandles::with_env_dbc_stmt();
+        assert_eq!(
+            set_attr(h.stmt, SQL_ATTR_CURSOR_SCROLLABLE, 1),
+            SQL_SUCCESS_WITH_INFO
+        );
+        assert_eq!(stmt_sql_state(h.stmt), SQLSTATE_01S02);
+        assert_eq!(
+            get_attr(h.stmt, SQL_ATTR_CURSOR_SCROLLABLE),
+            SQL_NONSCROLLABLE
+        );
+        assert_eq!(
+            get_attr(h.stmt, SQL_ATTR_CURSOR_TYPE),
+            SQL_CURSOR_FORWARD_ONLY
+        );
+    }
+
+    /// The pair can never disagree, because scrollability is derived from the
+    /// cursor type rather than stored alongside it.
+    #[test]
+    fn cursor_scrollable_stays_consistent_with_cursor_type() {
+        let h = TestHandles::with_env_dbc_stmt();
+        assert_eq!(
+            set_attr(h.stmt, SQL_ATTR_CURSOR_TYPE, 2),
+            SQL_SUCCESS_WITH_INFO
+        );
+        assert_eq!(
+            get_attr(h.stmt, SQL_ATTR_CURSOR_SCROLLABLE),
+            SQL_NONSCROLLABLE
+        );
+    }
+
+    #[test]
+    fn max_rows_defaults_to_unlimited_and_round_trips() {
+        let h = TestHandles::with_env_dbc_stmt();
+        assert_eq!(get_attr(h.stmt, SQL_ATTR_MAX_ROWS), 0);
+        assert_eq!(set_attr(h.stmt, SQL_ATTR_MAX_ROWS, 3), SQL_SUCCESS);
+        assert_eq!(get_attr(h.stmt, SQL_ATTR_MAX_ROWS), 3);
+        assert_eq!(set_attr(h.stmt, SQL_ATTR_MAX_ROWS, 0), SQL_SUCCESS);
+        assert_eq!(get_attr(h.stmt, SQL_ATTR_MAX_ROWS), 0);
+    }
+
+    /// `SQL_ATTR_ROW_NUMBER` is get-only; the set falls through to the
+    /// recognition table, which knows msodbcsql rejects it.
+    #[test]
+    fn row_number_cannot_be_set() {
+        let h = TestHandles::with_env_dbc_stmt();
+        assert_eq!(set_attr(h.stmt, SQL_ATTR_ROW_NUMBER, 1), SQL_ERROR);
+        assert_eq!(stmt_sql_state(h.stmt), SQLSTATE_HY092);
+    }
+
+    /// Answerable only while the cursor sits on a row. A fresh statement has no
+    /// cursor, so msodbcsql reports `24000` rather than a position.
+    #[test]
+    fn row_number_without_a_cursor_is_invalid_cursor_state() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let mut out: SqlULen = 0;
+        let rc = unsafe {
+            sql_get_stmt_attr_w(
+                h.stmt,
+                SQL_ATTR_ROW_NUMBER,
+                (&mut out as *mut SqlULen).cast(),
+                0,
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(rc, SQL_ERROR);
+        assert_eq!(stmt_sql_state(h.stmt), SQLSTATE_24000);
+    }
+
+    /// Positioned, msodbcsql answers 0 rather than an ordinal: a forward-only
+    /// cursor keeps no rowset origin to number rows against.
+    #[test]
+    fn row_number_on_a_positioned_cursor_is_zero() {
+        let h = TestHandles::with_env_dbc_stmt();
+        {
+            let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+            stmt.inner.lock().unwrap().row_positioned = true;
+        }
+        assert_eq!(get_attr(h.stmt, SQL_ATTR_ROW_NUMBER), 0);
+    }
+
+    /// The inert table is a linear scan over identifiers, so a duplicate would
+    /// make the second entry unreachable and pin its attribute to the first
+    /// one's value.
+    #[test]
+    fn inert_attribute_identifiers_are_unique() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        let state = stmt.inner.lock().unwrap();
+        let ids: Vec<SqlInteger> = InertStmtAttrs::identifiers().collect();
+        assert!(!ids.is_empty());
+        for (i, attribute) in ids.iter().enumerate() {
+            assert!(
+                !ids[..i].contains(attribute),
+                "duplicate inert attribute {attribute}"
+            );
+            assert!(state.inert_attrs.get(*attribute).is_some());
+        }
     }
 }

--- a/mssql-odbc/src/handles/stmt.rs
+++ b/mssql-odbc/src/handles/stmt.rs
@@ -11,7 +11,9 @@ use mssql_tds::connection::tds_client::{PreparedStatement, StatementId};
 
 use super::desc::{DescHandle, DescKind};
 use super::{DbcHandle, HandleType, HasObjectType, free_handle, handle_to_raw};
-use crate::api::odbc_types::{SqlLen, SqlPointer, SqlSmallInt, SqlULen, SqlUSmallInt};
+use crate::api::odbc_types::{
+    self, SqlInteger, SqlLen, SqlPointer, SqlSmallInt, SqlULen, SqlUSmallInt,
+};
 use crate::error::{DiagRecord, HasDiagnostics};
 use crate::params::BoundParam;
 use mssql_tds::datatypes::column_values::ColumnValues;
@@ -190,6 +192,106 @@ pub(crate) struct StmtState {
     /// tracked separately (AB#46385), so a non-zero value does not yet cancel
     /// anything. msodbcsql does enforce it and answers `HYT00` on expiry.
     pub(crate) query_timeout: u32,
+    /// `SQL_ATTR_MAX_ROWS`: cap on the number of rows returned from each result
+    /// set; `0` (the ODBC default) means no cap.
+    ///
+    /// Unlike the rest of the S4 attributes this one is genuinely enforced.
+    /// msodbcsql stops the cursor at the cap — a `SELECT TOP 10` under
+    /// `MAX_ROWS = 3` yields exactly three rows — so merely storing the value
+    /// would quietly hand the application seven rows it asked not to receive.
+    pub(crate) max_rows: SqlULen,
+    /// Rows already handed to the application from the current result set.
+    /// Counted solely to enforce [`Self::max_rows`], and restarted by
+    /// [`Self::begin_result_set`] because the cap is per result set.
+    pub(crate) rows_returned: SqlULen,
+    /// Statement attributes msodbcsql accepts and round-trips but that have no
+    /// effect on this driver's forward-only, read-only cursor.
+    pub(crate) inert_attrs: InertStmtAttrs,
+}
+
+/// Statement attributes msodbcsql stores and round-trips without acting on,
+/// paired with the default it reports before any set.
+///
+/// Every entry was measured against msodbcsql 18 rather than taken from the
+/// ODBC headers, because several defaults are driver choices rather than
+/// specification values: `SQL_ATTR_SIMULATE_CURSOR` reports `SQL_SC_UNIQUE`,
+/// `SQL_ROWSET_SIZE` reports 1, and `SQL_ATTR_CURSOR_SENSITIVITY` reports
+/// `SQL_INSENSITIVE` even though the header default is `SQL_UNSPECIFIED`.
+/// See `docs/attributes_plan.md` §8.
+const INERT_STMT_ATTRS: &[(SqlInteger, SqlULen)] = &[
+    (
+        odbc_types::SQL_ATTR_CURSOR_SENSITIVITY,
+        odbc_types::SQL_INSENSITIVE,
+    ),
+    (odbc_types::SQL_ATTR_NOSCAN, 0),
+    (odbc_types::SQL_ATTR_MAX_LENGTH, 0),
+    (odbc_types::SQL_ATTR_ASYNC_ENABLE, 0),
+    (odbc_types::SQL_ATTR_KEYSET_SIZE, 0),
+    (odbc_types::SQL_ROWSET_SIZE, 1),
+    (
+        odbc_types::SQL_ATTR_SIMULATE_CURSOR,
+        odbc_types::SQL_SC_UNIQUE,
+    ),
+    (odbc_types::SQL_ATTR_RETRIEVE_DATA, odbc_types::SQL_RD_ON),
+    (odbc_types::SQL_ATTR_USE_BOOKMARKS, 0),
+    (odbc_types::SQL_ATTR_ENABLE_AUTO_IPD, 0),
+    (odbc_types::SQL_ATTR_FETCH_BOOKMARK_PTR, 0),
+    (odbc_types::SQL_ATTR_PARAM_BIND_OFFSET_PTR, 0),
+    (odbc_types::SQL_ATTR_PARAM_BIND_TYPE, 0),
+    (odbc_types::SQL_ATTR_PARAM_OPERATION_PTR, 0),
+    (odbc_types::SQL_ATTR_PARAM_STATUS_PTR, 0),
+    (odbc_types::SQL_ATTR_PARAMS_PROCESSED_PTR, 0),
+    (odbc_types::SQL_ATTR_ROW_OPERATION_PTR, 0),
+    (odbc_types::SQL_ATTR_METADATA_ID, 0),
+];
+
+/// Values for the [`INERT_STMT_ATTRS`] identifiers, positionally aligned with
+/// that table.
+///
+/// A flat array keyed by a linear scan is deliberate: the set is small and
+/// fixed, and holding the identifiers and their defaults in one auditable
+/// table keeps a measured default from drifting away from the attribute it
+/// belongs to, which nineteen separate struct fields would invite.
+#[derive(Debug, Clone)]
+pub(crate) struct InertStmtAttrs([SqlULen; INERT_STMT_ATTRS.len()]);
+
+impl Default for InertStmtAttrs {
+    fn default() -> Self {
+        let mut values = [0; INERT_STMT_ATTRS.len()];
+        for (slot, (_, default)) in values.iter_mut().zip(INERT_STMT_ATTRS) {
+            *slot = *default;
+        }
+        Self(values)
+    }
+}
+
+impl InertStmtAttrs {
+    /// The identifiers this store covers, in table order. Test-only: it exists
+    /// so a new entry cannot be added without an asserted msodbcsql default.
+    #[cfg(test)]
+    pub(crate) fn identifiers() -> impl Iterator<Item = SqlInteger> {
+        INERT_STMT_ATTRS.iter().map(|(id, _)| *id)
+    }
+
+    fn index_of(attribute: SqlInteger) -> Option<usize> {
+        INERT_STMT_ATTRS.iter().position(|(id, _)| *id == attribute)
+    }
+    /// Returns the stored value, or `None` when `attribute` is not one of the
+    /// inert identifiers.
+    pub(crate) fn get(&self, attribute: SqlInteger) -> Option<SqlULen> {
+        Self::index_of(attribute).map(|i| self.0[i])
+    }
+
+    /// Stores `value`, returning whether `attribute` is an inert identifier.
+    pub(crate) fn set(&mut self, attribute: SqlInteger, value: SqlULen) -> bool {
+        match Self::index_of(attribute) {
+            Some(i) => {
+                self.0[i] = value;
+                true
+            }
+            None => false,
+        }
+    }
 }
 
 /// A prepared statement bundled with the marker count of its rewritten SQL, so
@@ -248,6 +350,24 @@ impl StmtState {
     /// Drops every column binding — `SQLFreeStmt(SQL_UNBIND)`.
     pub(crate) fn clear_bindings(&mut self) {
         self.bindings.clear();
+    }
+
+    /// Makes `metadata` the current result set, restarting the
+    /// `SQL_ATTR_MAX_ROWS` budget.
+    ///
+    /// The cap is per result set, so every path that advances onto a new one
+    /// must come through here; assigning `column_metadata` directly would leave
+    /// a spent budget in place and truncate the next result set.
+    pub(crate) fn begin_result_set(&mut self, metadata: Vec<ColumnMetadata>) {
+        self.column_metadata = metadata;
+        self.rows_returned = 0;
+    }
+
+    /// Whether `SQL_ATTR_MAX_ROWS` has already been satisfied for the current
+    /// result set, meaning the cursor must report end-of-data without pulling
+    /// another row.
+    pub(crate) fn max_rows_reached(&self) -> bool {
+        self.max_rows != 0 && self.rows_returned >= self.max_rows
     }
 
     /// Clears all row-stream state (cursor invalidated, no PLP in progress).
@@ -352,6 +472,9 @@ impl StmtHandle {
                 bindings: Vec::new(),
                 state_flags: 0,
                 query_timeout,
+                max_rows: 0,
+                rows_returned: 0,
+                inert_attrs: InertStmtAttrs::default(),
             }),
         }
     }

--- a/mssql-odbc/src/handles/stmt.rs
+++ b/mssql-odbc/src/handles/stmt.rs
@@ -292,6 +292,27 @@ impl InertStmtAttrs {
             None => false,
         }
     }
+
+    /// Reads the byte offset `SQL_ATTR_PARAM_BIND_OFFSET_PTR` currently points
+    /// at, or 0 when the application has not set one.
+    ///
+    /// The attribute holds a *pointer to* the offset rather than the offset
+    /// itself, so the application can move every binding by writing one
+    /// `SQLLEN` between executions. It is therefore read at execute time, not
+    /// at set time.
+    ///
+    /// # Safety
+    /// When set, the pointer must address a live, aligned `SQLLEN` for the
+    /// duration of the execution, per the `SQLSetStmtAttr` contract.
+    pub(crate) unsafe fn param_bind_offset(&self) -> isize {
+        let ptr = self
+            .get(odbc_types::SQL_ATTR_PARAM_BIND_OFFSET_PTR)
+            .unwrap_or(0) as *const odbc_types::SqlLen;
+        if ptr.is_null() {
+            return 0;
+        }
+        unsafe { ptr.read() }
+    }
 }
 
 /// A prepared statement bundled with the marker count of its rewritten SQL, so

--- a/mssql-odbc/src/params/bound_param.rs
+++ b/mssql-odbc/src/params/bound_param.rs
@@ -39,3 +39,94 @@ pub(crate) struct BoundParam {
     /// time). May be null.
     pub(crate) strlen_or_ind_ptr: *mut SqlLen,
 }
+
+impl BoundParam {
+    /// Returns the binding with `SQL_ATTR_PARAM_BIND_OFFSET_PTR` applied.
+    ///
+    /// ODBC adds the offset, in bytes, to the value pointer and the
+    /// length/indicator pointer alike, which lets an application walk a
+    /// binding across a buffer without rebinding it. A null pointer stays
+    /// null — the offset addresses a buffer that was never supplied, and
+    /// offsetting null would turn "no indicator" into a wild pointer.
+    pub(crate) fn with_bind_offset(mut self, offset: isize) -> Self {
+        if offset == 0 {
+            return self;
+        }
+        if !self.parameter_value_ptr.is_null() {
+            self.parameter_value_ptr = self.parameter_value_ptr.wrapping_byte_offset(offset);
+        }
+        if !self.strlen_or_ind_ptr.is_null() {
+            self.strlen_or_ind_ptr = self.strlen_or_ind_ptr.wrapping_byte_offset(offset);
+        }
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::odbc_types::{SQL_C_CHAR, SQL_PARAM_INPUT, SQL_VARCHAR};
+
+    fn param(value: *mut c_void, ind: *mut SqlLen) -> BoundParam {
+        BoundParam {
+            input_output_type: SQL_PARAM_INPUT,
+            c_type: SQL_C_CHAR,
+            sql_type: SQL_VARCHAR,
+            column_size: 8,
+            decimal_digits: 0,
+            parameter_value_ptr: value,
+            buffer_length: 8,
+            strlen_or_ind_ptr: ind,
+        }
+    }
+
+    /// The offset moves both pointers by the same byte count, which is what
+    /// lets an application step a whole binding across a buffer.
+    #[test]
+    fn bind_offset_shifts_value_and_indicator_together() {
+        let mut buf = [0u8; 32];
+        let mut ind: SqlLen = 4;
+        let value = buf.as_mut_ptr().cast::<c_void>();
+        let shifted = param(value, &raw mut ind).with_bind_offset(16);
+        assert_eq!(shifted.parameter_value_ptr as usize, value as usize + 16);
+        assert_eq!(
+            shifted.strlen_or_ind_ptr as usize,
+            (&raw mut ind) as usize + 16
+        );
+    }
+
+    /// A negative offset is legal: ODBC does not constrain the direction.
+    #[test]
+    fn bind_offset_may_be_negative() {
+        let mut buf = [0u8; 32];
+        let value = unsafe { buf.as_mut_ptr().add(16) }.cast::<c_void>();
+        let shifted = param(value, std::ptr::null_mut()).with_bind_offset(-16);
+        assert_eq!(shifted.parameter_value_ptr as usize, value as usize - 16);
+    }
+
+    /// A null indicator means "no indicator supplied", so offsetting it would
+    /// manufacture a wild pointer out of the absence of one.
+    #[test]
+    fn bind_offset_leaves_a_null_indicator_null() {
+        let mut buf = [0u8; 32];
+        let shifted = param(buf.as_mut_ptr().cast(), std::ptr::null_mut()).with_bind_offset(8);
+        assert!(shifted.strlen_or_ind_ptr.is_null());
+    }
+
+    /// The overwhelmingly common case, and the one that must stay free.
+    #[test]
+    fn zero_offset_returns_the_binding_unchanged() {
+        let mut buf = [0u8; 32];
+        let mut ind: SqlLen = 4;
+        let original = param(buf.as_mut_ptr().cast(), &raw mut ind);
+        let shifted = original.with_bind_offset(0);
+        assert_eq!(
+            shifted.parameter_value_ptr as usize,
+            original.parameter_value_ptr as usize
+        );
+        assert_eq!(
+            shifted.strlen_or_ind_ptr as usize,
+            original.strlen_or_ind_ptr as usize
+        );
+    }
+}

--- a/mssql-odbc/tests/e2e/tests/attributes_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/attributes_test.cpp
@@ -1,12 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// attributes_test.cpp  -  Tests for SQL_ATTR_QUERY_TIMEOUT and
-//                         SQL_ATTR_CURRENT_CATALOG.
+// attributes_test.cpp  -  Tests for the ODBC connection and statement
+//                         attributes mssql-python depends on.
 //
-// Both attributes are cutover blockers for mssql-python: cursor.timeout maps to
-// SQL_ATTR_QUERY_TIMEOUT, and the connection-pool check-in path plus
-// `Connection.setcatalog` map to SQL_ATTR_CURRENT_CATALOG. Every assertion here
-// was measured against msodbcsql 18 first, so the suite doubles as the parity
-// contract for `run_e2e.ps1 -CompareWithMsodbcsql`.
+// SQL_ATTR_QUERY_TIMEOUT and SQL_ATTR_CURRENT_CATALOG are cutover blockers:
+// cursor.timeout maps to the first, and the connection-pool check-in path plus
+// `Connection.setcatalog` map to the second. The rest of the statement
+// attributes reach the driver through the SQLSetStmtAttr pass-through surface
+// (plan §4.10). Every assertion here was measured against msodbcsql 18 first,
+// so the suite doubles as the parity contract for
+// `run_e2e.ps1 -CompareWithMsodbcsql`.
 //
 // Query timeout:
 //   1.  QueryTimeoutDefaultsToNoLimit      - statement default is 0
@@ -46,6 +48,20 @@
 //   30. UnimplementedConnectionAttributeIsNotImplemented - HYC00 on the get path
 //   31. HostileAttributePayloadDoesNotFault            - HYC00, session survives
 //   32. KeystoreDataGetIsRecognizedNotUnknown          - recognized on both, never HY092
+//
+// Remaining statement attributes:
+//   33. StatementAttributeDefaultsMatchMsodbcsql       - four defaults are not 0
+//   34. StatementAttributesRoundTrip                   - written values survive
+//   35. RowsetSizeIsIndependentOfRowArraySize          - 9 and 27 are not aliases
+//   36. MaxLengthIsSubstitutedWithAWarning             - non-zero -> 8000 + 01S02
+//   37. KeysetSizeIsRefusedWithAWarning                - non-zero -> 01S02, stays 0
+//   38. SimulateCursorOnlyAcceptsUnique                - anything else -> 01S02
+//   39. CursorSensitivityUnspecifiedNormalisesToInsensitive - silent normalisation
+//   40. CursorScrollableAgreesWithCursorType           - one setting, two names
+//   41. RowNumberRequiresAnOpenCursor                  - 24000 off a row
+//   42. MaxRowsBoundsTheResultSet                      - the cap is enforced
+//   43. MaxRowsAppliesToEachResultSet                  - per result set, not per stmt
+//   44. MaxRowsCutoffLeavesTheCursorOffTheRow          - cap end == natural end
 
 #include "odbc_test_fixture.h"
 
@@ -79,9 +95,16 @@ constexpr SQLINTEGER kRowArraySizeAttr = 27;
 // Connection-only (SQL_ATTR_ENLIST_IN_DTC). Rejected on a statement handle.
 constexpr SQLINTEGER kEnlistInDtcAttr = 1207;
 
-// SQL_ATTR_NOSCAN - a real statement attribute msodbcsql implements and this
-// driver does not yet, so the two legs diverge by design.
-constexpr SQLINTEGER kNoScanAttr = 2;
+// SQL_ROWSET_SIZE - the ODBC 2.x rowset size. It has no SQL_ATTR_ alias in
+// sqlext.h, and msodbcsql keeps it in a slot of its own rather than aliasing
+// SQL_ATTR_ROW_ARRAY_SIZE (Variation 35).
+constexpr SQLINTEGER kRowsetSizeAttr = 9;
+
+// SQL_SOPT_SS_DEFER_PREPARE - a vendor statement attribute msodbcsql accepts
+// and this driver defers (plan §S6), so the two legs diverge by design. Its
+// ODBC-standard neighbours are all honoured after slice S4, which is why the
+// remaining "not implemented here" example has to come from the vendor band.
+constexpr SQLINTEGER kDeferPrepareAttr = 1232;
 
 // SQL_ATTR_ROW_NUMBER - readable but not settable on msodbcsql, which makes it
 // the statement-side mirror of the connection-side SQL_ATTR_QUERY_TIMEOUT
@@ -205,6 +228,37 @@ protected:
             }
         }
         return true;
+    }
+
+    // --- remaining statement attributes -------------------------------------
+
+    SQLRETURN SetStmtULen(SQLINTEGER attribute, SQLULEN value) {
+        return SQLSetStmtAttr(stmt_, attribute,
+                              reinterpret_cast<SQLPOINTER>(value), 0);
+    }
+
+    SQLULEN GetStmtULen(SQLINTEGER attribute) {
+        SQLULEN out = 0xdeadbeef;
+        SQLRETURN rc =
+            SQLGetStmtAttr(stmt_, attribute, &out, sizeof(out), nullptr);
+        EXPECT_SQL_OK(rc, SQL_HANDLE_STMT, stmt_);
+        return out;
+    }
+
+    /// Rows a `SELECT` actually hands back, which is what SQL_ATTR_MAX_ROWS has
+    /// to bound. Counted through SQLFetch rather than a server-side aggregate,
+    /// because the cap is a driver-side promise.
+    int FetchedRowCount(const std::string& sql) {
+        SqlTString wide = ODBCTestUtils::ToSqlTStr(sql);
+        EXPECT_SQL_OK(SQLExecDirect(stmt_, const_cast<SQLTCHAR*>(wide.c_str()),
+                                    SQL_NTS),
+                      SQL_HANDLE_STMT, stmt_);
+        int rows = 0;
+        while (SQL_SUCCEEDED(SQLFetch(stmt_))) {
+            ++rows;
+        }
+        SQLCloseCursor(stmt_);
+        return rows;
     }
 };
 
@@ -638,8 +692,8 @@ TEST_F(AttributesTest, UnimplementedStatementAttributeIsNotImplemented) {
     SKIP_IF_COMPARING_MSODBCSQL();
 
     EXPECT_EQ(SQL_ERROR,
-              SQLSetStmtAttr(stmt_, kNoScanAttr,
-                             reinterpret_cast<SQLPOINTER>(0), 0));
+              SQLSetStmtAttr(stmt_, kDeferPrepareAttr,
+                             reinterpret_cast<SQLPOINTER>(1), 0));
     EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "HYC00");
 }
 
@@ -707,4 +761,321 @@ TEST_F(AttributesTest, KeystoreDataGetIsRecognizedNotUnknown) {
     }
 
     EXPECT_FALSE(DbName().empty());
+}
+
+// ===========================================================================
+// Remaining statement attributes
+//
+// mssql-python does not set these itself, but pyodbc-shaped code and ORMs do,
+// and SQLSetStmtAttr is a pass-through surface (plan §4.10). Every default and
+// every warning below was measured against msodbcsql 18 first.
+// ===========================================================================
+
+// -------------------------------------------------------------------
+// Variation 33 - the defaults a caller reads before deciding whether to
+// change anything. Four of them are non-zero, so answering a blanket 0
+// would send an application down a different branch on each driver.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, StatementAttributeDefaultsMatchMsodbcsql) {
+    EXPECT_EQ(0u, GetStmtULen(SQL_ATTR_NOSCAN));
+    EXPECT_EQ(0u, GetStmtULen(SQL_ATTR_MAX_ROWS));
+    EXPECT_EQ(0u, GetStmtULen(SQL_ATTR_MAX_LENGTH));
+    EXPECT_EQ(0u, GetStmtULen(SQL_ATTR_ASYNC_ENABLE));
+    EXPECT_EQ(0u, GetStmtULen(SQL_ATTR_KEYSET_SIZE));
+    EXPECT_EQ(0u, GetStmtULen(SQL_ATTR_USE_BOOKMARKS));
+    EXPECT_EQ(0u, GetStmtULen(SQL_ATTR_ENABLE_AUTO_IPD));
+    EXPECT_EQ(0u, GetStmtULen(SQL_ATTR_METADATA_ID));
+
+    // The four that are not zero.
+    EXPECT_EQ(1u, GetStmtULen(kRowsetSizeAttr));
+    EXPECT_EQ(static_cast<SQLULEN>(SQL_SC_UNIQUE),
+              GetStmtULen(SQL_ATTR_SIMULATE_CURSOR));
+    EXPECT_EQ(static_cast<SQLULEN>(SQL_RD_ON),
+              GetStmtULen(SQL_ATTR_RETRIEVE_DATA));
+    EXPECT_EQ(static_cast<SQLULEN>(SQL_INSENSITIVE),
+              GetStmtULen(SQL_ATTR_CURSOR_SENSITIVITY));
+}
+
+// -------------------------------------------------------------------
+// Variation 34 - a written value has to survive the round trip. Silently
+// discarding the write and answering the default is the failure mode this
+// slice exists to remove: it looks like success at the call site.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, StatementAttributesRoundTrip) {
+    struct AttrCase {
+        SQLINTEGER attribute;
+        SQLULEN value;
+    };
+    const AttrCase cases[] = {
+        {SQL_ATTR_NOSCAN, SQL_NOSCAN_ON},
+        {SQL_ATTR_ASYNC_ENABLE, SQL_ASYNC_ENABLE_OFF},
+        {SQL_ATTR_RETRIEVE_DATA, SQL_RD_ON},
+        {SQL_ATTR_USE_BOOKMARKS, SQL_UB_VARIABLE},
+        {SQL_ATTR_ENABLE_AUTO_IPD, SQL_FALSE},
+        {SQL_ATTR_METADATA_ID, SQL_TRUE},
+        {SQL_ATTR_PARAM_BIND_TYPE, 16},
+        {kRowsetSizeAttr, 10},
+    };
+    for (const AttrCase& c : cases) {
+        EXPECT_EQ(SQL_SUCCESS, SetStmtULen(c.attribute, c.value))
+            << "set " << c.attribute;
+        EXPECT_EQ(c.value, GetStmtULen(c.attribute))
+            << "readback " << c.attribute;
+    }
+}
+
+// -------------------------------------------------------------------
+// Variation 35 - SQL_ROWSET_SIZE (9) and SQL_ATTR_ROW_ARRAY_SIZE (27)
+// have overlapping documentation but separate storage on msodbcsql.
+// Aliasing them would silently resize an application's rowset.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, RowsetSizeIsIndependentOfRowArraySize) {
+    EXPECT_EQ(SQL_SUCCESS, SetStmtULen(kRowsetSizeAttr, 7));
+    EXPECT_EQ(7u, GetStmtULen(kRowsetSizeAttr));
+    EXPECT_EQ(1u, GetStmtULen(SQL_ATTR_ROW_ARRAY_SIZE));
+
+    EXPECT_EQ(SQL_SUCCESS, SetStmtULen(SQL_ATTR_ROW_ARRAY_SIZE, 5));
+    EXPECT_EQ(5u, GetStmtULen(SQL_ATTR_ROW_ARRAY_SIZE));
+    EXPECT_EQ(7u, GetStmtULen(kRowsetSizeAttr));
+}
+
+// -------------------------------------------------------------------
+// Variation 36 - SQL_ATTR_MAX_LENGTH is not honoured, so msodbcsql
+// substitutes its own limit and says so rather than accepting a cap it
+// will not apply. Zero means "no limit" and passes silently.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, MaxLengthIsSubstitutedWithAWarning) {
+    EXPECT_EQ(SQL_SUCCESS, SetStmtULen(SQL_ATTR_MAX_LENGTH, 0));
+    EXPECT_EQ(0u, GetStmtULen(SQL_ATTR_MAX_LENGTH));
+
+    EXPECT_EQ(SQL_SUCCESS_WITH_INFO, SetStmtULen(SQL_ATTR_MAX_LENGTH, 100));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "01S02");
+    EXPECT_EQ(8000u, GetStmtULen(SQL_ATTR_MAX_LENGTH));
+}
+
+// -------------------------------------------------------------------
+// Variation 37 - keyset-driven cursors are not available, so a non-zero
+// keyset size is reported as changed and the attribute stays at 0. A
+// caller that reads it back learns the cursor is not keyset-driven.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, KeysetSizeIsRefusedWithAWarning) {
+    EXPECT_EQ(SQL_SUCCESS, SetStmtULen(SQL_ATTR_KEYSET_SIZE, 0));
+
+    EXPECT_EQ(SQL_SUCCESS_WITH_INFO, SetStmtULen(SQL_ATTR_KEYSET_SIZE, 10));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "01S02");
+    EXPECT_EQ(0u, GetStmtULen(SQL_ATTR_KEYSET_SIZE));
+}
+
+// -------------------------------------------------------------------
+// Variation 38 - the only cursor simulation on offer is SQL_SC_UNIQUE,
+// which is also the default. Asking for a different one is answered with
+// the substitution warning, not an error.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, SimulateCursorOnlyAcceptsUnique) {
+    EXPECT_EQ(SQL_SUCCESS,
+              SetStmtULen(SQL_ATTR_SIMULATE_CURSOR, SQL_SC_UNIQUE));
+    EXPECT_EQ(static_cast<SQLULEN>(SQL_SC_UNIQUE),
+              GetStmtULen(SQL_ATTR_SIMULATE_CURSOR));
+
+    EXPECT_EQ(SQL_SUCCESS_WITH_INFO,
+              SetStmtULen(SQL_ATTR_SIMULATE_CURSOR, SQL_SC_NON_UNIQUE));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "01S02");
+    EXPECT_EQ(static_cast<SQLULEN>(SQL_SC_UNIQUE),
+              GetStmtULen(SQL_ATTR_SIMULATE_CURSOR));
+}
+
+// -------------------------------------------------------------------
+// Variation 39 - SQL_ATTR_CURSOR_SENSITIVITY defaults to SQL_INSENSITIVE
+// and normalises SQL_UNSPECIFIED to it silently: "I don't care" is
+// answered with what the driver actually does, with no diagnostic.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, CursorSensitivityUnspecifiedNormalisesToInsensitive) {
+    EXPECT_EQ(SQL_SUCCESS,
+              SetStmtULen(SQL_ATTR_CURSOR_SENSITIVITY, SQL_UNSPECIFIED));
+    EXPECT_EQ("", ODBCTestUtils::GetDiagState(SQL_HANDLE_STMT, stmt_));
+    EXPECT_EQ(static_cast<SQLULEN>(SQL_INSENSITIVE),
+              GetStmtULen(SQL_ATTR_CURSOR_SENSITIVITY));
+
+    EXPECT_EQ(SQL_SUCCESS,
+              SetStmtULen(SQL_ATTR_CURSOR_SENSITIVITY, SQL_INSENSITIVE));
+    EXPECT_EQ(static_cast<SQLULEN>(SQL_INSENSITIVE),
+              GetStmtULen(SQL_ATTR_CURSOR_SENSITIVITY));
+}
+
+// -------------------------------------------------------------------
+// Variation 40 - SQL_ATTR_CURSOR_SCROLLABLE is the boolean face of
+// SQL_ATTR_CURSOR_TYPE, so the two must never disagree. That invariant is
+// asserted on both drivers; the reachable values differ, because
+// msodbcsql really does have scrollable cursors and this driver does not
+// (the same divergence Variation 26's cursor-type sibling records).
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, CursorScrollableAgreesWithCursorType) {
+    EXPECT_EQ(static_cast<SQLULEN>(SQL_NONSCROLLABLE),
+              GetStmtULen(SQL_ATTR_CURSOR_SCROLLABLE));
+    EXPECT_EQ(SQL_SUCCESS,
+              SetStmtULen(SQL_ATTR_CURSOR_SCROLLABLE, SQL_NONSCROLLABLE));
+    EXPECT_EQ(static_cast<SQLULEN>(SQL_NONSCROLLABLE),
+              GetStmtULen(SQL_ATTR_CURSOR_SCROLLABLE));
+
+    const SQLRETURN rc = SetStmtULen(SQL_ATTR_CURSOR_SCROLLABLE, SQL_SCROLLABLE);
+    const SQLULEN scrollable = GetStmtULen(SQL_ATTR_CURSOR_SCROLLABLE);
+    const SQLULEN cursor_type = GetStmtULen(SQL_ATTR_CURSOR_TYPE);
+
+    // The shared invariant: scrollability and cursor type are one setting.
+    EXPECT_EQ(scrollable == static_cast<SQLULEN>(SQL_NONSCROLLABLE),
+              cursor_type == static_cast<SQLULEN>(SQL_CURSOR_FORWARD_ONLY));
+
+    const char* target = std::getenv("ODBC_TEST_TARGET");
+    if (target && std::string(target) == "msodbcsql") {
+        EXPECT_EQ(SQL_SUCCESS, rc);
+        EXPECT_EQ(static_cast<SQLULEN>(SQL_SCROLLABLE), scrollable);
+    } else {
+        // Only forward-only cursors exist here, so the request is reported
+        // as changed rather than silently accepted and ignored.
+        EXPECT_EQ(SQL_SUCCESS_WITH_INFO, rc);
+        EXPECT_EQ(static_cast<SQLULEN>(SQL_NONSCROLLABLE), scrollable);
+    }
+}
+
+// -------------------------------------------------------------------
+// Variation 41 - SQL_ATTR_ROW_NUMBER reports the cursor position, so it
+// is only answerable while there is one. Returning 0 for "no cursor"
+// would be indistinguishable from a legitimate position.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, RowNumberRequiresAnOpenCursor) {
+    SQLULEN out = 0xdeadbeef;
+
+    // No cursor at all.
+    EXPECT_EQ(SQL_ERROR, SQLGetStmtAttr(stmt_, kRowNumberAttr, &out,
+                                        sizeof(out), nullptr));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "24000");
+
+    SqlTString sql = ODBCTestUtils::ToSqlTStr("SELECT 1 UNION ALL SELECT 2");
+    EXPECT_SQL_OK(
+        SQLExecDirect(stmt_, const_cast<SQLTCHAR*>(sql.c_str()), SQL_NTS),
+        SQL_HANDLE_STMT, stmt_);
+
+    // Executed, but not yet positioned on a row.
+    EXPECT_EQ(SQL_ERROR, SQLGetStmtAttr(stmt_, kRowNumberAttr, &out,
+                                        sizeof(out), nullptr));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "24000");
+
+    // Positioned: answerable. Forward-only cursors do not track an absolute
+    // row number, so both drivers report 0 rather than a running count.
+    EXPECT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(0u, GetStmtULen(kRowNumberAttr));
+
+    // And unanswerable again once the cursor is gone.
+    SQLCloseCursor(stmt_);
+    EXPECT_EQ(SQL_ERROR, SQLGetStmtAttr(stmt_, kRowNumberAttr, &out,
+                                        sizeof(out), nullptr));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "24000");
+}
+
+// -------------------------------------------------------------------
+// Variation 42 - SQL_ATTR_MAX_ROWS is the one attribute in this group
+// that changes what comes back over the wire, so it is asserted on rows
+// rather than on a read-back.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, MaxRowsBoundsTheResultSet) {
+    const std::string sql =
+        "SELECT TOP 10 object_id FROM sys.objects ORDER BY object_id";
+    ASSERT_EQ(10, FetchedRowCount(sql));
+
+    EXPECT_EQ(SQL_SUCCESS, SetStmtULen(SQL_ATTR_MAX_ROWS, 3));
+    EXPECT_EQ(3u, GetStmtULen(SQL_ATTR_MAX_ROWS));
+    EXPECT_EQ(3, FetchedRowCount(sql));
+
+    // A cap above the row count is not a cap.
+    EXPECT_EQ(SQL_SUCCESS, SetStmtULen(SQL_ATTR_MAX_ROWS, 50));
+    EXPECT_EQ(10, FetchedRowCount(sql));
+
+    // 0 is the documented "unlimited", not "no rows".
+    EXPECT_EQ(SQL_SUCCESS, SetStmtULen(SQL_ATTR_MAX_ROWS, 0));
+    EXPECT_EQ(10, FetchedRowCount(sql));
+}
+
+// -------------------------------------------------------------------
+// Variation 43 - the cap applies per result set, not per statement, so a
+// batch returns up to MAX_ROWS rows from each. Counting across the whole
+// batch instead would truncate every result set after the first.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, MaxRowsAppliesToEachResultSet) {
+    EXPECT_EQ(SQL_SUCCESS, SetStmtULen(SQL_ATTR_MAX_ROWS, 2));
+
+    SqlTString sql = ODBCTestUtils::ToSqlTStr(
+        "SELECT TOP 5 object_id FROM sys.objects ORDER BY object_id; "
+        "SELECT TOP 5 object_id FROM sys.objects ORDER BY object_id");
+    EXPECT_SQL_OK(
+        SQLExecDirect(stmt_, const_cast<SQLTCHAR*>(sql.c_str()), SQL_NTS),
+        SQL_HANDLE_STMT, stmt_);
+
+    int first = 0;
+    while (SQL_SUCCEEDED(SQLFetch(stmt_))) {
+        ++first;
+    }
+    EXPECT_SQL_OK(SQLMoreResults(stmt_), SQL_HANDLE_STMT, stmt_);
+
+    int second = 0;
+    while (SQL_SUCCEEDED(SQLFetch(stmt_))) {
+        ++second;
+    }
+    SQLCloseCursor(stmt_);
+
+    EXPECT_EQ(2, first);
+    EXPECT_EQ(2, second);
+}
+
+// -------------------------------------------------------------------
+// Variation 44 - stopping at SQL_ATTR_MAX_ROWS must leave the cursor in the
+// same state as running off the end of the result set: off the row, with
+// SQL_ATTR_ROW_NUMBER and SQLGetData both reporting 24000. A driver that
+// short-circuits the fetch without invalidating the row stream would keep
+// the last row readable past SQL_NO_DATA, so an application looping on
+// SQLFetch and then reading columns would see one phantom row here and not
+// on msodbcsql.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, MaxRowsCutoffLeavesTheCursorOffTheRow) {
+    SqlTString sql = ODBCTestUtils::ToSqlTStr(
+        "SELECT TOP 4 object_id FROM sys.objects ORDER BY object_id");
+
+    // State after the cap cuts the third fetch off, and after the fourth fetch
+    // of a two-row-capped set would have run out anyway: both must match the
+    // state at the natural end of an uncapped set.
+    struct Case {
+        SQLULEN max_rows;
+        int fetches;
+        const char* label;
+    } const cases[] = {
+        {2, 3, "cap cutoff"},
+        {0, 5, "natural end"},
+    };
+
+    for (const Case& c : cases) {
+        SCOPED_TRACE(c.label);
+        EXPECT_EQ(SQL_SUCCESS, SetStmtULen(SQL_ATTR_MAX_ROWS, c.max_rows));
+        EXPECT_SQL_OK(
+            SQLExecDirect(stmt_, const_cast<SQLTCHAR*>(sql.c_str()), SQL_NTS),
+            SQL_HANDLE_STMT, stmt_);
+
+        SQLRETURN last = SQL_SUCCESS;
+        for (int i = 0; i < c.fetches; ++i) {
+            last = SQLFetch(stmt_);
+        }
+        EXPECT_EQ(SQL_NO_DATA, last);
+
+        SQLULEN row = 0xdeadbeef;
+        EXPECT_EQ(SQL_ERROR, SQLGetStmtAttr(stmt_, SQL_ATTR_ROW_NUMBER, &row,
+                                            sizeof(row), nullptr));
+        EXPECT_EQ("24000", ODBCTestUtils::GetDiagState(SQL_HANDLE_STMT, stmt_));
+
+        SQLINTEGER value = 0;
+        SQLLEN indicator = 0;
+        EXPECT_EQ(SQL_ERROR,
+                  SQLGetData(stmt_, 1, SQL_C_SLONG, &value, sizeof(value),
+                             &indicator));
+        EXPECT_EQ("24000", ODBCTestUtils::GetDiagState(SQL_HANDLE_STMT, stmt_));
+
+        SQLCloseCursor(stmt_);
+    }
 }

--- a/mssql-odbc/tests/e2e/tests/attributes_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/attributes_test.cpp
@@ -62,9 +62,13 @@
 //   42. MaxRowsBoundsTheResultSet                      - the cap is enforced
 //   43. MaxRowsAppliesToEachResultSet                  - per result set, not per stmt
 //   44. MaxRowsCutoffLeavesTheCursorOffTheRow          - cap end == natural end
+//   45. MaxRowsBoundsCatalogResultSets                 - the cap reaches SQLTables too
+//   46. ParamBindOffsetShiftsTheBoundBuffers           - the offset is honored
 
 #include "odbc_test_fixture.h"
 
+#include <cstring>
+#include <functional>
 #include <string>
 
 #ifndef SQL_ATTR_CURRENT_CATALOG
@@ -1077,5 +1081,121 @@ TEST_F(AttributesTest, MaxRowsCutoffLeavesTheCursorOffTheRow) {
         EXPECT_EQ("24000", ODBCTestUtils::GetDiagState(SQL_HANDLE_STMT, stmt_));
 
         SQLCloseCursor(stmt_);
+    }
+}
+
+// -------------------------------------------------------------------
+// 45. MAX_ROWS bounds catalog result sets as well.
+//
+// Catalog functions are metadata RPCs whose rows come back through the
+// ordinary fetch path, and msodbcsql caps them exactly like a query. A
+// driver that special-cased catalog cursors would return more rows than
+// the application asked for.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, MaxRowsBoundsCatalogResultSets) {
+    struct Case {
+        const char* label;
+        std::function<SQLRETURN()> call;
+    };
+    const Case cases[] = {
+        {"SQLTables", [&] {
+             return SQLTables(stmt_, nullptr, 0, nullptr, 0, nullptr, 0,
+                              nullptr, 0);
+         }},
+        {"SQLColumns", [&] {
+             return SQLColumns(stmt_, nullptr, 0, nullptr, 0, nullptr, 0,
+                               nullptr, 0);
+         }},
+        {"SQLGetTypeInfo", [&] {
+             return SQLGetTypeInfo(stmt_, SQL_ALL_TYPES);
+         }},
+    };
+
+    auto count_open_cursor = [&] {
+        int rows = 0;
+        while (SQL_SUCCEEDED(SQLFetch(stmt_))) {
+            ++rows;
+        }
+        return rows;
+    };
+
+    for (const Case& c : cases) {
+        SCOPED_TRACE(c.label);
+        EXPECT_EQ(SQL_SUCCESS, SetStmtULen(SQL_ATTR_MAX_ROWS, 2));
+        ASSERT_SQL_OK(c.call(), SQL_HANDLE_STMT, stmt_);
+        EXPECT_EQ(2, count_open_cursor());
+        SQLCloseCursor(stmt_);
+    }
+
+    // And the cap really was the reason: without it there is more to read.
+    EXPECT_EQ(SQL_SUCCESS, SetStmtULen(SQL_ATTR_MAX_ROWS, 0));
+    ASSERT_SQL_OK(SQLGetTypeInfo(stmt_, SQL_ALL_TYPES), SQL_HANDLE_STMT, stmt_);
+    EXPECT_GT(count_open_cursor(), 2);
+    SQLCloseCursor(stmt_);
+}
+
+// -------------------------------------------------------------------
+// 46. SQL_ATTR_PARAM_BIND_OFFSET_PTR shifts the bound buffers.
+//
+// The attribute stores a pointer to an SQLLEN, and the driver adds that
+// many bytes to the parameter's value pointer and its length/indicator
+// pointer at execute time. Accepting the attribute and ignoring it would
+// silently send the wrong value, so this checks the parameter the server
+// actually received rather than a round-trip of the attribute.
+//
+// Both buffers advance by one offset, so they are laid out in a single
+// struct whose size is the stride.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, ParamBindOffsetShiftsTheBoundBuffers) {
+#pragma pack(push, 8)
+    struct Slot {
+        SQLLEN indicator;
+        char text[8];
+    };
+#pragma pack(pop)
+
+    Slot slots[2] = {};
+    slots[0].indicator = 4;
+    std::memcpy(slots[0].text, "AAAA", 4);
+    slots[1].indicator = 4;
+    std::memcpy(slots[1].text, "BBBB", 4);
+
+    const SqlTString sql = ODBCTestUtils::ToSqlTStr("SELECT ? AS v");
+
+    struct Case {
+        SQLLEN offset;
+        const char* expected;
+    };
+    const Case cases[] = {
+        {0, "AAAA"},
+        {static_cast<SQLLEN>(sizeof(Slot)), "BBBB"},
+        {0, "AAAA"},  // and it is not sticky
+    };
+
+    for (const Case& c : cases) {
+        SCOPED_TRACE(c.offset);
+        SQLLEN offset = c.offset;
+        EXPECT_SQL_OK(SQLSetStmtAttr(stmt_, SQL_ATTR_PARAM_BIND_OFFSET_PTR,
+                                     &offset, 0),
+                      SQL_HANDLE_STMT, stmt_);
+        ASSERT_SQL_OK(SQLBindParameter(stmt_, 1, SQL_PARAM_INPUT, SQL_C_CHAR,
+                                       SQL_VARCHAR, 8, 0, slots[0].text,
+                                       sizeof(slots[0].text),
+                                       &slots[0].indicator),
+                      SQL_HANDLE_STMT, stmt_);
+        ASSERT_SQL_OK(
+            SQLExecDirect(stmt_, const_cast<SQLTCHAR*>(sql.c_str()), SQL_NTS),
+            SQL_HANDLE_STMT, stmt_);
+        ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+
+        char received[32] = {};
+        SQLLEN got = 0;
+        ASSERT_SQL_OK(SQLGetData(stmt_, 1, SQL_C_CHAR, received,
+                                 sizeof(received), &got),
+                      SQL_HANDLE_STMT, stmt_);
+        EXPECT_STREQ(c.expected, received);
+
+        SQLCloseCursor(stmt_);
+        SQLFreeStmt(stmt_, SQL_RESET_PARAMS);
     }
 }

--- a/mssql-odbc/tests/e2e/tests/attributes_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/attributes_test.cpp
@@ -69,6 +69,7 @@
 
 #include <cstring>
 #include <functional>
+#include <vector>
 #include <string>
 
 #ifndef SQL_ATTR_CURRENT_CATALOG
@@ -1198,4 +1199,68 @@ TEST_F(AttributesTest, ParamBindOffsetShiftsTheBoundBuffers) {
         SQLCloseCursor(stmt_);
         SQLFreeStmt(stmt_, SQL_RESET_PARAMS);
     }
+}
+
+// -------------------------------------------------------------------
+// 47. MAX_ROWS truncates a rowset rather than rounding it.
+//
+// SQL_ATTR_MAX_ROWS was measured against single-row fetches, which leaves
+// open whether the cap is a row budget or a rowset boundary. Measured on
+// msodbcsql it is a budget: a cap of 5 under SQL_ATTR_ROW_ARRAY_SIZE = 4
+// returns 4 rows and then a partial rowset of 1. A driver that stopped on
+// the boundary instead would hand back either 8 rows or 4.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, MaxRowsTruncatesARowsetRatherThanRoundingIt) {
+    constexpr SQLULEN kArraySize = 4;
+    SQLINTEGER values[kArraySize] = {};
+    SQLLEN indicators[kArraySize] = {};
+    SQLULEN fetched = 0;
+
+    EXPECT_EQ(SQL_SUCCESS, SetStmtULen(SQL_ATTR_ROW_ARRAY_SIZE, kArraySize));
+    EXPECT_SQL_OK(SQLSetStmtAttr(stmt_, SQL_ATTR_ROWS_FETCHED_PTR, &fetched, 0),
+                  SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLBindCol(stmt_, 1, SQL_C_SLONG, values, sizeof(values[0]),
+                             indicators),
+                  SQL_HANDLE_STMT, stmt_);
+
+    const SqlTString sql = ODBCTestUtils::ToSqlTStr(
+        "SELECT TOP 20 ROW_NUMBER() OVER (ORDER BY object_id) AS n "
+        "FROM sys.objects");
+
+    struct Case {
+        SQLULEN cap;
+        std::vector<SQLULEN> rowsets;
+    };
+    const Case cases[] = {
+        {5, {4, 1}},   // the cap lands inside the second rowset
+        {6, {4, 2}},   //
+        {8, {4, 4}},   // and on a boundary it is simply two full rowsets
+        {3, {3}},      // a cap below one rowset truncates the first
+    };
+
+    for (const Case& c : cases) {
+        SCOPED_TRACE(c.cap);
+        EXPECT_EQ(SQL_SUCCESS, SetStmtULen(SQL_ATTR_MAX_ROWS, c.cap));
+        ASSERT_SQL_OK(
+            SQLExecDirect(stmt_, const_cast<SQLTCHAR*>(sql.c_str()), SQL_NTS),
+            SQL_HANDLE_STMT, stmt_);
+
+        SQLINTEGER next = 1;
+        for (SQLULEN expected : c.rowsets) {
+            fetched = 0;
+            ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+            EXPECT_EQ(expected, fetched);
+            // The rows are the next ones in order, so a short rowset is a
+            // truncation and not a skip.
+            for (SQLULEN i = 0; i < expected; ++i) {
+                EXPECT_EQ(next++, values[i]);
+            }
+        }
+        EXPECT_EQ(SQL_NO_DATA, SQLFetch(stmt_));
+        SQLCloseCursor(stmt_);
+    }
+
+    SQLFreeStmt(stmt_, SQL_UNBIND);
+    EXPECT_EQ(SQL_SUCCESS, SetStmtULen(SQL_ATTR_MAX_ROWS, 0));
+    EXPECT_EQ(SQL_SUCCESS, SetStmtULen(SQL_ATTR_ROW_ARRAY_SIZE, 1));
 }


### PR DESCRIPTION
> **Stacked on #349** — review that first. This PR's diff against `main` includes its parent's commits.

Implements **[AB#47456](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47456) — remaining ODBC statement attributes**, part of [AB#46377](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/46377). Completes the standard statement-attribute surface so `mssql-python` sees the same values, warnings and cursor behavior it does on the in-package `msodbcsql18`.

## Why this is measured, not read off the headers

Every value in this PR came from probing live msodbcsql 18 through the Driver Manager. That mattered more than expected:

- **Four defaults are not 0** — `SQL_ROWSET_SIZE` is 1, `SQL_ATTR_SIMULATE_CURSOR` is `SQL_SC_UNIQUE`, `SQL_ATTR_RETRIEVE_DATA` is `SQL_RD_ON`, `SQL_ATTR_CURSOR_SENSITIVITY` is `SQL_INSENSITIVE`. An application that reads an attribute to decide whether to change it takes a different branch on a driver that answers a blanket 0.
- **`SQL_ATTR_ROW_NUMBER` is not unconditionally 0.** A first probe read it mid-fetch and saw 0. A full cursor-lifecycle probe showed `24000` with no cursor, `24000` after execute but before the first fetch, 0 while positioned, and `24000` once exhausted or closed.
- **`HY024` on out-of-range values comes from the Driver Manager, not the driver** — the diagnostics carry `[Microsoft][ODBC Driver Manager]`. The DM range-checks documented booleans and enums before dispatch, so driver-side range rejection is unreachable code. It is deliberately absent here. Identifiers *do* reach the driver, which is also how `CURSOR_SCROLLABLE` is shown to alias `CURSOR_TYPE` driver-side.

## The measured contract

| id | attribute | default | behavior |
|---|---|---|---|
| 1 | `MAX_ROWS` | 0 | **enforced** — bounds each result set; 0 is unlimited |
| 2 | `NOSCAN` | 0 | stored, round-trips |
| 3 | `MAX_LENGTH` | 0 | 0 and 8000 → success; any other non-zero → `01S02`, value substituted with 8000 |
| 4 | `ASYNC_ENABLE` | 0 | stored, round-trips |
| 8 | `KEYSET_SIZE` | 0 | non-zero → `01S02`, stays 0 |
| 9 | `SQL_ROWSET_SIZE` | **1** | stored, **independent of `ROW_ARRAY_SIZE`** |
| 10 | `SIMULATE_CURSOR` | **`SQL_SC_UNIQUE`** | anything else → `01S02`, value unchanged |
| 11 | `RETRIEVE_DATA` | **`SQL_RD_ON`** | stored, round-trips |
| 12 | `USE_BOOKMARKS` | 0 | stored, round-trips |
| 14 | `ROW_NUMBER` | — | get-only; `24000` unless positioned on a row |
| 15 | `ENABLE_AUTO_IPD` | 0 | stored, round-trips |
| 17 | `PARAM_BIND_OFFSET_PTR` | 0 | **enforced** — dereferenced at execute and added to both bound pointers |
| 16, 18–21, 23–24 | pointer / bind attributes | 0 | stored, round-trip |
| 22 | `PARAMSET_SIZE` | 1 | 1 succeeds; above 1 → `HYC00` (array binding is deferred) |
| 10014 | `METADATA_ID` | 0 | stored, round-trips |
| -1 | `CURSOR_SCROLLABLE` | `SQL_NONSCROLLABLE` | **derived from `CURSOR_TYPE`**, not stored |
| -2 | `CURSOR_SENSITIVITY` | **`SQL_INSENSITIVE`** | `SQL_UNSPECIFIED` normalises silently |

Refusals substitute the supported value and post `01S02` rather than failing, which is what msodbcsql does — a driver that returns `SQL_ERROR` here breaks applications that treat the set as advisory.

### `SQL_ATTR_MAX_ROWS` is enforced, and the cutoff invalidates the row stream

The cap is per **result set**, not per statement, so a batch returns up to `MAX_ROWS` rows from each; counting across the batch would truncate every result set after the first.

Stopping at the cap also has to leave the cursor exactly where the natural end of a result set leaves it. Measured on both drivers:

| | `SQLFetch` | `SQL_ATTR_ROW_NUMBER` | `SQLGetData` |
|---|---|---|---|
| cap cutoff | `SQL_NO_DATA` | `24000` | `24000` |
| natural end | `SQL_NO_DATA` | `24000` | `24000` |

Returning `SQL_NO_DATA` without resetting the row stream would keep the previous row readable past end-of-data, so an application looping on `SQLFetch` and then reading columns would see one phantom row here and none on msodbcsql. Variation 44 pins both columns of that table.

The cursor stays open and the connection stays busy on the statement, so `SQLMoreResults` / `SQLCloseCursor` still drain the remainder normally.

## Verification

- **15 new e2e variations** (33–47) in `attributes_test.cpp`, run unmodified against both drivers. Each was confirmed against **msodbcsql first**, so the assertions encode measured behavior rather than this implementation's.
  - `mssql-odbc`: **44 / 44 pass**
  - `msodbcsql 18`: **41 pass + 3 intentional skips** (the three cases that assert this driver's not-implemented responses)
- **Full statement-attribute sweep** across both drivers: divergence went from **119 rows to 2**, and both remaining rows are `SQL_ATTR_CURSOR_SCROLLABLE = SQL_SCROLLABLE` — the same single divergence already recorded for `SQL_ATTR_CURSOR_TYPE`, since the two are one setting. Variation 40 asserts the shared invariant on both drivers plus the per-driver state.
- **927 unit tests pass**; `cargo bfmt` and `cargo bclippy` clean.
- **Diff coverage 96.22%.** The uncovered lines are a `debug!` macro argument and a poisoned-mutex arm.

## Notes for reviewers

- The stored-attribute table asserts its defaults against the measured msodbcsql values, and a guard test fails if an identifier is added to the store without a measured default — so this can't silently grow invented values.
- `SQL_ATTR_CURSOR_SCROLLABLE` is derived from `CURSOR_TYPE` on the get path rather than stored separately, so the pair can never disagree.
- `SQL_ATTR_METADATA_ID` is stored and round-trips, but `catalog.rs` still hardcodes "never TRUE" — wiring it into catalog-function matching belongs to the follow-up work item, [AB#47526](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47526).
- `SQL_ATTR_NOSCAN` is now readable, which [AB#46384](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46384) (ODBC escape sequences) needs.
- Variation 29 previously used `SQL_ATTR_NOSCAN` as its "implemented there, not here" example. This PR implements every standard statement attribute, so it was re-measured and retargeted to `SQL_SOPT_SS_DEFER_PREPARE` (1232), a vendor attribute handled one PR up in #352.

## Out of scope

`SQL_ATTR_MAX_ROWS` was measured to bound catalog result sets too: with the cap at 2, `SQLTables` returns 2 of 501 rows, `SQLColumns` 2 of 501 and `SQLGetTypeInfo` 2 of 37 - identical on both drivers. Catalog calls run through `finish_execute` and then the ordinary fetch path, so this driver matches without special-casing.

---

### Rebased onto `main`

Main gained #322, which moved the row loop out of `fetch.rs` into `fetch_scroll.rs::fill_rowset` and gave `SQL_ATTR_ROW_BIND_OFFSET_PTR` a real implementation. Two consequences here:

- `SQL_ATTR_MAX_ROWS` enforcement was **ported, not merged** — it is now a row budget inside `fill_rowset` rather than a check in `fetch.rs`. The inert-table entry for `SQL_ATTR_ROW_BIND_OFFSET_PTR` was dropped, since #322 intercepts both the set and the get.
- That generalisation was unmeasured, because the cap had only ever been tested against single-row `SQLFetch`. **Measured now:** the cap is a row budget, not a rowset boundary — a cap of 5 under `SQL_ATTR_ROW_ARRAY_SIZE = 4` yields 4 rows and then a *partial* rowset of 1. Variation 47 pins it and passes on both drivers.

One known difference, out of scope here: on `SQL_NO_DATA` msodbcsql leaves `SQL_ATTR_ROWS_FETCHED_PTR` untouched where this driver writes 0. It reproduces with `SQL_ATTR_MAX_ROWS` off entirely, so it belongs to #322 / [AB#46580](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46580) rather than this PR — and writing 0 is the safer of the two, since the stale count is only readable by an application that ignores the return code.

