### PR TITLE
mssql-odbc: vendor statement attributes (SQL_SOPT_SS_*)

### DIFF
--- a/mssql-odbc/docs/attributes_plan.md
+++ b/mssql-odbc/docs/attributes_plan.md
@@ -483,20 +483,106 @@ identically to msodbcsql.
 
 ---
 
-### S6 — Vendor statement attributes (`SQL_SOPT_SS_*`)
+### S6 — Vendor statement attributes (`SQL_SOPT_SS_*`) — **shipped**
 
-> `mssql-odbc | Vendor statement attributes`
+> `mssql-odbc | Vendor statement attributes` (AB#47458)
 
-**Scope:** `TEXTPTR_LOGGING`, `CURRENT_COMMAND`, `HIDDEN_COLUMNS`,
-`NOBROWSETABLE`, `REGIONALIZE`, `CURSOR_OPTIONS`, `NOCOUNT_STATUS`,
-`DEFER_PREPARE`, `QUERYNOTIFICATION_*`, `PARAM_FOCUS`, `NAME_SCOPE`,
-`COLUMN_ENCRYPTION`. Mostly clean rejection; `DEFER_PREPARE` and `PARAM_FOCUS`
-are the two with real semantics (`PARAM_FOCUS` couples to AB#46374 Descriptors).
+**Scope:** the fourteen driver-private statement attributes in 1225–1238. These
+are below the Driver Manager's knowledge, so unlike S4 the DM neither
+range-checks values nor answers on the driver's behalf: every byte of the
+contract below is the driver's own.
 
-**Why last:** mssql-python does not set any of these. Value is pass-through
-robustness and parity-sweep completeness only.
+#### Measured contract
 
-**Size:** S–M. **Depends on:** S1.
+Measured against msodbcsql 18 with the §8 sweep plus five targeted probe
+suites; none of it came from `msodbcsql.h`.
+
+| id | attribute | shape | default | set behavior |
+|---|---|---|---|---|
+| 1225 | `TEXTPTR_LOGGING` | int | **1** | `{0,1}`, else `HY024` |
+| 1226 | `CURRENT_COMMAND` | int | 0 | **get-only** → `HY092` |
+| 1227 | `HIDDEN_COLUMNS` | int | 0 | `{0,1}` |
+| 1228 | `NOBROWSETABLE` | int | 0 | `{0,1}` |
+| 1229 | `REGIONALIZE` | int | 0 | `{0,1}` |
+| 1230 | `CURSOR_OPTIONS` | int | 0 | range `0..=7` (3-bit mask) |
+| 1231 | `NOCOUNT_STATUS` | int | **1** | **get-only** → `HY092` |
+| 1232 | `DEFER_PREPARE` | int | **1** | `{0,1}` |
+| 1233 | `QUERYNOTIFICATION_TIMEOUT` | int | **432000** | `1..=i32::MAX` — **0 is rejected** |
+| 1234 | `QUERYNOTIFICATION_MSGTEXT` | **string** | `""` | any string |
+| 1235 | `QUERYNOTIFICATION_OPTIONS` | **string** | `""` | any string |
+| 1236 | `PARAM_FOCUS` | int | 0 | **always `HY024`** |
+| 1237 | `NAME_SCOPE` | int | 0 | range `0..=3` |
+| 1238 | `COLUMN_ENCRYPTION` | int | 0 | **always `HY024`** |
+
+A rejected set leaves the previous value in place. `PARAM_FOCUS` and
+`COLUMN_ENCRYPTION` reject *every* value including 0 — `COLUMN_ENCRYPTION` does
+so even on a connection opened with `ColumnEncryption=Enabled`, so the rejection
+is unconditional rather than a licence check.
+
+Five findings changed the implementation:
+
+- **Value rejection is mandatory here, unlike S4.** S4 deliberately skipped
+  range validation because `HY024` for standard attributes is emitted by the DM
+  before dispatch. For 1225–1238 the DM has no knowledge and passes any value
+  through, so the driver must validate or it silently accepts garbage msodbcsql
+  refuses. Probes distinguish the two sources by the message's bracketed prefix.
+- **`SQLGetStmtAttrW` writes `StringLength` on integer gets.** msodbcsql writes
+  `8` on every success and leaves the pointer *untouched* on failure. An
+  application that zeroes the out-parameter and checks it cannot tell success
+  from failure on a driver that never writes.
+- **`CURRENT_COMMAND` is a per-execute result-set ordinal, not a counter.** 0 on
+  a fresh statement, 1 after execute, 2 and 3 as `SQLMoreResults` advances, and
+  it holds at the last value once the batch is exhausted. Re-executing resets it
+  to 1; `SQLCloseCursor` and `SQLFreeStmt(SQL_CLOSE)` do not reset it. Modelled
+  as `begin_batch()` (zero, then increment) versus `begin_result_set()`.
+- **`NOCOUNT_STATUS` is a constant, not session state.** It reports `1` after
+  both `SET NOCOUNT ON` and `SET NOCOUNT OFF`, so it is a fixed default rather
+  than a read of the connection's real `NOCOUNT` setting.
+- **A zero `StringLength` must never dereference the value pointer.** Found by
+  probing 1234 with a placeholder `(void*)1` and a length of 0: msodbcsql
+  returns `SQL_SUCCESS` and never touches the pointer, while this driver formed
+  a zero-length slice from it and hit Rust's alignment precondition, which is a
+  *non-unwinding* panic and therefore an `abort()`. See "Robustness fix" below.
+
+#### Robustness fix — zero-length string writes
+
+`read_utf16_long` is the shared string-reading helper behind every character
+attribute, so the abort above was reachable from
+`SQLSetConnectAttrW(dbc, SQL_ATTR_CURRENT_CATALOG, ptr, 0)` too — it predates
+S6 and shipped with S3. It is fixed at the root: a null pointer and any
+non-positive length both read as the empty string without forming a slice.
+
+This matters more than a parity nit because mssql-python loads the driver
+in-process inside CPython. An `abort()` takes down the interpreter with no
+traceback and no catchable exception. A driver at an FFI boundary must degrade,
+not die. A *non-zero* length with a bad pointer is still undefined — that is a
+genuine caller-contract violation with real data to read, and msodbcsql
+access-violates on it as well.
+
+#### Two attributes that cannot be compared through the Driver Manager
+
+- **`SQL_ATTR_ASYNC_STMT_EVENT` (29).** The sweep recorded a plain success for
+  msodbcsql, which made it look like the ideal "recognized but not implemented
+  here" exemplar. Through the DM against this driver it returns `HY118` —
+  *"Driver does not support asynchronous notification"* — from the DM itself.
+  The DM gates the identifier on the driver advertising async notification, so
+  the call never reaches the driver and no driver-side answer is observable.
+  Unit tests still cover it, because they call the entry point directly.
+- **The descriptor-handle attributes (10010–10013).** Their value *is* a handle
+  and msodbcsql dereferences it unchecked, so probing them with a placeholder
+  access-violates inside msodbcsql. Recognition is asserted through the get path
+  instead.
+
+With S6 in, no statement attribute remains that msodbcsql accepts and this
+driver refuses. Variation 29 is therefore inverted from "this one is not
+implemented" into a completeness sweep asserting that all 41 comparable
+identifiers answer with neither `HY092` nor `HYC00`.
+
+**Cross-story notes:** `PARAM_FOCUS` rejects every value today, which matches
+msodbcsql; if AB#46374 (Descriptors) later implements it, the rejection is the
+single line to revisit.
+
+**Size:** M. **Depends on:** S1, S3 (string I/O), S4 (`begin_batch` call sites).
 
 ---
 

--- a/mssql-odbc/docs/attributes_plan.md
+++ b/mssql-odbc/docs/attributes_plan.md
@@ -508,8 +508,8 @@ suites; none of it came from `msodbcsql.h`.
 | 1231 | `NOCOUNT_STATUS` | int | **1** | **get-only** → `HY092` |
 | 1232 | `DEFER_PREPARE` | int | **1** | `{0,1}` |
 | 1233 | `QUERYNOTIFICATION_TIMEOUT` | int | **432000** | `1..=i32::MAX` — **0 is rejected** |
-| 1234 | `QUERYNOTIFICATION_MSGTEXT` | **string** | `""` | any string |
-| 1235 | `QUERYNOTIFICATION_OPTIONS` | **string** | `""` | any string |
+| 1234 | `QUERYNOTIFICATION_MSGTEXT` | **string** | `""` | any string; `StringLength` ≥ 0 or `SQL_NTS` |
+| 1235 | `QUERYNOTIFICATION_OPTIONS` | **string** | `""` | any string; `StringLength` ≥ 0 or `SQL_NTS` |
 | 1236 | `PARAM_FOCUS` | int | 0 | **always `HY024`** |
 | 1237 | `NAME_SCOPE` | int | 0 | range `0..=3` |
 | 1238 | `COLUMN_ENCRYPTION` | int | 0 | **always `HY024`** |
@@ -517,9 +517,11 @@ suites; none of it came from `msodbcsql.h`.
 A rejected set leaves the previous value in place. `PARAM_FOCUS` and
 `COLUMN_ENCRYPTION` reject *every* value including 0 — `COLUMN_ENCRYPTION` does
 so even on a connection opened with `ColumnEncryption=Enabled`, so the rejection
-is unconditional rather than a licence check.
+is unconditional rather than a licence check. The QN timeout ceiling is
+`i32::MAX`, not the full `SQLULEN` width the pointer slot can carry on a 64-bit
+build: 2147483647 succeeds, 2147483648 and above are `HY024`.
 
-Five findings changed the implementation:
+Seven findings changed the implementation:
 
 - **Value rejection is mandatory here, unlike S4.** S4 deliberately skipped
   range validation because `HY024` for standard attributes is emitted by the DM
@@ -535,6 +537,28 @@ Five findings changed the implementation:
   it holds at the last value once the batch is exhausted. Re-executing resets it
   to 1; `SQLCloseCursor` and `SQLFreeStmt(SQL_CLOSE)` do not reset it. Modelled
   as `begin_batch()` (zero, then increment) versus `begin_result_set()`.
+- **The ordinal counts *every* statement in the batch, not just row-returning
+  ones.** Measured across four batch shapes; msodbcsql reports 1, 2, 3 for all
+  of them:
+
+  | batch | msodbcsql | this driver, before the fix |
+  |---|---|---|
+  | 3 SELECTs | 1 → 2 → 3 | 1 → 2 → 3 |
+  | SELECT, DML, SELECT | 1 → 2 → 3 | 1 → 1 → 2 |
+  | 3 DMLs | 1 → 2 → 3 | 1 → 1 → 1 |
+  | PRINT, SELECT, PRINT | 1 → 2 → 3 | 1 → 2 → 2 |
+
+  Only the all-SELECT shape agreed, which is why the original variation missed
+  it. `SQLMoreResults` had two paths that stepped the batch without calling
+  `begin_result_set`: draining a queued DML row count, and the `NoRows` advance.
+  A stored procedure that mixes DML and SELECT hits both.
+- **`SQL_NTS` is the only negative `StringLength` the QN string attributes
+  accept.** −2, −5 and −100 are all `HY024` with the stored string left intact;
+  0, a positive byte count and `SQL_NTS` all succeed. Note the SQLSTATE differs
+  from `SQL_ATTR_CURRENT_CATALOG`, which answers `HY090` — that one is a
+  standard attribute the DM knows about, these are vendor attributes the driver
+  validates itself. Reading a bad negative length as "empty" would silently
+  clear an attribute the caller never meant to write.
 - **`NOCOUNT_STATUS` is a constant, not session state.** It reports `1` after
   both `SET NOCOUNT ON` and `SET NOCOUNT OFF`, so it is a fixed default rather
   than a read of the connection's real `NOCOUNT` setting.

--- a/mssql-odbc/src/api/attributes.rs
+++ b/mssql-odbc/src/api/attributes.rs
@@ -315,6 +315,24 @@ pub(crate) fn unimplemented_attr_diag(
     }
 }
 
+/// The statement attribute identifiers msodbcsql recognizes for `op`.
+///
+/// Test-only. It backs the assertion that every statement attribute msodbcsql
+/// answers is also answered here, so adding a row to [`STMT_ATTRS`] without
+/// implementing it fails the suite rather than surfacing as `HYC00` to an
+/// application.
+#[cfg(test)]
+pub(crate) fn stmt_attr_ids(op: AttrOp) -> impl Iterator<Item = SqlInteger> {
+    let wanted = match op {
+        AttrOp::Set => OP_SET,
+        AttrOp::Get => OP_GET,
+    };
+    STMT_ATTRS
+        .iter()
+        .filter(move |(_, _, ops)| ops & wanted != 0)
+        .map(|(id, _, _)| *id)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/mssql-odbc/src/api/exec_common.rs
+++ b/mssql-odbc/src/api/exec_common.rs
@@ -259,7 +259,7 @@ pub(super) fn finish_execute(
             return_client_busy(dbc, client);
             return SQL_ERROR;
         };
-        stmt_state.begin_result_set(metadata); // empty (0 columns)
+        stmt_state.begin_batch(metadata); // empty (0 columns)
         // Statement-wise: report this no-row (DML/PRINT/RAISERROR) statement's
         // own affected-row count for SQLRowCount. Later statements' counts are
         // surfaced as SQLMoreResults advances onto each in turn (not pre-queued).
@@ -295,7 +295,7 @@ pub(super) fn finish_execute(
             return_client_idle(dbc, statement_handle, client);
             return SQL_ERROR;
         };
-        stmt_state.begin_result_set(metadata); // empty
+        stmt_state.begin_batch(metadata); // empty
         stmt_state.row_count = first_count;
         stmt_state.pending_row_counts = dml_counts;
         stmt_state.set_state(STMT_STATE_EXEC_CONTEXT);
@@ -317,7 +317,7 @@ pub(super) fn finish_execute(
         return_client_busy(dbc, client);
         return SQL_ERROR;
     };
-    stmt_state.begin_result_set(metadata);
+    stmt_state.begin_batch(metadata);
     stmt_state.row_count = client.last_rows_affected();
     stmt_state.pending_row_counts.clear();
     stmt_state.set_state(STMT_STATE_EXEC_CONTEXT | STMT_STATE_CURSOR_OPEN);

--- a/mssql-odbc/src/api/more_results.rs
+++ b/mssql-odbc/src/api/more_results.rs
@@ -57,6 +57,10 @@ fn sql_more_results_safe(statement_handle: SqlHandle, stmt: &StmtHandle) -> SqlR
         // A pure-DML batch queued one row count per statement; step through them
         // in memory (no cursor or connection) before falling back to the wire.
         if let Some(next) = stmt_state.pending_row_counts.pop_front() {
+            // A queued count is still a result set, so the batch ordinal has to
+            // advance with it: msodbcsql reports 1, 2, 3 across a pure-DML batch
+            // exactly as it does across a batch of SELECTs.
+            stmt_state.begin_result_set(Vec::new());
             stmt_state.row_count = next;
             debug!("SQLMoreResults: advanced to next DML result set");
             return SQL_SUCCESS;
@@ -143,7 +147,7 @@ fn sql_more_results_safe(statement_handle: SqlHandle, stmt: &StmtHandle) -> SqlR
                 }
                 return SQL_ERROR;
             };
-            stmt_state.column_metadata.clear();
+            stmt_state.begin_result_set(Vec::new());
             // Surface this no-row statement's own affected-row count for
             // SQLRowCount now that we are positioned on it.
             stmt_state.row_count = client.last_rows_affected();
@@ -376,5 +380,32 @@ mod tests {
 
         // Queue drained and no cursor open -> end of batch.
         assert_eq!(unsafe { sql_more_results(h.stmt) }, SQL_NO_DATA);
+    }
+
+    /// A queued DML count is a result set as far as the batch ordinal is
+    /// concerned. msodbcsql reports command 1, 2, 3 across a pure-DML batch
+    /// exactly as it does across three SELECTs, so stepping the queue without
+    /// advancing the ordinal would leave `SQL_SOPT_SS_CURRENT_COMMAND` stuck at
+    /// 1 while `SQLMoreResults` walked the batch.
+    #[test]
+    fn stepping_pending_dml_counts_advances_the_command_ordinal() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        {
+            let mut s = stmt.inner.lock().unwrap();
+            s.begin_batch(Vec::new());
+            s.pending_row_counts = VecDeque::from(vec![2, 1]);
+        }
+        assert_eq!(stmt.inner.lock().unwrap().current_command, 1);
+
+        assert_eq!(unsafe { sql_more_results(h.stmt) }, SQL_SUCCESS);
+        assert_eq!(stmt.inner.lock().unwrap().current_command, 2);
+
+        assert_eq!(unsafe { sql_more_results(h.stmt) }, SQL_SUCCESS);
+        assert_eq!(stmt.inner.lock().unwrap().current_command, 3);
+
+        // End of batch holds the final ordinal rather than advancing past it.
+        assert_eq!(unsafe { sql_more_results(h.stmt) }, SQL_NO_DATA);
+        assert_eq!(stmt.inner.lock().unwrap().current_command, 3);
     }
 }

--- a/mssql-odbc/src/api/odbc_types.rs
+++ b/mssql-odbc/src/api/odbc_types.rs
@@ -568,6 +568,62 @@ pub const SYSNAMELEN: usize = 128;
 /// literally named `(Default)`.
 pub const DEFAULT_CATALOG: &str = "(Default)";
 
+// SQL Server vendor statement attributes (`SQL_SOPT_SS_*`, 1225-1238). These
+// share their numeric range with the `SQL_COPT_SS_*` connection attributes, so
+// the two are only distinguishable by the handle scope they arrive on.
+//
+// Every default and accepted-value set below was measured against msodbcsql 18
+// rather than read out of the headers, because the headers document what the
+// constants mean, not which the driver actually honors. See
+// `docs/attributes_plan.md` §S6.
+
+/// Logging of text pointers. Accepts `SQL_TL_OFF` / `SQL_TL_ON` only.
+pub const SQL_SOPT_SS_TEXTPTR_LOGGING: SqlInteger = 1225;
+/// Ordinal of the command being processed within a batch. Get-only.
+pub const SQL_SOPT_SS_CURRENT_COMMAND: SqlInteger = 1226;
+/// Exposure of the hidden key columns of a browse-mode result set.
+pub const SQL_SOPT_SS_HIDDEN_COLUMNS: SqlInteger = 1227;
+/// Suppression of the `FOR BROWSE` metadata query.
+pub const SQL_SOPT_SS_NOBROWSETABLE: SqlInteger = 1228;
+/// Client-locale conversion of date, time, and money output.
+pub const SQL_SOPT_SS_REGIONALIZE: SqlInteger = 1229;
+/// Cursor behavior bit mask (fast-forward-only, autofetch, firehose).
+pub const SQL_SOPT_SS_CURSOR_OPTIONS: SqlInteger = 1230;
+/// Whether `SET NOCOUNT` is in effect. Get-only.
+pub const SQL_SOPT_SS_NOCOUNT_STATUS: SqlInteger = 1231;
+/// Deferred preparation: skip the server round trip until execute.
+pub const SQL_SOPT_SS_DEFER_PREPARE: SqlInteger = 1232;
+/// Query-notification subscription timeout, in seconds.
+pub const SQL_SOPT_SS_QUERYNOTIFICATION_TIMEOUT: SqlInteger = 1233;
+/// Query-notification message text. String-valued.
+pub const SQL_SOPT_SS_QUERYNOTIFICATION_MSGTEXT: SqlInteger = 1234;
+/// Query-notification service/broker options. String-valued.
+pub const SQL_SOPT_SS_QUERYNOTIFICATION_OPTIONS: SqlInteger = 1235;
+/// Table-valued-parameter column focus for descriptor binding.
+pub const SQL_SOPT_SS_PARAM_FOCUS: SqlInteger = 1236;
+/// Scope of the name matching used by the catalog functions.
+pub const SQL_SOPT_SS_NAME_SCOPE: SqlInteger = 1237;
+/// Always Encrypted column-encryption mode.
+pub const SQL_SOPT_SS_COLUMN_ENCRYPTION: SqlInteger = 1238;
+
+/// `SQL_SOPT_SS_TEXTPTR_LOGGING` default: msodbcsql reports text-pointer
+/// logging on before any set, unlike most vendor options which default off.
+pub const SQL_TL_ON: SqlULen = 1;
+/// Largest `SQL_SOPT_SS_CURSOR_OPTIONS` value msodbcsql accepts. The option is
+/// a three-bit mask (fast-forward-only, autofetch, firehose autofetch), so
+/// every combination through 7 is valid and 8 is the first rejected value.
+pub const SQL_CO_MAX: SqlULen = 7;
+/// `SQL_SOPT_SS_NOCOUNT_STATUS` value msodbcsql reports. Measured constant:
+/// it answers 1 whether the session has `SET NOCOUNT ON` or `OFF`.
+pub const SQL_NC_ON: SqlULen = 1;
+/// `SQL_SOPT_SS_DEFER_PREPARE` default: deferred preparation is on.
+pub const SQL_DP_ON: SqlULen = 1;
+/// `SQL_SOPT_SS_QUERYNOTIFICATION_TIMEOUT` default, in seconds (five days).
+pub const SQL_QN_TIMEOUT_DEFAULT: SqlULen = 432_000;
+/// Largest `SQL_SOPT_SS_NAME_SCOPE` value msodbcsql accepts (`TABLE`,
+/// `TABLE_TYPE`, `EXTENDED`, `SPARSE_COLUMN_SET`).
+pub const SQL_SS_NAME_SCOPE_MAX: SqlULen = 3;
+
 // Per-row status codes written into a `SQL_ATTR_ROW_STATUS_PTR` array.
 pub const SQL_ROW_SUCCESS: SqlUSmallInt = 0;
 pub const SQL_ROW_SUCCESS_WITH_INFO: SqlUSmallInt = 6;

--- a/mssql-odbc/src/api/set_stmt_attr.rs
+++ b/mssql-odbc/src/api/set_stmt_attr.rs
@@ -50,7 +50,7 @@ use crate::api::odbc_types::{
     SQL_ATTR_ROW_ARRAY_SIZE, SQL_ATTR_ROW_BIND_OFFSET_PTR, SQL_ATTR_ROW_BIND_TYPE,
     SQL_ATTR_ROW_NUMBER, SQL_ATTR_ROW_STATUS_PTR, SQL_ATTR_ROWS_FETCHED_PTR,
     SQL_ATTR_SIMULATE_CURSOR, SQL_CONCUR_READ_ONLY, SQL_CURSOR_FORWARD_ONLY, SQL_ERROR,
-    SQL_INSENSITIVE, SQL_INVALID_HANDLE, SQL_NONSCROLLABLE, SQL_SC_UNIQUE,
+    SQL_INSENSITIVE, SQL_INVALID_HANDLE, SQL_NONSCROLLABLE, SQL_NTS, SQL_SC_UNIQUE,
     SQL_SOPT_SS_CURRENT_COMMAND, SQL_SOPT_SS_QUERYNOTIFICATION_MSGTEXT,
     SQL_SOPT_SS_QUERYNOTIFICATION_OPTIONS, SQL_SUCCESS, SQL_SUCCESS_WITH_INFO, SqlHandle,
     SqlInteger, SqlPointer, SqlReturn, SqlULen, SqlUSmallInt, SqlWChar,
@@ -362,6 +362,19 @@ unsafe fn sql_set_stmt_attr_w_safe(
             // is a byte count (or SQL_NTS), which is why the set entry point
             // has to forward it rather than treating the pointer slot as an
             // integer like every other attribute here.
+            //
+            // `SQL_NTS` is the only negative length ODBC defines for a
+            // character attribute. msodbcsql answers HY024 for any other
+            // negative value and leaves the stored string alone; reading it as
+            // empty instead would silently clear the attribute.
+            if string_length < 0 && string_length != SqlInteger::from(SQL_NTS) {
+                error!(
+                    attribute,
+                    string_length, "SQLSetStmtAttrW: invalid string length"
+                );
+                post_diag(&mut state, ERR_INVALID_ATTRIBUTE_VALUE);
+                return SQL_ERROR;
+            }
             let value = unsafe { read_utf16_attr(value_ptr as *const SqlWChar, string_length) };
             if attribute == SQL_SOPT_SS_QUERYNOTIFICATION_MSGTEXT {
                 state.qn_msgtext = value;
@@ -1645,9 +1658,10 @@ mod tests {
         assert_eq!(attrs.get(9999), None);
     }
 
-    /// Defaults msodbcsql reports before any set. Three are non-zero, which is
-    /// the whole reason the table stores a default per attribute rather than
-    /// zero-initialising.
+    /// Defaults msodbcsql reports before any set. Four are non-zero
+    /// (`TEXTPTR_LOGGING`, `NOCOUNT_STATUS`, `DEFER_PREPARE` and the five-day
+    /// `QUERYNOTIFICATION_TIMEOUT`), which is the whole reason the table stores
+    /// a default per attribute rather than zero-initialising.
     #[test]
     fn vendor_attribute_defaults_match_msodbcsql() {
         let h = TestHandles::with_env_dbc_stmt();
@@ -1751,7 +1765,7 @@ mod tests {
             432_000
         );
 
-        for value in [1, 432_000, u32::MAX as SqlULen] {
+        for value in [1, 432_000, i32::MAX as SqlULen] {
             let ret = unsafe {
                 sql_set_stmt_attr_w(
                     h.stmt,
@@ -1765,6 +1779,51 @@ mod tests {
                 get_attr(h.stmt, SQL_SOPT_SS_QUERYNOTIFICATION_TIMEOUT),
                 value
             );
+        }
+
+        // The ceiling is i32::MAX, not the full SQLULEN width: on a 64-bit
+        // build the pointer slot can carry more, and msodbcsql refuses it.
+        for value in [i32::MAX as SqlULen + 1, u32::MAX as SqlULen] {
+            let ret = unsafe {
+                sql_set_stmt_attr_w(
+                    h.stmt,
+                    SQL_SOPT_SS_QUERYNOTIFICATION_TIMEOUT,
+                    value as SqlPointer,
+                    0,
+                )
+            };
+            assert_eq!(ret, SQL_ERROR, "qn timeout {value} should be rejected");
+            assert_eq!(stmt_sql_state(h.stmt), SQLSTATE_HY024);
+            assert_eq!(
+                get_attr(h.stmt, SQL_SOPT_SS_QUERYNOTIFICATION_TIMEOUT),
+                i32::MAX as SqlULen,
+                "a rejected set must leave the previous value in place"
+            );
+        }
+    }
+
+    /// `SQL_NTS` is the only negative `StringLength` ODBC defines for a
+    /// character attribute. msodbcsql answers `HY024` for any other negative
+    /// value and keeps the stored string; reading it as empty would silently
+    /// clear an attribute the caller never meant to touch.
+    #[test]
+    fn query_notification_strings_reject_a_negative_length_other_than_nts() {
+        let h = TestHandles::with_env_dbc_stmt();
+        for attribute in [
+            SQL_SOPT_SS_QUERYNOTIFICATION_MSGTEXT,
+            SQL_SOPT_SS_QUERYNOTIFICATION_OPTIONS,
+        ] {
+            assert_eq!(
+                set_str_attr(h.stmt, attribute, "SEED", SQL_NTS.into()),
+                SQL_SUCCESS
+            );
+
+            for length in [-2, -5, -100] {
+                let ret = set_str_attr(h.stmt, attribute, "REPLACED", length);
+                assert_eq!(ret, SQL_ERROR, "attr {attribute} length {length}");
+                assert_eq!(stmt_sql_state(h.stmt), SQLSTATE_HY024);
+                assert_eq!(get_str_attr(h.stmt, attribute, 64).1, "SEED");
+            }
         }
     }
 

--- a/mssql-odbc/src/api/set_stmt_attr.rs
+++ b/mssql-odbc/src/api/set_stmt_attr.rs
@@ -25,6 +25,17 @@
 //! would execute only the first row. Unrecognized attribute identifiers fail
 //! with `HY092`.
 //!
+//! The SQL Server vendor attributes (`SQL_SOPT_SS_*`, ids 1225-1238) differ from
+//! the rest in that the driver, not the Driver Manager, validates their values:
+//! the DM knows nothing about these identifiers and forwards whatever it is
+//! given, so each one carries the accept rule measured from msodbcsql and
+//! answers `HY024` outside it, leaving the previous value in place. Two are
+//! get-only and answer `HY092` on set (`SQL_SOPT_SS_CURRENT_COMMAND`, which
+//! reports the batch command ordinal, and `SQL_SOPT_SS_NOCOUNT_STATUS`), and two
+//! are string-valued (the query-notification message text and options) — the
+//! only statement attributes that use `buffer_length` / `string_length_ptr`
+//! rather than passing an integer in the pointer slot.
+//!
 //! Each entry point follows the crate's mandatory layering: FFI panic boundary
 //! → `unsafe` raw-handle shim → safe core (`README.md`; `num_result_cols.rs`).
 
@@ -39,16 +50,18 @@ use crate::api::odbc_types::{
     SQL_ATTR_ROW_ARRAY_SIZE, SQL_ATTR_ROW_BIND_OFFSET_PTR, SQL_ATTR_ROW_BIND_TYPE,
     SQL_ATTR_ROW_NUMBER, SQL_ATTR_ROW_STATUS_PTR, SQL_ATTR_ROWS_FETCHED_PTR,
     SQL_ATTR_SIMULATE_CURSOR, SQL_CONCUR_READ_ONLY, SQL_CURSOR_FORWARD_ONLY, SQL_ERROR,
-    SQL_INSENSITIVE, SQL_INVALID_HANDLE, SQL_NONSCROLLABLE, SQL_SC_UNIQUE, SQL_SUCCESS,
-    SQL_SUCCESS_WITH_INFO, SqlHandle, SqlInteger, SqlPointer, SqlReturn, SqlULen, SqlUSmallInt,
+    SQL_INSENSITIVE, SQL_INVALID_HANDLE, SQL_NONSCROLLABLE, SQL_SC_UNIQUE,
+    SQL_SOPT_SS_CURRENT_COMMAND, SQL_SOPT_SS_QUERYNOTIFICATION_MSGTEXT,
+    SQL_SOPT_SS_QUERYNOTIFICATION_OPTIONS, SQL_SUCCESS, SQL_SUCCESS_WITH_INFO, SqlHandle,
+    SqlInteger, SqlPointer, SqlReturn, SqlULen, SqlUSmallInt, SqlWChar,
 };
 use crate::api::sqlstate::{
     ERR_FUNCTION_SEQUENCE, ERR_INVALID_ATTRIBUTE_VALUE, ERR_INVALID_CURSOR_STATE, SQLSTATE_01S02,
     SQLSTATE_HYC00, WARN_OPTION_VALUE_CHANGED, post_diag,
 };
-use crate::api::util::write_if_some;
+use crate::api::util::{read_utf16_attr, write_if_some, write_wide_attr};
 use crate::error::{free_errors, post_sql_error};
-use crate::handles::stmt::STMT_STATE_FETCH_IN_PROGRESS;
+use crate::handles::stmt::{STMT_STATE_FETCH_IN_PROGRESS, VendorStmtAttrs};
 use crate::handles::{HandleType, StmtHandle, handle_from_raw};
 
 /// Clamps a requested `SQL_ATTR_QUERY_TIMEOUT` to the largest value the driver
@@ -87,7 +100,7 @@ pub(crate) unsafe fn sql_set_stmt_attr_w(
         "SQLSetStmtAttrW called",
     );
     crate::ffi_entry!("SQLSetStmtAttrW", unsafe {
-        sql_set_stmt_attr_w_impl(statement_handle, attribute, value_ptr)
+        sql_set_stmt_attr_w_impl(statement_handle, attribute, value_ptr, string_length)
     })
 }
 
@@ -95,6 +108,7 @@ unsafe fn sql_set_stmt_attr_w_impl(
     statement_handle: SqlHandle,
     attribute: SqlInteger,
     value_ptr: SqlPointer,
+    string_length: SqlInteger,
 ) -> SqlReturn {
     if statement_handle.is_null() {
         error!("SQLSetStmtAttrW: statement_handle is null");
@@ -107,13 +121,20 @@ unsafe fn sql_set_stmt_attr_w_impl(
         HandleType::Stmt,
         "SQLSetStmtAttrW: handle is not a STMT"
     );
-    sql_set_stmt_attr_w_safe(stmt, attribute, value_ptr)
+    unsafe { sql_set_stmt_attr_w_safe(stmt, attribute, value_ptr, string_length) }
 }
 
-fn sql_set_stmt_attr_w_safe(
+/// # Safety
+/// For the two string-valued attributes (`SQL_SOPT_SS_QUERYNOTIFICATION_MSGTEXT`
+/// and `..._OPTIONS`) `value_ptr` must point to `string_length` readable bytes of
+/// UTF-16, or to a NUL-terminated string when `string_length` is `SQL_NTS`. For
+/// every other attribute `value_ptr` is an integer passed in the pointer slot and
+/// is never dereferenced.
+unsafe fn sql_set_stmt_attr_w_safe(
     stmt: &StmtHandle,
     attribute: SqlInteger,
     value_ptr: SqlPointer,
+    string_length: SqlInteger,
 ) -> SqlReturn {
     let Ok(mut state) = stmt.inner.lock() else {
         error!("SQLSetStmtAttrW: stmt mutex poisoned");
@@ -336,6 +357,42 @@ fn sql_set_stmt_attr_w_safe(
                 .set(SQL_ATTR_CURSOR_SENSITIVITY, effective);
             SQL_SUCCESS
         }
+        SQL_SOPT_SS_QUERYNOTIFICATION_MSGTEXT | SQL_SOPT_SS_QUERYNOTIFICATION_OPTIONS => {
+            // The only two string-valued statement attributes. `string_length`
+            // is a byte count (or SQL_NTS), which is why the set entry point
+            // has to forward it rather than treating the pointer slot as an
+            // integer like every other attribute here.
+            let value = unsafe { read_utf16_attr(value_ptr as *const SqlWChar, string_length) };
+            if attribute == SQL_SOPT_SS_QUERYNOTIFICATION_MSGTEXT {
+                state.qn_msgtext = value;
+            } else {
+                state.qn_options = value;
+            }
+            SQL_SUCCESS
+        }
+        // SQL Server vendor attributes. Unlike the inert set these validate
+        // before storing: the Driver Manager has no knowledge of ids 1225-1238
+        // and passes any value straight through, so rejecting an out-of-range
+        // value is the driver's job. A rejected set leaves the previous value
+        // in place.
+        //
+        // The get-only ids are deliberately excluded by `is_settable` so they
+        // fall through to the identifier-rejection path below, which answers
+        // the `HY092` msodbcsql gives them rather than `HY024`.
+        attribute if VendorStmtAttrs::is_settable(attribute) => {
+            if state.vendor_attrs.set(attribute, value_ptr as SqlULen) {
+                debug!(attribute, "SQLSetStmtAttrW: vendor attribute stored");
+                SQL_SUCCESS
+            } else {
+                error!(
+                    attribute,
+                    value = value_ptr as SqlULen,
+                    "SQLSetStmtAttrW: value rejected for vendor attribute"
+                );
+                post_diag(&mut state, ERR_INVALID_ATTRIBUTE_VALUE);
+                SQL_ERROR
+            }
+        }
         // Recognized attributes stored and round-tripped without effect: these
         // param / cursor / descriptor controls do not change the implemented
         // forward-only, read-only behavior, but msodbcsql reports back whatever
@@ -384,7 +441,13 @@ pub(crate) unsafe fn sql_get_stmt_attr_w(
         "SQLGetStmtAttrW called",
     );
     crate::ffi_entry!("SQLGetStmtAttrW", unsafe {
-        sql_get_stmt_attr_w_impl(statement_handle, attribute, value_ptr)
+        sql_get_stmt_attr_w_impl(
+            statement_handle,
+            attribute,
+            value_ptr,
+            buffer_length,
+            string_length_ptr,
+        )
     })
 }
 
@@ -392,6 +455,8 @@ unsafe fn sql_get_stmt_attr_w_impl(
     statement_handle: SqlHandle,
     attribute: SqlInteger,
     value_ptr: SqlPointer,
+    buffer_length: SqlInteger,
+    string_length_ptr: *mut SqlInteger,
 ) -> SqlReturn {
     if statement_handle.is_null() {
         error!("SQLGetStmtAttrW: statement_handle is null");
@@ -404,13 +469,21 @@ unsafe fn sql_get_stmt_attr_w_impl(
         HandleType::Stmt,
         "SQLGetStmtAttrW: handle is not a STMT"
     );
-    sql_get_stmt_attr_w_safe(stmt, attribute, value_ptr)
+    unsafe {
+        sql_get_stmt_attr_w_safe(stmt, attribute, value_ptr, buffer_length, string_length_ptr)
+    }
 }
 
-fn sql_get_stmt_attr_w_safe(
+/// # Safety
+/// `value_ptr`, when non-null, must be writable for `buffer_length` bytes for
+/// the two string-valued attributes, and for one pointer-sized value otherwise.
+/// `string_length_ptr`, when non-null, must be writable for one `SQLINTEGER`.
+unsafe fn sql_get_stmt_attr_w_safe(
     stmt: &StmtHandle,
     attribute: SqlInteger,
     value_ptr: SqlPointer,
+    buffer_length: SqlInteger,
+    string_length_ptr: *mut SqlInteger,
 ) -> SqlReturn {
     let Ok(mut state) = stmt.inner.lock() else {
         error!("SQLGetStmtAttrW: stmt mutex poisoned");
@@ -418,9 +491,27 @@ fn sql_get_stmt_attr_w_safe(
     };
     free_errors(&mut state);
 
-    // Every attribute reported here is a pointer-sized integer or pointer.
+    // Every attribute reported here is a pointer-sized integer or pointer,
+    // except the two query-notification strings, which return directly because
+    // they own `buffer_length` / `string_length_ptr` themselves.
     // `write_if_some` is a no-op when `value_ptr` is null.
     match attribute {
+        SQL_SOPT_SS_QUERYNOTIFICATION_MSGTEXT | SQL_SOPT_SS_QUERYNOTIFICATION_OPTIONS => {
+            let value = if attribute == SQL_SOPT_SS_QUERYNOTIFICATION_MSGTEXT {
+                state.qn_msgtext.clone()
+            } else {
+                state.qn_options.clone()
+            };
+            return unsafe {
+                write_wide_attr(
+                    &mut *state,
+                    value_ptr as *mut SqlWChar,
+                    buffer_length,
+                    string_length_ptr,
+                    &value,
+                )
+            };
+        }
         SQL_ATTR_ROW_ARRAY_SIZE => unsafe {
             write_if_some(value_ptr as *mut SqlULen, state.row_array_size);
         },
@@ -491,10 +582,19 @@ fn sql_get_stmt_attr_w_safe(
         SQL_ATTR_IMP_PARAM_DESC => unsafe {
             write_if_some(value_ptr as *mut SqlHandle, stmt.ipd);
         },
+        SQL_SOPT_SS_CURRENT_COMMAND => unsafe {
+            // Get-only: the ordinal of the command being processed within the
+            // current batch, maintained by the result-set advance hooks.
+            write_if_some(value_ptr as *mut SqlULen, state.current_command);
+        },
         // Attributes the set path stores without effect share the table that
         // holds their measured defaults, so a get before any set answers what
         // msodbcsql answers. Anything not in it is genuinely unhandled.
-        _ => match state.inert_attrs.get(attribute) {
+        _ => match state
+            .inert_attrs
+            .get(attribute)
+            .or_else(|| state.vendor_attrs.get(attribute))
+        {
             Some(value) => unsafe {
                 write_if_some(value_ptr as *mut SqlULen, value);
             },
@@ -508,6 +608,18 @@ fn sql_get_stmt_attr_w_safe(
         },
     }
 
+    // Integer gets report the value's width. msodbcsql writes this on every
+    // successful integer `SQLGetStmtAttrW`, so leaving the pointer untouched
+    // hands the caller whatever was already in that memory. Every failure path
+    // above returns early, and msodbcsql likewise leaves the pointer alone on
+    // error, so writing once here is correct for both outcomes.
+    unsafe {
+        write_if_some(
+            string_length_ptr,
+            SqlInteger::try_from(size_of::<SqlULen>()).unwrap_or(SqlInteger::MAX),
+        );
+    }
+
     SQL_SUCCESS
 }
 
@@ -519,10 +631,14 @@ mod tests {
         SQL_ATTR_METADATA_ID, SQL_ATTR_NOSCAN, SQL_ATTR_PARAM_BIND_OFFSET_PTR,
         SQL_ATTR_PARAM_BIND_TYPE, SQL_ATTR_PARAM_OPERATION_PTR, SQL_ATTR_PARAM_STATUS_PTR,
         SQL_ATTR_PARAMS_PROCESSED_PTR, SQL_ATTR_RETRIEVE_DATA, SQL_ATTR_ROW_BIND_OFFSET_PTR,
-        SQL_ATTR_ROW_OPERATION_PTR, SQL_ATTR_USE_BOOKMARKS, SQL_BIND_BY_COLUMN, SQL_NULL_HANDLE,
-        SQL_RD_ON, SQL_ROWSET_SIZE, SqlLen,
+        SQL_ATTR_ROW_OPERATION_PTR, SQL_ATTR_USE_BOOKMARKS, SQL_BIND_BY_COLUMN, SQL_NTS,
+        SQL_NULL_HANDLE, SQL_RD_ON, SQL_ROWSET_SIZE, SQL_SOPT_SS_COLUMN_ENCRYPTION,
+        SQL_SOPT_SS_CURSOR_OPTIONS, SQL_SOPT_SS_DEFER_PREPARE, SQL_SOPT_SS_HIDDEN_COLUMNS,
+        SQL_SOPT_SS_NAME_SCOPE, SQL_SOPT_SS_NOBROWSETABLE, SQL_SOPT_SS_NOCOUNT_STATUS,
+        SQL_SOPT_SS_PARAM_FOCUS, SQL_SOPT_SS_QUERYNOTIFICATION_TIMEOUT, SQL_SOPT_SS_REGIONALIZE,
+        SQL_SOPT_SS_TEXTPTR_LOGGING, SqlLen,
     };
-    use crate::api::sqlstate::{SQLSTATE_24000, SQLSTATE_HY092};
+    use crate::api::sqlstate::{SQLSTATE_01004, SQLSTATE_24000, SQLSTATE_HY024, SQLSTATE_HY092};
     use crate::handles::handle_from_raw;
     use crate::handles::stmt::InertStmtAttrs;
     use crate::test_support::TestHandles;
@@ -813,31 +929,54 @@ mod tests {
 
     /// An identifier msodbcsql implements but this driver does not must report
     /// `HYC00`, not `HY092`: a caller probing for the feature has to be able to
-    /// tell "unavailable" from "not an attribute". `SQL_SOPT_SS_DEFER_PREPARE`
-    /// (1232) is a statement attribute msodbcsql honors.
+    /// tell "unavailable" from "not an attribute".
+    ///
+    /// `SQL_ATTR_ASYNC_STMT_EVENT` (29) is the last statement attribute
+    /// msodbcsql accepts that this driver does not implement, so it is the only
+    /// remaining witness for this class. If asynchronous execution is ever
+    /// implemented, this test needs a new subject — or deleting, if by then
+    /// nothing is left in that class.
     #[test]
     fn set_attribute_known_to_msodbcsql_reports_not_implemented() {
         let h = TestHandles::with_env_dbc_stmt();
-        let ret = unsafe { sql_set_stmt_attr_w(h.stmt, 1232, 0 as SqlPointer, 0) };
+        let ret = unsafe { sql_set_stmt_attr_w(h.stmt, 29, 0 as SqlPointer, 0) };
         assert_eq!(ret, SQL_ERROR);
         assert_eq!(stmt_sql_state(h.stmt), SQLSTATE_HYC00);
     }
 
+    /// Every statement attribute msodbcsql answers on a get, this driver also
+    /// answers. Asserted over the recognition table rather than a hand-picked
+    /// identifier so that adding a row without implementing it fails here
+    /// instead of reaching an application as `HYC00`.
+    ///
+    /// This replaced a test that used `SQL_SOPT_SS_DEFER_PREPARE` as its
+    /// unimplemented example; no gettable statement attribute is left in that
+    /// class, which is the point.
     #[test]
-    fn get_attribute_known_to_msodbcsql_reports_not_implemented() {
-        let h = TestHandles::with_env_dbc_stmt();
-        let mut out: SqlULen = 7;
-        let ret = unsafe {
-            sql_get_stmt_attr_w(
-                h.stmt,
-                1232,
-                (&mut out as *mut SqlULen).cast(),
-                0,
-                std::ptr::null_mut(),
-            )
-        };
-        assert_eq!(ret, SQL_ERROR);
-        assert_eq!(stmt_sql_state(h.stmt), SQLSTATE_HYC00);
+    fn every_gettable_statement_attribute_is_implemented() {
+        for id in crate::api::attributes::stmt_attr_ids(AttrOp::Get) {
+            let h = TestHandles::with_env_dbc_stmt();
+            // SQL_ATTR_ROW_NUMBER is the one legitimate error: it is answerable
+            // only while the cursor sits on a row, and reports 24000 otherwise.
+            if id == SQL_ATTR_ROW_NUMBER {
+                continue;
+            }
+            let mut out: SqlULen = 0;
+            let mut written: SqlInteger = 0;
+            let ret = unsafe {
+                sql_get_stmt_attr_w(
+                    h.stmt,
+                    id,
+                    (&mut out as *mut SqlULen).cast(),
+                    size_of::<SqlULen>() as SqlInteger,
+                    &mut written,
+                )
+            };
+            assert_ne!(
+                ret, SQL_ERROR,
+                "attribute {id} is recognized by msodbcsql but not served by this driver",
+            );
+        }
     }
 
     /// A connection attribute aimed at a statement stays `HY092`; the tables are
@@ -1471,5 +1610,438 @@ mod tests {
             );
             assert!(state.inert_attrs.get(*attribute).is_some());
         }
+    }
+
+    // ---- SQL Server vendor statement attributes (SQL_SOPT_SS_*) ----
+    //
+    // Every expectation below is a measurement taken from msodbcsql 18 with
+    // `probe_vendor_stmt.py` / `probe_vendor_bounds.py`, not a reading of the
+    // ODBC headers: two of these attributes accept values the headers do not
+    // name, and two reject every value the headers do name.
+
+    /// The vendor table is scanned linearly like the inert one, so a duplicate
+    /// identifier would silently shadow the second entry's default and rule.
+    #[test]
+    fn vendor_attribute_identifiers_are_unique() {
+        let ids: Vec<SqlInteger> = VendorStmtAttrs::identifiers().collect();
+        assert!(!ids.is_empty());
+        for (i, attribute) in ids.iter().enumerate() {
+            assert!(
+                !ids[..i].contains(attribute),
+                "duplicate vendor attribute {attribute}"
+            );
+        }
+    }
+
+    /// `set` is documented to reject anything the table does not know rather
+    /// than silently accept it. Callers check `is_settable` first, so this
+    /// guard is defensive — but a future caller that forgets would otherwise
+    /// write past the table.
+    #[test]
+    fn vendor_set_rejects_an_identifier_outside_the_table() {
+        let mut attrs = VendorStmtAttrs::default();
+        assert!(!attrs.set(SQL_ATTR_QUERY_TIMEOUT, 0));
+        assert!(!attrs.set(9999, 1));
+        assert_eq!(attrs.get(9999), None);
+    }
+
+    /// Defaults msodbcsql reports before any set. Three are non-zero, which is
+    /// the whole reason the table stores a default per attribute rather than
+    /// zero-initialising.
+    #[test]
+    fn vendor_attribute_defaults_match_msodbcsql() {
+        let h = TestHandles::with_env_dbc_stmt();
+        for (attribute, expected) in [
+            (SQL_SOPT_SS_TEXTPTR_LOGGING, 1),
+            (SQL_SOPT_SS_CURRENT_COMMAND, 0),
+            (SQL_SOPT_SS_HIDDEN_COLUMNS, 0),
+            (SQL_SOPT_SS_NOBROWSETABLE, 0),
+            (SQL_SOPT_SS_REGIONALIZE, 0),
+            (SQL_SOPT_SS_CURSOR_OPTIONS, 0),
+            (SQL_SOPT_SS_NOCOUNT_STATUS, 1),
+            (SQL_SOPT_SS_DEFER_PREPARE, 1),
+            (SQL_SOPT_SS_QUERYNOTIFICATION_TIMEOUT, 432_000),
+            (SQL_SOPT_SS_PARAM_FOCUS, 0),
+            (SQL_SOPT_SS_NAME_SCOPE, 0),
+            (SQL_SOPT_SS_COLUMN_ENCRYPTION, 0),
+        ] {
+            assert_eq!(
+                get_attr(h.stmt, attribute),
+                expected,
+                "default for vendor attribute {attribute}"
+            );
+        }
+    }
+
+    /// The boolean-valued vendor attributes take 0 and 1 and nothing else.
+    #[test]
+    fn vendor_boolean_attributes_accept_only_zero_and_one() {
+        for attribute in [
+            SQL_SOPT_SS_TEXTPTR_LOGGING,
+            SQL_SOPT_SS_HIDDEN_COLUMNS,
+            SQL_SOPT_SS_NOBROWSETABLE,
+            SQL_SOPT_SS_REGIONALIZE,
+            SQL_SOPT_SS_DEFER_PREPARE,
+        ] {
+            let h = TestHandles::with_env_dbc_stmt();
+            for value in [0, 1] {
+                let ret = unsafe { sql_set_stmt_attr_w(h.stmt, attribute, value as SqlPointer, 0) };
+                assert_eq!(ret, SQL_SUCCESS, "set {attribute} = {value}");
+                assert_eq!(get_attr(h.stmt, attribute), value);
+            }
+            let ret = unsafe { sql_set_stmt_attr_w(h.stmt, attribute, 2 as SqlPointer, 0) };
+            assert_eq!(ret, SQL_ERROR, "set {attribute} = 2 should be rejected");
+            assert_eq!(stmt_sql_state(h.stmt), SQLSTATE_HY024);
+        }
+    }
+
+    /// `SQL_SOPT_SS_CURSOR_OPTIONS` is a three-bit mask, so it accepts the whole
+    /// 0..=7 range rather than an enumerated set — a detail the headers do not
+    /// state and only the value sweep revealed.
+    #[test]
+    fn vendor_cursor_options_accepts_the_three_bit_range() {
+        let h = TestHandles::with_env_dbc_stmt();
+        for value in 0..=7 {
+            let ret = unsafe {
+                sql_set_stmt_attr_w(h.stmt, SQL_SOPT_SS_CURSOR_OPTIONS, value as SqlPointer, 0)
+            };
+            assert_eq!(ret, SQL_SUCCESS, "cursor options {value}");
+            assert_eq!(get_attr(h.stmt, SQL_SOPT_SS_CURSOR_OPTIONS), value);
+        }
+        let ret =
+            unsafe { sql_set_stmt_attr_w(h.stmt, SQL_SOPT_SS_CURSOR_OPTIONS, 8 as SqlPointer, 0) };
+        assert_eq!(ret, SQL_ERROR);
+        assert_eq!(stmt_sql_state(h.stmt), SQLSTATE_HY024);
+    }
+
+    /// `SQL_SOPT_SS_NAME_SCOPE` tops out at 3.
+    #[test]
+    fn vendor_name_scope_range_is_bounded() {
+        let h = TestHandles::with_env_dbc_stmt();
+        for value in 0..=3 {
+            let ret = unsafe {
+                sql_set_stmt_attr_w(h.stmt, SQL_SOPT_SS_NAME_SCOPE, value as SqlPointer, 0)
+            };
+            assert_eq!(ret, SQL_SUCCESS, "name scope {value}");
+        }
+        let ret =
+            unsafe { sql_set_stmt_attr_w(h.stmt, SQL_SOPT_SS_NAME_SCOPE, 4 as SqlPointer, 0) };
+        assert_eq!(ret, SQL_ERROR);
+        assert_eq!(stmt_sql_state(h.stmt), SQLSTATE_HY024);
+    }
+
+    /// Zero is rejected for the query-notification timeout, unlike most ODBC
+    /// timeouts where zero means "no limit". Measured, not assumed.
+    #[test]
+    fn vendor_query_notification_timeout_rejects_zero() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let ret = unsafe {
+            sql_set_stmt_attr_w(
+                h.stmt,
+                SQL_SOPT_SS_QUERYNOTIFICATION_TIMEOUT,
+                0 as SqlPointer,
+                0,
+            )
+        };
+        assert_eq!(ret, SQL_ERROR);
+        assert_eq!(stmt_sql_state(h.stmt), SQLSTATE_HY024);
+        // The rejected set must not have disturbed the default.
+        assert_eq!(
+            get_attr(h.stmt, SQL_SOPT_SS_QUERYNOTIFICATION_TIMEOUT),
+            432_000
+        );
+
+        for value in [1, 432_000, u32::MAX as SqlULen] {
+            let ret = unsafe {
+                sql_set_stmt_attr_w(
+                    h.stmt,
+                    SQL_SOPT_SS_QUERYNOTIFICATION_TIMEOUT,
+                    value as SqlPointer,
+                    0,
+                )
+            };
+            assert_eq!(ret, SQL_SUCCESS, "qn timeout {value}");
+            assert_eq!(
+                get_attr(h.stmt, SQL_SOPT_SS_QUERYNOTIFICATION_TIMEOUT),
+                value
+            );
+        }
+    }
+
+    /// `SQL_SOPT_SS_PARAM_FOCUS` and `SQL_SOPT_SS_COLUMN_ENCRYPTION` name
+    /// features neither driver offers here, and msodbcsql refuses every value
+    /// for them — including the "off" value its own headers define, and
+    /// including `COLUMN_ENCRYPTION` on a connection opened with
+    /// `ColumnEncryption=Enabled`. They are recognized, so the answer is
+    /// `HY024` (bad value) rather than `HY092` (bad identifier).
+    #[test]
+    fn vendor_unsupported_features_reject_every_value() {
+        for attribute in [SQL_SOPT_SS_PARAM_FOCUS, SQL_SOPT_SS_COLUMN_ENCRYPTION] {
+            for value in [0, 1, 2] {
+                let h = TestHandles::with_env_dbc_stmt();
+                let ret = unsafe { sql_set_stmt_attr_w(h.stmt, attribute, value as SqlPointer, 0) };
+                assert_eq!(ret, SQL_ERROR, "set {attribute} = {value}");
+                assert_eq!(stmt_sql_state(h.stmt), SQLSTATE_HY024);
+            }
+        }
+    }
+
+    /// A rejected value leaves the previous one in place — a failed set is not
+    /// a reset.
+    #[test]
+    fn vendor_rejected_value_leaves_previous_in_place() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let ret =
+            unsafe { sql_set_stmt_attr_w(h.stmt, SQL_SOPT_SS_CURSOR_OPTIONS, 5 as SqlPointer, 0) };
+        assert_eq!(ret, SQL_SUCCESS);
+        let ret =
+            unsafe { sql_set_stmt_attr_w(h.stmt, SQL_SOPT_SS_CURSOR_OPTIONS, 99 as SqlPointer, 0) };
+        assert_eq!(ret, SQL_ERROR);
+        assert_eq!(get_attr(h.stmt, SQL_SOPT_SS_CURSOR_OPTIONS), 5);
+    }
+
+    /// The two get-only vendor attributes answer `HY092` on a set, not `HY024`:
+    /// msodbcsql treats them as identifiers that are not settable at all rather
+    /// than settable ones given a bad value.
+    #[test]
+    fn vendor_get_only_attributes_reject_set_as_bad_identifier() {
+        for attribute in [SQL_SOPT_SS_CURRENT_COMMAND, SQL_SOPT_SS_NOCOUNT_STATUS] {
+            let h = TestHandles::with_env_dbc_stmt();
+            let ret = unsafe { sql_set_stmt_attr_w(h.stmt, attribute, 0 as SqlPointer, 0) };
+            assert_eq!(ret, SQL_ERROR, "set {attribute}");
+            assert_eq!(stmt_sql_state(h.stmt), SQLSTATE_HY092);
+        }
+    }
+
+    /// `SQL_SOPT_SS_CURRENT_COMMAND` is the ordinal of the command being
+    /// processed, not a flag: it starts at 0, becomes 1 on the first result
+    /// set, and advances with each further one.
+    #[test]
+    fn current_command_tracks_the_result_set_ordinal() {
+        let h = TestHandles::with_env_dbc_stmt();
+        assert_eq!(get_attr(h.stmt, SQL_SOPT_SS_CURRENT_COMMAND), 0);
+
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        stmt.inner.lock().unwrap().begin_batch(Vec::new());
+        assert_eq!(get_attr(h.stmt, SQL_SOPT_SS_CURRENT_COMMAND), 1);
+
+        stmt.inner.lock().unwrap().begin_result_set(Vec::new());
+        assert_eq!(get_attr(h.stmt, SQL_SOPT_SS_CURRENT_COMMAND), 2);
+
+        // A second execution restarts the count rather than continuing it.
+        stmt.inner.lock().unwrap().begin_batch(Vec::new());
+        assert_eq!(get_attr(h.stmt, SQL_SOPT_SS_CURRENT_COMMAND), 1);
+    }
+
+    /// Reads a string statement attribute into a fixed buffer, returning the
+    /// return code, the decoded value and the reported byte length.
+    fn get_str_attr(
+        stmt: SqlHandle,
+        attribute: SqlInteger,
+        buffer_bytes: usize,
+    ) -> (SqlReturn, String, SqlInteger) {
+        let mut buf = vec![0u16; buffer_bytes.div_ceil(2)];
+        let mut written: SqlInteger = -1;
+        let rc = unsafe {
+            sql_get_stmt_attr_w(
+                stmt,
+                attribute,
+                buf.as_mut_ptr().cast(),
+                buffer_bytes as SqlInteger,
+                &mut written,
+            )
+        };
+        let end = buf.iter().position(|&c| c == 0).unwrap_or(buf.len());
+        (rc, String::from_utf16_lossy(&buf[..end]), written)
+    }
+
+    /// Sets a string statement attribute from a UTF-16 buffer.
+    fn set_str_attr(
+        stmt: SqlHandle,
+        attribute: SqlInteger,
+        value: &str,
+        byte_length: SqlInteger,
+    ) -> SqlReturn {
+        let utf16: Vec<u16> = value.encode_utf16().chain(std::iter::once(0)).collect();
+        unsafe { sql_set_stmt_attr_w(stmt, attribute, utf16.as_ptr() as SqlPointer, byte_length) }
+    }
+
+    /// The two query-notification attributes are the only string-valued
+    /// statement attributes, and they default to empty.
+    #[test]
+    fn query_notification_strings_default_to_empty() {
+        let h = TestHandles::with_env_dbc_stmt();
+        for attribute in [
+            SQL_SOPT_SS_QUERYNOTIFICATION_MSGTEXT,
+            SQL_SOPT_SS_QUERYNOTIFICATION_OPTIONS,
+        ] {
+            let (rc, value, written) = get_str_attr(h.stmt, attribute, 64);
+            assert_eq!(rc, SQL_SUCCESS);
+            assert_eq!(value, "");
+            assert_eq!(written, 0);
+        }
+    }
+
+    #[test]
+    fn query_notification_strings_round_trip_independently() {
+        let h = TestHandles::with_env_dbc_stmt();
+        assert_eq!(
+            set_str_attr(
+                h.stmt,
+                SQL_SOPT_SS_QUERYNOTIFICATION_MSGTEXT,
+                "msg",
+                SQL_NTS.into()
+            ),
+            SQL_SUCCESS
+        );
+        assert_eq!(
+            set_str_attr(
+                h.stmt,
+                SQL_SOPT_SS_QUERYNOTIFICATION_OPTIONS,
+                "service=x",
+                SQL_NTS.into()
+            ),
+            SQL_SUCCESS
+        );
+
+        let (rc, value, written) = get_str_attr(h.stmt, SQL_SOPT_SS_QUERYNOTIFICATION_MSGTEXT, 64);
+        assert_eq!((rc, value.as_str(), written), (SQL_SUCCESS, "msg", 6));
+        let (rc, value, written) = get_str_attr(h.stmt, SQL_SOPT_SS_QUERYNOTIFICATION_OPTIONS, 64);
+        assert_eq!(
+            (rc, value.as_str(), written),
+            (SQL_SUCCESS, "service=x", 18)
+        );
+    }
+
+    /// `StringLength` on the set side is a **byte** count, so an explicit 6
+    /// stores three characters. Treating it as a character count would store
+    /// six and read past the caller's intent.
+    #[test]
+    fn query_notification_set_length_is_a_byte_count() {
+        let h = TestHandles::with_env_dbc_stmt();
+        assert_eq!(
+            set_str_attr(
+                h.stmt,
+                SQL_SOPT_SS_QUERYNOTIFICATION_MSGTEXT,
+                "abcdefghij",
+                6
+            ),
+            SQL_SUCCESS
+        );
+        let (_, value, written) = get_str_attr(h.stmt, SQL_SOPT_SS_QUERYNOTIFICATION_MSGTEXT, 64);
+        assert_eq!((value.as_str(), written), ("abc", 6));
+    }
+
+    /// A short buffer truncates with `01004` but still reports the full byte
+    /// length the value needs, so a caller can size a second call. A buffer
+    /// exactly the size of the value still truncates, because the NUL needs
+    /// room.
+    #[test]
+    fn query_notification_get_truncates_and_reports_full_length() {
+        let h = TestHandles::with_env_dbc_stmt();
+        set_str_attr(
+            h.stmt,
+            SQL_SOPT_SS_QUERYNOTIFICATION_MSGTEXT,
+            "abcdefghij",
+            SQL_NTS.into(),
+        );
+
+        for (buffer_bytes, expected) in [(4, "a"), (10, "abcd"), (20, "abcdefghi")] {
+            let (rc, value, written) =
+                get_str_attr(h.stmt, SQL_SOPT_SS_QUERYNOTIFICATION_MSGTEXT, buffer_bytes);
+            assert_eq!(rc, SQL_SUCCESS_WITH_INFO, "buffer of {buffer_bytes} bytes");
+            assert_eq!(value, expected);
+            assert_eq!(written, 20, "full length is always reported");
+            assert_eq!(stmt_sql_state(h.stmt), SQLSTATE_01004);
+        }
+
+        // One more SQLWCHAR of room for the terminator and it fits.
+        let (rc, value, written) = get_str_attr(h.stmt, SQL_SOPT_SS_QUERYNOTIFICATION_MSGTEXT, 22);
+        assert_eq!(
+            (rc, value.as_str(), written),
+            (SQL_SUCCESS, "abcdefghij", 20)
+        );
+    }
+
+    /// A null value pointer is the documented length-query form: it succeeds
+    /// and reports the length without writing.
+    #[test]
+    fn query_notification_null_pointer_is_a_length_query() {
+        let h = TestHandles::with_env_dbc_stmt();
+        set_str_attr(
+            h.stmt,
+            SQL_SOPT_SS_QUERYNOTIFICATION_MSGTEXT,
+            "abcdefghij",
+            SQL_NTS.into(),
+        );
+        let mut written: SqlInteger = -1;
+        let rc = unsafe {
+            sql_get_stmt_attr_w(
+                h.stmt,
+                SQL_SOPT_SS_QUERYNOTIFICATION_MSGTEXT,
+                std::ptr::null_mut(),
+                0,
+                &mut written,
+            )
+        };
+        assert_eq!((rc, written), (SQL_SUCCESS, 20));
+    }
+
+    /// msodbcsql writes the value's width into `StringLength` on every
+    /// successful integer get. Leaving it untouched hands the caller whatever
+    /// happened to be in that memory, so this is a correctness fix and not
+    /// cosmetic.
+    #[test]
+    fn integer_gets_report_the_value_width() {
+        let h = TestHandles::with_env_dbc_stmt();
+        for attribute in [
+            SQL_ATTR_QUERY_TIMEOUT,
+            SQL_ATTR_MAX_ROWS,
+            SQL_ATTR_NOSCAN,
+            SQL_ATTR_CURSOR_TYPE,
+            SQL_ATTR_CONCURRENCY,
+            SQL_ATTR_ROW_ARRAY_SIZE,
+            SQL_ATTR_METADATA_ID,
+            SQL_SOPT_SS_DEFER_PREPARE,
+        ] {
+            let mut out: SqlULen = 0;
+            let mut written: SqlInteger = -1;
+            let rc = unsafe {
+                sql_get_stmt_attr_w(
+                    h.stmt,
+                    attribute,
+                    (&mut out as *mut SqlULen).cast(),
+                    size_of::<SqlULen>() as SqlInteger,
+                    &mut written,
+                )
+            };
+            assert_eq!(rc, SQL_SUCCESS, "get {attribute}");
+            assert_eq!(
+                written,
+                size_of::<SqlULen>() as SqlInteger,
+                "StringLength for attribute {attribute}",
+            );
+        }
+    }
+
+    /// On a failed get msodbcsql leaves `StringLength` alone, so the success
+    /// write must not have been hoisted ahead of the error paths.
+    #[test]
+    fn failed_integer_get_leaves_string_length_untouched() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let mut out: SqlULen = 0;
+        let mut written: SqlInteger = -12345;
+        // SQL_ATTR_ROW_NUMBER with no open cursor is 24000.
+        let rc = unsafe {
+            sql_get_stmt_attr_w(
+                h.stmt,
+                SQL_ATTR_ROW_NUMBER,
+                (&mut out as *mut SqlULen).cast(),
+                size_of::<SqlULen>() as SqlInteger,
+                &mut written,
+            )
+        };
+        assert_eq!(rc, SQL_ERROR);
+        assert_eq!(written, -12345);
     }
 }

--- a/mssql-odbc/src/api/util.rs
+++ b/mssql-odbc/src/api/util.rs
@@ -92,12 +92,21 @@ pub(crate) unsafe fn read_utf16(ptr: *const SqlWChar, length: SqlSmallInt) -> St
 /// [`read_utf16`] for entry points whose length argument is a `SQLINTEGER`
 /// rather than a `SQLSMALLINT`.
 ///
+/// A length of zero reads nothing, so the pointer is never dereferenced — an
+/// application is entitled to pair a zero length with a placeholder pointer,
+/// and msodbcsql accepts that combination. A null pointer is likewise treated
+/// as an empty value rather than faulting: this is an FFI boundary, and a
+/// driver that aborts takes its host process down with it.
+///
 /// # Safety
 /// - `ptr` must be readable for `length` `SQLWCHAR`s, or up to and including the
 ///   first NUL terminator when `length == SQL_NTS`.
 /// - `length` must be non-negative or exactly `SQL_NTS`; callers validate that
 ///   first and report `HY090` otherwise.
 pub(crate) unsafe fn read_utf16_long(ptr: *const SqlWChar, length: SqlInteger) -> String {
+    if ptr.is_null() {
+        return String::new();
+    }
     let slice = if length == SqlInteger::from(SQL_NTS) {
         let mut len = 0usize;
         unsafe {
@@ -107,7 +116,10 @@ pub(crate) unsafe fn read_utf16_long(ptr: *const SqlWChar, length: SqlInteger) -
         }
         unsafe { slice::from_raw_parts(ptr, len) }
     } else {
-        unsafe { slice::from_raw_parts(ptr, usize::try_from(length).unwrap_or(0)) }
+        match usize::try_from(length) {
+            Ok(0) | Err(_) => return String::new(),
+            Ok(len) => unsafe { slice::from_raw_parts(ptr, len) },
+        }
     };
     String::from_utf16_lossy(slice)
 }
@@ -391,6 +403,42 @@ mod tests {
             unsafe { read_utf16_attr(buf.as_ptr(), SqlInteger::from(SQL_NTS)) },
             "master"
         );
+    }
+
+    /// A zero length reads nothing, so the pointer must never be dereferenced —
+    /// not even to form an empty slice, which still requires alignment and so
+    /// aborts the process under Rust's UB checks. msodbcsql accepts a
+    /// placeholder pointer with a zero length, and an ODBC driver that aborts
+    /// takes its host process down with it.
+    #[test]
+    fn zero_length_never_dereferences_the_pointer() {
+        let hostile = std::ptr::without_provenance::<SqlWChar>(1);
+        assert_eq!(unsafe { read_utf16_long(hostile, 0) }, "");
+        assert_eq!(unsafe { read_utf16_attr(hostile, 0) }, "");
+        // An odd byte count below one whole SQLWCHAR is also nothing to read.
+        assert_eq!(unsafe { read_utf16_attr(hostile, 1) }, "");
+    }
+
+    /// A null pointer is an empty value rather than a fault, for the same
+    /// reason.
+    #[test]
+    fn null_pointer_reads_as_empty() {
+        let null = std::ptr::null::<SqlWChar>();
+        assert_eq!(unsafe { read_utf16_long(null, 4) }, "");
+        assert_eq!(
+            unsafe { read_utf16_long(null, SqlInteger::from(SQL_NTS)) },
+            ""
+        );
+        assert_eq!(unsafe { read_utf16_attr(null, 8) }, "");
+    }
+
+    /// A negative length that is not `SQL_NTS` is a caller error the entry
+    /// points reject with `HY090`; the reader must not turn it into a huge
+    /// slice on the way there.
+    #[test]
+    fn negative_length_reads_as_empty() {
+        let buf: Vec<SqlWChar> = "master".encode_utf16().collect();
+        assert_eq!(unsafe { read_utf16_long(buf.as_ptr(), -7) }, "");
     }
 
     #[test]

--- a/mssql-odbc/src/handles/stmt.rs
+++ b/mssql-odbc/src/handles/stmt.rs
@@ -207,6 +207,21 @@ pub(crate) struct StmtState {
     /// Statement attributes msodbcsql accepts and round-trips but that have no
     /// effect on this driver's forward-only, read-only cursor.
     pub(crate) inert_attrs: InertStmtAttrs,
+    /// SQL Server vendor statement attributes (`SQL_SOPT_SS_*`), which unlike
+    /// the inert set validate their value before storing it.
+    pub(crate) vendor_attrs: VendorStmtAttrs,
+    /// Query-notification message text (`SQL_SOPT_SS_QUERYNOTIFICATION_MSGTEXT`)
+    /// and options (`..._OPTIONS`). The only two string-valued statement
+    /// attributes, so they sit beside [`Self::vendor_attrs`] rather than in it.
+    /// Stored and round-tripped; query notifications themselves are a separate
+    /// feature.
+    pub(crate) qn_msgtext: String,
+    pub(crate) qn_options: String,
+    /// Ordinal of the command being processed within the current batch, which
+    /// is what `SQL_SOPT_SS_CURRENT_COMMAND` reports: `0` before execute, then
+    /// one per result set begun. msodbcsql holds the final value once the batch
+    /// is exhausted rather than advancing past it.
+    pub(crate) current_command: SqlULen,
 }
 
 /// Statement attributes msodbcsql stores and round-trips without acting on,
@@ -315,6 +330,163 @@ impl InertStmtAttrs {
     }
 }
 
+/// How msodbcsql validates a vendor statement attribute's value.
+///
+/// Each rule was established by sweeping the value space against msodbcsql 18
+/// and recording where it flipped from success to `HY024`, not by reading the
+/// documented constants — two attributes accept values the headers do not name,
+/// and two reject every value the headers do name.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum ValueRule {
+    /// Accepts exactly these values.
+    OneOf(&'static [SqlULen]),
+    /// Accepts any value in this inclusive range.
+    Range(SqlULen, SqlULen),
+    /// Recognized, but refuses every value. Both attributes in this class name
+    /// features the driver does not implement (table-valued parameters, Always
+    /// Encrypted), and msodbcsql itself refuses them here too — including their
+    /// documented "off" value, and including `SQL_SOPT_SS_COLUMN_ENCRYPTION` on
+    /// a connection opened with `ColumnEncryption=Enabled`.
+    Rejected,
+    /// Reported by the get path but not settable. Set is left to fall through
+    /// to the identifier-rejection path, because msodbcsql answers `HY092`
+    /// ("invalid attribute identifier") rather than `HY024` for these.
+    GetOnly,
+}
+
+/// Vendor statement attributes, their msodbcsql defaults, and the values
+/// msodbcsql accepts for each.
+///
+/// Held as one table for the same reason as [`INERT_STMT_ATTRS`]: the default
+/// and the accept rule are both measurements, and keeping them adjacent to the
+/// identifier stops one from drifting without the other.
+const VENDOR_STMT_ATTRS: &[(SqlInteger, SqlULen, ValueRule)] = &[
+    (
+        odbc_types::SQL_SOPT_SS_TEXTPTR_LOGGING,
+        odbc_types::SQL_TL_ON,
+        ValueRule::OneOf(&[0, 1]),
+    ),
+    (
+        odbc_types::SQL_SOPT_SS_CURRENT_COMMAND,
+        0,
+        ValueRule::GetOnly,
+    ),
+    (
+        odbc_types::SQL_SOPT_SS_HIDDEN_COLUMNS,
+        0,
+        ValueRule::OneOf(&[0, 1]),
+    ),
+    (
+        odbc_types::SQL_SOPT_SS_NOBROWSETABLE,
+        0,
+        ValueRule::OneOf(&[0, 1]),
+    ),
+    (
+        odbc_types::SQL_SOPT_SS_REGIONALIZE,
+        0,
+        ValueRule::OneOf(&[0, 1]),
+    ),
+    (
+        odbc_types::SQL_SOPT_SS_CURSOR_OPTIONS,
+        0,
+        ValueRule::Range(0, odbc_types::SQL_CO_MAX),
+    ),
+    (
+        odbc_types::SQL_SOPT_SS_NOCOUNT_STATUS,
+        odbc_types::SQL_NC_ON,
+        ValueRule::GetOnly,
+    ),
+    (
+        odbc_types::SQL_SOPT_SS_DEFER_PREPARE,
+        odbc_types::SQL_DP_ON,
+        ValueRule::OneOf(&[0, 1]),
+    ),
+    (
+        odbc_types::SQL_SOPT_SS_QUERYNOTIFICATION_TIMEOUT,
+        odbc_types::SQL_QN_TIMEOUT_DEFAULT,
+        // Zero is rejected, unlike most ODBC timeouts where it means "no limit".
+        ValueRule::Range(1, u32::MAX as SqlULen),
+    ),
+    (odbc_types::SQL_SOPT_SS_PARAM_FOCUS, 0, ValueRule::Rejected),
+    (
+        odbc_types::SQL_SOPT_SS_NAME_SCOPE,
+        0,
+        ValueRule::Range(0, odbc_types::SQL_SS_NAME_SCOPE_MAX),
+    ),
+    (
+        odbc_types::SQL_SOPT_SS_COLUMN_ENCRYPTION,
+        0,
+        ValueRule::Rejected,
+    ),
+];
+
+/// Values for the [`VENDOR_STMT_ATTRS`] identifiers, positionally aligned with
+/// that table.
+#[derive(Debug, Clone)]
+pub(crate) struct VendorStmtAttrs([SqlULen; VENDOR_STMT_ATTRS.len()]);
+
+impl Default for VendorStmtAttrs {
+    fn default() -> Self {
+        let mut values = [0; VENDOR_STMT_ATTRS.len()];
+        for (slot, (_, default, _)) in values.iter_mut().zip(VENDOR_STMT_ATTRS) {
+            *slot = *default;
+        }
+        Self(values)
+    }
+}
+
+impl VendorStmtAttrs {
+    /// The identifiers this store covers, in table order. Test-only: it exists
+    /// so a new entry cannot be added without an asserted msodbcsql default.
+    #[cfg(test)]
+    pub(crate) fn identifiers() -> impl Iterator<Item = SqlInteger> {
+        VENDOR_STMT_ATTRS.iter().map(|(id, _, _)| *id)
+    }
+
+    fn index_of(attribute: SqlInteger) -> Option<usize> {
+        VENDOR_STMT_ATTRS
+            .iter()
+            .position(|(id, _, _)| *id == attribute)
+    }
+
+    /// Whether `attribute` is a vendor attribute the set path owns.
+    ///
+    /// False for the get-only identifiers, so they fall through to the
+    /// identifier-rejection path and answer `HY092` rather than `HY024`.
+    pub(crate) fn is_settable(attribute: SqlInteger) -> bool {
+        Self::index_of(attribute)
+            .is_some_and(|i| !matches!(VENDOR_STMT_ATTRS[i].2, ValueRule::GetOnly))
+    }
+
+    /// Returns the stored value, or `None` when `attribute` is not a vendor
+    /// statement attribute.
+    pub(crate) fn get(&self, attribute: SqlInteger) -> Option<SqlULen> {
+        Self::index_of(attribute).map(|i| self.0[i])
+    }
+
+    /// Validates `value` against the attribute's measured rule, storing it and
+    /// returning `true` on success.
+    ///
+    /// A rejected value leaves the previous one in place, which is what
+    /// msodbcsql does — a failed set is not a reset. Callers are expected to
+    /// have checked [`Self::is_settable`]; anything else is reported as
+    /// rejected rather than silently accepted.
+    pub(crate) fn set(&mut self, attribute: SqlInteger, value: SqlULen) -> bool {
+        let Some(i) = Self::index_of(attribute) else {
+            return false;
+        };
+        let accepted = match VENDOR_STMT_ATTRS[i].2 {
+            ValueRule::OneOf(allowed) => allowed.contains(&value),
+            ValueRule::Range(lo, hi) => (lo..=hi).contains(&value),
+            ValueRule::Rejected | ValueRule::GetOnly => false,
+        };
+        if accepted {
+            self.0[i] = value;
+        }
+        accepted
+    }
+}
+
 /// A prepared statement bundled with the marker count of its rewritten SQL, so
 /// the two can only be set together (the count is a property of the rewritten
 /// `@P1..@Pn` text and must always agree with it).
@@ -374,14 +546,32 @@ impl StmtState {
     }
 
     /// Makes `metadata` the current result set, restarting the
-    /// `SQL_ATTR_MAX_ROWS` budget.
+    /// `SQL_ATTR_MAX_ROWS` budget and advancing the batch command ordinal.
     ///
     /// The cap is per result set, so every path that advances onto a new one
     /// must come through here; assigning `column_metadata` directly would leave
     /// a spent budget in place and truncate the next result set.
+    ///
+    /// This is the *advance* form, for `SQLMoreResults`. The first result set of
+    /// a new execution goes through [`Self::begin_batch`] instead, so that the
+    /// command ordinal restarts rather than climbing across executions.
     pub(crate) fn begin_result_set(&mut self, metadata: Vec<ColumnMetadata>) {
         self.column_metadata = metadata;
         self.rows_returned = 0;
+        self.current_command += 1;
+    }
+
+    /// Makes `metadata` the first result set of a new execution.
+    ///
+    /// Identical to [`Self::begin_result_set`] except that the batch command
+    /// ordinal restarts, so `SQL_SOPT_SS_CURRENT_COMMAND` answers 1 on the
+    /// first result set of every execution. msodbcsql restarts it per execute
+    /// and holds the final value across `SQLCloseCursor` /
+    /// `SQLFreeStmt(SQL_CLOSE)`, so a statement handle reused for a second
+    /// query reports 1 again rather than continuing to climb.
+    pub(crate) fn begin_batch(&mut self, metadata: Vec<ColumnMetadata>) {
+        self.current_command = 0;
+        self.begin_result_set(metadata);
     }
 
     /// Whether `SQL_ATTR_MAX_ROWS` has already been satisfied for the current
@@ -496,6 +686,10 @@ impl StmtHandle {
                 max_rows: 0,
                 rows_returned: 0,
                 inert_attrs: InertStmtAttrs::default(),
+                vendor_attrs: VendorStmtAttrs::default(),
+                qn_msgtext: String::new(),
+                qn_options: String::new(),
+                current_command: 0,
             }),
         }
     }

--- a/mssql-odbc/src/handles/stmt.rs
+++ b/mssql-odbc/src/handles/stmt.rs
@@ -404,8 +404,10 @@ const VENDOR_STMT_ATTRS: &[(SqlInteger, SqlULen, ValueRule)] = &[
     (
         odbc_types::SQL_SOPT_SS_QUERYNOTIFICATION_TIMEOUT,
         odbc_types::SQL_QN_TIMEOUT_DEFAULT,
-        // Zero is rejected, unlike most ODBC timeouts where it means "no limit".
-        ValueRule::Range(1, u32::MAX as SqlULen),
+        // Zero is rejected, unlike most ODBC timeouts where it means "no limit",
+        // and the ceiling is i32::MAX rather than the full SQLULEN width:
+        // msodbcsql answers HY024 from 2^31 upwards on 64-bit.
+        ValueRule::Range(1, i32::MAX as SqlULen),
     ),
     (odbc_types::SQL_SOPT_SS_PARAM_FOCUS, 0, ValueRule::Rejected),
     (

--- a/mssql-odbc/tests/e2e/tests/attributes_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/attributes_test.cpp
@@ -75,6 +75,9 @@
 //   53. CurrentCommandTracksTheResultSetOrdinal        - per execute, not a flag
 //   54. QueryNotificationStringsFollowTheByteLengthContract - bytes, not chars
 //   55. IntegerGetsReportTheValueWidth                 - StringLength on success
+//   56. CurrentCommandAdvancesThroughNonRowResults     - DML counts too
+//   57. QueryNotificationStringsRejectBadNegativeLengths - only SQL_NTS
+//   58. QueryNotificationTimeoutCeilingIsIntMax        - INT_MAX, not SQLULEN
 
 #include "odbc_test_fixture.h"
 
@@ -1519,7 +1522,111 @@ TEST_F(AttributesTest, IntegerGetsReportTheValueWidth) {
 }
 
 // -------------------------------------------------------------------
-// 56. MAX_ROWS truncates a rowset rather than rounding it.
+// Variation 56 - CURRENT_COMMAND counts every statement in the batch,
+// not just the row-returning ones. A batch that mixes SELECTs, DML and
+// PRINT still reports 1, 2, 3. Advancing the ordinal only where a
+// cursor opens agrees on an all-SELECT batch and stalls on every other
+// shape, which is exactly the batch a stored procedure produces.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, CurrentCommandAdvancesThroughNonRowResults) {
+    struct Batch {
+        const char* label;
+        const char* sql;
+    };
+    const Batch batches[] = {
+        {"select-dml-select",
+         "SELECT 1; DECLARE @t TABLE(i INT); INSERT INTO @t VALUES(1); SELECT 2"},
+        {"pure-dml",
+         "DECLARE @t TABLE(i INT); INSERT INTO @t VALUES(1); "
+         "INSERT INTO @t VALUES(2); INSERT INTO @t VALUES(3)"},
+        {"print-select-print", "PRINT 'a'; SELECT 1; PRINT 'b'"},
+    };
+
+    for (const Batch& batch : batches) {
+        SCOPED_TRACE(batch.label);
+        SqlTString sql = ODBCTestUtils::ToSqlTStr(batch.sql);
+        SQLRETURN rc = SQLExecDirect(stmt_, const_cast<SQLTCHAR*>(sql.c_str()),
+                                     SQL_NTS);
+        ASSERT_SQL_OK(rc, SQL_HANDLE_STMT, stmt_);
+
+        for (SQLULEN expected = 1; expected <= 3; ++expected) {
+            EXPECT_EQ(expected, GetStmtULen(kSsCurrentCommand))
+                << "result " << expected;
+            if (expected < 3) {
+                ASSERT_SQL_OK(SQLMoreResults(stmt_), SQL_HANDLE_STMT, stmt_);
+            }
+        }
+        EXPECT_EQ(SQL_NO_DATA, SQLMoreResults(stmt_));
+        EXPECT_EQ(SQLULEN{3}, GetStmtULen(kSsCurrentCommand));
+        SQLCloseCursor(stmt_);
+    }
+}
+
+// -------------------------------------------------------------------
+// Variation 57 - SQL_NTS is the only negative StringLength a character
+// attribute accepts. Any other negative value is HY024 and leaves the
+// stored string untouched; reading it as a terminated string instead
+// would silently clear an attribute the caller never meant to write.
+// Note the SQLSTATE differs from SQL_ATTR_CURRENT_CATALOG's HY090 -
+// these are vendor attributes the driver validates itself.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, QueryNotificationStringsRejectBadNegativeLengths) {
+    const SQLINTEGER attributes[] = {kSsQnMsgtext, kSsQnOptions};
+    SqlTString seed = ODBCTestUtils::ToSqlTStr("SEED");
+    SqlTString other = ODBCTestUtils::ToSqlTStr("REPLACED");
+
+    for (SQLINTEGER attribute : attributes) {
+        SCOPED_TRACE(attribute);
+        ASSERT_SQL_OK(SQLSetStmtAttr(stmt_, attribute,
+                                     const_cast<SQLTCHAR*>(seed.c_str()),
+                                     SQL_NTS),
+                      SQL_HANDLE_STMT, stmt_);
+
+        for (SQLINTEGER length : {-2, -5, -100}) {
+            SCOPED_TRACE(length);
+            EXPECT_EQ(SQL_ERROR,
+                      SQLSetStmtAttr(stmt_, attribute,
+                                     const_cast<SQLTCHAR*>(other.c_str()),
+                                     length));
+            EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "HY024");
+
+            SQLTCHAR buffer[32] = {};
+            SQLINTEGER written = -1;
+            EXPECT_SQL_OK(SQLGetStmtAttr(stmt_, attribute, buffer,
+                                         sizeof(buffer), &written),
+                          SQL_HANDLE_STMT, stmt_);
+            EXPECT_EQ("SEED", ODBCTestUtils::ToNarrow(SqlTString(buffer)));
+        }
+    }
+}
+
+// -------------------------------------------------------------------
+// Variation 58 - the query-notification timeout tops out at INT_MAX,
+// not at the full SQLULEN width the pointer slot can carry. Values
+// above it are HY024 and leave the previous timeout in place.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, QueryNotificationTimeoutCeilingIsIntMax) {
+    ASSERT_SQL_OK(SQLSetStmtAttr(stmt_, kSsQnTimeout,
+                                 reinterpret_cast<SQLPOINTER>(
+                                     static_cast<SQLULEN>(2147483647)),
+                                 0),
+                  SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(SQLULEN{2147483647}, GetStmtULen(kSsQnTimeout));
+
+    const SQLULEN rejected[] = {2147483648ULL, 3000000000ULL, 4294967295ULL};
+    for (SQLULEN value : rejected) {
+        SCOPED_TRACE(value);
+        EXPECT_EQ(SQL_ERROR,
+                  SQLSetStmtAttr(stmt_, kSsQnTimeout,
+                                 reinterpret_cast<SQLPOINTER>(value), 0));
+        EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "HY024");
+        EXPECT_EQ(SQLULEN{2147483647}, GetStmtULen(kSsQnTimeout))
+            << "a rejected set must leave the previous value in place";
+    }
+}
+
+// -------------------------------------------------------------------
+// 59. MAX_ROWS truncates a rowset rather than rounding it.
 //
 // SQL_ATTR_MAX_ROWS was measured against single-row fetches, which leaves
 // open whether the cap is a row budget or a rowset boundary. Measured on

--- a/mssql-odbc/tests/e2e/tests/attributes_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/attributes_test.cpp
@@ -44,7 +44,7 @@
 //   26. StatementOnlyAttributeIsRejectedOnAConnection  - scope-keyed HY092
 //   27. ConnectionOnlyAttributeIsRejectedOnAStatement  - the mirror image
 //   28. RowNumberIsNotSettable                         - operation-keyed HY092
-//   29. UnimplementedStatementAttributeIsNotImplemented- HYC00, not HY092
+//   29. EveryRecognizedStatementAttributeIsAnswered    - no HY092/HYC00 left
 //   30. UnimplementedConnectionAttributeIsNotImplemented - HYC00 on the get path
 //   31. HostileAttributePayloadDoesNotFault            - HYC00, session survives
 //   32. KeystoreDataGetIsRecognizedNotUnknown          - recognized on both, never HY092
@@ -64,6 +64,17 @@
 //   44. MaxRowsCutoffLeavesTheCursorOffTheRow          - cap end == natural end
 //   45. MaxRowsBoundsCatalogResultSets                 - the cap reaches SQLTables too
 //   46. ParamBindOffsetShiftsTheBoundBuffers           - the offset is honored
+//
+// SQL Server vendor statement attributes (SQL_SOPT_SS_*):
+//   47. VendorStatementAttributeDefaultsMatchMsodbcsql - four defaults are not 0
+//   48. VendorBooleanAttributesRejectOutOfRangeValues  - driver-sourced HY024
+//   49. VendorRangeAttributesAcceptTheirWholeRange     - masks, not enumerations
+//   50. QueryNotificationTimeoutRejectsZeroAndKeepsItsValue - 0 is not "no limit"
+//   51. VendorUnsupportedFeatureAttributesRefuseEveryValue - HY024, not HY092
+//   52. VendorGetOnlyAttributesAreNotSettable          - HY092, not HY024
+//   53. CurrentCommandTracksTheResultSetOrdinal        - per execute, not a flag
+//   54. QueryNotificationStringsFollowTheByteLengthContract - bytes, not chars
+//   55. IntegerGetsReportTheValueWidth                 - StringLength on success
 
 #include "odbc_test_fixture.h"
 
@@ -105,11 +116,24 @@ constexpr SQLINTEGER kEnlistInDtcAttr = 1207;
 // SQL_ATTR_ROW_ARRAY_SIZE (Variation 35).
 constexpr SQLINTEGER kRowsetSizeAttr = 9;
 
-// SQL_SOPT_SS_DEFER_PREPARE - a vendor statement attribute msodbcsql accepts
-// and this driver defers (plan §S6), so the two legs diverge by design. Its
-// ODBC-standard neighbours are all honoured after slice S4, which is why the
-// remaining "not implemented here" example has to come from the vendor band.
-constexpr SQLINTEGER kDeferPrepareAttr = 1232;
+// SQL_SOPT_SS_* - the SQL Server vendor statement attributes (slice S6).
+// They share the 1225-1238 band with the SQL_COPT_SS_* connection attributes,
+// so recognition is keyed by scope as well as identifier: 1232 is
+// DEFER_PREPARE on a statement and PRESERVE_CURSORS on a connection.
+constexpr SQLINTEGER kSsTextptrLogging = 1225;
+constexpr SQLINTEGER kSsCurrentCommand = 1226;
+constexpr SQLINTEGER kSsHiddenColumns = 1227;
+constexpr SQLINTEGER kSsNobrowsetable = 1228;
+constexpr SQLINTEGER kSsRegionalize = 1229;
+constexpr SQLINTEGER kSsCursorOptions = 1230;
+constexpr SQLINTEGER kSsNocountStatus = 1231;
+constexpr SQLINTEGER kSsDeferPrepare = 1232;
+constexpr SQLINTEGER kSsQnTimeout = 1233;
+constexpr SQLINTEGER kSsQnMsgtext = 1234;
+constexpr SQLINTEGER kSsQnOptions = 1235;
+constexpr SQLINTEGER kSsParamFocus = 1236;
+constexpr SQLINTEGER kSsNameScope = 1237;
+constexpr SQLINTEGER kSsColumnEncryption = 1238;
 
 // SQL_ATTR_ROW_NUMBER - readable but not settable on msodbcsql, which makes it
 // the statement-side mirror of the connection-side SQL_ATTR_QUERY_TIMEOUT
@@ -689,17 +713,48 @@ TEST_F(AttributesTest, RowNumberIsNotSettable) {
 }
 
 // -------------------------------------------------------------------
-// Variation 29 - a statement attribute msodbcsql implements and this
-// driver does not: HYC00, so a caller can tell "unavailable here" from
-// "never an attribute". msodbcsql returns success, hence the skip.
+// Variation 29 - every statement attribute msodbcsql recognizes on the
+// set path is recognized here too. Before slice S6 this variation held
+// the opposite: an attribute msodbcsql accepted and this driver answered
+// with HYC00. That class is now empty, so the useful assertion is that it
+// stays empty - a new row in the recognition table that nobody wired up
+// fails here rather than reaching an application as HYC00.
+//
+// Recognition is asserted independently of the value, because 21 of these
+// reject the probe value with HY024; what must never come back is HY092
+// ("no such attribute") or HYC00 ("known but unavailable").
+//
+// SQL_ATTR_ASYNC_STMT_EVENT (29) is deliberately absent: the Driver
+// Manager answers it itself with HY118 for any driver that does not
+// advertise asynchronous notification, so it never reaches either
+// driver's set path and cannot be compared here.
+//
+// The descriptor-handle attributes (SQL_ATTR_APP_ROW_DESC and its three
+// neighbours, 10010-10013) are absent for a different reason: their value
+// is a handle, and msodbcsql dereferences it without checking, so probing
+// them with a placeholder access-violates inside the driver. Recognition
+// of those is covered by the get path instead.
 // -------------------------------------------------------------------
-TEST_F(AttributesTest, UnimplementedStatementAttributeIsNotImplemented) {
-    SKIP_IF_COMPARING_MSODBCSQL();
+TEST_F(AttributesTest, EveryRecognizedStatementAttributeIsAnswered) {
+    const SQLINTEGER attributes[] = {
+        -2,   -1,   0,    1,    2,    3,    4,    5,    6,    7,
+        8,    9,    10,   11,   12,   15,   16,   17,   18,   19,
+        20,   21,   22,   23,   24,   25,   26,   27,   1225, 1227,
+        1228, 1229, 1230, 1232, 1233, 1234, 1235, 1236, 1237, 1238,
+        10014,
+    };
 
-    EXPECT_EQ(SQL_ERROR,
-              SQLSetStmtAttr(stmt_, kDeferPrepareAttr,
-                             reinterpret_cast<SQLPOINTER>(1), 0));
-    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "HYC00");
+    for (SQLINTEGER attribute : attributes) {
+        SCOPED_TRACE(attribute);
+        SQLRETURN rc = SetStmtULen(attribute, 1);
+        if (SQL_SUCCEEDED(rc)) {
+            continue;
+        }
+        const std::string state =
+            ODBCTestUtils::GetDiagState(SQL_HANDLE_STMT, stmt_);
+        EXPECT_NE("HY092", state) << "identifier not recognized";
+        EXPECT_NE("HYC00", state) << "recognized but not implemented";
+    }
 }
 
 // -------------------------------------------------------------------
@@ -1201,8 +1256,270 @@ TEST_F(AttributesTest, ParamBindOffsetShiftsTheBoundBuffers) {
     }
 }
 
+
 // -------------------------------------------------------------------
-// 47. MAX_ROWS truncates a rowset rather than rounding it.
+// Variation 47 - the SQL Server vendor statement attributes have
+// defaults, and four of them are not 0. A caller that assumes a
+// zero-initialised block reads TEXTPTR_LOGGING, NOCOUNT_STATUS and
+// DEFER_PREPARE as "off" when the driver has them on, and sees a
+// query-notification timeout of 0 rather than the five-day default.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, VendorStatementAttributeDefaultsMatchMsodbcsql) {
+    struct Case {
+        SQLINTEGER attribute;
+        SQLULEN expected;
+        const char* label;
+    } const cases[] = {
+        {kSsTextptrLogging, 1, "TEXTPTR_LOGGING"},
+        {kSsCurrentCommand, 0, "CURRENT_COMMAND"},
+        {kSsHiddenColumns, 0, "HIDDEN_COLUMNS"},
+        {kSsNobrowsetable, 0, "NOBROWSETABLE"},
+        {kSsRegionalize, 0, "REGIONALIZE"},
+        {kSsCursorOptions, 0, "CURSOR_OPTIONS"},
+        {kSsNocountStatus, 1, "NOCOUNT_STATUS"},
+        {kSsDeferPrepare, 1, "DEFER_PREPARE"},
+        {kSsQnTimeout, 432000, "QUERYNOTIFICATION_TIMEOUT"},
+        {kSsParamFocus, 0, "PARAM_FOCUS"},
+        {kSsNameScope, 0, "NAME_SCOPE"},
+        {kSsColumnEncryption, 0, "COLUMN_ENCRYPTION"},
+    };
+
+    for (const Case& c : cases) {
+        SCOPED_TRACE(c.label);
+        EXPECT_EQ(c.expected, GetStmtULen(c.attribute));
+    }
+}
+
+// -------------------------------------------------------------------
+// Variation 48 - the boolean vendor attributes take 0 and 1 and reject
+// everything else with HY024. Unlike the standard attributes, this
+// rejection comes from the driver rather than the Driver Manager, which
+// does not know these identifiers and passes their values straight
+// through.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, VendorBooleanAttributesRejectOutOfRangeValues) {
+    const SQLINTEGER attributes[] = {kSsTextptrLogging, kSsHiddenColumns,
+                                     kSsNobrowsetable, kSsRegionalize,
+                                     kSsDeferPrepare};
+
+    for (SQLINTEGER attribute : attributes) {
+        SCOPED_TRACE(attribute);
+        for (SQLULEN value : {SQLULEN{0}, SQLULEN{1}}) {
+            EXPECT_EQ(SQL_SUCCESS, SetStmtULen(attribute, value));
+            EXPECT_EQ(value, GetStmtULen(attribute));
+        }
+
+        EXPECT_EQ(SQL_ERROR, SetStmtULen(attribute, 2));
+        EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "HY024");
+    }
+}
+
+// -------------------------------------------------------------------
+// Variation 49 - CURSOR_OPTIONS is a three-bit mask rather than an
+// enumeration, so the whole 0..7 range is legal. Treating it as a set of
+// named constants would reject combinations a caller is entitled to pass.
+// NAME_SCOPE is the neighbouring bounded range, capped at 3.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, VendorRangeAttributesAcceptTheirWholeRange) {
+    for (SQLULEN value = 0; value <= 7; ++value) {
+        SCOPED_TRACE(value);
+        EXPECT_EQ(SQL_SUCCESS, SetStmtULen(kSsCursorOptions, value));
+        EXPECT_EQ(value, GetStmtULen(kSsCursorOptions));
+    }
+    EXPECT_EQ(SQL_ERROR, SetStmtULen(kSsCursorOptions, 8));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "HY024");
+
+    for (SQLULEN value = 0; value <= 3; ++value) {
+        SCOPED_TRACE(value);
+        EXPECT_EQ(SQL_SUCCESS, SetStmtULen(kSsNameScope, value));
+        EXPECT_EQ(value, GetStmtULen(kSsNameScope));
+    }
+    EXPECT_EQ(SQL_ERROR, SetStmtULen(kSsNameScope, 4));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "HY024");
+}
+
+// -------------------------------------------------------------------
+// Variation 50 - the query-notification timeout rejects 0, which is the
+// opposite of the ODBC convention where 0 on a timeout means "no limit".
+// A driver that copied that convention would silently accept a value
+// msodbcsql refuses. A refused set also leaves the previous value alone:
+// failing is not resetting.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, QueryNotificationTimeoutRejectsZeroAndKeepsItsValue) {
+    EXPECT_EQ(SQL_ERROR, SetStmtULen(kSsQnTimeout, 0));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "HY024");
+    EXPECT_EQ(SQLULEN{432000}, GetStmtULen(kSsQnTimeout));
+
+    EXPECT_EQ(SQL_SUCCESS, SetStmtULen(kSsQnTimeout, 60));
+    EXPECT_EQ(SQL_ERROR, SetStmtULen(kSsQnTimeout, 0));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "HY024");
+    EXPECT_EQ(SQLULEN{60}, GetStmtULen(kSsQnTimeout));
+}
+
+// -------------------------------------------------------------------
+// Variation 51 - PARAM_FOCUS and COLUMN_ENCRYPTION are recognized
+// identifiers whose features are unavailable, so every value is refused
+// with HY024 rather than the identifier being refused with HY092. The
+// distinction matters: a caller probing for Always Encrypted must be able
+// to tell "this driver knows the attribute but cannot honour it" from
+// "this is not an attribute".
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, VendorUnsupportedFeatureAttributesRefuseEveryValue) {
+    for (SQLINTEGER attribute : {kSsParamFocus, kSsColumnEncryption}) {
+        SCOPED_TRACE(attribute);
+        for (SQLULEN value : {SQLULEN{0}, SQLULEN{1}, SQLULEN{2}}) {
+            EXPECT_EQ(SQL_ERROR, SetStmtULen(attribute, value));
+            EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "HY024");
+        }
+        EXPECT_EQ(SQLULEN{0}, GetStmtULen(attribute));
+    }
+}
+
+// -------------------------------------------------------------------
+// Variation 52 - CURRENT_COMMAND and NOCOUNT_STATUS are readable but not
+// settable, and the refusal is HY092 rather than the HY024 of Variation
+// 49. This is the vendor-band mirror of Variation 28: recognition is
+// keyed by operation, so "not settable" reads as an unknown identifier
+// for the set operation, not as a bad value.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, VendorGetOnlyAttributesAreNotSettable) {
+    for (SQLINTEGER attribute : {kSsCurrentCommand, kSsNocountStatus}) {
+        SCOPED_TRACE(attribute);
+        EXPECT_EQ(SQL_ERROR, SetStmtULen(attribute, 0));
+        EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "HY092");
+    }
+}
+
+// -------------------------------------------------------------------
+// Variation 53 - CURRENT_COMMAND is the ordinal of the result set being
+// processed, not a boolean. It starts at 0, reaches 1 on the first result
+// set, advances with SQLMoreResults, holds once the batch is exhausted,
+// and restarts at 1 on the next execution. Modelling it as a bare counter
+// agrees on the first query and diverges on the second.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, CurrentCommandTracksTheResultSetOrdinal) {
+    SqlTString sql = ODBCTestUtils::ToSqlTStr("SELECT 1; SELECT 2; SELECT 3");
+
+    EXPECT_EQ(SQLULEN{0}, GetStmtULen(kSsCurrentCommand)) << "fresh statement";
+
+    for (int pass = 0; pass < 2; ++pass) {
+        SCOPED_TRACE(pass);
+        ASSERT_SQL_OK(
+            SQLExecDirect(stmt_, const_cast<SQLTCHAR*>(sql.c_str()), SQL_NTS),
+            SQL_HANDLE_STMT, stmt_);
+
+        for (SQLULEN expected = 1; expected <= 3; ++expected) {
+            EXPECT_EQ(expected, GetStmtULen(kSsCurrentCommand));
+            if (expected < 3) {
+                ASSERT_SQL_OK(SQLMoreResults(stmt_), SQL_HANDLE_STMT, stmt_);
+            }
+        }
+
+        // Exhausting the batch holds the last ordinal rather than clearing it,
+        // and so does closing the cursor.
+        EXPECT_EQ(SQL_NO_DATA, SQLMoreResults(stmt_));
+        EXPECT_EQ(SQLULEN{3}, GetStmtULen(kSsCurrentCommand));
+
+        SQLCloseCursor(stmt_);
+        EXPECT_EQ(SQLULEN{3}, GetStmtULen(kSsCurrentCommand))
+            << "close does not reset";
+    }
+}
+
+// -------------------------------------------------------------------
+// Variation 54 - the two query-notification attributes are the only
+// string-valued statement attributes. StringLength is a byte count on
+// both legs, so an explicit 6 stores three characters, and a get always
+// reports the full byte width even when the buffer could not hold it.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, QueryNotificationStringsFollowTheByteLengthContract) {
+    SQLTCHAR buffer[32] = {};
+    SQLINTEGER written = -1;
+
+    // Both default to empty.
+    for (SQLINTEGER attribute : {kSsQnMsgtext, kSsQnOptions}) {
+        SCOPED_TRACE(attribute);
+        written = -1;
+        EXPECT_SQL_OK(SQLGetStmtAttr(stmt_, attribute, buffer, sizeof(buffer),
+                                     &written),
+                      SQL_HANDLE_STMT, stmt_);
+        EXPECT_EQ(0, written);
+    }
+
+    SqlTString value = ODBCTestUtils::ToSqlTStr("abcdefghij");
+    SQLTCHAR* msg = const_cast<SQLTCHAR*>(value.c_str());
+
+    // A NUL-terminated set round-trips, and the two are independent.
+    EXPECT_EQ(SQL_SUCCESS, SQLSetStmtAttr(stmt_, kSsQnMsgtext, msg, SQL_NTS));
+    written = -1;
+    EXPECT_SQL_OK(
+        SQLGetStmtAttr(stmt_, kSsQnMsgtext, buffer, sizeof(buffer), &written),
+        SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(20, written);
+
+    written = -1;
+    EXPECT_SQL_OK(
+        SQLGetStmtAttr(stmt_, kSsQnOptions, buffer, sizeof(buffer), &written),
+        SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(0, written) << "options untouched by a msgtext set";
+
+    // StringLength on the set path is bytes, so 6 stores three characters.
+    EXPECT_EQ(SQL_SUCCESS, SQLSetStmtAttr(stmt_, kSsQnMsgtext, msg, 6));
+    written = -1;
+    EXPECT_SQL_OK(
+        SQLGetStmtAttr(stmt_, kSsQnMsgtext, buffer, sizeof(buffer), &written),
+        SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(6, written);
+
+    // A short buffer truncates with 01004 but still reports the full width, so
+    // a caller can size a second call from the first one's answer. A null
+    // pointer is the documented length-only query.
+    EXPECT_EQ(SQL_SUCCESS, SQLSetStmtAttr(stmt_, kSsQnMsgtext, msg, SQL_NTS));
+    written = -1;
+    EXPECT_EQ(SQL_SUCCESS_WITH_INFO,
+              SQLGetStmtAttr(stmt_, kSsQnMsgtext, buffer, 10, &written));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "01004");
+    EXPECT_EQ(20, written);
+
+    written = -1;
+    EXPECT_EQ(SQL_SUCCESS,
+              SQLGetStmtAttr(stmt_, kSsQnMsgtext, nullptr, 0, &written));
+    EXPECT_EQ(20, written);
+}
+
+// -------------------------------------------------------------------
+// Variation 55 - a successful integer get writes the value's width into
+// StringLength, and a failed one leaves the caller's variable alone.
+// Skipping the write on success hands back whatever was in that memory.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, IntegerGetsReportTheValueWidth) {
+    const SQLINTEGER attributes[] = {
+        SQL_ATTR_QUERY_TIMEOUT, SQL_ATTR_MAX_ROWS,       SQL_ATTR_NOSCAN,
+        SQL_ATTR_CURSOR_TYPE,   SQL_ATTR_CONCURRENCY,    SQL_ATTR_ROW_ARRAY_SIZE,
+        SQL_ATTR_METADATA_ID,   kSsDeferPrepare,         kSsCurrentCommand,
+    };
+
+    for (SQLINTEGER attribute : attributes) {
+        SCOPED_TRACE(attribute);
+        SQLULEN value = 0;
+        SQLINTEGER written = -1;
+        EXPECT_SQL_OK(
+            SQLGetStmtAttr(stmt_, attribute, &value, sizeof(value), &written),
+            SQL_HANDLE_STMT, stmt_);
+        EXPECT_EQ(static_cast<SQLINTEGER>(sizeof(SQLULEN)), written);
+    }
+
+    // SQL_ATTR_ROW_NUMBER without an open cursor fails (Variation 41), and the
+    // failure must not have written a length first.
+    SQLULEN value = 0;
+    SQLINTEGER written = -12345;
+    EXPECT_EQ(SQL_ERROR, SQLGetStmtAttr(stmt_, kRowNumberAttr, &value,
+                                        sizeof(value), &written));
+    EXPECT_EQ(-12345, written);
+}
+
+// -------------------------------------------------------------------
+// 56. MAX_ROWS truncates a rowset rather than rounding it.
 //
 // SQL_ATTR_MAX_ROWS was measured against single-row fetches, which leaves
 // open whether the cap is a row budget or a rowset boundary. Measured on


### PR DESCRIPTION
Implements **[AB#47458](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47458) — mssql-odbc | Vendor statement attributes**, part of
[AB#46377](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46377). Stacked on #350; review that first.

The fourteen `SQL_SOPT_SS_*` statement attributes (1225–1238) are driver-private,
so the Driver Manager neither range-checks their values nor answers on the
driver's behalf. Everything below is the driver's own contract, measured against
live msodbcsql 18 rather than read out of `msodbcsql.h`.

## Measured contract

| id | attribute | shape | default | set behavior |
|---|---|---|---|---|
| 1225 | `TEXTPTR_LOGGING` | int | **1** | `{0,1}`, else `HY024` |
| 1226 | `CURRENT_COMMAND` | int | 0 | **get-only** → `HY092` |
| 1227 | `HIDDEN_COLUMNS` | int | 0 | `{0,1}` |
| 1228 | `NOBROWSETABLE` | int | 0 | `{0,1}` |
| 1229 | `REGIONALIZE` | int | 0 | `{0,1}` |
| 1230 | `CURSOR_OPTIONS` | int | 0 | range `0..=7` |
| 1231 | `NOCOUNT_STATUS` | int | **1** | **get-only** → `HY092` |
| 1232 | `DEFER_PREPARE` | int | **1** | `{0,1}` |
| 1233 | `QUERYNOTIFICATION_TIMEOUT` | int | **432000** | `1..=i32::MAX`, **0 rejected** |
| 1234 | `QUERYNOTIFICATION_MSGTEXT` | **string** | `""` | any string |
| 1235 | `QUERYNOTIFICATION_OPTIONS` | **string** | `""` | any string |
| 1236 | `PARAM_FOCUS` | int | 0 | **always `HY024`** |
| 1237 | `NAME_SCOPE` | int | 0 | range `0..=3` |
| 1238 | `COLUMN_ENCRYPTION` | int | 0 | **always `HY024`** |

A rejected set leaves the previous value in place.

## ⚠️ Robustness fix to already-shipped code

**`read_utf16_long` could abort the host process.** Probing 1234 with a
placeholder `(void*)1` and `StringLength = 0` produced:

```
panicked at util.rs:96: unsafe precondition(s) violated: slice::from_raw_parts
requires the pointer to be aligned and non-null
thread caused non-unwinding panic. aborting.
```

`slice::from_raw_parts(ptr, 0)` still requires alignment even at zero length.
msodbcsql returns `SQL_SUCCESS` and never touches the pointer.

**This is not new behavior in this PR.** `read_utf16_long` already backed
`SQL_ATTR_CURRENT_CATALOG`, shipped in #348, so
`SQLSetConnectAttrW(dbc, SQL_ATTR_CURRENT_CATALOG, ptr, 0)` was equally
reachable. This PR only widened the surface that exposes it. Fixed at the root: a
null pointer or any non-positive length reads as the empty string without
forming a slice.

It matters because mssql-python loads this driver **in-process inside CPython**.
An `abort()` kills the interpreter with no traceback and no catchable exception.
A driver at an FFI boundary must degrade, not die.

A *non-zero* length with a bad pointer is deliberately left undefined — that is
a real caller-contract violation with data to read, and msodbcsql
access-violates on it too.

## Findings that changed the implementation

- **Value rejection is mandatory here, unlike #350.** #350 skipped range validation
  because `HY024` for standard attributes comes from the DM before dispatch. For
  1225–1238 the DM has no knowledge and passes any value through, so the driver
  must validate or it silently accepts what msodbcsql refuses. Probes
  distinguish the two sources by the message's bracketed prefix.
- **`SQLGetStmtAttrW` writes `StringLength` on integer gets** — `8` on success,
  pointer left untouched on failure. An application that zeroes the
  out-parameter and checks it cannot otherwise tell the two apart.
- **`CURRENT_COMMAND` is a per-execute result-set ordinal.** 0 fresh, 1 after
  execute, 2 and 3 as `SQLMoreResults` advances, holding at the last value once
  exhausted. Re-execute resets to 1; `SQLCloseCursor` and
  `SQLFreeStmt(SQL_CLOSE)` do not.
- **`NOCOUNT_STATUS` is a constant.** It reports `1` after both `SET NOCOUNT ON`
  and `OFF`, so it is a fixed default rather than a read of session state.
- **`COLUMN_ENCRYPTION` rejects every value** including 0, and does so even on a
  connection opened with `ColumnEncryption=Enabled` — the rejection is
  unconditional, not a licence check.

## Two attributes that cannot be compared through the Driver Manager

- **`SQL_ATTR_ASYNC_STMT_EVENT` (29)** looked like the ideal "recognized but
  unimplemented here" exemplar, since the sweep recorded a plain success for
  msodbcsql. Through the DM against this driver it returns `HY118` — *"Driver
  does not support asynchronous notification"* — **from the DM itself**. The DM
  gates the identifier on the driver advertising async notification, so the call
  never reaches the driver. Unit tests still cover it by calling the entry point
  directly.
- **The descriptor-handle attributes (10010–10013)** take a handle as their
  value and msodbcsql dereferences it unchecked, so probing them with a
  placeholder access-violates *inside msodbcsql*. Recognition is asserted
  through the get path instead.

With this in, **no statement attribute remains that msodbcsql accepts and this
driver refuses.** e2e Variation 29 is therefore inverted from "this one is not
implemented" into a completeness sweep over all 41 comparable identifiers,
asserting neither `HY092` nor `HYC00` — and it now runs against both drivers
instead of being skipped for msodbcsql.

## Testing

| Check | Result |
|---|---|
| `cargo nextest run -p mssql-odbc` | 812 passed (was 784) |
| e2e vs **msodbcsql** | 56 passed, 2 skipped, 0 failed |
| e2e vs **mssql-odbc** | **58/58** |
| Vendor probe suites (7) | 0 divergent (baseline was 121) |
| `cargo bfmt` / `cargo bclippy` | clean |
| Diff coverage | **97.27%** cumulative across the stack |

e2e Variations 47–58 were written and run **against msodbcsql first** to
validate the contract, then against this driver to prove parity.

### Review round — three measured divergences fixed

Review raised three cases this suite did not cover. All three were measured
against msodbcsql 18 before any code changed, and all three were real:

| # | Divergence | msodbcsql | before the fix |
|---|---|---|---|
| 1 | Negative `StringLength` on the QN string attributes | `HY024`, stored value kept | `SQL_SUCCESS`, value cleared |
| 2 | QN timeout above `INT_MAX` | `HY024`, previous value kept | accepted up to `u32::MAX` |
| 3 | `CURRENT_COMMAND` on a batch that is not all SELECTs | 1 → 2 → 3 | stalls |

Divergence 3 is the significant one. The ordinal advances on **every** result
in the batch, not just row-returning ones:

| batch | msodbcsql | before the fix |
|---|---|---|
| 3 SELECTs | 1 → 2 → 3 | 1 → 2 → 3 ✅ |
| SELECT, DML, SELECT | 1 → 2 → 3 | 1 → 1 → 2 ❌ |
| 3 DMLs | 1 → 2 → 3 | 1 → 1 → 1 ❌ |
| PRINT, SELECT, PRINT | 1 → 2 → 3 | 1 → 2 → 2 ❌ |

Only the all-SELECT shape agreed, and that was the only shape Variation 53
exercised — so the attribute was wrong for essentially any stored procedure
while the suite stayed green. `SQLMoreResults` had two paths that stepped the
batch without calling `begin_result_set`: draining a queued DML row count, and
the `NoRows` advance. Variations 56–58 cover all three fixes and pass
identically on both drivers. The generator
`emit_attrs_rs.py` now emits `stmt_attr_ids()`, so regenerating `attributes.rs`
no longer drops it — verified by round-trip diff.

## Checklist

- [x] Behavior measured against live msodbcsql, not inferred from headers
- [x] Unit tests for every new branch
- [x] e2e parity tests run unmodified against both drivers
- [x] `cargo bfmt`, `cargo bclippy`, `cargo nextest` clean
- [x] Plan doc updated with the shipped contract
- [ ] Ready for review (draft while the stack below it lands)

[AB#47458](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47458)

---

### Rebased onto the restacked #350

`attributes_test.cpp` grows by appending, so the whole stack had to be re-laid after main advanced. Two things worth knowing when reading this diff:

- **Variation numbering shifted.** #350 gained a MAX_ROWS-against-a-rowset test numbered 47 on its own branch. This PR already owned 47–58, so that test moves to **59** here and the vendor variations keep their numbers. A given number therefore means one test in the merged file; it is only #350's newest variation that is labelled differently on the two branches.
- **`SQL_SOPT_SS_PARAM_FOCUS` stays deferred.** It was deferred because descriptors did not exist; main has since landed the descriptor model (#345), so the reason was re-checked rather than carried forward. `PARAM_FOCUS` selects which *record set* subsequent `SQLBindParameter` calls address, which needs the APD to be the backing store for parameter binding. It is not: `sql_bind_parameter` writes into `StmtState.params` and never reads the APD, so the descriptor model is still a parallel structure. Wiring the two together is [AB#46374](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46374).

Validated at this tip: 950 unit tests, `cargo bfmt` / `cargo bclippy` clean, and the full e2e suite run unmodified against both drivers — 59/59 on mssql-odbc, 57 passed plus the 2 driver-specific skips on msodbcsql.

