### PR TITLE
Do not treat SQLSELECT-tagged DONE_COUNT as an update count

### DIFF
--- a/mssql-odbc/src/api/exec_direct.rs
+++ b/mssql-odbc/src/api/exec_direct.rs
@@ -324,8 +324,11 @@ mod tests {
         assert!(ds.client.is_some());
     }
 
+    /// SQL Server compiles variable assignment as a SQLSELECT command carrying
+    /// DONE_COUNT. `SQLExecDirect` must skip past it and open the following row
+    /// set, so an immediate `SQLFetch` succeeds instead of failing with 24000.
     #[test]
-    fn exec_direct_skips_declare_count_and_opens_rowset() {
+    fn exec_direct_skips_assignment_count_and_opens_rowset() {
         use crate::api::odbc_types::SQL_SUCCESS;
         use crate::handles::dbc::DbcHandle;
         use mssql_tds::test_client_support::{
@@ -337,15 +340,18 @@ mod tests {
         h.mark_dbc_connected();
         let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
         let client = tds_client_from_tokens(vec![
-            done_more_select_with_count(0),
+            done_more_select_with_count(1),
             col_metadata(int_columns(1)),
             done_no_more(),
         ]);
         dbc.inner.lock().unwrap().client = Some(client);
 
         let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
-        let ret =
-            sql_exec_direct_w_safe(h.stmt, stmt, "DECLARE @value int; EXEC dbo.p;".to_string());
+        let ret = sql_exec_direct_w_safe(
+            h.stmt,
+            stmt,
+            "DECLARE @out int = 1; EXEC dbo.p;".to_string(),
+        );
 
         assert_eq!(ret, SQL_SUCCESS);
         let state = stmt.inner.lock().unwrap();

--- a/mssql-odbc/src/api/exec_direct.rs
+++ b/mssql-odbc/src/api/exec_direct.rs
@@ -324,6 +324,36 @@ mod tests {
         assert!(ds.client.is_some());
     }
 
+    #[test]
+    fn exec_direct_skips_declare_count_and_opens_rowset() {
+        use crate::api::odbc_types::SQL_SUCCESS;
+        use crate::handles::dbc::DbcHandle;
+        use mssql_tds::test_client_support::{
+            col_metadata, done_more_select_with_count, done_no_more, int_columns,
+            tds_client_from_tokens,
+        };
+
+        let h = TestHandles::with_env_dbc_stmt();
+        h.mark_dbc_connected();
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        let client = tds_client_from_tokens(vec![
+            done_more_select_with_count(0),
+            col_metadata(int_columns(1)),
+            done_no_more(),
+        ]);
+        dbc.inner.lock().unwrap().client = Some(client);
+
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        let ret =
+            sql_exec_direct_w_safe(h.stmt, stmt, "DECLARE @value int; EXEC dbo.p;".to_string());
+
+        assert_eq!(ret, SQL_SUCCESS);
+        let state = stmt.inner.lock().unwrap();
+        assert!(state.has_state(STMT_STATE_CURSOR_OPEN));
+        assert_eq!(state.column_metadata.len(), 1);
+        assert_eq!(state.row_count, -1);
+    }
+
     /// A no-row statement that also produced a message surfaces its diagnostics
     /// with SQL_SUCCESS_WITH_INFO from the `finish_execute` no-row branch.
     #[test]

--- a/mssql-odbc/tests/e2e/tests/exec_direct_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/exec_direct_test.cpp
@@ -384,7 +384,10 @@ TEST_F(ExecDirectLiveTest, UpdateCountStillPrecedesRowSetAfterAssignment) {
 
 // A warning raised by the assignment itself puts a message and a SQLSELECT
 // count on the same DONE. The message-only result still surfaces, but must
-// report SQLRowCount -1 rather than the assignment's count.
+// report SQLRowCount -1 rather than the assignment's count -- or the preceding
+// UPDATE's. The UPDATE is what makes the -1 assertion meaningful: without it
+// SQLRowCount is still -1 from execution start and the test would pass even if
+// a prior count leaked.
 TEST_F(ExecDirectLiveTest, AssignmentWarningResultReportsNoRowCount) {
     SqlTString setup =
         ODBCTestUtils::ToSqlTStr("CREATE TABLE #agg(v int); INSERT INTO #agg VALUES (1),(NULL);");
@@ -398,18 +401,59 @@ TEST_F(ExecDirectLiveTest, AssignmentWarningResultReportsNoRowCount) {
     // SELECT @x = MAX(v) over a NULL emits "Null value is eliminated by an
     // aggregate or other SET operation" (msg 8153) on the assignment's DONE.
     SqlTString sql = ODBCTestUtils::ToSqlTStr(
-        "DECLARE @x int; SELECT @x = MAX(v) FROM #agg; SELECT 5 AS a;");
+        "UPDATE #agg SET v = v; DECLARE @x int; SELECT @x = MAX(v) FROM #agg; SELECT 5 AS a;");
     rc = SQLExecDirect(stmt_, const_cast<SQLTCHAR*>(sql.c_str()), SQL_NTS);
     ASSERT_SQL_OK(rc, SQL_HANDLE_STMT, stmt_);
 
+    // The UPDATE's genuine count.
     SQLSMALLINT cols = -1;
     ASSERT_SQL_OK(SQLNumResultCols(stmt_, &cols), SQL_HANDLE_STMT, stmt_);
     EXPECT_EQ(0, cols);
+    SQLLEN row_count = 0;
+    ASSERT_SQL_OK(SQLRowCount(stmt_, &row_count), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(2, row_count);
+
+    // The warning result: no count of its own, and the UPDATE's must not leak.
+    ASSERT_SQL_OK(SQLMoreResults(stmt_), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLNumResultCols(stmt_, &cols), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(0, cols);
+    ASSERT_SQL_OK(SQLRowCount(stmt_, &row_count), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(-1, row_count);
+
+    ASSERT_SQL_OK(SQLMoreResults(stmt_), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLNumResultCols(stmt_, &cols), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(1, cols);
+    EXPECT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
+}
+
+// A message-only statement (PRINT) after a DML count reports SQLRowCount -1,
+// not the preceding statement's count. Pre-existing shape, pinned here because
+// the assignment fix routes a new case onto the same branch.
+TEST_F(ExecDirectLiveTest, MessageOnlyResultAfterDmlReportsNoRowCount) {
+    SqlTString setup =
+        ODBCTestUtils::ToSqlTStr("CREATE TABLE #pr(v int); INSERT INTO #pr VALUES (1),(2);");
+    SQLRETURN rc = SQLExecDirect(stmt_, const_cast<SQLTCHAR*>(setup.c_str()), SQL_NTS);
+    ASSERT_SQL_OK(rc, SQL_HANDLE_STMT, stmt_);
+    for (SQLRETURN more = SQLMoreResults(stmt_); more != SQL_NO_DATA;
+         more = SQLMoreResults(stmt_)) {
+        ASSERT_SQL_OK(more, SQL_HANDLE_STMT, stmt_);
+    }
+
+    SqlTString sql = ODBCTestUtils::ToSqlTStr(
+        "UPDATE #pr SET v = v; PRINT 'hello'; SELECT 5 AS a;");
+    rc = SQLExecDirect(stmt_, const_cast<SQLTCHAR*>(sql.c_str()), SQL_NTS);
+    ASSERT_SQL_OK(rc, SQL_HANDLE_STMT, stmt_);
 
     SQLLEN row_count = 0;
     ASSERT_SQL_OK(SQLRowCount(stmt_, &row_count), SQL_HANDLE_STMT, stmt_);
-    EXPECT_EQ(-1, row_count) << "the warning result must not carry the assignment's count";
+    EXPECT_EQ(2, row_count);
 
+    ASSERT_SQL_OK(SQLMoreResults(stmt_), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLRowCount(stmt_, &row_count), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(-1, row_count) << "PRINT must not inherit the UPDATE's count";
+
+    SQLSMALLINT cols = -1;
     ASSERT_SQL_OK(SQLMoreResults(stmt_), SQL_HANDLE_STMT, stmt_);
     ASSERT_SQL_OK(SQLNumResultCols(stmt_, &cols), SQL_HANDLE_STMT, stmt_);
     EXPECT_EQ(1, cols);

--- a/mssql-odbc/tests/e2e/tests/exec_direct_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/exec_direct_test.cpp
@@ -250,3 +250,149 @@ TEST_F(ExecDirectLiveTest, GetDataBasicChar) {
     rc = SQLCloseCursor(stmt_);
     EXPECT_SQL_OK(rc, SQL_HANDLE_STMT, stmt_);
 }
+
+// --- Regression: variable assignment must not be exposed as a leading result ---
+//
+// SQL Server compiles variable assignment (DECLARE with an initializer, SET, or
+// SELECT @var = col) as a SQLSELECT command that still carries DONE_COUNT. The
+// driver must not turn that into an update-count result, otherwise SQLExecDirect
+// stops on a phantom 0-column result and an immediate SQLFetch fails with 24000.
+// msodbcsql behaves the same way, so these run unguarded against both drivers.
+
+namespace {
+
+// Executes `sql`, asserting it opens a row set directly, and returns the first
+// column of the first row as text.
+std::string ExecAndReadFirstCell(SQLHSTMT stmt, const char* sql) {
+    SqlTString text = ODBCTestUtils::ToSqlTStr(sql);
+    SQLRETURN rc = SQLExecDirect(stmt, const_cast<SQLTCHAR*>(text.c_str()), SQL_NTS);
+    EXPECT_SQL_OK(rc, SQL_HANDLE_STMT, stmt);
+
+    SQLSMALLINT cols = -1;
+    rc = SQLNumResultCols(stmt, &cols);
+    EXPECT_SQL_OK(rc, SQL_HANDLE_STMT, stmt);
+    EXPECT_EQ(1, cols) << "expected to be positioned on the row set, not a count";
+
+    SQLLEN row_count = 0;
+    rc = SQLRowCount(stmt, &row_count);
+    EXPECT_SQL_OK(rc, SQL_HANDLE_STMT, stmt);
+    EXPECT_EQ(-1, row_count) << "a row set must report SQLRowCount -1";
+
+    rc = SQLFetch(stmt);
+    EXPECT_SQL_OK(rc, SQL_HANDLE_STMT, stmt);
+
+    SQLCHAR buf[32] = {0};
+    SQLLEN ind = 0;
+    rc = SQLGetData(stmt, 1, SQL_C_CHAR, buf, sizeof(buf), &ind);
+    EXPECT_SQL_OK(rc, SQL_HANDLE_STMT, stmt);
+
+    EXPECT_EQ(SQL_NO_DATA, SQLFetch(stmt));
+    EXPECT_SQL_OK(SQLCloseCursor(stmt), SQL_HANDLE_STMT, stmt);
+    return std::string(reinterpret_cast<const char*>(buf));
+}
+
+}  // namespace
+
+// DECLARE with an initializer, followed by a SELECT.
+TEST_F(ExecDirectLiveTest, DeclareWithInitializerDoesNotPrecedeRowSet) {
+    EXPECT_EQ("7", ExecAndReadFirstCell(stmt_, "DECLARE @x int = 1; SELECT 7 AS a;"));
+}
+
+// SET assignment is compiled the same way as an initialized DECLARE.
+TEST_F(ExecDirectLiveTest, SetAssignmentDoesNotPrecedeRowSet) {
+    EXPECT_EQ("8", ExecAndReadFirstCell(stmt_, "DECLARE @x int; SET @x = 1; SELECT 8 AS a;"));
+}
+
+// Assignment-SELECT reports the source row count on its DONE token.
+TEST_F(ExecDirectLiveTest, AssignmentSelectDoesNotPrecedeRowSet) {
+    EXPECT_EQ("9", ExecAndReadFirstCell(stmt_, "DECLARE @x int; SELECT @x = 1; SELECT 9 AS a;"));
+}
+
+// Several assignments in a row all collapse into the following row set.
+TEST_F(ExecDirectLiveTest, ConsecutiveAssignmentsDoNotPrecedeRowSet) {
+    EXPECT_EQ("10",
+              ExecAndReadFirstCell(
+                  stmt_, "DECLARE @a int = 1; DECLARE @b int = 2; SET @a = 3; SELECT 10 AS a;"));
+}
+
+// The reported scenario: DECLARE then EXEC of a stored procedure. An immediate
+// SQLFetch must return the procedure's rows without an intervening
+// SQLMoreResults.
+TEST_F(ExecDirectLiveTest, DeclareThenExecProcOpensProcRowSet) {
+    SqlTString create = ODBCTestUtils::ToSqlTStr(
+        "CREATE PROCEDURE #decl_proc AS BEGIN SELECT 42 AS answer; END");
+    SQLRETURN rc = SQLExecDirect(stmt_, const_cast<SQLTCHAR*>(create.c_str()), SQL_NTS);
+    ASSERT_SQL_OK(rc, SQL_HANDLE_STMT, stmt_);
+
+    EXPECT_EQ("42", ExecAndReadFirstCell(stmt_, "DECLARE @out int = 1; EXEC #decl_proc;"));
+}
+
+// A batch that is only an assignment must not report a phantom row count.
+// msodbcsql reports SQLRowCount -1 here, not 1.
+TEST_F(ExecDirectLiveTest, AssignmentOnlyBatchReportsNoRowCount) {
+    SqlTString sql = ODBCTestUtils::ToSqlTStr("DECLARE @x int = 1;");
+    SQLRETURN rc = SQLExecDirect(stmt_, const_cast<SQLTCHAR*>(sql.c_str()), SQL_NTS);
+    ASSERT_SQL_OK(rc, SQL_HANDLE_STMT, stmt_);
+
+    SQLSMALLINT cols = -1;
+    rc = SQLNumResultCols(stmt_, &cols);
+    ASSERT_SQL_OK(rc, SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(0, cols);
+
+    SQLLEN row_count = 0;
+    rc = SQLRowCount(stmt_, &row_count);
+    ASSERT_SQL_OK(rc, SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(-1, row_count);
+
+    EXPECT_EQ(SQL_NO_DATA, SQLMoreResults(stmt_));
+}
+
+// Genuine DML counts are unaffected: the UPDATE count is still reported before
+// the trailing row set, even when preceded by an assignment.
+TEST_F(ExecDirectLiveTest, UpdateCountStillPrecedesRowSetAfterAssignment) {
+    SqlTString setup =
+        ODBCTestUtils::ToSqlTStr("CREATE TABLE #upd(v int); INSERT INTO #upd VALUES (1),(2);");
+    SQLRETURN rc = SQLExecDirect(stmt_, const_cast<SQLTCHAR*>(setup.c_str()), SQL_NTS);
+    ASSERT_SQL_OK(rc, SQL_HANDLE_STMT, stmt_);
+    while (SQLMoreResults(stmt_) != SQL_NO_DATA) {
+    }
+
+    SqlTString sql = ODBCTestUtils::ToSqlTStr(
+        "DECLARE @x int = 1; UPDATE #upd SET v = v; SELECT * FROM #upd;");
+    rc = SQLExecDirect(stmt_, const_cast<SQLTCHAR*>(sql.c_str()), SQL_NTS);
+    ASSERT_SQL_OK(rc, SQL_HANDLE_STMT, stmt_);
+
+    // Positioned on the UPDATE count, not on the assignment and not on the rows.
+    SQLSMALLINT cols = -1;
+    ASSERT_SQL_OK(SQLNumResultCols(stmt_, &cols), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(0, cols);
+
+    SQLLEN row_count = 0;
+    ASSERT_SQL_OK(SQLRowCount(stmt_, &row_count), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(2, row_count);
+
+    ASSERT_SQL_OK(SQLMoreResults(stmt_), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLNumResultCols(stmt_, &cols), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(1, cols);
+    EXPECT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
+}
+
+// SELECT ... INTO reports DONE_COUNT with no CurCmd, which is a genuine update
+// count and must survive the SQLSELECT filter.
+TEST_F(ExecDirectLiveTest, SelectIntoCountStillReported) {
+    SqlTString sql = ODBCTestUtils::ToSqlTStr("SELECT 1 AS a INTO #si; SELECT * FROM #si;");
+    SQLRETURN rc = SQLExecDirect(stmt_, const_cast<SQLTCHAR*>(sql.c_str()), SQL_NTS);
+    ASSERT_SQL_OK(rc, SQL_HANDLE_STMT, stmt_);
+
+    SQLLEN row_count = 0;
+    ASSERT_SQL_OK(SQLRowCount(stmt_, &row_count), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(1, row_count);
+
+    ASSERT_SQL_OK(SQLMoreResults(stmt_), SQL_HANDLE_STMT, stmt_);
+    SQLSMALLINT cols = -1;
+    ASSERT_SQL_OK(SQLNumResultCols(stmt_, &cols), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(1, cols);
+    EXPECT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
+}

--- a/mssql-odbc/tests/e2e/tests/exec_direct_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/exec_direct_test.cpp
@@ -354,7 +354,11 @@ TEST_F(ExecDirectLiveTest, UpdateCountStillPrecedesRowSetAfterAssignment) {
         ODBCTestUtils::ToSqlTStr("CREATE TABLE #upd(v int); INSERT INTO #upd VALUES (1),(2);");
     SQLRETURN rc = SQLExecDirect(stmt_, const_cast<SQLTCHAR*>(setup.c_str()), SQL_NTS);
     ASSERT_SQL_OK(rc, SQL_HANDLE_STMT, stmt_);
-    while (SQLMoreResults(stmt_) != SQL_NO_DATA) {
+    // Bounded drain: stop on SQL_ERROR instead of spinning, so a driver bug
+    // fails the test rather than hanging the CI leg.
+    for (SQLRETURN more = SQLMoreResults(stmt_); more != SQL_NO_DATA;
+         more = SQLMoreResults(stmt_)) {
+        ASSERT_SQL_OK(more, SQL_HANDLE_STMT, stmt_);
     }
 
     SqlTString sql = ODBCTestUtils::ToSqlTStr(

--- a/mssql-odbc/tests/e2e/tests/exec_direct_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/exec_direct_test.cpp
@@ -382,6 +382,41 @@ TEST_F(ExecDirectLiveTest, UpdateCountStillPrecedesRowSetAfterAssignment) {
     EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
 }
 
+// A warning raised by the assignment itself puts a message and a SQLSELECT
+// count on the same DONE. The message-only result still surfaces, but must
+// report SQLRowCount -1 rather than the assignment's count.
+TEST_F(ExecDirectLiveTest, AssignmentWarningResultReportsNoRowCount) {
+    SqlTString setup =
+        ODBCTestUtils::ToSqlTStr("CREATE TABLE #agg(v int); INSERT INTO #agg VALUES (1),(NULL);");
+    SQLRETURN rc = SQLExecDirect(stmt_, const_cast<SQLTCHAR*>(setup.c_str()), SQL_NTS);
+    ASSERT_SQL_OK(rc, SQL_HANDLE_STMT, stmt_);
+    for (SQLRETURN more = SQLMoreResults(stmt_); more != SQL_NO_DATA;
+         more = SQLMoreResults(stmt_)) {
+        ASSERT_SQL_OK(more, SQL_HANDLE_STMT, stmt_);
+    }
+
+    // SELECT @x = MAX(v) over a NULL emits "Null value is eliminated by an
+    // aggregate or other SET operation" (msg 8153) on the assignment's DONE.
+    SqlTString sql = ODBCTestUtils::ToSqlTStr(
+        "DECLARE @x int; SELECT @x = MAX(v) FROM #agg; SELECT 5 AS a;");
+    rc = SQLExecDirect(stmt_, const_cast<SQLTCHAR*>(sql.c_str()), SQL_NTS);
+    ASSERT_SQL_OK(rc, SQL_HANDLE_STMT, stmt_);
+
+    SQLSMALLINT cols = -1;
+    ASSERT_SQL_OK(SQLNumResultCols(stmt_, &cols), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(0, cols);
+
+    SQLLEN row_count = 0;
+    ASSERT_SQL_OK(SQLRowCount(stmt_, &row_count), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(-1, row_count) << "the warning result must not carry the assignment's count";
+
+    ASSERT_SQL_OK(SQLMoreResults(stmt_), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLNumResultCols(stmt_, &cols), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(1, cols);
+    EXPECT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
+}
+
 // SELECT ... INTO reports DONE_COUNT with no CurCmd, which is a genuine update
 // count and must survive the SQLSELECT filter.
 TEST_F(ExecDirectLiveTest, SelectIntoCountStillReported) {

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -3645,6 +3645,16 @@ impl TdsClient {
                     // the SELECT, not the bare CREATE. `rows_affected` is
                     // `Some(n)` only for an update-count result.
                     if has_update_count || saw_message {
+                        if !has_update_count {
+                            // A message-only result carries no count. Clear any
+                            // count captured from a preceding statement in the
+                            // same batch so it is not re-reported as this
+                            // result's `SQLRowCount` — msodbcsql reports -1
+                            // here (verified for `UPDATE; PRINT`,
+                            // `UPDATE; RAISERROR` and `UPDATE;` followed by a
+                            // warning-raising assignment).
+                            self.last_rows_affected = -1;
+                        }
                         self.execution_context.set_has_open_batch(!is_last);
                         return Ok(ResultBoundaryKind::NoRows {
                             rows_affected: if has_update_count {
@@ -6746,23 +6756,62 @@ mod tests {
         );
     }
 
+    /// Divergence pin: msodbcsql excludes `SQLFETCHCURSOR` (0x21) and `SQLDBCC`
+    /// (0xe6) alongside `SQLSELECT`; this driver excludes only `SQLSELECT`,
+    /// matching .NET SqlClient. Neither value is modelled, so a `DONE_COUNT`
+    /// carrying one parses as `None` and *is* reported as an update count.
+    /// Fails the moment someone adopts the msodbcsql-only exclusions, forcing
+    /// that `SQLRowCount` change to be deliberate rather than incidental.
+    #[tokio::test]
+    async fn done_count_for_msodbcsql_only_exclusions_is_an_update_count() {
+        for raw in [0x21u16, 0xe6] {
+            let cmd = CurrentCommand::try_from(raw).unwrap();
+            let mut client = create_test_client_with_tokens(vec![done_count(cmd, 3, false)]);
+
+            let result = client
+                .execute("EXEC sp_cursorfetch @handle".to_string(), ())
+                .await
+                .unwrap();
+
+            assert_eq!(
+                result,
+                StatementResult::NoRows {
+                    rows_affected: Some(3)
+                },
+                "raw cur_cmd {raw:#x}"
+            );
+            assert_eq!(client.last_rows_affected(), 3, "raw cur_cmd {raw:#x}");
+            assert_eq!(
+                client.take_dml_result_counts(),
+                vec![3],
+                "raw cur_cmd {raw:#x}"
+            );
+        }
+    }
+
     /// The only path where `saw_message` and `has_count` land on the *same* DONE:
     /// a warning raised by the assignment itself. The result must still surface
     /// so the message is visible, but must carry no row count — this PR changed
     /// `rows_affected` here from `Some(1)` to `None`.
     ///
+    /// A genuine `UPDATE` precedes the assignment so the assertion is real: with
+    /// a bare assignment `last_rows_affected` is still `-1` from `begin_command`
+    /// and would pass even if the message-only branch leaked a prior count.
+    ///
     /// Live capture for
-    /// `DECLARE @x int; SELECT @x = MAX(v) FROM #t; SELECT 5 AS a;`
+    /// `UPDATE #t SET v = v; DECLARE @x int; SELECT @x = MAX(v) FROM #t; SELECT 5 AS a;`
     /// where `#t.v` contains a NULL:
     /// ```text
+    /// DONE status=MORE|COUNT cur_cmd=Update row_count=2
     /// INFO 8153 "Warning: Null value is eliminated by an aggregate or other SET operation."
     /// DONE status=MORE|COUNT cur_cmd=Select row_count=1
     /// COLMETADATA(1) + row
     /// ```
-    /// msodbcsql reports `cols=0 rowcount=-1` then `cols=1 rowcount=-1`.
+    /// msodbcsql reports `rowcount=2`, then `rowcount=-1`, then `rowcount=-1`.
     #[tokio::test]
     async fn execute_surfaces_assignment_warning_without_rowcount() {
         let mut client = create_test_client_with_tokens(vec![
+            done_count(CurrentCommand::Update, 2, true),
             info_token(
                 8153,
                 0,
@@ -6774,7 +6823,8 @@ mod tests {
 
         let first = client
             .execute(
-                "DECLARE @x int; SELECT @x = MAX(v) FROM #t; SELECT 5 AS a;".to_string(),
+                "UPDATE #t SET v = v; DECLARE @x int; SELECT @x = MAX(v) FROM #t; SELECT 5 AS a;"
+                    .to_string(),
                 (),
             )
             .await
@@ -6782,14 +6832,26 @@ mod tests {
         assert_eq!(
             first,
             StatementResult::NoRows {
+                rows_affected: Some(2)
+            }
+        );
+        assert_eq!(client.last_rows_affected(), 2);
+
+        let second = client.advance().await.unwrap();
+        assert_eq!(
+            second,
+            StatementResult::NoRows {
                 rows_affected: None
             }
         );
-        assert_eq!(client.last_rows_affected(), -1);
-        assert!(client.take_dml_result_counts().is_empty());
+        assert_eq!(
+            client.last_rows_affected(),
+            -1,
+            "the UPDATE's count must not leak into the message-only result"
+        );
 
-        let second = client.advance().await.unwrap();
-        assert_eq!(second, StatementResult::Rows);
+        let third = client.advance().await.unwrap();
+        assert_eq!(third, StatementResult::Rows);
         assert_eq!(
             client
                 .get_current_metadata()

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -6673,7 +6673,7 @@ mod tests {
             done_count(CurrentCommand::Select, 1, true),
             done_count(CurrentCommand::Select, 1, true),
             done_count(CurrentCommand::Select, 2, true),
-            empty_col_metadata(),
+            int_col_metadata(1),
         ]);
 
         let result = client
@@ -6686,18 +6686,25 @@ mod tests {
             .unwrap();
 
         assert_eq!(result, StatementResult::Rows);
+        assert_eq!(
+            client
+                .get_current_metadata()
+                .map(|m| m.columns.len())
+                .unwrap_or(0),
+            1
+        );
         assert_eq!(client.last_rows_affected(), -1);
     }
 
-    /// A PRINT before the assignment must still surface as its own message-only
-    /// result; only the assignment's count is suppressed.
+    /// A PRINT on its own statement surfaces as a message-only result (its DONE
+    /// carries no count); the following assignment's count is still suppressed.
     #[tokio::test]
     async fn execute_surfaces_message_but_skips_select_count() {
         let mut client = create_test_client_with_tokens(vec![
             info_token(0, 0, "hi"),
             done_more(),
             done_count(CurrentCommand::Select, 1, true),
-            empty_col_metadata(),
+            int_col_metadata(1),
         ]);
 
         let first = client
@@ -6710,10 +6717,71 @@ mod tests {
                 rows_affected: None
             }
         );
+        assert_eq!(client.last_rows_affected(), -1);
+        assert!(client.take_dml_result_counts().is_empty());
 
         let second = client.advance().await.unwrap();
         assert_eq!(second, StatementResult::Rows);
+        assert_eq!(
+            client
+                .get_current_metadata()
+                .map(|m| m.columns.len())
+                .unwrap_or(0),
+            1
+        );
+    }
+
+    /// The only path where `saw_message` and `has_count` land on the *same* DONE:
+    /// a warning raised by the assignment itself. The result must still surface
+    /// so the message is visible, but must carry no row count — this PR changed
+    /// `rows_affected` here from `Some(1)` to `None`.
+    ///
+    /// Live capture for
+    /// `DECLARE @x int; SELECT @x = MAX(v) FROM #t; SELECT 5 AS a;`
+    /// where `#t.v` contains a NULL:
+    /// ```text
+    /// INFO 8153 "Warning: Null value is eliminated by an aggregate or other SET operation."
+    /// DONE status=MORE|COUNT cur_cmd=Select row_count=1
+    /// COLMETADATA(1) + row
+    /// ```
+    /// msodbcsql reports `cols=0 rowcount=-1` then `cols=1 rowcount=-1`.
+    #[tokio::test]
+    async fn execute_surfaces_assignment_warning_without_rowcount() {
+        let mut client = create_test_client_with_tokens(vec![
+            info_token(
+                8153,
+                0,
+                "Warning: Null value is eliminated by an aggregate or other SET operation.",
+            ),
+            done_count(CurrentCommand::Select, 1, true),
+            int_col_metadata(1),
+        ]);
+
+        let first = client
+            .execute(
+                "DECLARE @x int; SELECT @x = MAX(v) FROM #t; SELECT 5 AS a;".to_string(),
+                (),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            first,
+            StatementResult::NoRows {
+                rows_affected: None
+            }
+        );
         assert_eq!(client.last_rows_affected(), -1);
+        assert!(client.take_dml_result_counts().is_empty());
+
+        let second = client.advance().await.unwrap();
+        assert_eq!(second, StatementResult::Rows);
+        assert_eq!(
+            client
+                .get_current_metadata()
+                .map(|m| m.columns.len())
+                .unwrap_or(0),
+            1
+        );
     }
 
     /// A genuine DML count following an assignment is still reported.
@@ -6722,7 +6790,7 @@ mod tests {
         let mut client = create_test_client_with_tokens(vec![
             done_count(CurrentCommand::Select, 1, true),
             done_count(CurrentCommand::Update, 2, true),
-            empty_col_metadata(),
+            int_col_metadata(1),
         ]);
 
         let first = client
@@ -6739,6 +6807,7 @@ mod tests {
             }
         );
         assert_eq!(client.last_rows_affected(), 2);
+        assert_eq!(client.take_dml_result_counts(), vec![2]);
 
         let second = client.advance().await.unwrap();
         assert_eq!(second, StatementResult::Rows);
@@ -6750,7 +6819,7 @@ mod tests {
     async fn execute_keeps_select_into_count() {
         let mut client = create_test_client_with_tokens(vec![
             done_count(CurrentCommand::None, 1, true),
-            empty_col_metadata(),
+            int_col_metadata(1),
         ]);
 
         let first = client
@@ -6764,6 +6833,7 @@ mod tests {
             }
         );
         assert_eq!(client.last_rows_affected(), 1);
+        assert_eq!(client.take_dml_result_counts(), vec![1]);
     }
 
     #[tokio::test]

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -3598,9 +3598,10 @@ impl TdsClient {
                     // Capture update counts for `SQLRowCount`. DONE_COUNT on a
                     // SQLSELECT command is not an update-count result.
                     let has_count = done.status.contains(DoneStatus::COUNT);
-                    // SQL Server can tag non-row-producing statements such as
-                    // DECLARE with SQLSELECT and DONE_COUNT. msodbcsql does not
-                    // expose those as update-count results.
+                    // SQL Server compiles variable assignment (`DECLARE @x int = 1`,
+                    // `SET @x = 1`, `SELECT @x = col FROM t`) as a SQLSELECT command
+                    // and still sets DONE_COUNT. msodbcsql does not expose those as
+                    // update-count results, so neither do we.
                     let has_update_count = has_count && done.cur_cmd != CurrentCommand::Select;
                     if has_update_count {
                         let count = i64::try_from(done.row_count).unwrap_or(i64::MAX);
@@ -6593,21 +6594,141 @@ mod tests {
         assert_eq!(r2, StatementResult::End);
     }
 
+    /// SQL Server compiles variable assignment as a SQLSELECT command and still
+    /// sets DONE_COUNT. Such a DONE must collapse into the following row set
+    /// rather than surface as a leading update-count result.
+    /// Observed token sequence for `DECLARE @out int = 1; EXEC dbo.p;`.
     #[tokio::test]
     async fn execute_skips_select_count_before_rowset() {
         let mut client = create_test_client_with_tokens(vec![
-            done_count(CurrentCommand::Select, 0, true),
+            done_count(CurrentCommand::Select, 1, true),
             empty_col_metadata(),
         ]);
 
         let result = client
-            .execute("DECLARE @value int; EXEC dbo.p;".to_string(), ())
+            .execute("DECLARE @out int = 1; EXEC dbo.p;".to_string(), ())
             .await
             .unwrap();
 
         assert_eq!(result, StatementResult::Rows);
         assert_eq!(client.last_rows_affected(), -1);
         assert!(client.take_dml_result_counts().is_empty());
+    }
+
+    /// `DECLARE @x int = 1;` on its own must not report a phantom result.
+    #[tokio::test]
+    async fn execute_select_count_only_batch_ends_immediately() {
+        let mut client =
+            create_test_client_with_tokens(vec![done_count(CurrentCommand::Select, 1, false)]);
+
+        let result = client
+            .execute("DECLARE @x int = 1;".to_string(), ())
+            .await
+            .unwrap();
+
+        assert_eq!(result, StatementResult::End);
+        assert_eq!(client.last_rows_affected(), -1);
+        assert!(client.take_dml_result_counts().is_empty());
+    }
+
+    /// Several assignments in a row all collapse.
+    #[tokio::test]
+    async fn execute_skips_consecutive_select_counts() {
+        let mut client = create_test_client_with_tokens(vec![
+            done_count(CurrentCommand::Select, 1, true),
+            done_count(CurrentCommand::Select, 1, true),
+            done_count(CurrentCommand::Select, 2, true),
+            empty_col_metadata(),
+        ]);
+
+        let result = client
+            .execute(
+                "DECLARE @a int = 1; SET @a = 2; SELECT @a = v FROM t; SELECT * FROM t;"
+                    .to_string(),
+                (),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result, StatementResult::Rows);
+        assert_eq!(client.last_rows_affected(), -1);
+    }
+
+    /// A PRINT before the assignment must still surface as its own message-only
+    /// result; only the assignment's count is suppressed.
+    #[tokio::test]
+    async fn execute_surfaces_message_but_skips_select_count() {
+        let mut client = create_test_client_with_tokens(vec![
+            info_token(0, 0, "hi"),
+            done_more(),
+            done_count(CurrentCommand::Select, 1, true),
+            empty_col_metadata(),
+        ]);
+
+        let first = client
+            .execute("PRINT 'hi'; DECLARE @x int = 1; SELECT 1;".to_string(), ())
+            .await
+            .unwrap();
+        assert_eq!(
+            first,
+            StatementResult::NoRows {
+                rows_affected: None
+            }
+        );
+
+        let second = client.advance().await.unwrap();
+        assert_eq!(second, StatementResult::Rows);
+        assert_eq!(client.last_rows_affected(), -1);
+    }
+
+    /// A genuine DML count following an assignment is still reported.
+    #[tokio::test]
+    async fn execute_keeps_update_count_after_select_count() {
+        let mut client = create_test_client_with_tokens(vec![
+            done_count(CurrentCommand::Select, 1, true),
+            done_count(CurrentCommand::Update, 2, true),
+            empty_col_metadata(),
+        ]);
+
+        let first = client
+            .execute(
+                "DECLARE @x int = 1; UPDATE t SET v = v; SELECT * FROM t;".to_string(),
+                (),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            first,
+            StatementResult::NoRows {
+                rows_affected: Some(2)
+            }
+        );
+        assert_eq!(client.last_rows_affected(), 2);
+
+        let second = client.advance().await.unwrap();
+        assert_eq!(second, StatementResult::Rows);
+    }
+
+    /// `SELECT ... INTO` reports DONE_COUNT with no CurCmd, which is a genuine
+    /// update count and must survive the SQLSELECT filter.
+    #[tokio::test]
+    async fn execute_keeps_select_into_count() {
+        let mut client = create_test_client_with_tokens(vec![
+            done_count(CurrentCommand::None, 1, true),
+            empty_col_metadata(),
+        ]);
+
+        let first = client
+            .execute("SELECT 1 AS a INTO #t; SELECT * FROM #t;".to_string(), ())
+            .await
+            .unwrap();
+        assert_eq!(
+            first,
+            StatementResult::NoRows {
+                rows_affected: Some(1)
+            }
+        );
+        assert_eq!(client.last_rows_affected(), 1);
     }
 
     #[tokio::test]

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -6478,6 +6478,17 @@ mod tests {
         Tokens::ColMetadata(ColMetadataToken::default())
     }
 
+    /// A COLMETADATA token for `n` nullable `int` columns, so tests can assert
+    /// the client is positioned on a real row set rather than a 0-column one.
+    fn int_col_metadata(n: usize) -> Tokens {
+        let columns = crate::test_client_support::int_columns(n);
+        Tokens::ColMetadata(ColMetadataToken {
+            column_count: u16::try_from(columns.len()).unwrap_or(u16::MAX),
+            columns,
+            cek_table: Vec::new(),
+        })
+    }
+
     fn stale_metadata() -> Arc<ColMetadataToken> {
         Arc::new(ColMetadataToken::default())
     }
@@ -6614,7 +6625,7 @@ mod tests {
     async fn execute_skips_select_count_before_rowset() {
         let mut client = create_test_client_with_tokens(vec![
             done_count(CurrentCommand::Select, 1, true),
-            empty_col_metadata(),
+            int_col_metadata(1),
         ]);
 
         let result = client
@@ -6623,6 +6634,14 @@ mod tests {
             .unwrap();
 
         assert_eq!(result, StatementResult::Rows);
+        assert_eq!(
+            client
+                .get_current_metadata()
+                .map(|m| m.columns.len())
+                .unwrap_or(0),
+            1,
+            "must be positioned on the procedure's row set"
+        );
         assert_eq!(client.last_rows_affected(), -1);
         assert!(client.take_dml_result_counts().is_empty());
     }

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -3595,28 +3595,30 @@ impl TdsClient {
 
                     let is_last = !done.has_more();
 
-                    // Capture update counts for `SQLRowCount`.
+                    // Capture update counts for `SQLRowCount`. DONE_COUNT on a
+                    // SQLSELECT command is not an update-count result.
                     let has_count = done.status.contains(DoneStatus::COUNT);
                     // SQL Server compiles variable assignment (`DECLARE @x int = 1`,
                     // `SET @x = 1`, `SELECT @x = col FROM t`) as a SQLSELECT command
-                    // and still sets DONE_COUNT. msodbcsql does not expose those as
-                    // update-count results, so neither do we.
+                    // and still sets DONE_COUNT. Neither reference driver exposes
+                    // those as update-count results, so neither do we:
+                    //   - msodbcsql: `Info != SQLSELECT` (sqlctokn.cpp:2150)
+                    //   - .NET SqlClient: `if (curCmd != TdsEnums.SELECT)`
+                    //     (TdsParser.cs `TryProcessDone`, "Skip the bogus DONE
+                    //     counts sent by the server")
                     //
-                    // The same three exclusions msodbcsql applies
-                    // (sqlctokn.cpp:2149-2152): SQLSELECT (0xc1), SQLFETCHCURSOR
-                    // (0x21) and SQLDBCC (0xe6). `sp_cursorfetch` reaches here via
-                    // `cursor_ops::cursor_fetch` -> `next_rowset`, so the cursor
-                    // exclusion is not hypothetical; a live SQL Server 2022 tags that
-                    // DONEINPROC `status: MORE|COUNT, cur_cmd: 0xc1` (already covered
-                    // by the SQLSELECT arm), but 0x21 is excluded explicitly so the
-                    // fetch buffer size can never be mistaken for an update count.
-                    let has_update_count = has_count
-                        && !matches!(
-                            done.cur_cmd,
-                            CurrentCommand::Select
-                                | CurrentCommand::FetchCursor
-                                | CurrentCommand::Dbcc
-                        );
+                    // msodbcsql additionally excludes SQLFETCHCURSOR (0x21) and
+                    // SQLDBCC (0xe6) (sqlctokn.cpp:2151-2152); SqlClient does not,
+                    // and does not even define those constants. We follow SqlClient
+                    // because neither is observable here: no DBCC was found to set
+                    // DONE_COUNT, and although `cursor_ops::cursor_fetch` does route
+                    // `sp_cursorfetch` through `next_rowset` into this function, a
+                    // live SQL Server 2022 tags that DONEINPROC
+                    // `status: MORE|COUNT, cur_cmd: 0xc1` — SQLSELECT, already
+                    // handled below. `last_rows_affected` measured -1 across block
+                    // fetches with and without this guard. Add the variants only if
+                    // a capture ever shows 0x21 or 0xe6 arriving with DONE_COUNT.
+                    let has_update_count = has_count && done.cur_cmd != CurrentCommand::Select;
                     if has_update_count {
                         let count = i64::try_from(done.row_count).unwrap_or(i64::MAX);
                         self.last_rows_affected = count;
@@ -6762,44 +6764,6 @@ mod tests {
             }
         );
         assert_eq!(client.last_rows_affected(), 1);
-    }
-
-    /// `sp_cursorfetch` reaches `advance_to_result_boundary` via
-    /// `cursor_ops::cursor_fetch` -> `next_rowset`. Its DONE reports the fetch
-    /// buffer size, which is not an update count; msodbcsql excludes it with
-    /// `Info != SQLFETCHCURSOR` (sqlctokn.cpp:2151).
-    #[tokio::test]
-    async fn execute_skips_fetch_cursor_count() {
-        let mut client = create_test_client_with_tokens(vec![
-            done_count(CurrentCommand::FetchCursor, 2, true),
-            int_col_metadata(1),
-        ]);
-
-        let result = client
-            .execute("sp_cursorfetch".to_string(), ())
-            .await
-            .unwrap();
-
-        assert_eq!(result, StatementResult::Rows);
-        assert_eq!(client.last_rows_affected(), -1);
-        assert!(client.take_dml_result_counts().is_empty());
-    }
-
-    /// msodbcsql excludes DBCC from update counts with `Info != SQLDBCC`
-    /// (sqlctokn.cpp:2152).
-    #[tokio::test]
-    async fn execute_skips_dbcc_count() {
-        let mut client =
-            create_test_client_with_tokens(vec![done_count(CurrentCommand::Dbcc, 3, false)]);
-
-        let result = client
-            .execute("DBCC CHECKIDENT('t')".to_string(), ())
-            .await
-            .unwrap();
-
-        assert_eq!(result, StatementResult::End);
-        assert_eq!(client.last_rows_affected(), -1);
-        assert!(client.take_dml_result_counts().is_empty());
     }
 
     #[tokio::test]

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -3602,6 +3602,18 @@ impl TdsClient {
                     // `SET @x = 1`, `SELECT @x = col FROM t`) as a SQLSELECT command
                     // and still sets DONE_COUNT. msodbcsql does not expose those as
                     // update-count results, so neither do we.
+                    //
+                    // msodbcsql also excludes SQLFETCHCURSOR (0x21) and SQLDBCC
+                    // (0xe6) here (sqlctokn.cpp:2149-2156). We do not, because
+                    // `CurrentCommand` folds every unrecognized value into `None`,
+                    // and `None` is what a genuine `SELECT ... INTO` count reports —
+                    // so those two cannot be told apart without dedicated variants.
+                    // Neither is reachable today: no DBCC command was observed to
+                    // set DONE_COUNT, and SQLFETCHCURSOR belongs to the server-side
+                    // cursor path this driver does not implement yet. Add
+                    // `CurrentCommand::{FetchCursor, Dbcc}` and exclude them here
+                    // when server-side cursors land, or if a DBCC is found to
+                    // report a count.
                     let has_update_count = has_count && done.cur_cmd != CurrentCommand::Select;
                     if has_update_count {
                         let count = i64::try_from(done.row_count).unwrap_or(i64::MAX);

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -3515,8 +3515,9 @@ impl TdsClient {
     /// With `true` (ODBC statement-wise navigation, matching msodbcsql), a
     /// no-row statement's DONE token can be its own result boundary, returned
     /// as [`ResultBoundaryKind::NoRows`] instead of always being skipped. It is
-    /// surfaced only when the statement carries a row count (DONE `COUNT` flag)
-    /// or produced an informational message (PRINT / low-severity RAISERROR);
+    /// surfaced only when the statement carries an update count (DONE `COUNT`
+    /// on a non-`SQLSELECT` command) or produced an informational message
+    /// (PRINT / low-severity RAISERROR);
     /// a pure no-op statement with neither — e.g. a bare `CREATE TABLE` — is
     /// still collapsed into the following result, exactly as in result-set
     /// navigation. This mirrors msodbcsql, which exposes a statement as its own
@@ -3594,30 +3595,31 @@ impl TdsClient {
 
                     let is_last = !done.has_more();
 
-                    // Capture the affected-row count for `SQLRowCount`, but only
-                    // when the DONE_COUNT flag is set — otherwise `row_count` is
-                    // not meaningful (DDL, SET NOCOUNT ON) and must stay -1. Each
-                    // counted DONE is also appended in order so a pure-DML batch
-                    // surfaces one count per statement.
+                    // Capture update counts for `SQLRowCount`. DONE_COUNT on a
+                    // SQLSELECT command is not an update-count result.
                     let has_count = done.status.contains(DoneStatus::COUNT);
-                    if has_count {
+                    // SQL Server can tag non-row-producing statements such as
+                    // DECLARE with SQLSELECT and DONE_COUNT. msodbcsql does not
+                    // expose those as update-count results.
+                    let has_update_count = has_count && done.cur_cmd != CurrentCommand::Select;
+                    if has_update_count {
                         let count = i64::try_from(done.row_count).unwrap_or(i64::MAX);
                         self.last_rows_affected = count;
                         self.dml_result_counts.push(count);
                     }
 
                     // Statement-wise navigation (msodbcsql parity): this DONE is
-                    // a navigable result only if the statement returned a row
-                    // count (COUNT flag) or produced messages. Pure DDL / no-op
+                    // a navigable result only if the statement returned an update
+                    // count or produced messages. Pure DDL / no-op
                     // statements (no count, no messages) are collapsed, exactly
                     // like result-set navigation, so a batch such as
                     // `CREATE; INSERT; SELECT` exposes the INSERT's row count and
                     // the SELECT, not the bare CREATE. `rows_affected` is
-                    // `Some(n)` only when the DONE carried a COUNT.
-                    if has_count || saw_message {
+                    // `Some(n)` only for an update-count result.
+                    if has_update_count || saw_message {
                         self.execution_context.set_has_open_batch(!is_last);
                         return Ok(ResultBoundaryKind::NoRows {
-                            rows_affected: if has_count {
+                            rows_affected: if has_update_count {
                                 Some(done.row_count)
                             } else {
                                 None
@@ -5786,7 +5788,7 @@ impl From<()> for ExecuteOptions<'_> {
 /// [`advance()`](TdsClient::advance).
 ///
 /// This is the lossless, statement-wise view of a batch: every statement that
-/// returns rows, carries a row count, or produced a message is surfaced as its
+/// returns rows, carries an update count, or produced a message is surfaced as its
 /// own result (matching msodbcsql's `SQLMoreResults` and JDBC's
 /// `getMoreResults`/`getUpdateCount`). Consumers that only care about
 /// row-returning result sets can collapse no-row statements with
@@ -6589,6 +6591,23 @@ mod tests {
 
         let r2 = client.advance().await.unwrap();
         assert_eq!(r2, StatementResult::End);
+    }
+
+    #[tokio::test]
+    async fn execute_skips_select_count_before_rowset() {
+        let mut client = create_test_client_with_tokens(vec![
+            done_count(CurrentCommand::Select, 0, true),
+            empty_col_metadata(),
+        ]);
+
+        let result = client
+            .execute("DECLARE @value int; EXEC dbo.p;".to_string(), ())
+            .await
+            .unwrap();
+
+        assert_eq!(result, StatementResult::Rows);
+        assert_eq!(client.last_rows_affected(), -1);
+        assert!(client.take_dml_result_counts().is_empty());
     }
 
     #[tokio::test]

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -3595,26 +3595,28 @@ impl TdsClient {
 
                     let is_last = !done.has_more();
 
-                    // Capture update counts for `SQLRowCount`. DONE_COUNT on a
-                    // SQLSELECT command is not an update-count result.
+                    // Capture update counts for `SQLRowCount`.
                     let has_count = done.status.contains(DoneStatus::COUNT);
                     // SQL Server compiles variable assignment (`DECLARE @x int = 1`,
                     // `SET @x = 1`, `SELECT @x = col FROM t`) as a SQLSELECT command
                     // and still sets DONE_COUNT. msodbcsql does not expose those as
                     // update-count results, so neither do we.
                     //
-                    // msodbcsql also excludes SQLFETCHCURSOR (0x21) and SQLDBCC
-                    // (0xe6) here (sqlctokn.cpp:2149-2156). We do not, because
-                    // `CurrentCommand` folds every unrecognized value into `None`,
-                    // and `None` is what a genuine `SELECT ... INTO` count reports —
-                    // so those two cannot be told apart without dedicated variants.
-                    // Neither is reachable today: no DBCC command was observed to
-                    // set DONE_COUNT, and SQLFETCHCURSOR belongs to the server-side
-                    // cursor path this driver does not implement yet. Add
-                    // `CurrentCommand::{FetchCursor, Dbcc}` and exclude them here
-                    // when server-side cursors land, or if a DBCC is found to
-                    // report a count.
-                    let has_update_count = has_count && done.cur_cmd != CurrentCommand::Select;
+                    // The same three exclusions msodbcsql applies
+                    // (sqlctokn.cpp:2149-2152): SQLSELECT (0xc1), SQLFETCHCURSOR
+                    // (0x21) and SQLDBCC (0xe6). `sp_cursorfetch` reaches here via
+                    // `cursor_ops::cursor_fetch` -> `next_rowset`, so the cursor
+                    // exclusion is not hypothetical; a live SQL Server 2022 tags that
+                    // DONEINPROC `status: MORE|COUNT, cur_cmd: 0xc1` (already covered
+                    // by the SQLSELECT arm), but 0x21 is excluded explicitly so the
+                    // fetch buffer size can never be mistaken for an update count.
+                    let has_update_count = has_count
+                        && !matches!(
+                            done.cur_cmd,
+                            CurrentCommand::Select
+                                | CurrentCommand::FetchCursor
+                                | CurrentCommand::Dbcc
+                        );
                     if has_update_count {
                         let count = i64::try_from(done.row_count).unwrap_or(i64::MAX);
                         self.last_rows_affected = count;
@@ -6760,6 +6762,44 @@ mod tests {
             }
         );
         assert_eq!(client.last_rows_affected(), 1);
+    }
+
+    /// `sp_cursorfetch` reaches `advance_to_result_boundary` via
+    /// `cursor_ops::cursor_fetch` -> `next_rowset`. Its DONE reports the fetch
+    /// buffer size, which is not an update count; msodbcsql excludes it with
+    /// `Info != SQLFETCHCURSOR` (sqlctokn.cpp:2151).
+    #[tokio::test]
+    async fn execute_skips_fetch_cursor_count() {
+        let mut client = create_test_client_with_tokens(vec![
+            done_count(CurrentCommand::FetchCursor, 2, true),
+            int_col_metadata(1),
+        ]);
+
+        let result = client
+            .execute("sp_cursorfetch".to_string(), ())
+            .await
+            .unwrap();
+
+        assert_eq!(result, StatementResult::Rows);
+        assert_eq!(client.last_rows_affected(), -1);
+        assert!(client.take_dml_result_counts().is_empty());
+    }
+
+    /// msodbcsql excludes DBCC from update counts with `Info != SQLDBCC`
+    /// (sqlctokn.cpp:2152).
+    #[tokio::test]
+    async fn execute_skips_dbcc_count() {
+        let mut client =
+            create_test_client_with_tokens(vec![done_count(CurrentCommand::Dbcc, 3, false)]);
+
+        let result = client
+            .execute("DBCC CHECKIDENT('t')".to_string(), ())
+            .await
+            .unwrap();
+
+        assert_eq!(result, StatementResult::End);
+        assert_eq!(client.last_rows_affected(), -1);
+        assert!(client.take_dml_result_counts().is_empty());
     }
 
     #[tokio::test]

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -293,9 +293,11 @@ pub struct TdsClient {
     /// Rows affected by the most recent statement; see [`last_rows_affected`](Self::last_rows_affected).
     last_rows_affected: i64,
     /// Per-statement affected-row counts captured (in order) from every counted
-    /// DONE token seen since the last COLMETADATA or command start. For a
-    /// pure-DML batch (`UPDATE; DELETE; INSERT`) this holds one entry per
-    /// statement so the ODBC layer can surface each as its own result set via
+    /// DONE token seen since the last COLMETADATA or command start, excluding
+    /// `SQLSELECT`-tagged counts (see
+    /// [`last_rows_affected`](Self::last_rows_affected)). For a pure-DML batch
+    /// (`UPDATE; DELETE; INSERT`) this holds one entry per statement so the ODBC
+    /// layer can surface each as its own result set via
     /// [`take_dml_result_counts`](Self::take_dml_result_counts).
     dml_result_counts: Vec<i64>,
 
@@ -945,10 +947,17 @@ impl TdsClient {
     /// Rows affected by the most recently executed statement.
     ///
     /// Returns the row count from the last DONE token that carried the
-    /// `DONE_COUNT` flag, or `-1` when no count is available (DDL,
-    /// `SET NOCOUNT ON`, a forward-only SELECT whose trailing DONE has not been
-    /// read, or before any statement has executed). This maps directly to the
-    /// value ODBC `SQLRowCount` reports.
+    /// `DONE_COUNT` flag **and** was not tagged with the `SQLSELECT` command,
+    /// or `-1` when no such count is available (DDL, `SET NOCOUNT ON`, a
+    /// forward-only SELECT whose trailing DONE has not been read, or before any
+    /// statement has executed). This maps directly to the value ODBC
+    /// `SQLRowCount` reports.
+    ///
+    /// The `SQLSELECT` exclusion exists because SQL Server sets `DONE_COUNT` on
+    /// variable assignment (`DECLARE @x int = 1`, `SET @x = 1`,
+    /// `SELECT @x = col FROM t`) while tagging it `SQLSELECT`; that count is not
+    /// an update count and neither msodbcsql nor .NET SqlClient reports it. See
+    /// the comment in `advance_to_result_boundary`.
     pub fn last_rows_affected(&self) -> i64 {
         self.last_rows_affected
     }
@@ -956,8 +965,10 @@ impl TdsClient {
     /// Drains the per-statement affected-row counts captured since the last
     /// COLMETADATA (or command start), in statement order. Used by the ODBC
     /// layer to surface each DML statement in a pure-DML batch as its own
-    /// result set. Returns an empty vec when the batch produced no counted DONE
-    /// (e.g. DDL, `SET NOCOUNT ON`).
+    /// result set. `SQLSELECT`-tagged counts are excluded, as for
+    /// [`last_rows_affected`](Self::last_rows_affected). Returns an empty vec
+    /// when the batch produced no qualifying counted DONE (e.g. DDL,
+    /// `SET NOCOUNT ON`, or only variable assignments).
     pub fn take_dml_result_counts(&mut self) -> Vec<i64> {
         std::mem::take(&mut self.dml_result_counts)
     }
@@ -5819,11 +5830,15 @@ pub enum StatementResult {
     Rows,
     /// A statement that produced no result set but is still individually
     /// navigable. `rows_affected` is `Some(n)` when the statement's DONE token
-    /// carried a row count (DML), or `None` for a message-only statement
+    /// carried an update count (DML), or `None` for a message-only statement
     /// (`PRINT` / low-severity `RAISERROR`) or plain DDL. Messages are drained
     /// separately via [`take_info_messages`](TdsClient::take_info_messages).
     NoRows {
-        /// Rows affected, when the DONE token carried a COUNT; otherwise `None`.
+        /// Rows affected, when the DONE token carried a COUNT that was not
+        /// tagged `SQLSELECT` — see
+        /// [`TdsClient::last_rows_affected`] for why assignment counts are
+        /// excluded. `None` otherwise, including for a `SQLSELECT` count that
+        /// only surfaces because the statement also raised a message.
         rows_affected: Option<u64>,
     },
     /// No more statements remain in the batch; the connection is idle.

--- a/mssql-tds/src/test_client_support.rs
+++ b/mssql-tds/src/test_client_support.rs
@@ -258,6 +258,15 @@ pub fn col_metadata_empty() -> ScriptedToken {
     ScriptedToken(Tokens::ColMetadata(ColMetadataToken::default()))
 }
 
+/// A COLMETADATA token for the supplied columns.
+pub fn col_metadata(columns: Vec<ColumnMetadata>) -> ScriptedToken {
+    ScriptedToken(Tokens::ColMetadata(ColMetadataToken {
+        column_count: u16::try_from(columns.len()).unwrap_or(u16::MAX),
+        columns,
+        cek_table: Vec::new(),
+    }))
+}
+
 /// A `Vec<ColumnMetadata>` of `n` nullable `int` columns named `c1..=cn`.
 ///
 /// For consumer-side tests (e.g. the ODBC `SQLGetData` column-range and
@@ -322,6 +331,16 @@ pub fn done_more_with_count(row_count: u64) -> ScriptedToken {
     ScriptedToken(Tokens::Done(DoneToken {
         status: DoneStatus::MORE | DoneStatus::COUNT,
         cur_cmd: CurrentCommand::Insert,
+        row_count,
+    }))
+}
+
+/// A SQLSELECT DONE token carrying COUNT and MORE, as emitted for a DECLARE
+/// before a later statement result.
+pub fn done_more_select_with_count(row_count: u64) -> ScriptedToken {
+    ScriptedToken(Tokens::Done(DoneToken {
+        status: DoneStatus::MORE | DoneStatus::COUNT,
+        cur_cmd: CurrentCommand::Select,
         row_count,
     }))
 }

--- a/mssql-tds/src/token/tokens.rs
+++ b/mssql-tds/src/token/tokens.rs
@@ -1097,12 +1097,6 @@ pub(crate) enum CurrentCommand {
     EndXact = 0xd5,
     BulkInsert = 0xf0,
     OpenCursor = 0x20,
-    /// `sp_cursorfetch` completion. Excluded from update counts, matching
-    /// msodbcsql (`Info != SQLFETCHCURSOR`, sqlctokn.cpp:2151).
-    FetchCursor = 0x21,
-    /// `DBCC` completion. Excluded from update counts, matching msodbcsql
-    /// (`Info != SQLDBCC`, sqlctokn.cpp:2152).
-    Dbcc = 0xe6,
     Merge = 0x117,
 }
 
@@ -1120,21 +1114,17 @@ impl TryFrom<u16> for CurrentCommand {
             0xd5 => Ok(CurrentCommand::EndXact),
             0xf0 => Ok(CurrentCommand::BulkInsert),
             0x20 => Ok(CurrentCommand::OpenCursor),
-            0x21 => Ok(CurrentCommand::FetchCursor),
-            0xe6 => Ok(CurrentCommand::Dbcc),
             0x117 => Ok(CurrentCommand::Merge),
             // All unknown values are treated as None, and considered valid.
             //
             // This catch-all carries correctness weight: `advance_to_result_boundary`
             // gates `SQLRowCount` semantics on `cur_cmd`, so an unrecognized value
             // lands in the "this DONE_COUNT is a real update count" branch. That is
-            // deliberate and matches msodbcsql, which uses a deny-list
-            // (`Info != SQLSELECT && != SQLFETCHCURSOR && != SQLDBCC`,
-            // sqlctokn.cpp:2149-2152) rather than an allow-list, so an unknown
-            // command with a valid count still yields RS_COUNT. Do not convert this
-            // to an allow-list without a matching change in the reference driver;
-            // instead add the specific variant that must be excluded, as was done
-            // for `FetchCursor` and `Dbcc`.
+            // deliberate: both reference drivers deny-list rather than allow-list
+            // (msodbcsql `Info != SQLSELECT && ...`, sqlctokn.cpp:2149-2152; .NET
+            // SqlClient `curCmd != TdsEnums.SELECT`), so an unknown command with a
+            // valid count still counts there too. Do not convert this to an
+            // allow-list; exclude a command by adding its specific variant.
             _ => Ok(CurrentCommand::None),
         }
     }
@@ -1523,8 +1513,6 @@ mod coverage_tests {
             (0xd5, CurrentCommand::EndXact),
             (0xf0, CurrentCommand::BulkInsert),
             (0x20, CurrentCommand::OpenCursor),
-            (0x21, CurrentCommand::FetchCursor),
-            (0xe6, CurrentCommand::Dbcc),
             (0x117, CurrentCommand::Merge),
         ];
         for &(val, expected) in cases {

--- a/mssql-tds/src/token/tokens.rs
+++ b/mssql-tds/src/token/tokens.rs
@@ -1520,6 +1520,24 @@ mod coverage_tests {
         }
     }
 
+    /// Divergence pin: msodbcsql also excludes `SQLFETCHCURSOR` (0x21) and
+    /// `SQLDBCC` (0xe6) from update counts (sqlctokn.cpp:2151-2152). This driver
+    /// follows .NET SqlClient, which models neither, so both fall through the
+    /// catch-all to `None` and their counts are reported. Adding either variant
+    /// silently changes `SQLRowCount` semantics — see
+    /// `done_count_for_msodbcsql_only_exclusions_is_an_update_count`.
+    #[test]
+    fn msodbcsql_only_exclusions_are_not_modelled() {
+        assert_eq!(
+            CurrentCommand::try_from(0x21).unwrap(),
+            CurrentCommand::None
+        );
+        assert_eq!(
+            CurrentCommand::try_from(0xe6).unwrap(),
+            CurrentCommand::None
+        );
+    }
+
     #[test]
     fn current_command_try_from_unknown_maps_to_none() {
         assert_eq!(

--- a/mssql-tds/src/token/tokens.rs
+++ b/mssql-tds/src/token/tokens.rs
@@ -1097,6 +1097,12 @@ pub(crate) enum CurrentCommand {
     EndXact = 0xd5,
     BulkInsert = 0xf0,
     OpenCursor = 0x20,
+    /// `sp_cursorfetch` completion. Excluded from update counts, matching
+    /// msodbcsql (`Info != SQLFETCHCURSOR`, sqlctokn.cpp:2151).
+    FetchCursor = 0x21,
+    /// `DBCC` completion. Excluded from update counts, matching msodbcsql
+    /// (`Info != SQLDBCC`, sqlctokn.cpp:2152).
+    Dbcc = 0xe6,
     Merge = 0x117,
 }
 
@@ -1114,6 +1120,8 @@ impl TryFrom<u16> for CurrentCommand {
             0xd5 => Ok(CurrentCommand::EndXact),
             0xf0 => Ok(CurrentCommand::BulkInsert),
             0x20 => Ok(CurrentCommand::OpenCursor),
+            0x21 => Ok(CurrentCommand::FetchCursor),
+            0xe6 => Ok(CurrentCommand::Dbcc),
             0x117 => Ok(CurrentCommand::Merge),
             // All unknown values are treated as None, and considered valid.
             //
@@ -1125,7 +1133,8 @@ impl TryFrom<u16> for CurrentCommand {
             // sqlctokn.cpp:2149-2152) rather than an allow-list, so an unknown
             // command with a valid count still yields RS_COUNT. Do not convert this
             // to an allow-list without a matching change in the reference driver;
-            // instead add the specific variant that must be excluded.
+            // instead add the specific variant that must be excluded, as was done
+            // for `FetchCursor` and `Dbcc`.
             _ => Ok(CurrentCommand::None),
         }
     }
@@ -1514,6 +1523,8 @@ mod coverage_tests {
             (0xd5, CurrentCommand::EndXact),
             (0xf0, CurrentCommand::BulkInsert),
             (0x20, CurrentCommand::OpenCursor),
+            (0x21, CurrentCommand::FetchCursor),
+            (0xe6, CurrentCommand::Dbcc),
             (0x117, CurrentCommand::Merge),
         ];
         for &(val, expected) in cases {

--- a/mssql-tds/src/token/tokens.rs
+++ b/mssql-tds/src/token/tokens.rs
@@ -1116,6 +1116,16 @@ impl TryFrom<u16> for CurrentCommand {
             0x20 => Ok(CurrentCommand::OpenCursor),
             0x117 => Ok(CurrentCommand::Merge),
             // All unknown values are treated as None, and considered valid.
+            //
+            // This catch-all carries correctness weight: `advance_to_result_boundary`
+            // gates `SQLRowCount` semantics on `cur_cmd`, so an unrecognized value
+            // lands in the "this DONE_COUNT is a real update count" branch. That is
+            // deliberate and matches msodbcsql, which uses a deny-list
+            // (`Info != SQLSELECT && != SQLFETCHCURSOR && != SQLDBCC`,
+            // sqlctokn.cpp:2149-2152) rather than an allow-list, so an unknown
+            // command with a valid count still yields RS_COUNT. Do not convert this
+            // to an allow-list without a matching change in the reference driver;
+            // instead add the specific variant that must be excluded.
             _ => Ok(CurrentCommand::None),
         }
     }


### PR DESCRIPTION
Fixes [AB#47538](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47538/) and [AB#47535](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47535/)

## Problem

`test_execute_stored_procedure_without_parameters` (mssql-python suite) failed with SQLSTATE `24000`. `SQLExecDirect` positioned the statement on a leading no-row result, so the immediate `fetchall()` never reached the procedure's rows.

## Cause

SQL Server compiles variable assignment (`DECLARE @x int = 1`, `SET`, `SELECT @x = col`) as a **`SQLSELECT` (`0xc1`)** command that still sets `DONE_COUNT`. Captured from SQL Server 2022:

```
DECLARE @out int = 1; EXEC dbo.p;

 -> DoneToken { status: MORE | COUNT, cur_cmd: Select, row_count: 1 }   <- assignment
 -> COLMETADATA + rows                                                  <- EXEC
```

`advance_to_result_boundary` treated any `DONE_COUNT` as an update count, so it stopped on the assignment and exposed a 0-column cursor. (A bare `DECLARE @out int;` sets no `COUNT` flag and was never affected.)

## Fix

Treat `DONE_COUNT` as an update count only when the command is not `SQLSELECT`. Verified against a live server:

| Batch | Before | After (and msodbcsql) |
|---|---|---|
| `DECLARE @out int = 1; EXEC dbo.p;` | `NoRows{1}`, `Rows` | `Rows` |
| `DECLARE @x int; SET @x = 1; SELECT 1;` | `NoRows{1}`, `Rows` | `Rows` |
| `DECLARE @x int = 1;` | `NoRows{1}` (`SQLRowCount` 1) | end of results (`SQLRowCount` -1) |
| `UPDATE t SET v = v; SELECT * FROM t;` | `NoRows{2}`, `Rows` | unchanged |
| `SELECT 1 AS a INTO #t; SELECT * FROM #t;` | `NoRows{1}`, `Rows` | unchanged |

Genuine DML counts are unaffected: `INSERT`/`UPDATE`/`DELETE`/`MERGE` report their own `CurCmd`, and `SELECT ... INTO` reports `DONE_COUNT` with no `CurCmd`.

### Second fix: stale count on message-only results

`advance_to_result_boundary` never cleared `last_rows_affected` when returning a message-only result, and both `SQLRowCount` sites (`exec_common.rs:262`, `more_results.rs:149`) read that field rather than the enum's `rows_affected` — so the preceding statement's count was reported on the message. Partly pre-existing, but this PR routes the warned-assignment case onto that branch, so it is fixed here. Each case below has a genuine `UPDATE` in front; msodbcsql reports `2`, `-1`, `-1` and we now match:

`UPDATE; PRINT 'x'; SELECT 5` · `UPDATE; <assignment raising a warning>; SELECT 5` · `UPDATE; RAISERROR(...,0,1); SELECT 5` — all were `2`, `2`, `-1` before.

`dml_result_counts` does not leak the same way: its only consumer is the `!has_open_batch()` branch at `exec_common.rs:287`, unreachable while positioned on a message-only result.

## Reference driver parity

**.NET SqlClient** (`TdsParser.TryProcessDone`) applies exactly this one guard — `if (curCmd != TdsEnums.SELECT)`, with `SELECT = 0xc1` — under the comment *"Skip the bogus DONE counts sent by the server"*.

**msodbcsql** (`sqlctokn.cpp:2149-2156`) applies four:

| Guard | Here | Notes |
|---|---|---|
| `Info != SQLSELECT` (0xc1) | implemented | this fix; also SqlClient's only guard |
| `RSTypeOld != RS_SELECTION` | not needed | `sqlctokn.cpp:2689` resets it to `RS_NONE` while looping. Confirmed: msodbcsql reports the count for `SELECT * FROM t; UPDATE t SET v = v;`, and so do we |
| `Info != SQLFETCHCURSOR` (0x21) | not implemented | not observable — see below. SqlClient omits it too |
| `Info != SQLDBCC` (0xe6) | not implemented | no DBCC found that sets `DONE_COUNT`. SqlClient omits it too |
| `IS2xAPP(...)` | N/A | ODBC 2.x compatibility |

**Why the cursor guard is not needed.** `cursor_ops::cursor_fetch` does route `sp_cursorfetch` through the changed function, so this was checked rather than assumed. Raw tokens from a live 2-row block fetch:

```
DONEINPROC  status=0x11 (MORE|COUNT)  cur_cmd=0xc1  row_count=2
DONEPROC    status=0x00               cur_cmd=0xe0  row_count=0
```

The server tags the fetch DONE `0xc1`, so this PR's guard already covers it; `last_rows_affected` measured `-1` throughout. `0x21` was never seen on the wire, and a variant for it would be untestable. Probed and found not to set `DONE_COUNT`: `DBCC` (CHECKIDENT, UPDATEUSAGE, CLEANTABLE, CHECKTABLE, USEROPTIONS, OPENTRAN, SQLPERF, INPUTBUFFER, TRACEON), T-SQL cursor `OPEN`/`FETCH`, `MERGE`, `IF`, `SET NOCOUNT`.

**Unknown `CurCmd`.** The `_ => CurrentCommand::None` catch-all in `tokens.rs` is now load-bearing: an unrecognized `CurCmd` lands in the "real update count" branch. That is deliberate parity — both reference drivers deny-list rather than allow-list. A comment records this.

## Tests

- **9 unit tests** in `mssql-tds` over token streams scripted from the live captures: leading assignment count, assignment-only batch, consecutive assignments, assignment preceded by a message, a warning raised *by* the assignment, update count after an assignment, `SELECT ... INTO`.
- 2 of those are tripwires for the deliberate `SQLFETCHCURSOR`/`SQLDBCC` divergence, which only a comment held before. Verified they trip by modelling `0x21` then excluding it — they fail on different steps, so both are needed.
- **1 unit test** in `mssql-odbc`: `SQLExecDirect` opens the row set with `SQLRowCount` -1.
- **10 e2e tests** in `exec_direct_test.cpp`, unguarded and passing against real msodbcsql18, so they pin behavior to the reference driver rather than to us.

## Validation

`cargo bfmt` / `cargo bclippy` clean. Scoped `cargo nextest` 226/226. e2e verified locally against msodbcsql (24/24); the Rust-driver leg needs admin to register the driver, so it runs in CI.

## mssql-python suite impact

Build [169897](https://sqlclientdrivers.visualstudio.com/public/_build/results?buildId=169897) is this PR's head (`0980561163`); baselines are contemporaneous runs without this fix (169833, 169866, 169885). Identical pattern across two heads of this PR and all three baselines — no flakiness.

**Fixed (6):** `test_execute_stored_procedure_without_parameters` ([AB#47538](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47538)) and `test_long_print_message[2047, 4000, 8000, 8001, 80000]` ([AB#47535](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47535)).

The five `PRINT` tests are the same root cause: stopping on the leading SQLSELECT-tagged `DONE_COUNT` meant the batch's INFO token was never read, so `cursor.messages` was empty and the tests died on `IndexError`. **This PR closes [AB#47535](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47535) as well.**

**Newly red (2) — pre-existing bug unmasked, tracked as [AB#47532](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47532):** `test_long_raiserror[2047]` and `[4000]` were passing *vacuously* — the body is a `try/except ProgrammingError` with no `else` and no `pytest.fail`, so an `execute()` that raises nothing passes having asserted nothing. Before this PR the ERROR token was never read, so nothing was raised. Now it surfaces: `RAISERROR` reports server error 50000, which is unmapped, and `post_tds_error` falls back to a flat `HY000` → `OperationalError`, while the test catches `ProgrammingError`. msodbcsql instead applies a severity-tiered fallback yielding `42000` for severity 11–18 (`sqlcerr.cpp:1385-1401`).

No file in this PR touches SQLSTATE mapping, so this is not a regression from it — had the baseline raised at all, it would have raised the same `OperationalError` and failed then too. Root cause and suggested fix are recorded on [AB#47532](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47532).

**Net: 6 fixed, 2 unmasked, +4 passing. No other test changed state.**
