### PR TITLE
Complete Vector feature v2 (float16) serialization and bulk copy support

### DIFF
--- a/mssql-tds/src/connection/client_context.rs
+++ b/mssql-tds/src/connection/client_context.rs
@@ -511,8 +511,7 @@ impl ClientContext {
                 port: 1433,
                 instance_name: None,
             },
-            // TODO: make V2 as default when full V2 support is added
-            vector_version: VectorVersion::V1,
+            vector_version: VectorVersion::V2,
             column_encryption_setting: ColumnEncryptionSetting::Disabled,
             column_encryption_key_store_providers: std::sync::Arc::new(
                 crate::security::keystore::ColumnEncryptionKeyStoreProviderRegistry::new(),
@@ -574,8 +573,7 @@ impl ClientContext {
                 port: 1433,
                 instance_name: None,
             },
-            // TODO: make V2 as default when full V2 support is added
-            vector_version: VectorVersion::V1,
+            vector_version: VectorVersion::V2,
             column_encryption_setting: ColumnEncryptionSetting::Disabled,
             column_encryption_key_store_providers: std::sync::Arc::new(
                 crate::security::keystore::ColumnEncryptionKeyStoreProviderRegistry::new(),

--- a/mssql-tds/src/datatypes/bulk_copy_metadata.rs
+++ b/mssql-tds/src/datatypes/bulk_copy_metadata.rs
@@ -710,8 +710,14 @@ impl BulkCopyColumnMetadata {
             SqlDbType::Variant => "sql_variant".to_string(),
             SqlDbType::Json => "nvarchar(max)".to_string(),
             SqlDbType::Vector => {
+                use crate::datatypes::sqldatatypes::VectorBaseType;
+
                 let dims = self.vector_dimensions()?;
-                format!("vector({})", dims)
+                // `vector(N)` implies the float32 base type; float16 must be spelled out.
+                match VectorBaseType::try_from(self.scale)? {
+                    VectorBaseType::Float32 => format!("vector({})", dims),
+                    VectorBaseType::Float16 => format!("vector({}, float16)", dims),
+                }
             }
         })
     }
@@ -1520,6 +1526,34 @@ mod tests {
             )
             .with_scale(0);
         assert_eq!(meta.get_sql_type_definition().unwrap(), "vector(3)");
+    }
+
+    #[test]
+    fn vector_dimensions_valid_float16() {
+        use crate::datatypes::sqldatatypes::VECTOR_HEADER_SIZE;
+        // Float16 (scale=1), element_size=2, 3 dimensions: header(8) + 3*2 = 14
+        let meta = BulkCopyColumnMetadata::new("v", SqlDbType::Vector, 0xF5)
+            .with_length(
+                (VECTOR_HEADER_SIZE + 3 * 2) as i32,
+                TypeLength::Variable((VECTOR_HEADER_SIZE + 3 * 2) as i32),
+            )
+            .with_scale(1);
+        assert_eq!(meta.vector_dimensions().unwrap(), 3);
+    }
+
+    #[test]
+    fn vector_sql_type_definition_float16() {
+        use crate::datatypes::sqldatatypes::VECTOR_HEADER_SIZE;
+        let meta = BulkCopyColumnMetadata::new("v", SqlDbType::Vector, 0xF5)
+            .with_length(
+                (VECTOR_HEADER_SIZE + 3 * 2) as i32,
+                TypeLength::Variable((VECTOR_HEADER_SIZE + 3 * 2) as i32),
+            )
+            .with_scale(1);
+        assert_eq!(
+            meta.get_sql_type_definition().unwrap(),
+            "vector(3, float16)"
+        );
     }
 
     #[test]

--- a/mssql-tds/src/datatypes/sql_vector.rs
+++ b/mssql-tds/src/datatypes/sql_vector.rs
@@ -306,4 +306,20 @@ mod tests {
         let vector = SqlVector::try_from_f32(values).unwrap();
         assert_eq!(vector.base_type(), VectorBaseType::Float32);
     }
+
+    #[test]
+    fn test_from_f16_valid() {
+        let vector = SqlVector::try_from_f16(vec![1.0, 2.0, 3.0]).unwrap();
+        assert_eq!(vector.base_type(), VectorBaseType::Float16);
+        assert_eq!(vector.dimension_count(), 3);
+        assert_eq!(vector.as_f32(), Some(&[1.0, 2.0, 3.0][..]));
+        assert_eq!(vector.total_size(), VECTOR_HEADER_SIZE + 3 * 2);
+    }
+
+    #[test]
+    fn test_f16_allows_more_dimensions_than_f32() {
+        let values = vec![0.0f32; VectorBaseType::Float16.max_dimensions() as usize];
+        assert!(SqlVector::try_from_f16(values.clone()).is_ok());
+        assert!(SqlVector::try_from_f32(values).is_err());
+    }
 }

--- a/mssql-tds/src/datatypes/tds_value_serializer.rs
+++ b/mssql-tds/src/datatypes/tds_value_serializer.rs
@@ -1717,8 +1717,13 @@ impl TdsValueSerializer {
                     writer.write_i32_async((*f).to_bits() as i32).await?;
                 }
             }
-            VectorData::Float16(_) => {
-                todo!("Phase 2: Float16 serialization");
+            VectorData::Float16(vs) => {
+                // Narrow to IEEE 754 half-precision (round-to-nearest-even)
+                for f in vs {
+                    writer
+                        .write_u16_async(half::f16::from_f32(*f).to_bits())
+                        .await?;
+                }
             }
         }
 
@@ -3741,6 +3746,72 @@ mod serializer_tests {
         assert_eq!(&p[0..4], &13u32.to_le_bytes());
         assert_eq!(p[4], 0xE7); // NVARCHAR
         assert_eq!(p[5], 0x07); // prop_len = 7
+    }
+
+    // ── serialize_vector ──
+
+    fn vector_ctx(exact_size: usize) -> TdsTypeContext {
+        let mut ctx = nullable_ctx(crate::datatypes::sqldatatypes::TdsDataType::Vector as u8);
+        ctx.max_size = exact_size;
+        ctx
+    }
+
+    #[test]
+    fn vector_float32_elements() {
+        let mut mock = MockNetworkWriter::new(64);
+        let mut w = PacketWriter::new(PacketType::TabularResult, &mut mock, None, None);
+        let vector =
+            crate::datatypes::sql_vector::SqlVector::try_from_f32(vec![1.0, 2.0, 3.0]).unwrap();
+        let ctx = vector_ctx(8 + 3 * 4);
+        block_on(TdsValueSerializer::serialize_value(
+            &mut w,
+            &ColumnValues::Vector(vector),
+            &ctx,
+        ))
+        .unwrap();
+        let p = payload(&w);
+        assert_eq!(&p[0..2], &20u16.to_le_bytes()); // 8 header + 3 * 4
+        assert_eq!(&p[2..10], &[0xA9, 0x01, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00]);
+        assert_eq!(&p[10..14], &1.0f32.to_le_bytes());
+        assert_eq!(&p[14..18], &2.0f32.to_le_bytes());
+        assert_eq!(&p[18..22], &3.0f32.to_le_bytes());
+    }
+
+    #[test]
+    fn vector_float16_elements() {
+        let mut mock = MockNetworkWriter::new(64);
+        let mut w = PacketWriter::new(PacketType::TabularResult, &mut mock, None, None);
+        let vector =
+            crate::datatypes::sql_vector::SqlVector::try_from_f16(vec![1.0, 2.0, 3.0]).unwrap();
+        let ctx = vector_ctx(8 + 3 * 2);
+        block_on(TdsValueSerializer::serialize_value(
+            &mut w,
+            &ColumnValues::Vector(vector),
+            &ctx,
+        ))
+        .unwrap();
+        let p = payload(&w);
+        assert_eq!(&p[0..2], &14u16.to_le_bytes()); // 8 header + 3 * 2
+        // base type byte is 0x01 (float16)
+        assert_eq!(&p[2..10], &[0xA9, 0x01, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00]);
+        assert_eq!(&p[10..16], &[0x00, 0x3C, 0x00, 0x40, 0x00, 0x42]);
+    }
+
+    #[test]
+    fn vector_float16_rounds_to_nearest_even() {
+        let mut mock = MockNetworkWriter::new(64);
+        let mut w = PacketWriter::new(PacketType::TabularResult, &mut mock, None, None);
+        // 0.1 is not representable in f16; nearest half is 0x2E66.
+        let vector = crate::datatypes::sql_vector::SqlVector::try_from_f16(vec![0.1]).unwrap();
+        let ctx = vector_ctx(8 + 2);
+        block_on(TdsValueSerializer::serialize_value(
+            &mut w,
+            &ColumnValues::Vector(vector),
+            &ctx,
+        ))
+        .unwrap();
+        let p = payload(&w);
+        assert_eq!(&p[10..12], &0x2E66u16.to_le_bytes());
     }
 }
 

--- a/mssql-tds/src/message/features/vectorfeature.rs
+++ b/mssql-tds/src/message/features/vectorfeature.rs
@@ -161,6 +161,15 @@ mod tests {
     }
 
     #[test]
+    fn test_deserialize_v2_acknowledged() {
+        let mut feature = VectorFeature::default();
+        feature.set_acknowledged(true);
+        feature.deserialize(&[2u8]).unwrap();
+        assert!(feature.is_acknowledged());
+        assert_eq!(feature.negotiated_version(), 2);
+    }
+
+    #[test]
     fn test_deserialize_invalid_length() {
         let mut feature = VectorFeature::default();
         let data = vec![1u8, 0u8]; // Wrong length (2 bytes instead of 1)

--- a/mssql-tds/tests/common/mod.rs
+++ b/mssql-tds/tests/common/mod.rs
@@ -60,7 +60,7 @@ pub fn create_context() -> ClientContext {
                 .map_err(|_| std::env::VarError::NotPresent)
         })
         .expect("SQL_PASSWORD environment variable not set and /tmp/password could not be read");
-    context.database = "master".to_string();
+    context.database = env::var("DB_DATABASE").unwrap_or_else(|_| "master".to_string());
     context.encryption_options = EncryptionOptions {
         mode: EncryptionSetting::On,
         trust_server_certificate: trust_server_certificate(),

--- a/mssql-tds/tests/test_bulk_copy_vector.rs
+++ b/mssql-tds/tests/test_bulk_copy_vector.rs
@@ -14,6 +14,7 @@ mod bulk_copy_vector_tests {
     use mssql_tds::core::TdsResult;
     use mssql_tds::datatypes::column_values::ColumnValues;
     use mssql_tds::datatypes::sql_vector::SqlVector;
+    use mssql_tds::datatypes::sqldatatypes::VectorBaseType;
 
     #[ctor::ctor]
     fn init() {
@@ -524,5 +525,468 @@ mod bulk_copy_vector_tests {
             result.is_err(),
             "Expected bulk copy to fail with dimension mismatch (4 vs 3)"
         );
+    }
+
+    #[derive(Debug, Clone)]
+    struct Vector16Row {
+        id: i32,
+        vector_col: Option<Vec<f32>>,
+    }
+
+    #[async_trait]
+    impl BulkLoadRow for Vector16Row {
+        async fn write_to_packet(
+            &self,
+            writer: &mut mssql_tds::message::bulk_load::StreamingBulkLoadWriter<'_>,
+            column_index: &mut usize,
+        ) -> TdsResult<()> {
+            writer
+                .write_column_value(*column_index, &ColumnValues::Int(self.id))
+                .await?;
+            *column_index += 1;
+            let vector_val = if let Some(vec_data) = &self.vector_col {
+                ColumnValues::Vector(SqlVector::try_from_f16(vec_data.clone())?)
+            } else {
+                ColumnValues::Null
+            };
+            writer
+                .write_column_value(*column_index, &vector_val)
+                .await?;
+            *column_index += 1;
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl BulkLoadRow for &Vector16Row {
+        async fn write_to_packet(
+            &self,
+            writer: &mut mssql_tds::message::bulk_load::StreamingBulkLoadWriter<'_>,
+            column_index: &mut usize,
+        ) -> TdsResult<()> {
+            writer
+                .write_column_value(*column_index, &ColumnValues::Int(self.id))
+                .await?;
+            *column_index += 1;
+            let vector_val = if let Some(vec_data) = &self.vector_col {
+                ColumnValues::Vector(SqlVector::try_from_f16(vec_data.clone())?)
+            } else {
+                ColumnValues::Null
+            };
+            writer
+                .write_column_value(*column_index, &vector_val)
+                .await?;
+            *column_index += 1;
+            Ok(())
+        }
+    }
+
+    /// Bulk copy into a `VECTOR(n, float16)` column.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_bulk_copy_vector16_basic() {
+        let mut client = begin_connection(&build_tcp_datasource()).await;
+
+        client
+            .execute(
+                "CREATE TABLE #BulkCopyVector16Test (id INT NOT NULL, vector_col VECTOR(3, float16) NULL)"
+                    .to_string(),
+                (),
+            )
+            .await
+            .unwrap();
+
+        // All values are exactly representable in IEEE 754 half-precision.
+        let test_vec1 = vec![1.0, 2.0, 3.0];
+        let test_vec2 = vec![0.0, 0.0, 0.0];
+        let test_vec3 = vec![-1.5, 2.5, -3.5];
+
+        let rows = vec![
+            Vector16Row {
+                id: 1,
+                vector_col: Some(test_vec1.clone()),
+            },
+            Vector16Row {
+                id: 2,
+                vector_col: None,
+            },
+            Vector16Row {
+                id: 3,
+                vector_col: Some(test_vec2.clone()),
+            },
+            Vector16Row {
+                id: 4,
+                vector_col: Some(test_vec3.clone()),
+            },
+        ];
+
+        let result = {
+            let bulk_copy = BulkCopy::new(&mut client, "#BulkCopyVector16Test");
+            bulk_copy
+                .batch_size(1000)
+                .write_to_server_zerocopy(&rows)
+                .await
+                .expect("Bulk copy failed")
+        };
+        assert_eq!(result.rows_affected, 4, "Expected 4 rows to be inserted");
+
+        client
+            .execute(
+                "SELECT id, vector_col FROM #BulkCopyVector16Test ORDER BY id".to_string(),
+                (),
+            )
+            .await
+            .expect("Failed to select data");
+
+        let mut row_count = 0;
+        if client.on_rows() {
+            while let Some(row) = client.next_row().await.expect("Failed to read row") {
+                row_count += 1;
+                let expected = match row_count {
+                    1 => Some(&test_vec1),
+                    2 => None,
+                    3 => Some(&test_vec2),
+                    4 => Some(&test_vec3),
+                    _ => panic!("Unexpected row count: {}", row_count),
+                };
+                assert_eq!(row[0], ColumnValues::Int(row_count));
+                match (&row[1], expected) {
+                    (ColumnValues::Null, None) => {}
+                    (ColumnValues::Vector(vec), Some(exp)) => {
+                        assert_eq!(vec.base_type(), VectorBaseType::Float16);
+                        assert_eq!(vec.as_f32().expect("Expected f32 values"), exp.as_slice());
+                    }
+                    _ => panic!("Unexpected value for row {}: {:?}", row_count, row[1]),
+                }
+            }
+        }
+        assert_eq!(row_count, 4, "Expected 4 rows in result set");
+    }
+
+    /// Bulk copy float16 vectors at the maximum dimension count (3996).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_bulk_copy_vector16_max_dimensions() {
+        let mut client = begin_connection(&build_tcp_datasource()).await;
+
+        let dims = VectorBaseType::Float16.max_dimensions();
+
+        client
+            .execute(
+                format!(
+                    "CREATE TABLE #BulkCopyVector16Large (id INT NOT NULL, embedding VECTOR({}, float16))",
+                    dims
+                ),
+                (),
+            )
+            .await
+            .unwrap();
+
+        // Keep values within f16's exactly-representable integer range.
+        let vec1: Vec<f32> = (0..dims).map(|i| (i % 2048) as f32).collect();
+        let vec2: Vec<f32> = (0..dims).map(|i| -((i % 2048) as f32)).collect();
+
+        let rows = vec![
+            Vector16Row {
+                id: 1,
+                vector_col: Some(vec1.clone()),
+            },
+            Vector16Row {
+                id: 2,
+                vector_col: Some(vec2.clone()),
+            },
+        ];
+
+        let result = {
+            let bulk_copy = BulkCopy::new(&mut client, "#BulkCopyVector16Large");
+            bulk_copy
+                .batch_size(1000)
+                .write_to_server_zerocopy(&rows)
+                .await
+                .expect("Bulk copy failed")
+        };
+        assert_eq!(result.rows_affected, 2, "Expected 2 rows to be inserted");
+
+        client
+            .execute(
+                "SELECT id, embedding FROM #BulkCopyVector16Large ORDER BY id".to_string(),
+                (),
+            )
+            .await
+            .expect("Failed to select data");
+
+        let mut row_count = 0;
+        if client.on_rows() {
+            while let Some(row) = client.next_row().await.expect("Failed to read row") {
+                row_count += 1;
+                let expected = match row_count {
+                    1 => &vec1,
+                    2 => &vec2,
+                    _ => panic!("Unexpected row count: {}", row_count),
+                };
+                assert_eq!(row[0], ColumnValues::Int(row_count));
+                if let ColumnValues::Vector(vec) = &row[1] {
+                    assert_eq!(vec.base_type(), VectorBaseType::Float16);
+                    assert_eq!(vec.dimension_count(), dims);
+                    assert_eq!(
+                        vec.as_f32().expect("Expected f32 values"),
+                        expected.as_slice()
+                    );
+                } else {
+                    panic!("Expected Vector, got {:?}", row[1]);
+                }
+            }
+        }
+        assert_eq!(row_count, 2, "Expected 2 rows in result set");
+    }
+
+    /// Bulk copy float16 values that are not exactly representable as IEEE 754
+    /// halves, verifying the server round-trips the narrowed values.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_bulk_copy_vector16_precision_loss() {
+        let mut client = begin_connection(&build_tcp_datasource()).await;
+
+        client
+            .execute(
+                "CREATE TABLE #BulkCopyVector16Precision (id INT NOT NULL, vector_col VECTOR(4, float16))"
+                    .to_string(),
+                (),
+            )
+            .await
+            .unwrap();
+
+        let sent = vec![0.1f32, 1.0 / 3.0, -0.1, 65504.0];
+        let expected: Vec<f32> = sent
+            .iter()
+            .map(|v| half::f16::from_f32(*v).to_f32())
+            .collect();
+
+        let rows = vec![Vector16Row {
+            id: 1,
+            vector_col: Some(sent.clone()),
+        }];
+
+        let result = {
+            let bulk_copy = BulkCopy::new(&mut client, "#BulkCopyVector16Precision");
+            bulk_copy
+                .batch_size(1000)
+                .write_to_server_zerocopy(&rows)
+                .await
+                .expect("Bulk copy failed")
+        };
+        assert_eq!(result.rows_affected, 1, "Expected 1 row to be inserted");
+
+        client
+            .execute(
+                "SELECT vector_col FROM #BulkCopyVector16Precision".to_string(),
+                (),
+            )
+            .await
+            .expect("Failed to select data");
+
+        let mut row_count = 0;
+        if client.on_rows() {
+            while let Some(row) = client.next_row().await.expect("Failed to read row") {
+                row_count += 1;
+                if let ColumnValues::Vector(vec) = &row[0] {
+                    assert_eq!(vec.base_type(), VectorBaseType::Float16);
+                    assert_eq!(
+                        vec.as_f32().expect("Expected f32 values"),
+                        expected.as_slice()
+                    );
+                } else {
+                    panic!("Expected Vector, got {:?}", row[0]);
+                }
+            }
+        }
+        assert_eq!(row_count, 1, "Expected 1 row in result set");
+    }
+
+    /// Bulk copy into a table holding both float32 and float16 vector columns,
+    /// exercising per-column base types in the bulk load column metadata.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_bulk_copy_mixed_vector_base_types() {
+        let mut client = begin_connection(&build_tcp_datasource()).await;
+
+        client
+            .execute(
+                "CREATE TABLE #BulkCopyMixedVectorTest (id INT NOT NULL, vec32 VECTOR(3), vec16 VECTOR(3, float16) NULL)"
+                    .to_string(),
+                (),
+            )
+            .await
+            .unwrap();
+
+        #[derive(Debug, Clone)]
+        struct MixedVectorRow {
+            id: i32,
+            vec32: Vec<f32>,
+            vec16: Option<Vec<f32>>,
+        }
+
+        #[async_trait]
+        impl BulkLoadRow for MixedVectorRow {
+            async fn write_to_packet(
+                &self,
+                writer: &mut mssql_tds::message::bulk_load::StreamingBulkLoadWriter<'_>,
+                column_index: &mut usize,
+            ) -> TdsResult<()> {
+                writer
+                    .write_column_value(*column_index, &ColumnValues::Int(self.id))
+                    .await?;
+                *column_index += 1;
+                writer
+                    .write_column_value(
+                        *column_index,
+                        &ColumnValues::Vector(SqlVector::try_from_f32(self.vec32.clone())?),
+                    )
+                    .await?;
+                *column_index += 1;
+                let vec16_val = if let Some(vec_data) = &self.vec16 {
+                    ColumnValues::Vector(SqlVector::try_from_f16(vec_data.clone())?)
+                } else {
+                    ColumnValues::Null
+                };
+                writer.write_column_value(*column_index, &vec16_val).await?;
+                *column_index += 1;
+                Ok(())
+            }
+        }
+
+        #[async_trait]
+        impl BulkLoadRow for &MixedVectorRow {
+            async fn write_to_packet(
+                &self,
+                writer: &mut mssql_tds::message::bulk_load::StreamingBulkLoadWriter<'_>,
+                column_index: &mut usize,
+            ) -> TdsResult<()> {
+                writer
+                    .write_column_value(*column_index, &ColumnValues::Int(self.id))
+                    .await?;
+                *column_index += 1;
+                writer
+                    .write_column_value(
+                        *column_index,
+                        &ColumnValues::Vector(SqlVector::try_from_f32(self.vec32.clone())?),
+                    )
+                    .await?;
+                *column_index += 1;
+                let vec16_val = if let Some(vec_data) = &self.vec16 {
+                    ColumnValues::Vector(SqlVector::try_from_f16(vec_data.clone())?)
+                } else {
+                    ColumnValues::Null
+                };
+                writer.write_column_value(*column_index, &vec16_val).await?;
+                *column_index += 1;
+                Ok(())
+            }
+        }
+
+        let vec32_row1 = vec![1.5, 2.5, 3.5];
+        let vec16_row1 = vec![4.0, 5.0, 6.0];
+        let vec32_row2 = vec![-1.5, 0.0, 7.25];
+
+        let rows = vec![
+            MixedVectorRow {
+                id: 1,
+                vec32: vec32_row1.clone(),
+                vec16: Some(vec16_row1.clone()),
+            },
+            MixedVectorRow {
+                id: 2,
+                vec32: vec32_row2.clone(),
+                vec16: None,
+            },
+        ];
+
+        let result = {
+            let bulk_copy = BulkCopy::new(&mut client, "#BulkCopyMixedVectorTest");
+            bulk_copy
+                .batch_size(1000)
+                .write_to_server_zerocopy(&rows)
+                .await
+                .expect("Bulk copy failed")
+        };
+        assert_eq!(result.rows_affected, 2, "Expected 2 rows to be inserted");
+
+        client
+            .execute(
+                "SELECT id, vec32, vec16 FROM #BulkCopyMixedVectorTest ORDER BY id".to_string(),
+                (),
+            )
+            .await
+            .expect("Failed to select data");
+
+        let mut row_count = 0;
+        if client.on_rows() {
+            while let Some(row) = client.next_row().await.expect("Failed to read row") {
+                row_count += 1;
+                assert_eq!(row[0], ColumnValues::Int(row_count));
+
+                let expected32 = match row_count {
+                    1 => &vec32_row1,
+                    2 => &vec32_row2,
+                    _ => panic!("Unexpected row count: {}", row_count),
+                };
+                if let ColumnValues::Vector(vec) = &row[1] {
+                    assert_eq!(vec.base_type(), VectorBaseType::Float32);
+                    assert_eq!(
+                        vec.as_f32().expect("Expected f32 values"),
+                        expected32.as_slice()
+                    );
+                } else {
+                    panic!("Expected Vector, got {:?}", row[1]);
+                }
+
+                match (row_count, &row[2]) {
+                    (1, ColumnValues::Vector(vec)) => {
+                        assert_eq!(vec.base_type(), VectorBaseType::Float16);
+                        assert_eq!(
+                            vec.as_f32().expect("Expected f32 values"),
+                            vec16_row1.as_slice()
+                        );
+                    }
+                    (2, ColumnValues::Null) => {}
+                    _ => panic!("Unexpected value for row {}: {:?}", row_count, row[2]),
+                }
+            }
+        }
+        assert_eq!(row_count, 2, "Expected 2 rows in result set");
+    }
+
+    /// A float16 vector whose dimension count does not match the target column
+    /// must be rejected.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_bulk_copy_vector16_dimension_mismatch() {
+        let mut client = begin_connection(&build_tcp_datasource()).await;
+
+        client
+            .execute(
+                "CREATE TABLE #BulkCopyVector16MismatchTest (id INT NOT NULL, vector_col VECTOR(3, float16))"
+                    .to_string(),
+                (),
+            )
+            .await
+            .unwrap();
+
+        for (id, values) in [(1, vec![1.0, 2.0]), (2, vec![1.0, 2.0, 3.0, 4.0])] {
+            let dims = values.len();
+            let rows = vec![Vector16Row {
+                id,
+                vector_col: Some(values),
+            }];
+
+            let result = {
+                let bulk_copy = BulkCopy::new(&mut client, "#BulkCopyVector16MismatchTest");
+                bulk_copy
+                    .batch_size(1000)
+                    .write_to_server_zerocopy(&rows)
+                    .await
+            };
+
+            assert!(
+                result.is_err(),
+                "Expected bulk copy to fail with dimension mismatch ({} vs 3)",
+                dims
+            );
+        }
     }
 }

--- a/mssql-tds/tests/test_vector_type.rs
+++ b/mssql-tds/tests/test_vector_type.rs
@@ -66,48 +66,29 @@ mod vector_integration_tests {
         }
     }
 
-    /// Test basic vector16 deserialization with a simple 3-dimensional vector
+    /// Test basic vector16 deserialization with a simple 3-dimensional float16 vector
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    #[ignore = "Not supported in pipeline currently so skipping"]
     async fn test_vector16_basic_deserialization() {
         let mut client = begin_connection(&build_tcp_datasource()).await;
 
-        // Enable preview features before testing
-        // TODO: disable once v16 is available in sql server
-        client
-            .execute("USE UserDatabase;".to_string(), ())
-            .await
-            .unwrap();
-        client
-            .execute(
-                "ALTER DATABASE SCOPED CONFIGURATION SET PREVIEW_FEATURES = ON;".to_string(),
-                (),
-            )
-            .await
-            .unwrap();
-
-        // Query a simple 3-dimensional float16 vector
         let query = "SELECT CAST('[1.0, 2.0, 3.0]' AS VECTOR(3, float16)) AS VectorColumn";
+
         client.execute(query.to_string(), ()).await.unwrap();
 
         if client.on_rows() {
-            // Verify metadata
             let columns = client.get_metadata();
             assert_eq!(columns.len(), 1);
             assert_eq!(columns[0].column_name, "VectorColumn");
 
-            // Read the row
             let mut row_count = 0;
             while let Some(row) = client.next_row().await.unwrap() {
                 row_count += 1;
                 assert_eq!(row.len(), 1);
-
-                // Verify the vector data
                 match &row[0] {
                     ColumnValues::Vector(vector) => {
                         assert_eq!(vector.dimension_count(), 3);
                         assert_eq!(vector.base_type(), VectorBaseType::Float16);
-                        let values = vector.as_f32().expect("Should unpack to f32 vector slice");
+                        let values = vector.as_f32().expect("Float16 should decode to f32");
                         assert_eq!(values.len(), 3);
                         assert!((values[0] - 1.0).abs() < 0.001);
                         assert!((values[1] - 2.0).abs() < 0.001);
@@ -1256,5 +1237,426 @@ mod vector_integration_tests {
             }
             _ => panic!("Expected Vector output parameter"),
         }
+    }
+
+    /// Test sending a float16 Vector as a query parameter
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_vector16_parameter_basic() {
+        use mssql_tds::datatypes::sql_vector::SqlVector;
+        use mssql_tds::datatypes::sqltypes::SqlType;
+        use mssql_tds::message::parameters::rpc_parameters::{RpcParameter, StatusFlags};
+
+        let mut client = begin_connection(&build_tcp_datasource()).await;
+
+        let vector = SqlVector::try_from_f16(vec![1.0f32, 2.0f32, 3.0f32]).unwrap();
+        let param = RpcParameter::new(
+            Some("@p1".to_string()),
+            StatusFlags::NONE,
+            SqlType::Vector(Some(vector), 3, VectorBaseType::Float16),
+        );
+
+        client
+            .execute_sp_executesql("SELECT @p1 AS ReturnedVector".to_string(), vec![param], ())
+            .await
+            .unwrap();
+
+        assert!(client.on_rows(), "Expected a result set");
+        let mut row_count = 0;
+        while let Some(row) = client.next_row().await.unwrap() {
+            row_count += 1;
+            match &row[0] {
+                ColumnValues::Vector(returned_vector) => {
+                    assert_eq!(returned_vector.dimension_count(), 3);
+                    assert_eq!(returned_vector.base_type(), VectorBaseType::Float16);
+                    let values = returned_vector.as_f32().unwrap();
+                    assert!((values[0] - 1.0).abs() < 0.001);
+                    assert!((values[1] - 2.0).abs() < 0.001);
+                    assert!((values[2] - 3.0).abs() < 0.001);
+                }
+                _ => panic!("Expected Vector column value, got: {:?}", row[0]),
+            }
+        }
+        assert_eq!(row_count, 1, "Expected exactly 1 row");
+    }
+
+    /// Test NULL float16 Vector parameter
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_vector16_parameter_null() {
+        use mssql_tds::datatypes::sqltypes::SqlType;
+        use mssql_tds::message::parameters::rpc_parameters::{RpcParameter, StatusFlags};
+
+        let mut client = begin_connection(&build_tcp_datasource()).await;
+
+        let param = RpcParameter::new(
+            Some("@p1".to_string()),
+            StatusFlags::NONE,
+            SqlType::Vector(None, 10, VectorBaseType::Float16),
+        );
+
+        let query = "SELECT @p1 AS NullVector, CASE WHEN @p1 IS NULL THEN 1 ELSE 0 END AS IsNull";
+
+        client
+            .execute_sp_executesql(query.to_string(), vec![param], ())
+            .await
+            .unwrap();
+
+        assert!(client.on_rows(), "Expected a result set");
+        let mut row_count = 0;
+        while let Some(row) = client.next_row().await.unwrap() {
+            row_count += 1;
+            assert!(matches!(row[0], ColumnValues::Null));
+            match &row[1] {
+                ColumnValues::Int(val) => assert_eq!(*val, 1, "Expected IsNull to be 1"),
+                _ => panic!("Expected Int(1), got: {:?}", row[1]),
+            }
+        }
+        assert_eq!(row_count, 1, "Expected exactly 1 row");
+    }
+
+    /// Test float16 Vector parameter in a WHERE clause against a float16 column
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_vector16_parameter_in_where_clause() {
+        use mssql_tds::datatypes::sql_vector::SqlVector;
+        use mssql_tds::datatypes::sqltypes::SqlType;
+        use mssql_tds::message::parameters::rpc_parameters::{RpcParameter, StatusFlags};
+
+        let mut client = begin_connection(&build_tcp_datasource()).await;
+
+        let create_table = "
+            CREATE TABLE #Vector16Test (
+                id INT,
+                vec VECTOR(3, float16)
+            );
+            INSERT INTO #Vector16Test VALUES (1, CAST('[1.0, 2.0, 3.0]' AS VECTOR(3, float16)));
+            INSERT INTO #Vector16Test VALUES (2, CAST('[4.0, 5.0, 6.0]' AS VECTOR(3, float16)));
+            INSERT INTO #Vector16Test VALUES (3, CAST('[1.0, 2.0, 3.0]' AS VECTOR(3, float16)));
+        ";
+
+        client.execute(create_table.to_string(), ()).await.unwrap();
+
+        while client.advance_to_rows().await.unwrap() {}
+
+        let vector = SqlVector::try_from_f16(vec![1.0f32, 2.0f32, 3.0f32]).unwrap();
+        let param = RpcParameter::new(
+            Some("@p1".to_string()),
+            StatusFlags::NONE,
+            SqlType::Vector(Some(vector), 3, VectorBaseType::Float16),
+        );
+
+        let query = "SELECT id FROM #Vector16Test WHERE VECTOR_DISTANCE('cosine', vec, @p1) < 1e-6";
+
+        client
+            .execute_sp_executesql(query.to_string(), vec![param], ())
+            .await
+            .unwrap();
+
+        assert!(client.on_rows(), "Expected a result set");
+        let mut found_ids = vec![];
+        while let Some(row) = client.next_row().await.unwrap() {
+            match &row[0] {
+                ColumnValues::Int(id) => found_ids.push(*id),
+                _ => panic!("Expected Int column, got: {:?}", row[0]),
+            }
+        }
+
+        assert_eq!(found_ids.len(), 2, "Expected 2 matching rows");
+        assert!(found_ids.contains(&1), "Expected to find id 1");
+        assert!(found_ids.contains(&3), "Expected to find id 3");
+    }
+
+    /// Test float16 Vector parameter at the maximum dimension count (3996)
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_vector16_parameter_max_dimensions() {
+        use mssql_tds::datatypes::sql_vector::SqlVector;
+        use mssql_tds::datatypes::sqltypes::SqlType;
+        use mssql_tds::message::parameters::rpc_parameters::{RpcParameter, StatusFlags};
+
+        let mut client = begin_connection(&build_tcp_datasource()).await;
+
+        let dims = VectorBaseType::Float16.max_dimensions();
+        // Keep values within f16's exactly-representable integer range (<= 2048).
+        let values: Vec<f32> = (0..dims).map(|i| (i % 2048) as f32).collect();
+        let vector = SqlVector::try_from_f16(values.clone()).unwrap();
+        let param = RpcParameter::new(
+            Some("@p1".to_string()),
+            StatusFlags::NONE,
+            SqlType::Vector(Some(vector), dims, VectorBaseType::Float16),
+        );
+
+        client
+            .execute_sp_executesql("SELECT @p1 AS MaxVector".to_string(), vec![param], ())
+            .await
+            .unwrap();
+
+        assert!(client.on_rows(), "Expected a result set");
+        let mut row_count = 0;
+        while let Some(row) = client.next_row().await.unwrap() {
+            row_count += 1;
+            match &row[0] {
+                ColumnValues::Vector(returned_vector) => {
+                    assert_eq!(returned_vector.dimension_count(), dims);
+                    assert_eq!(returned_vector.base_type(), VectorBaseType::Float16);
+                    let returned = returned_vector.as_f32().unwrap();
+                    assert_eq!(returned, values.as_slice());
+                }
+                _ => panic!("Expected Vector column value, got: {:?}", row[0]),
+            }
+        }
+        assert_eq!(row_count, 1, "Expected exactly 1 row");
+    }
+
+    /// Test that float16 narrowing is lossy but round-trips through the server
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_vector16_parameter_precision_loss() {
+        use mssql_tds::datatypes::sql_vector::SqlVector;
+        use mssql_tds::datatypes::sqltypes::SqlType;
+        use mssql_tds::message::parameters::rpc_parameters::{RpcParameter, StatusFlags};
+
+        let mut client = begin_connection(&build_tcp_datasource()).await;
+
+        // 0.1 and 1/3 are not representable in f16; the server must return the
+        // same narrowed values the client sent.
+        let sent = vec![0.1f32, 1.0f32 / 3.0f32, -0.1f32];
+        let expected: Vec<f32> = sent
+            .iter()
+            .map(|v| half::f16::from_f32(*v).to_f32())
+            .collect();
+
+        let vector = SqlVector::try_from_f16(sent).unwrap();
+        let param = RpcParameter::new(
+            Some("@p1".to_string()),
+            StatusFlags::NONE,
+            SqlType::Vector(Some(vector), 3, VectorBaseType::Float16),
+        );
+
+        client
+            .execute_sp_executesql("SELECT @p1 AS Narrowed".to_string(), vec![param], ())
+            .await
+            .unwrap();
+
+        assert!(client.on_rows(), "Expected a result set");
+        let mut row_count = 0;
+        while let Some(row) = client.next_row().await.unwrap() {
+            row_count += 1;
+            match &row[0] {
+                ColumnValues::Vector(returned_vector) => {
+                    assert_eq!(returned_vector.base_type(), VectorBaseType::Float16);
+                    assert_eq!(returned_vector.as_f32().unwrap(), expected.as_slice());
+                }
+                _ => panic!("Expected Vector column value, got: {:?}", row[0]),
+            }
+        }
+        assert_eq!(row_count, 1, "Expected exactly 1 row");
+    }
+
+    /// Test mixing float32 and float16 Vector parameters in one call
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_mixed_vector_base_type_parameters() {
+        use mssql_tds::datatypes::sql_vector::SqlVector;
+        use mssql_tds::datatypes::sqltypes::SqlType;
+        use mssql_tds::message::parameters::rpc_parameters::{RpcParameter, StatusFlags};
+
+        let mut client = begin_connection(&build_tcp_datasource()).await;
+
+        let vec32 = SqlVector::try_from_f32(vec![1.0f32, 2.0f32, 3.0f32]).unwrap();
+        let vec16 = SqlVector::try_from_f16(vec![4.0f32, 5.0f32, 6.0f32]).unwrap();
+
+        let params = vec![
+            RpcParameter::new(
+                Some("@p1".to_string()),
+                StatusFlags::NONE,
+                SqlType::Vector(Some(vec32), 3, VectorBaseType::Float32),
+            ),
+            RpcParameter::new(
+                Some("@p2".to_string()),
+                StatusFlags::NONE,
+                SqlType::Vector(Some(vec16), 3, VectorBaseType::Float16),
+            ),
+        ];
+
+        client
+            .execute_sp_executesql("SELECT @p1 AS Vec32, @p2 AS Vec16".to_string(), params, ())
+            .await
+            .unwrap();
+
+        assert!(client.on_rows(), "Expected a result set");
+        let mut row_count = 0;
+        while let Some(row) = client.next_row().await.unwrap() {
+            row_count += 1;
+            match &row[0] {
+                ColumnValues::Vector(v) => {
+                    assert_eq!(v.base_type(), VectorBaseType::Float32);
+                    assert_eq!(v.as_f32().unwrap(), &[1.0, 2.0, 3.0]);
+                }
+                _ => panic!("Expected Vector for first column"),
+            }
+            match &row[1] {
+                ColumnValues::Vector(v) => {
+                    assert_eq!(v.base_type(), VectorBaseType::Float16);
+                    assert_eq!(v.as_f32().unwrap(), &[4.0, 5.0, 6.0]);
+                }
+                _ => panic!("Expected Vector for second column"),
+            }
+        }
+        assert_eq!(row_count, 1, "Expected exactly 1 row");
+    }
+
+    /// Test float16 Vector as output parameter from a stored procedure
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_vector16_output_parameter() {
+        use mssql_tds::datatypes::sqltypes::SqlType;
+        use mssql_tds::message::parameters::rpc_parameters::{RpcParameter, StatusFlags};
+
+        let mut client = begin_connection(&build_tcp_datasource()).await;
+
+        let create_proc = "
+            CREATE PROCEDURE #TestVector16Output
+                @OutputVector VECTOR(3, float16) OUTPUT
+            AS
+            BEGIN
+                SET @OutputVector = CAST('[7.0, 8.0, 9.0]' AS VECTOR(3, float16));
+            END
+        ";
+
+        client.execute(create_proc.to_string(), ()).await.unwrap();
+
+        while client.advance_to_rows().await.unwrap() {}
+
+        let output_param = RpcParameter::new(
+            Some("@OutputVector".to_string()),
+            StatusFlags::BY_REF_VALUE,
+            SqlType::Vector(None, 3, VectorBaseType::Float16),
+        );
+
+        client
+            .execute_stored_procedure(
+                "#TestVector16Output".to_string(),
+                None,
+                Some(vec![output_param]),
+                (),
+            )
+            .await
+            .unwrap();
+
+        client.advance_to_rows().await.unwrap();
+        let output_params = client.retrieve_output_params().unwrap().unwrap();
+        assert_eq!(output_params.len(), 1, "Expected 1 output parameter");
+
+        match &output_params[0].value {
+            ColumnValues::Vector(vector) => {
+                assert_eq!(vector.dimension_count(), 3);
+                assert_eq!(vector.base_type(), VectorBaseType::Float16);
+                let values = vector.as_f32().unwrap();
+                assert!((values[0] - 7.0).abs() < 0.001);
+                assert!((values[1] - 8.0).abs() < 0.001);
+                assert!((values[2] - 9.0).abs() < 0.001);
+            }
+            _ => panic!(
+                "Expected Vector output parameter, got: {:?}",
+                output_params[0].value
+            ),
+        }
+    }
+
+    /// Test float16 Vector as both input and output parameter
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_vector16_input_output_parameter() {
+        use mssql_tds::datatypes::sql_vector::SqlVector;
+        use mssql_tds::datatypes::sqltypes::SqlType;
+        use mssql_tds::message::parameters::rpc_parameters::{RpcParameter, StatusFlags};
+
+        let mut client = begin_connection(&build_tcp_datasource()).await;
+
+        let create_proc = "
+            CREATE PROCEDURE #TestVector16InOut
+                @InputVector VECTOR(3, float16),
+                @OutputVector VECTOR(3, float16) OUTPUT
+            AS
+            BEGIN
+                SET @OutputVector = @InputVector;
+            END
+        ";
+
+        client.execute(create_proc.to_string(), ()).await.unwrap();
+
+        while client.advance_to_rows().await.unwrap() {}
+
+        // 10.5 / 20.5 / 30.5 are exactly representable in f16.
+        let input_vector = SqlVector::try_from_f16(vec![10.5f32, 20.5f32, 30.5f32]).unwrap();
+        let params = vec![
+            RpcParameter::new(
+                Some("@InputVector".to_string()),
+                StatusFlags::NONE,
+                SqlType::Vector(Some(input_vector), 3, VectorBaseType::Float16),
+            ),
+            RpcParameter::new(
+                Some("@OutputVector".to_string()),
+                StatusFlags::BY_REF_VALUE,
+                SqlType::Vector(None, 3, VectorBaseType::Float16),
+            ),
+        ];
+
+        client
+            .execute_stored_procedure("#TestVector16InOut".to_string(), None, Some(params), ())
+            .await
+            .unwrap();
+
+        client.advance_to_rows().await.unwrap();
+        let output_params = client.retrieve_output_params().unwrap().unwrap();
+        assert_eq!(output_params.len(), 1, "Expected 1 output parameter");
+
+        match &output_params[0].value {
+            ColumnValues::Vector(vector) => {
+                assert_eq!(vector.base_type(), VectorBaseType::Float16);
+                assert_eq!(vector.as_f32().unwrap(), &[10.5, 20.5, 30.5]);
+            }
+            _ => panic!(
+                "Expected Vector output parameter, got: {:?}",
+                output_params[0].value
+            ),
+        }
+    }
+
+    /// Test NULL float16 Vector as output parameter
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_vector16_output_parameter_null() {
+        use mssql_tds::datatypes::sqltypes::SqlType;
+        use mssql_tds::message::parameters::rpc_parameters::{RpcParameter, StatusFlags};
+
+        let mut client = begin_connection(&build_tcp_datasource()).await;
+
+        let create_proc = "
+            CREATE PROCEDURE #TestVector16OutputNull
+                @OutputVector VECTOR(5, float16) OUTPUT
+            AS
+            BEGIN
+                SET @OutputVector = NULL;
+            END
+        ";
+
+        client.execute(create_proc.to_string(), ()).await.unwrap();
+
+        while client.advance_to_rows().await.unwrap() {}
+
+        let output_param = RpcParameter::new(
+            Some("@OutputVector".to_string()),
+            StatusFlags::BY_REF_VALUE,
+            SqlType::Vector(None, 5, VectorBaseType::Float16),
+        );
+
+        client
+            .execute_stored_procedure(
+                "#TestVector16OutputNull".to_string(),
+                None,
+                Some(vec![output_param]),
+                (),
+            )
+            .await
+            .unwrap();
+
+        client.advance_to_rows().await.unwrap();
+        let output_params = client.retrieve_output_params().unwrap().unwrap();
+        assert_eq!(output_params.len(), 1, "Expected 1 output parameter");
+        assert!(matches!(output_params[0].value, ColumnValues::Null));
     }
 }


### PR DESCRIPTION
## Description

Completes Phase 2 of Vector feature v2 (float16) support in `mssql-tds`. Phase 1
(feature negotiation and deserialization) landed in PR 7493 and left
`todo!("Phase 2: Float16 serialization")` in the value serializer, so float16
vectors could be read from the server but not written back. This PR implements
the write path and enables float16 by default.

**Serialization** — `tds_value_serializer.rs` replaces the `todo!()` with a real
implementation that narrows `f32` values to IEEE 754 half-precision using
round-to-nearest-even (via the `half` crate), matching the msodbcsql reference
driver's `Float32ToFloat16Bits`. Elements are written little-endian, 2 bytes each,
behind the standard 8-byte vector header.

**Bulk copy** — `bulk_copy_metadata.rs` now emits `vector(N, float16)` in generated
DDL when the column's base type is float16. Previously it always emitted
`vector(N)`, which SQL Server interprets as float32, so bulk copy of float16
columns produced a type mismatch.

**Default version** — `client_context.rs` flips the default `VectorVersion` from
`V1` to `V2`, resolving the `// TODO: make V2 as default when full V2 support is
added` left by Phase 1. Version negotiation is unchanged: the client advertises
v2, and the server may still ack v1, in which case behavior is identical to today.

### Tests

- 3 serializer unit tests covering float32 elements, float16 elements, and
  round-to-nearest-even behavior (`0.1f32` → `0x2E66`)
- 2 bulk copy metadata tests for float16 dimension math and DDL generation
- 2 `SqlVector` tests for `try_from_f16` and the higher float16 dimension ceiling
  (3996 vs. 1998)
- 1 feature negotiation test for a v2 ack
- 14 float16 integration tests covering query, parameter binding, output
  parameters, NULL handling, max dimensions, precision loss, mixed base types,
  and bulk copy

`mssql-tds/tests/common/mod.rs` now honors a `DB_DATABASE` env var so integration
tests can target a database with `PREVIEW_FEATURES = 1` enabled, defaulting to
`master` as before.


## Related Issues
https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/45020
https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/45021

<!--
Required: link a GitHub issue OR an Azure DevOps work item. The PR check will
fail without one.
GitHub issue: Fixes #123 (or https://github.com/microsoft/mssql-rs/issues/123)
ADO work item: https://sqlclientdrivers.visualstudio.com/<...>/_workitems/edit/<ID>
  (any project/collection path is accepted, e.g. .../<project>/_workitems/edit/123
  or .../DefaultCollection/<project>/_workitems/edit/123)
-->

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes
- [ ] New/changed functionality has tests
- [ ] Public API changes are documented
