### PR TITLE
Vendor OpenSSL for the fuzz build to survive apt mirror outages

### DIFF
--- a/mssql-tds/fuzz/Cargo.toml
+++ b/mssql-tds/fuzz/Cargo.toml
@@ -14,6 +14,17 @@ tokio = { version = "1.45.1", features = ["full"] }
 arbitrary = { version = "1.3", features = ["derive"] }
 async-trait = "0.1"
 
+# Build OpenSSL from vendored source for the fuzz targets instead of linking the
+# system library. mssql-tds pulls in openssl-sys on Linux (via native-tls and the
+# direct `openssl` dependency), which normally needs `libssl-dev` + `pkg-config`
+# from apt. Scheduled fuzz runs were failing to compile openssl-sys whenever the
+# Ubuntu apt mirror was transiently unreachable and those packages couldn't be
+# installed. Vendoring makes the fuzz build self-contained (only a C compiler and
+# perl are required, both present on the CI image) so a flaky mirror no longer
+# breaks fuzzing. Scoped to the fuzz crate; the shipped library build is unchanged.
+[target.'cfg(all(not(windows), not(target_os = "macos")))'.dependencies]
+openssl = { version = "0.10.66", features = ["vendored"] }
+
 # Prevent this from interfering with workspaces
 [workspace]
 members = ["."]


### PR DESCRIPTION
## Summary

The scheduled **GH-Rust Fuzz Test** pipeline (ADO definitionId 2207) had failing runs on 2026-08-19 (builds **167989**, **168079**, **168173**) that were **not** fuzz crashes. They failed because the Linux dependency install (`scripts/install-deps.sh`) could not reach the Ubuntu apt mirror (`azure.archive.ubuntu.com`, connection timed out) across all 5 retries, so `pkg-config` and `libssl-dev` were never installed. `mssql-tds` links system OpenSSL on Linux (via `native-tls` and a direct `openssl` dependency), so `openssl-sys 0.9.117` failed to build and the fuzz target binaries never compiled.

Evidence from build 167989 (`Run Fuzzer` step):

```
cargo:warning=Could not find directory of OpenSSL installation ...
... `libssl-dev` on Ubuntu ...
... requires the `pkg-config` utility ... `pkg-config` could not be found.
openssl-sys = 0.9.117
Error: failed to build fuzz script: ... "cargo" "build" ... "--bin" "fuzz_tds_client"
No artifacts directory found
```

`FuzzCrashesFound` was `false` on every run and "Prepare Crash Artifacts" was skipped, so no crash artifact was produced — libFuzzer never ran because the harness didn't compile.

## Change

Build OpenSSL from **vendored source** for the fuzz crate only, by adding `openssl = { version = "0.10.66", features = ["vendored"] }` scoped to non-Windows/non-macOS targets in `mssql-tds/fuzz/Cargo.toml`. This makes `openssl-sys` (shared by both `native-tls` and the direct `openssl` dependency) compile from source, so the fuzz build no longer needs `libssl-dev`/`pkg-config` from apt. Only a C compiler and perl are required, both already present on the CI image.

Scoped to the fuzz crate (`publish = false`); the shipped `mssql-tds` library build is unchanged.

## Testing

- `cargo metadata` in `mssql-tds/fuzz` confirms the manifest resolves and the vendored `openssl` dependency is correctly scoped to Linux/other non-macOS Unix targets.
- Full `cargo fuzz` compilation is Linux/nightly-only and will be validated by the pipeline.

## Related work item

Fixes [AB#47487](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47487)