### PR TITLE
Vendor OpenSSL for the fuzz build to survive apt/pkg-config outages

### DIFF
--- a/mssql-tds/fuzz/Cargo.toml
+++ b/mssql-tds/fuzz/Cargo.toml
@@ -14,6 +14,16 @@ tokio = { version = "1.45.1", features = ["full"] }
 arbitrary = { version = "1.3", features = ["derive"] }
 async-trait = "0.1"
 
+# Build OpenSSL from vendored source on the targets where mssql-tds links it
+# (every non-Windows, non-macOS target -- see mssql-tds/Cargo.toml). The fuzz CI
+# agents intermittently fail to `apt install libssl-dev`/`pkg-config` from the
+# Ubuntu mirror, which leaves `openssl-sys` unable to locate OpenSSL and breaks
+# the entire fuzz stage. Enabling the vendored feature compiles OpenSSL from
+# source (the shared openssl-sys also backs native-tls here), so the fuzz build
+# no longer depends on those apt-provided system packages.
+[target.'cfg(all(not(windows), not(target_os = "macos")))'.dependencies]
+openssl = { version = "0.10.66", features = ["vendored"] }
+
 # Prevent this from interfering with workspaces
 [workspace]
 members = ["."]


### PR DESCRIPTION
## Summary

The **GH-Rust Fuzz Test** pipeline (`definitionId=2207`, "Rust TDS Lib Fuzz Testing") intermittently fails on `main`. This PR makes the fuzz build independent of apt-provided OpenSSL so those runs stop going red.

Work item: **[AB#47459](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47459)**

## Root cause (not a fuzz crash)

I investigated the recent failing runs (168173, 168079, 167989 — all 2026-08-19). In every case the **"Run Fuzzer" step fails at build time, not at fuzz time**:

```
error: failed to run custom build command for `openssl-sys v0.9.117`
Error: failed to build fuzz script: ... cargo build --manifest-path .../mssql-tds/fuzz/Cargo.toml ... --bin fuzz_token_stream
##[error]Bash exited with code '1'.
```

`openssl-sys` cannot locate OpenSSL because `libssl-dev`/`pkg-config` were not installed (intermittent apt/mirror outage on the CI agent). This is **not a libFuzzer crash**:

- No `fuzz-crashes-*` pipeline artifacts were produced (log shows `No artifacts directory found`).
- The fuzz targets that *did* build (e.g. `fuzz_tds_client` in build 168173) ran to completion with `oom/timeout/crash: 0/0/0` and reported `No crashes found`.

So the fuzz stage is silently skipped whenever the agent can't `apt install` OpenSSL, and the pipeline reports a build failure.

## Fix

Enable the `openssl` **vendored** feature in `mssql-tds/fuzz/Cargo.toml`, target-gated to the same `cfg(all(not(windows), not(target_os = "macos")))` targets where `mssql-tds` already links OpenSSL. `openssl-sys` then compiles OpenSSL from source, so the fuzz build no longer depends on apt-provided `libssl-dev`/`pkg-config`.

```toml
[target.'cfg(all(not(windows), not(target_os = "macos")))'.dependencies]
openssl = { version = "0.10.66", features = ["vendored"] }
```

This is a shared `openssl-sys` (also backs `native-tls`), so no new crate is introduced — only the vendored build path is turned on for the fuzz crate.

## Testing

- `cargo metadata --manifest-path mssql-tds/fuzz/Cargo.toml --no-deps` parses cleanly.
- `cargo bfmt` passes.
- The fuzz crate is its own workspace (excluded from the main workspace), so `bclippy`/`btest` on the workspace are unaffected; the vendored build is exercised by the Linux fuzz pipeline itself.

## Notes

Draft pending a green GH-Rust Fuzz Test run on this branch. Associated ADO bug **[AB#47459](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47459)** documents the failing runs and links build 168173 as evidence.