### PR TITLE
Remove PLP chunk-count cap that limited LOB reads to ~763 MB

### DIFF
--- a/mssql-tds/src/datatypes/decoder.rs
+++ b/mssql-tds/src/datatypes/decoder.rs
@@ -297,7 +297,6 @@ pub(crate) struct PlpChunkStreamReader {
     chunk_remaining: usize,
     reached_end: bool,
     total_read: usize,
-    chunks_seen: u32,
 }
 
 #[cfg_attr(not(test), allow(dead_code))]
@@ -308,7 +307,6 @@ impl PlpChunkStreamReader {
             chunk_remaining: 0,
             reached_end: false,
             total_read: 0,
-            chunks_seen: 0,
         }
     }
 
@@ -383,15 +381,6 @@ impl PlpChunkStreamReader {
                 )));
             }
             return Ok(false);
-        }
-
-        self.chunks_seen += 1;
-        if self.chunks_seen > GenericDecoder::MAX_PLP_CHUNKS {
-            return Err(crate::error::Error::ProtocolError(format!(
-                "Too many PLP chunks: {} (max {})",
-                self.chunks_seen,
-                GenericDecoder::MAX_PLP_CHUNKS
-            )));
         }
 
         if chunk_len > GenericDecoder::MAX_PLP_CHUNK_SIZE {
@@ -612,10 +601,6 @@ impl GenericDecoder {
     const SQL_PLP_UNKNOWNLEN: usize = 0xfffffffffffffffe;
     #[cfg_attr(not(test), allow(dead_code))]
     const SQL_PLP_MAXLEN: usize = 0xfffffffffffffffd;
-    #[cfg(fuzzing)]
-    const MAX_PLP_CHUNKS: u32 = 1000;
-    #[cfg(not(fuzzing))]
-    const MAX_PLP_CHUNKS: u32 = 100000;
     #[cfg(fuzzing)]
     const MAX_PLP_CHUNK_SIZE: usize = 8 * 1024;
     #[cfg(not(fuzzing))]
@@ -1192,19 +1177,19 @@ impl GenericDecoder {
         let mut vector_capacity: usize = 0;
         let mut chunk_len = read_sync_first!(reader, try_read_uint32, read_uint32) as usize;
         let mut offset: usize = 0;
+        #[cfg(fuzzing)]
         let mut chunk_count = 0u32;
 
         while chunk_len > 0 {
-            chunk_count += 1;
-
             #[cfg(fuzzing)]
             {
+                chunk_count += 1;
                 eprintln!(
                     "[ALLOC] read_plp_chunks_unknown_len: chunk #{chunk_count}, chunk_len={chunk_len}, total_capacity={vector_capacity}"
                 );
             }
 
-            Self::check_plp_chunk(chunk_count, chunk_len)?;
+            Self::check_plp_chunk(chunk_len)?;
 
             // Use checked_add to prevent capacity overflow
             vector_capacity = vector_capacity.checked_add(chunk_len).ok_or_else(|| {
@@ -1229,15 +1214,17 @@ impl GenericDecoder {
         Ok(plp_buffer)
     }
 
-    /// Validates a PLP chunk header against the per-value chunk limits.
-    fn check_plp_chunk(chunk_count: u32, chunk_len: usize) -> TdsResult<()> {
-        if chunk_count > Self::MAX_PLP_CHUNKS {
-            return Err(crate::error::Error::ProtocolError(format!(
-                "Too many PLP chunks: {chunk_count} (max {})",
-                Self::MAX_PLP_CHUNKS
-            )));
-        }
-
+    /// Validates a PLP chunk header against the per-chunk size limit.
+    ///
+    /// There is deliberately no cap on the *number* of chunks. Every PLP loop
+    /// consumes a strictly positive `chunk_len` per iteration and is bounded by
+    /// a total-byte check (`MAX_PLP_SIZE`, the wire-declared length, or the
+    /// destination slice), so the work a peer can induce is already
+    /// proportional to the bytes it actually sends. A chunk *count* limit adds
+    /// no protection and silently caps the value size a client can read: SQL
+    /// Server emits `varbinary(max)` in 8000-byte chunks, so a 100 000-chunk
+    /// cap rejected any LOB above ~763 MB even though the protocol allows 2 GB.
+    fn check_plp_chunk(chunk_len: usize) -> TdsResult<()> {
         // Limit individual chunk size
         if chunk_len > Self::MAX_PLP_CHUNK_SIZE {
             return Err(crate::error::Error::ProtocolError(format!(
@@ -1289,16 +1276,19 @@ impl GenericDecoder {
     {
         let mut chunk_len = read_sync_first!(reader, try_read_uint32, read_uint32) as usize;
         let mut offset: usize = 0;
+        #[cfg(fuzzing)]
         let mut chunk_count = 0u32;
 
         while chunk_len > 0 {
-            chunk_count += 1;
             #[cfg(fuzzing)]
-            eprintln!(
-                "[ALLOC] read_plp_chunks_into_slice: chunk #{chunk_count}, chunk_len={chunk_len}, wire_declared_len={declared_len}, destination_len={}",
-                dest.len()
-            );
-            Self::check_plp_chunk(chunk_count, chunk_len)?;
+            {
+                chunk_count += 1;
+                eprintln!(
+                    "[ALLOC] read_plp_chunks_into_slice: chunk #{chunk_count}, chunk_len={chunk_len}, wire_declared_len={declared_len}, destination_len={}",
+                    dest.len()
+                );
+            }
+            Self::check_plp_chunk(chunk_len)?;
 
             let end_offset = offset.checked_add(chunk_len).ok_or_else(|| {
                 crate::error::Error::ProtocolError(format!(
@@ -4558,23 +4548,33 @@ mod test {
             );
         }
 
+        /// The chunk *count* cap that used to live here was removed: it was a
+        /// fuzz-only tripwire that leaked into production builds and silently
+        /// capped readable LOB size. Streaming many small chunks must now
+        /// succeed — the stream is bounded by bytes, not by chunk count.
+        #[cfg(not(fuzzing))]
         #[tokio::test]
-        async fn plp_chunk_stream_reader_chunk_count_limit_errors() {
-            let mut stream = PlpChunkStreamReader {
-                length: PlpChunkReadLength::Unknown,
-                chunk_remaining: 0,
-                reached_end: false,
-                total_read: 0,
-                chunks_seen: GenericDecoder::MAX_PLP_CHUNKS,
-            };
-            let mut reader = ByteReader::new(vec![1, 0, 0, 0]);
-            let mut out = [0u8; 1];
+        async fn plp_chunk_stream_reader_accepts_more_chunks_than_the_removed_count_cap() {
+            let mut reader = ByteReader::new(unknown_len_plp_wire(REMOVED_MAX_PLP_CHUNKS + 1));
+            let mut stream = PlpChunkStreamReader::begin(&mut reader)
+                .await
+                .expect("begin")
+                .expect("not null");
 
-            let err = stream.read_into(&mut reader, &mut out).await.unwrap_err();
-            assert!(
-                err.to_string().contains("Too many PLP chunks"),
-                "unexpected error: {err}"
-            );
+            let mut total = 0usize;
+            let mut out = [0u8; 1];
+            loop {
+                let read = stream.read_into(&mut reader, &mut out).await.expect(
+                    "streaming past the removed chunk-count cap must not fail: a chunk count \
+                     limit rejects large LOBs that the protocol allows",
+                );
+                if read == 0 {
+                    break;
+                }
+                total += read;
+            }
+
+            assert_eq!(total, REMOVED_MAX_PLP_CHUNKS + 1);
         }
 
         #[tokio::test]
@@ -4584,7 +4584,6 @@ mod test {
                 chunk_remaining: 0,
                 reached_end: false,
                 total_read: MAX_PLP_SIZE,
-                chunks_seen: 0,
             };
             let mut reader = ByteReader::new(vec![1, 0, 0, 0]);
             let mut out = [0u8; 1];
@@ -4612,6 +4611,74 @@ mod test {
                     .contains("exceeds maximum allowed chunk size"),
                 "unexpected error: {err}"
             );
+        }
+
+        /// The chunk-count cap that used to bound every PLP read. It was
+        /// introduced as a `#[cfg(fuzzing)]`-only tripwire, then hoisted into
+        /// production builds by a commit titled "Fix clippy warnings". SQL
+        /// Server emits `varbinary(max)` in 8000-byte chunks, so this cap
+        /// rejected any LOB above ~763 MB with "Too many PLP chunks" even
+        /// though TDS allows 2 GB. It is gone; these tests keep it gone.
+        #[cfg(not(fuzzing))]
+        const REMOVED_MAX_PLP_CHUNKS: usize = 100_000;
+
+        /// Builds an unknown-length PLP value made of `chunks` single-byte
+        /// chunks, terminated by the zero-length chunk.
+        #[cfg(not(fuzzing))]
+        fn unknown_len_plp_wire(chunks: usize) -> Vec<u8> {
+            let mut buf = Vec::with_capacity(8 + chunks * 5 + 4);
+            buf.extend_from_slice(&0xFFFFFFFFFFFFFFFEu64.to_le_bytes());
+            for i in 0..chunks {
+                buf.extend_from_slice(&1u32.to_le_bytes());
+                buf.push(i as u8);
+            }
+            buf.extend_from_slice(&0u32.to_le_bytes());
+            buf
+        }
+
+        /// Unknown-length path: a value split into more chunks than the removed
+        /// cap allowed must decode, not error.
+        #[cfg(not(fuzzing))]
+        #[tokio::test]
+        async fn read_plp_bytes_accepts_more_chunks_than_the_removed_count_cap() {
+            let chunks = REMOVED_MAX_PLP_CHUNKS + 1;
+            let mut reader = ByteReader::new(unknown_len_plp_wire(chunks));
+
+            let value = GenericDecoder::read_plp_bytes(&mut reader)
+                .await
+                .expect(
+                    "a PLP value split into more chunks than the removed cap must decode: \
+                     rejecting it caps readable LOB size far below the 2 GB the protocol allows",
+                )
+                .expect("not null");
+
+            assert_eq!(value.len(), chunks);
+            assert_eq!(value[0], 0);
+            assert_eq!(value[chunks - 1], ((chunks - 1) % 256) as u8);
+        }
+
+        /// Known-length path (`read_plp_chunks_into_slice`) carried the same
+        /// cap and needs the same guarantee.
+        #[cfg(not(fuzzing))]
+        #[tokio::test]
+        async fn read_plp_bytes_accepts_many_chunks_for_a_known_length_value() {
+            let chunks = REMOVED_MAX_PLP_CHUNKS + 1;
+            let mut buf = Vec::with_capacity(8 + chunks * 5 + 4);
+            buf.extend_from_slice(&(chunks as u64).to_le_bytes());
+            for i in 0..chunks {
+                buf.extend_from_slice(&1u32.to_le_bytes());
+                buf.push(i as u8);
+            }
+            buf.extend_from_slice(&0u32.to_le_bytes());
+
+            let mut reader = ByteReader::new(buf);
+            let value = GenericDecoder::read_plp_bytes(&mut reader)
+                .await
+                .expect("known-length PLP value with many chunks must decode")
+                .expect("not null");
+
+            assert_eq!(value.len(), chunks);
+            assert_eq!(value[chunks - 1], ((chunks - 1) % 256) as u8);
         }
 
         #[tokio::test]

--- a/mssql-tds/tests/test_large_value_read.rs
+++ b/mssql-tds/tests/test_large_value_read.rs
@@ -1,0 +1,129 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Live-server coverage for reading very large `varbinary(max)` values.
+//!
+//! These complement the unit tests in `datatypes::decoder`: they prove the
+//! chunk framing works against a real SQL Server, which emits `varbinary(max)`
+//! in 8000-byte PLP chunks. A 2 GB value therefore arrives as ~268 000 chunks,
+//! which the removed `MAX_PLP_CHUNKS` cap of 100 000 rejected outright.
+//!
+//! They are `#[ignore]`d because they move gigabytes and take minutes. Run them
+//! explicitly against a configured server:
+//!
+//! ```text
+//! cargo nextest run --release -p mssql-tds --test test_large_value_read --run-ignored all
+//! ```
+
+mod common;
+
+use std::time::Instant;
+
+use mssql_tds::connection::tds_client::{ExecuteOptions, ResultSet, TdsClient};
+use mssql_tds::datatypes::column_values::ColumnValues;
+
+/// T-SQL producing a single `varbinary(max)` value of exactly `bytes` bytes.
+fn large_varbinary_query(bytes: usize) -> String {
+    format!("SELECT CONVERT(varbinary(max), REPLICATE(CONVERT(varchar(max), 'a'), {bytes}))")
+}
+
+/// Reads the single-column, single-row result and returns its byte length.
+async fn read_single_large_value(client: &mut TdsClient) -> Result<usize, String> {
+    let mut length = None;
+    while let Some(row) = client.next_row().await.map_err(|e| e.to_string())? {
+        match row.first() {
+            Some(ColumnValues::Bytes(bytes)) => length = Some(bytes.len()),
+            Some(other) => return Err(format!("unexpected column value: {other:?}")),
+            None => return Err("row had no columns".to_string()),
+        }
+    }
+    client.close_query().await.map_err(|e| e.to_string())?;
+    length.ok_or_else(|| "result set produced no rows".to_string())
+}
+
+/// Connects, runs one sized query, and returns the byte count read.
+async fn probe_size(bytes: usize) -> Result<usize, String> {
+    let mut client = common::create_client(&common::build_tcp_datasource())
+        .await
+        .map_err(|e| e.to_string())?;
+
+    client
+        .execute(
+            large_varbinary_query(bytes),
+            ExecuteOptions::new().timeout_secs(0),
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+
+    read_single_large_value(&mut client).await
+}
+
+/// Walks `varbinary(max)` sizes upward. Every size below SQL Server's own 2 GB
+/// limit must be readable — the driver must not impose a lower ceiling.
+///
+/// Before the chunk-count cap was removed this failed at 768 MB with
+/// "Too many PLP chunks: 100001 (max 100000)".
+#[tokio::test]
+#[ignore = "moves ~2.7 GB against a live server"]
+async fn large_varbinary_sizes_are_readable_up_to_the_server_limit() {
+    common::init_tracing();
+
+    const MB: usize = 1024 * 1024;
+    let sizes = [
+        MB,
+        16 * MB,
+        64 * MB,
+        256 * MB,
+        512 * MB,
+        768 * MB,
+        1024 * MB,
+    ];
+
+    let mut first_failure = None;
+    for size in sizes {
+        let started = Instant::now();
+        match probe_size(size).await {
+            Ok(read) => {
+                println!(
+                    "{:>6} MB: read {read} bytes in {:?}",
+                    size / MB,
+                    started.elapsed()
+                );
+                assert_eq!(read, size, "short read at {} MB", size / MB);
+            }
+            Err(error) => {
+                println!(
+                    "{:>6} MB: FAILED after {:?}: {error}",
+                    size / MB,
+                    started.elapsed()
+                );
+                first_failure.get_or_insert((size, error));
+            }
+        }
+    }
+
+    if let Some((size, error)) = first_failure {
+        panic!(
+            "a {} MB varbinary(max) is well within SQL Server's 2 GB limit but the driver \
+             refused it: {error}",
+            size / MB
+        );
+    }
+}
+
+/// The 2 GB case from the original hang report. `varbinary(max)` tops out at
+/// 2 147 483 647 bytes on the server, so this is the largest single value TDS
+/// can carry.
+#[tokio::test]
+#[ignore = "moves 2 GB against a live server and buffers it client-side"]
+async fn two_gigabyte_varbinary_is_readable() {
+    common::init_tracing();
+
+    let started = Instant::now();
+    let read = probe_size(i32::MAX as usize)
+        .await
+        .unwrap_or_else(|error| panic!("2 GB varbinary(max) read failed: {error}"));
+
+    println!("2 GB: read {read} bytes in {:?}", started.elapsed());
+    assert_eq!(read, i32::MAX as usize);
+}


### PR DESCRIPTION
## Description

Removes `MAX_PLP_CHUNKS`, which capped a PLP value at 100 000 chunks. SQL Server emits `varbinary(max)` in **8000-byte** chunks on the wire, so this was an effective hard ceiling of ~763 MB on any LOB read — well below the 2 GB TDS allows. Larger values failed with `Protocol Error: Too many PLP chunks: 100001 (max 100000)`.

Because the cap fires *mid-value* while the server is still streaming, it also left the reader desynchronized inside the LOB payload and the batch permanently open, so the connection could not be recovered (`close_query()` → `Unknown token type: 0x61`, then every call → `open batch` usage error). That is what the original "hangs / becomes unresponsive on a 2 GB read" report looked like from the application side.

### Why the cap was safe to remove

It was never a considered production limit. It was introduced in `b275cea3` as a `#[cfg(fuzzing)]`-only tripwire, then hoisted into production builds seven minutes later by `849c6168` ("Fix clippy warnings" → *"Move PLP chunk count validation outside fuzzing-only block"*). `c19d2dde` (#109) later replicated it into the streaming reader.

It is also redundant. All three PLP loops consume a strictly positive `chunk_len` per iteration and are each already bounded by a total-byte check:

| loop | existing bound |
|---|---|
| `read_plp_chunks_unknown_len` | `vector_capacity > MAX_PLP_SIZE` |
| `read_plp_chunks_into_slice` | `end_offset > declared_len \|\| end_offset > dest.len()` |
| `PlpChunkStreamReader::ensure_active_chunk` | `next_total > MAX_PLP_SIZE` |

Induced work is therefore already proportional to bytes actually sent. The byte-based limits are untouched: `MAX_PLP_CHUNK_SIZE` (16 MB) still bounds any single allocation and `MAX_PLP_SIZE` (2 GB) still bounds the total — which is what the original OOM hardening in `b275cea3` was actually protecting.

`chunks_seen` is dropped from `PlpChunkStreamReader`, and the fuzzing-only `chunk_count` diagnostic counters are now `#[cfg(fuzzing)]`-scoped alongside the `eprintln!` they feed.

## Tests

**Unit tests** (`mssql-tds/src/datatypes/decoder.rs`) — three new tests drive `100_001` single-byte chunks through each affected path and assert the value decodes:

- `read_plp_bytes_accepts_more_chunks_than_the_removed_count_cap` (unknown-length)
- `read_plp_bytes_accepts_many_chunks_for_a_known_length_value` (known-length)
- `plp_chunk_stream_reader_accepts_more_chunks_than_the_removed_count_cap` (streaming)

`plp_chunk_stream_reader_chunk_count_limit_errors` is replaced by the streaming test above. The tests that assert the byte-based limits still fire (`..._accumulated_size_limit_errors`, `read_plp_bytes_rejects_oversized_chunk_in_existing_path`) are unchanged and still pass.

**Integration tests** (`mssql-tds/tests/test_large_value_read.rs`, new, `#[ignore]`d — they move gigabytes):

- `large_varbinary_sizes_are_readable_up_to_the_server_limit`
- `two_gigabyte_varbinary_is_readable`

Verified against SQL Server 2022 (16.0.4252.3):

| size | before | after |
|---|---|---|
| 512 MB | OK — 7.4 s | OK — 7.4 s |
| 768 MB | ❌ `Too many PLP chunks` | OK — 11.0 s |
| 1 GB | ❌ `Too many PLP chunks` | OK — 17.4 s |
| 2 GB | ❌ `Too many PLP chunks` | OK — **2 147 483 647 bytes in 31.8 s** |

## Related Issues

Fixes #358

Overlaps the first bullet of #258 (extract a shared `PlpChunkValidator`) — that cleanup should now drop `chunks_seen` rather than preserve it.

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes — 1863/1870 `mssql-tds` unit tests pass; the 7 failures are pre-existing expired-test-certificate failures in `certificate_validator` / `win_tls::validate`, confirmed identical on a clean tree
- [x] New/changed functionality has tests
- [x] Public API changes are documented — no public API change (`MAX_PLP_CHUNKS` was a private associated const)