### PR TITLE
Fix Linux test compilation after session recovery update

### DIFF
--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -6074,6 +6074,7 @@ mod tests {
             negotiated_settings,
             execution_context,
             client_context,
+            Vec::new(),
         );
         (client, fail)
     }


### PR DESCRIPTION
## Description

Pass an empty login session-state token list when constructing the failing capture test client. `TdsClient::new` gained this argument in #230, but this test-only call site was missed because it was added by #207, which merged shortly before 230, causing E0061 in the Linux x64 and ARM builds on `main`.

## Related Issues

https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47254
Fixes #355

## Testing

- `cargo bfmt`
- `cargo bclippy`
- `cargo test -p mssql-tds --lib --no-run`
- `cargo nextest run -p mssql-tds --lib --no-fail-fast` (1,777 passed)
- Full `cargo btest` against disposable SQL Server 2022: 2,920 passed; 28 environment/server-capability tests failed (Entra auth, certificate policy, and vector support)

## Breaking Changes / Migration Notes

None.

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [ ] `cargo btest` passes in the repository CI environment
- [x] New/changed functionality has tests
- [x] Public API changes are documented (not applicable)