### PR TITLE
[DO NOT MERGE][py-core] Fix Rust unit test linking on Linux x64

### DIFF
--- a/.pipeline/scripts/containerized-python-test.sh
+++ b/.pipeline/scripts/containerized-python-test.sh
@@ -10,14 +10,10 @@ source ~/.cargo/env
 # Set Python path
 export PATH="/usr/local/bin:$PATH"
 
-# Some ARM64 build images have rustup and Cargo but omit rustc from the
-# repository-selected toolchain.
-cd /workspace
-rustup component add rustc
-
 # Run Python tests using the dev script
 # Pass through any arguments (e.g., --skip-integration)
 echo "Running Python tests for mssql-py-core..."
+cd /workspace
 ./dev/test-python.sh "$@"
 
 echo "Python tests completed successfully"

--- a/.pipeline/scripts/containerized-python-test.sh
+++ b/.pipeline/scripts/containerized-python-test.sh
@@ -10,10 +10,14 @@ source ~/.cargo/env
 # Set Python path
 export PATH="/usr/local/bin:$PATH"
 
+# Some ARM64 build images have rustup and Cargo but omit rustc from the
+# repository-selected toolchain.
+cd /workspace
+rustup component add rustc
+
 # Run Python tests using the dev script
 # Pass through any arguments (e.g., --skip-integration)
 echo "Running Python tests for mssql-py-core..."
-cd /workspace
 ./dev/test-python.sh "$@"
 
 echo "Python tests completed successfully"

--- a/mssql-py-core/Cargo.toml
+++ b/mssql-py-core/Cargo.toml
@@ -9,7 +9,7 @@ name = "mssql_py_core"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.29.0", features = ["extension-module"] }
+pyo3 = { version = "0.29.0" }
 pyo3-async-runtimes = { version = "0.29", features = ["tokio-runtime"] }
 mssql-tds = { path = "../mssql-tds" }
 tokio = { version = "1", features = ["full", "rt-multi-thread"] }
@@ -25,6 +25,11 @@ rust_decimal = "1.36"
 serde_json = "1.0"
 uuid = "1.19"
 arrow = { version = "55", default-features = false, features = ["ffi"] }
+
+# Unit tests link a standalone binary, so they need libpython and an
+# initialized interpreter. Resolver v2 keeps this out of the cdylib/wheel build.
+[dev-dependencies]
+pyo3 = { version = "0.29.0", features = ["auto-initialize"] }
 
 [build-dependencies]
 pyo3-build-config = "0.29.0"

--- a/mssql-py-core/pyproject.toml
+++ b/mssql-py-core/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
 
 [tool.maturin]
 module-name = "mssql_py_core"
+features = ["pyo3/extension-module"]
 # Don't vendor shared libraries (libssl, libcrypto) into the wheel.
 # Built on manylinux_2_34 (AlmaLinux 9) so the native extension links against
 # libssl.so.3 / libcrypto.so.3 and expects the OS to provide OpenSSL 3.x at runtime.

--- a/mssql-py-core/src/async_connection.rs
+++ b/mssql-py-core/src/async_connection.rs
@@ -22,7 +22,7 @@ use mssql_tds::connection::tds_client::TdsClient;
 use mssql_tds::connection_provider::tds_connection_provider::TdsConnectionProvider;
 
 use crate::async_cursor::PyAsyncCursor;
-use crate::async_session::AsyncConnectionState;
+use crate::async_session::{AsyncConnectionState, ClaimError, OperationId};
 use crate::connection::PyCoreConnection;
 use crate::python_logger_adapter::python_logger_dispatch;
 
@@ -53,6 +53,45 @@ fn emit_preview_warning(py: Python<'_>) -> PyResult<()> {
 fn map_tds_error(op: &str, user_msg: &str, e: impl std::fmt::Display) -> PyErr {
     tracing::error!("PyAsyncConnection::{op}: failed: {e}");
     PyRuntimeError::new_err(format!("{user_msg}: {e}"))
+}
+
+fn map_claim_error(error: ClaimError) -> PyErr {
+    match error {
+        ClaimError::Closing => PyRuntimeError::new_err("Connection is closing"),
+        ClaimError::Closed => PyRuntimeError::new_err("Connection is closed"),
+        ClaimError::Broken => PyRuntimeError::new_err("Connection is broken"),
+        ClaimError::Busy => PyRuntimeError::new_err("Connection is busy with another operation"),
+    }
+}
+
+struct ConnectionOperationGuard {
+    session_state: Arc<AsyncConnectionState>,
+    operation_id: OperationId,
+    completed: bool,
+}
+
+impl ConnectionOperationGuard {
+    fn new(session_state: Arc<AsyncConnectionState>, operation_id: OperationId) -> Self {
+        Self {
+            session_state,
+            operation_id,
+            completed: false,
+        }
+    }
+
+    fn complete(&mut self) {
+        self.session_state.release_operation(self.operation_id);
+        self.completed = true;
+    }
+}
+
+impl Drop for ConnectionOperationGuard {
+    fn drop(&mut self) {
+        if !self.completed {
+            self.session_state.mark_broken();
+            self.session_state.release_operation(self.operation_id);
+        }
+    }
 }
 
 async fn with_optional_dispatch<F>(future: F, dispatch: Option<tracing::Dispatch>) -> F::Output
@@ -382,26 +421,40 @@ impl PyAsyncConnection {
             .ok_or_else(|| PyRuntimeError::new_err("Connection is closed"))?
             .clone();
         let dispatch = self.tracing_dispatch.clone();
+        let session_state = self.session_state.clone();
+        let operation_id = session_state
+            .claim_connection_operation()
+            .map_err(map_claim_error)?;
 
-        pyo3_async_runtimes::tokio::future_into_py(
+        let result = pyo3_async_runtimes::tokio::future_into_py(
             py,
             with_optional_dispatch(
                 async move {
-                    let mut guard = client.lock().await;
-                    if !guard.has_active_transaction() {
-                        return Python::attach(|py| Ok(py.None()));
+                    let mut operation_guard =
+                        ConnectionOperationGuard::new(session_state, operation_id);
+                    let result = async {
+                        let mut client = client.lock().await;
+                        if client.has_active_transaction() {
+                            tracing::info!("PyAsyncConnection::commit: sending TM_COMMIT");
+                            client
+                                .commit_transaction(None, None)
+                                .await
+                                .map_err(|error| map_tds_error("commit", "Commit failed", error))?;
+                            tracing::info!("PyAsyncConnection::commit: transaction committed");
+                        }
+                        Python::attach(|py| Ok(py.None()))
                     }
-                    tracing::info!("PyAsyncConnection::commit: sending TM_COMMIT");
-                    guard
-                        .commit_transaction(None, None)
-                        .await
-                        .map_err(|e| map_tds_error("commit", "Commit failed", e))?;
-                    tracing::info!("PyAsyncConnection::commit: transaction committed");
-                    Python::attach(|py| Ok(py.None()))
+                    .await;
+                    operation_guard.complete();
+                    result
                 },
                 dispatch,
             ),
-        )
+        );
+        if result.is_err() {
+            self.session_state.release_operation(operation_id);
+        }
+        result
     }
 
     /// Roll back the current transaction. No-op if none is active.
@@ -414,26 +467,42 @@ impl PyAsyncConnection {
             .ok_or_else(|| PyRuntimeError::new_err("Connection is closed"))?
             .clone();
         let dispatch = self.tracing_dispatch.clone();
+        let session_state = self.session_state.clone();
+        let operation_id = session_state
+            .claim_connection_operation()
+            .map_err(map_claim_error)?;
 
-        pyo3_async_runtimes::tokio::future_into_py(
+        let result = pyo3_async_runtimes::tokio::future_into_py(
             py,
             with_optional_dispatch(
                 async move {
-                    let mut guard = client.lock().await;
-                    if !guard.has_active_transaction() {
-                        return Python::attach(|py| Ok(py.None()));
+                    let mut operation_guard =
+                        ConnectionOperationGuard::new(session_state, operation_id);
+                    let result = async {
+                        let mut client = client.lock().await;
+                        if client.has_active_transaction() {
+                            tracing::info!("PyAsyncConnection::rollback: sending TM_ROLLBACK");
+                            client
+                                .rollback_transaction(None, None)
+                                .await
+                                .map_err(|error| {
+                                    map_tds_error("rollback", "Rollback failed", error)
+                                })?;
+                            tracing::info!("PyAsyncConnection::rollback: transaction rolled back");
+                        }
+                        Python::attach(|py| Ok(py.None()))
                     }
-                    tracing::info!("PyAsyncConnection::rollback: sending TM_ROLLBACK");
-                    guard
-                        .rollback_transaction(None, None)
-                        .await
-                        .map_err(|e| map_tds_error("rollback", "Rollback failed", e))?;
-                    tracing::info!("PyAsyncConnection::rollback: transaction rolled back");
-                    Python::attach(|py| Ok(py.None()))
+                    .await;
+                    operation_guard.complete();
+                    result
                 },
                 dispatch,
             ),
-        )
+        );
+        if result.is_err() {
+            self.session_state.release_operation(operation_id);
+        }
+        result
     }
 
     /// Create an async cursor. Sync per DB-API 2.0. Raises `RuntimeError` if the

--- a/mssql-py-core/src/async_connection.rs
+++ b/mssql-py-core/src/async_connection.rs
@@ -55,6 +55,10 @@ fn map_tds_error(op: &str, user_msg: &str, e: impl std::fmt::Display) -> PyErr {
     PyRuntimeError::new_err(format!("{user_msg}: {e}"))
 }
 
+/// Maps a connection lifecycle or session-ownership rejection to `RuntimeError`.
+///
+/// A busy connection may be owned by either a cursor or another connection-level
+/// operation. DB-API-specific exception mapping is tracked separately.
 fn map_claim_error(error: ClaimError) -> PyErr {
     match error {
         ClaimError::Closing => PyRuntimeError::new_err("Connection is closing"),
@@ -64,6 +68,11 @@ fn map_claim_error(error: ClaimError) -> PyErr {
     }
 }
 
+/// Owns the session claim for an in-flight commit or rollback.
+///
+/// `complete()` releases the claim after success or a handled TDS error. Dropping
+/// before completion indicates cancellation or an interrupted protocol exchange,
+/// so the connection is marked broken before the claim is released.
 struct ConnectionOperationGuard {
     session_state: Arc<AsyncConnectionState>,
     operation_id: OperationId,
@@ -71,6 +80,7 @@ struct ConnectionOperationGuard {
 }
 
 impl ConnectionOperationGuard {
+    /// Creates a guard for an already-acquired connection-operation claim.
     fn new(session_state: Arc<AsyncConnectionState>, operation_id: OperationId) -> Self {
         Self {
             session_state,
@@ -79,6 +89,7 @@ impl ConnectionOperationGuard {
         }
     }
 
+    /// Releases the claim and prevents drop-time connection poisoning.
     fn complete(&mut self) {
         self.session_state.release_operation(self.operation_id);
         self.completed = true;
@@ -86,6 +97,7 @@ impl ConnectionOperationGuard {
 }
 
 impl Drop for ConnectionOperationGuard {
+    /// Marks the connection broken when an operation is cancelled or interrupted.
     fn drop(&mut self) {
         if !self.completed {
             self.session_state.mark_broken();

--- a/mssql-py-core/src/async_connection.rs
+++ b/mssql-py-core/src/async_connection.rs
@@ -266,6 +266,9 @@ impl PyAsyncConnection {
 
     /// Whether statements use SQL Server autocommit mode. The mode is fixed at
     /// connection time until async transition semantics are implemented.
+    // TODO: Add an awaitable mode-change API. Enabling autocommit must commit
+    // active work before changing mode and preserve the old mode on failure;
+    // disabling it must defer begin until the next execute.
     #[getter]
     fn autocommit(&self) -> bool {
         self.autocommit.load(Ordering::Relaxed)

--- a/mssql-py-core/src/async_connection.rs
+++ b/mssql-py-core/src/async_connection.rs
@@ -447,6 +447,7 @@ impl PyAsyncConnection {
             .clone();
         Ok(PyAsyncCursor::new(
             client,
+            self.tracing_dispatch.clone(),
             self.autocommit.clone(),
             self.session_state.clone(),
             self.session_state.allocate_cursor_id(),

--- a/mssql-py-core/src/async_connection.rs
+++ b/mssql-py-core/src/async_connection.rs
@@ -129,13 +129,9 @@ async fn close_client(client: Arc<Mutex<TdsClient>>, autocommit: bool) -> bool {
 
 /// Asynchronous Python connection backed by the Core TDS client.
 ///
-/// Preview API — unstable.
-///
-/// TODO(User Story 47180 [mssql-python] Cancel API and Cancellation Bridge):
-/// cancellation of a suspended `commit`, `rollback`, or `close` future can
-/// desync the TDS byte stream. Callers must not cancel these awaitables
-/// against a connection they intend to keep using.
-/// <https://sqlclientdrivers.visualstudio.com/mssql-python/_workitems/edit/47180>
+/// This API is a preview and may change between minor releases. Do not cancel
+/// an in-progress `commit()`, `rollback()`, or `close()` if the connection will
+/// be reused.
 #[pyclass]
 pub struct PyAsyncConnection {
     /// `Option` so `close()` can `take()`; `Arc<Mutex<>>` for cursor sharing.
@@ -152,8 +148,10 @@ pub struct PyAsyncConnection {
 
 #[pymethods]
 impl PyAsyncConnection {
-    /// Establish a TDS connection. Dict parsing is synchronous; the network
-    /// handshake runs on the shared Tokio runtime.
+    /// Establish a connection and return an awaitable resolving to it.
+    ///
+    /// `client_context_dict` supplies the SQL Server connection options.
+    /// `autocommit` defaults to `False`.
     #[classmethod]
     #[pyo3(signature = (client_context_dict, python_logger=None, autocommit=false))]
     fn connect<'py>(

--- a/mssql-py-core/src/async_cursor.rs
+++ b/mssql-py-core/src/async_cursor.rs
@@ -348,8 +348,9 @@ impl CursorCleanup {
         };
 
         cleanup_guard.fail(has_open_batch);
-        result?;
+        // Cleanup consumes the close attempt even when draining or unprepare fails.
         self.closed.store(true, Ordering::Release);
+        result?;
         Ok(())
     }
 }
@@ -474,6 +475,10 @@ impl Drop for PyAsyncCursor {
         let session_state = self.session_state.clone();
         let claim = match session_state.claim_cursor_close(self.cursor_id) {
             Ok(claim) => claim,
+            Err(ClaimError::Closing | ClaimError::Closed) => {
+                self.closed.store(true, Ordering::Release);
+                return;
+            }
             Err(error) => {
                 tracing::warn!("PyAsyncCursor finalizer could not claim cleanup: {error:?}");
                 session_state.abandon_cursor(self.cursor_id);
@@ -733,6 +738,12 @@ impl PyAsyncCursor {
         let session_state = cleanup.session_state.clone();
         let claim = match session_state.claim_cursor_close(cleanup.cursor_id) {
             Ok(claim) => claim,
+            Err(ClaimError::Closing | ClaimError::Closed) => {
+                cleanup.closed.store(true, Ordering::Release);
+                return pyo3_async_runtimes::tokio::future_into_py(py, async move {
+                    Python::attach(|py| Ok(py.None()))
+                });
+            }
             Err(error) => {
                 cleanup_started.store(false, Ordering::Release);
                 return Err(map_claim_error(error));

--- a/mssql-py-core/src/async_cursor.rs
+++ b/mssql-py-core/src/async_cursor.rs
@@ -103,16 +103,9 @@ impl Drop for ExecuteGuard {
 
 /// Asynchronous Python cursor backed by the Core TDS client.
 ///
-/// # ⚠️ Preview API — unstable
-///
-/// Preview surface: API, method signatures, error behavior, and internal
-/// semantics may change without notice in minor releases. Do not depend on
-/// it from production code.
-///
-/// Created via [`crate::async_connection::PyAsyncConnection::cursor`].
-/// Instances share the parent connection's `TdsClient` — closing the
-/// connection while cursors exist is legal but any in-flight I/O will fail
-/// once the underlying transport is torn down.
+/// Create instances with `PyAsyncConnection.cursor()`. Cursors on one
+/// connection share a TDS session, so only one cursor may own an active batch.
+/// This API is a preview and may change between minor releases.
 #[pyclass]
 pub struct PyAsyncCursor {
     /// Cloned from the parent `PyAsyncConnection`. The `Arc` keeps the
@@ -175,7 +168,10 @@ impl PyAsyncCursor {
         self.default_query_timeout
     }
 
-    /// Set one-shot SQL type, size, and scale hints for the next successful execute.
+    /// Set SQL type, size, and scale hints for the next successful `execute()`.
+    ///
+    /// Each item is a SQL type integer or `(sql_type, size, decimal_digits)`.
+    /// Hints are consumed only after an execution is successfully dispatched.
     fn setinputsizes(&mut self, sizes: &Bound<'_, PyAny>) -> PyResult<()> {
         if self.closed.load(Ordering::Acquire) {
             return Err(PyRuntimeError::new_err("Cursor is closed"));
@@ -185,7 +181,11 @@ impl PyAsyncCursor {
         Ok(())
     }
 
-    /// Prepare and execute a T-SQL operation, resolving to this cursor.
+    /// Execute T-SQL and return an awaitable resolving to this cursor.
+    ///
+    /// Positional parameters use `?` markers. A single mapping uses
+    /// `%(name)s` markers. `use_prepare=False` skips prepared execution;
+    /// `reset_cursor=False` permits reuse of a compatible prepared statement.
     #[pyo3(signature = (operation, *parameters, use_prepare=true, reset_cursor=true))]
     fn execute<'py>(
         slf: Py<Self>,
@@ -344,6 +344,9 @@ impl PyAsyncCursor {
     }
 
     /// Drain pending results, release prepared handles, and close this cursor.
+    ///
+    /// Returns an awaitable resolving to `None`. Closing an already closed
+    /// cursor is a no-op.
     fn close<'py>(slf: Py<Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let (client, dispatch, prepared_state, session_state, cursor_id, timeout, closed) = {
             let cursor = slf.borrow(py);

--- a/mssql-py-core/src/async_cursor.rs
+++ b/mssql-py-core/src/async_cursor.rs
@@ -469,4 +469,6 @@ impl PyAsyncCursor {
     // - Convert TVP row iterators directly instead of collecting Bound cells first.
     // - Add Criterion benchmarks for placeholder scanning, scalar binding,
     //   prepared reuse, and representative TVP row counts.
+    // - If placeholder benchmarks justify it, cache rewritten SQL and marker
+    //   metadata with bounded storage and explicit parameter-style invalidation.
 }

--- a/mssql-py-core/src/async_cursor.rs
+++ b/mssql-py-core/src/async_cursor.rs
@@ -23,14 +23,80 @@
 //! preserved.
 
 use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
 
+use mssql_tds::connection::tds_client::{
+    ExecuteOptions, PreparedStatement, StatementId, StatementResult,
+};
+use mssql_tds::message::transaction_management::TransactionIsolationLevel;
+use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
+use pyo3::types::PyTuple;
 use tokio::sync::Mutex;
+use tracing::instrument::WithSubscriber;
 
 use mssql_tds::connection::tds_client::TdsClient;
 
-use crate::async_session::{AsyncConnectionState, CursorId};
+use crate::async_parameters::{bind_parameters, parse_input_sizes};
+use crate::async_session::{AsyncConnectionState, ClaimError, CursorId, OperationId};
+
+#[derive(Default)]
+struct PreparedState {
+    statement: Option<PreparedStatement>,
+    orphaned: Option<StatementId>,
+}
+
+fn map_claim_error(error: ClaimError) -> PyErr {
+    match error {
+        ClaimError::Closing => PyRuntimeError::new_err("Connection is closing"),
+        ClaimError::Closed => PyRuntimeError::new_err("Connection is closed"),
+        ClaimError::Broken => PyRuntimeError::new_err("Connection is broken"),
+        ClaimError::Busy => {
+            PyRuntimeError::new_err("Connection is busy with another cursor operation")
+        }
+    }
+}
+
+fn map_execute_error(error: impl std::fmt::Display) -> PyErr {
+    tracing::error!("PyAsyncCursor::execute: failed: {error}");
+    PyRuntimeError::new_err(format!("Query execution failed: {error}"))
+}
+
+struct ExecuteGuard {
+    session_state: Arc<AsyncConnectionState>,
+    operation_id: OperationId,
+    completed: bool,
+}
+
+impl ExecuteGuard {
+    fn new(session_state: Arc<AsyncConnectionState>, operation_id: OperationId) -> Self {
+        Self {
+            session_state,
+            operation_id,
+            completed: false,
+        }
+    }
+
+    fn complete(&mut self, has_open_batch: bool) {
+        self.session_state
+            .finish_execute(self.operation_id, has_open_batch);
+        self.completed = true;
+    }
+
+    fn fail(&mut self) {
+        self.session_state.release_operation(self.operation_id);
+        self.completed = true;
+    }
+}
+
+impl Drop for ExecuteGuard {
+    fn drop(&mut self) {
+        if !self.completed {
+            self.session_state.mark_broken();
+            self.session_state.release_operation(self.operation_id);
+        }
+    }
+}
 
 /// Asynchronous Python cursor backed by the Core TDS client.
 ///
@@ -51,6 +117,8 @@ pub struct PyAsyncCursor {
     /// serializes wire access across `.await` points.
     #[allow(dead_code)] // Consumed by upcoming async execute/fetch/close APIs.
     tds_client: Arc<Mutex<TdsClient>>,
+    tracing_dispatch: Option<tracing::Dispatch>,
+    prepared_state: Arc<Mutex<PreparedState>>,
     /// Shared with the parent connection for future execute-time transaction handling.
     #[allow(dead_code)]
     autocommit: Arc<AtomicBool>,
@@ -64,6 +132,7 @@ pub struct PyAsyncCursor {
     /// `cursor()` time (`0` = no timeout). Applied by the future `execute`
     /// path unless overridden per-call.
     default_query_timeout: u32,
+    input_sizes: Option<Vec<crate::types::ParameterHint>>,
 }
 
 impl PyAsyncCursor {
@@ -72,6 +141,7 @@ impl PyAsyncCursor {
     /// Called only from `PyAsyncConnection::cursor`.
     pub(crate) fn new(
         tds_client: Arc<Mutex<TdsClient>>,
+        tracing_dispatch: Option<tracing::Dispatch>,
         autocommit: Arc<AtomicBool>,
         session_state: Arc<AsyncConnectionState>,
         cursor_id: CursorId,
@@ -79,10 +149,13 @@ impl PyAsyncCursor {
     ) -> Self {
         Self {
             tds_client,
+            tracing_dispatch,
+            prepared_state: Arc::new(Mutex::new(PreparedState::default())),
             autocommit,
             session_state,
             cursor_id,
             default_query_timeout,
+            input_sizes: None,
         }
     }
 }
@@ -95,13 +168,167 @@ impl PyAsyncCursor {
         self.default_query_timeout
     }
 
-    // TODO(async execute transaction semantics):
-    // - Hold the shared client mutex across the active-transaction check,
-    //   optional begin, and statement submission.
-    // - When autocommit is false, lazily begin before execution if no
-    //   transaction is active.
-    // - After commit or rollback, begin a fresh transaction on the next execute.
-    // - When autocommit is true, submit without an explicit transaction.
+    /// Set one-shot SQL type, size, and scale hints for the next successful execute.
+    fn setinputsizes(&mut self, sizes: &Bound<'_, PyAny>) -> PyResult<()> {
+        self.input_sizes = parse_input_sizes(sizes)?;
+        Ok(())
+    }
+
+    /// Prepare and execute a T-SQL operation, resolving to this cursor.
+    #[pyo3(signature = (operation, *parameters, use_prepare=true, reset_cursor=true))]
+    fn execute<'py>(
+        slf: Py<Self>,
+        py: Python<'py>,
+        operation: String,
+        parameters: &Bound<'_, PyTuple>,
+        use_prepare: bool,
+        reset_cursor: bool,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let (
+            operation,
+            rpc_parameters,
+            client,
+            dispatch,
+            prepared_state,
+            autocommit,
+            session_state,
+            cursor_id,
+            timeout,
+        ) = {
+            let mut cursor = slf.borrow_mut(py);
+            // TODO(async execute preflight): Parameter normalization and Python-to-TDS
+            // conversion currently run synchronously under the GIL before the awaitable is
+            // returned. Bound or chunk large parameter/TVP conversion so execute does not
+            // block the caller's event-loop thread during preflight.
+            let (operation, rpc_parameters) =
+                bind_parameters(operation, parameters, cursor.input_sizes.as_deref())?;
+            cursor.input_sizes = None;
+            (
+                operation,
+                rpc_parameters,
+                cursor.tds_client.clone(),
+                cursor.tracing_dispatch.clone(),
+                cursor.prepared_state.clone(),
+                cursor.autocommit.load(Ordering::Relaxed),
+                cursor.session_state.clone(),
+                cursor.cursor_id,
+                cursor.default_query_timeout,
+            )
+        };
+        let claim = session_state
+            .claim_execute(cursor_id)
+            .map_err(map_claim_error)?;
+        let operation_id = claim.operation_id;
+        let future_state = session_state.clone();
+
+        let future = async move {
+            let mut execute_guard = ExecuteGuard::new(future_state, operation_id);
+            tracing::info!(
+                "PyAsyncCursor::execute: executing query; parameter_count={}, use_prepare={}, reset_cursor={}",
+                rpc_parameters.len(),
+                use_prepare,
+                reset_cursor
+            );
+
+            let result = async {
+                let mut client = client.lock().await;
+                if claim.drain_previous {
+                    client.close_query().await?;
+                }
+                if !autocommit && !client.has_active_transaction() {
+                    client
+                        .begin_transaction(TransactionIsolationLevel::ReadCommitted, None)
+                        .await?;
+                }
+
+                let options = ExecuteOptions {
+                    timeout: Some(timeout),
+                    cancel: Some(&claim.cancel_handle),
+                    ..Default::default()
+                };
+                let first = if use_prepare {
+                    let mut state = prepared_state.lock().await;
+                    let replace_statement = state
+                        .statement
+                        .as_ref()
+                        .is_none_or(|statement| statement.sql() != operation);
+                    if replace_statement {
+                        if let Some(mut statement) = state.statement.take()
+                            && let Some(statement_id) = statement.take_id()
+                        {
+                            state.orphaned = Some(statement_id);
+                        }
+                        state.statement = Some(PreparedStatement::new(operation));
+                    }
+                    let PreparedState {
+                        statement,
+                        orphaned,
+                    } = &mut *state;
+                    client
+                        .execute_prepared(
+                            statement
+                                .as_mut()
+                                .expect("prepared statement was initialized"),
+                            rpc_parameters,
+                            orphaned,
+                            options,
+                        )
+                        .await?
+                } else if rpc_parameters.is_empty() {
+                    client.execute(operation, options).await?
+                } else {
+                    client
+                        .execute_sp_executesql(operation, rpc_parameters, options)
+                        .await?
+                };
+                if !matches!(first, StatementResult::Rows) {
+                    client.advance_to_rows().await?;
+                }
+                Ok::<bool, mssql_tds::error::Error>(client.has_open_batch())
+            }
+            .await;
+
+            match result {
+                Ok(has_open_batch) => {
+                    execute_guard.complete(has_open_batch);
+                    tracing::info!("PyAsyncCursor::execute: query executed successfully");
+                    Ok(slf)
+                }
+                Err(error) => {
+                    execute_guard.fail();
+                    Err(map_execute_error(error))
+                }
+            }
+        };
+        let future = async move {
+            match dispatch {
+                Some(dispatch) => future.with_subscriber(dispatch).await,
+                None => future.await,
+            }
+        };
+
+        match pyo3_async_runtimes::tokio::future_into_py(py, future) {
+            Ok(awaitable) => Ok(awaitable),
+            Err(error) => {
+                session_state.release_operation(operation_id);
+                Err(error)
+            }
+        }
+    }
+
+    // TODO(mssql-tds blockers for async execute parity):
+    // - Add a public, general TdsClient parameter-description API backed by
+    //   sp_describe_undeclared_parameters. The existing describe path is
+    //   private and specific to Always Encrypted, so an unhinted Python None
+    //   still falls back to NVARCHAR(1).
+    // - Add declaration metadata to nullable Decimal/Numeric RPC parameters.
+    //   RpcParameter/SqlType cannot carry precision and scale separately from
+    //   a non-NULL DecimalParts value, and declaration generation hardcodes
+    //   SqlType::{Decimal, Numeric}(None) to (18,10).
+    // - Add a public SqlType::Udt input contract and RPC serializer carrying
+    //   database, schema, and server UDT type names. mssql-tds currently parses
+    //   UDT result metadata internally but cannot send a typed UDT parameter.
+    // TODO(remaining async transaction work):
     // - Add an awaitable connection mode-change API rather than a synchronous
     //   property setter: false -> true commits active work before changing
     //   mode and leaves the mode unchanged if commit fails; true -> false
@@ -109,19 +336,12 @@ impl PyAsyncCursor {
     // - Test lazy begin, restart after commit/rollback, both mode transitions,
     //   context finalization, and cleanup-error precedence.
     //
-    // TODO(async execute/fetch/cancel ownership):
-    // - Execute claims ActiveOperation with this cursor_id and a fresh
-    //   operation_id before touching TdsClient; reject another cursor with a
-    //   clear connection-busy error.
-    // - Preserve ownership while results remain and transition the phase from
-    //   Executing to Fetching; release it on exhaustion, close, cancel, or error.
-    // - Install a root CancelHandle in ActiveOperation and pass a child handle
-    //   to TdsClient. cancel() may remove and trigger it only when both cursor
-    //   and operation IDs match.
-    // - Completion clears state only for its own operation_id so a stale future
-    //   cannot release a newer operation.
-    // - Reject new work when lifecycle is Closing, Closed, or Broken; mark the
-    //   connection Broken when cancellation or protocol failure makes reuse unsafe.
+    // TODO(remaining async fetch/close/cancel ownership work):
+    // - Release Fetching ownership when results are exhausted or the cursor is
+    //   closed.
+    // - Add cursor cancel(), triggering the root CancelHandle only when cursor
+    //   and operation IDs match; complete ATTENTION cleanup before deciding
+    //   whether the connection remains reusable or must be marked Broken.
     // - Add a two-cursor acceptance test with a multi-packet result: reject
     //   cursor B with a typed busy-state error while cursor A has unread rows,
     //   verify A can drain its remaining rows, then verify B can execute after

--- a/mssql-py-core/src/async_cursor.rs
+++ b/mssql-py-core/src/async_cursor.rs
@@ -47,7 +47,7 @@ struct PreparedState {
     orphaned: Option<StatementId>,
 }
 
-fn map_claim_error_with_busy_message(error: ClaimError, busy_message: &str) -> PyErr {
+fn map_claim_error_with_busy_message(error: ClaimError, busy_message: &'static str) -> PyErr {
     match error {
         ClaimError::Closing => PyRuntimeError::new_err("Connection is closing"),
         ClaimError::Closed => PyRuntimeError::new_err("Connection is closed"),
@@ -57,10 +57,7 @@ fn map_claim_error_with_busy_message(error: ClaimError, busy_message: &str) -> P
 }
 
 fn map_claim_error(error: ClaimError) -> PyErr {
-    map_claim_error_with_busy_message(
-        error,
-        "Connection is busy with another cursor operation",
-    )
+    map_claim_error_with_busy_message(error, "Connection is busy with another cursor operation")
 }
 
 fn map_execute_error(error: impl std::fmt::Display) -> PyErr {

--- a/mssql-py-core/src/async_cursor.rs
+++ b/mssql-py-core/src/async_cursor.rs
@@ -47,15 +47,20 @@ struct PreparedState {
     orphaned: Option<StatementId>,
 }
 
-fn map_claim_error(error: ClaimError) -> PyErr {
+fn map_claim_error_with_busy_message(error: ClaimError, busy_message: &str) -> PyErr {
     match error {
         ClaimError::Closing => PyRuntimeError::new_err("Connection is closing"),
         ClaimError::Closed => PyRuntimeError::new_err("Connection is closed"),
         ClaimError::Broken => PyRuntimeError::new_err("Connection is broken"),
-        ClaimError::Busy => {
-            PyRuntimeError::new_err("Connection is busy with another cursor operation")
-        }
+        ClaimError::Busy => PyRuntimeError::new_err(busy_message),
     }
+}
+
+fn map_claim_error(error: ClaimError) -> PyErr {
+    map_claim_error_with_busy_message(
+        error,
+        "Connection is busy with another cursor operation",
+    )
 }
 
 fn map_execute_error(error: impl std::fmt::Display) -> PyErr {

--- a/mssql-py-core/src/async_cursor.rs
+++ b/mssql-py-core/src/async_cursor.rs
@@ -257,7 +257,7 @@ impl PyAsyncCursor {
                 }
 
                 let options = ExecuteOptions {
-                    timeout: Some(timeout),
+                    timeout: if timeout == 0 { None } else { Some(timeout) },
                     cancel: Some(&claim.cancel_handle),
                     ..Default::default()
                 };

--- a/mssql-py-core/src/async_cursor.rs
+++ b/mssql-py-core/src/async_cursor.rs
@@ -40,13 +40,18 @@ use mssql_tds::connection::tds_client::TdsClient;
 use crate::async_parameters::{ParameterMetadata, bind_parameters, parse_input_sizes};
 use crate::async_session::{AsyncConnectionState, ClaimError, CursorId, OperationId};
 
+/// Cursor-local state for prepared execution and deferred handle cleanup.
 #[derive(Default)]
 struct PreparedState {
+    /// The current prepared statement and its optional live server handle.
     statement: Option<PreparedStatement>,
+    /// Metadata shape used to determine whether the statement must be rebound.
     parameter_signature: Vec<ParameterMetadata>,
+    /// A superseded statement retained until its unprepare request is serialized.
     orphaned: Option<StatementId>,
 }
 
+/// Converts a failed session claim into a Python error with operation-specific busy text.
 fn map_claim_error_with_busy_message(error: ClaimError, busy_message: &'static str) -> PyErr {
     match error {
         ClaimError::Closing => PyRuntimeError::new_err("Connection is closing"),
@@ -56,15 +61,18 @@ fn map_claim_error_with_busy_message(error: ClaimError, busy_message: &'static s
     }
 }
 
+/// Converts a failed cursor operation claim into a Python error.
 fn map_claim_error(error: ClaimError) -> PyErr {
     map_claim_error_with_busy_message(error, "Connection is busy with another cursor operation")
 }
 
+/// Logs a TDS execution failure and exposes it as a Python runtime error.
 fn map_execute_error(error: impl std::fmt::Display) -> PyErr {
     tracing::error!("PyAsyncCursor::execute: failed: {error}");
     PyRuntimeError::new_err(format!("Query execution failed: {error}"))
 }
 
+/// Releases an execute or close claim and poisons the session if the future is interrupted.
 struct ExecuteGuard {
     session_state: Arc<AsyncConnectionState>,
     operation_id: OperationId,
@@ -72,6 +80,7 @@ struct ExecuteGuard {
 }
 
 impl ExecuteGuard {
+    /// Guards an operation claim already acquired from the session state.
     fn new(session_state: Arc<AsyncConnectionState>, operation_id: OperationId) -> Self {
         Self {
             session_state,
@@ -80,12 +89,14 @@ impl ExecuteGuard {
         }
     }
 
+    /// Completes execution and transitions ownership to fetching or idle.
     fn complete(&mut self, has_open_batch: bool) {
         self.session_state
             .finish_execute(self.operation_id, has_open_batch);
         self.completed = true;
     }
 
+    /// Releases ownership after an outcome that was handled without interruption.
     fn fail(&mut self) {
         self.session_state.release_operation(self.operation_id);
         self.completed = true;
@@ -93,6 +104,7 @@ impl ExecuteGuard {
 }
 
 impl Drop for ExecuteGuard {
+    /// Marks the session broken when cancellation or unwinding interrupts an operation.
     fn drop(&mut self) {
         if !self.completed {
             self.session_state.mark_broken();
@@ -472,6 +484,8 @@ impl PyAsyncCursor {
     // - Convert TVP row iterators directly instead of collecting Bound cells first.
     // - Add Criterion benchmarks for placeholder scanning, scalar binding,
     //   prepared reuse, and representative TVP row counts.
-    // - If placeholder benchmarks justify it, cache rewritten SQL and marker
-    //   metadata with bounded storage and explicit parameter-style invalidation.
+    // - Placeholder rewriting still runs under the GIL before the awaitable is
+    //   returned. If benchmarks of the optimized scanner justify caching, share
+    //   rewritten SQL and marker metadata at connection scope, use borrowed raw
+    //   SQL plus parameter style for hit-path lookup, and bound retained bytes.
 }

--- a/mssql-py-core/src/async_cursor.rs
+++ b/mssql-py-core/src/async_cursor.rs
@@ -43,6 +43,7 @@ use crate::async_session::{AsyncConnectionState, ClaimError, CursorId, Operation
 #[derive(Default)]
 struct PreparedState {
     statement: Option<PreparedStatement>,
+    parameter_signature: Vec<String>,
     orphaned: Option<StatementId>,
 }
 
@@ -133,6 +134,7 @@ pub struct PyAsyncCursor {
     /// path unless overridden per-call.
     default_query_timeout: u32,
     input_sizes: Option<Vec<crate::types::ParameterHint>>,
+    input_sizes_generation: u64,
 }
 
 impl PyAsyncCursor {
@@ -156,6 +158,7 @@ impl PyAsyncCursor {
             cursor_id,
             default_query_timeout,
             input_sizes: None,
+            input_sizes_generation: 0,
         }
     }
 }
@@ -171,6 +174,7 @@ impl PyAsyncCursor {
     /// Set one-shot SQL type, size, and scale hints for the next successful execute.
     fn setinputsizes(&mut self, sizes: &Bound<'_, PyAny>) -> PyResult<()> {
         self.input_sizes = parse_input_sizes(sizes)?;
+        self.input_sizes_generation = self.input_sizes_generation.wrapping_add(1);
         Ok(())
     }
 
@@ -187,6 +191,7 @@ impl PyAsyncCursor {
         let (
             operation,
             rpc_parameters,
+            parameter_signature,
             client,
             dispatch,
             prepared_state,
@@ -194,18 +199,19 @@ impl PyAsyncCursor {
             session_state,
             cursor_id,
             timeout,
+            input_sizes_generation,
         ) = {
-            let mut cursor = slf.borrow_mut(py);
+            let cursor = slf.borrow(py);
             // TODO(async execute preflight): Parameter normalization and Python-to-TDS
             // conversion currently run synchronously under the GIL before the awaitable is
             // returned. Bound or chunk large parameter/TVP conversion so execute does not
             // block the caller's event-loop thread during preflight.
-            let (operation, rpc_parameters) =
+            let (operation, rpc_parameters, parameter_signature) =
                 bind_parameters(operation, parameters, cursor.input_sizes.as_deref())?;
-            cursor.input_sizes = None;
             (
                 operation,
                 rpc_parameters,
+                parameter_signature,
                 cursor.tds_client.clone(),
                 cursor.tracing_dispatch.clone(),
                 cursor.prepared_state.clone(),
@@ -213,6 +219,7 @@ impl PyAsyncCursor {
                 cursor.session_state.clone(),
                 cursor.cursor_id,
                 cursor.default_query_timeout,
+                cursor.input_sizes_generation,
             )
         };
         let claim = session_state
@@ -248,10 +255,12 @@ impl PyAsyncCursor {
                 };
                 let first = if use_prepare {
                     let mut state = prepared_state.lock().await;
-                    let replace_statement = state
-                        .statement
-                        .as_ref()
-                        .is_none_or(|statement| statement.sql() != operation);
+                    let replace_statement = reset_cursor
+                        || state
+                            .statement
+                            .as_ref()
+                            .is_none_or(|statement| statement.sql() != operation)
+                        || state.parameter_signature != parameter_signature;
                     if replace_statement {
                         if let Some(mut statement) = state.statement.take()
                             && let Some(statement_id) = statement.take_id()
@@ -259,9 +268,11 @@ impl PyAsyncCursor {
                             state.orphaned = Some(statement_id);
                         }
                         state.statement = Some(PreparedStatement::new(operation));
+                        state.parameter_signature = parameter_signature;
                     }
                     let PreparedState {
                         statement,
+                        parameter_signature: _,
                         orphaned,
                     } = &mut *state;
                     client
@@ -291,6 +302,12 @@ impl PyAsyncCursor {
             match result {
                 Ok(has_open_batch) => {
                     execute_guard.complete(has_open_batch);
+                    Python::attach(|py| {
+                        let mut cursor = slf.borrow_mut(py);
+                        if cursor.input_sizes_generation == input_sizes_generation {
+                            cursor.input_sizes = None;
+                        }
+                    });
                     tracing::info!("PyAsyncCursor::execute: query executed successfully");
                     Ok(slf)
                 }

--- a/mssql-py-core/src/async_cursor.rs
+++ b/mssql-py-core/src/async_cursor.rs
@@ -28,6 +28,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use mssql_tds::connection::tds_client::{
     ExecuteOptions, PreparedStatement, StatementId, StatementResult,
 };
+use mssql_tds::error::Error;
+use mssql_tds::message::parameters::rpc_parameters::RpcParameter;
 use mssql_tds::message::transaction_management::TransactionIsolationLevel;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
@@ -38,7 +40,9 @@ use tracing::instrument::WithSubscriber;
 use mssql_tds::connection::tds_client::TdsClient;
 
 use crate::async_parameters::{ParameterMetadata, bind_parameters, parse_input_sizes};
-use crate::async_session::{AsyncConnectionState, ClaimError, CursorId, OperationId};
+use crate::async_session::{
+    AsyncConnectionState, ClaimError, CursorCloseClaim, CursorId, ExecuteClaim, OperationId,
+};
 
 /// Cursor-local state for prepared execution and deferred handle cleanup.
 #[derive(Default)]
@@ -49,6 +53,167 @@ struct PreparedState {
     parameter_signature: Vec<ParameterMetadata>,
     /// A superseded statement retained until its unprepare request is serialized.
     orphaned: Option<StatementId>,
+}
+
+/// Whether execute must replace the cursor's current prepared statement.
+fn should_replace_prepared_statement(
+    state: &PreparedState,
+    operation: &str,
+    parameter_signature: &[ParameterMetadata],
+    reset_cursor: bool,
+) -> bool {
+    reset_cursor
+        || state
+            .statement
+            .as_ref()
+            .is_none_or(|statement| statement.sql() != operation)
+        || state.parameter_signature != parameter_signature
+}
+
+/// Python-free inputs required to execute one command on the TDS session.
+struct ExecuteRequest {
+    operation: String,
+    rpc_parameters: Vec<RpcParameter>,
+    parameter_signature: Vec<ParameterMetadata>,
+    use_prepare: bool,
+    reset_cursor: bool,
+    timeout: u32,
+    autocommit: bool,
+}
+
+/// Cursor state captured under the GIL before constructing the execute future.
+struct ExecuteSnapshot {
+    request: ExecuteRequest,
+    client: Arc<Mutex<TdsClient>>,
+    dispatch: Option<tracing::Dispatch>,
+    prepared_state: Arc<Mutex<PreparedState>>,
+    session_state: Arc<AsyncConnectionState>,
+    cursor_id: CursorId,
+    input_sizes_generation: u64,
+    cleanup_required: Arc<AtomicBool>,
+}
+
+/// Ownership state left by a successful command dispatch.
+enum ExecuteOutcome {
+    Idle,
+    Fetching,
+}
+
+impl ExecuteOutcome {
+    fn has_open_batch(&self) -> bool {
+        matches!(self, Self::Fetching)
+    }
+}
+
+/// Protocol failure and whether ownership must poison the connection.
+struct ExecuteFailure {
+    error: Error,
+    break_connection: bool,
+}
+
+impl ExecuteFailure {
+    fn broken(error: Error) -> Self {
+        Self {
+            error,
+            break_connection: true,
+        }
+    }
+}
+
+impl From<Error> for ExecuteFailure {
+    fn from(error: Error) -> Self {
+        Self {
+            error,
+            break_connection: false,
+        }
+    }
+}
+
+/// Runs the protocol portion of execute without accessing Python objects.
+async fn execute_on_client(
+    client: &mut TdsClient,
+    prepared_state: &Mutex<PreparedState>,
+    claim: &ExecuteClaim,
+    request: ExecuteRequest,
+) -> Result<ExecuteOutcome, ExecuteFailure> {
+    let ExecuteRequest {
+        operation,
+        rpc_parameters,
+        parameter_signature,
+        use_prepare,
+        reset_cursor,
+        timeout,
+        autocommit,
+    } = request;
+
+    if claim.drain_previous {
+        client.close_query().await?;
+    }
+    let options = ExecuteOptions {
+        timeout: if timeout == 0 { None } else { Some(timeout) },
+        cancel: Some(&claim.cancel_handle),
+        ..Default::default()
+    };
+    if !autocommit && !client.has_active_transaction() {
+        // TODO(mssql-tds): Add an options-aware begin_transaction API that applies
+        // reconnect timeout accounting and cancellation, and records whether the
+        // transaction-manager request reached the wire. Until then, any BEGIN
+        // failure must conservatively poison the session.
+        client
+            .begin_transaction(TransactionIsolationLevel::ReadCommitted, None)
+            .await
+            .map_err(ExecuteFailure::broken)?;
+    }
+
+    let first = if use_prepare {
+        // TODO(performance): Benchmark prepared-statement reuse independently
+        // from placeholder scanning and scalar conversion.
+        let mut state = prepared_state.lock().await;
+        let replace_statement = should_replace_prepared_statement(
+            &state,
+            &operation,
+            &parameter_signature,
+            reset_cursor,
+        );
+        if replace_statement {
+            if let Some(mut statement) = state.statement.take()
+                && let Some(statement_id) = statement.take_id()
+            {
+                state.orphaned = Some(statement_id);
+            }
+            state.statement = Some(PreparedStatement::new(operation));
+            state.parameter_signature = parameter_signature;
+        }
+        let PreparedState {
+            statement,
+            parameter_signature: _,
+            orphaned,
+        } = &mut *state;
+        client
+            .execute_prepared(
+                statement
+                    .as_mut()
+                    .expect("prepared statement was initialized"),
+                rpc_parameters,
+                orphaned,
+                options,
+            )
+            .await?
+    } else if rpc_parameters.is_empty() {
+        client.execute(operation, options).await?
+    } else {
+        client
+            .execute_sp_executesql(operation, rpc_parameters, options)
+            .await?
+    };
+    if !matches!(first, StatementResult::Rows) {
+        client.advance_to_rows().await?;
+    }
+    Ok(if client.has_open_batch() {
+        ExecuteOutcome::Fetching
+    } else {
+        ExecuteOutcome::Idle
+    })
 }
 
 /// Converts a failed session claim into a Python error with operation-specific busy text.
@@ -90,16 +255,32 @@ impl ExecuteGuard {
     }
 
     /// Completes execution and transitions ownership to fetching or idle.
-    fn complete(&mut self, has_open_batch: bool) {
+    fn complete(&mut self, outcome: &ExecuteOutcome) {
         self.session_state
-            .finish_execute(self.operation_id, has_open_batch);
+            .finish_execute(self.operation_id, outcome.has_open_batch());
         self.completed = true;
     }
 
-    /// Releases ownership after an outcome that was handled without interruption.
-    fn fail(&mut self) {
+    /// Releases ownership after an error that left the protocol reusable.
+    fn release(&mut self) {
         self.session_state.release_operation(self.operation_id);
         self.completed = true;
+    }
+
+    /// Marks the connection broken after an error left protocol work pending.
+    fn break_connection(&mut self) {
+        self.session_state.mark_broken();
+        self.session_state.release_operation(self.operation_id);
+        self.completed = true;
+    }
+
+    /// Completes a handled error according to the remaining protocol state.
+    fn fail(&mut self, has_open_batch: bool) {
+        if has_open_batch {
+            self.break_connection();
+        } else {
+            self.release();
+        }
     }
 }
 
@@ -109,6 +290,96 @@ impl Drop for ExecuteGuard {
         if !self.completed {
             self.session_state.mark_broken();
             self.session_state.release_operation(self.operation_id);
+        }
+    }
+}
+
+/// Python-independent resources required to drain and release a cursor.
+struct CursorCleanup {
+    client: Arc<Mutex<TdsClient>>,
+    prepared_state: Arc<Mutex<PreparedState>>,
+    session_state: Arc<AsyncConnectionState>,
+    cursor_id: CursorId,
+    timeout: u32,
+    closed: Arc<AtomicBool>,
+}
+
+impl CursorCleanup {
+    async fn run(self, claim: CursorCloseClaim) -> Result<(), Error> {
+        let mut cleanup_guard = ExecuteGuard::new(self.session_state.clone(), claim.operation_id);
+        let (result, has_open_batch) = {
+            let mut client = self.client.lock().await;
+            let result = async {
+                if claim.drain_previous {
+                    client.close_query().await?;
+                }
+                let statement_ids = {
+                    let mut state = self.prepared_state.lock().await;
+                    let current = state
+                        .statement
+                        .as_mut()
+                        .and_then(PreparedStatement::take_id);
+                    let orphaned = state.orphaned.take();
+                    state.statement = None;
+                    state.parameter_signature.clear();
+                    [current, orphaned]
+                };
+                let mut released = None;
+                for statement_id in statement_ids.into_iter().flatten() {
+                    if released == Some(statement_id) {
+                        continue;
+                    }
+                    client
+                        .unprepare(
+                            statement_id,
+                            ExecuteOptions {
+                                timeout: Some(self.timeout),
+                                ..Default::default()
+                            },
+                        )
+                        .await?;
+                    released = Some(statement_id);
+                }
+                Ok::<(), Error>(())
+            }
+            .await;
+            let has_open_batch = client.has_open_batch();
+            (result, has_open_batch)
+        };
+
+        cleanup_guard.fail(has_open_batch);
+        result?;
+        self.closed.store(true, Ordering::Release);
+        Ok(())
+    }
+}
+
+/// Ensures abandoned finalizer tasks synchronously poison session ownership.
+struct FinalizerCleanup {
+    cleanup: Option<CursorCleanup>,
+    session_state: Arc<AsyncConnectionState>,
+    cursor_id: CursorId,
+    completed: bool,
+}
+
+impl FinalizerCleanup {
+    async fn run(mut self, claim: CursorCloseClaim) {
+        let cleanup = self.cleanup.take().expect("finalizer cleanup is available");
+        match cleanup.run(claim).await {
+            Ok(()) => self.completed = true,
+            Err(error) => {
+                tracing::warn!("PyAsyncCursor finalizer cleanup failed: {error}");
+                self.session_state.abandon_cursor(self.cursor_id);
+                self.completed = true;
+            }
+        }
+    }
+}
+
+impl Drop for FinalizerCleanup {
+    fn drop(&mut self) {
+        if !self.completed {
+            self.session_state.abandon_cursor(self.cursor_id);
         }
     }
 }
@@ -142,6 +413,8 @@ pub struct PyAsyncCursor {
     default_query_timeout: u32,
     input_sizes: Option<Vec<crate::types::ParameterHint>>,
     input_sizes_generation: u64,
+    cleanup_required: Arc<AtomicBool>,
+    cleanup_started: Arc<AtomicBool>,
     closed: Arc<AtomicBool>,
 }
 
@@ -167,8 +440,138 @@ impl PyAsyncCursor {
             default_query_timeout,
             input_sizes: None,
             input_sizes_generation: 0,
+            cleanup_required: Arc::new(AtomicBool::new(false)),
+            cleanup_started: Arc::new(AtomicBool::new(false)),
             closed: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    fn cleanup(&self) -> CursorCleanup {
+        CursorCleanup {
+            client: self.tds_client.clone(),
+            prepared_state: self.prepared_state.clone(),
+            session_state: self.session_state.clone(),
+            cursor_id: self.cursor_id,
+            timeout: self.default_query_timeout,
+            closed: self.closed.clone(),
+        }
+    }
+}
+
+impl Drop for PyAsyncCursor {
+    fn drop(&mut self) {
+        if !self.cleanup_required.load(Ordering::Acquire)
+            || self.closed.load(Ordering::Acquire)
+            || self
+                .cleanup_started
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                .is_err()
+        {
+            return;
+        }
+
+        let cleanup = self.cleanup();
+        let session_state = self.session_state.clone();
+        let claim = match session_state.claim_cursor_close(self.cursor_id) {
+            Ok(claim) => claim,
+            Err(error) => {
+                tracing::warn!("PyAsyncCursor finalizer could not claim cleanup: {error:?}");
+                session_state.abandon_cursor(self.cursor_id);
+                return;
+            }
+        };
+        let finalizer = FinalizerCleanup {
+            cleanup: Some(cleanup),
+            session_state,
+            cursor_id: self.cursor_id,
+            completed: false,
+        };
+        pyo3_async_runtimes::tokio::get_runtime().spawn(finalizer.run(claim));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::should_replace_prepared_statement;
+    use super::{ExecuteGuard, ParameterMetadata, PreparedState, PreparedStatement};
+    use crate::async_session::{AsyncConnectionState, ClaimError, ConnectionLifecycle};
+
+    fn prepared_state(sql: &str, signature: Vec<ParameterMetadata>) -> PreparedState {
+        PreparedState {
+            statement: Some(PreparedStatement::new(sql.to_string())),
+            parameter_signature: signature,
+            orphaned: None,
+        }
+    }
+
+    #[test]
+    fn compatible_prepared_statement_is_reused_when_reset_is_false() {
+        let signature = vec![ParameterMetadata::Scalar("int")];
+        let state = prepared_state("SELECT @P1", signature.clone());
+
+        assert!(!should_replace_prepared_statement(
+            &state,
+            "SELECT @P1",
+            &signature,
+            false,
+        ));
+    }
+
+    #[test]
+    fn prepared_statement_is_replaced_for_each_incompatible_input() {
+        let signature = vec![ParameterMetadata::Scalar("int")];
+        let state = prepared_state("SELECT @P1", signature.clone());
+
+        assert!(should_replace_prepared_statement(
+            &state,
+            "SELECT @P1",
+            &signature,
+            true,
+        ));
+        assert!(should_replace_prepared_statement(
+            &state,
+            "SELECT @P1 + 1",
+            &signature,
+            false,
+        ));
+        assert!(should_replace_prepared_statement(
+            &state,
+            "SELECT @P1",
+            &[ParameterMetadata::Scalar("bigint")],
+            false,
+        ));
+        assert!(should_replace_prepared_statement(
+            &PreparedState::default(),
+            "SELECT @P1",
+            &signature,
+            false,
+        ));
+    }
+
+    #[test]
+    fn handled_error_releases_reusable_session() {
+        let state = Arc::new(AsyncConnectionState::new());
+        let claim = state.claim_execute(1).unwrap();
+        let mut guard = ExecuteGuard::new(Arc::clone(&state), claim.operation_id);
+
+        guard.fail(false);
+
+        assert_eq!(state.lifecycle(), ConnectionLifecycle::Open);
+        assert!(state.claim_execute(2).is_ok());
+    }
+
+    #[test]
+    fn handled_error_breaks_session_with_open_batch() {
+        let state = Arc::new(AsyncConnectionState::new());
+        let claim = state.claim_execute(1).unwrap();
+        let mut guard = ExecuteGuard::new(Arc::clone(&state), claim.operation_id);
+
+        guard.fail(true);
+
+        assert_eq!(state.lifecycle(), ConnectionLifecycle::Broken);
+        assert_eq!(state.claim_execute(2).unwrap_err(), ClaimError::Broken);
     }
 }
 
@@ -207,19 +610,7 @@ impl PyAsyncCursor {
         use_prepare: bool,
         reset_cursor: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let (
-            operation,
-            rpc_parameters,
-            parameter_signature,
-            client,
-            dispatch,
-            prepared_state,
-            autocommit,
-            session_state,
-            cursor_id,
-            timeout,
-            input_sizes_generation,
-        ) = {
+        let snapshot = {
             let cursor = slf.borrow(py);
             if cursor.closed.load(Ordering::Acquire) {
                 return Err(PyRuntimeError::new_err("Cursor is closed"));
@@ -230,20 +621,35 @@ impl PyAsyncCursor {
             // block the caller's event-loop thread during preflight.
             let (operation, rpc_parameters, parameter_signature) =
                 bind_parameters(operation, parameters, cursor.input_sizes.as_deref())?;
-            (
-                operation,
-                rpc_parameters,
-                parameter_signature,
-                cursor.tds_client.clone(),
-                cursor.tracing_dispatch.clone(),
-                cursor.prepared_state.clone(),
-                cursor.autocommit.load(Ordering::Relaxed),
-                cursor.session_state.clone(),
-                cursor.cursor_id,
-                cursor.default_query_timeout,
-                cursor.input_sizes_generation,
-            )
+            ExecuteSnapshot {
+                request: ExecuteRequest {
+                    operation,
+                    rpc_parameters,
+                    parameter_signature,
+                    use_prepare,
+                    reset_cursor,
+                    timeout: cursor.default_query_timeout,
+                    autocommit: cursor.autocommit.load(Ordering::Relaxed),
+                },
+                client: cursor.tds_client.clone(),
+                dispatch: cursor.tracing_dispatch.clone(),
+                prepared_state: cursor.prepared_state.clone(),
+                session_state: cursor.session_state.clone(),
+                cursor_id: cursor.cursor_id,
+                input_sizes_generation: cursor.input_sizes_generation,
+                cleanup_required: cursor.cleanup_required.clone(),
+            }
         };
+        let ExecuteSnapshot {
+            request,
+            client,
+            dispatch,
+            prepared_state,
+            session_state,
+            cursor_id,
+            input_sizes_generation,
+            cleanup_required,
+        } = snapshot;
         let claim = session_state
             .claim_execute(cursor_id)
             .map_err(map_claim_error)?;
@@ -252,78 +658,24 @@ impl PyAsyncCursor {
 
         let future = async move {
             let mut execute_guard = ExecuteGuard::new(future_state, operation_id);
+            cleanup_required.store(true, Ordering::Release);
             tracing::info!(
                 "PyAsyncCursor::execute: executing query; parameter_count={}, use_prepare={}, reset_cursor={}",
-                rpc_parameters.len(),
-                use_prepare,
-                reset_cursor
+                request.rpc_parameters.len(),
+                request.use_prepare,
+                request.reset_cursor
             );
 
-            let result = async {
+            let (result, has_open_batch) = {
                 let mut client = client.lock().await;
-                if claim.drain_previous {
-                    client.close_query().await?;
-                }
-                if !autocommit && !client.has_active_transaction() {
-                    client
-                        .begin_transaction(TransactionIsolationLevel::ReadCommitted, None)
-                        .await?;
-                }
-
-                let options = ExecuteOptions {
-                    timeout: if timeout == 0 { None } else { Some(timeout) },
-                    cancel: Some(&claim.cancel_handle),
-                    ..Default::default()
-                };
-                let first = if use_prepare {
-                    let mut state = prepared_state.lock().await;
-                    let replace_statement = reset_cursor
-                        || state
-                            .statement
-                            .as_ref()
-                            .is_none_or(|statement| statement.sql() != operation)
-                        || state.parameter_signature != parameter_signature;
-                    if replace_statement {
-                        if let Some(mut statement) = state.statement.take()
-                            && let Some(statement_id) = statement.take_id()
-                        {
-                            state.orphaned = Some(statement_id);
-                        }
-                        state.statement = Some(PreparedStatement::new(operation));
-                        state.parameter_signature = parameter_signature;
-                    }
-                    let PreparedState {
-                        statement,
-                        parameter_signature: _,
-                        orphaned,
-                    } = &mut *state;
-                    client
-                        .execute_prepared(
-                            statement
-                                .as_mut()
-                                .expect("prepared statement was initialized"),
-                            rpc_parameters,
-                            orphaned,
-                            options,
-                        )
-                        .await?
-                } else if rpc_parameters.is_empty() {
-                    client.execute(operation, options).await?
-                } else {
-                    client
-                        .execute_sp_executesql(operation, rpc_parameters, options)
-                        .await?
-                };
-                if !matches!(first, StatementResult::Rows) {
-                    client.advance_to_rows().await?;
-                }
-                Ok::<bool, mssql_tds::error::Error>(client.has_open_batch())
-            }
-            .await;
+                let result = execute_on_client(&mut client, &prepared_state, &claim, request).await;
+                let has_open_batch = client.has_open_batch();
+                (result, has_open_batch)
+            };
 
             match result {
-                Ok(has_open_batch) => {
-                    execute_guard.complete(has_open_batch);
+                Ok(outcome) => {
+                    execute_guard.complete(&outcome);
                     Python::attach(|py| {
                         let mut cursor = slf.borrow_mut(py);
                         if cursor.input_sizes_generation == input_sizes_generation {
@@ -334,8 +686,8 @@ impl PyAsyncCursor {
                     Ok(slf)
                 }
                 Err(error) => {
-                    execute_guard.fail();
-                    Err(map_execute_error(error))
+                    execute_guard.fail(error.break_connection || has_open_batch);
+                    Err(map_execute_error(error.error))
                 }
             }
         };
@@ -360,72 +712,38 @@ impl PyAsyncCursor {
     /// Returns an awaitable resolving to `None`. Closing an already closed
     /// cursor is a no-op.
     fn close<'py>(slf: Py<Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        let (client, dispatch, prepared_state, session_state, cursor_id, timeout, closed) = {
+        let (cleanup, cleanup_started, dispatch) = {
             let cursor = slf.borrow(py);
-            if cursor.closed.load(Ordering::Acquire) {
+            if cursor.closed.load(Ordering::Acquire)
+                || cursor
+                    .cleanup_started
+                    .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                    .is_err()
+            {
                 return pyo3_async_runtimes::tokio::future_into_py(py, async move {
                     Python::attach(|py| Ok(py.None()))
                 });
             }
             (
-                cursor.tds_client.clone(),
+                cursor.cleanup(),
+                cursor.cleanup_started.clone(),
                 cursor.tracing_dispatch.clone(),
-                cursor.prepared_state.clone(),
-                cursor.session_state.clone(),
-                cursor.cursor_id,
-                cursor.default_query_timeout,
-                cursor.closed.clone(),
             )
         };
-        let claim = session_state
-            .claim_cursor_close(cursor_id)
-            .map_err(map_claim_error)?;
-        let operation_id = claim.operation_id;
-        let future_state = session_state.clone();
-        let future = async move {
-            let mut close_guard = ExecuteGuard::new(future_state, operation_id);
-            let result = async {
-                let mut client = client.lock().await;
-                if claim.drain_previous {
-                    client.close_query().await?;
-                }
-                let statement_ids = {
-                    let mut state = prepared_state.lock().await;
-                    let current = state
-                        .statement
-                        .as_mut()
-                        .and_then(PreparedStatement::take_id);
-                    let orphaned = state.orphaned.take();
-                    state.statement = None;
-                    state.parameter_signature.clear();
-                    [current, orphaned]
-                };
-                let mut released = None;
-                for statement_id in statement_ids.into_iter().flatten() {
-                    if released == Some(statement_id) {
-                        continue;
-                    }
-                    client
-                        .unprepare(
-                            statement_id,
-                            ExecuteOptions {
-                                timeout: Some(timeout),
-                                ..Default::default()
-                            },
-                        )
-                        .await?;
-                    released = Some(statement_id);
-                }
-                Ok::<(), mssql_tds::error::Error>(())
+        let session_state = cleanup.session_state.clone();
+        let claim = match session_state.claim_cursor_close(cleanup.cursor_id) {
+            Ok(claim) => claim,
+            Err(error) => {
+                cleanup_started.store(false, Ordering::Release);
+                return Err(map_claim_error(error));
             }
-            .await;
-
-            close_guard.fail();
-            result.map_err(|error| {
+        };
+        let operation_id = claim.operation_id;
+        let future = async move {
+            cleanup.run(claim).await.map_err(|error| {
                 tracing::error!("PyAsyncCursor::close: failed: {error}");
                 PyRuntimeError::new_err(format!("Cursor close failed: {error}"))
             })?;
-            closed.store(true, Ordering::Release);
             Python::attach(|py| Ok(py.None()))
         };
         let future = async move {
@@ -438,54 +756,9 @@ impl PyAsyncCursor {
             Ok(awaitable) => Ok(awaitable),
             Err(error) => {
                 session_state.release_operation(operation_id);
+                cleanup_started.store(false, Ordering::Release);
                 Err(error)
             }
         }
     }
-
-    // TODO(mssql-tds blockers for async execute parity):
-    // - Add a public, general TdsClient parameter-description API backed by
-    //   sp_describe_undeclared_parameters. The existing describe path is
-    //   private and specific to Always Encrypted, so an unhinted Python None
-    //   still falls back to NVARCHAR(1).
-    // - Add declaration metadata to nullable Decimal/Numeric RPC parameters.
-    //   RpcParameter/SqlType cannot carry precision and scale separately from
-    //   a non-NULL DecimalParts value, and declaration generation hardcodes
-    //   SqlType::{Decimal, Numeric}(None) to (18,10).
-    // - Add a public SqlType::Udt input contract and RPC serializer carrying
-    //   database, schema, and server UDT type names. mssql-tds currently parses
-    //   UDT result metadata internally but cannot send a typed UDT parameter.
-    // TODO(remaining async transaction work):
-    // - Add an awaitable connection mode-change API rather than a synchronous
-    //   property setter: false -> true commits active work before changing
-    //   mode and leaves the mode unchanged if commit fails; true -> false
-    //   defers begin until the next execute.
-    // - Test lazy begin, restart after commit/rollback, both mode transitions,
-    //   context finalization, and cleanup-error precedence.
-    //
-    // TODO(remaining async fetch/close/cancel ownership work):
-    // - Release Fetching ownership when results are exhausted or the cursor is
-    //   closed.
-    // - Add cursor cancel(), triggering the root CancelHandle only when cursor
-    //   and operation IDs match; complete ATTENTION cleanup before deciding
-    //   whether the connection remains reusable or must be marked Broken.
-    // - Add a two-cursor acceptance test with a multi-packet result: reject
-    //   cursor B with a typed busy-state error while cursor A has unread rows,
-    //   verify A can drain its remaining rows, then verify B can execute after
-    //   A drains or closes.
-    //
-    // TODO(performance opportunities):
-    // - Move large parameter/TVP preflight off the Python event-loop thread by
-    //   introducing a chunked or pre-converted input contract; Python objects
-    //   still require the GIL, so spawn_blocking alone is insufficient.
-    // - Remove the per-execution TVP deep clone when mssql-tds supports shared
-    //   TvpTableData ownership.
-    // - Cache or compute datetime base ordinals in the bulk-copy conversion path.
-    // - Convert TVP row iterators directly instead of collecting Bound cells first.
-    // - Add Criterion benchmarks for placeholder scanning, scalar binding,
-    //   prepared reuse, and representative TVP row counts.
-    // - Placeholder rewriting still runs under the GIL before the awaitable is
-    //   returned. If benchmarks of the optimized scanner justify caching, share
-    //   rewritten SQL and marker metadata at connection scope, use borrowed raw
-    //   SQL plus parameter style for hit-path lookup, and bound retained bytes.
 }

--- a/mssql-py-core/src/async_cursor.rs
+++ b/mssql-py-core/src/async_cursor.rs
@@ -37,13 +37,13 @@ use tracing::instrument::WithSubscriber;
 
 use mssql_tds::connection::tds_client::TdsClient;
 
-use crate::async_parameters::{bind_parameters, parse_input_sizes};
+use crate::async_parameters::{ParameterMetadata, bind_parameters, parse_input_sizes};
 use crate::async_session::{AsyncConnectionState, ClaimError, CursorId, OperationId};
 
 #[derive(Default)]
 struct PreparedState {
     statement: Option<PreparedStatement>,
-    parameter_signature: Vec<String>,
+    parameter_signature: Vec<ParameterMetadata>,
     orphaned: Option<StatementId>,
 }
 
@@ -135,6 +135,7 @@ pub struct PyAsyncCursor {
     default_query_timeout: u32,
     input_sizes: Option<Vec<crate::types::ParameterHint>>,
     input_sizes_generation: u64,
+    closed: Arc<AtomicBool>,
 }
 
 impl PyAsyncCursor {
@@ -159,6 +160,7 @@ impl PyAsyncCursor {
             default_query_timeout,
             input_sizes: None,
             input_sizes_generation: 0,
+            closed: Arc::new(AtomicBool::new(false)),
         }
     }
 }
@@ -173,6 +175,9 @@ impl PyAsyncCursor {
 
     /// Set one-shot SQL type, size, and scale hints for the next successful execute.
     fn setinputsizes(&mut self, sizes: &Bound<'_, PyAny>) -> PyResult<()> {
+        if self.closed.load(Ordering::Acquire) {
+            return Err(PyRuntimeError::new_err("Cursor is closed"));
+        }
         self.input_sizes = parse_input_sizes(sizes)?;
         self.input_sizes_generation = self.input_sizes_generation.wrapping_add(1);
         Ok(())
@@ -202,6 +207,9 @@ impl PyAsyncCursor {
             input_sizes_generation,
         ) = {
             let cursor = slf.borrow(py);
+            if cursor.closed.load(Ordering::Acquire) {
+                return Err(PyRuntimeError::new_err("Cursor is closed"));
+            }
             // TODO(async execute preflight): Parameter normalization and Python-to-TDS
             // conversion currently run synchronously under the GIL before the awaitable is
             // returned. Bound or chunk large parameter/TVP conversion so execute does not
@@ -333,6 +341,91 @@ impl PyAsyncCursor {
         }
     }
 
+    /// Drain pending results, release prepared handles, and close this cursor.
+    fn close<'py>(slf: Py<Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let (client, dispatch, prepared_state, session_state, cursor_id, timeout, closed) = {
+            let cursor = slf.borrow(py);
+            if cursor.closed.load(Ordering::Acquire) {
+                return pyo3_async_runtimes::tokio::future_into_py(py, async move {
+                    Python::attach(|py| Ok(py.None()))
+                });
+            }
+            (
+                cursor.tds_client.clone(),
+                cursor.tracing_dispatch.clone(),
+                cursor.prepared_state.clone(),
+                cursor.session_state.clone(),
+                cursor.cursor_id,
+                cursor.default_query_timeout,
+                cursor.closed.clone(),
+            )
+        };
+        let claim = session_state
+            .claim_cursor_close(cursor_id)
+            .map_err(map_claim_error)?;
+        let operation_id = claim.operation_id;
+        let future_state = session_state.clone();
+        let future = async move {
+            let mut close_guard = ExecuteGuard::new(future_state, operation_id);
+            let result = async {
+                let mut client = client.lock().await;
+                if claim.drain_previous {
+                    client.close_query().await?;
+                }
+                let statement_ids = {
+                    let mut state = prepared_state.lock().await;
+                    let current = state
+                        .statement
+                        .as_mut()
+                        .and_then(PreparedStatement::take_id);
+                    let orphaned = state.orphaned.take();
+                    state.statement = None;
+                    state.parameter_signature.clear();
+                    [current, orphaned]
+                };
+                let mut released = None;
+                for statement_id in statement_ids.into_iter().flatten() {
+                    if released == Some(statement_id) {
+                        continue;
+                    }
+                    client
+                        .unprepare(
+                            statement_id,
+                            ExecuteOptions {
+                                timeout: Some(timeout),
+                                ..Default::default()
+                            },
+                        )
+                        .await?;
+                    released = Some(statement_id);
+                }
+                Ok::<(), mssql_tds::error::Error>(())
+            }
+            .await;
+
+            close_guard.fail();
+            result.map_err(|error| {
+                tracing::error!("PyAsyncCursor::close: failed: {error}");
+                PyRuntimeError::new_err(format!("Cursor close failed: {error}"))
+            })?;
+            closed.store(true, Ordering::Release);
+            Python::attach(|py| Ok(py.None()))
+        };
+        let future = async move {
+            match dispatch {
+                Some(dispatch) => future.with_subscriber(dispatch).await,
+                None => future.await,
+            }
+        };
+        match pyo3_async_runtimes::tokio::future_into_py(py, future) {
+            Ok(awaitable) => Ok(awaitable),
+            Err(error) => {
+                session_state.release_operation(operation_id);
+                Err(error)
+            }
+        }
+    }
+
     // TODO(mssql-tds blockers for async execute parity):
     // - Add a public, general TdsClient parameter-description API backed by
     //   sp_describe_undeclared_parameters. The existing describe path is
@@ -363,4 +456,15 @@ impl PyAsyncCursor {
     //   cursor B with a typed busy-state error while cursor A has unread rows,
     //   verify A can drain its remaining rows, then verify B can execute after
     //   A drains or closes.
+    //
+    // TODO(performance opportunities):
+    // - Move large parameter/TVP preflight off the Python event-loop thread by
+    //   introducing a chunked or pre-converted input contract; Python objects
+    //   still require the GIL, so spawn_blocking alone is insufficient.
+    // - Remove the per-execution TVP deep clone when mssql-tds supports shared
+    //   TvpTableData ownership.
+    // - Cache or compute datetime base ordinals in the bulk-copy conversion path.
+    // - Convert TVP row iterators directly instead of collecting Bound cells first.
+    // - Add Criterion benchmarks for placeholder scanning, scalar binding,
+    //   prepared reuse, and representative TVP row counts.
 }

--- a/mssql-py-core/src/async_parameters.rs
+++ b/mssql-py-core/src/async_parameters.rs
@@ -10,6 +10,63 @@ use pyo3::types::{PyDict, PyList, PyTuple};
 
 use crate::types::{ParameterHint, null_sql_type, py_to_sql_type, py_to_sql_type_with_hint};
 
+fn sql_type_signature(value: &SqlType) -> String {
+    match value {
+        SqlType::Bit(_) => "bit".to_string(),
+        SqlType::TinyInt(_) => "tinyint".to_string(),
+        SqlType::SmallInt(_) => "smallint".to_string(),
+        SqlType::Int(_) => "int".to_string(),
+        SqlType::BigInt(_) => "bigint".to_string(),
+        SqlType::Real(_) => "real".to_string(),
+        SqlType::Float(_) => "float".to_string(),
+        SqlType::Decimal(value) => value.as_ref().map_or_else(
+            || "decimal(18,10)".to_string(),
+            |value| format!("decimal({},{})", value.precision, value.scale),
+        ),
+        SqlType::Numeric(value) => value.as_ref().map_or_else(
+            || "numeric(18,10)".to_string(),
+            |value| format!("numeric({},{})", value.precision, value.scale),
+        ),
+        SqlType::Money(_) => "money".to_string(),
+        SqlType::SmallMoney(_) => "smallmoney".to_string(),
+        SqlType::Time(value) => format!("time({})", value.as_ref().map_or(7, |value| value.scale)),
+        SqlType::DateTime2(value) => format!(
+            "datetime2({})",
+            value.as_ref().map_or(7, |value| value.time.scale)
+        ),
+        SqlType::DateTimeOffset(value) => format!(
+            "datetimeoffset({})",
+            value.as_ref().map_or(7, |value| value.datetime2.time.scale)
+        ),
+        SqlType::SmallDateTime(_) => "smalldatetime".to_string(),
+        SqlType::DateTime(_) => "datetime".to_string(),
+        SqlType::Date(_) => "date".to_string(),
+        SqlType::NVarchar(_, length) => format!("nvarchar({length})"),
+        SqlType::NVarcharMax(_) => "nvarchar(max)".to_string(),
+        SqlType::Varchar(_, length) => format!("varchar({length})"),
+        SqlType::VarcharMax(_) => "varchar(max)".to_string(),
+        SqlType::VarBinary(_, length) => format!("varbinary({length})"),
+        SqlType::VarBinaryMax(_) => "varbinary(max)".to_string(),
+        SqlType::Binary(_, length) => format!("binary({length})"),
+        SqlType::Char(_, length) => format!("char({length})"),
+        SqlType::NChar(_, length) => format!("nchar({length})"),
+        SqlType::Text(_) => "text".to_string(),
+        SqlType::NText(_) => "ntext".to_string(),
+        SqlType::Json(_) => "json".to_string(),
+        SqlType::Xml(_) => "xml".to_string(),
+        SqlType::Uuid(_) => "uniqueidentifier".to_string(),
+        SqlType::Vector(_, dimensions, base_type) => {
+            format!("vector({dimensions},{base_type:?})")
+        }
+        SqlType::Variant(inner) => format!("sql_variant<{}>", sql_type_signature(inner)),
+        SqlType::Table(type_name, _) => format!(
+            "tvp({}.{})",
+            type_name.schema_name.as_deref().unwrap_or("dbo"),
+            type_name.type_name
+        ),
+    }
+}
+
 #[pyclass(name = "TableValuedParameter", frozen)]
 pub(crate) struct PyTableValuedParameter {
     type_name: TvpTypeName,
@@ -96,6 +153,17 @@ fn parse_tvp_type_name(type_name: String, schema: Option<String>) -> PyResult<Tv
             "TVP schema and type name must not be empty",
         ));
     }
+    // TODO(mssql-tds): Escape closing brackets when formatting TVP parameter
+    // declarations. Until then, reject names that cannot be represented safely.
+    if type_name.contains(']')
+        || schema_name
+            .as_deref()
+            .is_some_and(|schema| schema.contains(']'))
+    {
+        return Err(PyValueError::new_err(
+            "TVP schema and type name must not contain ']'",
+        ));
+    }
     Ok(TvpTypeName::new(schema_name, type_name.to_string()))
 }
 
@@ -161,9 +229,9 @@ pub(crate) fn bind_parameters(
     operation: String,
     parameters: &Bound<'_, PyTuple>,
     hints: Option<&[ParameterHint]>,
-) -> PyResult<(String, Vec<RpcParameter>)> {
+) -> PyResult<(String, Vec<RpcParameter>, Vec<String>)> {
     if parameters.is_empty() {
-        return Ok((operation, Vec::new()));
+        return Ok((operation, Vec::new(), Vec::new()));
     }
 
     if parameters.len() == 1 {
@@ -226,7 +294,7 @@ fn bind_positional<'py>(
     operation: String,
     values: impl Iterator<Item = Bound<'py, PyAny>>,
     hints: Option<&[ParameterHint]>,
-) -> PyResult<(String, Vec<RpcParameter>)> {
+) -> PyResult<(String, Vec<RpcParameter>, Vec<String>)> {
     let values = values.collect::<Vec<_>>();
     let (operation, names) = rewrite_placeholders(&operation, false)?;
     if names.len() != values.len() {
@@ -236,7 +304,7 @@ fn bind_positional<'py>(
             values.len()
         )));
     }
-    let parameters = names
+    let bound_parameters = names
         .into_iter()
         .zip(values)
         .enumerate()
@@ -247,17 +315,18 @@ fn bind_positional<'py>(
                 hints.and_then(|hints| hints.get(index)),
             )
         })
-        .collect::<PyResult<_>>()?;
-    Ok((operation, parameters))
+        .collect::<PyResult<Vec<_>>>()?;
+    let (parameters, parameter_signature) = bound_parameters.into_iter().unzip();
+    Ok((operation, parameters, parameter_signature))
 }
 
 fn bind_named(
     operation: String,
     values: &Bound<'_, PyDict>,
     hints: Option<&[ParameterHint]>,
-) -> PyResult<(String, Vec<RpcParameter>)> {
+) -> PyResult<(String, Vec<RpcParameter>, Vec<String>)> {
     let (operation, names) = rewrite_placeholders(&operation, true)?;
-    let parameters = names
+    let bound_parameters = names
         .into_iter()
         .enumerate()
         .map(|(index, placeholder)| {
@@ -273,15 +342,16 @@ fn bind_named(
                 hints.and_then(|hints| hints.get(index)),
             )
         })
-        .collect::<PyResult<_>>()?;
-    Ok((operation, parameters))
+        .collect::<PyResult<Vec<_>>>()?;
+    let (parameters, parameter_signature) = bound_parameters.into_iter().unzip();
+    Ok((operation, parameters, parameter_signature))
 }
 
 fn rpc_parameter(
     name: String,
     value: &Bound<'_, PyAny>,
     hint: Option<&ParameterHint>,
-) -> PyResult<RpcParameter> {
+) -> PyResult<(RpcParameter, String)> {
     let (value, status) = if let Ok(tvp) = value.extract::<PyRef<'_, PyTableValuedParameter>>() {
         if hint.is_some() {
             return Err(PyTypeError::new_err(
@@ -304,7 +374,8 @@ fn rpc_parameter(
             StatusFlags::NONE,
         )
     };
-    Ok(RpcParameter::new(Some(name), status, value))
+    let signature = sql_type_signature(&value);
+    Ok((RpcParameter::new(Some(name), status, value), signature))
 }
 
 fn rewrite_placeholders(sql: &str, named: bool) -> PyResult<(String, Vec<Placeholder>)> {
@@ -312,6 +383,7 @@ fn rewrite_placeholders(sql: &str, named: bool) -> PyResult<(String, Vec<Placeho
     let mut output = String::with_capacity(sql.len());
     let mut names = Vec::new();
     let mut state = ScanState::Normal;
+    let mut block_comment_depth = 0usize;
     let mut index = 0;
 
     while index < chars.len() {
@@ -338,6 +410,7 @@ fn rewrite_placeholders(sql: &str, named: bool) -> PyResult<(String, Vec<Placeho
                 }
                 ('/', Some('*')) => {
                     state = ScanState::BlockComment;
+                    block_comment_depth = 1;
                     output.push_str("/*");
                     index += 1;
                 }
@@ -427,11 +500,19 @@ fn rewrite_placeholders(sql: &str, named: bool) -> PyResult<(String, Vec<Placeho
                 }
             }
             ScanState::BlockComment => {
-                output.push(current);
-                if current == '*' && next == Some('/') {
-                    output.push('/');
+                if current == '/' && next == Some('*') {
+                    output.push_str("/*");
                     index += 1;
-                    state = ScanState::Normal;
+                    block_comment_depth += 1;
+                } else if current == '*' && next == Some('/') {
+                    output.push_str("*/");
+                    index += 1;
+                    block_comment_depth -= 1;
+                    if block_comment_depth == 0 {
+                        state = ScanState::Normal;
+                    }
+                } else {
+                    output.push(current);
                 }
             }
         }
@@ -531,7 +612,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "sync compatibility gap: nested SQL Server block comments are not tracked"]
     fn preserves_markers_in_nested_block_comments() {
         let sql = "SELECT /* outer /* inner */ ? still outer */ ?";
         let (sql, names) = rewrite_placeholders(sql, false).unwrap();

--- a/mssql-py-core/src/async_parameters.rs
+++ b/mssql-py-core/src/async_parameters.rs
@@ -127,6 +127,7 @@ impl PyTableValuedParameter {
 
 impl PyTableValuedParameter {
     fn sql_type(&self) -> SqlType {
+        // TODO: Use shared TVP ownership when mssql-tds supports Arc<TvpTableData>.
         SqlType::Table(self.type_name.clone(), self.table.clone())
     }
 }
@@ -379,16 +380,14 @@ fn rpc_parameter(
 }
 
 fn rewrite_placeholders(sql: &str, named: bool) -> PyResult<(String, Vec<Placeholder>)> {
-    let chars = sql.chars().collect::<Vec<_>>();
     let mut output = String::with_capacity(sql.len());
     let mut names = Vec::new();
     let mut state = ScanState::Normal;
     let mut block_comment_depth = 0usize;
-    let mut index = 0;
+    let mut chars = sql.char_indices().peekable();
 
-    while index < chars.len() {
-        let current = chars[index];
-        let next = chars.get(index + 1).copied();
+    while let Some((byte_index, current)) = chars.next() {
+        let next = chars.peek().map(|(_, next)| *next);
         match state {
             ScanState::Normal => match (current, next) {
                 ('\'', _) => {
@@ -406,13 +405,13 @@ fn rewrite_placeholders(sql: &str, named: bool) -> PyResult<(String, Vec<Placeho
                 ('-', Some('-')) => {
                     state = ScanState::LineComment;
                     output.push_str("--");
-                    index += 1;
+                    chars.next();
                 }
                 ('/', Some('*')) => {
                     state = ScanState::BlockComment;
                     block_comment_depth = 1;
                     output.push_str("/*");
-                    index += 1;
+                    chars.next();
                 }
                 ('?', _) if !named => {
                     let rpc_name = format!("@P{}", names.len() + 1);
@@ -429,21 +428,23 @@ fn rewrite_placeholders(sql: &str, named: bool) -> PyResult<(String, Vec<Placeho
                 }
                 ('%', Some('%')) if named => {
                     output.push('%');
-                    index += 1;
+                    chars.next();
                 }
                 ('%', Some('(')) => {
-                    let name_start = index + 2;
-                    let mut name_end = name_start;
-                    while name_end < chars.len() && chars[name_end] != ')' {
-                        name_end += 1;
-                    }
-                    if name_end + 1 < chars.len() && chars[name_end + 1] == 's' {
+                    let name_start = byte_index + 2;
+                    let marker_end = sql[name_start..].find(')').and_then(|relative_end| {
+                        let name_end = name_start + relative_end;
+                        sql[name_end + 1..]
+                            .starts_with('s')
+                            .then_some((name_end, name_end + 1))
+                    });
+                    if let Some((name_end, marker_end)) = marker_end {
                         if !named {
                             return Err(PyTypeError::new_err(
                                 "Parameter style mismatch: query uses named placeholders (%(name)s) but positional parameters were provided",
                             ));
                         }
-                        let source_name = chars[name_start..name_end].iter().collect::<String>();
+                        let source_name = sql[name_start..name_end].to_string();
                         if source_name.is_empty() {
                             return Err(PyTypeError::new_err("Named parameter cannot be empty"));
                         }
@@ -453,7 +454,9 @@ fn rewrite_placeholders(sql: &str, named: bool) -> PyResult<(String, Vec<Placeho
                             rpc_name,
                             source_name: Some(source_name),
                         });
-                        index = name_end + 1;
+                        while chars.peek().is_some_and(|(index, _)| *index <= marker_end) {
+                            chars.next();
+                        }
                     } else {
                         output.push(current);
                     }
@@ -465,7 +468,7 @@ fn rewrite_placeholders(sql: &str, named: bool) -> PyResult<(String, Vec<Placeho
                 if current == '\'' {
                     if next == Some('\'') {
                         output.push('\'');
-                        index += 1;
+                        chars.next();
                     } else {
                         state = ScanState::Normal;
                     }
@@ -476,7 +479,7 @@ fn rewrite_placeholders(sql: &str, named: bool) -> PyResult<(String, Vec<Placeho
                 if current == '"' {
                     if next == Some('"') {
                         output.push('"');
-                        index += 1;
+                        chars.next();
                     } else {
                         state = ScanState::Normal;
                     }
@@ -487,7 +490,7 @@ fn rewrite_placeholders(sql: &str, named: bool) -> PyResult<(String, Vec<Placeho
                 if current == ']' {
                     if next == Some(']') {
                         output.push(']');
-                        index += 1;
+                        chars.next();
                     } else {
                         state = ScanState::Normal;
                     }
@@ -502,11 +505,11 @@ fn rewrite_placeholders(sql: &str, named: bool) -> PyResult<(String, Vec<Placeho
             ScanState::BlockComment => {
                 if current == '/' && next == Some('*') {
                     output.push_str("/*");
-                    index += 1;
+                    chars.next();
                     block_comment_depth += 1;
                 } else if current == '*' && next == Some('/') {
                     output.push_str("*/");
-                    index += 1;
+                    chars.next();
                     block_comment_depth -= 1;
                     if block_comment_depth == 0 {
                         state = ScanState::Normal;
@@ -516,7 +519,6 @@ fn rewrite_placeholders(sql: &str, named: bool) -> PyResult<(String, Vec<Placeho
                 }
             }
         }
-        index += 1;
     }
 
     Ok((output, names))
@@ -555,6 +557,14 @@ mod tests {
                 ("@P3".to_string(), "name".to_string()),
             ]
         );
+    }
+
+    #[test]
+    fn rewrites_named_parameters_with_unicode() {
+        let (sql, names) = rewrite_placeholders("SELECT N'東京', %(café)s", true).unwrap();
+
+        assert_eq!(sql, "SELECT N'東京', @P1");
+        assert_eq!(names[0].source_name.as_deref(), Some("café"));
     }
 
     #[test]

--- a/mssql-py-core/src/async_parameters.rs
+++ b/mssql-py-core/src/async_parameters.rs
@@ -8,7 +8,6 @@ use mssql_tds::message::parameters::rpc_parameters::{RpcParameter, StatusFlags};
 use pyo3::exceptions::{PyKeyError, PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyTuple};
-use std::fmt::Write as _;
 
 use crate::types::{ParameterHint, null_sql_type, py_to_sql_type, py_to_sql_type_with_hint};
 
@@ -259,11 +258,13 @@ fn parse_tvp_type_name(type_name: String, schema: Option<String>) -> PyResult<Tv
 
 /// Builds TVP column metadata and converts each row using its matching hint.
 fn build_tvp_table(columns: &Bound<'_, PyAny>, rows: &Bound<'_, PyAny>) -> PyResult<TvpTableData> {
+    // TODO(performance): Convert TVP row iterators without first collecting
+    // Bound cells, and benchmark representative row counts.
     let hints = parse_input_sizes(columns)?
         .ok_or_else(|| PyValueError::new_err("A TVP must define at least one column"))?;
     let mut column_defs = Vec::with_capacity(hints.len());
     for hint in &hints {
-        if matches!(hint.sql_type(), -151 | -1 | -10) {
+        if !hint.supports_tvp_column() {
             return Err(PyValueError::new_err(
                 "TVP columns do not support UDT, TEXT, or NTEXT input types",
             ));
@@ -323,7 +324,7 @@ enum ScanState {
 
 /// A rewritten parameter marker in RPC wire order.
 struct Placeholder {
-    /// The generated `@Pn` name used in both the SQL text and RPC parameter.
+    /// The generated collision-free name used in both SQL text and RPC metadata.
     rpc_name: String,
     /// The dictionary key for `%(name)s`, or `None` for positional `?`.
     source_name: Option<String>,
@@ -337,6 +338,14 @@ fn parse_pyformat_marker(sql: &str, start: usize, close: Option<usize>) -> Optio
     Some((source_name, close + ")s".len() - start))
 }
 
+fn rpc_prefix(sql: &str) -> String {
+    let lowercase_sql = sql.to_ascii_lowercase();
+    (0_u32..)
+        .map(|suffix| format!("@__mssql_py_{suffix}_"))
+        .find(|candidate| !lowercase_sql.contains(candidate))
+        .expect("an unused generated RPC prefix exists")
+}
+
 /// Normalizes Python execute arguments and binds them as positional or named RPC parameters.
 ///
 /// A sole dictionary selects `%(name)s` binding. A sole tuple, list, or DB-API
@@ -347,10 +356,6 @@ pub(crate) fn bind_parameters(
     parameters: &Bound<'_, PyTuple>,
     hints: Option<&[ParameterHint]>,
 ) -> PyResult<(String, Vec<RpcParameter>, Vec<ParameterMetadata>)> {
-    if parameters.is_empty() {
-        return Ok((operation, Vec::new(), Vec::new()));
-    }
-
     if parameters.len() == 1 {
         let parameter = parameters.get_item(0)?;
         if let Ok(values) = parameter.cast::<PyDict>() {
@@ -486,6 +491,10 @@ fn rpc_parameter(
     value: &Bound<'_, PyAny>,
     hint: Option<&ParameterHint>,
 ) -> PyResult<(RpcParameter, ParameterMetadata)> {
+    // TODO(mssql-tds): Expose general parameter description backed by
+    // sp_describe_undeclared_parameters. The existing private path is specific
+    // to Always Encrypted, so an unhinted Python None falls back to NVARCHAR(1).
+    // TODO(performance): Benchmark representative scalar binding conversions.
     let (value, status) = if let Ok(tvp) = value.extract::<PyRef<'_, PyTableValuedParameter>>() {
         if hint.is_some() {
             return Err(PyTypeError::new_err(
@@ -512,7 +521,7 @@ fn rpc_parameter(
     Ok((RpcParameter::new(Some(name), status, value), signature))
 }
 
-/// Rewrites DB-API parameter markers to SQL Server `@P1` through `@Pn` names.
+/// Rewrites DB-API parameter markers to collision-free SQL Server RPC names.
 ///
 /// Positional mode recognizes `?`; dictionary-backed named mode recognizes
 /// `%(name)s` and converts `%%` to `%`. A valid marker from the other mode is
@@ -521,8 +530,13 @@ fn rpc_parameter(
 /// Malformed pyformat candidates and unsupported `:name` markers are left
 /// unchanged for the caller's marker-count validation.
 fn rewrite_placeholders(sql: &str, named: bool) -> PyResult<(String, Vec<Placeholder>)> {
+    // TODO(performance): Benchmark placeholder scanning. If results justify
+    // caching, share rewritten SQL and marker metadata at connection scope,
+    // use borrowed SQL plus parameter style for hit-path lookup, and bound the
+    // retained bytes.
     let mut output = String::with_capacity(sql.len() + sql.len() / 2);
     let mut names = Vec::new();
+    let rpc_prefix = rpc_prefix(sql);
     let mut state = ScanState::Normal;
     let mut block_comment_depth = 0usize;
     let mut chars = sql.char_indices().peekable();
@@ -556,10 +570,8 @@ fn rewrite_placeholders(sql: &str, named: bool) -> PyResult<(String, Vec<Placeho
                     chars.next();
                 }
                 ('?', _) if !named => {
-                    let start = output.len();
-                    write!(&mut output, "@P{}", names.len() + 1)
-                        .expect("writing to a String cannot fail");
-                    let rpc_name = output[start..].to_owned();
+                    let rpc_name = format!("{rpc_prefix}{}", names.len() + 1);
+                    output.push_str(&rpc_name);
                     names.push(Placeholder {
                         rpc_name,
                         source_name: None,
@@ -593,10 +605,8 @@ fn rewrite_placeholders(sql: &str, named: bool) -> PyResult<(String, Vec<Placeho
                         if source_name.is_empty() {
                             return Err(PyTypeError::new_err("Named parameter cannot be empty"));
                         }
-                        let start = output.len();
-                        write!(&mut output, "@P{}", names.len() + 1)
-                            .expect("writing to a String cannot fail");
-                        let rpc_name = output[start..].to_owned();
+                        let rpc_name = format!("{rpc_prefix}{}", names.len() + 1);
+                        output.push_str(&rpc_name);
                         names.push(Placeholder {
                             rpc_name,
                             source_name: Some(source_name.to_owned()),
@@ -680,13 +690,16 @@ mod tests {
     fn rewrites_only_executable_qmarks() {
         let sql = "SELECT ?, '?', [??] -- ?\n/* ? */ WHERE value = ?";
         let (sql, names) = rewrite_placeholders(sql, false).unwrap();
-        assert_eq!(sql, "SELECT @P1, '?', [??] -- ?\n/* ? */ WHERE value = @P2");
+        assert_eq!(
+            sql,
+            "SELECT @__mssql_py_0_1, '?', [??] -- ?\n/* ? */ WHERE value = @__mssql_py_0_2"
+        );
         assert_eq!(
             names
                 .into_iter()
                 .map(|placeholder| placeholder.rpc_name)
                 .collect::<Vec<_>>(),
-            vec!["@P1", "@P2"]
+            vec!["@__mssql_py_0_1", "@__mssql_py_0_2"]
         );
     }
 
@@ -694,7 +707,7 @@ mod tests {
     fn line_comment_ends_at_carriage_return() {
         let (sql, names) = rewrite_placeholders("SELECT 1 -- c\rWHERE a = ?", false).unwrap();
 
-        assert_eq!(sql, "SELECT 1 -- c\rWHERE a = @P1");
+        assert_eq!(sql, "SELECT 1 -- c\rWHERE a = @__mssql_py_0_1");
         assert_eq!(names.len(), 1);
     }
 
@@ -702,7 +715,7 @@ mod tests {
     fn line_comment_still_ends_at_crlf() {
         let (sql, names) = rewrite_placeholders("SELECT 1 -- c\r\nWHERE a = ?", false).unwrap();
 
-        assert_eq!(sql, "SELECT 1 -- c\r\nWHERE a = @P1");
+        assert_eq!(sql, "SELECT 1 -- c\r\nWHERE a = @__mssql_py_0_1");
         assert_eq!(names.len(), 1);
     }
 
@@ -710,7 +723,7 @@ mod tests {
     fn leading_line_comment_ends_at_carriage_return() {
         let (sql, names) = rewrite_placeholders("-- lead\rSELECT ?, ?", false).unwrap();
 
-        assert_eq!(sql, "-- lead\rSELECT @P1, @P2");
+        assert_eq!(sql, "-- lead\rSELECT @__mssql_py_0_1, @__mssql_py_0_2");
         assert_eq!(names.len(), 2);
     }
 
@@ -720,35 +733,64 @@ mod tests {
         let (sql, names) = rewrite_placeholders(&sql, false).unwrap();
 
         assert_eq!(names.len(), 2000);
-        assert_eq!(names.first().unwrap().rpc_name, "@P1");
-        assert_eq!(names.last().unwrap().rpc_name, "@P2000");
+        assert_eq!(names.first().unwrap().rpc_name, "@__mssql_py_0_1");
+        assert_eq!(names.last().unwrap().rpc_name, "@__mssql_py_0_2000");
         assert_eq!(sql.split(", ").count(), 2000);
-        assert!(sql.starts_with("@P1, @P2"));
-        assert!(sql.ends_with("@P1999, @P2000"));
+        assert!(sql.starts_with("@__mssql_py_0_1, @__mssql_py_0_2"));
+        assert!(sql.ends_with("@__mssql_py_0_1999, @__mssql_py_0_2000"));
     }
 
     #[test]
     fn rewrites_named_parameters_in_occurrence_order() {
         let (sql, names) = rewrite_placeholders("SELECT %(id)s, %(id)s, %(name)s", true).unwrap();
-        assert_eq!(sql, "SELECT @P1, @P2, @P3");
+        assert_eq!(
+            sql,
+            "SELECT @__mssql_py_0_1, @__mssql_py_0_2, @__mssql_py_0_3"
+        );
         assert_eq!(
             names
                 .into_iter()
                 .map(|placeholder| (placeholder.rpc_name, placeholder.source_name.unwrap()))
                 .collect::<Vec<_>>(),
             vec![
-                ("@P1".to_string(), "id".to_string()),
-                ("@P2".to_string(), "id".to_string()),
-                ("@P3".to_string(), "name".to_string()),
+                ("@__mssql_py_0_1".to_string(), "id".to_string()),
+                ("@__mssql_py_0_2".to_string(), "id".to_string()),
+                ("@__mssql_py_0_3".to_string(), "name".to_string()),
             ]
         );
+    }
+
+    #[test]
+    fn generated_names_do_not_collide_with_existing_parameter_names() {
+        let sql = "DECLARE @P1 int = 10; SELECT @P1, ?, ?";
+        let (sql, names) = rewrite_placeholders(sql, false).unwrap();
+
+        assert_eq!(
+            sql,
+            "DECLARE @P1 int = 10; SELECT @P1, @__mssql_py_0_1, @__mssql_py_0_2"
+        );
+        assert_eq!(names[0].rpc_name, "@__mssql_py_0_1");
+        assert_eq!(names[1].rpc_name, "@__mssql_py_0_2");
+    }
+
+    #[test]
+    fn generated_prefix_collision_check_is_case_insensitive() {
+        let sql = "DECLARE @__MsSqL_Py_0_1 int; SELECT %(first)s, %(second)s";
+        let (sql, names) = rewrite_placeholders(sql, true).unwrap();
+
+        assert_eq!(
+            sql,
+            "DECLARE @__MsSqL_Py_0_1 int; SELECT @__mssql_py_1_1, @__mssql_py_1_2"
+        );
+        assert_eq!(names[0].rpc_name, "@__mssql_py_1_1");
+        assert_eq!(names[1].rpc_name, "@__mssql_py_1_2");
     }
 
     #[test]
     fn rewrites_named_parameters_with_unicode() {
         let (sql, names) = rewrite_placeholders("SELECT N'東京', %(café)s", true).unwrap();
 
-        assert_eq!(sql, "SELECT N'東京', @P1");
+        assert_eq!(sql, "SELECT N'東京', @__mssql_py_0_1");
         assert_eq!(names[0].source_name.as_deref(), Some("café"));
     }
 
@@ -759,7 +801,7 @@ mod tests {
 
         assert_eq!(
             sql,
-            "SELECT 'it''s ?', \"col\"\"?\", [col]]?] WHERE value = @P1"
+            "SELECT 'it''s ?', \"col\"\"?\", [col]]?] WHERE value = @__mssql_py_0_1"
         );
         assert_eq!(names.len(), 1);
     }
@@ -783,7 +825,7 @@ mod tests {
         let (sql, names) =
             rewrite_placeholders("SELECT %(broken)x, %(value)s, %(unterminated", true).unwrap();
 
-        assert_eq!(sql, "SELECT %(broken)x, @P1, %(unterminated");
+        assert_eq!(sql, "SELECT %(broken)x, @__mssql_py_0_1, %(unterminated");
         assert_eq!(names.len(), 1);
         assert_eq!(names[0].source_name.as_deref(), Some("value"));
     }
@@ -793,7 +835,10 @@ mod tests {
         let (sql, names) =
             rewrite_placeholders("SELECT a %(SELECT c FROM t WHERE id = ?) FROM u", false).unwrap();
 
-        assert_eq!(sql, "SELECT a %(SELECT c FROM t WHERE id = @P1) FROM u");
+        assert_eq!(
+            sql,
+            "SELECT a %(SELECT c FROM t WHERE id = @__mssql_py_0_1) FROM u"
+        );
         assert_eq!(names.len(), 1);
     }
 
@@ -801,7 +846,7 @@ mod tests {
     fn unterminated_percent_paren_does_not_swallow_later_markers() {
         let (sql, names) = rewrite_placeholders("SELECT a %(b FROM t WHERE c = ?", false).unwrap();
 
-        assert_eq!(sql, "SELECT a %(b FROM t WHERE c = @P1");
+        assert_eq!(sql, "SELECT a %(b FROM t WHERE c = @__mssql_py_0_1");
         assert_eq!(names.len(), 1);
     }
 
@@ -809,7 +854,7 @@ mod tests {
     fn quoting_is_tracked_after_a_bare_percent_paren() {
         let (sql, names) = rewrite_placeholders("SELECT a %(b, '?' , ? FROM t", false).unwrap();
 
-        assert_eq!(sql, "SELECT a %(b, '?' , @P1 FROM t");
+        assert_eq!(sql, "SELECT a %(b, '?' , @__mssql_py_0_1 FROM t");
         assert_eq!(names.len(), 1);
     }
 
@@ -818,7 +863,7 @@ mod tests {
         let sql = format!("SELECT {} ?", "%(".repeat(2000));
         let (rewritten, names) = rewrite_placeholders(&sql, false).unwrap();
 
-        assert!(rewritten.ends_with("@P1"));
+        assert!(rewritten.ends_with("@__mssql_py_0_1"));
         assert_eq!(names.len(), 1);
     }
 
@@ -827,7 +872,7 @@ mod tests {
         let (sql, names) =
             rewrite_placeholders("SELECT 100%%, %(value)s, '%%(ignored)s'", true).unwrap();
 
-        assert_eq!(sql, "SELECT 100%, @P1, '%%(ignored)s'");
+        assert_eq!(sql, "SELECT 100%, @__mssql_py_0_1, '%%(ignored)s'");
         assert_eq!(names.len(), 1);
         assert_eq!(names[0].source_name.as_deref(), Some("value"));
     }
@@ -855,7 +900,10 @@ mod tests {
         let sql = "SELECT /* outer /* inner */ ? still outer */ ?";
         let (sql, names) = rewrite_placeholders(sql, false).unwrap();
 
-        assert_eq!(sql, "SELECT /* outer /* inner */ ? still outer */ @P1");
+        assert_eq!(
+            sql,
+            "SELECT /* outer /* inner */ ? still outer */ @__mssql_py_0_1"
+        );
         assert_eq!(names.len(), 1);
     }
 
@@ -864,7 +912,7 @@ mod tests {
     fn accepts_empty_named_parameter() {
         let (sql, names) = rewrite_placeholders("SELECT %()s", true).unwrap();
 
-        assert_eq!(sql, "SELECT @P1");
+        assert_eq!(sql, "SELECT @__mssql_py_0_1");
         assert_eq!(names[0].source_name.as_deref(), Some(""));
     }
 }

--- a/mssql-py-core/src/async_parameters.rs
+++ b/mssql-py-core/src/async_parameters.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 use mssql_tds::datatypes::sql_tvp::{TvpColumnDef, TvpTableData, TvpTypeName};
+use mssql_tds::datatypes::sqldatatypes::VectorBaseType;
 use mssql_tds::datatypes::sqltypes::SqlType;
 use mssql_tds::message::parameters::rpc_parameters::{RpcParameter, StatusFlags};
 use pyo3::exceptions::{PyKeyError, PyTypeError, PyValueError};
@@ -10,60 +11,113 @@ use pyo3::types::{PyDict, PyList, PyTuple};
 
 use crate::types::{ParameterHint, null_sql_type, py_to_sql_type, py_to_sql_type_with_hint};
 
-fn sql_type_signature(value: &SqlType) -> String {
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum ParameterMetadata {
+    Scalar(&'static str),
+    Decimal {
+        numeric: bool,
+        precision: u8,
+        scale: u8,
+    },
+    Temporal {
+        kind: &'static str,
+        scale: u8,
+    },
+    Sized {
+        kind: &'static str,
+        length: u16,
+    },
+    Vector {
+        dimensions: u16,
+        base_type: VectorBaseType,
+    },
+    Variant(Box<ParameterMetadata>),
+    Table {
+        schema: String,
+        name: String,
+    },
+}
+
+fn sql_type_metadata(value: &SqlType) -> ParameterMetadata {
     match value {
-        SqlType::Bit(_) => "bit".to_string(),
-        SqlType::TinyInt(_) => "tinyint".to_string(),
-        SqlType::SmallInt(_) => "smallint".to_string(),
-        SqlType::Int(_) => "int".to_string(),
-        SqlType::BigInt(_) => "bigint".to_string(),
-        SqlType::Real(_) => "real".to_string(),
-        SqlType::Float(_) => "float".to_string(),
-        SqlType::Decimal(value) => value.as_ref().map_or_else(
-            || "decimal(18,10)".to_string(),
-            |value| format!("decimal({},{})", value.precision, value.scale),
-        ),
-        SqlType::Numeric(value) => value.as_ref().map_or_else(
-            || "numeric(18,10)".to_string(),
-            |value| format!("numeric({},{})", value.precision, value.scale),
-        ),
-        SqlType::Money(_) => "money".to_string(),
-        SqlType::SmallMoney(_) => "smallmoney".to_string(),
-        SqlType::Time(value) => format!("time({})", value.as_ref().map_or(7, |value| value.scale)),
-        SqlType::DateTime2(value) => format!(
-            "datetime2({})",
-            value.as_ref().map_or(7, |value| value.time.scale)
-        ),
-        SqlType::DateTimeOffset(value) => format!(
-            "datetimeoffset({})",
-            value.as_ref().map_or(7, |value| value.datetime2.time.scale)
-        ),
-        SqlType::SmallDateTime(_) => "smalldatetime".to_string(),
-        SqlType::DateTime(_) => "datetime".to_string(),
-        SqlType::Date(_) => "date".to_string(),
-        SqlType::NVarchar(_, length) => format!("nvarchar({length})"),
-        SqlType::NVarcharMax(_) => "nvarchar(max)".to_string(),
-        SqlType::Varchar(_, length) => format!("varchar({length})"),
-        SqlType::VarcharMax(_) => "varchar(max)".to_string(),
-        SqlType::VarBinary(_, length) => format!("varbinary({length})"),
-        SqlType::VarBinaryMax(_) => "varbinary(max)".to_string(),
-        SqlType::Binary(_, length) => format!("binary({length})"),
-        SqlType::Char(_, length) => format!("char({length})"),
-        SqlType::NChar(_, length) => format!("nchar({length})"),
-        SqlType::Text(_) => "text".to_string(),
-        SqlType::NText(_) => "ntext".to_string(),
-        SqlType::Json(_) => "json".to_string(),
-        SqlType::Xml(_) => "xml".to_string(),
-        SqlType::Uuid(_) => "uniqueidentifier".to_string(),
-        SqlType::Vector(_, dimensions, base_type) => {
-            format!("vector({dimensions},{base_type:?})")
-        }
-        SqlType::Variant(inner) => format!("sql_variant<{}>", sql_type_signature(inner)),
-        SqlType::Table(type_name, _) => format!(
-            "tvp({}.{})",
-            type_name.schema_name.as_deref().unwrap_or("dbo"),
-            type_name.type_name
-        ),
+        SqlType::Bit(_) => ParameterMetadata::Scalar("bit"),
+        SqlType::TinyInt(_) => ParameterMetadata::Scalar("tinyint"),
+        SqlType::SmallInt(_) => ParameterMetadata::Scalar("smallint"),
+        SqlType::Int(_) => ParameterMetadata::Scalar("int"),
+        SqlType::BigInt(_) => ParameterMetadata::Scalar("bigint"),
+        SqlType::Real(_) => ParameterMetadata::Scalar("real"),
+        SqlType::Float(_) => ParameterMetadata::Scalar("float"),
+        SqlType::Decimal(value) => ParameterMetadata::Decimal {
+            numeric: false,
+            precision: value.as_ref().map_or(18, |value| value.precision),
+            scale: value.as_ref().map_or(10, |value| value.scale),
+        },
+        SqlType::Numeric(value) => ParameterMetadata::Decimal {
+            numeric: true,
+            precision: value.as_ref().map_or(18, |value| value.precision),
+            scale: value.as_ref().map_or(10, |value| value.scale),
+        },
+        SqlType::Money(_) => ParameterMetadata::Scalar("money"),
+        SqlType::SmallMoney(_) => ParameterMetadata::Scalar("smallmoney"),
+        SqlType::Time(value) => ParameterMetadata::Temporal {
+            kind: "time",
+            scale: value.as_ref().map_or(7, |value| value.scale),
+        },
+        SqlType::DateTime2(value) => ParameterMetadata::Temporal {
+            kind: "datetime2",
+            scale: value.as_ref().map_or(7, |value| value.time.scale),
+        },
+        SqlType::DateTimeOffset(value) => ParameterMetadata::Temporal {
+            kind: "datetimeoffset",
+            scale: value.as_ref().map_or(7, |value| value.datetime2.time.scale),
+        },
+        SqlType::SmallDateTime(_) => ParameterMetadata::Scalar("smalldatetime"),
+        SqlType::DateTime(_) => ParameterMetadata::Scalar("datetime"),
+        SqlType::Date(_) => ParameterMetadata::Scalar("date"),
+        SqlType::NVarchar(_, length) => ParameterMetadata::Sized {
+            kind: "nvarchar",
+            length: *length,
+        },
+        SqlType::NVarcharMax(_) => ParameterMetadata::Scalar("nvarchar(max)"),
+        SqlType::Varchar(_, length) => ParameterMetadata::Sized {
+            kind: "varchar",
+            length: *length,
+        },
+        SqlType::VarcharMax(_) => ParameterMetadata::Scalar("varchar(max)"),
+        SqlType::VarBinary(_, length) => ParameterMetadata::Sized {
+            kind: "varbinary",
+            length: *length,
+        },
+        SqlType::VarBinaryMax(_) => ParameterMetadata::Scalar("varbinary(max)"),
+        SqlType::Binary(_, length) => ParameterMetadata::Sized {
+            kind: "binary",
+            length: *length,
+        },
+        SqlType::Char(_, length) => ParameterMetadata::Sized {
+            kind: "char",
+            length: *length,
+        },
+        SqlType::NChar(_, length) => ParameterMetadata::Sized {
+            kind: "nchar",
+            length: *length,
+        },
+        SqlType::Text(_) => ParameterMetadata::Scalar("text"),
+        SqlType::NText(_) => ParameterMetadata::Scalar("ntext"),
+        SqlType::Json(_) => ParameterMetadata::Scalar("json"),
+        SqlType::Xml(_) => ParameterMetadata::Scalar("xml"),
+        SqlType::Uuid(_) => ParameterMetadata::Scalar("uniqueidentifier"),
+        SqlType::Vector(_, dimensions, base_type) => ParameterMetadata::Vector {
+            dimensions: *dimensions,
+            base_type: *base_type,
+        },
+        SqlType::Variant(inner) => ParameterMetadata::Variant(Box::new(sql_type_metadata(inner))),
+        SqlType::Table(type_name, _) => ParameterMetadata::Table {
+            schema: type_name
+                .schema_name
+                .clone()
+                .unwrap_or_else(|| "dbo".to_string()),
+            name: type_name.type_name.clone(),
+        },
     }
 }
 
@@ -230,7 +284,7 @@ pub(crate) fn bind_parameters(
     operation: String,
     parameters: &Bound<'_, PyTuple>,
     hints: Option<&[ParameterHint]>,
-) -> PyResult<(String, Vec<RpcParameter>, Vec<String>)> {
+) -> PyResult<(String, Vec<RpcParameter>, Vec<ParameterMetadata>)> {
     if parameters.is_empty() {
         return Ok((operation, Vec::new(), Vec::new()));
     }
@@ -295,7 +349,7 @@ fn bind_positional<'py>(
     operation: String,
     values: impl Iterator<Item = Bound<'py, PyAny>>,
     hints: Option<&[ParameterHint]>,
-) -> PyResult<(String, Vec<RpcParameter>, Vec<String>)> {
+) -> PyResult<(String, Vec<RpcParameter>, Vec<ParameterMetadata>)> {
     let values = values.collect::<Vec<_>>();
     let (operation, names) = rewrite_placeholders(&operation, false)?;
     if names.len() != values.len() {
@@ -325,7 +379,7 @@ fn bind_named(
     operation: String,
     values: &Bound<'_, PyDict>,
     hints: Option<&[ParameterHint]>,
-) -> PyResult<(String, Vec<RpcParameter>, Vec<String>)> {
+) -> PyResult<(String, Vec<RpcParameter>, Vec<ParameterMetadata>)> {
     let (operation, names) = rewrite_placeholders(&operation, true)?;
     let bound_parameters = names
         .into_iter()
@@ -352,7 +406,7 @@ fn rpc_parameter(
     name: String,
     value: &Bound<'_, PyAny>,
     hint: Option<&ParameterHint>,
-) -> PyResult<(RpcParameter, String)> {
+) -> PyResult<(RpcParameter, ParameterMetadata)> {
     let (value, status) = if let Ok(tvp) = value.extract::<PyRef<'_, PyTableValuedParameter>>() {
         if hint.is_some() {
             return Err(PyTypeError::new_err(
@@ -375,7 +429,7 @@ fn rpc_parameter(
             StatusFlags::NONE,
         )
     };
-    let signature = sql_type_signature(&value);
+    let signature = sql_type_metadata(&value);
     Ok((RpcParameter::new(Some(name), status, value), signature))
 }
 
@@ -386,7 +440,7 @@ fn rewrite_placeholders(sql: &str, named: bool) -> PyResult<(String, Vec<Placeho
     let mut block_comment_depth = 0usize;
     let mut chars = sql.char_indices().peekable();
 
-    while let Some((byte_index, current)) = chars.next() {
+    while let Some((_, current)) = chars.next() {
         let next = chars.peek().map(|(_, next)| *next);
         match state {
             ScanState::Normal => match (current, next) {
@@ -431,20 +485,28 @@ fn rewrite_placeholders(sql: &str, named: bool) -> PyResult<(String, Vec<Placeho
                     chars.next();
                 }
                 ('%', Some('(')) => {
-                    let name_start = byte_index + 2;
-                    let marker_end = sql[name_start..].find(')').and_then(|relative_end| {
-                        let name_end = name_start + relative_end;
-                        sql[name_end + 1..]
-                            .starts_with('s')
-                            .then_some((name_end, name_end + 1))
-                    });
-                    if let Some((name_end, marker_end)) = marker_end {
+                    chars.next();
+                    let mut source_name = String::new();
+                    let mut original = String::from("%(");
+                    let mut complete = false;
+                    while let Some((_, marker_char)) = chars.next() {
+                        original.push(marker_char);
+                        if marker_char == ')' {
+                            if chars.peek().is_some_and(|(_, next)| *next == 's') {
+                                chars.next();
+                                original.push('s');
+                                complete = true;
+                            }
+                            break;
+                        }
+                        source_name.push(marker_char);
+                    }
+                    if complete {
                         if !named {
                             return Err(PyTypeError::new_err(
                                 "Parameter style mismatch: query uses named placeholders (%(name)s) but positional parameters were provided",
                             ));
                         }
-                        let source_name = sql[name_start..name_end].to_string();
                         if source_name.is_empty() {
                             return Err(PyTypeError::new_err("Named parameter cannot be empty"));
                         }
@@ -454,11 +516,8 @@ fn rewrite_placeholders(sql: &str, named: bool) -> PyResult<(String, Vec<Placeho
                             rpc_name,
                             source_name: Some(source_name),
                         });
-                        while chars.peek().is_some_and(|(index, _)| *index <= marker_end) {
-                            chars.next();
-                        }
                     } else {
-                        output.push(current);
+                        output.push_str(&original);
                     }
                 }
                 _ => output.push(current),
@@ -591,6 +650,16 @@ mod tests {
             assert_eq!(rewritten, sql);
             assert!(names.is_empty());
         }
+    }
+
+    #[test]
+    fn preserves_malformed_named_markers_and_rewrites_later_valid_markers() {
+        let (sql, names) =
+            rewrite_placeholders("SELECT %(broken)x, %(value)s, %(unterminated", true).unwrap();
+
+        assert_eq!(sql, "SELECT %(broken)x, @P1, %(unterminated");
+        assert_eq!(names.len(), 1);
+        assert_eq!(names[0].source_name.as_deref(), Some("value"));
     }
 
     #[test]

--- a/mssql-py-core/src/async_parameters.rs
+++ b/mssql-py-core/src/async_parameters.rs
@@ -1,0 +1,551 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use mssql_tds::datatypes::sql_tvp::{TvpColumnDef, TvpTableData, TvpTypeName};
+use mssql_tds::datatypes::sqltypes::SqlType;
+use mssql_tds::message::parameters::rpc_parameters::{RpcParameter, StatusFlags};
+use pyo3::exceptions::{PyKeyError, PyTypeError, PyValueError};
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList, PyTuple};
+
+use crate::types::{ParameterHint, null_sql_type, py_to_sql_type, py_to_sql_type_with_hint};
+
+#[pyclass(name = "TableValuedParameter", frozen)]
+pub(crate) struct PyTableValuedParameter {
+    type_name: TvpTypeName,
+    table: Option<TvpTableData>,
+}
+
+#[pymethods]
+impl PyTableValuedParameter {
+    #[new]
+    #[pyo3(signature = (type_name, columns=None, rows=None, *, schema=None))]
+    fn new(
+        type_name: String,
+        columns: Option<&Bound<'_, PyAny>>,
+        rows: Option<&Bound<'_, PyAny>>,
+        schema: Option<String>,
+    ) -> PyResult<Self> {
+        let type_name = parse_tvp_type_name(type_name, schema)?;
+        let rows = rows.filter(|rows| !rows.is_none());
+        let table = match rows {
+            None => None,
+            Some(rows) => {
+                let columns = columns
+                    .filter(|columns| !columns.is_none())
+                    .ok_or_else(|| {
+                        PyValueError::new_err("A non-NULL TVP requires column definitions")
+                    })?;
+                Some(build_tvp_table(columns, rows)?)
+            }
+        };
+        Ok(Self { type_name, table })
+    }
+
+    #[getter]
+    fn type_name(&self) -> &str {
+        &self.type_name.type_name
+    }
+
+    #[getter]
+    fn schema(&self) -> Option<&str> {
+        self.type_name.schema_name.as_deref()
+    }
+
+    #[getter]
+    fn is_null(&self) -> bool {
+        self.table.is_none()
+    }
+
+    #[getter]
+    fn column_count(&self) -> usize {
+        self.table.as_ref().map_or(0, |table| table.columns.len())
+    }
+
+    #[getter]
+    fn row_count(&self) -> usize {
+        self.table.as_ref().map_or(0, |table| table.rows.len())
+    }
+}
+
+impl PyTableValuedParameter {
+    fn sql_type(&self) -> SqlType {
+        SqlType::Table(self.type_name.clone(), self.table.clone())
+    }
+}
+
+fn parse_tvp_type_name(type_name: String, schema: Option<String>) -> PyResult<TvpTypeName> {
+    let parts = type_name.split('.').collect::<Vec<_>>();
+    let (schema_name, type_name) = match (schema, parts.as_slice()) {
+        (Some(schema), [type_name]) => (Some(schema), *type_name),
+        (None, [type_name]) => (None, *type_name),
+        (None, [schema, type_name]) => (Some((*schema).to_string()), *type_name),
+        (Some(_), _) => {
+            return Err(PyValueError::new_err(
+                "Specify the TVP schema either in type_name or with schema, not both",
+            ));
+        }
+        (None, _) => {
+            return Err(PyValueError::new_err(
+                "TVP type_name must be 'TypeName' or 'schema.TypeName'",
+            ));
+        }
+    };
+    if type_name.is_empty() || schema_name.as_deref() == Some("") {
+        return Err(PyValueError::new_err(
+            "TVP schema and type name must not be empty",
+        ));
+    }
+    Ok(TvpTypeName::new(schema_name, type_name.to_string()))
+}
+
+fn build_tvp_table(columns: &Bound<'_, PyAny>, rows: &Bound<'_, PyAny>) -> PyResult<TvpTableData> {
+    let hints = parse_input_sizes(columns)?
+        .ok_or_else(|| PyValueError::new_err("A TVP must define at least one column"))?;
+    let mut column_defs = Vec::with_capacity(hints.len());
+    for hint in &hints {
+        if matches!(hint.sql_type(), -151 | -1 | -10) {
+            return Err(PyValueError::new_err(
+                "TVP columns do not support UDT, TEXT, or NTEXT input types",
+            ));
+        }
+        let mut column = TvpColumnDef::new(
+            null_sql_type(*hint).map_err(|error| PyValueError::new_err(error.to_string()))?,
+        );
+        column.precision = hint.precision();
+        column.scale = hint.scale();
+        column_defs.push(column);
+    }
+
+    let mut converted_rows = Vec::new();
+    for (row_index, row) in rows.try_iter()?.enumerate() {
+        let row = row?;
+        let cells = row.try_iter()?.collect::<PyResult<Vec<_>>>()?;
+        if cells.len() != hints.len() {
+            return Err(PyValueError::new_err(format!(
+                "TVP row {row_index} has {} values but {} columns were declared",
+                cells.len(),
+                hints.len()
+            )));
+        }
+        let converted = cells
+            .iter()
+            .zip(&hints)
+            .map(|(cell, hint)| {
+                py_to_sql_type_with_hint(cell, *hint)
+                    .map_err(|error| PyTypeError::new_err(error.to_string()))
+            })
+            .collect::<PyResult<Vec<_>>>()?;
+        converted_rows.push(converted);
+    }
+
+    Ok(TvpTableData::new(column_defs, converted_rows))
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum ScanState {
+    Normal,
+    SingleQuote,
+    DoubleQuote,
+    Bracket,
+    LineComment,
+    BlockComment,
+}
+
+struct Placeholder {
+    rpc_name: String,
+    source_name: Option<String>,
+}
+
+pub(crate) fn bind_parameters(
+    operation: String,
+    parameters: &Bound<'_, PyTuple>,
+    hints: Option<&[ParameterHint]>,
+) -> PyResult<(String, Vec<RpcParameter>)> {
+    if parameters.is_empty() {
+        return Ok((operation, Vec::new()));
+    }
+
+    if parameters.len() == 1 {
+        let parameter = parameters.get_item(0)?;
+        if let Ok(values) = parameter.cast::<PyDict>() {
+            return bind_named(operation, values, hints);
+        }
+        if let Ok(values) = parameter.cast::<PyTuple>() {
+            return bind_positional(operation, values.iter(), hints);
+        }
+        if let Ok(values) = parameter.cast::<PyList>() {
+            return bind_positional(operation, values.iter(), hints);
+        }
+        if parameter.get_type().name()? == "Row" {
+            let values = parameter.try_iter()?.collect::<PyResult<Vec<_>>>()?;
+            return bind_positional(operation, values.into_iter(), hints);
+        }
+    }
+
+    bind_positional(operation, parameters.iter(), hints)
+}
+
+pub(crate) fn parse_input_sizes(sizes: &Bound<'_, PyAny>) -> PyResult<Option<Vec<ParameterHint>>> {
+    if sizes.is_none() {
+        return Ok(None);
+    }
+    let mut hints = Vec::new();
+    for item in sizes.try_iter()? {
+        let item = item?;
+        let (sql_type, size, scale) = if let Ok(values) = item.cast::<PyTuple>() {
+            if values.is_empty() || values.len() > 3 {
+                return Err(PyValueError::new_err(
+                    "Each input size tuple must contain (sql_type[, size[, decimal_digits]])",
+                ));
+            }
+            let sql_type = values.get_item(0)?.extract::<i32>()?;
+            let size = if values.len() >= 2 {
+                values.get_item(1)?.extract::<u32>()?
+            } else {
+                0
+            };
+            let scale = if values.len() == 3 {
+                values.get_item(2)?.extract::<u8>()?
+            } else {
+                0
+            };
+            (sql_type, size, scale)
+        } else {
+            (item.extract::<i32>()?, 0, 0)
+        };
+        hints.push(
+            ParameterHint::new(sql_type, size, scale)
+                .map_err(|error| PyValueError::new_err(error.to_string()))?,
+        );
+    }
+    Ok((!hints.is_empty()).then_some(hints))
+}
+
+fn bind_positional<'py>(
+    operation: String,
+    values: impl Iterator<Item = Bound<'py, PyAny>>,
+    hints: Option<&[ParameterHint]>,
+) -> PyResult<(String, Vec<RpcParameter>)> {
+    let values = values.collect::<Vec<_>>();
+    let (operation, names) = rewrite_placeholders(&operation, false)?;
+    if names.len() != values.len() {
+        return Err(PyTypeError::new_err(format!(
+            "The SQL contains {} parameter markers, but {} parameters were supplied",
+            names.len(),
+            values.len()
+        )));
+    }
+    let parameters = names
+        .into_iter()
+        .zip(values)
+        .enumerate()
+        .map(|(index, (placeholder, value))| {
+            rpc_parameter(
+                placeholder.rpc_name,
+                &value,
+                hints.and_then(|hints| hints.get(index)),
+            )
+        })
+        .collect::<PyResult<_>>()?;
+    Ok((operation, parameters))
+}
+
+fn bind_named(
+    operation: String,
+    values: &Bound<'_, PyDict>,
+    hints: Option<&[ParameterHint]>,
+) -> PyResult<(String, Vec<RpcParameter>)> {
+    let (operation, names) = rewrite_placeholders(&operation, true)?;
+    let parameters = names
+        .into_iter()
+        .enumerate()
+        .map(|(index, placeholder)| {
+            let source_name = placeholder
+                .source_name
+                .expect("named placeholders include source names");
+            let value = values
+                .get_item(&source_name)?
+                .ok_or_else(|| PyKeyError::new_err(source_name.clone()))?;
+            rpc_parameter(
+                placeholder.rpc_name,
+                &value,
+                hints.and_then(|hints| hints.get(index)),
+            )
+        })
+        .collect::<PyResult<_>>()?;
+    Ok((operation, parameters))
+}
+
+fn rpc_parameter(
+    name: String,
+    value: &Bound<'_, PyAny>,
+    hint: Option<&ParameterHint>,
+) -> PyResult<RpcParameter> {
+    let (value, status) = if let Ok(tvp) = value.extract::<PyRef<'_, PyTableValuedParameter>>() {
+        if hint.is_some() {
+            return Err(PyTypeError::new_err(
+                "setinputsizes hints cannot be applied to a TableValuedParameter",
+            ));
+        }
+        let status = if tvp.is_null() {
+            StatusFlags::DEFAULT_VALUE
+        } else {
+            StatusFlags::NONE
+        };
+        (tvp.sql_type(), status)
+    } else {
+        (
+            match hint {
+                Some(hint) => py_to_sql_type_with_hint(value, *hint),
+                None => py_to_sql_type(value),
+            }
+            .map_err(|error| PyTypeError::new_err(error.to_string()))?,
+            StatusFlags::NONE,
+        )
+    };
+    Ok(RpcParameter::new(Some(name), status, value))
+}
+
+fn rewrite_placeholders(sql: &str, named: bool) -> PyResult<(String, Vec<Placeholder>)> {
+    let chars = sql.chars().collect::<Vec<_>>();
+    let mut output = String::with_capacity(sql.len());
+    let mut names = Vec::new();
+    let mut state = ScanState::Normal;
+    let mut index = 0;
+
+    while index < chars.len() {
+        let current = chars[index];
+        let next = chars.get(index + 1).copied();
+        match state {
+            ScanState::Normal => match (current, next) {
+                ('\'', _) => {
+                    state = ScanState::SingleQuote;
+                    output.push(current);
+                }
+                ('"', _) => {
+                    state = ScanState::DoubleQuote;
+                    output.push(current);
+                }
+                ('[', _) => {
+                    state = ScanState::Bracket;
+                    output.push(current);
+                }
+                ('-', Some('-')) => {
+                    state = ScanState::LineComment;
+                    output.push_str("--");
+                    index += 1;
+                }
+                ('/', Some('*')) => {
+                    state = ScanState::BlockComment;
+                    output.push_str("/*");
+                    index += 1;
+                }
+                ('?', _) if !named => {
+                    let rpc_name = format!("@P{}", names.len() + 1);
+                    output.push_str(&rpc_name);
+                    names.push(Placeholder {
+                        rpc_name,
+                        source_name: None,
+                    });
+                }
+                ('?', _) => {
+                    return Err(PyTypeError::new_err(
+                        "Parameter style mismatch: query uses positional placeholders (?) but a dict was provided",
+                    ));
+                }
+                ('%', Some('%')) if named => {
+                    output.push('%');
+                    index += 1;
+                }
+                ('%', Some('(')) => {
+                    let name_start = index + 2;
+                    let mut name_end = name_start;
+                    while name_end < chars.len() && chars[name_end] != ')' {
+                        name_end += 1;
+                    }
+                    if name_end + 1 < chars.len() && chars[name_end + 1] == 's' {
+                        if !named {
+                            return Err(PyTypeError::new_err(
+                                "Parameter style mismatch: query uses named placeholders (%(name)s) but positional parameters were provided",
+                            ));
+                        }
+                        let source_name = chars[name_start..name_end].iter().collect::<String>();
+                        if source_name.is_empty() {
+                            return Err(PyTypeError::new_err("Named parameter cannot be empty"));
+                        }
+                        let rpc_name = format!("@P{}", names.len() + 1);
+                        output.push_str(&rpc_name);
+                        names.push(Placeholder {
+                            rpc_name,
+                            source_name: Some(source_name),
+                        });
+                        index = name_end + 1;
+                    } else {
+                        output.push(current);
+                    }
+                }
+                _ => output.push(current),
+            },
+            ScanState::SingleQuote => {
+                output.push(current);
+                if current == '\'' {
+                    if next == Some('\'') {
+                        output.push('\'');
+                        index += 1;
+                    } else {
+                        state = ScanState::Normal;
+                    }
+                }
+            }
+            ScanState::DoubleQuote => {
+                output.push(current);
+                if current == '"' {
+                    if next == Some('"') {
+                        output.push('"');
+                        index += 1;
+                    } else {
+                        state = ScanState::Normal;
+                    }
+                }
+            }
+            ScanState::Bracket => {
+                output.push(current);
+                if current == ']' {
+                    if next == Some(']') {
+                        output.push(']');
+                        index += 1;
+                    } else {
+                        state = ScanState::Normal;
+                    }
+                }
+            }
+            ScanState::LineComment => {
+                output.push(current);
+                if current == '\n' {
+                    state = ScanState::Normal;
+                }
+            }
+            ScanState::BlockComment => {
+                output.push(current);
+                if current == '*' && next == Some('/') {
+                    output.push('/');
+                    index += 1;
+                    state = ScanState::Normal;
+                }
+            }
+        }
+        index += 1;
+    }
+
+    Ok((output, names))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rewrite_placeholders;
+
+    #[test]
+    fn rewrites_only_executable_qmarks() {
+        let sql = "SELECT ?, '?', [??] -- ?\n/* ? */ WHERE value = ?";
+        let (sql, names) = rewrite_placeholders(sql, false).unwrap();
+        assert_eq!(sql, "SELECT @P1, '?', [??] -- ?\n/* ? */ WHERE value = @P2");
+        assert_eq!(
+            names
+                .into_iter()
+                .map(|placeholder| placeholder.rpc_name)
+                .collect::<Vec<_>>(),
+            vec!["@P1", "@P2"]
+        );
+    }
+
+    #[test]
+    fn rewrites_named_parameters_in_occurrence_order() {
+        let (sql, names) = rewrite_placeholders("SELECT %(id)s, %(id)s, %(name)s", true).unwrap();
+        assert_eq!(sql, "SELECT @P1, @P2, @P3");
+        assert_eq!(
+            names
+                .into_iter()
+                .map(|placeholder| (placeholder.rpc_name, placeholder.source_name.unwrap()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("@P1".to_string(), "id".to_string()),
+                ("@P2".to_string(), "id".to_string()),
+                ("@P3".to_string(), "name".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn preserves_markers_in_escaped_quoted_contexts() {
+        let sql = "SELECT 'it''s ?', \"col\"\"?\", [col]]?] WHERE value = ?";
+        let (sql, names) = rewrite_placeholders(sql, false).unwrap();
+
+        assert_eq!(
+            sql,
+            "SELECT 'it''s ?', \"col\"\"?\", [col]]?] WHERE value = @P1"
+        );
+        assert_eq!(names.len(), 1);
+    }
+
+    #[test]
+    fn preserves_markers_in_unterminated_contexts() {
+        for sql in [
+            "SELECT 'unterminated ?",
+            "SELECT \"unterminated ?",
+            "SELECT [unterminated ?",
+            "SELECT /* unterminated ?",
+        ] {
+            let (rewritten, names) = rewrite_placeholders(sql, false).unwrap();
+            assert_eq!(rewritten, sql);
+            assert!(names.is_empty());
+        }
+    }
+
+    #[test]
+    fn restores_escaped_percent_for_named_parameters() {
+        let (sql, names) =
+            rewrite_placeholders("SELECT 100%%, %(value)s, '%%(ignored)s'", true).unwrap();
+
+        assert_eq!(sql, "SELECT 100%, @P1, '%%(ignored)s'");
+        assert_eq!(names.len(), 1);
+        assert_eq!(names[0].source_name.as_deref(), Some("value"));
+    }
+
+    #[test]
+    fn rejects_positional_markers_with_named_parameters() {
+        let error = match rewrite_placeholders("SELECT [q?mark], ?", true) {
+            Ok(_) => panic!("expected positional marker rejection"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("positional placeholders"));
+    }
+
+    #[test]
+    fn rejects_named_markers_with_positional_parameters() {
+        let error = match rewrite_placeholders("SELECT %(value)s", false) {
+            Ok(_) => panic!("expected named marker rejection"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("named placeholders"));
+    }
+
+    #[test]
+    #[ignore = "sync compatibility gap: nested SQL Server block comments are not tracked"]
+    fn preserves_markers_in_nested_block_comments() {
+        let sql = "SELECT /* outer /* inner */ ? still outer */ ?";
+        let (sql, names) = rewrite_placeholders(sql, false).unwrap();
+
+        assert_eq!(sql, "SELECT /* outer /* inner */ ? still outer */ @P1");
+        assert_eq!(names.len(), 1);
+    }
+
+    #[test]
+    #[ignore = "sync compatibility gap: empty pyformat parameter names are rejected"]
+    fn accepts_empty_named_parameter() {
+        let (sql, names) = rewrite_placeholders("SELECT %()s", true).unwrap();
+
+        assert_eq!(sql, "SELECT @P1");
+        assert_eq!(names[0].source_name.as_deref(), Some(""));
+    }
+}

--- a/mssql-py-core/src/async_parameters.rs
+++ b/mssql-py-core/src/async_parameters.rs
@@ -122,6 +122,11 @@ fn sql_type_metadata(value: &SqlType) -> ParameterMetadata {
     }
 }
 
+/// A SQL Server table-valued parameter for asynchronous execution.
+///
+/// `type_name` may be `TypeName` or `schema.TypeName`. `columns` contains SQL
+/// type hints in `setinputsizes()` format. Omitting `rows` creates a NULL TVP;
+/// non-NULL TVPs require both `columns` and `rows`.
 #[pyclass(name = "TableValuedParameter", frozen)]
 pub(crate) struct PyTableValuedParameter {
     type_name: TvpTypeName,
@@ -130,6 +135,7 @@ pub(crate) struct PyTableValuedParameter {
 
 #[pymethods]
 impl PyTableValuedParameter {
+    /// Create a table-valued parameter.
     #[new]
     #[pyo3(signature = (type_name, columns=None, rows=None, *, schema=None))]
     fn new(
@@ -154,26 +160,31 @@ impl PyTableValuedParameter {
         Ok(Self { type_name, table })
     }
 
+    /// Unqualified SQL Server table type name.
     #[getter]
     fn type_name(&self) -> &str {
         &self.type_name.type_name
     }
 
+    /// Optional SQL Server schema name.
     #[getter]
     fn schema(&self) -> Option<&str> {
         self.type_name.schema_name.as_deref()
     }
 
+    /// Whether this value represents a NULL TVP.
     #[getter]
     fn is_null(&self) -> bool {
         self.table.is_none()
     }
 
+    /// Number of declared TVP columns, or zero for a NULL TVP.
     #[getter]
     fn column_count(&self) -> usize {
         self.table.as_ref().map_or(0, |table| table.columns.len())
     }
 
+    /// Number of TVP rows, or zero for a NULL TVP.
     #[getter]
     fn row_count(&self) -> usize {
         self.table.as_ref().map_or(0, |table| table.rows.len())

--- a/mssql-py-core/src/async_parameters.rs
+++ b/mssql-py-core/src/async_parameters.rs
@@ -12,33 +12,54 @@ use std::fmt::Write as _;
 
 use crate::types::{ParameterHint, null_sql_type, py_to_sql_type, py_to_sql_type_with_hint};
 
+/// Comparable SQL declaration metadata used to decide whether a prepared
+/// statement can be reused with a new set of bound values.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum ParameterMetadata {
+    /// A type whose declaration is fully represented by its SQL type name.
     Scalar(&'static str),
+    /// A decimal declaration with its family, precision, and scale.
     Decimal {
+        /// Whether the declaration uses `numeric` rather than `decimal`.
         numeric: bool,
+        /// Declared precision.
         precision: u8,
+        /// Declared scale.
         scale: u8,
     },
+    /// A temporal declaration whose identity includes fractional-second scale.
     Temporal {
+        /// SQL temporal type name.
         kind: &'static str,
+        /// Declared fractional-second scale.
         scale: u8,
     },
+    /// A character or binary declaration whose identity includes length.
     Sized {
+        /// SQL character or binary type name.
         kind: &'static str,
+        /// Declared type length.
         length: u16,
     },
+    /// A vector declaration identified by dimension count and element type.
     Vector {
+        /// Number of vector dimensions.
         dimensions: u16,
+        /// SQL vector element type.
         base_type: VectorBaseType,
     },
+    /// A `sql_variant` declaration carrying the metadata of its value.
     Variant(Box<ParameterMetadata>),
+    /// A table-valued parameter declaration identified by server type name.
     Table {
+        /// SQL schema containing the table type.
         schema: String,
+        /// Unqualified table type name.
         name: String,
     },
 }
 
+/// Extracts the declaration identity used for prepared-statement reuse.
 fn sql_type_metadata(value: &SqlType) -> ParameterMetadata {
     match value {
         SqlType::Bit(_) => ParameterMetadata::Scalar("bit"),
@@ -192,12 +213,14 @@ impl PyTableValuedParameter {
 }
 
 impl PyTableValuedParameter {
+    /// Converts this Python wrapper into the SQL type consumed by RPC binding.
     fn sql_type(&self) -> SqlType {
         // TODO: Use shared TVP ownership when mssql-tds supports Arc<TvpTableData>.
         SqlType::Table(self.type_name.clone(), self.table.clone())
     }
 }
 
+/// Validates and normalizes a possibly schema-qualified TVP type name.
 fn parse_tvp_type_name(type_name: String, schema: Option<String>) -> PyResult<TvpTypeName> {
     let parts = type_name.split('.').collect::<Vec<_>>();
     let (schema_name, type_name) = match (schema, parts.as_slice()) {
@@ -234,6 +257,7 @@ fn parse_tvp_type_name(type_name: String, schema: Option<String>) -> PyResult<Tv
     Ok(TvpTypeName::new(schema_name, type_name.to_string()))
 }
 
+/// Builds TVP column metadata and converts each row using its matching hint.
 fn build_tvp_table(columns: &Bound<'_, PyAny>, rows: &Bound<'_, PyAny>) -> PyResult<TvpTableData> {
     let hints = parse_input_sizes(columns)?
         .ok_or_else(|| PyValueError::new_err("A TVP must define at least one column"))?;
@@ -277,21 +301,47 @@ fn build_tvp_table(columns: &Bound<'_, PyAny>, rows: &Bound<'_, PyAny>) -> PyRes
     Ok(TvpTableData::new(column_defs, converted_rows))
 }
 
+/// Lexer state for [`rewrite_placeholders`].
+///
+/// Only [`ScanState::Normal`] recognizes placeholders. Every other state
+/// preserves marker-like text inside a quoted token or comment.
 #[derive(Clone, Copy, Eq, PartialEq)]
 enum ScanState {
+    /// Executable SQL where parameter markers may be rewritten.
     Normal,
+    /// A single-quoted string, where `''` escapes a quote.
     SingleQuote,
+    /// A double-quoted token, where `""` escapes a quote.
     DoubleQuote,
+    /// A bracketed identifier, where `]]` escapes a closing bracket.
     Bracket,
+    /// A `--` comment ending at either `\r` or `\n`.
     LineComment,
+    /// A nested `/* ... */` comment tracked by `block_comment_depth`.
     BlockComment,
 }
 
+/// A rewritten parameter marker in RPC wire order.
 struct Placeholder {
+    /// The generated `@Pn` name used in both the SQL text and RPC parameter.
     rpc_name: String,
+    /// The dictionary key for `%(name)s`, or `None` for positional `?`.
     source_name: Option<String>,
 }
 
+fn parse_pyformat_marker(sql: &str, start: usize, close: Option<usize>) -> Option<(&str, usize)> {
+    let body_start = start.checked_add("%(".len())?;
+    let close = close.filter(|close| *close >= body_start)?;
+    sql.get(close + 1..)?.strip_prefix('s')?;
+    let source_name = sql.get(body_start..close)?;
+    Some((source_name, close + ")s".len() - start))
+}
+
+/// Normalizes Python execute arguments and binds them as positional or named RPC parameters.
+///
+/// A sole dictionary selects `%(name)s` binding. A sole tuple, list, or DB-API
+/// `Row` is expanded positionally; all other argument tuples bind positionally
+/// as supplied. The returned metadata is in placeholder occurrence order.
 pub(crate) fn bind_parameters(
     operation: String,
     parameters: &Bound<'_, PyTuple>,
@@ -321,6 +371,10 @@ pub(crate) fn bind_parameters(
     bind_positional(operation, parameters.iter(), hints)
 }
 
+/// Parses `setinputsizes()` entries into validated conversion hints.
+///
+/// Each entry may be a SQL type integer or `(sql_type[, size[, scale]])`.
+/// `None` and an empty iterable both produce no hints.
 pub(crate) fn parse_input_sizes(sizes: &Bound<'_, PyAny>) -> PyResult<Option<Vec<ParameterHint>>> {
     if sizes.is_none() {
         return Ok(None);
@@ -357,6 +411,7 @@ pub(crate) fn parse_input_sizes(sizes: &Bound<'_, PyAny>) -> PyResult<Option<Vec
     Ok((!hints.is_empty()).then_some(hints))
 }
 
+/// Rewrites and binds positional values in `?` occurrence order.
 fn bind_positional<'py>(
     operation: String,
     values: impl Iterator<Item = Bound<'py, PyAny>>,
@@ -387,6 +442,7 @@ fn bind_positional<'py>(
     Ok((operation, parameters, parameter_signature))
 }
 
+/// Rewrites `%(name)s` markers and looks up each value by dictionary key.
 fn bind_named(
     operation: String,
     values: &Bound<'_, PyDict>,
@@ -421,6 +477,10 @@ fn bind_named(
     Ok((operation, parameters, parameter_signature))
 }
 
+/// Converts one Python value into an RPC parameter and its declaration metadata.
+///
+/// TVPs reject `setinputsizes()` hints and use the default-value status for a
+/// NULL table. Scalar conversion failures are exposed as Python type errors.
 fn rpc_parameter(
     name: String,
     value: &Bound<'_, PyAny>,
@@ -452,14 +512,23 @@ fn rpc_parameter(
     Ok((RpcParameter::new(Some(name), status, value), signature))
 }
 
+/// Rewrites DB-API parameter markers to SQL Server `@P1` through `@Pn` names.
+///
+/// Positional mode recognizes `?`; dictionary-backed named mode recognizes
+/// `%(name)s` and converts `%%` to `%`. A valid marker from the other mode is
+/// rejected as a style mismatch. Markers are rewritten only in
+/// [`ScanState::Normal`], while quoted tokens and comments are preserved.
+/// Malformed pyformat candidates and unsupported `:name` markers are left
+/// unchanged for the caller's marker-count validation.
 fn rewrite_placeholders(sql: &str, named: bool) -> PyResult<(String, Vec<Placeholder>)> {
     let mut output = String::with_capacity(sql.len() + sql.len() / 2);
     let mut names = Vec::new();
     let mut state = ScanState::Normal;
     let mut block_comment_depth = 0usize;
     let mut chars = sql.char_indices().peekable();
+    let mut close_parentheses = sql.match_indices(')').map(|(offset, _)| offset).peekable();
 
-    while let Some((_, current)) = chars.next() {
+    while let Some((index, current)) = chars.next() {
         let next = chars.peek().map(|(_, next)| *next);
         match state {
             ScanState::Normal => match (current, next) {
@@ -506,23 +575,16 @@ fn rewrite_placeholders(sql: &str, named: bool) -> PyResult<(String, Vec<Placeho
                     chars.next();
                 }
                 ('%', Some('(')) => {
-                    chars.next();
-                    let mut source_name = String::new();
-                    let mut original = String::from("%(");
-                    let mut complete = false;
-                    while let Some((_, marker_char)) = chars.next() {
-                        original.push(marker_char);
-                        if marker_char == ')' {
-                            if chars.peek().is_some_and(|(_, next)| *next == 's') {
-                                chars.next();
-                                original.push('s');
-                                complete = true;
-                            }
-                            break;
-                        }
-                        source_name.push(marker_char);
+                    let body_start = index + "%(".len();
+                    while close_parentheses
+                        .peek()
+                        .is_some_and(|close| *close < body_start)
+                    {
+                        close_parentheses.next();
                     }
-                    if complete {
+                    if let Some((source_name, consumed)) =
+                        parse_pyformat_marker(sql, index, close_parentheses.peek().copied())
+                    {
                         if !named {
                             return Err(PyTypeError::new_err(
                                 "Parameter style mismatch: query uses named placeholders (%(name)s) but positional parameters were provided",
@@ -537,10 +599,14 @@ fn rewrite_placeholders(sql: &str, named: bool) -> PyResult<(String, Vec<Placeho
                         let rpc_name = output[start..].to_owned();
                         names.push(Placeholder {
                             rpc_name,
-                            source_name: Some(source_name),
+                            source_name: Some(source_name.to_owned()),
                         });
+                        let end = index + consumed;
+                        while chars.peek().is_some_and(|(offset, _)| *offset < end) {
+                            chars.next();
+                        }
                     } else {
-                        output.push_str(&original);
+                        output.push(current);
                     }
                 }
                 _ => output.push(current),
@@ -580,7 +646,7 @@ fn rewrite_placeholders(sql: &str, named: bool) -> PyResult<(String, Vec<Placeho
             }
             ScanState::LineComment => {
                 output.push(current);
-                if current == '\n' {
+                if current == '\n' || current == '\r' {
                     state = ScanState::Normal;
                 }
             }
@@ -622,6 +688,30 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["@P1", "@P2"]
         );
+    }
+
+    #[test]
+    fn line_comment_ends_at_carriage_return() {
+        let (sql, names) = rewrite_placeholders("SELECT 1 -- c\rWHERE a = ?", false).unwrap();
+
+        assert_eq!(sql, "SELECT 1 -- c\rWHERE a = @P1");
+        assert_eq!(names.len(), 1);
+    }
+
+    #[test]
+    fn line_comment_still_ends_at_crlf() {
+        let (sql, names) = rewrite_placeholders("SELECT 1 -- c\r\nWHERE a = ?", false).unwrap();
+
+        assert_eq!(sql, "SELECT 1 -- c\r\nWHERE a = @P1");
+        assert_eq!(names.len(), 1);
+    }
+
+    #[test]
+    fn leading_line_comment_ends_at_carriage_return() {
+        let (sql, names) = rewrite_placeholders("-- lead\rSELECT ?, ?", false).unwrap();
+
+        assert_eq!(sql, "-- lead\rSELECT @P1, @P2");
+        assert_eq!(names.len(), 2);
     }
 
     #[test]
@@ -696,6 +786,40 @@ mod tests {
         assert_eq!(sql, "SELECT %(broken)x, @P1, %(unterminated");
         assert_eq!(names.len(), 1);
         assert_eq!(names[0].source_name.as_deref(), Some("value"));
+    }
+
+    #[test]
+    fn rewrites_marker_inside_a_modulo_parenthesis() {
+        let (sql, names) =
+            rewrite_placeholders("SELECT a %(SELECT c FROM t WHERE id = ?) FROM u", false).unwrap();
+
+        assert_eq!(sql, "SELECT a %(SELECT c FROM t WHERE id = @P1) FROM u");
+        assert_eq!(names.len(), 1);
+    }
+
+    #[test]
+    fn unterminated_percent_paren_does_not_swallow_later_markers() {
+        let (sql, names) = rewrite_placeholders("SELECT a %(b FROM t WHERE c = ?", false).unwrap();
+
+        assert_eq!(sql, "SELECT a %(b FROM t WHERE c = @P1");
+        assert_eq!(names.len(), 1);
+    }
+
+    #[test]
+    fn quoting_is_tracked_after_a_bare_percent_paren() {
+        let (sql, names) = rewrite_placeholders("SELECT a %(b, '?' , ? FROM t", false).unwrap();
+
+        assert_eq!(sql, "SELECT a %(b, '?' , @P1 FROM t");
+        assert_eq!(names.len(), 1);
+    }
+
+    #[test]
+    fn repeated_malformed_percent_parens_do_not_hide_a_later_marker() {
+        let sql = format!("SELECT {} ?", "%(".repeat(2000));
+        let (rewritten, names) = rewrite_placeholders(&sql, false).unwrap();
+
+        assert!(rewritten.ends_with("@P1"));
+        assert_eq!(names.len(), 1);
     }
 
     #[test]

--- a/mssql-py-core/src/async_parameters.rs
+++ b/mssql-py-core/src/async_parameters.rs
@@ -8,6 +8,7 @@ use mssql_tds::message::parameters::rpc_parameters::{RpcParameter, StatusFlags};
 use pyo3::exceptions::{PyKeyError, PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyTuple};
+use std::fmt::Write as _;
 
 use crate::types::{ParameterHint, null_sql_type, py_to_sql_type, py_to_sql_type_with_hint};
 
@@ -381,6 +382,13 @@ fn bind_named(
     hints: Option<&[ParameterHint]>,
 ) -> PyResult<(String, Vec<RpcParameter>, Vec<ParameterMetadata>)> {
     let (operation, names) = rewrite_placeholders(&operation, true)?;
+    if names.is_empty() && !values.is_empty() {
+        return Err(PyTypeError::new_err(format!(
+            "The SQL contains no parameter markers, but {} parameters were supplied. \
+             Named parameters use the %(name)s style.",
+            values.len()
+        )));
+    }
     let bound_parameters = names
         .into_iter()
         .enumerate()
@@ -434,7 +442,7 @@ fn rpc_parameter(
 }
 
 fn rewrite_placeholders(sql: &str, named: bool) -> PyResult<(String, Vec<Placeholder>)> {
-    let mut output = String::with_capacity(sql.len());
+    let mut output = String::with_capacity(sql.len() + sql.len() / 2);
     let mut names = Vec::new();
     let mut state = ScanState::Normal;
     let mut block_comment_depth = 0usize;
@@ -468,8 +476,10 @@ fn rewrite_placeholders(sql: &str, named: bool) -> PyResult<(String, Vec<Placeho
                     chars.next();
                 }
                 ('?', _) if !named => {
-                    let rpc_name = format!("@P{}", names.len() + 1);
-                    output.push_str(&rpc_name);
+                    let start = output.len();
+                    write!(&mut output, "@P{}", names.len() + 1)
+                        .expect("writing to a String cannot fail");
+                    let rpc_name = output[start..].to_owned();
                     names.push(Placeholder {
                         rpc_name,
                         source_name: None,
@@ -510,8 +520,10 @@ fn rewrite_placeholders(sql: &str, named: bool) -> PyResult<(String, Vec<Placeho
                         if source_name.is_empty() {
                             return Err(PyTypeError::new_err("Named parameter cannot be empty"));
                         }
-                        let rpc_name = format!("@P{}", names.len() + 1);
-                        output.push_str(&rpc_name);
+                        let start = output.len();
+                        write!(&mut output, "@P{}", names.len() + 1)
+                            .expect("writing to a String cannot fail");
+                        let rpc_name = output[start..].to_owned();
                         names.push(Placeholder {
                             rpc_name,
                             source_name: Some(source_name),
@@ -599,6 +611,19 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["@P1", "@P2"]
         );
+    }
+
+    #[test]
+    fn rewrites_dense_positional_parameters() {
+        let sql = (0..2000).map(|_| "?").collect::<Vec<_>>().join(", ");
+        let (sql, names) = rewrite_placeholders(&sql, false).unwrap();
+
+        assert_eq!(names.len(), 2000);
+        assert_eq!(names.first().unwrap().rpc_name, "@P1");
+        assert_eq!(names.last().unwrap().rpc_name, "@P2000");
+        assert_eq!(sql.split(", ").count(), 2000);
+        assert!(sql.starts_with("@P1, @P2"));
+        assert!(sql.ends_with("@P1999, @P2000"));
     }
 
     #[test]

--- a/mssql-py-core/src/async_session.rs
+++ b/mssql-py-core/src/async_session.rs
@@ -9,6 +9,7 @@ use mssql_tds::core::CancelHandle;
 pub(crate) type CursorId = u64;
 pub(crate) type OperationId = u64;
 
+/// Exclusive execute ownership granted for one cursor operation.
 #[derive(Debug)]
 pub(crate) struct ExecuteClaim {
     pub(crate) operation_id: OperationId,
@@ -16,6 +17,7 @@ pub(crate) struct ExecuteClaim {
     pub(crate) drain_previous: bool,
 }
 
+/// Exclusive cursor-close ownership and its pending result-drain requirement.
 #[derive(Debug)]
 pub(crate) struct CursorCloseClaim {
     pub(crate) operation_id: OperationId,
@@ -42,10 +44,10 @@ pub(crate) enum ConnectionLifecycle {
 pub(crate) enum OperationPhase {
     Executing,
     Fetching,
-    #[allow(dead_code)]
     Closing,
 }
 
+/// The operation that currently owns the shared TDS session.
 #[derive(Debug)]
 pub(crate) struct ActiveOperation {
     pub(crate) cursor_id: Option<CursorId>,
@@ -54,12 +56,14 @@ pub(crate) struct ActiveOperation {
     pub(crate) cancel_handle: Option<CancelHandle>,
 }
 
+/// Mutex-protected connection lifecycle and operation ownership state.
 #[derive(Debug)]
 struct AsyncSessionState {
     lifecycle: ConnectionLifecycle,
     active_operation: Option<ActiveOperation>,
 }
 
+/// Connection-wide coordinator shared by the connection and all its cursors.
 #[derive(Debug)]
 pub(crate) struct AsyncConnectionState {
     next_cursor_id: AtomicU64,

--- a/mssql-py-core/src/async_session.rs
+++ b/mssql-py-core/src/async_session.rs
@@ -43,6 +43,7 @@ pub(crate) enum ConnectionLifecycle {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum OperationPhase {
     Executing,
+    // TODO: Release Fetching ownership when async fetch exhausts the results.
     Fetching,
     Closing,
 }
@@ -53,6 +54,9 @@ pub(crate) struct ActiveOperation {
     pub(crate) cursor_id: Option<CursorId>,
     pub(crate) operation_id: OperationId,
     pub(crate) phase: OperationPhase,
+    // TODO: Add cursor cancellation that triggers this root handle only when
+    // cursor and operation IDs match. Complete ATTENTION cleanup before marking
+    // the connection reusable or broken.
     pub(crate) cancel_handle: Option<CancelHandle>,
 }
 
@@ -217,6 +221,18 @@ impl AsyncConnectionState {
         }
     }
 
+    pub(crate) fn abandon_cursor(&self, cursor_id: CursorId) {
+        let mut state = self.lock();
+        if state
+            .active_operation
+            .as_ref()
+            .is_some_and(|active| active.cursor_id == Some(cursor_id))
+        {
+            state.active_operation = None;
+        }
+        state.lifecycle = ConnectionLifecycle::Broken;
+    }
+
     pub(crate) fn begin_close(&self) {
         let mut state = self.lock();
         if state.lifecycle == ConnectionLifecycle::Open {
@@ -328,6 +344,22 @@ mod tests {
             OperationPhase::Closing
         );
         state.release_operation(close.operation_id);
+    }
+
+    #[test]
+    fn abandoning_cursor_breaks_session_and_only_releases_its_ownership() {
+        let state = AsyncConnectionState::new();
+        let execute = state.claim_execute(1).unwrap();
+
+        state.abandon_cursor(2);
+        assert_eq!(state.lifecycle(), ConnectionLifecycle::Broken);
+        assert_eq!(
+            state.lock().active_operation.as_ref().unwrap().operation_id,
+            execute.operation_id
+        );
+
+        state.abandon_cursor(1);
+        assert!(state.lock().active_operation.is_none());
     }
 
     #[test]

--- a/mssql-py-core/src/async_session.rs
+++ b/mssql-py-core/src/async_session.rs
@@ -9,6 +9,21 @@ use mssql_tds::core::CancelHandle;
 pub(crate) type CursorId = u64;
 pub(crate) type OperationId = u64;
 
+#[derive(Debug)]
+pub(crate) struct ExecuteClaim {
+    pub(crate) operation_id: OperationId,
+    pub(crate) cancel_handle: CancelHandle,
+    pub(crate) drain_previous: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ClaimError {
+    Closing,
+    Closed,
+    Broken,
+    Busy,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ConnectionLifecycle {
     Open,
@@ -17,15 +32,14 @@ pub(crate) enum ConnectionLifecycle {
     Broken,
 }
 
-#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum OperationPhase {
     Executing,
     Fetching,
+    #[allow(dead_code)]
     Closing,
 }
 
-#[allow(dead_code)]
 #[derive(Debug)]
 pub(crate) struct ActiveOperation {
     pub(crate) cursor_id: CursorId,
@@ -37,14 +51,12 @@ pub(crate) struct ActiveOperation {
 #[derive(Debug)]
 struct AsyncSessionState {
     lifecycle: ConnectionLifecycle,
-    #[allow(dead_code)]
     active_operation: Option<ActiveOperation>,
 }
 
 #[derive(Debug)]
 pub(crate) struct AsyncConnectionState {
     next_cursor_id: AtomicU64,
-    #[allow(dead_code)]
     next_operation_id: AtomicU64,
     inner: Mutex<AsyncSessionState>,
 }
@@ -65,9 +77,76 @@ impl AsyncConnectionState {
         self.next_cursor_id.fetch_add(1, Ordering::Relaxed)
     }
 
-    #[allow(dead_code)]
     pub(crate) fn allocate_operation_id(&self) -> OperationId {
         self.next_operation_id.fetch_add(1, Ordering::Relaxed)
+    }
+
+    pub(crate) fn claim_execute(&self, cursor_id: CursorId) -> Result<ExecuteClaim, ClaimError> {
+        let mut state = self.lock();
+        match state.lifecycle {
+            ConnectionLifecycle::Open => {}
+            ConnectionLifecycle::Closing => return Err(ClaimError::Closing),
+            ConnectionLifecycle::Closed => return Err(ClaimError::Closed),
+            ConnectionLifecycle::Broken => return Err(ClaimError::Broken),
+        }
+
+        let drain_previous = match state.active_operation.as_ref() {
+            None => false,
+            Some(active)
+                if active.cursor_id == cursor_id && active.phase == OperationPhase::Fetching =>
+            {
+                true
+            }
+            Some(_) => return Err(ClaimError::Busy),
+        };
+
+        let operation_id = self.allocate_operation_id();
+        let cancel_handle = CancelHandle::new();
+        state.active_operation = Some(ActiveOperation {
+            cursor_id,
+            operation_id,
+            phase: OperationPhase::Executing,
+            cancel_handle: Some(cancel_handle),
+        });
+
+        let child_handle = state
+            .active_operation
+            .as_ref()
+            .and_then(|active| active.cancel_handle.as_ref())
+            .expect("newly claimed operation has a cancel handle")
+            .child_handle();
+        Ok(ExecuteClaim {
+            operation_id,
+            cancel_handle: child_handle,
+            drain_previous,
+        })
+    }
+
+    pub(crate) fn finish_execute(&self, operation_id: OperationId, has_open_batch: bool) {
+        let mut state = self.lock();
+        let Some(active) = state.active_operation.as_mut() else {
+            return;
+        };
+        if active.operation_id != operation_id {
+            return;
+        }
+
+        if has_open_batch {
+            active.phase = OperationPhase::Fetching;
+        } else {
+            state.active_operation = None;
+        }
+    }
+
+    pub(crate) fn release_operation(&self, operation_id: OperationId) {
+        let mut state = self.lock();
+        if state
+            .active_operation
+            .as_ref()
+            .is_some_and(|active| active.operation_id == operation_id)
+        {
+            state.active_operation = None;
+        }
     }
 
     pub(crate) fn begin_close(&self) {
@@ -99,7 +178,7 @@ impl AsyncConnectionState {
 mod tests {
     use std::sync::Arc;
 
-    use super::{AsyncConnectionState, ConnectionLifecycle};
+    use super::{AsyncConnectionState, ClaimError, ConnectionLifecycle, OperationPhase};
 
     #[test]
     fn allocates_unique_cursor_ids() {
@@ -115,6 +194,40 @@ mod tests {
 
         assert_eq!(state.allocate_operation_id(), 1);
         assert_eq!(state.allocate_operation_id(), 2);
+    }
+
+    #[test]
+    fn execute_ownership_tracks_results_and_allows_same_cursor_reexecute() {
+        let state = AsyncConnectionState::new();
+
+        let first = state.claim_execute(1).unwrap();
+        assert!(!first.drain_previous);
+        assert_eq!(state.claim_execute(2).unwrap_err(), ClaimError::Busy);
+
+        state.finish_execute(first.operation_id, true);
+        assert_eq!(
+            state.lock().active_operation.as_ref().unwrap().phase,
+            OperationPhase::Fetching
+        );
+
+        let second = state.claim_execute(1).unwrap();
+        assert!(second.drain_previous);
+        state.finish_execute(second.operation_id, false);
+        assert!(state.lock().active_operation.is_none());
+    }
+
+    #[test]
+    fn stale_operation_cannot_release_current_owner() {
+        let state = AsyncConnectionState::new();
+        let first = state.claim_execute(1).unwrap();
+        state.finish_execute(first.operation_id, true);
+        let second = state.claim_execute(1).unwrap();
+
+        state.release_operation(first.operation_id);
+        assert_eq!(
+            state.lock().active_operation.as_ref().unwrap().operation_id,
+            second.operation_id
+        );
     }
 
     #[test]

--- a/mssql-py-core/src/async_session.rs
+++ b/mssql-py-core/src/async_session.rs
@@ -16,6 +16,12 @@ pub(crate) struct ExecuteClaim {
     pub(crate) drain_previous: bool,
 }
 
+#[derive(Debug)]
+pub(crate) struct CursorCloseClaim {
+    pub(crate) operation_id: OperationId,
+    pub(crate) drain_previous: bool,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ClaimError {
     Closing,
@@ -42,7 +48,7 @@ pub(crate) enum OperationPhase {
 
 #[derive(Debug)]
 pub(crate) struct ActiveOperation {
-    pub(crate) cursor_id: CursorId,
+    pub(crate) cursor_id: Option<CursorId>,
     pub(crate) operation_id: OperationId,
     pub(crate) phase: OperationPhase,
     pub(crate) cancel_handle: Option<CancelHandle>,
@@ -93,7 +99,8 @@ impl AsyncConnectionState {
         let drain_previous = match state.active_operation.as_ref() {
             None => false,
             Some(active)
-                if active.cursor_id == cursor_id && active.phase == OperationPhase::Fetching =>
+                if active.cursor_id == Some(cursor_id)
+                    && active.phase == OperationPhase::Fetching =>
             {
                 true
             }
@@ -103,7 +110,7 @@ impl AsyncConnectionState {
         let operation_id = self.allocate_operation_id();
         let cancel_handle = CancelHandle::new();
         state.active_operation = Some(ActiveOperation {
-            cursor_id,
+            cursor_id: Some(cursor_id),
             operation_id,
             phase: OperationPhase::Executing,
             cancel_handle: Some(cancel_handle),
@@ -118,6 +125,63 @@ impl AsyncConnectionState {
         Ok(ExecuteClaim {
             operation_id,
             cancel_handle: child_handle,
+            drain_previous,
+        })
+    }
+
+    pub(crate) fn claim_connection_operation(&self) -> Result<OperationId, ClaimError> {
+        let mut state = self.lock();
+        match state.lifecycle {
+            ConnectionLifecycle::Open => {}
+            ConnectionLifecycle::Closing => return Err(ClaimError::Closing),
+            ConnectionLifecycle::Closed => return Err(ClaimError::Closed),
+            ConnectionLifecycle::Broken => return Err(ClaimError::Broken),
+        }
+        if state.active_operation.is_some() {
+            return Err(ClaimError::Busy);
+        }
+
+        let operation_id = self.allocate_operation_id();
+        state.active_operation = Some(ActiveOperation {
+            cursor_id: None,
+            operation_id,
+            phase: OperationPhase::Executing,
+            cancel_handle: None,
+        });
+        Ok(operation_id)
+    }
+
+    pub(crate) fn claim_cursor_close(
+        &self,
+        cursor_id: CursorId,
+    ) -> Result<CursorCloseClaim, ClaimError> {
+        let mut state = self.lock();
+        match state.lifecycle {
+            ConnectionLifecycle::Open => {}
+            ConnectionLifecycle::Closing => return Err(ClaimError::Closing),
+            ConnectionLifecycle::Closed => return Err(ClaimError::Closed),
+            ConnectionLifecycle::Broken => return Err(ClaimError::Broken),
+        }
+
+        let drain_previous = match state.active_operation.as_ref() {
+            None => false,
+            Some(active)
+                if active.cursor_id == Some(cursor_id)
+                    && active.phase == OperationPhase::Fetching =>
+            {
+                true
+            }
+            Some(_) => return Err(ClaimError::Busy),
+        };
+        let operation_id = self.allocate_operation_id();
+        state.active_operation = Some(ActiveOperation {
+            cursor_id: Some(cursor_id),
+            operation_id,
+            phase: OperationPhase::Closing,
+            cancel_handle: None,
+        });
+        Ok(CursorCloseClaim {
+            operation_id,
             drain_previous,
         })
     }
@@ -228,6 +292,38 @@ mod tests {
             state.lock().active_operation.as_ref().unwrap().operation_id,
             second.operation_id
         );
+    }
+
+    #[test]
+    fn connection_operation_rejects_cursor_ownership() {
+        let state = AsyncConnectionState::new();
+        let execute = state.claim_execute(1).unwrap();
+
+        assert_eq!(
+            state.claim_connection_operation().unwrap_err(),
+            ClaimError::Busy
+        );
+        state.release_operation(execute.operation_id);
+
+        let connection_operation = state.claim_connection_operation().unwrap();
+        assert_eq!(state.claim_execute(1).unwrap_err(), ClaimError::Busy);
+        state.release_operation(connection_operation);
+    }
+
+    #[test]
+    fn cursor_close_can_drain_its_results_but_not_another_cursor() {
+        let state = AsyncConnectionState::new();
+        let execute = state.claim_execute(1).unwrap();
+        state.finish_execute(execute.operation_id, true);
+
+        assert_eq!(state.claim_cursor_close(2).unwrap_err(), ClaimError::Busy);
+        let close = state.claim_cursor_close(1).unwrap();
+        assert!(close.drain_previous);
+        assert_eq!(
+            state.lock().active_operation.as_ref().unwrap().phase,
+            OperationPhase::Closing
+        );
+        state.release_operation(close.operation_id);
     }
 
     #[test]

--- a/mssql-py-core/src/lib.rs
+++ b/mssql-py-core/src/lib.rs
@@ -9,6 +9,7 @@ use mssql_tds::connection::client_context::DriverVersion;
 mod arrow_bulkcopy;
 mod async_connection;
 mod async_cursor;
+mod async_parameters;
 mod async_runtime;
 mod async_session;
 mod bulkcopy;
@@ -93,6 +94,12 @@ fn mssql_py_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<cursor::PyCoreCursor>()?;
     m.add_class::<async_connection::PyAsyncConnection>()?;
     m.add_class::<async_cursor::PyAsyncCursor>()?;
+    m.add_class::<async_parameters::PyTableValuedParameter>()?;
+    m.add("SQL_MONEY", 60)?;
+    m.add("SQL_SMALLMONEY", 122)?;
+    m.add("SQL_XML", 241)?;
+    m.add("SQL_JSON", 244)?;
+    m.add("SQL_VECTOR", 245)?;
 
     // Test-only hook to drive PythonEntraIdTokenFactory::create_token from
     // Python tests. Underscore-prefixed to mark as internal/test-only.

--- a/mssql-py-core/src/lib.rs
+++ b/mssql-py-core/src/lib.rs
@@ -100,6 +100,10 @@ fn mssql_py_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("SQL_XML", 241)?;
     m.add("SQL_JSON", 244)?;
     m.add("SQL_VECTOR", 245)?;
+    m.add("apilevel", "2.0")?;
+    m.add("threadsafety", 1)?;
+    // DB-API allows one declared style; named pyformat markers are an extension.
+    m.add("paramstyle", "qmark")?;
 
     // Test-only hook to drive PythonEntraIdTokenFactory::create_token from
     // Python tests. Underscore-prefixed to mark as internal/test-only.

--- a/mssql-py-core/src/types.rs
+++ b/mssql-py-core/src/types.rs
@@ -33,12 +33,90 @@ fn uuid_type(py: Python<'_>) -> PyResult<&Bound<'_, PyType>> {
     UUID_TYPE.import(py, "uuid", "UUID")
 }
 
+/// A supported ODBC `setinputsizes()` type after boundary validation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum InputSqlType {
+    Bit,
+    TinyInt,
+    SmallInt,
+    Integer,
+    BigInt,
+    Real,
+    Float,
+    Numeric,
+    Decimal,
+    Char,
+    VarChar,
+    LongVarChar,
+    WChar,
+    WVarChar,
+    WLongVarChar,
+    Binary,
+    VarBinary,
+    LongVarBinary,
+    Date,
+    Time,
+    DateTime,
+    DateTimeOffset,
+    Guid,
+    Xml,
+    Json,
+    Vector,
+    Money,
+    SmallMoney,
+    Variant,
+    Udt,
+}
+
+impl TryFrom<i32> for InputSqlType {
+    type Error = Error;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        Ok(match value {
+            -7 => Self::Bit,
+            -6 => Self::TinyInt,
+            5 => Self::SmallInt,
+            4 => Self::Integer,
+            -5 => Self::BigInt,
+            7 => Self::Real,
+            6 | 8 => Self::Float,
+            2 => Self::Numeric,
+            3 => Self::Decimal,
+            1 => Self::Char,
+            12 => Self::VarChar,
+            -1 => Self::LongVarChar,
+            -8 => Self::WChar,
+            -9 => Self::WVarChar,
+            -10 => Self::WLongVarChar,
+            -2 => Self::Binary,
+            -3 => Self::VarBinary,
+            -4 => Self::LongVarBinary,
+            9 | 91 => Self::Date,
+            10 | 92 | -154 => Self::Time,
+            11 | 93 => Self::DateTime,
+            -155 => Self::DateTimeOffset,
+            -11 => Self::Guid,
+            -152 | 241 => Self::Xml,
+            244 => Self::Json,
+            245 => Self::Vector,
+            60 => Self::Money,
+            122 => Self::SmallMoney,
+            -150 => Self::Variant,
+            -151 => Self::Udt,
+            _ => {
+                return Err(Error::UsageError(format!(
+                    "Invalid SQL type: {value}. Must be a supported SQL type constant"
+                )));
+            }
+        })
+    }
+}
+
 /// A validated ODBC-compatible `setinputsizes()` entry lowered to [`SqlType`]
 /// before TDS serialization.
 #[derive(Clone, Copy)]
 pub(crate) struct ParameterHint {
-    /// A supported ODBC SQL type code.
-    sql_type: i32,
+    sql_type: InputSqlType,
     /// Precision, dimension count, or character/binary allocation size.
     size: u32,
     /// Numeric or temporal scale where the selected type supports one.
@@ -49,18 +127,22 @@ impl ParameterHint {
     /// Validates the type code and numeric bounds once so conversion matches
     /// can treat any remaining arm as unreachable.
     pub(crate) fn new(sql_type: i32, size: u32, scale: u8) -> TdsResult<Self> {
-        const VALID_TYPES: &[i32] = &[
-            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 91, 92, 93, -1, -2, -3, -4, -5, -6, -7, -8, -9,
-            -10, -11, -150, -151, -152, -154, -155, 60, 122, 241, 244, 245,
-        ];
-        if !VALID_TYPES.contains(&sql_type) {
-            return Err(Error::UsageError(format!(
-                "Invalid SQL type: {sql_type}. Must be a supported SQL type constant"
-            )));
+        let sql_type = InputSqlType::try_from(sql_type)?;
+        if matches!(sql_type, InputSqlType::Numeric | InputSqlType::Decimal) {
+            let precision = Self::effective_numeric_precision(size);
+            if precision > 38 || u32::from(scale) > precision {
+                return Err(Error::UsageError(format!(
+                    "Invalid numeric precision/scale: precision={precision}, scale={scale}"
+                )));
+            }
         }
-        if matches!(sql_type, 2 | 3) && (size > 38 || u32::from(scale) > size.max(1)) {
+        if matches!(
+            sql_type,
+            InputSqlType::Time | InputSqlType::DateTime | InputSqlType::DateTimeOffset
+        ) && scale > 7
+        {
             return Err(Error::UsageError(format!(
-                "Invalid numeric precision/scale: precision={size}, scale={scale}"
+                "Invalid temporal scale: {scale}. Expected a value from 0 to 7"
             )));
         }
         Ok(Self {
@@ -70,21 +152,35 @@ impl ParameterHint {
         })
     }
 
-    /// Returns the validated ODBC SQL type code for TVP compatibility checks.
-    pub(crate) fn sql_type(self) -> i32 {
-        self.sql_type
+    fn effective_numeric_precision(size: u32) -> u32 {
+        if size == 0 { 18 } else { size }
     }
 
-    /// Returns explicit decimal precision for TVP metadata, excluding zero as unspecified.
+    /// Whether SQL Server permits this type in TVP column metadata.
+    pub(crate) fn supports_tvp_column(self) -> bool {
+        !matches!(
+            self.sql_type,
+            InputSqlType::Udt | InputSqlType::LongVarChar | InputSqlType::WLongVarChar
+        )
+    }
+
+    /// Returns effective decimal precision for TVP metadata.
     pub(crate) fn precision(self) -> Option<u8> {
-        matches!(self.sql_type, 2 | 3)
-            .then(|| u8::try_from(self.size).unwrap_or(0))
-            .filter(|precision| *precision > 0)
+        matches!(self.sql_type, InputSqlType::Numeric | InputSqlType::Decimal)
+            .then(|| Self::effective_numeric_precision(self.size) as u8)
     }
 
     /// Returns scale only for numeric and scale-bearing temporal types.
     pub(crate) fn scale(self) -> Option<u8> {
-        matches!(self.sql_type, 2 | 3 | 10 | 11 | 92 | 93 | -154 | -155).then_some(self.scale)
+        matches!(
+            self.sql_type,
+            InputSqlType::Numeric
+                | InputSqlType::Decimal
+                | InputSqlType::Time
+                | InputSqlType::DateTime
+                | InputSqlType::DateTimeOffset
+        )
+        .then_some(self.scale)
     }
 }
 
@@ -206,7 +302,7 @@ pub(crate) fn py_to_sql_type(py_obj: &Bound<'_, PyAny>) -> TdsResult<SqlType> {
     }
 
     if py_obj.is_instance_of::<PyDateTime>() {
-        return py_datetime_to_sql_type(py_obj);
+        return py_datetime_to_sql_type(py_obj, None);
     }
 
     if py_obj.is_instance_of::<PyTime>() {
@@ -274,113 +370,138 @@ pub(crate) fn py_to_sql_type_with_hint(
     }
 
     match hint.sql_type {
-        -7 => Ok(SqlType::Bit(Some(py_obj.extract::<bool>().map_err(|error| {
+        InputSqlType::Bit => Ok(SqlType::Bit(Some(py_obj.extract::<bool>().map_err(|error| {
             Error::UsageError(format!("Failed to convert parameter to BIT: {error}"))
         })?))),
-        -6 => Ok(SqlType::TinyInt(Some(py_obj.extract::<u8>().map_err(
+        InputSqlType::TinyInt => Ok(SqlType::TinyInt(Some(py_obj.extract::<u8>().map_err(
             |error| Error::UsageError(format!("Failed to convert parameter to TINYINT: {error}")),
         )?))),
-        5 => Ok(SqlType::SmallInt(Some(py_obj.extract::<i16>().map_err(
+        InputSqlType::SmallInt => Ok(SqlType::SmallInt(Some(py_obj.extract::<i16>().map_err(
             |error| Error::UsageError(format!("Failed to convert parameter to SMALLINT: {error}")),
         )?))),
-        4 => Ok(SqlType::Int(Some(py_obj.extract::<i32>().map_err(
+        InputSqlType::Integer => Ok(SqlType::Int(Some(py_obj.extract::<i32>().map_err(
             |error| Error::UsageError(format!("Failed to convert parameter to INT: {error}")),
         )?))),
-        -5 => Ok(SqlType::BigInt(Some(py_obj.extract::<i64>().map_err(
+        InputSqlType::BigInt => Ok(SqlType::BigInt(Some(py_obj.extract::<i64>().map_err(
             |error| Error::UsageError(format!("Failed to convert parameter to BIGINT: {error}")),
         )?))),
-        7 => Ok(SqlType::Real(Some(py_obj.extract::<f32>().map_err(
+        InputSqlType::Real => Ok(SqlType::Real(Some(py_obj.extract::<f32>().map_err(
             |error| Error::UsageError(format!("Failed to convert parameter to REAL: {error}")),
         )?))),
-        6 | 8 => Ok(SqlType::Float(Some(py_obj.extract::<f64>().map_err(
+        InputSqlType::Float => Ok(SqlType::Float(Some(py_obj.extract::<f64>().map_err(
             |error| Error::UsageError(format!("Failed to convert parameter to FLOAT: {error}")),
         )?))),
-        2 | 3 => hinted_decimal(py_obj, hint),
-        1 | 12 | -1 | -8 | -9 | -10 => hinted_string(py_obj, hint),
-        -4..=-2 => hinted_binary(py_obj, hint),
-        9 | 91 => match py_to_sql_type(py_obj)? {
+        InputSqlType::Numeric | InputSqlType::Decimal => hinted_decimal(py_obj, hint),
+        InputSqlType::Char
+        | InputSqlType::VarChar
+        | InputSqlType::LongVarChar
+        | InputSqlType::WChar
+        | InputSqlType::WVarChar
+        | InputSqlType::WLongVarChar => hinted_string(py_obj, hint),
+        InputSqlType::Binary | InputSqlType::VarBinary | InputSqlType::LongVarBinary => {
+            hinted_binary(py_obj, hint)
+        }
+        InputSqlType::Date => match py_to_sql_type(py_obj)? {
             SqlType::Date(value) => Ok(SqlType::Date(value)),
             _ => Err(Error::UsageError("Expected a date parameter".to_string())),
         },
-        10 | 92 | -154 => Ok(SqlType::Time(Some(py_time(py_obj, hint.scale.min(7))?))),
-        11 | 93 => match py_datetime_to_sql_type(py_obj)? {
+        InputSqlType::Time => Ok(SqlType::Time(Some(py_time(py_obj, hint.scale)?))),
+        InputSqlType::DateTime => match py_datetime_to_sql_type(py_obj, Some(hint.scale))? {
             SqlType::DateTime2(value) => Ok(SqlType::DateTime2(value)),
             SqlType::DateTimeOffset(value) => Ok(SqlType::DateTime2(
                 value.map(|value| value.datetime2),
             )),
             _ => unreachable!("datetime conversion returns a temporal SQL type"),
         },
-        -155 => match py_datetime_to_sql_type(py_obj)? {
+        InputSqlType::DateTimeOffset => match py_datetime_to_sql_type(py_obj, Some(hint.scale))? {
             SqlType::DateTimeOffset(value) => Ok(SqlType::DateTimeOffset(value)),
             _ => Err(Error::UsageError(
                 "DATETIMEOFFSET requires a timezone-aware datetime".to_string(),
             )),
         },
-        -11 => match py_to_sql_type(py_obj)? {
+        InputSqlType::Guid => match py_to_sql_type(py_obj)? {
             SqlType::Uuid(value) => Ok(SqlType::Uuid(value)),
             _ => Err(Error::UsageError("Expected a UUID parameter".to_string())),
         },
-        -152 => {
+        InputSqlType::Xml => {
             let value = py_obj.extract::<String>().map_err(|error| {
                 Error::UsageError(format!("Failed to convert parameter to XML: {error}"))
             })?;
             Ok(SqlType::Xml(Some(SqlXml::from(value))))
         }
-        241 => {
-            let value = py_obj.extract::<String>().map_err(|error| {
-                Error::UsageError(format!("Failed to convert parameter to XML: {error}"))
-            })?;
-            Ok(SqlType::Xml(Some(SqlXml::from(value))))
-        }
-        244 => hinted_json(py_obj),
-        245 => hinted_vector(py_obj, hint),
-        60 | 122 => hinted_money(py_obj, hint),
-        -150 => Ok(SqlType::Variant(Box::new(py_to_sql_type(py_obj)?))),
-        -151 => Err(Error::UsageError(
+        InputSqlType::Json => hinted_json(py_obj),
+        InputSqlType::Vector => hinted_vector(py_obj, hint),
+        InputSqlType::Money | InputSqlType::SmallMoney => hinted_money(py_obj, hint),
+        InputSqlType::Variant => Ok(SqlType::Variant(Box::new(py_to_sql_type(py_obj)?))),
+        // TODO(mssql-tds): Add a public SqlType::Udt input contract and RPC
+        // serializer carrying database, schema, and server UDT type names.
+        InputSqlType::Udt => Err(Error::UsageError(
             "SQL_SS_UDT parameters require a server UDT type name, which setinputsizes does not provide"
                 .to_string(),
         )),
-        _ => unreachable!("ParameterHint validates SQL type constants"),
     }
 }
 
 /// Constructs the typed NULL required when inference has no Python value.
 ///
 /// Variable-length types may promote to `MAX`; fixed-width types reject sizes
-/// beyond SQL Server limits. Nullable decimal precision and scale cannot yet be
-/// retained because their value-free [`SqlType`] variants do not carry them.
+/// beyond SQL Server limits. NULL numeric and temporal hints are accepted only
+/// when their metadata matches the value-free [`SqlType`] defaults.
 pub(crate) fn null_sql_type(hint: ParameterHint) -> TdsResult<SqlType> {
     let size = hint.size.max(1);
     Ok(match hint.sql_type {
-        -7 => SqlType::Bit(None),
-        -6 => SqlType::TinyInt(None),
-        5 => SqlType::SmallInt(None),
-        4 => SqlType::Int(None),
-        -5 => SqlType::BigInt(None),
-        7 => SqlType::Real(None),
-        6 | 8 => SqlType::Float(None),
-        // TODO(mssql-tds): Nullable Decimal/Numeric variants must carry
-        // precision and scale independently of a value. SqlType currently
-        // falls back to (18,10), so py-core cannot preserve these hints here.
-        2 => SqlType::Numeric(None),
-        3 => SqlType::Decimal(None),
-        1 => SqlType::Char(None, checked_length(size, 8_000, "CHAR")?),
-        12 => sized_varchar(None, size),
-        -1 => SqlType::VarcharMax(None),
-        -8 => SqlType::NChar(None, checked_length(size, 4_000, "NCHAR")?),
-        -9 => sized_nvarchar(None, size),
-        -10 => SqlType::NText(None),
-        -2 => SqlType::Binary(None, checked_length(size, 8_000, "BINARY")?),
-        -3 => sized_varbinary(None, size),
-        -4 | -151 => SqlType::VarBinaryMax(None),
-        9 | 91 => SqlType::Date(None),
-        10 | 92 | -154 => SqlType::Time(None),
-        11 | 93 => SqlType::DateTime2(None),
-        -155 => SqlType::DateTimeOffset(None),
-        -11 => SqlType::Uuid(None),
-        -152 | 241 => SqlType::Xml(None),
-        244 => SqlType::Json(None),
-        245 => {
+        InputSqlType::Bit => SqlType::Bit(None),
+        InputSqlType::TinyInt => SqlType::TinyInt(None),
+        InputSqlType::SmallInt => SqlType::SmallInt(None),
+        InputSqlType::Integer => SqlType::Int(None),
+        InputSqlType::BigInt => SqlType::BigInt(None),
+        InputSqlType::Real => SqlType::Real(None),
+        InputSqlType::Float => SqlType::Float(None),
+        InputSqlType::Numeric | InputSqlType::Decimal => {
+            // TODO(mssql-tds): Carry NULL precision and scale independently of
+            // the optional value so py-core can preserve non-default metadata.
+            if hint.size != 18 || hint.scale != 10 {
+                return Err(Error::UsageError(format!(
+                    "NULL numeric parameters currently require precision 18 and scale 10; requested precision {} and scale {}",
+                    hint.size, hint.scale
+                )));
+            }
+            if hint.sql_type == InputSqlType::Numeric {
+                SqlType::Numeric(None)
+            } else {
+                SqlType::Decimal(None)
+            }
+        }
+        InputSqlType::Char => SqlType::Char(None, checked_length(size, 8_000, "CHAR")?),
+        InputSqlType::VarChar => sized_varchar(None, size),
+        InputSqlType::LongVarChar => SqlType::VarcharMax(None),
+        InputSqlType::WChar => SqlType::NChar(None, checked_length(size, 4_000, "NCHAR")?),
+        InputSqlType::WVarChar => sized_nvarchar(None, size),
+        InputSqlType::WLongVarChar => SqlType::NText(None),
+        InputSqlType::Binary => SqlType::Binary(None, checked_length(size, 8_000, "BINARY")?),
+        InputSqlType::VarBinary => sized_varbinary(None, size),
+        InputSqlType::LongVarBinary | InputSqlType::Udt => SqlType::VarBinaryMax(None),
+        InputSqlType::Date => SqlType::Date(None),
+        InputSqlType::Time | InputSqlType::DateTime | InputSqlType::DateTimeOffset => {
+            // TODO(mssql-tds): Carry NULL temporal scale independently of the
+            // optional value so py-core can preserve non-default metadata.
+            if hint.scale != 7 {
+                return Err(Error::UsageError(format!(
+                    "NULL temporal parameters currently require scale 7; requested scale {}",
+                    hint.scale
+                )));
+            }
+            match hint.sql_type {
+                InputSqlType::Time => SqlType::Time(None),
+                InputSqlType::DateTime => SqlType::DateTime2(None),
+                InputSqlType::DateTimeOffset => SqlType::DateTimeOffset(None),
+                _ => unreachable!("matched temporal input type"),
+            }
+        }
+        InputSqlType::Guid => SqlType::Uuid(None),
+        InputSqlType::Xml => SqlType::Xml(None),
+        InputSqlType::Json => SqlType::Json(None),
+        InputSqlType::Vector => {
             if hint.size == 0 {
                 return Err(Error::UsageError(
                     "A NULL VECTOR parameter requires its dimension count as the input size"
@@ -393,23 +514,22 @@ pub(crate) fn null_sql_type(hint: ParameterHint) -> TdsResult<SqlType> {
                 mssql_tds::datatypes::sqldatatypes::VectorBaseType::Float32,
             )
         }
-        60 => SqlType::Money(None),
-        122 => SqlType::SmallMoney(None),
-        -150 => SqlType::Variant(Box::new(SqlType::NVarchar(None, 1))),
-        _ => unreachable!("ParameterHint validates SQL type constants"),
+        InputSqlType::Money => SqlType::Money(None),
+        InputSqlType::SmallMoney => SqlType::SmallMoney(None),
+        InputSqlType::Variant => SqlType::Variant(Box::new(SqlType::NVarchar(None, 1))),
     })
 }
 
 /// Applies caller-specified decimal precision and scale instead of inferring
 /// them from the Python value.
 fn hinted_decimal(py_obj: &Bound<'_, PyAny>, hint: ParameterHint) -> TdsResult<SqlType> {
-    let precision = if hint.size == 0 { 18 } else { hint.size } as u8;
+    let precision = ParameterHint::effective_numeric_precision(hint.size) as u8;
     let value = py_obj
         .str()
         .and_then(|value| value.extract::<String>())
         .map_err(|error| Error::UsageError(format!("Failed to convert numeric value: {error}")))?;
     let parts = DecimalParts::from_string(&value, precision, hint.scale)?;
-    Ok(if hint.sql_type == 2 {
+    Ok(if hint.sql_type == InputSqlType::Numeric {
         SqlType::Numeric(Some(parts))
     } else {
         SqlType::Decimal(Some(parts))
@@ -422,7 +542,10 @@ fn hinted_string(py_obj: &Bound<'_, PyAny>, hint: ParameterHint) -> TdsResult<Sq
     let value = py_obj.extract::<String>().map_err(|error| {
         Error::UsageError(format!("Failed to convert parameter to string: {error}"))
     })?;
-    let actual = if matches!(hint.sql_type, -10..=-8) {
+    let actual = if matches!(
+        hint.sql_type,
+        InputSqlType::WChar | InputSqlType::WVarChar | InputSqlType::WLongVarChar
+    ) {
         value.encode_utf16().count() as u32
     } else {
         value.len() as u32
@@ -431,12 +554,12 @@ fn hinted_string(py_obj: &Bound<'_, PyAny>, hint: ParameterHint) -> TdsResult<Sq
     let size = hint.size.max(actual);
     let value = Some(SqlString::from_utf8_string(value));
     Ok(match hint.sql_type {
-        1 => SqlType::Char(value, checked_length(size, 8_000, "CHAR")?),
-        12 => sized_varchar(value, size),
-        -1 => SqlType::Text(value),
-        -8 => SqlType::NChar(value, checked_length(size, 4_000, "NCHAR")?),
-        -9 => sized_nvarchar(value, size),
-        -10 => SqlType::NText(value),
+        InputSqlType::Char => SqlType::Char(value, checked_length(size, 8_000, "CHAR")?),
+        InputSqlType::VarChar => sized_varchar(value, size),
+        InputSqlType::LongVarChar => SqlType::Text(value),
+        InputSqlType::WChar => SqlType::NChar(value, checked_length(size, 4_000, "NCHAR")?),
+        InputSqlType::WVarChar => sized_nvarchar(value, size),
+        InputSqlType::WLongVarChar => SqlType::NText(value),
         _ => unreachable!("hinted_string receives only string constants"),
     })
 }
@@ -448,9 +571,11 @@ fn hinted_binary(py_obj: &Bound<'_, PyAny>, hint: ParameterHint) -> TdsResult<Sq
     })?;
     let size = hint.size.max(value.len() as u32).max(1);
     Ok(match hint.sql_type {
-        -2 => SqlType::Binary(Some(value), checked_length(size, 8_000, "BINARY")?),
-        -3 => sized_varbinary(Some(value), size),
-        -4 => SqlType::VarBinaryMax(Some(value)),
+        InputSqlType::Binary => {
+            SqlType::Binary(Some(value), checked_length(size, 8_000, "BINARY")?)
+        }
+        InputSqlType::VarBinary => sized_varbinary(Some(value), size),
+        InputSqlType::LongVarBinary => SqlType::VarBinaryMax(Some(value)),
         _ => unreachable!("hinted_binary receives only binary constants"),
     })
 }
@@ -515,7 +640,7 @@ fn hinted_money(py_obj: &Bound<'_, PyAny>, hint: ParameterHint) -> TdsResult<Sql
         .and_then(|value| value.extract::<i64>())
         .map_err(|error| Error::UsageError(format!("Failed to scale money value: {error}")))?;
 
-    if hint.sql_type == 122 {
+    if hint.sql_type == InputSqlType::SmallMoney {
         let scaled = i32::try_from(scaled)
             .map_err(|_| Error::UsageError("Value is outside the SMALLMONEY range".to_string()))?;
         Ok(SqlType::SmallMoney(Some(SqlSmallMoney { int_val: scaled })))
@@ -561,7 +686,12 @@ fn sized_varbinary(value: Option<Vec<u8>>, size: u32) -> SqlType {
     }
 }
 
-fn py_datetime_to_sql_type(py_obj: &Bound<'_, PyAny>) -> TdsResult<SqlType> {
+// TODO(performance): Cache or compute datetime base ordinals in the bulk-copy
+// conversion path instead of calling Python's toordinal for each value.
+fn py_datetime_to_sql_type(
+    py_obj: &Bound<'_, PyAny>,
+    hinted_scale: Option<u8>,
+) -> TdsResult<SqlType> {
     let ordinal = py_obj
         .call_method0("toordinal")
         .and_then(|value| value.extract::<u32>())
@@ -576,7 +706,7 @@ fn py_datetime_to_sql_type(py_obj: &Bound<'_, PyAny>) -> TdsResult<SqlType> {
     if tzinfo.is_none() {
         return Ok(SqlType::DateTime2(Some(SqlDateTime2 {
             days,
-            time: py_time(py_obj, 6)?,
+            time: py_time(py_obj, hinted_scale.unwrap_or(6))?,
         })));
     }
 
@@ -594,20 +724,30 @@ fn py_datetime_to_sql_type(py_obj: &Bound<'_, PyAny>) -> TdsResult<SqlType> {
         .map_err(|error| {
             Error::UsageError(format!("Failed to get timezone offset seconds: {error}"))
         })?;
-    let offset_minutes = (offset_seconds / 60.0).round() as i16;
-    if !(-840..=840).contains(&offset_minutes) {
-        return Err(Error::UsageError(format!(
-            "Timezone offset {offset_minutes} minutes is outside the DATETIMEOFFSET range"
-        )));
-    }
+    let offset_minutes = datetimeoffset_minutes(offset_seconds)?;
 
     Ok(SqlType::DateTimeOffset(Some(SqlDateTimeOffset {
         datetime2: SqlDateTime2 {
             days,
-            time: py_time(py_obj, 7)?,
+            time: py_time(py_obj, hinted_scale.unwrap_or(7))?,
         },
         offset: offset_minutes,
     })))
+}
+
+fn datetimeoffset_minutes(offset_seconds: f64) -> TdsResult<i16> {
+    if !offset_seconds.is_finite() || offset_seconds % 60.0 != 0.0 {
+        return Err(Error::UsageError(
+            "DATETIMEOFFSET requires a whole-minute UTC offset".to_string(),
+        ));
+    }
+    let offset_minutes = offset_seconds / 60.0;
+    if !(-840.0..=840.0).contains(&offset_minutes) {
+        return Err(Error::UsageError(format!(
+            "Timezone offset {offset_minutes} minutes is outside the DATETIMEOFFSET range"
+        )));
+    }
+    Ok(offset_minutes as i16)
 }
 
 /// Converts Python time components to the 100-nanosecond units used by TDS,
@@ -638,6 +778,30 @@ fn is_decimal(py_obj: &Bound<'_, PyAny>) -> TdsResult<bool> {
         .map_err(|error| Error::UsageError(format!("Failed to inspect Decimal value: {error}")))
 }
 
+fn inferred_decimal_shape(digit_count: usize, exponent: i64) -> TdsResult<(u8, u8)> {
+    let precision = if exponent >= 0 {
+        digit_count.saturating_add(exponent as usize)
+    } else {
+        digit_count.max(exponent.unsigned_abs() as usize)
+    };
+    if precision == 0 || precision > 38 {
+        return Err(Error::UsageError(format!(
+            "Decimal precision {precision} is outside SQL Server's supported range of 1 to 38"
+        )));
+    }
+    let scale = if exponent < 0 {
+        exponent.unsigned_abs() as usize
+    } else {
+        0
+    };
+    if scale > 38 {
+        return Err(Error::UsageError(format!(
+            "Decimal scale {scale} exceeds SQL Server's maximum scale of 38"
+        )));
+    }
+    Ok((precision as u8, scale as u8))
+}
+
 fn py_decimal_to_sql_type(py_obj: &Bound<'_, PyAny>) -> TdsResult<SqlType> {
     let decimal_tuple = py_obj
         .call_method0("as_tuple")
@@ -652,27 +816,12 @@ fn py_decimal_to_sql_type(py_obj: &Bound<'_, PyAny>) -> TdsResult<SqlType> {
         .map_err(|_| {
             Error::UsageError("NaN and infinite Decimal values are unsupported".to_string())
         })?;
-    let precision = if exponent >= 0 {
-        digit_count.saturating_add(exponent as usize)
-    } else {
-        digit_count.max(exponent.unsigned_abs() as usize)
-    };
-    if precision == 0 || precision > 38 {
-        return Err(Error::UsageError(format!(
-            "Decimal precision {precision} is outside SQL Server's supported range of 1 to 38"
-        )));
-    }
-    let scale = exponent.saturating_neg() as usize;
-    if scale > 38 {
-        return Err(Error::UsageError(format!(
-            "Decimal scale {scale} exceeds SQL Server's maximum scale of 38"
-        )));
-    }
+    let (precision, scale) = inferred_decimal_shape(digit_count, exponent)?;
     let value = py_obj
         .call_method0("__str__")
         .and_then(|value| value.extract::<String>())
         .map_err(|error| Error::UsageError(format!("Failed to extract Decimal value: {error}")))?;
-    let value = DecimalParts::from_string(&value, precision as u8, scale as u8)?;
+    let value = DecimalParts::from_string(&value, precision, scale)?;
     Ok(SqlType::Numeric(Some(value)))
 }
 
@@ -886,21 +1035,13 @@ fn py_to_column_value_internal(
                                     e
                                 ))
                             })?;
-                        (offset_seconds / 60.0).round() as i16
+                        datetimeoffset_minutes(offset_seconds)?
                     }
                     _ => {
                         // No timezone info, default to UTC (0 offset)
                         0
                     }
                 };
-
-                // Validate offset range: -840 to +840 minutes (-14:00 to +14:00)
-                if !(-840..=840).contains(&offset_minutes) {
-                    return Err(Error::UsageError(format!(
-                        "Timezone offset {} minutes out of valid range for DATETIMEOFFSET (-840 to +840)",
-                        offset_minutes
-                    )));
-                }
 
                 return Ok(ColumnValues::DateTimeOffset(
                     mssql_tds::datatypes::column_values::SqlDateTimeOffset {
@@ -1323,6 +1464,126 @@ fn validate_type_compatibility(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn numeric_hints_validate_effective_precision() {
+        for sql_type in [2, 3] {
+            assert!(ParameterHint::new(sql_type, 0, 0).is_ok());
+            assert!(ParameterHint::new(sql_type, 0, 2).is_ok());
+            assert!(ParameterHint::new(sql_type, 2, 3).is_err());
+            assert!(ParameterHint::new(sql_type, 39, 0).is_err());
+            assert!(ParameterHint::new(sql_type, 38, 39).is_err());
+            assert_eq!(
+                ParameterHint::new(sql_type, 0, 2).unwrap().precision(),
+                Some(18)
+            );
+        }
+    }
+
+    #[test]
+    fn temporal_hints_accept_scales_zero_through_seven() {
+        for sql_type in [10, 11, 92, 93, -154, -155] {
+            for scale in [0, 3, 7] {
+                assert!(ParameterHint::new(sql_type, 0, scale).is_ok());
+            }
+            assert!(ParameterHint::new(sql_type, 0, 8).is_err());
+        }
+    }
+
+    #[test]
+    fn null_numeric_accepts_only_core_default_metadata() {
+        for sql_type in [2, 3] {
+            assert!(null_sql_type(ParameterHint::new(sql_type, 18, 10).unwrap()).is_ok());
+            assert!(null_sql_type(ParameterHint::new(sql_type, 9, 2).unwrap()).is_err());
+            assert!(null_sql_type(ParameterHint::new(sql_type, 0, 0).unwrap()).is_err());
+        }
+    }
+
+    #[test]
+    fn null_temporal_accepts_only_core_default_scale() {
+        for sql_type in [92, 93, -155] {
+            assert!(null_sql_type(ParameterHint::new(sql_type, 0, 7).unwrap()).is_ok());
+            assert!(null_sql_type(ParameterHint::new(sql_type, 0, 3).unwrap()).is_err());
+            assert!(null_sql_type(ParameterHint::new(sql_type, 0, 0).unwrap()).is_err());
+        }
+    }
+
+    #[test]
+    fn datetimeoffset_requires_whole_minute_offsets() {
+        assert!(datetimeoffset_minutes(30.0).is_err());
+        assert!(datetimeoffset_minutes(-30.0).is_err());
+        assert!(datetimeoffset_minutes(f64::NAN).is_err());
+        assert!(datetimeoffset_minutes(f64::INFINITY).is_err());
+    }
+
+    #[test]
+    fn datetimeoffset_accepts_range_boundaries() {
+        assert_eq!(datetimeoffset_minutes(14.0 * 60.0 * 60.0).unwrap(), 840);
+        assert_eq!(datetimeoffset_minutes(-14.0 * 60.0 * 60.0).unwrap(), -840);
+        assert!(datetimeoffset_minutes(841.0 * 60.0).is_err());
+        assert!(datetimeoffset_minutes(-841.0 * 60.0).is_err());
+    }
+
+    #[test]
+    fn decimal_shape_handles_positive_and_negative_exponents() {
+        assert_eq!(inferred_decimal_shape(1, 3).unwrap(), (4, 0));
+        assert_eq!(inferred_decimal_shape(1, -3).unwrap(), (3, 3));
+    }
+
+    #[test]
+    fn decimal_shape_enforces_precision_38_boundaries() {
+        assert_eq!(inferred_decimal_shape(38, 0).unwrap(), (38, 0));
+        assert!(inferred_decimal_shape(39, 0).is_err());
+        assert_eq!(inferred_decimal_shape(1, 37).unwrap(), (38, 0));
+        assert!(inferred_decimal_shape(1, 38).is_err());
+        assert_eq!(inferred_decimal_shape(1, -38).unwrap(), (38, 38));
+        assert!(inferred_decimal_shape(1, -39).is_err());
+    }
+
+    #[test]
+    fn input_sql_type_accepts_every_supported_odbc_code() {
+        let supported = [
+            -155, -154, -152, -151, -150, -11, -10, -9, -8, -7, -6, -5, -4, -3, -2, -1, 1, 2, 3, 4,
+            5, 6, 7, 8, 9, 10, 11, 12, 60, 91, 92, 93, 122, 241, 244, 245,
+        ];
+
+        for code in supported {
+            assert!(InputSqlType::try_from(code).is_ok(), "ODBC code {code}");
+        }
+    }
+
+    #[test]
+    fn input_sql_type_normalizes_equivalent_odbc_aliases() {
+        assert_eq!(InputSqlType::try_from(6).unwrap(), InputSqlType::Float);
+        assert_eq!(InputSqlType::try_from(8).unwrap(), InputSqlType::Float);
+        assert_eq!(InputSqlType::try_from(9).unwrap(), InputSqlType::Date);
+        assert_eq!(InputSqlType::try_from(91).unwrap(), InputSqlType::Date);
+        assert_eq!(InputSqlType::try_from(10).unwrap(), InputSqlType::Time);
+        assert_eq!(InputSqlType::try_from(92).unwrap(), InputSqlType::Time);
+        assert_eq!(InputSqlType::try_from(-154).unwrap(), InputSqlType::Time);
+        assert_eq!(InputSqlType::try_from(11).unwrap(), InputSqlType::DateTime);
+        assert_eq!(InputSqlType::try_from(93).unwrap(), InputSqlType::DateTime);
+        assert_eq!(InputSqlType::try_from(-152).unwrap(), InputSqlType::Xml);
+        assert_eq!(InputSqlType::try_from(241).unwrap(), InputSqlType::Xml);
+    }
+
+    #[test]
+    fn input_sql_type_rejects_unknown_odbc_code() {
+        let error = InputSqlType::try_from(0).unwrap_err();
+        assert!(error.to_string().contains("Invalid SQL type: 0"));
+    }
+
+    #[test]
+    fn parameter_hint_reports_tvp_column_support_symbolically() {
+        for code in [-151, -1, -10] {
+            assert!(
+                !ParameterHint::new(code, 0, 0)
+                    .unwrap()
+                    .supports_tvp_column()
+            );
+        }
+        assert!(ParameterHint::new(-9, 20, 0).unwrap().supports_tvp_column());
+    }
 
     #[test]
     fn datetime_to_ticks_rounds_up() {

--- a/mssql-py-core/src/types.rs
+++ b/mssql-py-core/src/types.rs
@@ -325,6 +325,9 @@ pub(crate) fn null_sql_type(hint: ParameterHint) -> TdsResult<SqlType> {
         -5 => SqlType::BigInt(None),
         7 => SqlType::Real(None),
         6 | 8 => SqlType::Float(None),
+        // TODO(mssql-tds): Nullable Decimal/Numeric variants must carry
+        // precision and scale independently of a value. SqlType currently
+        // falls back to (18,10), so py-core cannot preserve these hints here.
         2 => SqlType::Numeric(None),
         3 => SqlType::Decimal(None),
         1 => SqlType::Char(None, checked_length(size, 8_000, "CHAR")?),

--- a/mssql-py-core/src/types.rs
+++ b/mssql-py-core/src/types.rs
@@ -33,14 +33,21 @@ fn uuid_type(py: Python<'_>) -> PyResult<&Bound<'_, PyType>> {
     UUID_TYPE.import(py, "uuid", "UUID")
 }
 
+/// A validated ODBC-compatible `setinputsizes()` entry lowered to [`SqlType`]
+/// before TDS serialization.
 #[derive(Clone, Copy)]
 pub(crate) struct ParameterHint {
+    /// A supported ODBC SQL type code.
     sql_type: i32,
+    /// Precision, dimension count, or character/binary allocation size.
     size: u32,
+    /// Numeric or temporal scale where the selected type supports one.
     scale: u8,
 }
 
 impl ParameterHint {
+    /// Validates the type code and numeric bounds once so conversion matches
+    /// can treat any remaining arm as unreachable.
     pub(crate) fn new(sql_type: i32, size: u32, scale: u8) -> TdsResult<Self> {
         const VALID_TYPES: &[i32] = &[
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 91, 92, 93, -1, -2, -3, -4, -5, -6, -7, -8, -9,
@@ -63,16 +70,19 @@ impl ParameterHint {
         })
     }
 
+    /// Returns the validated ODBC SQL type code for TVP compatibility checks.
     pub(crate) fn sql_type(self) -> i32 {
         self.sql_type
     }
 
+    /// Returns explicit decimal precision for TVP metadata, excluding zero as unspecified.
     pub(crate) fn precision(self) -> Option<u8> {
         matches!(self.sql_type, 2 | 3)
             .then(|| u8::try_from(self.size).unwrap_or(0))
             .filter(|precision| *precision > 0)
     }
 
+    /// Returns scale only for numeric and scale-bearing temporal types.
     pub(crate) fn scale(self) -> Option<u8> {
         matches!(self.sql_type, 2 | 3 | 10 | 11 | 92 | 93 | -154 | -155).then_some(self.scale)
     }
@@ -250,6 +260,11 @@ pub(crate) fn py_to_sql_type(py_obj: &Bound<'_, PyAny>) -> TdsResult<SqlType> {
     })
 }
 
+/// Converts a Python value according to its validated `setinputsizes()` hint.
+///
+/// Hints select the SQL type, but size handling remains type-specific: decimal
+/// precision and scale are authoritative, strings and binary values widen to
+/// fit their contents, and vector dimensions are validated against the value.
 pub(crate) fn py_to_sql_type_with_hint(
     py_obj: &Bound<'_, PyAny>,
     hint: ParameterHint,
@@ -329,6 +344,11 @@ pub(crate) fn py_to_sql_type_with_hint(
     }
 }
 
+/// Constructs the typed NULL required when inference has no Python value.
+///
+/// Variable-length types may promote to `MAX`; fixed-width types reject sizes
+/// beyond SQL Server limits. Nullable decimal precision and scale cannot yet be
+/// retained because their value-free [`SqlType`] variants do not carry them.
 pub(crate) fn null_sql_type(hint: ParameterHint) -> TdsResult<SqlType> {
     let size = hint.size.max(1);
     Ok(match hint.sql_type {
@@ -380,6 +400,8 @@ pub(crate) fn null_sql_type(hint: ParameterHint) -> TdsResult<SqlType> {
     })
 }
 
+/// Applies caller-specified decimal precision and scale instead of inferring
+/// them from the Python value.
 fn hinted_decimal(py_obj: &Bound<'_, PyAny>, hint: ParameterHint) -> TdsResult<SqlType> {
     let precision = if hint.size == 0 { 18 } else { hint.size } as u8;
     let value = py_obj
@@ -394,6 +416,8 @@ fn hinted_decimal(py_obj: &Bound<'_, PyAny>, hint: ParameterHint) -> TdsResult<S
     })
 }
 
+/// Preserves the requested string allocation while widening it when needed to
+/// avoid declaring a type shorter than the encoded value.
 fn hinted_string(py_obj: &Bound<'_, PyAny>, hint: ParameterHint) -> TdsResult<SqlType> {
     let value = py_obj.extract::<String>().map_err(|error| {
         Error::UsageError(format!("Failed to convert parameter to string: {error}"))
@@ -417,6 +441,7 @@ fn hinted_string(py_obj: &Bound<'_, PyAny>, hint: ParameterHint) -> TdsResult<Sq
     })
 }
 
+/// Preserves the requested binary allocation while widening it to fit the value.
 fn hinted_binary(py_obj: &Bound<'_, PyAny>, hint: ParameterHint) -> TdsResult<SqlType> {
     let value = py_obj.extract::<Vec<u8>>().map_err(|error| {
         Error::UsageError(format!("Failed to convert parameter to binary: {error}"))
@@ -430,6 +455,7 @@ fn hinted_binary(py_obj: &Bound<'_, PyAny>, hint: ParameterHint) -> TdsResult<Sq
     })
 }
 
+/// Serializes arbitrary Python values through `json.dumps` for SQL JSON parameters.
 fn hinted_json(py_obj: &Bound<'_, PyAny>) -> TdsResult<SqlType> {
     let py = py_obj.py();
     let dumps = JSON_DUMPS
@@ -448,6 +474,7 @@ fn hinted_json(py_obj: &Bound<'_, PyAny>) -> TdsResult<SqlType> {
     Ok(SqlType::Json(Some(SqlJson::from(value))))
 }
 
+/// Converts a float32 vector and rejects a conflicting hinted dimension count.
 fn hinted_vector(py_obj: &Bound<'_, PyAny>, hint: ParameterHint) -> TdsResult<SqlType> {
     let values = py_obj.extract::<Vec<f32>>().map_err(|error| {
         Error::UsageError(format!("Failed to convert parameter to VECTOR: {error}"))
@@ -467,6 +494,8 @@ fn hinted_vector(py_obj: &Bound<'_, PyAny>, hint: ParameterHint) -> TdsResult<Sq
     ))
 }
 
+/// Quantizes through Python `Decimal` so MONEY values use SQL Server's fixed
+/// four-digit scale before range-checking SMALLMONEY.
 fn hinted_money(py_obj: &Bound<'_, PyAny>, hint: ParameterHint) -> TdsResult<SqlType> {
     let decimal_class = decimal_type(py_obj.py())
         .map_err(|error| Error::UsageError(format!("Failed to import Decimal: {error}")))?;
@@ -498,6 +527,7 @@ fn hinted_money(py_obj: &Bound<'_, PyAny>, hint: ParameterHint) -> TdsResult<Sql
     }
 }
 
+/// Enforces fixed-width SQL Server limits before narrowing a size to `u16`.
 fn checked_length(size: u32, maximum: u32, type_name: &str) -> TdsResult<u16> {
     if size > maximum {
         return Err(Error::UsageError(format!(
@@ -507,6 +537,7 @@ fn checked_length(size: u32, maximum: u32, type_name: &str) -> TdsResult<u16> {
     Ok(size as u16)
 }
 
+/// Selects `varchar(n)` when representable and `varchar(max)` otherwise.
 fn sized_varchar(value: Option<SqlString>, size: u32) -> SqlType {
     match u16::try_from(size) {
         Ok(size) if size <= 8_000 => SqlType::Varchar(value, size),
@@ -514,6 +545,7 @@ fn sized_varchar(value: Option<SqlString>, size: u32) -> SqlType {
     }
 }
 
+/// Selects `nvarchar(n)` when representable and `nvarchar(max)` otherwise.
 fn sized_nvarchar(value: Option<SqlString>, size: u32) -> SqlType {
     match u16::try_from(size) {
         Ok(size) if size <= 4_000 => SqlType::NVarchar(value, size),
@@ -521,6 +553,7 @@ fn sized_nvarchar(value: Option<SqlString>, size: u32) -> SqlType {
     }
 }
 
+/// Selects `varbinary(n)` when representable and `varbinary(max)` otherwise.
 fn sized_varbinary(value: Option<Vec<u8>>, size: u32) -> SqlType {
     match u16::try_from(size) {
         Ok(size) if size <= 8_000 => SqlType::VarBinary(value, size),
@@ -577,6 +610,8 @@ fn py_datetime_to_sql_type(py_obj: &Bound<'_, PyAny>) -> TdsResult<SqlType> {
     })))
 }
 
+/// Converts Python time components to the 100-nanosecond units used by TDS,
+/// retaining the scale selected by inference or the caller's hint.
 fn py_time(py_obj: &Bound<'_, PyAny>, scale: u8) -> TdsResult<SqlTime> {
     let component = |name: &str| {
         py_obj
@@ -594,6 +629,7 @@ fn py_time(py_obj: &Bound<'_, PyAny>, scale: u8) -> TdsResult<SqlTime> {
     })
 }
 
+/// Uses Python's `Decimal` class identity rather than accepting lookalike values.
 fn is_decimal(py_obj: &Bound<'_, PyAny>) -> TdsResult<bool> {
     let decimal = decimal_type(py_obj.py())
         .map_err(|error| Error::UsageError(format!("Failed to import decimal.Decimal: {error}")))?;

--- a/mssql-py-core/src/types.rs
+++ b/mssql-py-core/src/types.rs
@@ -556,7 +556,7 @@ fn hinted_string(py_obj: &Bound<'_, PyAny>, hint: ParameterHint) -> TdsResult<Sq
     Ok(match hint.sql_type {
         InputSqlType::Char => SqlType::Char(value, checked_length(size, 8_000, "CHAR")?),
         InputSqlType::VarChar => sized_varchar(value, size),
-        InputSqlType::LongVarChar => SqlType::Text(value),
+        InputSqlType::LongVarChar => SqlType::VarcharMax(value),
         InputSqlType::WChar => SqlType::NChar(value, checked_length(size, 4_000, "NCHAR")?),
         InputSqlType::WVarChar => sized_nvarchar(value, size),
         InputSqlType::WLongVarChar => SqlType::NText(value),

--- a/mssql-py-core/src/types.rs
+++ b/mssql-py-core/src/types.rs
@@ -15,9 +15,23 @@ use mssql_tds::datatypes::sql_vector::SqlVector;
 use mssql_tds::datatypes::sqltypes::SqlType;
 use mssql_tds::error::Error;
 use pyo3::prelude::*;
+use pyo3::sync::PyOnceLock;
 use pyo3::types::{
     PyBool, PyByteArray, PyBytes, PyDate, PyDateTime, PyFloat, PyInt, PyModule, PyString, PyTime,
+    PyType,
 };
+
+static DECIMAL_TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+static UUID_TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+static JSON_DUMPS: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
+
+fn decimal_type(py: Python<'_>) -> PyResult<&Bound<'_, PyType>> {
+    DECIMAL_TYPE.import(py, "decimal", "Decimal")
+}
+
+fn uuid_type(py: Python<'_>) -> PyResult<&Bound<'_, PyType>> {
+    UUID_TYPE.import(py, "uuid", "UUID")
+}
 
 #[derive(Clone, Copy)]
 pub(crate) struct ParameterHint {
@@ -228,11 +242,11 @@ pub(crate) fn py_to_sql_type(py_obj: &Bound<'_, PyAny>) -> TdsResult<SqlType> {
         ColumnValues::Null => SqlType::NVarchar(None, 1),
         ColumnValues::Uuid(value) => SqlType::Uuid(Some(value)),
         ColumnValues::Json(value) => SqlType::Json(Some(value)),
-        ColumnValues::Vector(value) => SqlType::Vector(
-            Some(value.clone()),
-            value.dimension_count(),
-            value.base_type(),
-        ),
+        ColumnValues::Vector(value) => {
+            let dimensions = value.dimension_count();
+            let base_type = value.base_type();
+            SqlType::Vector(Some(value), dimensions, base_type)
+        }
     })
 }
 
@@ -417,8 +431,16 @@ fn hinted_binary(py_obj: &Bound<'_, PyAny>, hint: ParameterHint) -> TdsResult<Sq
 }
 
 fn hinted_json(py_obj: &Bound<'_, PyAny>) -> TdsResult<SqlType> {
-    let value = PyModule::import(py_obj.py(), "json")
-        .and_then(|module| module.call_method1("dumps", (py_obj,)))
+    let py = py_obj.py();
+    let dumps = JSON_DUMPS
+        .get_or_try_init(py, || {
+            PyModule::import(py, "json")
+                .and_then(|module| module.getattr("dumps"))
+                .map(Bound::unbind)
+        })
+        .map(|dumps| dumps.bind(py));
+    let value = dumps
+        .and_then(|dumps| dumps.call1((py_obj,)))
         .and_then(|value| value.extract::<String>())
         .map_err(|error| {
             Error::UsageError(format!("Failed to serialize JSON parameter: {error}"))
@@ -446,8 +468,7 @@ fn hinted_vector(py_obj: &Bound<'_, PyAny>, hint: ParameterHint) -> TdsResult<Sq
 }
 
 fn hinted_money(py_obj: &Bound<'_, PyAny>, hint: ParameterHint) -> TdsResult<SqlType> {
-    let decimal_class = PyModule::import(py_obj.py(), "decimal")
-        .and_then(|module| module.getattr("Decimal"))
+    let decimal_class = decimal_type(py_obj.py())
         .map_err(|error| Error::UsageError(format!("Failed to import Decimal: {error}")))?;
     let value = py_obj
         .str()
@@ -574,11 +595,10 @@ fn py_time(py_obj: &Bound<'_, PyAny>, scale: u8) -> TdsResult<SqlTime> {
 }
 
 fn is_decimal(py_obj: &Bound<'_, PyAny>) -> TdsResult<bool> {
-    let decimal = PyModule::import(py_obj.py(), "decimal")
-        .and_then(|module| module.getattr("Decimal"))
+    let decimal = decimal_type(py_obj.py())
         .map_err(|error| Error::UsageError(format!("Failed to import decimal.Decimal: {error}")))?;
     py_obj
-        .is_instance(&decimal)
+        .is_instance(decimal)
         .map_err(|error| Error::UsageError(format!("Failed to inspect Decimal value: {error}")))
 }
 
@@ -1024,9 +1044,8 @@ fn py_to_column_value_internal(
     // Check for decimal.Decimal type
     // We need to check if the object is an instance of decimal.Decimal
     let py = py_obj.py();
-    if let Ok(decimal_module) = PyModule::import(py, "decimal")
-        && let Ok(decimal_class) = decimal_module.getattr("Decimal")
-        && let Ok(is_instance) = py_obj.is_instance(&decimal_class)
+    if let Ok(decimal_class) = decimal_type(py)
+        && let Ok(is_instance) = py_obj.is_instance(decimal_class)
         && is_instance
     {
         // Extract Decimal as string and parse it
@@ -1052,9 +1071,8 @@ fn py_to_column_value_internal(
 
     // Check for uuid.UUID type
     // Python's UUID type from the uuid module
-    if let Ok(uuid_module) = PyModule::import(py, "uuid")
-        && let Ok(uuid_class) = uuid_module.getattr("UUID")
-        && let Ok(is_instance) = py_obj.is_instance(&uuid_class)
+    if let Ok(uuid_class) = uuid_type(py)
+        && let Ok(is_instance) = py_obj.is_instance(uuid_class)
         && is_instance
     {
         // Extract UUID bytes (16 bytes in big-endian RFC 4122 format)

--- a/mssql-py-core/src/types.rs
+++ b/mssql-py-core/src/types.rs
@@ -5,14 +5,64 @@
 
 use mssql_tds::core::TdsResult;
 use mssql_tds::datatypes::bulk_copy_metadata::{BulkCopyColumnMetadata, SqlDbType};
-use mssql_tds::datatypes::column_values::ColumnValues;
+use mssql_tds::datatypes::column_values::{
+    ColumnValues, SqlDateTime2, SqlDateTimeOffset, SqlMoney, SqlSmallMoney, SqlTime, SqlXml,
+};
 use mssql_tds::datatypes::decoder::DecimalParts;
+use mssql_tds::datatypes::sql_json::SqlJson;
 use mssql_tds::datatypes::sql_string::SqlString;
+use mssql_tds::datatypes::sql_vector::SqlVector;
+use mssql_tds::datatypes::sqltypes::SqlType;
 use mssql_tds::error::Error;
 use pyo3::prelude::*;
 use pyo3::types::{
-    PyBool, PyByteArray, PyBytes, PyDate, PyDateTime, PyInt, PyModule, PyString, PyTime,
+    PyBool, PyByteArray, PyBytes, PyDate, PyDateTime, PyFloat, PyInt, PyModule, PyString, PyTime,
 };
+
+#[derive(Clone, Copy)]
+pub(crate) struct ParameterHint {
+    sql_type: i32,
+    size: u32,
+    scale: u8,
+}
+
+impl ParameterHint {
+    pub(crate) fn new(sql_type: i32, size: u32, scale: u8) -> TdsResult<Self> {
+        const VALID_TYPES: &[i32] = &[
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 91, 92, 93, -1, -2, -3, -4, -5, -6, -7, -8, -9,
+            -10, -11, -150, -151, -152, -154, -155, 60, 122, 241, 244, 245,
+        ];
+        if !VALID_TYPES.contains(&sql_type) {
+            return Err(Error::UsageError(format!(
+                "Invalid SQL type: {sql_type}. Must be a supported SQL type constant"
+            )));
+        }
+        if matches!(sql_type, 2 | 3) && (size > 38 || u32::from(scale) > size.max(1)) {
+            return Err(Error::UsageError(format!(
+                "Invalid numeric precision/scale: precision={size}, scale={scale}"
+            )));
+        }
+        Ok(Self {
+            sql_type,
+            size,
+            scale,
+        })
+    }
+
+    pub(crate) fn sql_type(self) -> i32 {
+        self.sql_type
+    }
+
+    pub(crate) fn precision(self) -> Option<u8> {
+        matches!(self.sql_type, 2 | 3)
+            .then(|| u8::try_from(self.size).unwrap_or(0))
+            .filter(|precision| *precision > 0)
+    }
+
+    pub(crate) fn scale(self) -> Option<u8> {
+        matches!(self.sql_type, 2 | 3 | 10 | 11 | 92 | 93 | -154 | -155).then_some(self.scale)
+    }
+}
 
 /// Convert a Python object to ColumnValues for TDS serialization
 ///
@@ -70,6 +120,501 @@ pub fn py_to_column_value(
     }
 
     Ok(result)
+}
+
+/// Convert a Python value to the inferred SQL type used by RPC parameters.
+pub(crate) fn py_to_sql_type(py_obj: &Bound<'_, PyAny>) -> TdsResult<SqlType> {
+    if py_obj.is_none() {
+        return Ok(SqlType::NVarchar(None, 1));
+    }
+
+    if py_obj.is_instance_of::<PyBool>() {
+        return py_obj
+            .extract::<bool>()
+            .map(|value| SqlType::Bit(Some(value)))
+            .map_err(|error| Error::UsageError(format!("Failed to extract bool: {error}")));
+    }
+
+    if py_obj.is_instance_of::<PyInt>() {
+        let value = py_obj.extract::<i64>().map_err(|error| {
+            Error::UsageError(format!(
+                "Integer parameter is outside the BIGINT range: {error}"
+            ))
+        })?;
+        return Ok(match value {
+            0..=255 => SqlType::TinyInt(Some(value as u8)),
+            -32_768..=32_767 => SqlType::SmallInt(Some(value as i16)),
+            -2_147_483_648..=2_147_483_647 => SqlType::Int(Some(value as i32)),
+            _ => SqlType::BigInt(Some(value)),
+        });
+    }
+
+    if py_obj.is_exact_instance_of::<PyFloat>() {
+        return py_obj
+            .extract::<f64>()
+            .map(|value| SqlType::Float(Some(value)))
+            .map_err(|error| Error::UsageError(format!("Failed to extract float: {error}")));
+    }
+
+    if py_obj.is_instance_of::<PyString>() {
+        let value = py_obj
+            .extract::<String>()
+            .map_err(|error| Error::UsageError(format!("Failed to extract string: {error}")))?;
+        let is_ascii = value.is_ascii();
+        let length = if is_ascii {
+            value.len()
+        } else {
+            value.encode_utf16().count()
+        }
+        .max(1);
+        let value = SqlString::from_utf8_string(value);
+        return Ok(if is_ascii {
+            match u16::try_from(length) {
+                Ok(length) if length <= 8_000 => SqlType::Varchar(Some(value), length),
+                _ => SqlType::VarcharMax(Some(value)),
+            }
+        } else {
+            match u16::try_from(length) {
+                Ok(length) if length <= 4_000 => SqlType::NVarchar(Some(value), length),
+                _ => SqlType::NVarcharMax(Some(value)),
+            }
+        });
+    }
+
+    if py_obj.is_instance_of::<PyDateTime>() {
+        return py_datetime_to_sql_type(py_obj);
+    }
+
+    if py_obj.is_instance_of::<PyTime>() {
+        let time = py_time(py_obj, 6)?;
+        return Ok(SqlType::Time(Some(time)));
+    }
+
+    if is_decimal(py_obj)? {
+        return py_decimal_to_sql_type(py_obj);
+    }
+
+    let value = py_to_column_value(py_obj, None)?;
+    Ok(match value {
+        ColumnValues::TinyInt(value) => SqlType::TinyInt(Some(value)),
+        ColumnValues::SmallInt(value) => SqlType::SmallInt(Some(value)),
+        ColumnValues::Int(value) => SqlType::Int(Some(value)),
+        ColumnValues::BigInt(value) => SqlType::BigInt(Some(value)),
+        ColumnValues::Real(value) => SqlType::Real(Some(value)),
+        ColumnValues::Float(value) => SqlType::Float(Some(value)),
+        ColumnValues::Decimal(value) => SqlType::Decimal(Some(value)),
+        ColumnValues::Numeric(value) => SqlType::Numeric(Some(value)),
+        ColumnValues::Bit(value) => SqlType::Bit(Some(value)),
+        ColumnValues::String(value) => {
+            let length = value.bytes.len().div_ceil(2).max(1);
+            match u16::try_from(length) {
+                Ok(length) if length <= 4_000 => SqlType::NVarchar(Some(value), length),
+                _ => SqlType::NVarcharMax(Some(value)),
+            }
+        }
+        ColumnValues::DateTime(value) => SqlType::DateTime(Some(value)),
+        ColumnValues::Date(value) => SqlType::Date(Some(value)),
+        ColumnValues::Time(value) => SqlType::Time(Some(value)),
+        ColumnValues::DateTime2(value) => SqlType::DateTime2(Some(value)),
+        ColumnValues::DateTimeOffset(value) => SqlType::DateTimeOffset(Some(value)),
+        ColumnValues::SmallDateTime(value) => SqlType::SmallDateTime(Some(value)),
+        ColumnValues::SmallMoney(value) => SqlType::SmallMoney(Some(value)),
+        ColumnValues::Money(value) => SqlType::Money(Some(value)),
+        ColumnValues::Bytes(value) => match u16::try_from(value.len().max(1)) {
+            Ok(length) if length <= 8_000 => SqlType::VarBinary(Some(value), length),
+            _ => SqlType::VarBinaryMax(Some(value)),
+        },
+        ColumnValues::Xml(value) => SqlType::Xml(Some(value)),
+        ColumnValues::Null => SqlType::NVarchar(None, 1),
+        ColumnValues::Uuid(value) => SqlType::Uuid(Some(value)),
+        ColumnValues::Json(value) => SqlType::Json(Some(value)),
+        ColumnValues::Vector(value) => SqlType::Vector(
+            Some(value.clone()),
+            value.dimension_count(),
+            value.base_type(),
+        ),
+    })
+}
+
+pub(crate) fn py_to_sql_type_with_hint(
+    py_obj: &Bound<'_, PyAny>,
+    hint: ParameterHint,
+) -> TdsResult<SqlType> {
+    if py_obj.is_none() {
+        return null_sql_type(hint);
+    }
+
+    match hint.sql_type {
+        -7 => Ok(SqlType::Bit(Some(py_obj.extract::<bool>().map_err(|error| {
+            Error::UsageError(format!("Failed to convert parameter to BIT: {error}"))
+        })?))),
+        -6 => Ok(SqlType::TinyInt(Some(py_obj.extract::<u8>().map_err(
+            |error| Error::UsageError(format!("Failed to convert parameter to TINYINT: {error}")),
+        )?))),
+        5 => Ok(SqlType::SmallInt(Some(py_obj.extract::<i16>().map_err(
+            |error| Error::UsageError(format!("Failed to convert parameter to SMALLINT: {error}")),
+        )?))),
+        4 => Ok(SqlType::Int(Some(py_obj.extract::<i32>().map_err(
+            |error| Error::UsageError(format!("Failed to convert parameter to INT: {error}")),
+        )?))),
+        -5 => Ok(SqlType::BigInt(Some(py_obj.extract::<i64>().map_err(
+            |error| Error::UsageError(format!("Failed to convert parameter to BIGINT: {error}")),
+        )?))),
+        7 => Ok(SqlType::Real(Some(py_obj.extract::<f32>().map_err(
+            |error| Error::UsageError(format!("Failed to convert parameter to REAL: {error}")),
+        )?))),
+        6 | 8 => Ok(SqlType::Float(Some(py_obj.extract::<f64>().map_err(
+            |error| Error::UsageError(format!("Failed to convert parameter to FLOAT: {error}")),
+        )?))),
+        2 | 3 => hinted_decimal(py_obj, hint),
+        1 | 12 | -1 | -8 | -9 | -10 => hinted_string(py_obj, hint),
+        -4..=-2 => hinted_binary(py_obj, hint),
+        9 | 91 => match py_to_sql_type(py_obj)? {
+            SqlType::Date(value) => Ok(SqlType::Date(value)),
+            _ => Err(Error::UsageError("Expected a date parameter".to_string())),
+        },
+        10 | 92 | -154 => Ok(SqlType::Time(Some(py_time(py_obj, hint.scale.min(7))?))),
+        11 | 93 => match py_datetime_to_sql_type(py_obj)? {
+            SqlType::DateTime2(value) => Ok(SqlType::DateTime2(value)),
+            SqlType::DateTimeOffset(value) => Ok(SqlType::DateTime2(
+                value.map(|value| value.datetime2),
+            )),
+            _ => unreachable!("datetime conversion returns a temporal SQL type"),
+        },
+        -155 => match py_datetime_to_sql_type(py_obj)? {
+            SqlType::DateTimeOffset(value) => Ok(SqlType::DateTimeOffset(value)),
+            _ => Err(Error::UsageError(
+                "DATETIMEOFFSET requires a timezone-aware datetime".to_string(),
+            )),
+        },
+        -11 => match py_to_sql_type(py_obj)? {
+            SqlType::Uuid(value) => Ok(SqlType::Uuid(value)),
+            _ => Err(Error::UsageError("Expected a UUID parameter".to_string())),
+        },
+        -152 => {
+            let value = py_obj.extract::<String>().map_err(|error| {
+                Error::UsageError(format!("Failed to convert parameter to XML: {error}"))
+            })?;
+            Ok(SqlType::Xml(Some(SqlXml::from(value))))
+        }
+        241 => {
+            let value = py_obj.extract::<String>().map_err(|error| {
+                Error::UsageError(format!("Failed to convert parameter to XML: {error}"))
+            })?;
+            Ok(SqlType::Xml(Some(SqlXml::from(value))))
+        }
+        244 => hinted_json(py_obj),
+        245 => hinted_vector(py_obj, hint),
+        60 | 122 => hinted_money(py_obj, hint),
+        -150 => Ok(SqlType::Variant(Box::new(py_to_sql_type(py_obj)?))),
+        -151 => Err(Error::UsageError(
+            "SQL_SS_UDT parameters require a server UDT type name, which setinputsizes does not provide"
+                .to_string(),
+        )),
+        _ => unreachable!("ParameterHint validates SQL type constants"),
+    }
+}
+
+pub(crate) fn null_sql_type(hint: ParameterHint) -> TdsResult<SqlType> {
+    let size = hint.size.max(1);
+    Ok(match hint.sql_type {
+        -7 => SqlType::Bit(None),
+        -6 => SqlType::TinyInt(None),
+        5 => SqlType::SmallInt(None),
+        4 => SqlType::Int(None),
+        -5 => SqlType::BigInt(None),
+        7 => SqlType::Real(None),
+        6 | 8 => SqlType::Float(None),
+        2 => SqlType::Numeric(None),
+        3 => SqlType::Decimal(None),
+        1 => SqlType::Char(None, checked_length(size, 8_000, "CHAR")?),
+        12 => sized_varchar(None, size),
+        -1 => SqlType::VarcharMax(None),
+        -8 => SqlType::NChar(None, checked_length(size, 4_000, "NCHAR")?),
+        -9 => sized_nvarchar(None, size),
+        -10 => SqlType::NText(None),
+        -2 => SqlType::Binary(None, checked_length(size, 8_000, "BINARY")?),
+        -3 => sized_varbinary(None, size),
+        -4 | -151 => SqlType::VarBinaryMax(None),
+        9 | 91 => SqlType::Date(None),
+        10 | 92 | -154 => SqlType::Time(None),
+        11 | 93 => SqlType::DateTime2(None),
+        -155 => SqlType::DateTimeOffset(None),
+        -11 => SqlType::Uuid(None),
+        -152 | 241 => SqlType::Xml(None),
+        244 => SqlType::Json(None),
+        245 => {
+            if hint.size == 0 {
+                return Err(Error::UsageError(
+                    "A NULL VECTOR parameter requires its dimension count as the input size"
+                        .to_string(),
+                ));
+            }
+            SqlType::Vector(
+                None,
+                checked_length(hint.size, 1_998, "VECTOR")?,
+                mssql_tds::datatypes::sqldatatypes::VectorBaseType::Float32,
+            )
+        }
+        60 => SqlType::Money(None),
+        122 => SqlType::SmallMoney(None),
+        -150 => SqlType::Variant(Box::new(SqlType::NVarchar(None, 1))),
+        _ => unreachable!("ParameterHint validates SQL type constants"),
+    })
+}
+
+fn hinted_decimal(py_obj: &Bound<'_, PyAny>, hint: ParameterHint) -> TdsResult<SqlType> {
+    let precision = if hint.size == 0 { 18 } else { hint.size } as u8;
+    let value = py_obj
+        .str()
+        .and_then(|value| value.extract::<String>())
+        .map_err(|error| Error::UsageError(format!("Failed to convert numeric value: {error}")))?;
+    let parts = DecimalParts::from_string(&value, precision, hint.scale)?;
+    Ok(if hint.sql_type == 2 {
+        SqlType::Numeric(Some(parts))
+    } else {
+        SqlType::Decimal(Some(parts))
+    })
+}
+
+fn hinted_string(py_obj: &Bound<'_, PyAny>, hint: ParameterHint) -> TdsResult<SqlType> {
+    let value = py_obj.extract::<String>().map_err(|error| {
+        Error::UsageError(format!("Failed to convert parameter to string: {error}"))
+    })?;
+    let actual = if matches!(hint.sql_type, -10..=-8) {
+        value.encode_utf16().count() as u32
+    } else {
+        value.len() as u32
+    }
+    .max(1);
+    let size = hint.size.max(actual);
+    let value = Some(SqlString::from_utf8_string(value));
+    Ok(match hint.sql_type {
+        1 => SqlType::Char(value, checked_length(size, 8_000, "CHAR")?),
+        12 => sized_varchar(value, size),
+        -1 => SqlType::Text(value),
+        -8 => SqlType::NChar(value, checked_length(size, 4_000, "NCHAR")?),
+        -9 => sized_nvarchar(value, size),
+        -10 => SqlType::NText(value),
+        _ => unreachable!("hinted_string receives only string constants"),
+    })
+}
+
+fn hinted_binary(py_obj: &Bound<'_, PyAny>, hint: ParameterHint) -> TdsResult<SqlType> {
+    let value = py_obj.extract::<Vec<u8>>().map_err(|error| {
+        Error::UsageError(format!("Failed to convert parameter to binary: {error}"))
+    })?;
+    let size = hint.size.max(value.len() as u32).max(1);
+    Ok(match hint.sql_type {
+        -2 => SqlType::Binary(Some(value), checked_length(size, 8_000, "BINARY")?),
+        -3 => sized_varbinary(Some(value), size),
+        -4 => SqlType::VarBinaryMax(Some(value)),
+        _ => unreachable!("hinted_binary receives only binary constants"),
+    })
+}
+
+fn hinted_json(py_obj: &Bound<'_, PyAny>) -> TdsResult<SqlType> {
+    let value = PyModule::import(py_obj.py(), "json")
+        .and_then(|module| module.call_method1("dumps", (py_obj,)))
+        .and_then(|value| value.extract::<String>())
+        .map_err(|error| {
+            Error::UsageError(format!("Failed to serialize JSON parameter: {error}"))
+        })?;
+    Ok(SqlType::Json(Some(SqlJson::from(value))))
+}
+
+fn hinted_vector(py_obj: &Bound<'_, PyAny>, hint: ParameterHint) -> TdsResult<SqlType> {
+    let values = py_obj.extract::<Vec<f32>>().map_err(|error| {
+        Error::UsageError(format!("Failed to convert parameter to VECTOR: {error}"))
+    })?;
+    let vector = SqlVector::try_from_f32(values)?;
+    let dimensions = vector.dimension_count();
+    if hint.size != 0 && hint.size != u32::from(dimensions) {
+        return Err(Error::UsageError(format!(
+            "VECTOR input size {} does not match value dimension count {dimensions}",
+            hint.size
+        )));
+    }
+    Ok(SqlType::Vector(
+        Some(vector),
+        dimensions,
+        mssql_tds::datatypes::sqldatatypes::VectorBaseType::Float32,
+    ))
+}
+
+fn hinted_money(py_obj: &Bound<'_, PyAny>, hint: ParameterHint) -> TdsResult<SqlType> {
+    let decimal_class = PyModule::import(py_obj.py(), "decimal")
+        .and_then(|module| module.getattr("Decimal"))
+        .map_err(|error| Error::UsageError(format!("Failed to import Decimal: {error}")))?;
+    let value = py_obj
+        .str()
+        .map_err(|error| Error::UsageError(format!("Failed to read money value: {error}")))?;
+    let decimal = decimal_class
+        .call1((value,))
+        .map_err(|error| Error::UsageError(format!("Failed to convert money value: {error}")))?;
+    let quantizer = decimal_class
+        .call1(("0.0001",))
+        .map_err(|error| Error::UsageError(format!("Failed to create money scale: {error}")))?;
+    let scaled = decimal
+        .call_method1("quantize", (quantizer,))
+        .and_then(|value| value.call_method1("scaleb", (4,)))
+        .and_then(|value| value.call_method0("__int__"))
+        .and_then(|value| value.extract::<i64>())
+        .map_err(|error| Error::UsageError(format!("Failed to scale money value: {error}")))?;
+
+    if hint.sql_type == 122 {
+        let scaled = i32::try_from(scaled)
+            .map_err(|_| Error::UsageError("Value is outside the SMALLMONEY range".to_string()))?;
+        Ok(SqlType::SmallMoney(Some(SqlSmallMoney { int_val: scaled })))
+    } else {
+        Ok(SqlType::Money(Some(SqlMoney {
+            lsb_part: scaled as u32 as i32,
+            msb_part: (scaled >> 32) as i32,
+        })))
+    }
+}
+
+fn checked_length(size: u32, maximum: u32, type_name: &str) -> TdsResult<u16> {
+    if size > maximum {
+        return Err(Error::UsageError(format!(
+            "{type_name} size {size} exceeds the maximum {maximum}"
+        )));
+    }
+    Ok(size as u16)
+}
+
+fn sized_varchar(value: Option<SqlString>, size: u32) -> SqlType {
+    match u16::try_from(size) {
+        Ok(size) if size <= 8_000 => SqlType::Varchar(value, size),
+        _ => SqlType::VarcharMax(value),
+    }
+}
+
+fn sized_nvarchar(value: Option<SqlString>, size: u32) -> SqlType {
+    match u16::try_from(size) {
+        Ok(size) if size <= 4_000 => SqlType::NVarchar(value, size),
+        _ => SqlType::NVarcharMax(value),
+    }
+}
+
+fn sized_varbinary(value: Option<Vec<u8>>, size: u32) -> SqlType {
+    match u16::try_from(size) {
+        Ok(size) if size <= 8_000 => SqlType::VarBinary(value, size),
+        _ => SqlType::VarBinaryMax(value),
+    }
+}
+
+fn py_datetime_to_sql_type(py_obj: &Bound<'_, PyAny>) -> TdsResult<SqlType> {
+    let ordinal = py_obj
+        .call_method0("toordinal")
+        .and_then(|value| value.extract::<u32>())
+        .map_err(|error| Error::UsageError(format!("Failed to get datetime ordinal: {error}")))?;
+    let days = ordinal.checked_sub(1).ok_or_else(|| {
+        Error::UsageError("Date ordinal is 0, expected a value greater than 0".to_string())
+    })?;
+
+    let tzinfo = py_obj
+        .getattr("tzinfo")
+        .map_err(|error| Error::UsageError(format!("Failed to get datetime tzinfo: {error}")))?;
+    if tzinfo.is_none() {
+        return Ok(SqlType::DateTime2(Some(SqlDateTime2 {
+            days,
+            time: py_time(py_obj, 6)?,
+        })));
+    }
+
+    let offset = py_obj
+        .call_method0("utcoffset")
+        .map_err(|error| Error::UsageError(format!("Failed to get timezone offset: {error}")))?;
+    if offset.is_none() {
+        return Err(Error::UsageError(
+            "Timezone-aware datetime returned no UTC offset".to_string(),
+        ));
+    }
+    let offset_seconds = offset
+        .call_method0("total_seconds")
+        .and_then(|value| value.extract::<f64>())
+        .map_err(|error| {
+            Error::UsageError(format!("Failed to get timezone offset seconds: {error}"))
+        })?;
+    let offset_minutes = (offset_seconds / 60.0).round() as i16;
+    if !(-840..=840).contains(&offset_minutes) {
+        return Err(Error::UsageError(format!(
+            "Timezone offset {offset_minutes} minutes is outside the DATETIMEOFFSET range"
+        )));
+    }
+
+    Ok(SqlType::DateTimeOffset(Some(SqlDateTimeOffset {
+        datetime2: SqlDateTime2 {
+            days,
+            time: py_time(py_obj, 7)?,
+        },
+        offset: offset_minutes,
+    })))
+}
+
+fn py_time(py_obj: &Bound<'_, PyAny>, scale: u8) -> TdsResult<SqlTime> {
+    let component = |name: &str| {
+        py_obj
+            .getattr(name)
+            .and_then(|value| value.extract::<u64>())
+            .map_err(|error| Error::UsageError(format!("Failed to get {name}: {error}")))
+    };
+    let time_nanoseconds = component("hour")? * 36_000_000_000
+        + component("minute")? * 600_000_000
+        + component("second")? * 10_000_000
+        + component("microsecond")? * 10;
+    Ok(SqlTime {
+        time_nanoseconds,
+        scale,
+    })
+}
+
+fn is_decimal(py_obj: &Bound<'_, PyAny>) -> TdsResult<bool> {
+    let decimal = PyModule::import(py_obj.py(), "decimal")
+        .and_then(|module| module.getattr("Decimal"))
+        .map_err(|error| Error::UsageError(format!("Failed to import decimal.Decimal: {error}")))?;
+    py_obj
+        .is_instance(&decimal)
+        .map_err(|error| Error::UsageError(format!("Failed to inspect Decimal value: {error}")))
+}
+
+fn py_decimal_to_sql_type(py_obj: &Bound<'_, PyAny>) -> TdsResult<SqlType> {
+    let decimal_tuple = py_obj
+        .call_method0("as_tuple")
+        .map_err(|error| Error::UsageError(format!("Failed to inspect Decimal value: {error}")))?;
+    let digit_count = decimal_tuple
+        .getattr("digits")
+        .and_then(|digits| digits.len())
+        .map_err(|error| Error::UsageError(format!("Failed to inspect Decimal digits: {error}")))?;
+    let exponent = decimal_tuple
+        .getattr("exponent")
+        .and_then(|value| value.extract::<i64>())
+        .map_err(|_| {
+            Error::UsageError("NaN and infinite Decimal values are unsupported".to_string())
+        })?;
+    let precision = if exponent >= 0 {
+        digit_count.saturating_add(exponent as usize)
+    } else {
+        digit_count.max(exponent.unsigned_abs() as usize)
+    };
+    if precision == 0 || precision > 38 {
+        return Err(Error::UsageError(format!(
+            "Decimal precision {precision} is outside SQL Server's supported range of 1 to 38"
+        )));
+    }
+    let scale = exponent.saturating_neg() as usize;
+    if scale > 38 {
+        return Err(Error::UsageError(format!(
+            "Decimal scale {scale} exceeds SQL Server's maximum scale of 38"
+        )));
+    }
+    let value = py_obj
+        .call_method0("__str__")
+        .and_then(|value| value.extract::<String>())
+        .map_err(|error| Error::UsageError(format!("Failed to extract Decimal value: {error}")))?;
+    let value = DecimalParts::from_string(&value, precision as u8, scale as u8)?;
+    Ok(SqlType::Numeric(Some(value)))
 }
 
 /// Internal conversion function without validation.

--- a/mssql-py-core/tests/test_async_connection.py
+++ b/mssql-py-core/tests/test_async_connection.py
@@ -22,6 +22,12 @@ class RecordingLogger:
         self.messages.append(message)
 
 
+def test_async_connection_exposes_user_facing_docstrings():
+    assert "Do not cancel" in mssql_py_core.PyAsyncConnection.__doc__
+    assert "autocommit" in mssql_py_core.PyAsyncConnection.connect.__doc__
+    assert "Idempotent" in mssql_py_core.PyAsyncConnection.close.__doc__
+
+
 # ---------------------------------------------------------------------------
 # Preview warning
 # ---------------------------------------------------------------------------

--- a/mssql-py-core/tests/test_async_connection.py
+++ b/mssql-py-core/tests/test_async_connection.py
@@ -153,6 +153,9 @@ def test_connection_operations_reuse_connect_logger(client_context):
 
 @pytest.mark.integration
 def test_autocommit_defaults_false_and_can_be_enabled(client_context):
+    # TODO: When mode changes are supported, cover lazy begin, restart after
+    # commit/rollback, both mode transitions, context finalization, and
+    # cleanup-error precedence.
     async def run():
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", FutureWarning)

--- a/mssql-py-core/tests/test_async_cursor.py
+++ b/mssql-py-core/tests/test_async_cursor.py
@@ -5,6 +5,7 @@
 
 import asyncio
 import datetime
+import gc
 import uuid
 import warnings
 from decimal import Decimal
@@ -51,6 +52,9 @@ def test_execute_drains_same_cursor_previous_results(client_context):
 
 @pytest.mark.integration
 def test_execute_rejects_another_cursor_while_results_are_pending(client_context):
+    # TODO: Extend this to a multi-packet result, drain the first cursor to
+    # exhaustion, and verify the second cursor can then execute. Closing the
+    # first cursor is already covered by test_cursor_close_drains_results.
     async def run():
         conn = await connect(client_context)
         try:
@@ -212,6 +216,27 @@ def test_execute_rejects_parameter_style_and_arity_mismatches(
 
 
 @pytest.mark.integration
+@pytest.mark.parametrize(
+    ("operation", "message"),
+    [
+        ("SELECT ?", "1 parameter markers, but 0 parameters"),
+        ("SELECT %(value)s", "named placeholders"),
+    ],
+)
+def test_execute_rejects_markers_without_arguments(client_context, operation, message):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            with pytest.raises(TypeError, match=message):
+                cursor.execute(operation)
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
 def test_execute_accepts_empty_mapping_without_markers(client_context):
     async def run():
         conn = await connect(client_context)
@@ -276,7 +301,10 @@ def test_execute_rejects_unsupported_parameter_value(client_context):
         ([(999999, 0, 0)], "Invalid SQL type"),
         ([(4, 0, 0, 0)], "must contain"),  # SQL_INTEGER
         ([(3, 39, 0)], "precision/scale"),  # SQL_DECIMAL
+        ([(3, 2, 3)], "precision/scale"),
+        ([(3, 38, 39)], "precision/scale"),
         ([(3, 10, 11)], "precision/scale"),
+        ([(93, 0, 8)], "Invalid temporal scale"),  # SQL_TYPE_TIMESTAMP
     ],
 )
 def test_setinputsizes_rejects_invalid_hints(client_context, sizes, message):
@@ -389,7 +417,17 @@ def test_execute_infers_parameter_sql_type(
 
 @pytest.mark.integration
 @pytest.mark.parametrize("use_prepare", [True, False])
-def test_execute_infers_decimal_precision_and_scale(client_context, use_prepare):
+@pytest.mark.parametrize(
+    ("value", "precision", "scale"),
+    [
+        (Decimal("123.4500"), 7, 4),
+        (Decimal("1E+3"), 4, 0),
+        (Decimal("1E-3"), 3, 3),
+    ],
+)
+def test_execute_infers_decimal_precision_and_scale(
+    client_context, use_prepare, value, precision, scale
+):
     async def run():
         conn = await connect(client_context)
         try:
@@ -398,11 +436,13 @@ def test_execute_infers_decimal_precision_and_scale(client_context, use_prepare)
                 """
                 DECLARE @value sql_variant = CAST(? AS sql_variant)
                 IF SQL_VARIANT_PROPERTY(@value, 'BaseType') <> 'numeric'
-                    OR SQL_VARIANT_PROPERTY(@value, 'Precision') <> 7
-                    OR SQL_VARIANT_PROPERTY(@value, 'Scale') <> 4
+                    OR SQL_VARIANT_PROPERTY(@value, 'Precision') <> ?
+                    OR SQL_VARIANT_PROPERTY(@value, 'Scale') <> ?
                     THROW 50000, 'Unexpected decimal parameter metadata', 1
                 """,
-                Decimal("123.4500"),
+                value,
+                precision,
+                scale,
                 use_prepare=use_prepare,
             )
         finally:
@@ -413,7 +453,17 @@ def test_execute_infers_decimal_precision_and_scale(client_context, use_prepare)
 
 @pytest.mark.integration
 @pytest.mark.parametrize("use_prepare", [True, False])
-def test_execute_preserves_datetimeoffset(client_context, use_prepare):
+@pytest.mark.parametrize(
+    ("offset", "expected_minutes"),
+    [
+        (datetime.timedelta(hours=-14), -840),
+        (datetime.timedelta(hours=5, minutes=30), 330),
+        (datetime.timedelta(hours=14), 840),
+    ],
+)
+def test_execute_preserves_datetimeoffset(
+    client_context, use_prepare, offset, expected_minutes
+):
     async def run():
         conn = await connect(client_context)
         try:
@@ -426,16 +476,81 @@ def test_execute_preserves_datetimeoffset(client_context, use_prepare):
                 34,
                 56,
                 123456,
-                tzinfo=datetime.timezone(datetime.timedelta(hours=5, minutes=30)),
+                tzinfo=datetime.timezone(offset),
             )
             await cursor.execute(
-                """
-                IF DATEPART(TZOFFSET, CAST(? AS datetimeoffset)) <> 330
+                f"""
+                IF DATEPART(TZOFFSET, CAST(? AS datetimeoffset)) <> {expected_minutes}
                     THROW 50000, 'Unexpected datetime offset', 1
                 """,
                 value,
                 use_prepare=use_prepare,
             )
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("use_prepare", [True, False])
+@pytest.mark.parametrize("scale", [0, 3, 7])
+@pytest.mark.parametrize(
+    ("hint", "value", "expected_type"),
+    [
+        ((92, 0), datetime.time(12, 34, 56), "time"),
+        ((93, 0), datetime.datetime(2026, 8, 20, 12, 34, 56), "datetime2"),
+        (
+            (-155, 0),
+            datetime.datetime(
+                2026, 8, 20, 12, 34, 56, tzinfo=datetime.timezone.utc
+            ),
+            "datetimeoffset",
+        ),
+    ],
+)
+def test_setinputsizes_preserves_temporal_scale(
+    client_context, use_prepare, scale, hint, value, expected_type
+):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            cursor.setinputsizes([(hint[0], hint[1], scale)])
+            await cursor.execute(
+                f"""
+                DECLARE @value sql_variant = CAST(? AS sql_variant)
+                IF SQL_VARIANT_PROPERTY(@value, 'BaseType') <> '{expected_type}'
+                    OR SQL_VARIANT_PROPERTY(@value, 'Scale') <> {scale}
+                    THROW 50000, 'Unexpected temporal parameter metadata', 1
+                """,
+                value,
+                use_prepare=use_prepare,
+            )
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("use_prepare", [True, False])
+@pytest.mark.parametrize("offset_seconds", [30, -30])
+def test_execute_rejects_sub_minute_datetimeoffset(
+    client_context, use_prepare, offset_seconds
+):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            value = datetime.datetime(
+                2026,
+                8,
+                20,
+                tzinfo=datetime.timezone(datetime.timedelta(seconds=offset_seconds)),
+            )
+            with pytest.raises(RuntimeError, match="whole-minute UTC offset"):
+                await cursor.execute("SELECT ?", value, use_prepare=use_prepare)
         finally:
             await conn.close()
 
@@ -455,6 +570,83 @@ def test_setinputsizes_binds_typed_null(client_context, use_prepare):
                 None,
                 use_prepare=use_prepare,
             )
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("use_prepare", [True, False])
+def test_setinputsizes_uses_default_numeric_precision(client_context, use_prepare):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            cursor.setinputsizes([(3, 0, 2)])  # SQL_DECIMAL, default precision
+            await cursor.execute(
+                """
+                DECLARE @value sql_variant = CAST(? AS sql_variant)
+                IF SQL_VARIANT_PROPERTY(@value, 'BaseType') <> 'decimal'
+                    OR SQL_VARIANT_PROPERTY(@value, 'Precision') <> 18
+                    OR SQL_VARIANT_PROPERTY(@value, 'Scale') <> 2
+                    THROW 50000, 'Unexpected decimal parameter metadata', 1
+                """,
+                Decimal("1.23"),
+                use_prepare=use_prepare,
+            )
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("hint", "message"),
+    [
+        ((3, 9, 2), "require precision 18 and scale 10"),
+        ((92, 0, 3), "require scale 7"),
+        ((93, 0, 3), "require scale 7"),
+        ((-155, 0, 3), "require scale 7"),
+    ],
+)
+def test_setinputsizes_rejects_unrepresentable_typed_null_metadata(
+    client_context, hint, message
+):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            cursor.setinputsizes([hint])
+            with pytest.raises(TypeError, match=message):
+                cursor.execute("SELECT ?", None)
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("use_prepare", [True, False])
+@pytest.mark.parametrize(
+    "hint",
+    [
+        (3, 18, 10),
+        (92, 0, 7),
+        (93, 0, 7),
+        (-155, 0, 7),
+    ],
+)
+def test_setinputsizes_accepts_representable_typed_null_metadata(
+    client_context, use_prepare, hint
+):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            cursor.setinputsizes([hint])
+            await cursor.execute("SELECT ?", None, use_prepare=use_prepare)
         finally:
             await conn.close()
 
@@ -651,6 +843,8 @@ def test_execute_binds_table_valued_parameter(client_context, use_prepare, rows)
 
 @pytest.mark.integration
 def test_execute_reuses_prepared_statement_when_reset_cursor_is_false(client_context):
+    # The py-core unit test pins the state-reuse decision; mssql-tds separately
+    # asserts that a retained live handle emits sp_execute rather than sp_prepexec.
     async def run():
         conn = await connect(client_context)
         try:
@@ -693,6 +887,37 @@ def test_cursor_close_drains_results_and_rejects_further_use(client_context):
                 await cursor.execute("SELECT 1")
             with pytest.raises(RuntimeError, match="Cursor is closed"):
                 cursor.setinputsizes([(4, 0, 0)])
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_dropped_cursor_with_unread_rows_does_not_leave_connection_busy(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            await cursor.execute("SELECT CAST(? AS int)", 1)
+            del cursor
+            gc.collect()
+
+            for _ in range(100):
+                await asyncio.sleep(0.01)
+                probe = conn.cursor()
+                try:
+                    await probe.execute("SET NOCOUNT ON", use_prepare=False)
+                except RuntimeError as error:
+                    if "busy" in str(error).lower():
+                        continue
+                    assert "broken" in str(error).lower()
+                    break
+                else:
+                    await probe.close()
+                    break
+            else:
+                pytest.fail("Dropped cursor left the connection permanently busy")
         finally:
             await conn.close()
 

--- a/mssql-py-core/tests/test_async_cursor.py
+++ b/mssql-py-core/tests/test_async_cursor.py
@@ -106,8 +106,8 @@ def test_execute_binds_named_parameters(client_context):
             cursor = conn.cursor()
             assert (
                 await cursor.execute(
-                    "SELECT %(value)s, %(value)s",
-                    {"value": "named"},
+                    "SELECT N'東京', %(café)s, %(café)s",
+                    {"café": "named"},
                 )
                 is cursor
             )

--- a/mssql-py-core/tests/test_async_cursor.py
+++ b/mssql-py-core/tests/test_async_cursor.py
@@ -170,6 +170,21 @@ def test_execute_ignores_markers_in_quoted_contexts(client_context):
 
 
 @pytest.mark.integration
+def test_execute_ignores_markers_in_nested_block_comments(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            await conn.cursor().execute(
+                "SELECT ? /* outer /* inner */ ignored ? still outer */",
+                42,
+            )
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
 @pytest.mark.parametrize(
     ("operation", "parameters", "message"),
     [
@@ -276,6 +291,29 @@ def test_setinputsizes_survives_synchronous_binding_failure(client_context):
                 """
                 IF SQL_VARIANT_PROPERTY(CAST(? AS sql_variant), 'BaseType') <> 'nvarchar'
                     THROW 50000, 'Input size was consumed by failed binding', 1
+                """,
+                "ascii",
+            )
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_setinputsizes_survives_asynchronous_execution_failure(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            cursor.setinputsizes([(-9, 20, 0)])  # SQL_WVARCHAR
+            with pytest.raises(RuntimeError, match="expected failure"):
+                await cursor.execute("THROW 50000, 'expected failure', 1; SELECT ?", "ascii")
+
+            await cursor.execute(
+                """
+                IF SQL_VARIANT_PROPERTY(CAST(? AS sql_variant), 'BaseType') <> 'nvarchar'
+                    THROW 50000, 'Input size was consumed by failed execute', 1
                 """,
                 "ascii",
             )
@@ -557,6 +595,8 @@ def test_table_valued_parameter_surface_and_validation():
         )
     with pytest.raises(ValueError, match="must be 'TypeName' or 'schema.TypeName'"):
         mssql_py_core.TableValuedParameter("database.dbo.OrderLinesType")
+    with pytest.raises(ValueError, match="must not contain ']'"):
+        mssql_py_core.TableValuedParameter("dbo.Order]LinesType")
 
 
 @pytest.mark.integration
@@ -604,6 +644,22 @@ def test_execute_reuses_prepared_statement_when_reset_cursor_is_false(client_con
             sql = "SELECT CAST(? AS int)"
             await cursor.execute(sql, 1)
             assert await cursor.execute(sql, 2, reset_cursor=False) is cursor
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("reset_cursor", [True, False])
+def test_execute_reprepares_when_parameter_metadata_changes(client_context, reset_cursor):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            sql = "IF LEN(?) <> ? THROW 50000, 'parameter metadata was stale', 1"
+            await cursor.execute(sql, "a", 1, reset_cursor=reset_cursor)
+            await cursor.execute(sql, "abcdef", 6, reset_cursor=reset_cursor)
         finally:
             await conn.close()
 

--- a/mssql-py-core/tests/test_async_cursor.py
+++ b/mssql-py-core/tests/test_async_cursor.py
@@ -666,10 +666,50 @@ def test_execute_reprepares_when_parameter_metadata_changes(client_context, rese
     asyncio.run(run())
 
 
+@pytest.mark.integration
+def test_cursor_close_drains_results_and_rejects_further_use(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            await cursor.execute("SELECT CAST(? AS int)", 1)
+            assert await cursor.close() is None
+            assert await cursor.close() is None
+            with pytest.raises(RuntimeError, match="Cursor is closed"):
+                await cursor.execute("SELECT 1")
+            with pytest.raises(RuntimeError, match="Cursor is closed"):
+                cursor.setinputsizes([(4, 0, 0)])
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("transaction_method", ["commit", "rollback"])
+def test_transaction_operation_rejects_pending_cursor_results(
+    client_context, transaction_method
+):
+    async def run():
+        conn = await connect(client_context, autocommit=False)
+        try:
+            cursor = conn.cursor()
+            await cursor.execute("SELECT 1", use_prepare=False)
+            with pytest.raises(RuntimeError, match="busy with another operation"):
+                await getattr(conn, transaction_method)()
+            await cursor.close()
+            assert await getattr(conn, transaction_method)() is None
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
 def test_module_exposes_pyasynccursor():
     """PyAsyncCursor is registered on the extension module."""
     assert hasattr(mssql_py_core, "PyAsyncCursor")
     assert hasattr(mssql_py_core.PyAsyncCursor, "setinputsizes")
+    assert hasattr(mssql_py_core.PyAsyncCursor, "close")
     assert hasattr(mssql_py_core, "TableValuedParameter")
     assert mssql_py_core.SQL_XML == 241
     assert mssql_py_core.SQL_JSON == 244

--- a/mssql-py-core/tests/test_async_cursor.py
+++ b/mssql-py-core/tests/test_async_cursor.py
@@ -1,23 +1,623 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-"""Tests for PyAsyncCursor: class registration and creation via PyAsyncConnection.
-
-PyAsyncCursor is a preview scaffold in this PR — no execute/fetch methods yet.
-These tests validate the surface that exists today: class existence, cursor()
-creation, and closed-connection semantics.
-"""
+"""Tests for PyAsyncCursor registration, creation, and execution."""
 
 import asyncio
+import datetime
+import uuid
 import warnings
+from decimal import Decimal
 
 import pytest
 import mssql_py_core
 
 
+async def connect(client_context, *, autocommit=True):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        return await mssql_py_core.PyAsyncConnection.connect(
+            client_context, autocommit=autocommit
+        )
+
+
+@pytest.mark.integration
+def test_execute_returns_same_cursor(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            result = await cursor.execute("SET NOCOUNT ON")
+            assert result is cursor
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_execute_drains_same_cursor_previous_results(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            await cursor.execute("SELECT 1")
+            assert await cursor.execute("SET NOCOUNT ON") is cursor
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_execute_rejects_another_cursor_while_results_are_pending(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            first = conn.cursor()
+            second = conn.cursor()
+            await first.execute("SELECT 1")
+            with pytest.raises(RuntimeError, match="busy with another cursor"):
+                await second.execute("SELECT 2")
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_execute_after_connection_close_raises(client_context):
+    async def run():
+        conn = await connect(client_context)
+        cursor = conn.cursor()
+        await conn.close()
+        with pytest.raises(RuntimeError, match="Connection is closed"):
+            await cursor.execute("SELECT 1")
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("use_prepare", [True, False])
+def test_execute_binds_positional_parameters(client_context, use_prepare):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            assert (
+                await cursor.execute(
+                    "SELECT CAST(? AS int)",
+                    42,
+                    use_prepare=use_prepare,
+                )
+                is cursor
+            )
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_execute_binds_named_parameters(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            assert (
+                await cursor.execute(
+                    "SELECT %(value)s, %(value)s",
+                    {"value": "named"},
+                )
+                is cursor
+            )
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("container", [(10, 20), [10, 20]])
+def test_execute_unwraps_single_positional_container(client_context, container):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            await conn.cursor().execute(
+                "IF ? + ? <> 30 THROW 50000, 'Unexpected positional values', 1",
+                container,
+            )
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_execute_binds_bytearray_as_single_parameter(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            await conn.cursor().execute(
+                "IF ? <> 0x010203 THROW 50000, 'Unexpected binary value', 1",
+                bytearray([1, 2, 3]),
+            )
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_execute_ignores_markers_in_quoted_contexts(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            await conn.cursor().execute(
+                """
+                SELECT '?', [q?mark], "q?mark"
+                FROM (VALUES (CAST(%(value)s AS int))) AS source([q?mark])
+                WHERE source.[q?mark] = %(value)s -- ignored ?
+                  AND 'ignored %(value)s' = 'ignored %(value)s'
+                  /* ignored ? and %(value)s */
+                """,
+                {"value": 42},
+            )
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("operation", "parameters", "message"),
+    [
+        ("SELECT ?", {"value": 1}, "positional placeholders"),
+        ("SELECT %(value)s", (1,), "named placeholders"),
+        ("SELECT ?, ?", (1,), "2 parameter markers, but 1 parameters"),
+        ("SELECT ?", (1, 2), "1 parameter markers, but 2 parameters"),
+    ],
+)
+def test_execute_rejects_parameter_style_and_arity_mismatches(
+    client_context, operation, parameters, message
+):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            with pytest.raises(TypeError, match=message):
+                cursor.execute(operation, parameters)
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_execute_rejects_missing_named_parameter(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            with pytest.raises(KeyError, match="name"):
+                cursor.execute(
+                    "SELECT %(id)s, %(name)s",
+                    {"id": 1},
+                )
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_execute_ignores_extra_named_parameters(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            await conn.cursor().execute(
+                "IF %(value)s <> 42 THROW 50000, 'Unexpected named value', 1",
+                {"value": 42, "extra": "ignored"},
+            )
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_execute_rejects_unsupported_parameter_value(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            with pytest.raises(TypeError, match="Unsupported Python type"):
+                cursor.execute("SELECT ?", {1, 2, 3})
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("sizes", "message"),
+    [
+        ([(999999, 0, 0)], "Invalid SQL type"),
+        ([(4, 0, 0, 0)], "must contain"),  # SQL_INTEGER
+        ([(3, 39, 0)], "precision/scale"),  # SQL_DECIMAL
+        ([(3, 10, 11)], "precision/scale"),
+    ],
+)
+def test_setinputsizes_rejects_invalid_hints(client_context, sizes, message):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            with pytest.raises(ValueError, match=message):
+                conn.cursor().setinputsizes(sizes)
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_setinputsizes_survives_synchronous_binding_failure(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            cursor.setinputsizes([(-9, 20, 0)])  # SQL_WVARCHAR
+            with pytest.raises(TypeError, match="parameter markers"):
+                cursor.execute("SELECT ?, ?", "only one")
+
+            await cursor.execute(
+                """
+                IF SQL_VARIANT_PROPERTY(CAST(? AS sql_variant), 'BaseType') <> 'nvarchar'
+                    THROW 50000, 'Input size was consumed by failed binding', 1
+                """,
+                "ascii",
+            )
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("use_prepare", [True, False])
+@pytest.mark.parametrize(
+    ("value", "expected_type"),
+    [
+        (0, "tinyint"),
+        (-1, "smallint"),
+        (32768, "int"),
+        (2147483648, "bigint"),
+        ("ascii", "varchar"),
+        ("caf\u00e9", "nvarchar"),
+        (datetime.datetime(2026, 8, 20, 12, 34, 56, 123456), "datetime2"),
+        (
+            datetime.datetime(
+                2026,
+                8,
+                20,
+                12,
+                34,
+                56,
+                123456,
+                tzinfo=datetime.timezone(datetime.timedelta(hours=5, minutes=30)),
+            ),
+            "datetimeoffset",
+        ),
+        (datetime.time(12, 34, 56, 123456), "time"),
+    ],
+)
+def test_execute_infers_parameter_sql_type(
+    client_context, use_prepare, value, expected_type
+):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            await cursor.execute(
+                """
+                IF CONVERT(sysname, SQL_VARIANT_PROPERTY(CAST(? AS sql_variant), 'BaseType')) <> ?
+                    THROW 50000, 'Unexpected inferred parameter type', 1
+                """,
+                value,
+                expected_type,
+                use_prepare=use_prepare,
+            )
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("use_prepare", [True, False])
+def test_execute_infers_decimal_precision_and_scale(client_context, use_prepare):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            await cursor.execute(
+                """
+                DECLARE @value sql_variant = CAST(? AS sql_variant)
+                IF SQL_VARIANT_PROPERTY(@value, 'BaseType') <> 'numeric'
+                    OR SQL_VARIANT_PROPERTY(@value, 'Precision') <> 7
+                    OR SQL_VARIANT_PROPERTY(@value, 'Scale') <> 4
+                    THROW 50000, 'Unexpected decimal parameter metadata', 1
+                """,
+                Decimal("123.4500"),
+                use_prepare=use_prepare,
+            )
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("use_prepare", [True, False])
+def test_execute_preserves_datetimeoffset(client_context, use_prepare):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            value = datetime.datetime(
+                2026,
+                8,
+                20,
+                12,
+                34,
+                56,
+                123456,
+                tzinfo=datetime.timezone(datetime.timedelta(hours=5, minutes=30)),
+            )
+            await cursor.execute(
+                """
+                IF DATEPART(TZOFFSET, CAST(? AS datetimeoffset)) <> 330
+                    THROW 50000, 'Unexpected datetime offset', 1
+                """,
+                value,
+                use_prepare=use_prepare,
+            )
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("use_prepare", [True, False])
+def test_setinputsizes_binds_typed_null(client_context, use_prepare):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            cursor.setinputsizes([(-3, 100, 0)])  # SQL_VARBINARY
+            await cursor.execute(
+                "IF ? + 0x01 IS NOT NULL THROW 50000, 'Expected NULL', 1",
+                None,
+                use_prepare=use_prepare,
+            )
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("use_prepare", [True, False])
+def test_setinputsizes_is_consumed_after_successful_execute(client_context, use_prepare):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            cursor.setinputsizes([(-9, 20, 0)])  # SQL_WVARCHAR
+            await cursor.execute(
+                """
+                IF SQL_VARIANT_PROPERTY(CAST(? AS sql_variant), 'BaseType') <> 'nvarchar'
+                    THROW 50000, 'Expected hinted nvarchar', 1
+                """,
+                "ascii",
+                use_prepare=use_prepare,
+            )
+            await cursor.execute(
+                """
+                IF SQL_VARIANT_PROPERTY(CAST(? AS sql_variant), 'BaseType') <> 'varchar'
+                    THROW 50000, 'Expected inferred varchar', 1
+                """,
+                "ascii",
+                use_prepare=use_prepare,
+            )
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("use_prepare", [True, False])
+def test_setinputsizes_binds_xml(client_context, use_prepare):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            cursor.setinputsizes([mssql_py_core.SQL_XML])
+            await cursor.execute(
+                "DECLARE @value xml = ?; IF @value.exist('/root') <> 1 THROW 50000, 'Invalid XML', 1",
+                "<root />",
+                use_prepare=use_prepare,
+            )
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("use_prepare", [True, False])
+def test_setinputsizes_binds_json(client_context, use_prepare):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            cursor.setinputsizes([mssql_py_core.SQL_JSON])
+            await cursor.execute(
+                "IF JSON_VALUE(?, '$.answer') <> 42 THROW 50000, 'Invalid JSON', 1",
+                ({"answer": 42},),
+                use_prepare=use_prepare,
+            )
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("use_prepare", [True, False])
+def test_setinputsizes_binds_vector(client_context, use_prepare):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            cursor.setinputsizes(
+                [(mssql_py_core.SQL_VECTOR, 3, 0), (mssql_py_core.SQL_VECTOR, 3, 0)]
+            )
+            await cursor.execute(
+                "IF VECTOR_DISTANCE('euclidean', ?, ?) <> 0 THROW 50000, 'Invalid VECTOR', 1",
+                ([1.0, 2.0, 3.0], [1.0, 2.0, 3.0]),
+                use_prepare=use_prepare,
+            )
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("sql_type", "expected_type"),
+    [
+        (mssql_py_core.SQL_MONEY, "money"),
+        (mssql_py_core.SQL_SMALLMONEY, "smallmoney"),
+    ],
+)
+def test_setinputsizes_binds_money(client_context, sql_type, expected_type):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            cursor.setinputsizes([sql_type])
+            await cursor.execute(
+                """
+                IF SQL_VARIANT_PROPERTY(CAST(? AS sql_variant), 'BaseType') <> ?
+                    THROW 50000, 'Unexpected money type', 1
+                """,
+                Decimal("123.4500"),
+                expected_type,
+            )
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+def test_table_valued_parameter_surface_and_validation():
+    tvp = mssql_py_core.TableValuedParameter(
+        "dbo.OrderLinesType",
+        [(4, 0, 0), (-9, 50, 0)],
+        [(1, "first"), (2, None)],
+    )
+    assert tvp.schema == "dbo"
+    assert tvp.type_name == "OrderLinesType"
+    assert tvp.column_count == 2
+    assert tvp.row_count == 2
+    assert tvp.is_null is False
+
+    null_tvp = mssql_py_core.TableValuedParameter("dbo.OrderLinesType")
+    assert null_tvp.is_null is True
+    assert null_tvp.column_count == 0
+    assert null_tvp.row_count == 0
+
+    with pytest.raises(ValueError, match="requires column definitions"):
+        mssql_py_core.TableValuedParameter("dbo.OrderLinesType", rows=[(1,)])
+    with pytest.raises(ValueError, match="has 1 values but 2 columns"):
+        mssql_py_core.TableValuedParameter(
+            "dbo.OrderLinesType",
+            [(4, 0, 0), (-9, 50, 0)],
+            [(1,)],
+        )
+    with pytest.raises(ValueError, match="either in type_name or with schema"):
+        mssql_py_core.TableValuedParameter(
+            "dbo.OrderLinesType", schema="other_schema"
+        )
+    with pytest.raises(ValueError, match="must be 'TypeName' or 'schema.TypeName'"):
+        mssql_py_core.TableValuedParameter("database.dbo.OrderLinesType")
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("use_prepare", [True, False])
+@pytest.mark.parametrize("rows", [[(1, "first"), (2, "second")], [], None])
+def test_execute_binds_table_valued_parameter(client_context, use_prepare, rows):
+    async def run():
+        conn = await connect(client_context)
+        type_name = f"PyAsyncTvp_{uuid.uuid4().hex}"
+        qualified_type_name = f"dbo.{type_name}"
+        cursor = conn.cursor()
+        try:
+            await cursor.execute(
+                f"CREATE TYPE dbo.[{type_name}] AS TABLE (id INT, value NVARCHAR(50))"
+            )
+            tvp = mssql_py_core.TableValuedParameter(
+                qualified_type_name,
+                [(4, 0, 0), (-9, 50, 0)] if rows is not None else None,
+                rows,
+            )
+            expected_count = 0 if rows is None else len(rows)
+            await cursor.execute(
+                f"""
+                IF (SELECT COUNT(*) FROM ?) <> {expected_count}
+                    THROW 50000, 'Unexpected TVP row count', 1
+                """,
+                tvp,
+                use_prepare=use_prepare,
+            )
+        finally:
+            try:
+                await cursor.execute(f"DROP TYPE IF EXISTS dbo.[{type_name}]")
+            finally:
+                await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_execute_reuses_prepared_statement_when_reset_cursor_is_false(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            sql = "SELECT CAST(? AS int)"
+            await cursor.execute(sql, 1)
+            assert await cursor.execute(sql, 2, reset_cursor=False) is cursor
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
 def test_module_exposes_pyasynccursor():
     """PyAsyncCursor is registered on the extension module."""
     assert hasattr(mssql_py_core, "PyAsyncCursor")
+    assert hasattr(mssql_py_core.PyAsyncCursor, "setinputsizes")
+    assert hasattr(mssql_py_core, "TableValuedParameter")
+    assert mssql_py_core.SQL_XML == 241
+    assert mssql_py_core.SQL_JSON == 244
+    assert mssql_py_core.SQL_VECTOR == 245
 
 
 @pytest.mark.integration

--- a/mssql-py-core/tests/test_async_cursor.py
+++ b/mssql-py-core/tests/test_async_cursor.py
@@ -911,6 +911,21 @@ def test_cursor_close_drains_results_and_rejects_further_use(client_context):
 
 
 @pytest.mark.integration
+def test_cursor_close_after_connection_close_is_noop(client_context):
+    async def run():
+        conn = await connect(client_context)
+        cursor = conn.cursor()
+        await conn.close()
+
+        assert await cursor.close() is None
+        assert await cursor.close() is None
+        with pytest.raises(RuntimeError, match="Cursor is closed"):
+            await cursor.execute("SELECT 1")
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
 def test_dropped_cursor_with_unread_rows_does_not_leave_connection_busy(client_context):
     async def run():
         conn = await connect(client_context)

--- a/mssql-py-core/tests/test_async_cursor.py
+++ b/mssql-py-core/tests/test_async_cursor.py
@@ -730,6 +730,15 @@ def test_module_exposes_pyasynccursor():
     assert mssql_py_core.SQL_VECTOR == 245
 
 
+def test_async_api_exposes_user_facing_docstrings():
+    assert "only one cursor may own an active batch" in mssql_py_core.PyAsyncCursor.__doc__
+    assert "Positional parameters use `?` markers" in mssql_py_core.PyAsyncCursor.execute.__doc__
+    assert "consumed only after" in mssql_py_core.PyAsyncCursor.setinputsizes.__doc__
+    close_doc = " ".join(mssql_py_core.PyAsyncCursor.close.__doc__.split())
+    assert "Closing an already closed cursor is a no-op" in close_doc
+    assert "table-valued parameter" in mssql_py_core.TableValuedParameter.__doc__
+
+
 @pytest.mark.integration
 def test_conn_cursor_returns_pyasynccursor(client_context):
     """conn.cursor() is synchronous and returns a PyAsyncCursor instance."""

--- a/mssql-py-core/tests/test_async_cursor.py
+++ b/mssql-py-core/tests/test_async_cursor.py
@@ -190,6 +190,8 @@ def test_execute_ignores_markers_in_nested_block_comments(client_context):
     [
         ("SELECT ?", {"value": 1}, "positional placeholders"),
         ("SELECT %(value)s", (1,), "named placeholders"),
+        ("SELECT :value", {"value": 1}, "Named parameters use the %\\(name\\)s style"),
+        ("SELECT %s", {"value": 1}, "Named parameters use the %\\(name\\)s style"),
         ("SELECT ?, ?", (1,), "2 parameter markers, but 1 parameters"),
         ("SELECT ?", (1, 2), "1 parameter markers, but 2 parameters"),
     ],
@@ -203,6 +205,18 @@ def test_execute_rejects_parameter_style_and_arity_mismatches(
             cursor = conn.cursor()
             with pytest.raises(TypeError, match=message):
                 cursor.execute(operation, parameters)
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_execute_accepts_empty_mapping_without_markers(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            await conn.cursor().execute("SELECT 1", {})
         finally:
             await conn.close()
 

--- a/mssql-py-core/tests/test_async_cursor.py
+++ b/mssql-py-core/tests/test_async_cursor.py
@@ -367,6 +367,23 @@ def test_setinputsizes_survives_asynchronous_execution_failure(client_context):
 
 @pytest.mark.integration
 @pytest.mark.parametrize("use_prepare", [True, False])
+def test_setinputsizes_longvarchar_uses_varchar_max(client_context, use_prepare):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            statement = "DECLARE @length int = LEN(?)"
+            for value in ("value", None):
+                cursor.setinputsizes([(-1, 0, 0)])  # SQL_LONGVARCHAR
+                await cursor.execute(statement, value, use_prepare=use_prepare)
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("use_prepare", [True, False])
 @pytest.mark.parametrize(
     ("value", "expected_type"),
     [

--- a/mssql-py-core/tests/test_driver_info.py
+++ b/mssql-py-core/tests/test_driver_info.py
@@ -3,6 +3,16 @@
 
 """Tests for driver name and version information."""
 
+
+def test_dbapi_module_globals():
+    """Test the module's declared DB-API contract."""
+    import mssql_py_core
+
+    assert mssql_py_core.apilevel == "2.0"
+    assert mssql_py_core.threadsafety == 1
+    assert mssql_py_core.paramstyle == "qmark"
+
+
 def test_driver_version_parameter():
     """Test that driver_version parameter is accepted and stored."""
     import mssql_py_core


### PR DESCRIPTION
> ⚠️ **DO NOT MERGE / DO NOT REVIEW.** Throwaway branch used only to prove a CI fix for PR #340. It also contains PR #340's commits. It will be closed once the Linux x64 leg is confirmed green.

## Why this branch exists

This is a **CI validation experiment**, branched off `subrata-ms/AQE_PyCore_Cursor` (the head of PR #340, "[py-core] Async Execute Infrastructure"). It targets `main` only because the ADO "mssql-rs Pull request validation" policy is attached to `main`, so a PR targeting anything else would not trigger the pipeline.

Because it is branched off PR #340, its diff also contains all of PR #340's commits. **Only the last commit (`Link libpython for mssql-py-core unit tests`) is the actual subject of this experiment.**

## The failure being fixed

On the ADO validation pipeline, the **Build Linux (x64)** leg fails at the `Run Rust unit tests (mssql-py-core)` step, which runs `.pipeline/scripts/containerized-pycore-rust-test.sh` (`cargo llvm-cov nextest` inside `/workspace/mssql-py-core`):

```
rust-lld: error: undefined symbol: PyType_Type
rust-lld: error: undefined symbol: Py_IsInitialized
rust-lld: error: undefined symbol: PyGILState_Ensure
rust-lld: error: undefined symbol: PyUnicode_Type
collect2: error: ld returned 1 exit status
error: could not compile `mssql-py-core` (lib test)
```

### Root cause

`mssql-py-core/Cargo.toml` declared:

```toml
pyo3 = { version = "0.29.0", features = ["extension-module"] }
```

The `extension-module` feature intentionally suppresses linking against libpython, because a Python extension module resolves those symbols from the host interpreter at import time. That is correct for the shipped `.so`, but a `cargo test` unit-test binary is a **standalone executable** — nothing supplies those symbols, so linking fails.

The Linux ARM64 leg is green only because this step is excluded there by pipeline condition (`ne('${{ parameters.architecture }}', 'ARM64')` in `.pipeline/templates/build-template-container.yml`). So these Rust unit tests currently run on **no** leg.

## The fix

Mirrors the existing in-repo precedent from the sibling crate `mssql-mock-tds-py`, which already sets the feature at wheel-build time via maturin rather than hardcoding it in `Cargo.toml`.

**1. `mssql-py-core/Cargo.toml`** — drop the hardcoded feature so test binaries link libpython:

```toml
pyo3 = { version = "0.29.0" }
```

**2. `mssql-py-core/pyproject.toml`** — re-enable it for maturin wheel builds:

```toml
[tool.maturin]
features = ["pyo3/extension-module"]
```

`pyproject.toml` is the correct single place for this: no maturin invocation anywhere in the repo passes `--features` on the command line (checked `dev/test-python.sh`, `.pipeline/templates/build-python-wheels-template.yml`, `test-longhaul-template.yml`, `test-mssql-python-*-template.yml`, `containers/*.sh`).

**3. `.pipeline/scripts/containerized-python-test.sh`** — revert commit `cad10d3a`, which added `rustup component add rustc` to the Python test script. That change patched the wrong step and was a no-op (the ARM log shows `info: component rustc is up to date`).

## Additional change beyond the original plan

Linking alone was **not sufficient** — verified locally. Once the test binary links, two tests still fail at runtime:

```
async_parameters::tests::rejects_named_markers_with_positional_parameters
async_parameters::tests::rejects_positional_markers_with_named_parameters
```

```
panicked at pyo3-0.29.2/src/interpreter_lifecycle.rs:134:13:
The Python interpreter is not initialized and the `auto-initialize` feature is not enabled.
```

`rewrite_placeholders` returns `PyResult`, so its error is a `PyErr`, and these tests assert on `error.to_string()`. Formatting a `PyErr` requires a live interpreter. This reproduces under `cargo nextest` (the CI runner), so it would have left the Linux x64 leg red with a new error.

Fixed by scoping `auto-initialize` to dev-dependencies only:

```toml
[dev-dependencies]
pyo3 = { version = "0.29.0", features = ["auto-initialize"] }
```

Resolver v2 keeps dev-dependency features out of non-test builds, so the shipped cdylib/wheel is unaffected. Verified with `cargo tree`: `auto-initialize` appears in the test resolve and is absent from the `no-dev` (maturin/wheel) resolve.

## Local verification (Windows)

| Check | Result |
|---|---|
| `cargo test --lib --no-run` | Links and builds |
| `cargo nextest run --lib --frozen --no-fail-fast` | **188 passed, 1 skipped, 0 failed** |
| `cargo build --frozen --lib --features pyo3/extension-module` (maturin path) | Compiles clean |
| `cargo tree -e features,no-dev` | No `auto-initialize` leak into wheel build |
| `.\scripts\bfmt.ps1` | All formatting checks passed |
| `git status` | `Cargo.lock` unchanged — safe for CI's `--frozen` |

No `.rs` files were modified.
