### PR TITLE
Document perf-lab run triage and baseline-advance criteria

### DIFF
--- a/mssql-tds-bench/README.md
+++ b/mssql-tds-bench/README.md
@@ -92,8 +92,10 @@ CPU pinning (used by `perf-lab/run-benchmarks.sh` when SQL Server is colocated):
 ## Fixed-baseline comparison on the perf lab
 
 `perf-lab/run-benchmarks.sh` (Linux) and `perf-lab/run-benchmarks.ps1` (Windows)
-are the testScripts run by the shared `PerfTest` lab template
-(`.pipeline/perf-baseline-pipeline.yml`). They run on a dedicated perf-lab VM and:
+are the testScripts run by the shared `PerfTest` lab template, one ADO definition
+per platform (`.pipeline/perf-baseline-linux-pipeline.yml` and
+`.pipeline/perf-baseline-windows-pipeline.yml`). They run on a dedicated perf-lab
+VM and:
 
 1. Build and run the candidate (`mssql-tds` = working tree) with `--save-baseline candidate`.
 2. Replace the `mssql-tds` source at `../mssql-tds` in place with a local
@@ -105,4 +107,5 @@ The harness is always built from the candidate tree (it does not exist at the
 baseline commit); only the `mssql-tds` *source* is swapped, so the harness, Criterion
 version, and toolchain stay constant. `SQL_SERVER` and `SQL_PASSWORD` are injected
 by the lab template. The baseline commit is advanced via a pull request that edits
-`perf-lab/baseline-commit.txt`.
+`perf-lab/baseline-commit.txt`; see [`perf-lab/MONITORING.md`](perf-lab/MONITORING.md)
+for how the weekly runs are triaged and when the baseline may be advanced.

--- a/mssql-tds-bench/perf-lab/MONITORING.md
+++ b/mssql-tds-bench/perf-lab/MONITORING.md
@@ -32,12 +32,15 @@ the table can be reconstructed from it when quoting Windows results elsewhere.
 
 ## Triage
 
-- **Confirmed regression** (test script exits 1) — report the confirmed
-  benchmarks with their trip counts and worst ratios, plus the commit range since
-  the last green run on that platform. Do not retry: the quorum has already ruled
-  out noise.
-- **Infra failure** (the run fails before the test step — VM deploy, toolchain
-  bootstrap, SQL setup) — re-queue once. Escalate only if the retry also fails.
+- **Confirmed regression** (the completed summary verdict reports confirmed
+  regressions) — report the confirmed benchmarks with their trip counts and worst
+  ratios, plus the commit range since the last green run on that platform. Do not
+  retry: the quorum has already ruled out noise.
+- **Infra or harness failure** (no completed summary verdict, or the failing
+  phase is VM deploy, SQL setup, toolchain/critcmp install, baseline SHA
+  validation, missing bench binaries, or invalid `BENCH_*` settings) — re-queue
+  only if the phase looks transient; otherwise fix the code or config. Escalate
+  if a retry also fails.
 - **Green** — check for verified improvements and for sub-gate drift, then apply
   the lock-in rules below.
 

--- a/mssql-tds-bench/perf-lab/MONITORING.md
+++ b/mssql-tds-bench/perf-lab/MONITORING.md
@@ -1,0 +1,66 @@
+# Perf-lab monitoring runbook
+
+How the weekly perf-lab runs are triaged, and when the baseline is advanced.
+
+## The pipelines
+
+| Platform | Definition | Schedule (UTC) | Typical duration |
+|----------|-----------:|----------------|------------------|
+| Linux    | [2294](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build?definitionId=2294) | Mon 08:00 | ~1h |
+| Windows  | [2298](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build?definitionId=2298) | Mon 10:00 | ~1h40m |
+
+Both run against `refs/heads/main` of the ADO mirror, which can lag GitHub `main`
+by a few commits. Both compare that commit against the single SHA in
+[`baseline-commit.txt`](baseline-commit.txt), shared by the two platforms.
+
+## Reading a run
+
+`run-benchmarks.sh` / `.ps1` echo the generated `summary.md` into the "Run tests
+on perf VM" step log, fenced by `===== summary.md =====` markers, so triage needs
+no artifact download. The same file is also published in the `perf-results`
+artifact and rendered on the run's Summary tab.
+
+The gate is already noise-hardened: a benchmark ≥10% slower trips it, is then
+re-measured 4× interleaved, and is only confirmed when it trips in ≥3 of those 4
+re-runs. Apparent *improvements* ≥10% get the same treatment, so an unreproduced
+win is reported as an artifact rather than a gain. Take the verdict line at face
+value; do not re-litigate a cleared benchmark from the first-pass numbers.
+
+The Windows step log mangles the summary's UTF-8 (emoji, `±`, `µ`). The raw
+critcmp block is still readable, and the emoji bars are a pure function of Δ%, so
+the table can be reconstructed from it when quoting Windows results elsewhere.
+
+## Triage
+
+- **Confirmed regression** (test script exits 1) — report the confirmed
+  benchmarks with their trip counts and worst ratios, plus the commit range since
+  the last green run on that platform. Do not retry: the quorum has already ruled
+  out noise.
+- **Infra failure** (the run fails before the test step — VM deploy, toolchain
+  bootstrap, SQL setup) — re-queue once. Escalate only if the retry also fails.
+- **Green** — check for verified improvements and for sub-gate drift, then apply
+  the lock-in rules below.
+
+## Advancing the baseline
+
+Advancing makes the candidate's numbers the new floor: a later change that gives
+the gains back trips the gate instead of silently settling at the old level. That
+cuts both ways — a bump that carries an unaddressed slowdown legitimizes it, and
+the next 10% gate is then measured from the degraded point.
+
+Bump only when **all** of the following hold:
+
+1. Both platforms are green at the **same** commit.
+2. That commit is an ancestor of GitHub `main`.
+3. At least one *verified* improvement (reproduced in ≥ quorum) on either platform.
+4. No benchmark on **either** platform is more than **5%** slower than baseline —
+   tighter than the 10% gate, so drift is investigated rather than absorbed.
+
+When (1)–(3) hold but (4) does not, report the win and the drift together; the
+drift is the finding, and the bump waits for it to be explained or fixed.
+
+The bump is a pull request editing `baseline-commit.txt` — reviewed, recorded in
+git history, and attributable. See
+[#346](https://github.com/microsoft/mssql-rs/pull/346) for the expected shape:
+both platform tables inline, links to the two builds, and the outgoing → incoming
+SHA in the description.


### PR DESCRIPTION
## Description

Adds `mssql-tds-bench/perf-lab/MONITORING.md`, a runbook for the weekly perf-lab runs ([Linux 2294](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build?definitionId=2294), [Windows 2298](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build?definitionId=2298)). Docs only — no behavior change to the harness or the pipelines.

The harness already does the hard part: the 10% gate, the 4x interleaved auto-confirm with a 3-of-4 quorum, and the symmetric verification of apparent improvements. What was missing is everything downstream of a finished run — who looks at it, how a real regression is told apart from an infra failure, and on what grounds the baseline may be advanced.

That last point is the substantive one. Advancing the baseline makes the candidate's numbers the new floor, which is the whole value of doing it — a later change that gives the gains back trips the gate instead of silently settling at the old level. But it cuts both ways: a bump carrying an unaddressed slowdown legitimizes it, and the next 10% gate is then measured from the degraded point. So the runbook requires four things before a bump, the fourth being that **no benchmark on either platform is more than 5% slower than baseline** — deliberately tighter than the gate, so sub-gate drift gets investigated rather than absorbed.

**The 5% ceiling is the reviewable judgment call here.** It is picked to be strict enough to catch drift while loose enough to clear on a normal noisy run. Concretely, against the 2026-08-24 runs — both green — it blocks a bump: Windows verified a genuine `primitives/decode` win at 1.16x (reproduced 4/4), but the same run had `stored_procedure_output` +8.0%, `parameterized_sp_executesql` +7.0%, and `stored_procedure` +6.5%, all Windows-only and all in the RPC path. Under this policy that drift is the finding and the bump waits. If reviewers think that is too conservative, this is the place to say so.

Also fixes a stale reference in `mssql-tds-bench/README.md` to `.pipeline/perf-baseline-pipeline.yml`, which no longer exists — it was split into `perf-baseline-linux-pipeline.yml` and `perf-baseline-windows-pipeline.yml`.

## Changes

- `mssql-tds-bench/perf-lab/MONITORING.md` (new): pipeline/schedule table; how to read a run from the step log; the triage split between a confirmed regression and an infra failure; the four baseline-advance criteria; and a note that the Windows step log mangles the summary's UTF-8 while the emoji bars remain derivable from the raw critcmp Δ% values.
- `mssql-tds-bench/README.md`: link the runbook, and correct the split-pipeline reference.

## Related Issues

Fixes #368

## Checklist

- [x] `cargo bfmt` passes — N/A: no Rust sources touched, the diff is two `.md` files
- [x] `cargo bclippy` passes — N/A: same
- [x] `cargo btest` passes — N/A: same
- [x] New/changed functionality has tests — N/A: documentation only, no behavior change
- [x] Public API changes are documented — N/A: no public API changes