### PR TITLE
mssql-odbc: honor vendor connection attributes 1203/1223/1228 (AB#47457)

### DIFF
--- a/mssql-odbc/docs/attributes_plan.md
+++ b/mssql-odbc/docs/attributes_plan.md
@@ -446,27 +446,76 @@ hardcodes "never TRUE" — wiring it into catalog-function matching is S5 work.
 
 ---
 
-### S5 — Connection attributes: vendor + remaining standard, and `attrs_before` parity
+### S5a — Vendor connection attributes that route to a keyword — **shipped**
 
-> `mssql-odbc | Vendor connection attributes & attrs_before parity`
+> `mssql-odbc | Vendor connection attributes & attrs_before parity` (AB#47457)
+
+**Scope:** the three vendor connection attributes whose behaviour was measured
+end to end against msodbcsql, routed to the same setting the equivalent
+connection-string keyword drives.
+
+| id | attribute | keyword it duplicates |
+|---|---|---|
+| 1203 | `SQL_COPT_SS_INTEGRATED_SECURITY` | `Trusted_Connection` |
+| 1223 | `SQL_COPT_SS_ENCRYPT` | `Encrypt` |
+| 1228 | `SQL_COPT_SS_TRUST_SERVER_CERTIFICATE` | `TrustServerCertificate` |
+
+**Measured contract** (probes + e2e variations 59–62, both drivers):
+
+- **Precedence is per-attribute, not one global rule.** For all three of the
+  above the *attribute wins* over the keyword — `1228 = 0` overrides
+  `TrustServerCertificate=yes` hard enough to fail the handshake with `08001`.
+  This is the opposite of `SQL_ATTR_CURRENT_CATALOG` (109), where the `Database=`
+  keyword wins and the attribute is only a fallback (S3). So the rule has to be
+  established per id, not inherited.
+- **Values are normalized, not range-checked.** `SQL_COPT_SS_ENCRYPT` takes
+  `0` off / `1` on / `2` TDS 8.0 strict, but out-of-range input is *folded*
+  rather than rejected: set `7` and the connection comes up encrypted and a
+  later get returns `1`. No `HY024`. Strict is identifiable because it stops
+  honoring `TrustServerCertificate`, so `2` fails a self-signed handshake that
+  `1` accepts.
+- **Post-connect set is rejected** with `HY011`.
+- **The get reports the effective connection setting, not the stored input.**
+  With no attribute ever set, `Encrypt=no` reads back `0` and an encrypted
+  connection reads back `1` — the value is sourced from the keyword when the
+  attribute was never used. And `Encrypt=no;TrustServerCertificate=Yes` reads
+  the trust flag back as **`0`**: with encryption off there is no certificate in
+  play, so the flag reports the resolved state rather than echoing the keyword.
+  That last one was found by the parity e2e failing, not by a probe.
+
+**Implementation note:** `encryption_setting()` in `driver_connect.rs` is the
+single source of truth shared by the mssql-tds `EncryptionOptions` builder and
+the value reported back through `SQLGetConnectAttr`, pinned by a unit test, so
+the two cannot drift.
+
+**Deliberately not routed:** `APPLICATION_INTENT`, `MULTISUBNET_FAILOVER`,
+`CONNECT_RETRY_COUNT`/`_INTERVAL`, `SERVER_SPN`, `AUTHENTICATION` and the rest of
+the vendor band have S1 sweep return codes but no *confirmed routing*. They are
+left to S5b rather than wired up on the assumption that they behave like the
+three above — which the `CURRENT_CATALOG` contrast shows is not safe.
+
+**Size:** M. **Depends on:** S1, S3.
+
+---
+
+### S5b — Connection attributes: remaining routing, fan-out, and diagnostics
+
+> follow-up to AB#47457
 
 **Scope**
-- **Route to existing keyword settings (F5)** so the keyword path and the
-  attribute path land on the same place: `SQL_COPT_SS_ENCRYPT`,
-  `TRUST_SERVER_CERTIFICATE`, `AUTHENTICATION`, `APPLICATION_INTENT`,
-  `MULTISUBNET_FAILOVER`, `TNIR`, `CONNECT_RETRY_COUNT`, `CONNECT_RETRY_INTERVAL`,
-  `SERVER_SPN`, `FAILOVER_PARTNER`, `FAILOVER_PARTNER_SPN`, `ATTACHDBFILENAME`,
-  `INTEGRATED_SECURITY`, `OLDPWD`.
-- **Precedence rule**: decide and test what wins when both the connection string
-  and a pre-connect attribute set the same thing. Verify against msodbcsql — do
-  not assume.
+- **Route the remaining keyword-equivalent attributes (F5)**, each one measured
+  first: `AUTHENTICATION`, `APPLICATION_INTENT`, `MULTISUBNET_FAILOVER`, `TNIR`,
+  `CONNECT_RETRY_COUNT`, `CONNECT_RETRY_INTERVAL`, `SERVER_SPN`,
+  `FAILOVER_PARTNER`, `FAILOVER_PARTNER_SPN`, `ATTACHDBFILENAME`, `OLDPWD`.
 - **Read-only/diagnostic:** `SQL_COPT_SS_CLIENT_CONNECTION_ID`, `SQL_COPT_SS_SPID`,
   `SQL_COPT_SS_USER_DATA`.
-- **Standard leftovers:** `SQL_ATTR_METADATA_ID`, `SQL_ATTR_ASYNC_ENABLE`,
-  `SQL_ATTR_AUTO_IPD`, `SQL_ATTR_TRANSLATE_LIB`, `SQL_ATTR_TRANSLATE_OPTION`.
+- **Standard leftovers:** `SQL_ATTR_METADATA_ID` (stored today, but `catalog.rs`
+  still hardcodes "never TRUE"), `SQL_ATTR_ASYNC_ENABLE`, `SQL_ATTR_AUTO_IPD`,
+  `SQL_ATTR_TRANSLATE_LIB`, `SQL_ATTR_TRANSLATE_OPTION`.
 - **Implement the statement-option fan-out (F3)** so an unrecognized connection
   attribute that is a valid statement option propagates to the connection's
-  statements, as msodbcsql does at `sqlcmisc.cpp:2879`.
+  statements, as msodbcsql does at `sqlcmisc.cpp:2879` — generalizing the
+  `set_query_timeout` walk that already exists.
 - **Deferred, but cleanly rejected** with the SQLSTATE msodbcsql uses (not a
   generic `HYC00` if msodbcsql differs): MARS (`SQL_COPT_SS_MARS_ENABLED`),
   Always Encrypted (`COLUMN_ENCRYPTION`, `CEKEYSTOREPROVIDER`, `CEKEYSTOREDATA`,
@@ -478,8 +527,7 @@ returns the same `(SQLRETURN, SQLSTATE)` as msodbcsql under the S1 parity sweep;
 an `attrs_before` dict mixing supported, deferred, and garbage keys behaves
 identically to msodbcsql.
 
-**Size:** L — split further if the routing and the fan-out both grow.
-**Depends on:** S1, S3 (string I/O for the character-typed ones).
+**Size:** L. **Depends on:** S5a.
 
 ---
 

--- a/mssql-odbc/src/api/driver_connect.rs
+++ b/mssql-odbc/src/api/driver_connect.rs
@@ -6,8 +6,9 @@
 use tracing::{debug, error};
 
 use crate::api::odbc_types::{
-    SQL_DRIVER_NOPROMPT, SQL_ERROR, SQL_INVALID_HANDLE, SQL_NTS, SQL_SUCCESS,
-    SQL_SUCCESS_WITH_INFO, SqlHWnd, SqlHandle, SqlReturn, SqlSmallInt, SqlUSmallInt, SqlWChar,
+    SQL_DRIVER_NOPROMPT, SQL_EN_OFF, SQL_EN_ON, SQL_EN_STRICT, SQL_ERROR, SQL_INVALID_HANDLE,
+    SQL_NTS, SQL_SUCCESS, SQL_SUCCESS_WITH_INFO, SqlHWnd, SqlHandle, SqlReturn, SqlSmallInt,
+    SqlUSmallInt, SqlWChar,
 };
 use crate::api::sqlstate::{
     ERR_FUNCTION_SEQUENCE, ERR_INVALID_CONNECTION_STRING_ATTRIBUTE, ERR_INVALID_NULL_POINTER,
@@ -18,7 +19,7 @@ use crate::api::txn::apply_post_connect_txn_settings;
 use crate::api::util::{copy_with_nul, write_if_some};
 use crate::error::{free_errors, post_sql_error};
 use crate::handles::DbcHandle;
-use crate::handles::dbc::{ConnectionState, DbcState};
+use crate::handles::dbc::{ConnectionState, DbcState, VendorConnOverrides};
 use crate::handles::{HandleType, handle_from_raw};
 
 use mssql_tds::connection::client_context::{ClientContext, IPAddressPreference};
@@ -198,6 +199,71 @@ pub(crate) fn sql_driver_connect_w_safe(
     result
 }
 
+/// Lets the `SQL_COPT_SS_*` attribute forms win over the connection-string
+/// keywords they duplicate.
+///
+/// Only a caller-set attribute (`Some`) displaces anything, so a connection
+/// string on its own still behaves exactly as it did before.
+fn apply_vendor_overrides(params: &mut ConnectionParams, overrides: &VendorConnOverrides) {
+    if let Some(encrypt) = overrides.encrypt {
+        params.encrypt = Some(
+            match u64::from(encrypt) {
+                SQL_EN_OFF => "no",
+                SQL_EN_STRICT => "strict",
+                _ => "yes",
+            }
+            .to_string(),
+        );
+    }
+    if let Some(trust) = overrides.trust_server_certificate {
+        params.trust_server_certificate = trust != 0;
+    }
+    if let Some(integrated) = overrides.integrated_security {
+        params.trusted_connection = Some(integrated != 0);
+    }
+}
+
+/// Resolves the `Encrypt=` keyword vocabulary onto an mssql-tds setting.
+///
+/// `ENCRYPT_VALUES` accepts five spellings; `mandatory`/`optional` are the
+/// aliases of `yes`/`no`. An unspecified keyword means encryption on, which is
+/// the ODBC Driver 18 default.
+fn encryption_setting(encrypt: Option<&str>) -> EncryptionSetting {
+    match encrypt {
+        Some(e) if e.eq_ignore_ascii_case("no") || e.eq_ignore_ascii_case("optional") => {
+            EncryptionSetting::PreferOff
+        }
+        Some(e) if e.eq_ignore_ascii_case("strict") => EncryptionSetting::Strict,
+        _ => EncryptionSetting::On,
+    }
+}
+
+/// The settings a post-connect get should report, taken from the connection as
+/// it actually resolved.
+///
+/// Measured against msodbcsql: a get returns the effective value regardless of
+/// which path produced it. `Encrypt=no` with no attribute set reads back `0`,
+/// and an out-of-range attribute value of `7` reads back `1`, so neither the
+/// caller's raw input nor a fixed default would match.
+fn effective_vendor_settings(params: &ConnectionParams) -> VendorConnOverrides {
+    let mode = encryption_setting(params.encrypt.as_deref());
+    let encrypt = match mode {
+        EncryptionSetting::PreferOff => SQL_EN_OFF,
+        EncryptionSetting::Strict => SQL_EN_STRICT,
+        _ => SQL_EN_ON,
+    };
+    // With encryption off there is no server certificate, so nothing is being
+    // trusted. Measured: `Encrypt=no;TrustServerCertificate=Yes` reports the
+    // trust flag as 0 on msodbcsql, so this tracks the effective policy rather
+    // than echoing the keyword.
+    let trust = !matches!(mode, EncryptionSetting::PreferOff) && params.trust_server_certificate;
+    VendorConnOverrides {
+        encrypt: Some(encrypt as u32),
+        trust_server_certificate: Some(u32::from(trust)),
+        integrated_security: Some(u32::from(params.trusted_connection.unwrap_or(false))),
+    }
+}
+
 /// Inner connect logic, separated so the caller can reset state on failure.
 fn do_connect(
     dbc: &DbcHandle,
@@ -223,6 +289,20 @@ fn do_connect(
             return SQL_ERROR;
         }
     };
+
+    // Pre-connect vendor attributes override the matching keyword, which is the
+    // reverse of the `Database=` / `SQL_ATTR_CURRENT_CATALOG` ranking applied
+    // below. Both directions were measured, not assumed.
+    let mut params = params;
+    apply_vendor_overrides(&mut params, &state.vendor_overrides);
+    let params = params;
+
+    // Record what the connection actually resolved to, so a later get reports
+    // the effective setting rather than only what an attribute happened to set.
+    // Measured: with no attribute set at all, `Encrypt=no` reads back 0 and an
+    // absent `TrustServerCertificate` reads back 0, so msodbcsql sources the
+    // get from the keyword when the attribute was never used.
+    state.vendor_overrides = effective_vendor_settings(&params);
 
     // Validate required fields. Let mssql-tds validate based on auth method.
     if params.server.is_empty() {
@@ -311,16 +391,7 @@ fn do_connect(
 
     context.encryption_options = EncryptionOptions {
         trust_server_certificate: params.trust_server_certificate,
-        mode: match params.encrypt.as_deref() {
-            Some(e) if e.eq_ignore_ascii_case("yes") || e.eq_ignore_ascii_case("mandatory") => {
-                EncryptionSetting::On
-            }
-            Some(e) if e.eq_ignore_ascii_case("no") || e.eq_ignore_ascii_case("optional") => {
-                EncryptionSetting::PreferOff
-            }
-            Some(e) if e.eq_ignore_ascii_case("strict") => EncryptionSetting::Strict,
-            _ => EncryptionSetting::On, // ODBC default
-        },
+        mode: encryption_setting(params.encrypt.as_deref()),
         host_name_in_cert: None,
         server_certificate: None,
     };
@@ -444,6 +515,102 @@ mod tests {
         SQL_DRIVER_COMPLETE, SQL_HANDLE_DBC, SQL_INVALID_HANDLE, SQL_NTS, SQL_NULL_HANDLE,
     };
     use crate::test_support::{TestHandles, cs};
+
+    /// The value a get reports must match the encryption the connection
+    /// actually uses. These are two separate mappings over the same keyword
+    /// vocabulary, so pin them together rather than trusting them to stay in
+    /// step.
+    #[test]
+    fn reported_encrypt_matches_the_negotiated_setting() {
+        for (keyword, setting, code) in [
+            (Some("yes"), EncryptionSetting::On, 1u32),
+            (Some("mandatory"), EncryptionSetting::On, 1),
+            (Some("no"), EncryptionSetting::PreferOff, 0),
+            (Some("optional"), EncryptionSetting::PreferOff, 0),
+            (Some("strict"), EncryptionSetting::Strict, 2),
+            (Some("STRICT"), EncryptionSetting::Strict, 2),
+            (None, EncryptionSetting::On, 1),
+        ] {
+            assert_eq!(encryption_setting(keyword), setting, "keyword {keyword:?}");
+
+            let (mut params, _) = parse_connection_string(&cs("Server=h;UID=u;<PW>=p")).unwrap();
+            params.encrypt = keyword.map(str::to_string);
+            assert_eq!(
+                effective_vendor_settings(&params).encrypt,
+                Some(code),
+                "keyword {keyword:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn vendor_overrides_displace_the_matching_keyword() {
+        let base = cs("Server=h;UID=u;<PW>=p;Encrypt=no;TrustServerCertificate=yes");
+        let (params, _) = parse_connection_string(&base).unwrap();
+
+        // Nothing set: the connection string is left exactly as parsed.
+        let mut untouched = params.clone();
+        apply_vendor_overrides(&mut untouched, &VendorConnOverrides::default());
+        assert_eq!(untouched.encrypt, params.encrypt);
+        assert_eq!(
+            untouched.trust_server_certificate,
+            params.trust_server_certificate
+        );
+        assert_eq!(untouched.trusted_connection, params.trusted_connection);
+
+        // Each attribute wins over the keyword it duplicates.
+        let mut overridden = params.clone();
+        apply_vendor_overrides(
+            &mut overridden,
+            &VendorConnOverrides {
+                encrypt: Some(2),
+                trust_server_certificate: Some(0),
+                integrated_security: Some(1),
+            },
+        );
+        assert_eq!(overridden.encrypt.as_deref(), Some("strict"));
+        assert!(!overridden.trust_server_certificate);
+        assert_eq!(overridden.trusted_connection, Some(true));
+    }
+
+    #[test]
+    fn effective_settings_report_the_resolved_connection() {
+        // A get reads back what the connection resolved to, from whichever path
+        // set it -- measured: `Encrypt=no` with no attribute reads back 0.
+        let (params, _) =
+            parse_connection_string(&cs("Server=h;Trusted_Connection=yes;Encrypt=no")).unwrap();
+        assert_eq!(
+            effective_vendor_settings(&params),
+            VendorConnOverrides {
+                encrypt: Some(0),
+                trust_server_certificate: Some(0),
+                integrated_security: Some(1),
+            }
+        );
+    }
+
+    /// The trust flag reports the effective certificate policy, not the
+    /// keyword. Encryption off means there is no certificate in play, and
+    /// msodbcsql reports 0 for it even when `TrustServerCertificate=Yes` was
+    /// asked for -- found by running the e2e parity variation against the
+    /// vendor driver.
+    #[test]
+    fn trust_is_only_reported_when_something_is_encrypted() {
+        for (keywords, expected) in [
+            ("Encrypt=yes;TrustServerCertificate=yes", 1),
+            ("Encrypt=yes;TrustServerCertificate=no", 0),
+            ("Encrypt=no;TrustServerCertificate=yes", 0),
+            ("Encrypt=no;TrustServerCertificate=no", 0),
+        ] {
+            let (params, _) =
+                parse_connection_string(&cs(&format!("Server=h;UID=u;<PW>=p;{keywords}"))).unwrap();
+            assert_eq!(
+                effective_vendor_settings(&params).trust_server_certificate,
+                Some(expected),
+                "{keywords}"
+            );
+        }
+    }
 
     /// Read SQLSTATE for record `rec_number` on a DBC handle by calling the
     /// driver's own `SQLGetDiagRecW` entry point. Tests use this to verify

--- a/mssql-odbc/src/api/get_connect_attr.rs
+++ b/mssql-odbc/src/api/get_connect_attr.rs
@@ -20,8 +20,9 @@ use crate::api::odbc_types::{
     SQL_ATTR_ACCESS_MODE, SQL_ATTR_AUTOCOMMIT, SQL_ATTR_CONNECTION_DEAD,
     SQL_ATTR_CONNECTION_TIMEOUT, SQL_ATTR_CURRENT_CATALOG, SQL_ATTR_LOGIN_TIMEOUT,
     SQL_ATTR_PACKET_SIZE, SQL_ATTR_TXN_ISOLATION, SQL_AUTOCOMMIT_OFF, SQL_AUTOCOMMIT_ON,
-    SQL_CD_FALSE, SQL_CD_TRUE, SQL_COPT_SS_TXN_ISOLATION, SQL_ERROR, SQL_INVALID_HANDLE,
-    SQL_SUCCESS, SqlHandle, SqlInteger, SqlPointer, SqlReturn,
+    SQL_CD_FALSE, SQL_CD_TRUE, SQL_COPT_SS_ENCRYPT, SQL_COPT_SS_INTEGRATED_SECURITY,
+    SQL_COPT_SS_TRUST_SERVER_CERTIFICATE, SQL_COPT_SS_TXN_ISOLATION, SQL_EN_ON, SQL_ERROR,
+    SQL_INVALID_HANDLE, SQL_SUCCESS, SqlHandle, SqlInteger, SqlPointer, SqlReturn,
 };
 use crate::api::util::write_if_some;
 use crate::error::free_errors;
@@ -157,6 +158,39 @@ fn sql_get_connect_attr_w_safe(
             };
             unsafe { write_if_some(value_ptr as *mut u32, value) };
             debug!(attribute, value, "SQLGetConnectAttrW: attribute returned");
+            SQL_SUCCESS
+        }
+        // The `SQL_COPT_SS_*` forms of Encrypt / TrustServerCertificate /
+        // Trusted_Connection. `do_connect` rewrites the stored values to what the
+        // connection actually resolved to, so this reports the effective setting
+        // whether it came from the attribute or from the keyword -- measured:
+        // with no attribute set, `Encrypt=no` reads back 0.
+        //
+        // Before connect there is nothing to resolve, so an unset attribute falls
+        // back to the driver defaults (encryption on, no trust, no integrated
+        // auth). That pre-connect case is inferred from the defaults, not
+        // measured, unlike the post-connect behaviour above.
+        SQL_COPT_SS_ENCRYPT
+        | SQL_COPT_SS_TRUST_SERVER_CERTIFICATE
+        | SQL_COPT_SS_INTEGRATED_SECURITY => {
+            if value_ptr.is_null() {
+                error!(attribute, "SQLGetConnectAttrW: value pointer is null");
+                post_diag(&mut state, ERR_INVALID_NULL_POINTER);
+                return SQL_ERROR;
+            }
+            let overrides = &state.vendor_overrides;
+            let value = match attribute {
+                SQL_COPT_SS_ENCRYPT => overrides.encrypt.unwrap_or(SQL_EN_ON as u32),
+                SQL_COPT_SS_TRUST_SERVER_CERTIFICATE => {
+                    overrides.trust_server_certificate.unwrap_or(0)
+                }
+                _ => overrides.integrated_security.unwrap_or(0),
+            };
+            unsafe { write_if_some(value_ptr as *mut u32, value) };
+            debug!(
+                attribute,
+                value, "SQLGetConnectAttrW: vendor attribute returned"
+            );
             SQL_SUCCESS
         }
         SQL_ATTR_CONNECTION_DEAD => {

--- a/mssql-odbc/src/api/odbc_types.rs
+++ b/mssql-odbc/src/api/odbc_types.rs
@@ -59,6 +59,20 @@ pub const SQL_OV_ODBC3_80: u32 = 380;
 // of the UTF-16-LE-encoded token.
 pub const SQL_COPT_SS_ACCESS_TOKEN: SqlInteger = 1256;
 
+// msodbcsql-specific attribute forms of connection-string keywords. These are
+// applied pre-connect and, unlike SQL_ATTR_CURRENT_CATALOG, override the
+// matching keyword (see `handles::dbc::VendorConnOverrides`).
+pub const SQL_COPT_SS_INTEGRATED_SECURITY: SqlInteger = 1203;
+pub const SQL_COPT_SS_ENCRYPT: SqlInteger = 1223;
+pub const SQL_COPT_SS_TRUST_SERVER_CERTIFICATE: SqlInteger = 1228;
+
+// SQL_COPT_SS_ENCRYPT values. 0/1 are the historical off/on pair; 2 selects the
+// TDS 8.0 "strict" mode Driver 18 added. Measured: any other value is treated
+// as "on" rather than rejected.
+pub const SQL_EN_OFF: u64 = 0;
+pub const SQL_EN_ON: u64 = 1;
+pub const SQL_EN_STRICT: u64 = 2;
+
 // Standard ODBC connection attributes the Driver Manager commonly sets before
 // connecting. Accepted (currently ignored) so the DM handshake is not broken.
 pub const SQL_ATTR_ACCESS_MODE: SqlInteger = 101;

--- a/mssql-odbc/src/api/set_connect_attr.rs
+++ b/mssql-odbc/src/api/set_connect_attr.rs
@@ -21,8 +21,10 @@ use crate::api::odbc_types::{
     SQL_ATTR_ACCESS_MODE, SQL_ATTR_ANSI_APP, SQL_ATTR_AUTOCOMMIT, SQL_ATTR_CONNECTION_TIMEOUT,
     SQL_ATTR_CURRENT_CATALOG, SQL_ATTR_LOGIN_TIMEOUT, SQL_ATTR_PACKET_SIZE, SQL_ATTR_QUERY_TIMEOUT,
     SQL_ATTR_RESET_CONNECTION, SQL_ATTR_TXN_ISOLATION, SQL_COPT_SS_ACCESS_TOKEN,
-    SQL_COPT_SS_RESET_CONNECTION, SQL_COPT_SS_TXN_ISOLATION, SQL_ERROR, SQL_INVALID_HANDLE,
-    SQL_SUCCESS, SQL_SUCCESS_WITH_INFO, SqlHandle, SqlInteger, SqlPointer, SqlReturn,
+    SQL_COPT_SS_ENCRYPT, SQL_COPT_SS_INTEGRATED_SECURITY, SQL_COPT_SS_RESET_CONNECTION,
+    SQL_COPT_SS_TRUST_SERVER_CERTIFICATE, SQL_COPT_SS_TXN_ISOLATION, SQL_EN_OFF, SQL_EN_ON,
+    SQL_EN_STRICT, SQL_ERROR, SQL_INVALID_HANDLE, SQL_SUCCESS, SQL_SUCCESS_WITH_INFO, SqlHandle,
+    SqlInteger, SqlPointer, SqlReturn,
 };
 use crate::error::{free_errors, post_sql_error};
 use crate::handles::dbc::ConnectionState;
@@ -159,6 +161,41 @@ unsafe fn sql_set_connect_attr_w_impl(
                 }
             }
         }
+        // The attribute forms of Encrypt / TrustServerCertificate /
+        // Trusted_Connection. All three are pre-connect only (measured: HY011
+        // afterwards, like the access token) and all three override the keyword
+        // rather than yielding to it -- see `VendorConnOverrides`.
+        SQL_COPT_SS_ENCRYPT
+        | SQL_COPT_SS_TRUST_SERVER_CERTIFICATE
+        | SQL_COPT_SS_INTEGRATED_SECURITY => {
+            if state.connection_state != ConnectionState::Disconnected {
+                error!(
+                    attribute,
+                    "SQLSetConnectAttrW: vendor attribute set after connect"
+                );
+                post_sql_error(
+                    &mut state,
+                    SQLSTATE_HY011,
+                    0,
+                    "Attribute must be set before connecting",
+                );
+                return SQL_ERROR;
+            }
+            let value = value_ptr as usize as u64;
+            let overrides = &mut state.vendor_overrides;
+            match attribute {
+                SQL_COPT_SS_ENCRYPT => overrides.encrypt = Some(normalize_encrypt(value)),
+                SQL_COPT_SS_TRUST_SERVER_CERTIFICATE => {
+                    overrides.trust_server_certificate = Some(u32::from(value != 0));
+                }
+                _ => overrides.integrated_security = Some(u32::from(value != 0)),
+            }
+            debug!(
+                attribute,
+                value, "SQLSetConnectAttrW: vendor override stored"
+            );
+            SQL_SUCCESS
+        }
         SQL_ATTR_LOGIN_TIMEOUT => {
             // Integer attribute: the SQLUINTEGER value is passed by value in the
             // pointer slot (not a pointer to it). Store it so SQLDriverConnect
@@ -236,6 +273,25 @@ unsafe fn sql_set_connect_attr_w_impl(
             );
             SQL_ERROR
         }
+    }
+}
+
+/// Normalizes a `SQL_COPT_SS_ENCRYPT` value.
+///
+/// Measured against msodbcsql 18 by reading `encrypt_option` back from
+/// `sys.dm_exec_connections`: `0` connects unencrypted, `1` encrypted, and `2`
+/// selects TDS 8.0 strict mode -- which is distinguishable because strict stops
+/// honoring `TrustServerCertificate`, so it fails a self-signed handshake that
+/// `1` accepts.
+///
+/// Out-of-range values are **not** rejected. `3`, `7` and `-1` all connected
+/// encrypted, and setting `7` then reading the attribute back returns `1`, so
+/// they normalize to "on" rather than earning an `HY024`.
+fn normalize_encrypt(value: u64) -> u32 {
+    match value {
+        SQL_EN_OFF => SQL_EN_OFF as u32,
+        SQL_EN_STRICT => SQL_EN_STRICT as u32,
+        _ => SQL_EN_ON as u32,
     }
 }
 
@@ -354,6 +410,7 @@ mod tests {
         SQL_TXN_SERIALIZABLE, SQL_TXN_SS_SNAPSHOT,
     };
     use crate::error::HasDiagnostics;
+    use crate::handles::dbc::VendorConnOverrides;
     use crate::test_support::TestHandles;
 
     /// Build a `SQL_COPT_SS_ACCESS_TOKEN` struct the way msodbcsql apps do:
@@ -935,5 +992,75 @@ mod tests {
         assert_eq!(state.diag_records()[0].sql_state, SQLSTATE_HY011);
         assert_eq!(state.txn_isolation, SQL_TXN_READ_COMMITTED);
         state.local_tran_started = false;
+    }
+
+    #[test]
+    fn vendor_attributes_store_normalized_values() {
+        let h = TestHandles::with_env_dbc();
+        for (attribute, raw, expected) in [
+            (SQL_COPT_SS_ENCRYPT, 0usize, 0u32),
+            (SQL_COPT_SS_ENCRYPT, 1, 1),
+            (SQL_COPT_SS_ENCRYPT, 2, 2),
+            // Out of range folds to "on" rather than erroring: msodbcsql
+            // connects encrypted for 3, 7 and -1, and a get after setting 7
+            // reads back 1.
+            (SQL_COPT_SS_ENCRYPT, 7, 1),
+            (SQL_COPT_SS_TRUST_SERVER_CERTIFICATE, 0, 0),
+            (SQL_COPT_SS_TRUST_SERVER_CERTIFICATE, 7, 1),
+            (SQL_COPT_SS_INTEGRATED_SECURITY, 0, 0),
+            (SQL_COPT_SS_INTEGRATED_SECURITY, 1, 1),
+        ] {
+            let ret = unsafe { sql_set_connect_attr_w(h.dbc, attribute, raw as SqlPointer, 0) };
+            assert_eq!(ret, SQL_SUCCESS, "attribute {attribute} value {raw}");
+
+            let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+            let overrides = dbc.inner.lock().unwrap().vendor_overrides.clone();
+            let stored = match attribute {
+                SQL_COPT_SS_ENCRYPT => overrides.encrypt,
+                SQL_COPT_SS_TRUST_SERVER_CERTIFICATE => overrides.trust_server_certificate,
+                _ => overrides.integrated_security,
+            };
+            assert_eq!(stored, Some(expected), "attribute {attribute} value {raw}");
+        }
+    }
+
+    #[test]
+    fn vendor_attributes_after_connect_are_rejected() {
+        // These select the transport and the credential, both fixed by the
+        // handshake, so a late set could never apply. Measured against
+        // msodbcsql: post-connect sets in the vendor band return HY011.
+        for attribute in [
+            SQL_COPT_SS_ENCRYPT,
+            SQL_COPT_SS_TRUST_SERVER_CERTIFICATE,
+            SQL_COPT_SS_INTEGRATED_SECURITY,
+        ] {
+            let h = TestHandles::with_env_dbc();
+            let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+            dbc.inner.lock().unwrap().connection_state = ConnectionState::Connected;
+
+            let ret = unsafe { sql_set_connect_attr_w(h.dbc, attribute, 1usize as SqlPointer, 0) };
+            assert_eq!(ret, SQL_ERROR, "attribute {attribute}");
+            let state = dbc.inner.lock().unwrap();
+            assert_eq!(state.diag_records()[0].sql_state, SQLSTATE_HY011);
+            assert_eq!(
+                state.vendor_overrides,
+                VendorConnOverrides::default(),
+                "a rejected set must not change the stored value"
+            );
+        }
+    }
+
+    #[test]
+    fn encrypt_normalization_covers_the_whole_range() {
+        assert_eq!(normalize_encrypt(0), 0);
+        assert_eq!(normalize_encrypt(1), 1);
+        assert_eq!(normalize_encrypt(2), 2);
+        for out_of_range in [3u64, 7, u64::MAX] {
+            assert_eq!(
+                normalize_encrypt(out_of_range),
+                1,
+                "out-of-range {out_of_range} must fold to on, not error"
+            );
+        }
     }
 }

--- a/mssql-odbc/src/handles/dbc.rs
+++ b/mssql-odbc/src/handles/dbc.rs
@@ -48,6 +48,38 @@ pub(crate) struct DbcHandle {
 unsafe impl Send for DbcHandle {}
 unsafe impl Sync for DbcHandle {}
 
+/// Pre-connect values from the `SQL_COPT_SS_*` attributes that duplicate a
+/// connection-string keyword.
+///
+/// mssql-python applies `attrs_before` unfiltered at connect, so a caller can
+/// configure the same setting through either path. Measured against msodbcsql
+/// 18, the two paths do not rank the same way:
+///
+/// - The vendor attributes here **override** the keyword. `Encrypt=no` in the
+///   string plus `SQL_COPT_SS_ENCRYPT=1` connects encrypted, and the reverse
+///   pairing connects unencrypted; `SQL_COPT_SS_TRUST_SERVER_CERTIFICATE=0`
+///   overrides `TrustServerCertificate=yes` hard enough to fail the handshake.
+/// - `SQL_ATTR_CURRENT_CATALOG` is the opposite: the `Database=` keyword wins
+///   and the attribute is only a fallback (see `driver_connect`).
+///
+/// So this is deliberately not a general "attributes beat keywords" rule -- it
+/// is per attribute, and each field here was confirmed by observing the
+/// resulting session in `sys.dm_exec_connections` rather than by reading a
+/// header.
+///
+/// Values are normalized on the way in, matching msodbcsql: setting any of
+/// these to an out-of-range `7` and reading it back post-connect returns `1`,
+/// so the driver stores the effective value rather than the caller's input.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct VendorConnOverrides {
+    /// `SQL_COPT_SS_ENCRYPT` (1223): `0` no, `1` yes, `2` strict.
+    pub(crate) encrypt: Option<u32>,
+    /// `SQL_COPT_SS_TRUST_SERVER_CERTIFICATE` (1228): `0` or `1`.
+    pub(crate) trust_server_certificate: Option<u32>,
+    /// `SQL_COPT_SS_INTEGRATED_SECURITY` (1203): `0` or `1`.
+    pub(crate) integrated_security: Option<u32>,
+}
+
 /// Mutable state within a connection handle, protected by `inner`.
 pub(crate) struct DbcState {
     pub(crate) diag_records: Vec<DiagRecord>,
@@ -67,6 +99,10 @@ pub(crate) struct DbcState {
     /// Login timeout in seconds set via `SQL_ATTR_LOGIN_TIMEOUT`. Applied to the
     /// TDS login deadline at connect time. `Some(0)` means wait indefinitely.
     pub(crate) login_timeout: Option<u32>,
+    /// Pre-connect overrides from the `SQL_COPT_SS_*` attribute forms of
+    /// connection-string keywords. `None` means "the caller did not set this
+    /// attribute", which is what lets the keyword stand.
+    pub(crate) vendor_overrides: VendorConnOverrides,
     /// `SQL_ATTR_ACCESS_MODE`. Stored so a set/get round-trip agrees; the driver
     /// does not yet vary its behaviour on it.
     pub(crate) access_mode: u32,
@@ -176,6 +212,7 @@ impl DbcHandle {
                 active_stmt: None,
                 client: None,
                 access_token: None,
+                vendor_overrides: VendorConnOverrides::default(),
                 login_timeout: None,
                 access_mode: SQL_MODE_READ_WRITE,
                 connection_timeout: 0,

--- a/mssql-odbc/tests/e2e/tests/attributes_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/attributes_test.cpp
@@ -81,6 +81,7 @@
 
 #include "odbc_test_fixture.h"
 
+#include <cstdint>
 #include <cstring>
 #include <functional>
 #include <vector>
@@ -1687,4 +1688,230 @@ TEST_F(AttributesTest, MaxRowsTruncatesARowsetRatherThanRoundingIt) {
     SQLFreeStmt(stmt_, SQL_UNBIND);
     EXPECT_EQ(SQL_SUCCESS, SetStmtULen(SQL_ATTR_MAX_ROWS, 0));
     EXPECT_EQ(SQL_SUCCESS, SetStmtULen(SQL_ATTR_ROW_ARRAY_SIZE, 1));
+}
+
+// ===========================================================================
+// Vendor connection attributes (spec 4.2.2 / 4.10)
+//
+// mssql-python applies `attrs_before` unfiltered at connect, so the attribute
+// forms of Encrypt / TrustServerCertificate / Trusted_Connection can arrive
+// alongside -- or instead of -- the keywords that mean the same thing. That
+// makes two things part of the contract: which one wins when they disagree,
+// and what a later get reports.
+//
+// Both were measured against msodbcsql rather than read off a header, because
+// the ranking is not uniform: these attributes beat their keyword, while
+// SQL_ATTR_CURRENT_CATALOG loses to `Database=` (variation 22).
+// ===========================================================================
+
+#define SQL_COPT_SS_INTEGRATED_SECURITY 1203
+#define SQL_COPT_SS_ENCRYPT 1223
+#define SQL_COPT_SS_TRUST_SERVER_CERTIFICATE 1228
+
+namespace {
+
+// A connection string with `extra` appended. Reuses the shared builder so the
+// credential handling stays in one place.
+SqlTString ConnStrWith(const std::string& extra) {
+    return ODBCTestUtils::ToSqlTStr(
+        ODBCTestUtils::ToNarrow(ODBCTestUtils::BuildConnectionString()) + extra);
+}
+
+SQLRETURN ConnectWith(SQLHDBC dbc, const std::string& extra) {
+    SqlTString conn = ConnStrWith(extra);
+    SQLTCHAR out[1024] = {};
+    SQLSMALLINT out_len = 0;
+    return SQLDriverConnect(dbc, nullptr, const_cast<SQLTCHAR*>(conn.c_str()),
+                            static_cast<SQLSMALLINT>(conn.size()), out, 1024,
+                            &out_len, SQL_DRIVER_NOPROMPT);
+}
+
+// What the server says about this session, which is the only witness that an
+// attribute actually reached the wire rather than merely being stored.
+std::string EncryptOption(SQLHDBC dbc) {
+    SQLHSTMT stmt = SQL_NULL_HSTMT;
+    if (!SQL_SUCCEEDED(SQLAllocHandle(SQL_HANDLE_STMT, dbc, &stmt))) {
+        return "(no statement)";
+    }
+    SqlTString sql = ODBCTestUtils::ToSqlTStr(
+        "SELECT CONVERT(varchar(10), encrypt_option) "
+        "FROM sys.dm_exec_connections WHERE session_id = @@SPID");
+    std::string result = "(no row)";
+    if (SQL_SUCCEEDED(SQLExecDirect(stmt, const_cast<SQLTCHAR*>(sql.c_str()),
+                                    SQL_NTS)) &&
+        SQL_SUCCEEDED(SQLFetch(stmt))) {
+        SQLTCHAR buf[32] = {};
+        SQLLEN ind = 0;
+        if (SQL_SUCCEEDED(SQLGetData(stmt, 1, SQL_C_TCHAR, buf, sizeof(buf),
+                                     &ind))) {
+            result = ODBCTestUtils::ToNarrow(SqlTString(buf));
+        }
+    }
+    SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+    return result;
+}
+
+SQLUINTEGER GetVendorAttr(SQLHDBC dbc, SQLINTEGER attribute, SQLRETURN* rc) {
+    SQLUINTEGER value = 0xDEAD;
+    *rc = SQLGetConnectAttr(dbc, attribute, &value, SQL_IS_UINTEGER, nullptr);
+    return value;
+}
+
+SQLRETURN SetVendorAttr(SQLHDBC dbc, SQLINTEGER attribute, SQLUINTEGER value) {
+    return SQLSetConnectAttr(
+        dbc, attribute, reinterpret_cast<SQLPOINTER>(
+                            static_cast<std::uintptr_t>(value)),
+        SQL_IS_UINTEGER);
+}
+
+}  // namespace
+
+// -------------------------------------------------------------------
+// Variation 59 - SQL_COPT_SS_ENCRYPT outranks the Encrypt keyword, in both
+// directions. Asserted against sys.dm_exec_connections rather than against a
+// get, so a driver that stored the attribute but never applied it fails here.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, EncryptAttributeOutranksTheKeyword) {
+    const auto& cfg = ODBCTestConfig::Instance();
+    if (!cfg.Encrypt().empty()) {
+        GTEST_SKIP() << "ODBC_TEST_ENCRYPT would add a competing keyword";
+    }
+
+    struct Case {
+        const char* keyword;
+        SQLUINTEGER attr;
+        const char* expected;
+    };
+    // The keyword and the attribute always disagree, so whichever wins is
+    // unambiguous.
+    const Case cases[] = {
+        {"Encrypt=no;", 1, "TRUE"},
+        {"Encrypt=yes;", 0, "FALSE"},
+    };
+
+    for (const Case& c : cases) {
+        SCOPED_TRACE(std::string(c.keyword) + " attr=" + std::to_string(c.attr));
+
+        SQLHDBC dbc = SQL_NULL_HDBC;
+        ASSERT_TRUE(SQL_SUCCEEDED(SQLAllocHandle(SQL_HANDLE_DBC, env_, &dbc)));
+        EXPECT_TRUE(SQL_SUCCEEDED(SetVendorAttr(dbc, SQL_COPT_SS_ENCRYPT, c.attr)));
+
+        ASSERT_TRUE(SQL_SUCCEEDED(ConnectWith(dbc, c.keyword)))
+            << ODBCTestUtils::GetDiagMessage(SQL_HANDLE_DBC, dbc);
+        EXPECT_EQ(c.expected, EncryptOption(dbc));
+
+        SQLDisconnect(dbc);
+        SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+    }
+}
+
+// -------------------------------------------------------------------
+// Variation 60 - an out-of-range SQL_COPT_SS_ENCRYPT value is normalized, not
+// rejected. msodbcsql connects encrypted for 3, 7 and -1, and reading the
+// attribute back afterwards returns 1 rather than the value that was set, so
+// the driver reports the effective setting.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, OutOfRangeEncryptValueNormalizesToOn) {
+    const auto& cfg = ODBCTestConfig::Instance();
+    if (!cfg.Encrypt().empty()) {
+        GTEST_SKIP() << "ODBC_TEST_ENCRYPT would add a competing keyword";
+    }
+
+    SQLHDBC dbc = SQL_NULL_HDBC;
+    ASSERT_TRUE(SQL_SUCCEEDED(SQLAllocHandle(SQL_HANDLE_DBC, env_, &dbc)));
+    EXPECT_TRUE(SQL_SUCCEEDED(SetVendorAttr(dbc, SQL_COPT_SS_ENCRYPT, 7)))
+        << "an out-of-range value is accepted, not HY024";
+
+    ASSERT_TRUE(SQL_SUCCEEDED(ConnectWith(dbc, "")))
+        << ODBCTestUtils::GetDiagMessage(SQL_HANDLE_DBC, dbc);
+    EXPECT_EQ("TRUE", EncryptOption(dbc));
+
+    SQLRETURN rc = SQL_ERROR;
+    EXPECT_EQ(1u, GetVendorAttr(dbc, SQL_COPT_SS_ENCRYPT, &rc));
+    EXPECT_TRUE(SQL_SUCCEEDED(rc));
+
+    SQLDisconnect(dbc);
+    SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+}
+
+// -------------------------------------------------------------------
+// Variation 61 - all three select something the handshake fixes: the
+// transport, the certificate policy, and the credential. A late set could
+// never apply, and both drivers reject it with HY011 rather than accepting it
+// and silently doing nothing.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, VendorConnectionAttributesAreRejectedAfterConnect) {
+    for (SQLINTEGER attribute : {SQL_COPT_SS_ENCRYPT,
+                                 SQL_COPT_SS_TRUST_SERVER_CERTIFICATE,
+                                 SQL_COPT_SS_INTEGRATED_SECURITY}) {
+        SCOPED_TRACE(attribute);
+
+        SQLHDBC dbc = SQL_NULL_HDBC;
+        ASSERT_TRUE(SQL_SUCCEEDED(SQLAllocHandle(SQL_HANDLE_DBC, env_, &dbc)));
+        ASSERT_TRUE(SQL_SUCCEEDED(ConnectWith(dbc, "")))
+            << ODBCTestUtils::GetDiagMessage(SQL_HANDLE_DBC, dbc);
+
+        EXPECT_FALSE(SQL_SUCCEEDED(SetVendorAttr(dbc, attribute, 1)));
+        EXPECT_NE(std::string::npos,
+                  ODBCTestUtils::GetDiagMessage(SQL_HANDLE_DBC, dbc)
+                      .find("HY011"));
+
+        SQLDisconnect(dbc);
+        SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+    }
+}
+
+// -------------------------------------------------------------------
+// Variation 62 - with no attribute set at all, a get still reports the
+// connection's effective setting, sourced from the keyword. Measured:
+// `Encrypt=no` reads back 0 on msodbcsql even though nothing ever set the
+// attribute, so this is not an echo of a stored value.
+// -------------------------------------------------------------------
+TEST_F(AttributesTest, VendorAttributeGetReportsTheEffectiveSetting) {
+    const auto& cfg = ODBCTestConfig::Instance();
+    if (!cfg.Encrypt().empty()) {
+        GTEST_SKIP() << "ODBC_TEST_ENCRYPT would add a competing keyword";
+    }
+
+    SQLHDBC dbc = SQL_NULL_HDBC;
+    ASSERT_TRUE(SQL_SUCCEEDED(SQLAllocHandle(SQL_HANDLE_DBC, env_, &dbc)));
+    ASSERT_TRUE(SQL_SUCCEEDED(ConnectWith(dbc, "Encrypt=no;")))
+        << ODBCTestUtils::GetDiagMessage(SQL_HANDLE_DBC, dbc);
+
+    SQLRETURN rc = SQL_ERROR;
+    EXPECT_EQ(0u, GetVendorAttr(dbc, SQL_COPT_SS_ENCRYPT, &rc));
+    EXPECT_TRUE(SQL_SUCCEEDED(rc));
+    EXPECT_EQ("FALSE", EncryptOption(dbc));
+
+    // The other two follow the same rule. Encryption is off here, so there is
+    // no server certificate to trust and the flag reads 0 whatever the
+    // TrustServerCertificate keyword said.
+    EXPECT_EQ(0u, GetVendorAttr(dbc, SQL_COPT_SS_TRUST_SERVER_CERTIFICATE, &rc));
+    EXPECT_TRUE(SQL_SUCCEEDED(rc));
+
+    const SQLUINTEGER expected_integrated = cfg.HasCredentials() ? 0u : 1u;
+    EXPECT_EQ(expected_integrated,
+              GetVendorAttr(dbc, SQL_COPT_SS_INTEGRATED_SECURITY, &rc));
+    EXPECT_TRUE(SQL_SUCCEEDED(rc));
+
+    SQLDisconnect(dbc);
+    SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+
+    // The discriminating half: with encryption on, the same keyword does read
+    // back as trusted, so the 0 above is the encryption state talking and not
+    // the driver simply ignoring TrustServerCertificate.
+    if (cfg.TrustCert() != "Yes" && cfg.TrustCert() != "yes") {
+        return;
+    }
+    SQLHDBC encrypted = SQL_NULL_HDBC;
+    ASSERT_TRUE(SQL_SUCCEEDED(SQLAllocHandle(SQL_HANDLE_DBC, env_, &encrypted)));
+    ASSERT_TRUE(SQL_SUCCEEDED(ConnectWith(encrypted, "Encrypt=yes;")))
+        << ODBCTestUtils::GetDiagMessage(SQL_HANDLE_DBC, encrypted);
+
+    EXPECT_EQ(1u, GetVendorAttr(encrypted, SQL_COPT_SS_ENCRYPT, &rc));
+    EXPECT_EQ(1u,
+              GetVendorAttr(encrypted, SQL_COPT_SS_TRUST_SERVER_CERTIFICATE, &rc));
+
+    SQLDisconnect(encrypted);
+    SQLFreeHandle(SQL_HANDLE_DBC, encrypted);
 }


### PR DESCRIPTION
## What

Honors the three vendor connection attributes whose behaviour I could measure end to end against msodbcsql, routing each to the same setting its connection-string keyword drives.

| id | attribute | keyword it duplicates |
|---|---|---|
| 1203 | `SQL_COPT_SS_INTEGRATED_SECURITY` | `Trusted_Connection` |
| 1223 | `SQL_COPT_SS_ENCRYPT` | `Encrypt` |
| 1228 | `SQL_COPT_SS_TRUST_SERVER_CERTIFICATE` | `TrustServerCertificate` |

This is the `attrs_before` parity surface from spec §4.10: `mssql-python` applies that dict unfiltered at connect, so these ids reach the driver even though the post-connect `set_attr` allowlist never mentions them.

Part of [AB#46377](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46377). Stacked on #352.

## Measured contract

Everything below came from probing the real driver, not from the headers.

**Precedence is per-attribute, not one global rule.** For all three of these the *attribute wins* over the keyword — `1228 = 0` overrides `TrustServerCertificate=yes` hard enough to fail the handshake with `08001`. That is the opposite of `SQL_ATTR_CURRENT_CATALOG` (109), where the `Database=` keyword wins and the attribute is only a fallback (shipped in #348). So the rule has to be established per id; inheriting it would have got `CURRENT_CATALOG` backwards.

**Values are normalized, not range-checked.** `SQL_COPT_SS_ENCRYPT` takes `0` off / `1` on / `2` TDS 8.0 strict, but out-of-range input is folded rather than rejected: set `7` and the connection comes up encrypted and a later get returns `1`. No `HY024`. Strict is identifiable because it stops honoring `TrustServerCertificate`, so `2` fails a self-signed handshake that `1` accepts.

**Post-connect set returns `HY011`.**

**The get reports the effective connection setting, not the stored input.** With no attribute ever set, `Encrypt=no` reads back `0` and an encrypted connection reads back `1` — the value is sourced from the keyword when the attribute was never used. That drove the storage shape: values are kept as normalized `Option<u32>` codes and the connect path writes the *resolved* settings back, so the get is a trivial echo of something already correct.

And `Encrypt=no;TrustServerCertificate=Yes` reads the trust flag back as **`0`** — with encryption off there is no certificate in play. **I did not predict this one.** I wrote variation 62 asserting the flag tracked the keyword, it passed on the Rust driver and *failed on msodbcsql*, and the fix was to the Rust driver. The e2e caught a divergence the probes had left ambiguous, because the earlier probe used `Encrypt=no` with no `TrustServerCertificate` keyword at all, so `0` looked like it could just be the default.

## What is deliberately *not* in here

`APPLICATION_INTENT`, `MULTISUBNET_FAILOVER`, `CONNECT_RETRY_COUNT`/`_INTERVAL`, `SERVER_SPN`, `AUTHENTICATION` and the rest of the vendor band have sweep return codes in the recognition table from #349, but no *confirmed routing*. Wiring them up on the assumption that they behave like the three above is exactly the assumption `CURRENT_CATALOG` disproves, so they go to the follow-up work item, [AB#47526](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47526), with their own measurements. Same for the statement-option fan-out, the read-only diagnostics, and the deferred-feature rejections — see the follow-up section of `attributes_plan.md`.

## Implementation note

`encryption_setting()` in `driver_connect.rs` is now the single source of truth shared by the mssql-tds `EncryptionOptions` builder and the value reported back through `SQLGetConnectAttr`, pinned by a unit test. Before this the mapping was inline in the builder; duplicating it for the get path would have let the reported value drift from the negotiated one.

## Testing

- **6 new unit tests**, 957 total passing.
- **e2e variations 59–62** in `attributes_test.cpp`, covering both override directions, the out-of-range fold, the post-connect `HY011`, and the effective-value get. Variation 62 also connects a second time with `Encrypt=yes` to show the trust flag *does* read back as 1 there — otherwise the `0` in the first half could be read as the driver ignoring the keyword rather than reporting the encryption state.
- **All 63 variations pass on the Rust driver and all 61 non-skipped pass on msodbcsql**, unmodified.
- **Diff coverage 96.48%.**

## Checklist

- [x] `cargo bfmt`
- [x] `cargo bclippy`
- [x] `cargo btest`
- [x] e2e parity verified locally against both drivers
- [x] Plan doc updated with the measured contract and the follow-up split

