### PR TITLE
Fix mssql-tds test compilation broken by semantic merge conflict on main

### DIFF
--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -6074,6 +6074,7 @@ mod tests {
             negotiated_settings,
             execution_context,
             client_context,
+            Vec::new(),
         );
         (client, fail)
     }


### PR DESCRIPTION
## Description

**`main` is currently red for every PR in the repo.** This is a one-line CI-unblocking hotfix; please review and merge promptly.

`origin/main` (`c09c6711`) does not compile its test targets, so any PR whose validation test-compiles `mssql-tds` fails regardless of that PR's own content.

### Root cause: semantic merge conflict

Two PRs that were each green in isolation:

| Commit | PR | Merged (UTC) | What it did |
|---|---|---|---|
| `6a122251` | #207 | Aug 21 01:52 | Added a new `#[cfg(test)]` helper `create_failing_capturing_client` that calls `TdsClient::new` with 4 arguments |
| `c09c6711` | #230 | Aug 21 16:42 | Changed `TdsClient::new` to take a 5th parameter `login_session_state_tokens: Vec<SessionStateToken>` and updated only the callsites present in its own tree |

Neither PR's validation ever saw the other's tree, so both passed and `main` broke at merge time. #230 correctly updated the near-identical twin helper `create_capturing_client` (~line 6049) but missed its sibling `create_failing_capturing_client` (~line 6072).

### Why `cargo build` passes but test targets fail

The stale callsite lives inside a `#[cfg(test)]` module, so it is only compiled by test-compiling targets. `cargo build` at `c09c6711` succeeds, while `cargo clippy --all-targets`, `cargo nextest`, and `cargo btest` all fail with:

```
error[E0061]: this function takes 5 arguments but 4 arguments were supplied
    --> mssql-tds\src\connection\tds_client.rs:6072:22
     | argument #5 of type `std::vec::Vec<token::tokens::SessionStateToken>` is missing
note: associated function defined here
    --> mssql-tds\src\connection\tds_client.rs:379:19
error: could not compile `mssql-tds` (lib test) due to 1 previous error
```

This is why build-only CI legs are green while every test leg is red — which makes the breakage easy to misattribute to the PR under test rather than to `main`.

### The change

Exactly one line added, matching the convention already used by the two working callsites at ~line 5904 and ~line 6049:

```diff
@@ -6074,6 +6074,7 @@ mod tests {
             negotiated_settings,
             execution_context,
             client_context,
+            Vec::new(),
         );
         (client, fail)
     }
```

No signature changes, no refactors, no drive-by cleanups.

## Related Issues

Fixes #355

## Validation

Reproduced the failure on the unfixed tree first, then verified the fix locally on Windows.

| Command | Result |
|---|---|
| `cargo bclippy` (before fix) | **FAIL** — reproduced `E0061` / `could not compile mssql-tds (lib test)` |
| `cargo bfmt` | **PASS** — exit 0, no formatting diff |
| `cargo bclippy` (after fix) | **PASS** — exit 0, zero warnings, `Finished dev profile in 43.38s` |
| `cargo nextest run -p mssql-tds --lib --frozen --no-fail-fast` | **PASS** — `Summary [27.593s] 1868 tests run: 1868 passed, 0 skipped`, exit 0 |

The lib test target compiles again and the full `mssql-tds` lib suite is green.

<details>
<summary>Note on the first test run</summary>

An initial run reported 7 failures in `connection::transport::certificate_validator::tests` and `connection::transport::win_tls::validate::tests`. Those were purely environmental: the TLS fixtures (`valid_cert.pem` / `valid_cert.der`) are generated by `mssql-tds/tests/test_certificates/generate_certs.sh` and are gitignored (`*.pem`), so they did not exist in this fresh worktree. The failures were `CertificateNotFound { path: "tests/test_certificates/valid_cert.pem" }` and `read der fixture: NotFound`. After running the generator, all 1868 tests pass. Unrelated to this change.

</details>

`Cargo.lock` is gitignored in this repo and is not part of this change.

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [ ] `cargo btest` passes — intentionally skipped; the full coverage sweep is unnecessary for a one-line test-helper fix. Targeted `cargo nextest run -p mssql-tds --lib` was run instead and is fully green (see above).
- [x] New/changed functionality has tests — n/a, this repairs an existing test helper
- [x] Public API changes are documented — n/a, no public API change
