### PR TITLE
Bound the DONE_ATTN wait for query cancellation and timeout

### DIFF
--- a/mssql-tds/Cargo.toml
+++ b/mssql-tds/Cargo.toml
@@ -121,6 +121,9 @@ harness = false
 [dev-dependencies]
 rand = "0.9.2"
 dotenv = "0.15"
+# `test-util` is not part of tokio's `full`, and the transport tests need paused
+# time to exercise the attention-acknowledgement bound without sleeping for it.
+tokio = { version = "1.48.0", features = ["test-util"] }
 azure_identity = { version = "1.0", default-features = false, features = ["tokio"] }
 azure_core = { version = "1.1", default-features = false, features = [
     "reqwest",

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -2102,6 +2102,9 @@ impl TdsClient {
             // TDS protocol state so the connection can be reused.
             // The stream is always in a clean state here because writes are never
             // dropped mid-flight (issue #513).
+            // If the attention is never acknowledged the transport marks itself
+            // dead, so clearing the batch flag below cannot hand out a connection
+            // with an ATTENTION still outstanding.
             let attention_timeout = Duration::from_secs(ATTENTION_TIMEOUT_SECONDS);
             let _ = self.send_attention_with_timeout(attention_timeout).await;
             // Clear the open batch flag since we've cancelled the operation

--- a/mssql-tds/src/connection/transport/network_transport.rs
+++ b/mssql-tds/src/connection/transport/network_transport.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use crate::connection::bulk_copy_state::ATTENTION_TIMEOUT_SECONDS;
 use crate::connection::client_context::{IPAddressPreference, TransportContext};
 use crate::connection::transport::buffers::TdsReadBuffer;
 use crate::connection::transport::extractable_stream;
@@ -1132,94 +1133,91 @@ impl NetworkTransport {
         Ok(packet_size_from_header)
     }
 
-    /// Tells the server to stop sending tokens for the token stream being read and waits for
-    /// an acknowledgement.
-    async fn cancel_read_stream_and_wait(&mut self) -> TdsResult<()> {
-        self.cancel_read_stream().await?;
-        // Wait indefinitely for attention ACK
-        let _ = self.wait_for_attention_ack(None).await?;
-        Ok(())
+    /// Tells the server to stop sending tokens for the token stream being read
+    /// and waits, for a bounded time, for the acknowledgement.
+    ///
+    /// # Contract
+    ///
+    /// Cancelling a read is itself bounded: ATTENTION goes out and the response
+    /// is drained for at most [`ATTENTION_TIMEOUT_SECONDS`], matching
+    /// `Microsoft.Data.SqlClient`'s `AttentionTimeoutSeconds`. Callers get their
+    /// cancellation or timeout back within that bound whatever the server does,
+    /// so no separate cancellation-cleanup deadline is needed.
+    ///
+    /// Acknowledged, the connection is left at a message boundary and stays
+    /// reusable. Unacknowledged — the send failed, the drain errored, or the
+    /// bound elapsed — the stream is parked at an unknown point, so the
+    /// connection is marked known-dead and pools will not hand it out again.
+    ///
+    /// This reports nothing to the caller on purpose. It runs on a path that
+    /// already has an error to deliver (the cancellation or the timeout), and
+    /// replacing that with a cleanup failure would hide why the read stopped.
+    /// The known-dead flag is how a failed cleanup is observed.
+    async fn cancel_read_stream_and_wait(&mut self) {
+        if let Err(e) = self.cancel_read_stream().await {
+            debug!("Failed to send attention while cancelling the read stream: {e:?}");
+            self.known_dead = true;
+            return;
+        }
+
+        let attention_timeout = Duration::from_secs(ATTENTION_TIMEOUT_SECONDS);
+        match self.wait_for_attention_ack(attention_timeout).await {
+            Ok(true) => {}
+            Ok(false) => {
+                warn!(
+                    timeout = ?attention_timeout,
+                    "No attention acknowledgement within the bound; marking the connection dead"
+                );
+                self.known_dead = true;
+            }
+            Err(e) => {
+                debug!("Error draining to the attention acknowledgement: {e:?}");
+                self.known_dead = true;
+            }
+        }
     }
 
-    /// Wait for attention acknowledgment from server with optional timeout.
+    /// Wait for attention acknowledgment from server, bounded by
+    /// `attention_timeout`.
     ///
-    /// This helper reads tokens until it receives a DONE token with the ATTN flag set,
-    /// discarding any other tokens. If a timeout is specified and expires before
-    /// receiving the ACK, returns `Ok(false)`.
-    ///
-    /// # Arguments
-    ///
-    /// * `attention_timeout` - Optional timeout. If `None`, waits indefinitely.
+    /// Reads tokens until a DONE token with the ATTN flag arrives, discarding
+    /// everything else the server was still sending.
     ///
     /// # Returns
     ///
     /// * `Ok(true)` - Attention acknowledged by server
-    /// * `Ok(false)` - Timeout expired waiting for ACK (only when timeout specified)
+    /// * `Ok(false)` - `attention_timeout` elapsed before the acknowledgement
     /// * `Err(_)` - Error reading response
-    async fn wait_for_attention_ack(
-        &mut self,
-        attention_timeout: Option<Duration>,
-    ) -> TdsResult<bool> {
-        let dummy_context = ParserContext::None(());
-        let start = std::time::Instant::now();
+    async fn wait_for_attention_ack(&mut self, attention_timeout: Duration) -> TdsResult<bool> {
+        let start = tokio::time::Instant::now();
 
-        loop {
-            // Check timeout if specified
-            if let Some(timeout_duration) = attention_timeout
-                && start.elapsed() >= timeout_duration
-            {
-                debug!("Attention ACK timeout after {:?}", start.elapsed());
-                return Ok(false);
+        match timeout(attention_timeout, self.drain_to_attention_ack()).await {
+            Ok(Ok(())) => {
+                debug!("Attention ACK received after {:?}", start.elapsed());
+                Ok(true)
             }
-
-            // Read next token, with timeout if specified
-            let token_result = if let Some(timeout_duration) = attention_timeout {
-                let remaining = timeout_duration.saturating_sub(start.elapsed());
-                match timeout(
-                    remaining,
-                    receive_token_internal(self, &*PARSER_REGISTRY, &dummy_context),
-                )
-                .await
-                {
-                    Ok(result) => result,
-                    Err(_elapsed) => {
-                        debug!(
-                            "Attention ACK timeout (elapsed) after {:?}",
-                            start.elapsed()
-                        );
-                        return Ok(false);
-                    }
-                }
-            } else {
-                // No timeout - wait indefinitely
-                receive_token_internal(self, &*PARSER_REGISTRY, &dummy_context).await
-            };
-
-            match token_result {
-                Ok(token) => {
-                    if let Tokens::Done(done_token) = token
-                        && done_token.status.contains(DoneStatus::ATTN)
-                    {
-                        debug!("Attention ACK received after {:?}", start.elapsed());
-                        return Ok(true);
-                    }
-                    // Discard other tokens and continue waiting
-                }
-                Err(e) => {
-                    if attention_timeout.is_none() {
-                        // When waiting indefinitely, errors just break the loop (original behavior)
-                        break;
-                    }
-                    // When using timeout, propagate errors
-                    debug!(
-                        "Error reading token while waiting for attention ACK: {:?}",
-                        e
-                    );
-                    return Err(e);
-                }
+            Ok(Err(e)) => Err(e),
+            Err(_elapsed) => {
+                debug!("Attention ACK timeout after {:?}", start.elapsed());
+                Ok(false)
             }
         }
-        Ok(true)
+    }
+
+    /// Reads and discards tokens until the DONE carrying ATTN arrives.
+    ///
+    /// Unbounded on its own — every caller wraps it in a timeout.
+    async fn drain_to_attention_ack(&mut self) -> TdsResult<()> {
+        let dummy_context = ParserContext::None(());
+
+        loop {
+            let token = receive_token_internal(self, &*PARSER_REGISTRY, &dummy_context).await?;
+            if let Tokens::Done(done_token) = token
+                && done_token.status.contains(DoneStatus::ATTN)
+            {
+                return Ok(());
+            }
+        }
     }
 }
 
@@ -1677,7 +1675,7 @@ impl NetworkTransport {
             Ok(_) => {}
             Err(err) => match err {
                 OperationCancelledError(_) | TimeoutError(_) => {
-                    Box::pin(self.cancel_read_stream_and_wait()).await?;
+                    Box::pin(self.cancel_read_stream_and_wait()).await;
                 }
                 _ => {}
             },
@@ -1722,7 +1720,7 @@ impl NetworkTransport {
             Ok(_) => {}
             Err(err) => match err {
                 OperationCancelledError(_) | TimeoutError(_) => {
-                    Box::pin(self.cancel_read_stream_and_wait()).await?;
+                    Box::pin(self.cancel_read_stream_and_wait()).await;
                 }
                 _ => {}
             },
@@ -1757,7 +1755,7 @@ impl NetworkTransport {
             Ok(_) => {}
             Err(err) => match err {
                 OperationCancelledError(_) | TimeoutError(_) => {
-                    Box::pin(self.cancel_read_stream_and_wait()).await?;
+                    Box::pin(self.cancel_read_stream_and_wait()).await;
                 }
                 _ => {}
             },
@@ -1788,7 +1786,7 @@ impl NetworkTransport {
             Ok(_) => {}
             Err(err) => match err {
                 OperationCancelledError(_) | TimeoutError(_) => {
-                    Box::pin(self.cancel_read_stream_and_wait()).await?;
+                    Box::pin(self.cancel_read_stream_and_wait()).await;
                 }
                 _ => {}
             },
@@ -1815,7 +1813,7 @@ impl NetworkTransport {
             Ok(_) => {}
             Err(err) => match err {
                 OperationCancelledError(_) | TimeoutError(_) => {
-                    Box::pin(self.cancel_read_stream_and_wait()).await?;
+                    Box::pin(self.cancel_read_stream_and_wait()).await;
                 }
                 _ => {}
             },
@@ -1952,7 +1950,7 @@ impl crate::connection::transport::tds_transport::TdsTransport for NetworkTransp
         self.cancel_read_stream().await?;
 
         // Wait for ACK with timeout using the shared helper
-        self.wait_for_attention_ack(Some(attention_timeout)).await
+        self.wait_for_attention_ack(attention_timeout).await
     }
 
     fn is_connection_dead(&self) -> bool {
@@ -1982,7 +1980,7 @@ pub(crate) mod tests {
     use crate::test_packet_support::{
         TestPacketBuilder, create_network_transport_with_chunked_data,
         create_network_transport_with_data, create_network_transport_with_live_peer,
-        encode_utf16_le,
+        create_network_transport_with_live_peer_capturing_writes, encode_utf16_le,
     };
     use bytes::Bytes;
     use futures::SinkExt;
@@ -3628,6 +3626,184 @@ pub(crate) mod tests {
             reader.tds_read_buffer.get_remaining_byte_count(),
             0,
             "reset_reader must leave an empty buffer"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Attention acknowledgement (DONE_ATTN) after cancellation or timeout.
+    //
+    // Cancelling or timing out a read sends TDS ATTENTION and then drains the
+    // response until the server answers with a DONE carrying ATTN. That drain
+    // used to be unbounded, so a server that never answers — or a network that
+    // drops the answer — parked the caller inside its own cancellation
+    // forever, past any deadline the caller had set.
+    //
+    // These use `create_network_transport_with_live_peer_capturing_writes` so
+    // the socket stays open and silent after the scripted bytes are drained.
+    // A helper that drops its writer would hand the drain an EOF and end it no
+    // matter how unbounded it is, which is exactly the masking these tests
+    // exist to avoid. The peer also reads, so the ATTENTION write itself never
+    // blocks on a full duplex buffer.
+    //
+    // Time is paused, so the bound elapses the moment the runtime goes idle: a
+    // regression that arms no timer leaves only the outer guard, which then
+    // fires and fails the test instead of running for real minutes.
+    // ---------------------------------------------------------------------
+
+    /// A DONE token with `status`, framed as a message of its own — the shape
+    /// of an attention acknowledgement on the wire.
+    fn done_token_message(status: u16) -> Vec<u8> {
+        TestPacketBuilder::new(PacketType::TabularResult)
+            .append_byte(crate::token::tokens::TokenType::Done as u8)
+            .append_u16(status)
+            .append_u16(0) // CurCmd, unused by this path
+            .append_u64(0) // RowCount
+            .build()
+    }
+
+    /// A handle that is already cancelled, so the read it guards is abandoned
+    /// before a byte is consumed.
+    fn cancelled_handle() -> CancelHandle {
+        let parent = CancelHandle::new();
+        let child = parent.child_handle();
+        parent.cancel();
+        child
+    }
+
+    /// Reads the flag connection pools consult before handing a connection out
+    /// again.
+    fn is_known_dead(transport: &NetworkTransport) -> bool {
+        use crate::connection::transport::tds_transport::TdsTransport;
+        TdsTransport::connection_known_dead(transport)
+    }
+
+    /// The bug: cancellation waits for a `DONE_ATTN` that never comes.
+    ///
+    /// The peer acknowledges nothing, so before the bound the drain parked on
+    /// the socket and the caller never got its cancellation back.
+    #[tokio::test(start_paused = true)]
+    async fn cancellation_does_not_wait_forever_for_an_attention_acknowledgement() {
+        let (mut transport, mut written) =
+            create_network_transport_with_live_peer_capturing_writes(&[]);
+
+        let result = timeout(
+            Duration::from_secs(600),
+            transport.receive_token(&ParserContext::None(()), None, Some(&cancelled_handle())),
+        )
+        .await
+        .expect("cancellation hung waiting for a DONE_ATTN the server never sent");
+
+        assert!(
+            matches!(result, Err(OperationCancelledError(_))),
+            "the caller must still see its cancellation, got {result:?}"
+        );
+
+        let sent = written.recv().await.expect("the peer must observe a write");
+        assert_eq!(
+            sent[0],
+            PacketType::Attention as u8,
+            "cancellation must put an ATTENTION packet on the wire"
+        );
+    }
+
+    /// The same unbounded wait is reachable from a request timeout, which is
+    /// the shape a caller hits without ever holding a cancellation handle.
+    #[tokio::test(start_paused = true)]
+    async fn request_timeout_does_not_wait_forever_for_an_attention_acknowledgement() {
+        let (mut transport, _written) =
+            create_network_transport_with_live_peer_capturing_writes(&[]);
+
+        let result = timeout(
+            Duration::from_secs(600),
+            transport.receive_token(
+                &ParserContext::None(()),
+                Some(Duration::from_millis(50)),
+                None,
+            ),
+        )
+        .await
+        .expect("the timeout path hung waiting for a DONE_ATTN the server never sent");
+
+        assert!(
+            matches!(result, Err(TimeoutError(_))),
+            "the caller must still see its timeout, got {result:?}"
+        );
+    }
+
+    /// An unacknowledged ATTENTION leaves the TDS stream at an unknown point,
+    /// so the connection must become observably unusable rather than be handed
+    /// back to a pool.
+    #[tokio::test(start_paused = true)]
+    async fn an_unacknowledged_attention_marks_the_connection_dead() {
+        let (mut transport, _written) =
+            create_network_transport_with_live_peer_capturing_writes(&[]);
+
+        let _ = timeout(
+            Duration::from_secs(600),
+            transport.receive_token(&ParserContext::None(()), None, Some(&cancelled_handle())),
+        )
+        .await
+        .expect("cancellation hung waiting for a DONE_ATTN the server never sent");
+
+        assert!(
+            is_known_dead(&transport),
+            "a connection whose attention went unacknowledged must not be reused"
+        );
+    }
+
+    /// The check must stay quiet on a healthy cancellation: a server that
+    /// acknowledges keeps its connection usable. Without this, bounding the
+    /// wait could just condemn every cancelled connection and still pass the
+    /// tests above.
+    #[tokio::test(start_paused = true)]
+    async fn an_acknowledged_attention_leaves_the_connection_usable() {
+        let (mut transport, _written) = create_network_transport_with_live_peer_capturing_writes(
+            &done_token_message(DoneStatus::ATTN.bits()),
+        );
+
+        let result = timeout(
+            Duration::from_secs(600),
+            transport.receive_token(&ParserContext::None(()), None, Some(&cancelled_handle())),
+        )
+        .await
+        .expect("an acknowledged cancellation must not hang");
+
+        assert!(
+            matches!(result, Err(OperationCancelledError(_))),
+            "the caller must still see its cancellation, got {result:?}"
+        );
+        assert!(
+            !is_known_dead(&transport),
+            "an acknowledged attention leaves the connection reusable"
+        );
+    }
+
+    /// The drain discards whatever the server was still sending and stops at
+    /// the acknowledgement — tokens queued behind the ATTENTION must not be
+    /// mistaken for it, and must not push the wait past its bound either.
+    #[tokio::test(start_paused = true)]
+    async fn the_drain_discards_trailing_tokens_before_the_acknowledgement() {
+        // A plain DONE for the cancelled statement, then the acknowledgement.
+        let mut stream = done_token_message(DoneStatus::FINAL.bits());
+        stream.extend_from_slice(&done_token_message(DoneStatus::ATTN.bits()));
+
+        let (mut transport, _written) =
+            create_network_transport_with_live_peer_capturing_writes(&stream);
+
+        let result = timeout(
+            Duration::from_secs(600),
+            transport.receive_token(&ParserContext::None(()), None, Some(&cancelled_handle())),
+        )
+        .await
+        .expect("the drain hung instead of skipping past the trailing DONE");
+
+        assert!(
+            matches!(result, Err(OperationCancelledError(_))),
+            "the caller must still see its cancellation, got {result:?}"
+        );
+        assert!(
+            !is_known_dead(&transport),
+            "the acknowledgement arrived, so the connection stays usable"
         );
     }
 }

--- a/mssql-tds/src/connection/transport/network_transport.rs
+++ b/mssql-tds/src/connection/transport/network_transport.rs
@@ -1149,27 +1149,25 @@ impl NetworkTransport {
     /// reusable. Unacknowledged — the send failed or stalled, the drain
     /// errored, or the bound elapsed — the stream is parked at an unknown
     /// point, so the connection is marked known-dead and pools will not hand
-    /// it out again.
+    /// it out again. Once that verdict is in, a later cancelled read returns
+    /// straight away rather than spending the bound over again.
     ///
     /// This reports nothing to the caller on purpose. It runs on a path that
     /// already has an error to deliver (the cancellation or the timeout), and
     /// replacing that with a cleanup failure would hide why the read stopped.
     /// The known-dead flag is how a failed cleanup is observed.
     async fn cancel_read_stream_and_wait(&mut self) {
+        if self.known_dead {
+            // An earlier cancellation already spent the bound and gave up on
+            // this connection. There is nothing left to acknowledge, so
+            // re-entering would just charge this caller the bound again.
+            debug!("Skipping attention: the connection is already known dead");
+            return;
+        }
+
         let attention_timeout = Duration::from_secs(ATTENTION_TIMEOUT_SECONDS);
-        match self.send_attention_and_wait(attention_timeout).await {
-            Ok(true) => {}
-            Ok(false) => {
-                warn!(
-                    timeout = ?attention_timeout,
-                    "Attention went unacknowledged within the bound; marking the connection dead"
-                );
-                self.known_dead = true;
-            }
-            Err(e) => {
-                debug!("Failed to cancel the read stream: {e:?}");
-                self.known_dead = true;
-            }
+        if let Err(e) = self.send_attention_and_wait(attention_timeout).await {
+            debug!("Failed to cancel the read stream: {e:?}");
         }
     }
 
@@ -1181,6 +1179,11 @@ impl NetworkTransport {
     /// acknowledgement deadline would never be armed. The drain gets whatever
     /// the send left of the deadline.
     ///
+    /// Anything other than an acknowledgement leaves the stream parked at an
+    /// unknown point, so every such outcome marks the connection known-dead
+    /// here. Callers can then ignore the return value and still not reuse a
+    /// connection with an ATTENTION outstanding on it.
+    ///
     /// # Returns
     ///
     /// * `Ok(true)` - Attention acknowledged by server
@@ -1190,7 +1193,11 @@ impl NetworkTransport {
         let deadline = Instant::now() + attention_timeout;
 
         match timeout_at(deadline, self.cancel_read_stream()).await {
-            Ok(result) => result?,
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                self.known_dead = true;
+                return Err(e);
+            }
             Err(_elapsed) => {
                 // A stalled write leaves a partial packet on the wire, so the
                 // stream can never be resynchronised.
@@ -1203,7 +1210,21 @@ impl NetworkTransport {
             }
         }
 
-        self.wait_for_attention_ack(deadline).await
+        match self.wait_for_attention_ack(deadline).await {
+            Ok(true) => Ok(true),
+            Ok(false) => {
+                warn!(
+                    timeout = ?attention_timeout,
+                    "Attention went unacknowledged within the bound; marking the connection dead"
+                );
+                self.known_dead = true;
+                Ok(false)
+            }
+            Err(e) => {
+                self.known_dead = true;
+                Err(e)
+            }
+        }
     }
 
     /// Wait for attention acknowledgment from server until `deadline`.
@@ -2008,7 +2029,7 @@ pub(crate) mod tests {
     use crate::core::EncryptionOptions;
     use crate::message::messages::PacketType;
     use crate::test_packet_support::{
-        TestPacketBuilder, create_network_transport_with_chunked_data,
+        TestPacketBuilder, build_duplex_transport, create_network_transport_with_chunked_data,
         create_network_transport_with_data, create_network_transport_with_live_peer,
         create_network_transport_with_live_peer_capturing_writes, encode_utf16_le,
     };
@@ -3709,6 +3730,24 @@ pub(crate) mod tests {
         TdsTransport::connection_known_dead(transport)
     }
 
+    /// Runs one cancelled read under the outer guard and reports how long the
+    /// cancellation cleanup took.
+    async fn time_one_cancelled_read(transport: &mut NetworkTransport) -> Duration {
+        let started = Instant::now();
+        let result = timeout(
+            Duration::from_secs(600),
+            transport.receive_token(&ParserContext::None(()), None, Some(&cancelled_handle())),
+        )
+        .await
+        .expect("cancellation hung waiting for a DONE_ATTN the server never sent");
+
+        assert!(
+            matches!(result, Err(OperationCancelledError(_))),
+            "the caller must still see its cancellation, got {result:?}"
+        );
+        started.elapsed()
+    }
+
     /// The bug: cancellation waits for a `DONE_ATTN` that never comes.
     ///
     /// The peer acknowledges nothing, so before the bound the drain parked on
@@ -3744,14 +3783,24 @@ pub(crate) mod tests {
     /// The bound has to cover the ATTENTION write, not just the drain that
     /// follows it.
     ///
-    /// `create_network_transport_with_live_peer` never reads and sizes its
-    /// duplex buffer to the scripted data alone, so with no data the client's
-    /// 8-byte ATTENTION fills a 1-byte buffer and the write parks — a peer
-    /// whose receive window has closed, in miniature. Timing only the drain
-    /// leaves the caller stuck here, before any deadline is armed.
+    /// The duplex is one byte wide and the peer end is held without ever being
+    /// read, so the client's ATTENTION packet fills that byte and the write
+    /// parks — a peer whose receive window has closed, in miniature. Timing
+    /// only the drain leaves the caller stuck here, before any deadline is
+    /// armed.
+    ///
+    /// The sizing lives in the test rather than in a shared helper: borrowed,
+    /// it could be widened for some other test's benefit, the write would then
+    /// succeed, the drain would time out instead, and both assertions below
+    /// would still hold — leaving a passing test that no longer covers the
+    /// send. The last assertion pins the mechanism for the same reason.
     #[tokio::test(start_paused = true)]
     async fn a_stalled_attention_write_does_not_park_cancellation() {
-        let mut transport = create_network_transport_with_live_peer(&[]);
+        /// A TDS header with no payload, which is all an ATTENTION packet is.
+        const ATTENTION_PACKET_LEN: usize = 8;
+
+        let (client_side, mut peer) = duplex(1);
+        let mut transport = build_duplex_transport(client_side);
 
         let result = timeout(
             Duration::from_secs(600),
@@ -3767,6 +3816,51 @@ pub(crate) mod tests {
         assert!(
             is_known_dead(&transport),
             "a half-written attention leaves the stream unresynchronisable"
+        );
+
+        let mut buffer = [0u8; ATTENTION_PACKET_LEN];
+        let delivered = timeout(Duration::from_secs(600), peer.read(&mut buffer))
+            .await
+            .expect("the write left nothing with the peer, so nothing stalled")
+            .expect("reading the peer end must not fail");
+        assert!(
+            delivered < ATTENTION_PACKET_LEN,
+            "the write must have stalled part-way; a completed one would have \
+             delivered all {ATTENTION_PACKET_LEN} bytes, so this test would be \
+             measuring the drain instead"
+        );
+    }
+
+    /// The bound belongs to the connection, not to each call.
+    ///
+    /// Nothing consulted the known-dead flag on the way in, so a caller that
+    /// re-entered `receive_token` after a cancellation — closing a cursor,
+    /// draining what is left of a batch — paid the full bound again every
+    /// time, and the advertised ceiling multiplied by however many reads
+    /// followed.
+    #[tokio::test(start_paused = true)]
+    async fn a_second_cancellation_does_not_spend_the_bound_again() {
+        let bound = Duration::from_secs(ATTENTION_TIMEOUT_SECONDS);
+        let (mut transport, _written) =
+            create_network_transport_with_live_peer_capturing_writes(&[]);
+
+        let first = time_one_cancelled_read(&mut transport).await;
+        assert!(
+            first >= bound,
+            "the first cancellation waits out the whole bound for an \
+             acknowledgement that never comes, took {first:?}"
+        );
+        assert!(
+            is_known_dead(&transport),
+            "an unacknowledged attention must leave the connection dead"
+        );
+
+        let second = time_one_cancelled_read(&mut transport).await;
+        assert_eq!(
+            second,
+            Duration::ZERO,
+            "a connection already given up on has nothing left to acknowledge, \
+             so a later cancellation must return without waiting at all"
         );
     }
 

--- a/mssql-tds/src/connection/transport/network_transport.rs
+++ b/mssql-tds/src/connection/transport/network_transport.rs
@@ -1256,6 +1256,17 @@ impl NetworkTransport {
     /// Reads and discards tokens until the DONE carrying ATTN arrives.
     ///
     /// Unbounded on its own — every caller wraps it in a timeout.
+    ///
+    /// Tokens are read with a dummy context, so a ROW/NBCROW still in flight
+    /// ends this drain with a parse error rather than being skipped: those
+    /// tokens carry no length prefix and are parseable only with the preceding
+    /// COLMETADATA in the context. The caller treats that error like any other
+    /// failed drain and retires the connection, which is the safe outcome —
+    /// the alternative is handing back a connection with unparsed row bytes
+    /// still in the transport. Consuming those rows instead needs the
+    /// COLMETADATA-aware loop that `TdsClient::drain_stream` has, since a new
+    /// COLMETADATA can arrive mid-drain and a caller's context alone would not
+    /// cover it.
     async fn drain_to_attention_ack(&mut self) -> TdsResult<()> {
         let dummy_context = ParserContext::None(());
 
@@ -3962,6 +3973,48 @@ pub(crate) mod tests {
         assert!(
             !is_known_dead(&transport),
             "the acknowledgement arrived, so the connection stays usable"
+        );
+    }
+
+    /// A ROW queued behind the ATTENTION cannot be skipped. ROW/NBCROW tokens
+    /// carry no length prefix, so they are parseable only with the preceding
+    /// COLMETADATA in the parser context, and the drain reads with a dummy one.
+    /// The drain therefore ends on the parse error and the connection is
+    /// retired instead of being handed back desynchronized — the
+    /// acknowledgement sitting behind the ROW is never reached.
+    ///
+    /// This is the common shape for a cancelled row-returning query, so the
+    /// bound is doing its job here at the cost of the connection. Teaching the
+    /// drain to consume rows needs the COLMETADATA-aware loop that
+    /// `TdsClient::drain_stream` already has; this test pins today's outcome so
+    /// that change is a deliberate one rather than a silent behaviour flip.
+    ///
+    /// The ROW body is deliberately absent: the parser rejects on the context
+    /// before it reads a single value byte, so no body would ever be consumed.
+    #[tokio::test(start_paused = true)]
+    async fn a_row_in_flight_ends_the_drain_and_retires_the_connection() {
+        let mut stream = TestPacketBuilder::new(PacketType::TabularResult)
+            .append_byte(crate::token::tokens::TokenType::Row as u8)
+            .build();
+        stream.extend_from_slice(&done_token_message(DoneStatus::ATTN.bits()));
+
+        let (mut transport, _written) =
+            create_network_transport_with_live_peer_capturing_writes(&stream);
+
+        let result = timeout(
+            Duration::from_secs(600),
+            transport.receive_token(&ParserContext::None(()), None, Some(&cancelled_handle())),
+        )
+        .await
+        .expect("the drain hung instead of ending on the unparseable ROW");
+
+        assert!(
+            matches!(result, Err(OperationCancelledError(_))),
+            "the caller must see its cancellation, not the drain's parse error, got {result:?}"
+        );
+        assert!(
+            is_known_dead(&transport),
+            "the acknowledgement was never reached, so the connection must not be reused"
         );
     }
 }

--- a/mssql-tds/src/connection/transport/network_transport.rs
+++ b/mssql-tds/src/connection/transport/network_transport.rs
@@ -38,7 +38,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::{self, TcpStream};
-use tokio::time::timeout;
+use tokio::time::{Instant, timeout, timeout_at};
 use tracing::{debug, error, event, info, trace, warn};
 
 #[cfg(windows)]
@@ -1138,47 +1138,75 @@ impl NetworkTransport {
     ///
     /// # Contract
     ///
-    /// Cancelling a read is itself bounded: ATTENTION goes out and the response
-    /// is drained for at most [`ATTENTION_TIMEOUT_SECONDS`], matching
-    /// `Microsoft.Data.SqlClient`'s `AttentionTimeoutSeconds`. Callers get their
-    /// cancellation or timeout back within that bound whatever the server does,
-    /// so no separate cancellation-cleanup deadline is needed.
+    /// Cancelling a read is bounded end to end: the ATTENTION write and the
+    /// drain that follows it share a single [`ATTENTION_TIMEOUT_SECONDS`]
+    /// deadline, matching `Microsoft.Data.SqlClient`'s
+    /// `AttentionTimeoutSeconds`. Callers get their cancellation or timeout
+    /// back within that bound whatever the server does, so no separate
+    /// cancellation-cleanup deadline is needed.
     ///
     /// Acknowledged, the connection is left at a message boundary and stays
-    /// reusable. Unacknowledged — the send failed, the drain errored, or the
-    /// bound elapsed — the stream is parked at an unknown point, so the
-    /// connection is marked known-dead and pools will not hand it out again.
+    /// reusable. Unacknowledged — the send failed or stalled, the drain
+    /// errored, or the bound elapsed — the stream is parked at an unknown
+    /// point, so the connection is marked known-dead and pools will not hand
+    /// it out again.
     ///
     /// This reports nothing to the caller on purpose. It runs on a path that
     /// already has an error to deliver (the cancellation or the timeout), and
     /// replacing that with a cleanup failure would hide why the read stopped.
     /// The known-dead flag is how a failed cleanup is observed.
     async fn cancel_read_stream_and_wait(&mut self) {
-        if let Err(e) = self.cancel_read_stream().await {
-            debug!("Failed to send attention while cancelling the read stream: {e:?}");
-            self.known_dead = true;
-            return;
-        }
-
         let attention_timeout = Duration::from_secs(ATTENTION_TIMEOUT_SECONDS);
-        match self.wait_for_attention_ack(attention_timeout).await {
+        match self.send_attention_and_wait(attention_timeout).await {
             Ok(true) => {}
             Ok(false) => {
                 warn!(
                     timeout = ?attention_timeout,
-                    "No attention acknowledgement within the bound; marking the connection dead"
+                    "Attention went unacknowledged within the bound; marking the connection dead"
                 );
                 self.known_dead = true;
             }
             Err(e) => {
-                debug!("Error draining to the attention acknowledgement: {e:?}");
+                debug!("Failed to cancel the read stream: {e:?}");
                 self.known_dead = true;
             }
         }
     }
 
-    /// Wait for attention acknowledgment from server, bounded by
-    /// `attention_timeout`.
+    /// Sends ATTENTION and drains to the acknowledgement, both under a single
+    /// `attention_timeout` deadline.
+    ///
+    /// The send is bounded too. Writing the packet parks until the socket
+    /// accepts it, so a peer that has stopped reading stalls the send and the
+    /// acknowledgement deadline would never be armed. The drain gets whatever
+    /// the send left of the deadline.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(true)` - Attention acknowledged by server
+    /// * `Ok(false)` - The bound elapsed, sending or waiting
+    /// * `Err(_)` - Error sending attention or reading the response
+    async fn send_attention_and_wait(&mut self, attention_timeout: Duration) -> TdsResult<bool> {
+        let deadline = Instant::now() + attention_timeout;
+
+        match timeout_at(deadline, self.cancel_read_stream()).await {
+            Ok(result) => result?,
+            Err(_elapsed) => {
+                // A stalled write leaves a partial packet on the wire, so the
+                // stream can never be resynchronised.
+                warn!(
+                    timeout = ?attention_timeout,
+                    "Timed out sending the attention packet; marking the connection dead"
+                );
+                self.known_dead = true;
+                return Ok(false);
+            }
+        }
+
+        self.wait_for_attention_ack(deadline).await
+    }
+
+    /// Wait for attention acknowledgment from server until `deadline`.
     ///
     /// Reads tokens until a DONE token with the ATTN flag arrives, discarding
     /// everything else the server was still sending.
@@ -1186,12 +1214,12 @@ impl NetworkTransport {
     /// # Returns
     ///
     /// * `Ok(true)` - Attention acknowledged by server
-    /// * `Ok(false)` - `attention_timeout` elapsed before the acknowledgement
+    /// * `Ok(false)` - `deadline` passed before the acknowledgement
     /// * `Err(_)` - Error reading response
-    async fn wait_for_attention_ack(&mut self, attention_timeout: Duration) -> TdsResult<bool> {
-        let start = tokio::time::Instant::now();
+    async fn wait_for_attention_ack(&mut self, deadline: Instant) -> TdsResult<bool> {
+        let start = Instant::now();
 
-        match timeout(attention_timeout, self.drain_to_attention_ack()).await {
+        match timeout_at(deadline, self.drain_to_attention_ack()).await {
             Ok(Ok(())) => {
                 debug!("Attention ACK received after {:?}", start.elapsed());
                 Ok(true)
@@ -1940,17 +1968,19 @@ impl crate::connection::transport::tds_transport::TdsTransport for NetworkTransp
     /// 2. Wait for DONE token with ATTN (0x0020) status flag
     /// 3. If no acknowledgment within timeout, return false
     ///
+    /// `attention_timeout` covers the whole flow, not just step 2. Writing the
+    /// packet parks until the socket accepts it, so a peer that has stopped
+    /// reading stalls the send and the acknowledgement deadline would never be
+    /// armed. Both steps therefore share one deadline, and the drain gets
+    /// whatever the send left of it.
+    ///
     /// This is used by bulk copy timeout handling to implement the 5-second
     /// attention ACK timeout per SqlClient behavior.
     async fn send_attention_with_timeout(
         &mut self,
         attention_timeout: Duration,
     ) -> TdsResult<bool> {
-        // Send attention packet
-        self.cancel_read_stream().await?;
-
-        // Wait for ACK with timeout using the shared helper
-        self.wait_for_attention_ack(attention_timeout).await
+        self.send_attention_and_wait(attention_timeout).await
     }
 
     fn is_connection_dead(&self) -> bool {
@@ -3633,21 +3663,23 @@ pub(crate) mod tests {
     // Attention acknowledgement (DONE_ATTN) after cancellation or timeout.
     //
     // Cancelling or timing out a read sends TDS ATTENTION and then drains the
-    // response until the server answers with a DONE carrying ATTN. That drain
-    // used to be unbounded, so a server that never answers — or a network that
-    // drops the answer — parked the caller inside its own cancellation
-    // forever, past any deadline the caller had set.
+    // response until the server answers with a DONE carrying ATTN. Neither half
+    // used to be bounded, so a server that never answers — or one that has
+    // stopped reading, stalling the send — parked the caller inside its own
+    // cancellation forever, past any deadline the caller had set.
     //
-    // These use `create_network_transport_with_live_peer_capturing_writes` so
-    // the socket stays open and silent after the scripted bytes are drained.
+    // Most of these use `create_network_transport_with_live_peer_capturing_writes`
+    // so the socket stays open and silent after the scripted bytes are drained.
     // A helper that drops its writer would hand the drain an EOF and end it no
     // matter how unbounded it is, which is exactly the masking these tests
-    // exist to avoid. The peer also reads, so the ATTENTION write itself never
-    // blocks on a full duplex buffer.
+    // exist to avoid. The peer also reads, so the ATTENTION write only blocks
+    // in the one test that wants it to.
     //
     // Time is paused, so the bound elapses the moment the runtime goes idle: a
     // regression that arms no timer leaves only the outer guard, which then
-    // fires and fails the test instead of running for real minutes.
+    // fires and fails the test instead of running for real minutes. Every wait
+    // here is under such a guard, including the channel receives — an
+    // unguarded one would hang on the very regressions these tests target.
     // ---------------------------------------------------------------------
 
     /// A DONE token with `status`, framed as a message of its own — the shape
@@ -3698,11 +3730,43 @@ pub(crate) mod tests {
             "the caller must still see its cancellation, got {result:?}"
         );
 
-        let sent = written.recv().await.expect("the peer must observe a write");
+        let sent = timeout(Duration::from_secs(600), written.recv())
+            .await
+            .expect("cancellation returned without ever putting ATTENTION on the wire")
+            .expect("the peer must observe a write");
         assert_eq!(
             sent[0],
             PacketType::Attention as u8,
             "cancellation must put an ATTENTION packet on the wire"
+        );
+    }
+
+    /// The bound has to cover the ATTENTION write, not just the drain that
+    /// follows it.
+    ///
+    /// `create_network_transport_with_live_peer` never reads and sizes its
+    /// duplex buffer to the scripted data alone, so with no data the client's
+    /// 8-byte ATTENTION fills a 1-byte buffer and the write parks — a peer
+    /// whose receive window has closed, in miniature. Timing only the drain
+    /// leaves the caller stuck here, before any deadline is armed.
+    #[tokio::test(start_paused = true)]
+    async fn a_stalled_attention_write_does_not_park_cancellation() {
+        let mut transport = create_network_transport_with_live_peer(&[]);
+
+        let result = timeout(
+            Duration::from_secs(600),
+            transport.receive_token(&ParserContext::None(()), None, Some(&cancelled_handle())),
+        )
+        .await
+        .expect("cancellation hung writing ATTENTION to a peer that had stopped reading");
+
+        assert!(
+            matches!(result, Err(OperationCancelledError(_))),
+            "the caller must still see its cancellation, got {result:?}"
+        );
+        assert!(
+            is_known_dead(&transport),
+            "a half-written attention leaves the stream unresynchronisable"
         );
     }
 

--- a/mssql-tds/src/connection/transport/tds_transport.rs
+++ b/mssql-tds/src/connection/transport/tds_transport.rs
@@ -51,9 +51,15 @@ pub(crate) trait TdsTransport: TdsTokenStreamReader + Send + Sync + std::fmt::De
     ///
     /// * `Ok(true)` - Attention acknowledged by server
     /// * `Ok(false)` - Timeout expired before the acknowledgement, either while
-    ///   sending the attention or while waiting for the ACK. The connection is
-    ///   left unusable either way.
+    ///   sending the attention or while waiting for the ACK
     /// * `Err(_)` - Error sending attention or reading response
+    ///
+    /// Only `Ok(true)` leaves the connection at a message boundary. On either
+    /// other outcome an ATTENTION is outstanding with no acknowledgement to
+    /// pair it with, so a later read could pick up a stray DONE_ATTN and treat
+    /// it as the answer to a different request. Implementations must mark such
+    /// a connection dead rather than let it be reused, which is why callers may
+    /// ignore the return value.
     async fn send_attention_with_timeout(&mut self, timeout: Duration) -> TdsResult<bool>;
 
     /// Probe whether the underlying connection is dead via a non-blocking socket

--- a/mssql-tds/src/connection/transport/tds_transport.rs
+++ b/mssql-tds/src/connection/transport/tds_transport.rs
@@ -43,12 +43,16 @@ pub(crate) trait TdsTransport: TdsTokenStreamReader + Send + Sync + std::fmt::De
     ///
     /// # Arguments
     ///
-    /// * `timeout` - Maximum time to wait for acknowledgment
+    /// * `timeout` - Maximum time for the whole flow, covering the send as well
+    ///   as the wait. Writing the packet can itself stall on a peer that has
+    ///   stopped reading, so implementations must not leave the send unbounded.
     ///
     /// # Returns
     ///
     /// * `Ok(true)` - Attention acknowledged by server
-    /// * `Ok(false)` - Attention sent but timeout expired waiting for ACK
+    /// * `Ok(false)` - Timeout expired before the acknowledgement, either while
+    ///   sending the attention or while waiting for the ACK. The connection is
+    ///   left unusable either way.
     /// * `Err(_)` - Error sending attention or reading response
     async fn send_attention_with_timeout(&mut self, timeout: Duration) -> TdsResult<bool>;
 

--- a/mssql-tds/src/io/token_stream.rs
+++ b/mssql-tds/src/io/token_stream.rs
@@ -794,6 +794,11 @@ where
         }
     }
 
+    /// The fuzzing counterpart of `NetworkTransport::cancel_read_stream_and_wait`.
+    ///
+    /// No bound is needed here, unlike the network path: `FuzzReader` serves a
+    /// fixed in-memory buffer and returns EOF past its end, so this loop always
+    /// terminates. There is no socket for it to park on.
     async fn cancel_read_stream_and_wait(&mut self) -> TdsResult<()> {
         self.packet_reader.cancel_read_stream().await?;
         let dummy_context = ParserContext::None(());

--- a/mssql-tds/src/test_packet_support.rs
+++ b/mssql-tds/src/test_packet_support.rs
@@ -11,7 +11,8 @@
 //! token parser tests all pull from here instead.
 
 use byteorder::{BigEndian, ByteOrder, LittleEndian};
-use tokio::io::{AsyncWriteExt, DuplexStream, duplex};
+use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream, duplex};
+use tokio::sync::mpsc::{UnboundedReceiver, unbounded_channel};
 
 use crate::connection::client_context::ClientContext;
 use crate::connection::transport::network_transport::NetworkTransport;
@@ -163,6 +164,41 @@ pub(crate) fn create_network_transport_with_live_peer(data: &[u8]) -> NetworkTra
     });
 
     build_duplex_transport(client_side)
+}
+
+/// Builds a `NetworkTransport` fed `data` whose peer stays connected **and**
+/// reads everything the client sends, handing those bytes back on the returned
+/// channel.
+///
+/// [`create_network_transport_with_live_peer`] never reads, and sizes its
+/// duplex buffer to `data` alone, so a client that writes anything fills that
+/// buffer and blocks. Cancellation writes before it reads — it sends an
+/// ATTENTION packet and then drains for the acknowledgement — so testing it
+/// needs a peer that keeps the write direction moving. The captured bytes let a
+/// test confirm the ATTENTION really went out.
+///
+/// The peer never closes, so a client that cannot make progress blocks forever
+/// rather than being rescued by EOF. Tests using this helper must bound
+/// themselves with `tokio::time::timeout`.
+pub(crate) fn create_network_transport_with_live_peer_capturing_writes(
+    data: &[u8],
+) -> (NetworkTransport, UnboundedReceiver<Vec<u8>>) {
+    let (client_side, mut server_side) = duplex(data.len().max(4096));
+    let (sender, receiver) = unbounded_channel();
+    let owned = data.to_vec();
+    tokio::spawn(async move {
+        let _ = server_side.write_all(&owned).await;
+        let mut buffer = [0u8; 512];
+        while let Ok(read) = server_side.read(&mut buffer).await {
+            if read == 0 || sender.send(buffer[..read].to_vec()).is_err() {
+                break;
+            }
+        }
+        // Parks forever, keeping `server_side` alive so the client never sees EOF.
+        std::future::pending::<()>().await;
+    });
+
+    (build_duplex_transport(client_side), receiver)
 }
 
 #[cfg(test)]

--- a/mssql-tds/src/test_packet_support.rs
+++ b/mssql-tds/src/test_packet_support.rs
@@ -94,7 +94,7 @@ pub(crate) fn encode_utf16_le(value: &str) -> Vec<u8> {
         .collect()
 }
 
-fn build_duplex_transport(client_side: DuplexStream) -> NetworkTransport {
+pub(crate) fn build_duplex_transport(client_side: DuplexStream) -> NetworkTransport {
     let context = ClientContext::default();
     NetworkTransport::new(
         Box::new(client_side),


### PR DESCRIPTION
## Description

Cancelling a read sends TDS `ATTENTION` and then drains the response until the server answers with a `DONE` carrying `ATTN`. Neither half was bounded.

The drain was the reported bug: `cancel_read_stream_and_wait` called `wait_for_attention_ack(None)`, and `None` meant "no timer at all". A server that never answers, or a network that drops the answer, parked the caller inside its own cancellation forever, past whatever deadline the caller had set. Reachable from both the `OperationCancelledError` and `TimeoutError` paths, i.e. `TdsClient::cancel()` and request timeouts.

Review surfaced the same bug one step earlier: `NetworkWriter::send` awaits `write_all`, which parks until the socket accepts the packet, so a peer that has stopped reading stalls the *send* before the drain deadline is ever armed. Bounding only the drain would have left the advertised contract untrue on that path.

Bulk copy already had a bounded path (`send_attention_with_timeout`, 5s), so the contract existed — it just wasn't on the normal query path, and it had the same unbounded send.

**What changed**

- The send and the drain now share **one** deadline of `ATTENTION_TIMEOUT_SECONDS` (5s), the same constant bulk copy uses, documented in `bulk_copy_state.rs` as matching `Microsoft.Data.SqlClient`'s `AttentionTimeoutSeconds`. The drain gets whatever the send left of it.
- Acknowledged → the connection sits at a message boundary and stays reusable, as before.
- Unacknowledged (send stalled, send failed, drain errored, or the bound elapsed) → the stream is parked at an unknown point, so the connection is marked known-dead. That's observable through `TdsClient::is_connection_dead()`, so pools won't hand it out again. A stalled send is the clearest case: it leaves a partial packet on the wire, so the stream can never be resynchronised.
- The bound is spent **once per connection**, not once per call: a cancellation on a connection already known-dead returns immediately instead of paying another 5s. Found in review — repeated cancellations each cost a full 5s before this.
- `cancel_read_stream_and_wait` no longer returns a `Result`. Call sites used `...await?`, so a cleanup failure replaced the caller's `OperationCancelledError`/`TimeoutError` with an unrelated IO error and hid why the read stopped. The known-dead flag is how a failed cleanup is observed now.
- Removed a second bug in the same function: in the unbounded branch, a read error `break`s the loop and the function returned `Ok(true)` — reporting "acknowledged" when the read had actually failed.
- Both entry points share one inherent helper, `send_attention_and_wait`; the `TdsTransport::send_attention_with_timeout` trait method is now a thin delegate. Bulk copy already treats `Ok(false)` as "connection broken, close it", so it inherits the send bound with no call-site change.

`TokenStreamReader::cancel_read_stream_and_wait` in `io/token_stream.rs` has the same loop shape but is `cfg(fuzzing)` only, and its `FuzzReader` serves a fixed in-memory buffer and returns EOF past the end — there is no socket to park on, so the loop always terminates. Left as-is with a comment saying why.

## Tests

There was no coverage of this at all. `timeout_and_cancel.rs` needs a live SQL Server, and a real server always acknowledges, so it can't reach the unacknowledged case either way. Eight tests added in `network_transport.rs`, four of which fail without the fix:

| Test | What it does | Without the fix |
|---|---|---|
| `cancellation_does_not_wait_forever_for_an_attention_acknowledgement` | Pre-cancelled handle against a peer that acknowledges nothing. Asserts the caller still gets `OperationCancelledError`, and that an ATTENTION packet really went on the wire. | **hung** |
| `request_timeout_does_not_wait_forever_for_an_attention_acknowledgement` | Same hang reached via a 50ms request timeout with no cancel handle. Asserts `TimeoutError`. | **hung** |
| `an_unacknowledged_attention_marks_the_connection_dead` | Asserts the connection is observably unusable afterwards. | **hung** |
| `a_stalled_attention_write_does_not_park_cancellation` | Peer that never reads, with a 1-byte buffer, so the 8-byte ATTENTION write parks — a closed receive window in miniature. Asserts cancellation still returns, and the connection is dead. | **hung** |
| `an_acknowledged_attention_leaves_the_connection_usable` | Quiet-path check: peer sends `DONE` with `ATTN`; asserts the connection is **not** marked dead. | passed |
| `the_drain_discards_trailing_tokens_before_the_acknowledgement` | A plain `DONE` queued ahead of the `DONE_ATTN`; asserts the drain skips past it and still leaves the connection usable. | passed |
| `a_second_cancellation_does_not_spend_the_bound_again` | Cancels three times against a peer that never acknowledges; asserts only the first pays the 5s. | pins behaviour added in review |
| `a_row_in_flight_ends_the_drain_and_retires_the_connection` | A `ROW` queued ahead of the `DONE_ATTN`; asserts the drain ends on it, the caller still gets its cancellation, and the connection is retired. | pins current behaviour — see Deferred |

`an_acknowledged_attention_leaves_the_connection_usable` and `the_drain_discards_trailing_tokens_before_the_acknowledgement` are there so the fix can't pass by simply condemning every connection.

Each failing test was checked against the specific thing it pins, not just against the whole bug — e.g. pushing only the *send* deadline out to 24h fails `a_stalled_attention_write_does_not_park_cancellation` and leaves the other attention tests green.

Two details that matter for these tests:

- Most use a new `create_network_transport_with_live_peer_capturing_writes` helper. The existing live-peer helper never *reads*, and sizes its duplex buffer to `data.len().max(1)` — with empty data that's 1 byte, so the client's ATTENTION write blocks. That is the exact stall the new send bound addresses, so the stalled-write test owns its own `duplex(1)` deliberately, while the rest need a peer that keeps the write direction moving. A helper that drops its writer instead would hand the drain an EOF and end it no matter how unbounded it is, which is the masking these tests exist to avoid.
- `#[tokio::test(start_paused = true)]` means the 5s bound elapses as soon as the runtime goes idle. A regression that arms no timer leaves only the outer 600s guard, which then fires and fails the test in milliseconds instead of blocking the suite for real minutes. Every wait sits under that guard, channel receives included — an unguarded receive parks on a peer that never closes, so it would hang on the very regressions being tested. This needs tokio's `test-util` feature, which is **not** part of `full`, hence the dev-dependency addition. `Cargo.lock` records versions rather than features, so `--frozen` is unaffected.

## Deferred

A `ROW`/`NBCROW` still in flight behind the ATTENTION carries no length prefix, so it is parseable only with the preceding `COLMETADATA` in the parser context — and the drain reads with a dummy one. The drain therefore ends on that parse error and this PR retires the connection, which is the common shape for a cancelled row-returning query.

That is not a regression: before this PR the same input took the `break` → `Ok(true)` path and handed back a connection that was usable but desynchronised. Retiring it is strictly safer. It does mean the "acknowledged, stays reusable" branch is largely unreachable for the canonical cancellation, and we retire connections SqlClient would keep.

Making the drain consume those rows needs the `COLMETADATA`-aware loop `TdsClient::drain_stream` already has, not just a context passed down from the call site — only three of the five `cancel_read_stream_and_wait` call sites have a context in scope, and a fresh `COLMETADATA` can arrive mid-drain. That is a behavioural change to cancellation on its own merits, so it is tracked separately in #381 rather than bundled into bounding an unbounded wait. `a_row_in_flight_ends_the_drain_and_retires_the_connection` pins today's outcome so that flip has to be deliberate.

## Related Issues

Fixes #373
Follow-up: #381

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes — workspace lib suite is 2777 passed / 1 skipped / 0 failed, and the mock-server and drain-on-error integration tests pass (13/13). Integration and bench targets that need a live SQL Server and a `.env` don't run in my environment; they're unrelated to this change.
- [x] New/changed functionality has tests
- [x] Public API changes are documented — no signature change. `TdsTransport::send_attention_with_timeout`'s doc now states that its timeout covers the send as well as the wait, that `Ok(false)` can mean either, and that the transport marks itself dead so callers that ignore the return value still behave correctly.