### PR TITLE
perf(lab): lower the regression gate from 10% to 5%

### DIFF
--- a/docs/perf-testing-plan.md
+++ b/docs/perf-testing-plan.md
@@ -161,7 +161,7 @@ build.
 ### Regression gate
 
 The run **fails only when a *candidate* benchmark is slower than its baseline by at least
-the threshold** (`BENCH_REGRESSION_RATIO`, default `1.10` = 10%). A baseline-slower
+the threshold** (`BENCH_REGRESSION_RATIO`, default `1.05` = 5%). A baseline-slower
 result never fails the gate — it can only mean the comparison lost sensitivity, which is
 exactly what the interleaving + pinning + warm-up work keeps in check. Any benchmark that
 trips is re-measured by **auto-confirm** `BENCH_CONFIRM_RUNS` times (default 4) and only
@@ -170,6 +170,19 @@ verdict and the full `critcmp` table are written to `results/summary.md`, which 
 attaches to the run's **Summary** tab (`task.uploadsummary`) so the comparison renders
 inline on the pipeline run page. The summary is also echoed into the log, since the
 Summary tab is not visible when triaging from the log alone.
+
+The threshold is set at the level worth *verifying*, not the level worth tolerating. These
+pipelines are weekly and scheduled (`trigger: none`, `pr: none`), so a trip never blocks a
+PR — it costs one investigation. Best-of-N absorbs the resulting noise: every false trip
+observed so far cleared **0 of 4** re-runs, nowhere near the 3-of-4 quorum, because lab
+noise is spiky rather than sustained and interleaving cancels host-wide slowdowns across
+both sides. A 5% gate also makes a passing run a much stronger certificate that the
+baseline can safely be advanced, which is what makes automating that ratchet practical: a
+5-10% regression that is never challenged would otherwise be silently absorbed into the
+next baseline and become invisible. Expect Windows to re-measure more than Linux — its
+first-pass noise reaches 8-10%. **If a false positive ever survives the quorum, raise
+`BENCH_CONFIRM_RUNS`/`BENCH_CONFIRM_QUORUM` rather than the threshold**; reverting the
+threshold would discard the signal this buys.
 
 `summary.md` leads with a **diverging bar table** (🟩 faster / 🟥 slower, one square ≈ 1%,
 drawn only for |Δ| ≥ 1%) so a run's shape is readable at a glance; the raw `critcmp`
@@ -323,7 +336,7 @@ binaries keep the per-binary interleaving effective (see §2).
 - Perf-lab pipeline runs on a **dedicated host VM** via the shared `PerfTest` lab
   `extends` template; the build happens on the VM (the lab's documented model).
 - Comparison is **interleaved per bench binary** (not two full passes), and the run
-  **fails only on a candidate-slower regression ≥ threshold** (default 10%), with
+  **fails only on a candidate-slower regression ≥ threshold** (default 5%), with
   **best-of-N auto-confirm** (re-measure a tripped benchmark 4× and fail only on a
   majority) rejecting transient outliers before failing.
 - Runs on **both Linux and Windows** as two separate pipeline definitions (numbers are

--- a/mssql-tds-bench/perf-lab/run-benchmarks.ps1
+++ b/mssql-tds-bench/perf-lab/run-benchmarks.ps1
@@ -480,7 +480,7 @@ Write-Host $comparison
 [System.IO.File]::WriteAllText((Join-Path $ResultsDir 'comparison.txt'), $comparison + "`n", $Utf8NoBom)
 
 $thr = [double]($env:BENCH_REGRESSION_RATIO)
-if (-not $thr) { $thr = 1.10 }
+if (-not $thr) { $thr = 1.05 }
 $regressions = @(Get-CritcmpRegressions $comparison $thr)
 $impThr = [double]($env:BENCH_IMPROVEMENT_VERIFY_RATIO)
 # Same magnitude as the regression threshold by default: a baseline-slower

--- a/mssql-tds-bench/perf-lab/run-benchmarks.sh
+++ b/mssql-tds-bench/perf-lab/run-benchmarks.sh
@@ -322,7 +322,7 @@ cpu_sample "interleave-end" || true
 echo ">>> Comparing base -> candidate..."
 critcmp base candidate | tee "$RESULTS_DIR/comparison.txt"
 
-THR="${BENCH_REGRESSION_RATIO:-1.10}"
+THR="${BENCH_REGRESSION_RATIO:-1.05}"
 # Improvements are verified at the SAME magnitude as regressions by default: a
 # baseline-slower anomaly pollutes the recorded numbers (and the run-over-run
 # trend they feed) exactly as much as a candidate-slower one, and both directions


### PR DESCRIPTION
## Description

A 5-10% regression that is never challenged gets silently absorbed into the next baseline and is invisible from then on. Lowering the gate puts that band through the same best-of-N confirmation everything else already gets, and makes a passing run a strong enough certificate to **automate advancing the baseline**.

The threshold is being set at the level worth *verifying*, not the level worth tolerating. That is affordable because these pipelines are weekly and scheduled — `trigger: none`, `pr: none` — so a trip never blocks a PR; it costs one investigation.

**Noise is already handled by the quorum, not the threshold.** Every false trip observed so far cleared decisively, nowhere near the 3-of-4 quorum:

| benchmark | first pass | re-runs |
|---|---|---|
| `primitives/decode` | +26% | not reproduced |
| `strings` | +11% | **0/4** |
| `select_n_rows/1000` | tripped | **0/4** |
| `stored_procedure` (Win 08-24) | ≥10% | **0/4** |

Lab noise is spiky rather than sustained, and interleaving cancels host-wide slowdowns across both sides.

## Changes

- `run-benchmarks.sh` / `run-benchmarks.ps1` — `BENCH_REGRESSION_RATIO` default `1.10` → `1.05`. `BENCH_IMPROVEMENT_VERIFY_RATIO` already defaults to it, so improvement verification follows to 5%.
- `docs/perf-testing-plan.md` — document the new default, the reasoning, and the tuning lever.

## Expected cost

Measured against the four most recent runs:

| run | trip@10% | trip@5% |
|---|--:|--:|
| Linux 08-20 | 0 | 1 |
| Windows 08-20 | 0 | 0 |
| Linux 08-24 | 0 | 1 |
| Windows 08-24 | 1 | 4 |

Windows adds the most (its first-pass noise reaches 8-10%): on the 08-24 data the re-measure set becomes ~8 benchmarks including capped improvements, roughly +20 min. Linux adds 0-1.

## Tuning lever

**If a false positive ever survives the quorum, raise `BENCH_CONFIRM_RUNS`/`BENCH_CONFIRM_QUORUM` — not the threshold.** Reverting the threshold would discard the signal this buys. Noted in the plan doc.

## Validation

- `bash -n` and PowerShell AST parse clean; no stale `1.10`/10% references remain in the runners or docs.
- Exercised the new defaults against the real Windows 08-24 critcmp table: gate selects `stored_procedure` (1.10), `stored_procedure_output` (1.08), `parameterized_sp_executesql` (1.07), `strings` (1.05); improvement verification selects the top 3 at ≥5%; the verdict renders as `>=5%`.

## Related Issues

[AB#46061](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46061)

## Checklist

- [x] New/changed functionality has tests — N/A: perf-lab runner configuration; validated by replaying real run data through the changed selectors
- [x] Public API changes are documented — N/A: no public API changes