### PR TITLE
perf(lab): advance baseline to ecd8d6cb to lock in the decode improvement

### DIFF
--- a/mssql-tds-bench/perf-lab/baseline-commit.txt
+++ b/mssql-tds-bench/perf-lab/baseline-commit.txt
@@ -7,4 +7,4 @@
 #
 # Exactly one full 40-character commit SHA on its own line. Lines starting with
 # '#' and blank lines are ignored.
-c0c4c9e7ad1ab6c4eaf1d6943b09cde5a44b32c6
+ecd8d6cb596a0175651f7dee918de01b2e1c1855


### PR DESCRIPTION
## Description

Advances the perf baseline to `ecd8d6cb`, the commit measured by the latest scheduled runs, locking in the decode improvement they picked up.

Both runs passed with no benchmark slower than the 10% gate:

- Linux: [169195](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build/results?buildId=169195)
- Windows: [169220](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build/results?buildId=169220)

The headline movement is `primitives/decode`, faster on both platforms — **-13.4%** on Windows (re-measured and reproduced 4/4) and **-5.7%** on Linux. Windows also shows `prepared_prepexec` -7.4% and `select_n_rows/10000` -5.7%; Linux shows `simple_select_one_row` -6.5%.

**Likely source:** [#313](https://github.com/microsoft/mssql-rs/pull/313) *Decode and format decimals without allocating* (`7a89fc8a`) — it rewrites `datatypes/decoder.rs` to drop allocations on the decimal decode/format path, and `primitives/decode` selects a `DECIMAL(10,2)` column alongside BIT/TINYINT/SMALLINT/INT/BIGINT/FLOAT, so it exercises exactly that code. The other `mssql-tds` changes in the window are session recovery ([#230](https://github.com/microsoft/mssql-rs/pull/230), [#354](https://github.com/microsoft/mssql-rs/pull/354)) and PLP write-path work ([#207](https://github.com/microsoft/mssql-rs/pull/207), [#311](https://github.com/microsoft/mssql-rs/pull/311)), none of which touch the row-decode read path. Offered as the plausible candidate rather than a bisected result.

## Changes

`mssql-tds-bench/perf-lab/baseline-commit.txt`: `c0c4c9e7` -> `ecd8d6cb`.

## Validation

- Both scheduled runs above are green against the outgoing baseline.
- Verified locally by replicating the harness swap (`mssql-tds` replaced with a worktree checkout of `ecd8d6cb`): all bench binaries compile.

---

# Linux — build 169195

### Change vs baseline

_🟩 faster · 🟥 slower · 1 square ≈ 1% (drawn only for |Δ| ≥ 1%) · ⟳ re-measured (median of re-runs)_

| Benchmark | faster ◄ | Δ% | ► slower |
|---|--:|:--:|:--|
| `simple_select_one_row` | 🟩🟩🟩🟩🟩🟩🟩 | -6.5 |  |
| `primitives/decode` | 🟩🟩🟩🟩🟩🟩 | -5.7 |  |
| `scalars/decode` | 🟩🟩🟩🟩 | -3.8 |  |
| `packet_size_sensitivity/4096` | 🟩🟩🟩🟩 | -3.8 |  |
| `stored_procedure_output` | 🟩🟩🟩🟩 | -3.8 |  |
| `prepared_prepexec` | 🟩🟩🟩 | -2.9 |  |
| `packet_size_sensitivity/32768` | 🟩🟩 | -2.0 |  |
| `lob/1048576` |  | -1.0 |  |
| `stored_procedure` |  | -1.0 |  |
| `connect_close` |  | -1.0 |  |
| `packet_size_sensitivity/8192` |  | ±0.0 |  |
| `select_n_rows/100` |  | ±0.0 |  |
| `prepared_execute` |  | ±0.0 |  |
| `batched_statements` |  | ±0.0 |  |
| `lob/20971520` |  | ±0.0 |  |
| `temporal/decode` |  | ±0.0 |  |
| `single_insert` |  | +1.0 | 🟥 |
| `bulk_insert/5000` |  | +1.0 | 🟥 |
| `concurrent_connects/100` |  | +1.0 | 🟥 |
| `strings` |  | +1.0 | 🟥 |
| `concurrent_connects/50` |  | +1.0 | 🟥 |
| `bulk_insert/500` |  | +2.0 | 🟥🟥 |
| `select_n_rows/10000` |  | +2.0 | 🟥🟥 |
| `parameterized_sp_executesql` |  | +3.0 | 🟥🟥🟥 |
| `select_n_rows/1000` |  | +4.0 | 🟥🟥🟥🟥 |
| `row_iteration_throughput/next_row` |  | +6.0 | 🟥🟥🟥🟥🟥🟥 |

Baseline commit: `c0c4c9e7ad1ab6c4eaf1d6943b09cde5a44b32c6`

### Raw first-pass measurements

_Full critcmp table from the initial run. Benchmarks marked ⟳ above were re-measured; the chart shows the median and the re-runs are detailed below._

```
group                                base                                     candidate
-----                                ----                                     ---------
batched_statements                   1.00    240.9±2.94µs        ? ?/sec      1.00    241.8±8.31µs        ? ?/sec
bulk_insert/500                      1.00     38.4±0.55ms 254.4 KElem/sec     1.02     39.2±0.42ms 249.0 KElem/sec
bulk_insert/5000                     1.00      9.9±0.06ms 982.7 KElem/sec     1.01     10.0±0.08ms 977.7 KElem/sec
concurrent_connects/100              1.00     77.2±2.40ms  1296 Elem/sec      1.01     77.9±2.95ms  1283 Elem/sec
concurrent_connects/50               1.00     42.0±0.97ms  1191 Elem/sec      1.01     42.5±2.84ms  1175 Elem/sec
connect_close                        1.01      5.9±0.11ms        ? ?/sec      1.00      5.8±0.13ms        ? ?/sec
lob/1048576                          1.01      3.0±0.02ms   338.1 MB/sec      1.00      2.9±0.02ms   343.1 MB/sec
lob/20971520                         1.00     54.4±0.26ms   368.0 MB/sec      1.00     54.1±0.39ms   369.5 MB/sec
packet_size_sensitivity/32768        1.02     27.5±0.27ms   582.7 MB/sec      1.00     27.0±1.01ms   593.5 MB/sec
packet_size_sensitivity/4096         1.04     78.2±0.23ms   204.6 MB/sec      1.00     75.2±0.84ms   212.9 MB/sec
packet_size_sensitivity/8192         1.00     43.5±0.21ms   367.5 MB/sec      1.00     43.6±0.33ms   366.8 MB/sec
parameterized_sp_executesql          1.00    141.9±2.74µs        ? ?/sec      1.03    146.6±3.59µs        ? ?/sec
prepared_execute                     1.00    140.9±4.34µs        ? ?/sec      1.00    140.3±4.78µs        ? ?/sec
prepared_prepexec                    1.03    288.2±9.05µs        ? ?/sec      1.00   280.1±13.22µs        ? ?/sec
primitives/decode                    1.06   789.9±13.26µs 1236.4 KElem/sec    1.00   747.6±26.89µs 1306.3 KElem/sec
row_iteration_throughput/next_row    1.00     19.3±0.09ms  2.5 MElem/sec      1.06     20.4±0.18ms  2.3 MElem/sec
scalars/decode                       1.04   785.4±52.36µs 1243.5 KElem/sec    1.00   752.5±10.56µs 1297.7 KElem/sec
select_n_rows/100                    1.00    305.4±8.27µs 319.7 KElem/sec     1.00    305.5±5.85µs 319.6 KElem/sec
select_n_rows/1000                   1.00   825.2±19.57µs 1183.4 KElem/sec    1.04   856.4±34.03µs 1140.3 KElem/sec
select_n_rows/10000                  1.00      5.8±0.06ms 1692.2 KElem/sec    1.02      5.9±0.08ms 1653.9 KElem/sec
simple_select_one_row                1.07   216.2±12.27µs        ? ?/sec      1.00    202.8±3.79µs        ? ?/sec
single_insert                        1.00    310.8±9.72µs        ? ?/sec      1.01   314.8±13.00µs        ? ?/sec
stored_procedure                     1.01    156.5±9.67µs        ? ?/sec      1.00    155.0±4.84µs        ? ?/sec
stored_procedure_output              1.04   166.4±29.16µs        ? ?/sec      1.00    159.6±4.23µs        ? ?/sec
strings                              1.00    318.0±5.71µs        ? ?/sec      1.01    321.2±6.81µs        ? ?/sec
temporal/decode                      1.00   721.3±18.49µs 1353.9 KElem/sec    1.00   718.1±22.54µs 1359.9 KElem/sec
```

---

# Windows — build 169220

### Change vs baseline

_🟩 faster, 🟥 slower; 1 square ~ 1% (drawn only for changes of at least 1%); ⟳ re-measured (median of re-runs)_

| Benchmark | faster ◄ | Δ% | ► slower |
|---|--:|:--:|:--|
| `primitives/decode` ⟳ | 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 | -13.4 |  |
| `prepared_prepexec` | 🟩🟩🟩🟩🟩🟩🟩 | -7.4 |  |
| `select_n_rows/10000` | 🟩🟩🟩🟩🟩🟩 | -5.7 |  |
| `select_n_rows/1000` | 🟩🟩🟩🟩 | -3.8 |  |
| `row_iteration_throughput/next_row` | 🟩🟩🟩🟩 | -3.8 |  |
| `packet_size_sensitivity/4096` | 🟩🟩 | -2.0 |  |
| `lob/20971520` |  | -1.0 |  |
| `select_n_rows/100` |  | -1.0 |  |
| `packet_size_sensitivity/32768` ⟳ |  | -0.5 |  |
| `connect_close` |  | ±0.0 |  |
| `concurrent_connects/100` |  | ±0.0 |  |
| `prepared_execute` |  | ±0.0 |  |
| `bulk_insert/500` |  | +1.0 | 🟥 |
| `bulk_insert/5000` |  | +1.0 | 🟥 |
| `packet_size_sensitivity/8192` |  | +1.0 | 🟥 |
| `lob/1048576` |  | +1.0 | 🟥 |
| `single_insert` |  | +3.0 | 🟥🟥🟥 |
| `batched_statements` |  | +3.0 | 🟥🟥🟥 |
| `scalars/decode` |  | +3.0 | 🟥🟥🟥 |
| `concurrent_connects/50` |  | +4.0 | 🟥🟥🟥🟥 |
| `temporal/decode` |  | +4.0 | 🟥🟥🟥🟥 |
| `simple_select_one_row` |  | +4.0 | 🟥🟥🟥🟥 |
| `strings` |  | +5.0 | 🟥🟥🟥🟥🟥 |
| `stored_procedure` ⟳ |  | +6.5 | 🟥🟥🟥🟥🟥🟥 |
| `parameterized_sp_executesql` |  | +7.0 | 🟥🟥🟥🟥🟥🟥🟥 |
| `stored_procedure_output` |  | +8.0 | 🟥🟥🟥🟥🟥🟥🟥🟥 |

Baseline commit: `c0c4c9e7ad1ab6c4eaf1d6943b09cde5a44b32c6`

### Raw first-pass measurements

_Full critcmp table from the initial run. Benchmarks marked ⟳ above were re-measured; the chart shows the median and the re-runs are detailed below._

```
group                                base                                     candidate
-----                                ----                                     ---------
batched_statements                   1.00    230.8±6.97µs        ? ?/sec      1.03   237.0±12.19µs        ? ?/sec
bulk_insert/500                      1.00     38.3±0.13ms 254.9 KElem/sec     1.01     38.5±0.22ms 253.6 KElem/sec
bulk_insert/5000                     1.00     10.6±0.06ms 917.6 KElem/sec     1.01     10.7±0.11ms 910.1 KElem/sec
concurrent_connects/100              1.00       2.4±0.10s    41 Elem/sec      1.00       2.4±0.12s    41 Elem/sec
concurrent_connects/50               1.00  1333.4±82.46ms    37 Elem/sec      1.04  1382.3±111.42ms    36 Elem/sec
connect_close                        1.00    155.9±1.17ms        ? ?/sec      1.00    156.0±1.53ms        ? ?/sec
lob/1048576                          1.00  1875.7±36.70µs   533.1 MB/sec      1.01  1896.0±48.80µs   527.4 MB/sec
lob/20971520                         1.01     34.5±0.90ms   580.5 MB/sec      1.00     34.1±0.51ms   586.2 MB/sec
packet_size_sensitivity/32768        1.11     23.0±5.88ms   694.2 MB/sec      1.00     20.8±0.47ms   770.2 MB/sec
packet_size_sensitivity/4096         1.02     44.9±1.43ms   356.0 MB/sec      1.00     44.2±0.48ms   362.0 MB/sec
packet_size_sensitivity/8192         1.00     27.0±0.34ms   593.0 MB/sec      1.01     27.1±0.50ms   589.5 MB/sec
parameterized_sp_executesql          1.00    123.7±1.77µs        ? ?/sec      1.07    132.4±1.68µs        ? ?/sec
prepared_execute                     1.00    110.8±3.06µs        ? ?/sec      1.00    111.0±8.68µs        ? ?/sec
prepared_prepexec                    1.08    235.9±4.91µs        ? ?/sec      1.00    219.2±5.41µs        ? ?/sec
primitives/decode                    1.12   940.0±15.44µs 1038.9 KElem/sec    1.00    838.0±7.72µs 1165.3 KElem/sec
row_iteration_throughput/next_row    1.04     27.2±0.17ms 1794.5 KElem/sec    1.00     26.2±0.11ms 1866.2 KElem/sec
scalars/decode                       1.00    799.8±8.13µs 1221.0 KElem/sec    1.03   825.3±12.57µs 1183.2 KElem/sec
select_n_rows/100                    1.01    305.0±8.65µs 320.2 KElem/sec     1.00    302.9±3.77µs 322.4 KElem/sec
select_n_rows/1000                   1.04  1005.1±23.73µs 971.6 KElem/sec     1.00   969.0±17.95µs 1007.9 KElem/sec
select_n_rows/10000                  1.06      7.9±0.07ms 1238.8 KElem/sec    1.00      7.4±0.13ms 1313.2 KElem/sec
simple_select_one_row                1.00    187.8±4.66µs        ? ?/sec      1.04    195.2±3.77µs        ? ?/sec
single_insert                        1.00    291.2±4.73µs        ? ?/sec      1.03    299.5±5.89µs        ? ?/sec
stored_procedure                     1.00    122.5±4.43µs        ? ?/sec      1.10    134.4±2.77µs        ? ?/sec
stored_procedure_output              1.00    130.1±3.63µs        ? ?/sec      1.08    141.1±4.46µs        ? ?/sec
strings                              1.00    282.7±3.99µs        ? ?/sec      1.05    297.5±4.01µs        ? ?/sec
temporal/decode                      1.00   776.7±10.93µs 1257.3 KElem/sec    1.04   805.1±12.68µs 1212.9 KElem/sec
```

---

## Related Issues

[AB#46061](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46061)

## Checklist

- [x] New/changed functionality has tests — N/A: baseline pointer change; validated by the two lab runs above and a local compile against the new baseline
- [x] Public API changes are documented — N/A: no public API changes
