### PR TITLE
Harden the code-review skill: read all three review endpoints, replace facts that go stale, and record conventions mined from review history

### DIFF
--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review
-description: Review a pull request, diff, or set of proposed changes in microsoft/mssql-rs — from a GitHub or Azure DevOps PR link, a PR number, or local staged/unstaged changes. Use whenever the user asks to review a PR, asks for feedback on a diff, or asks whether changes are ready to merge. Covers correctness, security, tests, readability, performance, API/breaking changes, and mssql-rs repo conventions.
+description: Review a pull request, diff, or set of proposed changes in microsoft/mssql-rs — from a GitHub PR link, a PR number, or local staged/unstaged changes. Use whenever the user asks to review a PR, asks for feedback on a diff, or asks whether changes are ready to merge. Covers correctness, security, tests, readability, performance, API/breaking changes, and mssql-rs repo conventions.
 ---
 
 # Pull Request Review
@@ -36,28 +36,17 @@ you happen to be reviewing. Skill maintenance is not that author's problem.
    git diff --stat $BASE..HEAD
    ```
 
-   For Azure DevOps repos, use the `repo_pull_request` tool with `action: get`.
 3. **Read what has already been said before writing anything.** PRs here routinely go
    through several rounds of author self-review plus a Copilot bot review, and many
    obvious findings are already raised, verified, and answered. Re-filing an answered
    thread as a new finding — especially at a higher severity — wastes the author's
    time and misranks the review.
 
-   **Establish the provider first.** GitHub and Azure DevOps number pull requests
-   independently, so running the GitHub recipe against an ADO PR number silently
-   reads an unrelated PR that happens to share the number. Branch on where the PR
-   actually lives.
-
-   *Azure DevOps:* read discussion with the `repo_pull_request_thread` tool
-   (`action: list`, then `list_comments` for a thread), and build results with the
-   `pipelines_build` tool. The rest of this step's reasoning applies unchanged; only
-   the transport differs.
-
-   *GitHub:* prior discussion is split across three endpoints and you need all three.
-   Listing reviewer *names* is not reading the reviews — a PR reporting nine reviews
-   tells you nothing about what any of them said, and treating that silence as
-   novelty is how an answered finding gets re-filed as blocking. Save the responses;
-   the symbol search below needs something to search.
+   Prior discussion is split across three endpoints and you need all three. Listing
+   reviewer *names* is not reading the reviews — a PR reporting nine reviews tells
+   you nothing about what any of them said, and treating that silence as novelty is
+   how an answered finding gets re-filed as blocking. Save the responses; the symbol
+   search below needs something to search.
 
    ```bash
    R=repos/microsoft/mssql-rs
@@ -103,7 +92,7 @@ you happen to be reviewing. Skill maintenance is not that author's problem.
    failures have been `certificate_validator` tests looking for
    `tests/test_certificates/*.pem`. Confirm rather than assume.)
 6. **Present the review in chat and wait for explicit human confirmation before
-   posting anything to GitHub or ADO.** Inline comments are drafted against
+   posting anything to GitHub.** Inline comments are drafted against
    `file:line`, not submitted, until they say so. Having the review fully written and
    the posting mechanics ready is not permission to post.
 

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -70,27 +70,37 @@ you happen to be reviewing. Skill maintenance is not that author's problem.
    settled it, far cheaper than re-reading the whole history.
 
    *If* an automated **Code Coverage Report** comment is present, read it before
-   writing any coverage finding (see "Verify Before You Claim"). Its absence is
-   usually expected rather than a CI failure — see the same section.
+   writing any coverage finding; its absence is usually expected rather than a CI
+   failure. Both under "Verify Before You Claim".
 4. Verify claims against the actual code — do not assume. Read surrounding code when
    a change's correctness depends on context: callers of changed functions,
    implementers of changed traits, and the layer above and below the change.
-5. Run the suite yourself rather than trusting the checklist. The runner is
-   `cargo nextest` / `cargo btest`, never `cargo test`. Pick the crate and targets the
-   diff actually touches — a `-p mssql-tds --lib` run validates nothing in a PR
-   confined to `mssql-odbc`, the JS or Python bindings, or the e2e suites.
+5. **Run tests to answer a question, not to re-collect a verdict.** CI runs the suite
+   and the merge is gated on it, so `gh pr checks` from step 3 already tells you pass
+   or fail — across platforms and cross-repo suites you cannot reproduce locally.
+   Rebuilding the workspace to learn the same thing costs minutes and returns less.
+
+   Build and run when you need something the CI result cannot give you:
+
+   - **Does this new test actually guard the change?** Mutate the constant, operator
+     or condition the PR changed and confirm the test fails. This is what catches
+     vacuous tests and is the highest-value reason to build locally.
+   - **Is this failure the PR's, or pre-existing?** Run the *same invocation* on
+     `$BASE` and compare failure sets; only the difference belongs in the review.
+   - **Is this coverage gap real?** Introduce the bug the missing test would catch and
+     show the suite still passes.
 
    ```bash
    cargo nextest run -p <affected-crate> --lib --no-fail-fast   # or `cargo btest`
    ```
 
-   Some tests fail on a clean tree because their fixtures aren't generated locally, so
-   never attribute a failure to the PR without a baseline — run the *same invocation*
-   on `$BASE` and compare failure sets. Only the difference belongs in the review.
-   Feature selection changes both the test count and which tests fail, so don't
-   compare a `--all-features` run against a default one. (Historically the pre-existing
-   failures have been `certificate_validator` tests looking for
-   `tests/test_certificates/*.pem`. Confirm rather than assume.)
+   The runner is `cargo nextest` / `cargo btest`, never `cargo test`. Pick the crate
+   and targets the diff touches — `-p mssql-tds --lib` validates nothing in a PR
+   confined to `mssql-odbc`, the JS or Python bindings, or the e2e suites. Feature
+   selection changes both the test count and which tests fail, so never compare a
+   `--all-features` run against a default one. Some tests fail on a clean tree because
+   their fixtures aren't generated locally (historically `certificate_validator`
+   looking for `tests/test_certificates/*.pem`) — which is why the baseline matters.
 6. **Present the review in chat and wait for explicit human confirmation before
    posting anything to GitHub.** Inline comments are drafted against
    `file:line`, not submitted, until they say so. Having the review fully written and
@@ -113,28 +123,20 @@ you happen to be reviewing. Skill maintenance is not that author's problem.
 
 ## What to Check
 
-Evaluate each area. Skip areas that don't apply rather than padding the review.
+Correctness, security, tests, readability, performance and API surface all apply as
+usual — skip areas that don't apply rather than padding the review. What is worth
+stating here is only what is specific to this repo, or easy to get wrong in it:
 
-- **Correctness**: Logic bugs, off-by-one, null/empty/boundary cases, error handling,
-  race conditions, incorrect assumptions.
-- **Security**: OWASP Top 10 — injection, broken auth/access control, SSRF,
-  deserialization. Hardcoded secrets/credentials. Unvalidated input at trust
-  boundaries. Unsafe defaults.
-- **Tests**: New/changed behavior has tests. Tests assert real behavior (not
-  tautologies). Edge cases and failure paths covered. Flag untested risky changes.
-  When CI posts a diff-coverage comment, read it for the current target and whether
-  it is enforced rather than computing one locally (see "Verify Before You Claim").
-- **Readability & maintainability**: Clear naming, reasonable function size, no
-  needless complexity or duplication, comments explain *why* not *what*.
-- **Performance**: N+1 queries, lock contention and lock scope, memory copies,
-  unnecessary allocations in hot paths, blocking I/O on async paths, O(n²) where
-  avoidable, network round trips. Only raise when impact is plausible — and on the
-  row-decode path, only with a timing (see "Verify Before You Claim").
-- **API & breaking changes**: Public signatures, serialization formats, config, and
-  the FFI surface (`#[napi]`, `#[pyclass]`, `extern "C"`). Flag breaking changes and
-  whether they're versioned/documented.
-- **Repo conventions**: Match existing patterns, style, and structure in the
-  codebase. Respect `.github/copilot-instructions.md` and any `AGENTS.md`.
+- **Tests** are the highest-yield area. "Has a test" is not the question; "does the
+  test fail when the change is reverted" is.
+- **Performance** on the row-decode path needs a timing, never a byte table.
+- **API & breaking changes** include the FFI surface — `#[napi]`, `#[pyclass]`,
+  `extern "C"` — not just Rust signatures, and "breaking" needs a publication check.
+- **Repo conventions** live in `.github/copilot-instructions.md`,
+  `.github/instructions/*.md` and any `AGENTS.md`. Cite one before flagging a
+  convention.
+
+All four are expanded under "Verify Before You Claim", which is where the evidence is.
 
 ## mssql-rs Specifics
 
@@ -214,9 +216,8 @@ the rule exists and do not need re-deriving. Last reviewed 2026-08.
     `es-metadata.yml` never generates one; fork PRs need a maintainer to comment
     `/coverage`. Read the workflow's `paths-ignore` before reporting a missing report.
 - **Coverage gaps**: don't assert one, prove it. Introduce the bug the missing test
-  would catch, run `cargo nextest run -p mssql-tds --lib --no-fail-fast`, show the
-  suite still passes, then restore. Costs about two minutes and converts a concern
-  into a fact.
+  would catch, run the affected crate's suite, show it still passes, then restore.
+  One incremental build and a suite run converts a concern into a fact.
 - **"This is a breaking API change"**: check that anything outside the workspace could
   observe it. `mssql-tds` is unpublished and pre-1.0, and the sibling crates build
   `ClientContext` through `Default`/`From` rather than struct literals, so a field
@@ -301,17 +302,14 @@ than `gh pr review`, diff-hunk anchoring, `--paginate` when verifying — are in
 
 ## Principles
 
-- Be specific and actionable; avoid vague praise or vague criticism.
 - **Question a departure from the reference drivers before auditing inside it.** When
-  a change diverges from `msodbcsql` / `SqlClient` / `mssql-jdbc` behavior, the divergence
-  is the first thing to examine — hardening a path that shouldn't exist is wasted review.
-  If a PR's own design doc reaches opposite conclusions in two places, that contradiction
-  *is* the finding.
-- If a change is correct, don't invent problems. An empty severity group means "none
-  found" — say so briefly.
+  a change diverges from `msodbcsql` / `SqlClient` / `mssql-jdbc` behavior, the
+  divergence is the first thing to examine — hardening a path that shouldn't exist is
+  wasted review. If a PR's own design doc reaches opposite conclusions in two places,
+  that contradiction *is* the finding.
 - Distinguish facts (verified in code) from concerns (worth checking). Don't state
   guesses as defects. Say what you ran and what you read.
-- Prefer the smallest correct fix over large refactors unless the PR's goal requires
-  more.
+- If a change is correct, don't invent problems. An empty severity group means "none
+  found" — say so briefly.
 - Reviewing is not merging. The PR author owns the merge — never merge someone
   else's PR.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -10,8 +10,9 @@ affected code — do not critique pre-existing code outside the PR's scope.
 
 Every concrete number, constant, and known-failure list below is a dated observation,
 not a standing truth. Prefer the command that re-derives a fact over the value written
-here. If what you observe contradicts this file, trust the observation and say so in
-your summary so the file gets corrected.
+here. If what you observe contradicts this file, trust the observation and report the
+drift separately — an issue or PR against this skill, not the summary of whatever PR
+you happen to be reviewing. Skill maintenance is not that author's problem.
 
 ## Process
 
@@ -27,6 +28,7 @@ your summary so the file gets corrected.
 
    ```bash
    gh pr view <url-or-number> --json title,body,author,state,isDraft,baseRefName,headRefName,additions,deletions,changedFiles,commits
+   git fetch origin main                       # `origin/main` below must be current
    git fetch origin pull/<N>/head:pr<N>-review
    git worktree add ../mssql-rs-pr<N>-review pr<N>-review
    cd ../mssql-rs-pr<N>-review
@@ -41,19 +43,30 @@ your summary so the file gets corrected.
    thread as a new finding — especially at a higher severity — wastes the author's
    time and misranks the review.
 
-   Prior discussion is split across three endpoints and you need all three. Listing
-   reviewer *names* is not reading the reviews — a PR reporting nine reviews tells you
-   nothing about what any of them said, and treating that silence as novelty is how an
-   answered finding gets re-filed as blocking.
+   **Establish the provider first.** GitHub and Azure DevOps number pull requests
+   independently, so running the GitHub recipe against an ADO PR number silently
+   reads an unrelated PR that happens to share the number. Branch on where the PR
+   actually lives.
+
+   *Azure DevOps:* read discussion with the `repo_pull_request_thread` tool
+   (`action: list`, then `list_comments` for a thread), and build results with the
+   `pipelines_build` tool. The rest of this step's reasoning applies unchanged; only
+   the transport differs.
+
+   *GitHub:* prior discussion is split across three endpoints and you need all three.
+   Listing reviewer *names* is not reading the reviews — a PR reporting nine reviews
+   tells you nothing about what any of them said, and treating that silence as
+   novelty is how an answered finding gets re-filed as blocking. Save the responses;
+   the symbol search below needs something to search.
 
    ```bash
    R=repos/microsoft/mssql-rs
    gh api --paginate $R/pulls/<N>/comments \
-     -q '.[] | "--- \(.user.login) \(.path):\(.line)\n\(.body)"'   # inline threads
+     -q '.[] | "--- \(.user.login) \(.path):\(.line)\n\(.body)"' > /tmp/pr<N>-inline.txt
    gh api --paginate $R/pulls/<N>/reviews \
-     -q '.[] | "--- \(.user.login) \(.state)\n\(.body)"'           # review bodies
+     -q '.[] | "--- \(.user.login) \(.state)\n\(.body)"'          > /tmp/pr<N>-reviews.txt
    gh api --paginate $R/issues/<N>/comments \
-     -q '.[] | "--- \(.user.login)\n\(.body)"'                     # PR-level replies
+     -q '.[] | "--- \(.user.login)\n\(.body)"'                    > /tmp/pr<N>-toplevel.txt
    gh pr checks <N>
    ```
 
@@ -63,20 +76,23 @@ your summary so the file gets corrected.
    one is usually a PR-level comment. Read only the inline threads and both halves of
    that exchange are invisible.
 
-   Then, before drafting each finding, grep what you pulled for the symbol it
-   concerns. One search for a name like `mark_known_dead` surfaces the thread that
-   already settled it, far cheaper than re-reading the whole history.
+   Then, before drafting each finding, grep those files for the symbol it concerns.
+   One search for a name like `mark_known_dead` surfaces the thread that already
+   settled it, far cheaper than re-reading the whole history.
 
-   The issue comments include the automated **Code Coverage Report** — read it before
-   writing any coverage finding (see "Verify Before You Claim").
+   *If* an automated **Code Coverage Report** comment is present, read it before
+   writing any coverage finding (see "Verify Before You Claim"). Its absence is
+   usually expected rather than a CI failure — see the same section.
 4. Verify claims against the actual code — do not assume. Read surrounding code when
    a change's correctness depends on context: callers of changed functions,
    implementers of changed traits, and the layer above and below the change.
 5. Run the suite yourself rather than trusting the checklist. The runner is
-   `cargo nextest` / `cargo btest`, never `cargo test`.
+   `cargo nextest` / `cargo btest`, never `cargo test`. Pick the crate and targets the
+   diff actually touches — a `-p mssql-tds --lib` run validates nothing in a PR
+   confined to `mssql-odbc`, the JS or Python bindings, or the e2e suites.
 
    ```bash
-   cargo nextest run -p mssql-tds --lib --no-fail-fast
+   cargo nextest run -p <affected-crate> --lib --no-fail-fast   # or `cargo btest`
    ```
 
    Some tests fail on a clean tree because their fixtures aren't generated locally, so
@@ -117,9 +133,8 @@ Evaluate each area. Skip areas that don't apply rather than padding the review.
   boundaries. Unsafe defaults.
 - **Tests**: New/changed behavior has tests. Tests assert real behavior (not
   tautologies). Edge cases and failure paths covered. Flag untested risky changes.
-  CI reports a diff-coverage number on the PR — read that comment for the current
-  target and whether it is enforced, rather than computing one locally (see "Verify
-  Before You Claim").
+  When CI posts a diff-coverage comment, read it for the current target and whether
+  it is enforced rather than computing one locally (see "Verify Before You Claim").
 - **Readability & maintainability**: Clear naming, reasonable function size, no
   needless complexity or duplication, comments explain *why* not *what*.
 - **Performance**: N+1 queries, lock contention and lock scope, memory copies,
@@ -184,9 +199,10 @@ the rule exists and do not need re-deriving. Last reviewed 2026-08.
   - Cite the msodbcsql file and line, or ask as a question. Never assert parity from
     the spec.
   - **Read the caller, not just the table or validator.** msodbcsql normalizes on
-    entry, so a validator read in isolation misleads — one finding claimed a dead
-    `HYC00` arm was reachable because `SQLBindParameter` folds `SQL_DOUBLE` to
-    `SQL_FLOAT` *before* calling it. That one was retracted by its own author.
+    entry, so a validator read in isolation misleads. One finding called an `HYC00`
+    arm reachable after reading the validator alone; `SQLBindParameter` folds
+    `SQL_DOUBLE` to `SQL_FLOAT` *before* calling it, which is what makes that arm
+    dead. Retracted by its own author.
 - **A test that still passes when you break the thing it names guards nothing.** The
   most common defect in this repo's *tests*, and the cheapest to check: mutate the
   constant, operator or condition the change is about and confirm the test fails.
@@ -198,10 +214,16 @@ the rule exists and do not need re-deriving. Last reviewed 2026-08.
   redaction test whose secret rendered as `[171, 171, 171, 171]` and was never
   asserted against. Also check whether it passes on `$BASE` — a cursor the fix was
   meant to sweep had already been swept by the setup.
-- **Coverage**: read the automated "Code Coverage Report" comment on the PR. A local
-  `cargo llvm-cov --lib` badly understates the CI number for `mssql-odbc`, because CI
-  merges the cross-repo `mssql-python` suite into it — one PR measured 83.9% locally
-  and 97% in CI. The report also says diff coverage is *reported, not enforced*.
+- **Coverage**: when the automated "Code Coverage Report" comment is present, read it
+  rather than computing your own. A local `cargo llvm-cov --lib` badly understates the
+  CI number for `mssql-odbc`, because CI merges the cross-repo `mssql-python` suite
+  into it — one PR measured 83.9% locally and 97% in CI. The report also says diff
+  coverage is *reported, not enforced*.
+  - **Its absence is usually expected, not a CI failure.** `pr-code-coverage.yml`
+    mirrors the ADO path excludes, so a PR touching only `.github/**`, `docs/**`,
+    `README.md`, `CHANGELOG.md`, `CONTRIBUTING.md`, `SECURITY.md`, `LICENSE` or
+    `es-metadata.yml` never generates one; fork PRs need a maintainer to comment
+    `/coverage`. Read the workflow's `paths-ignore` before reporting a missing report.
 - **Coverage gaps**: don't assert one, prove it. Introduce the bug the missing test
   would catch, run `cargo nextest run -p mssql-tds --lib --no-fail-fast`, show the
   suite still passes, then restore. Costs about two minutes and converts a concern
@@ -274,7 +296,7 @@ When handed findings from a bot or another agent, adjudicate rather than forward
 Only after explicit confirmation, or under the automation carve-out in step 6.
 The mechanics that otherwise fail silently — inline comments needing the API rather
 than `gh pr review`, diff-hunk anchoring, `--paginate` when verifying — are in
-[posting.md](posting.md).
+[posting.md](./posting.md).
 
 ## Output Format
 

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -8,25 +8,103 @@ description: Review a pull request, diff, or set of proposed changes in microsof
 You are reviewing proposed changes. Review only what the diff changes plus directly
 affected code — do not critique pre-existing code outside the PR's scope.
 
+Every concrete number, constant, and known-failure list below is a dated observation,
+not a standing truth. Prefer the command that re-derives a fact over the value written
+here. If what you observe contradicts this file, trust the observation and say so in
+your summary so the file gets corrected.
+
 ## Process
 
 1. Read the PR title/description to understand intent. Flag if the description is
    missing or doesn't match the diff. This repo requires a linked GitHub issue or
    Azure DevOps work item — flag a PR that has neither.
-2. Review the full diff against the base branch before commenting.
+2. **Check the PR out locally.** A diff alone is not enough to review this codebase —
+   most defects here turn on unchanged code (the other implementer of a trait, the
+   caller three layers up, the `#[cfg]` variant of a constant). Use a dedicated
+   worktree so the main worktree stays clean, and diff against the merge base rather
+   than trusting per-commit stats: PRs here are commonly stacked and often carry a
+   merge from `main`.
 
    ```bash
-   gh pr view <url-or-number> --json title,body,author,state,baseRefName,files,additions,deletions
-   gh pr diff <url-or-number>
+   gh pr view <url-or-number> --json title,body,author,state,isDraft,baseRefName,headRefName,additions,deletions,changedFiles,commits
+   git fetch origin pull/<N>/head:pr<N>-review
+   git worktree add ../mssql-rs-pr<N>-review pr<N>-review
+   cd ../mssql-rs-pr<N>-review
+   BASE=$(git merge-base origin/main HEAD)
+   git diff --stat $BASE..HEAD
    ```
 
    For Azure DevOps repos, use the `repo_pull_request` tool with `action: get`.
-3. Verify claims against the actual code — do not assume. Read surrounding code when
+3. **Read what has already been said before writing anything.** PRs here routinely go
+   through several rounds of author self-review plus a Copilot bot review, and many
+   obvious findings are already raised, verified, and answered. Re-filing an answered
+   thread as a new finding — especially at a higher severity — wastes the author's
+   time and misranks the review.
+
+   Prior discussion is split across three endpoints and you need all three. Listing
+   reviewer *names* is not reading the reviews — a PR reporting nine reviews tells you
+   nothing about what any of them said, and treating that silence as novelty is how an
+   answered finding gets re-filed as blocking.
+
+   ```bash
+   R=repos/microsoft/mssql-rs
+   gh api --paginate $R/pulls/<N>/comments \
+     -q '.[] | "--- \(.user.login) \(.path):\(.line)\n\(.body)"'   # inline threads
+   gh api --paginate $R/pulls/<N>/reviews \
+     -q '.[] | "--- \(.user.login) \(.state)\n\(.body)"'           # review bodies
+   gh api --paginate $R/issues/<N>/comments \
+     -q '.[] | "--- \(.user.login)\n\(.body)"'                     # PR-level replies
+   gh pr checks <N>
+   ```
+
+   The review *body* is the easiest slot to miss and often the most important:
+   Copilot's low-confidence findings are **suppressed**, appearing only there inside a
+   collapsed `<details>` block, never as an inline comment. An author's rebuttal to
+   one is usually a PR-level comment. Read only the inline threads and both halves of
+   that exchange are invisible.
+
+   Then, before drafting each finding, grep what you pulled for the symbol it
+   concerns. One search for a name like `mark_known_dead` surfaces the thread that
+   already settled it, far cheaper than re-reading the whole history.
+
+   The issue comments include the automated **Code Coverage Report** — read it before
+   writing any coverage finding (see "Verify Before You Claim").
+4. Verify claims against the actual code — do not assume. Read surrounding code when
    a change's correctness depends on context: callers of changed functions,
    implementers of changed traits, and the layer above and below the change.
-4. **Present the review in chat and wait for explicit human confirmation before posting anything to GitHub or ADO.** Inline comments are drafted against `file:line`, not submitted, until they say so.
-5. Ground yourself in reference code and public/private documentation/specifications. If you don't know the codebase, or which references to use, ask for context before reviewing.
-6. 
+5. Run the suite yourself rather than trusting the checklist. The runner is
+   `cargo nextest` / `cargo btest`, never `cargo test`.
+
+   ```bash
+   cargo nextest run -p mssql-tds --lib --no-fail-fast
+   ```
+
+   Some tests fail on a clean tree because their fixtures aren't generated locally, so
+   never attribute a failure to the PR without a baseline — run the *same invocation*
+   on `$BASE` and compare failure sets. Only the difference belongs in the review.
+   Feature selection changes both the test count and which tests fail, so don't
+   compare a `--all-features` run against a default one. (Historically the pre-existing
+   failures have been `certificate_validator` tests looking for
+   `tests/test_certificates/*.pem`. Confirm rather than assume.)
+6. **Present the review in chat and wait for explicit human confirmation before
+   posting anything to GitHub or ADO.** Inline comments are drafted against
+   `file:line`, not submitted, until they say so. Having the review fully written and
+   the posting mechanics ready is not permission to post.
+
+   **Automated runs.** Skip the confirmation only when posting without it has been
+   explicitly authorized — an instruction in the invoking prompt, or a pipeline
+   configured to post. Inferring "this looks like an automated context" is not
+   authorization; when it is ambiguous, ask. An unattended run still:
+
+   - posts `event: "COMMENT"` only. Never `APPROVE` or `REQUEST_CHANGES` — an
+     automated approval can satisfy branch protection, which makes it a governance
+     problem rather than a review one.
+   - notes in the body that it came from an unattended run, so the author knows the
+     findings were not checked by a human first.
+   - never merges, and never resolves a thread it did not open.
+7. Ground yourself in reference code and public/private documentation/specifications.
+   If you don't know the codebase, or which references to use, ask for context before
+   reviewing.
 
 ## What to Check
 
@@ -39,12 +117,15 @@ Evaluate each area. Skip areas that don't apply rather than padding the review.
   boundaries. Unsafe defaults.
 - **Tests**: New/changed behavior has tests. Tests assert real behavior (not
   tautologies). Edge cases and failure paths covered. Flag untested risky changes.
-  Diff coverage should be at least 85% to match CI.
+  CI reports a diff-coverage number on the PR — read that comment for the current
+  target and whether it is enforced, rather than computing one locally (see "Verify
+  Before You Claim").
 - **Readability & maintainability**: Clear naming, reasonable function size, no
   needless complexity or duplication, comments explain *why* not *what*.
 - **Performance**: N+1 queries, lock contention and lock scope, memory copies,
   unnecessary allocations in hot paths, blocking I/O on async paths, O(n²) where
-  avoidable, network round trips. Only raise when impact is plausible.
+  avoidable, network round trips. Only raise when impact is plausible — and on the
+  row-decode path, only with a timing (see "Verify Before You Claim").
 - **API & breaking changes**: Public signatures, serialization formats, config, and
   the FFI surface (`#[napi]`, `#[pyclass]`, `extern "C"`). Flag breaking changes and
   whether they're versioned/documented.
@@ -70,6 +151,9 @@ Check these in addition to the general areas above.
 - **Naming**: `Tds` prefix on core public types.
 - **Unsafe code**: any new `unsafe` block — especially in `mssql-odbc` FFI — has a
   justification and upholds the invariants it assumes.
+- **ODBC attribute symmetry**: an attribute added to a setter needs the matching
+  getter arm, and the get side should answer what the set side accepts. Three PRs
+  shipped `SQL_SUCCESS` to set and `HY092` to read back the same attribute.
 - **Tests**: unit tests in inline `#[cfg(test)]` modules for pure logic, integration
   tests under `tests/`. Reuse existing fixtures and env helpers (`conftest.py` for
   Python) rather than inventing new patterns. Prefer `mssql-mock-tds` over requiring
@@ -80,6 +164,117 @@ Check these in addition to the general areas above.
   `cargo btest` pass. Flag a checked box that the CI run contradicts.
 - **No AI slop**: no comments restating what the code does, no filler phrases, no
   redundant validation or duplicated logic.
+
+## Verify Before You Claim
+
+These are findings that have been filed against this repo and turned out to be wrong.
+Each one costs a retraction, so check the stated source before raising that class.
+The measurements below are evidence for the rule, not current state — they explain why
+the rule exists and do not need re-deriving. Last reviewed 2026-08.
+
+- **Parity findings in `mssql-odbc`: msodbcsql is the contract, the ODBC spec is
+  not.** This is the single largest source of withdrawn findings here. Reviews have
+  argued from the spec or from internal consistency and been overturned by the
+  reference driver in both directions — a proposed `07006`→`07009` correction where
+  msodbcsql reports nothing at all; "write the non-NULL length too" where msodbcsql
+  writes nothing; "gate these renames on ODBC 2.x" where `DoDD()` applies them
+  unconditionally; "add the missing post-connect guard" where msodbcsql deliberately
+  has none. It also cuts the other way: `BufferLength = 0` *is* a length probe there,
+  and raising that as a question found a real divergence.
+  - Cite the msodbcsql file and line, or ask as a question. Never assert parity from
+    the spec.
+  - **Read the caller, not just the table or validator.** msodbcsql normalizes on
+    entry, so a validator read in isolation misleads — one finding claimed a dead
+    `HYC00` arm was reachable because `SQLBindParameter` folds `SQL_DOUBLE` to
+    `SQL_FLOAT` *before* calling it. That one was retracted by its own author.
+- **A test that still passes when you break the thing it names guards nothing.** The
+  most common defect in this repo's *tests*, and the cheapest to check: mutate the
+  constant, operator or condition the change is about and confirm the test fails.
+  Real examples — a limb-reassembly test where `<< (i * 32)` → `<< (i * 16)` left all
+  539 tests green; temporal tests built in nanoseconds and asserted against a
+  converter that divided by 1e9, self-consistently wrong while the driver ran 100x
+  off; a test that passed on `Err(ConnectionClosed)` rather than the behavior in its
+  name; an e2e case that passed with *and* without the guard it was added for; a
+  redaction test whose secret rendered as `[171, 171, 171, 171]` and was never
+  asserted against. Also check whether it passes on `$BASE` — a cursor the fix was
+  meant to sweep had already been swept by the setup.
+- **Coverage**: read the automated "Code Coverage Report" comment on the PR. A local
+  `cargo llvm-cov --lib` badly understates the CI number for `mssql-odbc`, because CI
+  merges the cross-repo `mssql-python` suite into it — one PR measured 83.9% locally
+  and 97% in CI. The report also says diff coverage is *reported, not enforced*.
+- **Coverage gaps**: don't assert one, prove it. Introduce the bug the missing test
+  would catch, run `cargo nextest run -p mssql-tds --lib --no-fail-fast`, show the
+  suite still passes, then restore. Costs about two minutes and converts a concern
+  into a fact.
+- **"This is a breaking API change"**: check that anything outside the workspace could
+  observe it. `mssql-tds` is unpublished and pre-1.0, and the sibling crates build
+  `ClientContext` through `Default`/`From` rather than struct literals, so a field
+  addition broke nothing. Verify with `cargo clippy --workspace --all-features
+  --all-targets` plus a `crates.io` check before calling it breaking.
+- **Unreachable branches**: worth flagging, together with any test that asserts the
+  tautology — but both dispositions are legitimate. Deleting is right when the check
+  reads as real validation; keeping it with a note is right when removal turns a
+  future drift into a panic across the FFI boundary. Ask, don't demand.
+- **Perf on the row-decode path**: if the claim is about time, cite a timing. Size and
+  time have measured *anti-correlated* here: cancellation plumbing came to ~70% of the
+  row future by size but +5.8% by time, while a per-row `tokio::time::timeout` cost
+  +112 B but +42.5%. A prototype that shrank the future 32% benchmarked *slower*. Byte
+  tables predict nothing on this path.
+- **Future-size budgets**: the budget asserted by `row_fetch_futures_stay_small` is a
+  ceiling, not a ratchet — read the current constant out of the test. Growth that
+  stays under it is not a regression without a timing. Also, `TdsTokenStreamReader` /
+  `TdsTransport` are `#[async_trait]`, so a caller future holds a pointer and bounds
+  nothing inside the trait method — measure at the real call site.
+- **Perf follow-ups**: check the issue tree first. Row-decode perf work is tracked
+  under a parent issue with a sub-issue per axis, so a "new" finding is often already
+  filed, with numbers attached. Find it rather than trusting a number written here:
+
+  ```bash
+  gh issue list --state all --search "row decode perf"
+  ```
+- **Repo conventions**: a real convention finding cites the file and line that
+  mandates it. Verify against `.github/PULL_REQUEST_TEMPLATE.md`,
+  `CONTRIBUTING.md` / `AGENTS.md` / `.github/copilot-instructions.md`, and actual
+  behavior in `git log origin/main -25`. Otherwise it is a guess, and guesses go in
+  the body as questions.
+- **A CHANGELOG.md entry is not required** — it is in no checklist, and the only
+  `.github/` reference is a `paths-ignore` that makes changelog-only edits *skip* CI.
+  Nit at most, never a finding on its own. The related finding that *is* real: a
+  behavior fix buried in a refactor or deletion PR should be named in the
+  description, wherever it ends up recorded.
+- **Removals in a stacked PR**: check the net `git diff $BASE..HEAD` before calling
+  something a removal. Scaffolding added in commit 1 and deleted in commit 3 of the
+  same PR is hygiene, not a defect — per-commit stats mislead.
+- **"This PR introduces X"**: check whether the same shape already exists on `main`.
+  A pre-existing, crate-wide gap — the raw-handle lifetime races are the standing
+  example, already tracked by a TODO in `disconnect.rs` — is a legitimate deferral,
+  because fixing it in one path and not the others is worse than scheduling it as its
+  own change.
+
+## Reviewing Alongside Other Reviewers
+
+When handed findings from a bot or another agent, adjudicate rather than forward.
+
+- Verify the mechanism against the code, then verify the *proposed fix* too. A remedy
+  can be broken independently of the diagnosis being right.
+- **Bot findings assert source and spec facts that often do not hold.** Check each
+  one against the actual file. Withdrawn examples: `SQL_ATTR_CURSOR_TYPE` is
+  `SQLULEN`, not the `SQLUINTEGER` the finding claimed; `ProcessRow` never reads the
+  field it said to cache; `DoDD()` has no version gate. Their "this issue also
+  appears at lines X, Y, Z" lists are worth checking individually — two PRs found
+  those extra locations were unrelated code.
+- Check whether the thread has already been raised and answered. A restatement at a
+  higher severity is not a new finding, and the existing reply usually contains the
+  reason the obvious fix was declined.
+- Reframe severity when the mechanism is real but the impact argument is not. Say
+  which part you kept and which part you corrected.
+
+## Posting the Review
+
+Only after explicit confirmation, or under the automation carve-out in step 6.
+The mechanics that otherwise fail silently — inline comments needing the API rather
+than `gh pr review`, diff-hunk anchoring, `--paginate` when verifying — are in
+[posting.md](posting.md).
 
 ## Output Format
 
@@ -96,10 +291,15 @@ Check these in addition to the general areas above.
 ## Principles
 
 - Be specific and actionable; avoid vague praise or vague criticism.
+- **Question a departure from the reference drivers before auditing inside it.** When
+  a change diverges from `msodbcsql` / `SqlClient` / `mssql-jdbc` behavior, the divergence
+  is the first thing to examine — hardening a path that shouldn't exist is wasted review.
+  If a PR's own design doc reaches opposite conclusions in two places, that contradiction
+  *is* the finding.
 - If a change is correct, don't invent problems. An empty severity group means "none
   found" — say so briefly.
 - Distinguish facts (verified in code) from concerns (worth checking). Don't state
-  guesses as defects.
+  guesses as defects. Say what you ran and what you read.
 - Prefer the smallest correct fix over large refactors unless the PR's goal requires
   more.
 - Reviewing is not merging. The PR author owns the merge — never merge someone

--- a/.github/skills/code-review/posting.md
+++ b/.github/skills/code-review/posting.md
@@ -22,10 +22,11 @@ only once posting has been authorized.
   ```
 
 - Inline comments must land on lines present in the diff or the API returns 422.
-  A hunk header `@@ -115,21 +143,206 @@` means the new-side range starts at 143;
-  lines before it are not in the diff even if they look adjacent in the file. Check
-  with `git diff $BASE..HEAD -- <file> | grep -n '^@@'`. Findings on unchanged lines
-  belong in the top-level body.
+  A hunk header `@@ -115,21 +143,206 @@` means that hunk covers new-side lines
+  143-348; a line outside it is only anchorable if some *other* hunk covers it. Check
+  the full set with `git diff $BASE..HEAD -- <file> | grep -n '^@@'` rather than
+  reasoning from the nearest one. Findings on lines no hunk covers belong in the
+  top-level body.
 - On your own PR, `COMMENT` reviews with inline comments are allowed — only `APPROVE`
   and `REQUEST_CHANGES` are blocked. Don't downgrade to a single top-level comment.
 - Verify what landed; the comments endpoint pages at 30, so a fresh review looks

--- a/.github/skills/code-review/posting.md
+++ b/.github/skills/code-review/posting.md
@@ -1,0 +1,40 @@
+# Posting a Review
+
+Mechanics for submitting a review to GitHub. Referenced from `SKILL.md`; read this
+only once posting has been authorized.
+
+- `gh pr review --comment --body-file` posts **only** a top-level body. For inline
+  comments use the API directly:
+
+  ```bash
+  gh api repos/microsoft/mssql-rs/pulls/<N>/reviews -X POST --input review.json
+  ```
+
+  ```jsonc
+  {
+    "commit_id": "<head sha>",
+    "body": "## Summary ...",
+    "event": "COMMENT",
+    "comments": [
+      { "path": "mssql-tds/src/foo.rs", "line": 634, "side": "RIGHT", "body": "..." }
+    ]
+  }
+  ```
+
+- Inline comments must land on lines present in the diff or the API returns 422.
+  A hunk header `@@ -115,21 +143,206 @@` means the new-side range starts at 143;
+  lines before it are not in the diff even if they look adjacent in the file. Check
+  with `git diff $BASE..HEAD -- <file> | grep -n '^@@'`. Findings on unchanged lines
+  belong in the top-level body.
+- On your own PR, `COMMENT` reviews with inline comments are allowed — only `APPROVE`
+  and `REQUEST_CHANGES` are blocked. Don't downgrade to a single top-level comment.
+- Verify what landed; the comments endpoint pages at 30, so a fresh review looks
+  missing without `--paginate`:
+
+  ```bash
+  gh api --paginate repos/microsoft/mssql-rs/pulls/<N>/comments \
+    -q '.[] | select(.pull_request_review_id==<ID>) | "\(.path):\(.line)"'
+  ```
+
+- Remove mid-sentence line wrapping from the body before posting so GitHub can wrap
+  it. Wrapping is fine while previewing in chat.


### PR DESCRIPTION
## Description

Corrects the `code-review` skill added in #332. Two fixes grounded in what went wrong on #360, plus a set of conventions mined from this repo's own review history.

### 1. The skill never told a reviewer to read the prior review discussion

Two independent reviews of #360 hit the same consequence. GitHub splits review discussion across three endpoints, and Copilot's low-confidence findings are *suppressed* — they appear only in `pulls/<N>/reviews[].body` inside a collapsed `<details>` block, never as an inline comment. Verified on that PR:

| endpoint | contains the `mark_known_dead` finding |
| --- | --- |
| `pulls/360/comments` (inline threads) | no |
| `pulls/360/reviews` (review bodies) | yes — `copilot-pull-request-reviewer[bot]` |
| `issues/360/comments` (PR-level) | the author's rebuttal |

`gh pr view --json reviews` reports nine reviews and none of their content. Inferring novelty from that silence is how an already-answered finding gets re-filed as **Blocking**. Step 3 now queries all three endpoints, saves the responses, names the suppressed-comment trap, and adds a cheaper guard: grep what you saved for the symbol a finding concerns before drafting it.

### 2. The file hardcoded facts that go stale on their own schedules

A tracking issue number, a future-size constant, a coverage threshold, and a list of "known" failing tests — each replaced by the command that re-derives it. The known-failure list mattered most: once those cert fixtures exist in CI, it tells a reviewer to ignore a genuine regression. Failures are now baselined against the merge base with a matching invocation, which generalizes to any pre-existing failure and catches the `--all-features`-vs-default discrepancy that made two reviewers report different baselines for the same tree.

A standing note says every concrete number below is a dated observation, and that an observation contradicting the file should be reported — against the skill, not in the reviewed PR's summary.

### 3. Conventions mined from this repo's review history

617 review threads across the 34 merged PRs carrying ten or more, filtered to reviewer-finding-then-author-rebuttal, read in full. Only what recurred was kept. Two patterns dominate:

**In `mssql-odbc`, msodbcsql is the contract — the ODBC spec is not.** The largest single source of withdrawn findings here. Reviews argued from the spec or from internal consistency and were overturned in both directions: a proposed `07006`→`07009` correction where msodbcsql reports nothing at all; "write the non-NULL length too" where it writes nothing; "gate these renames on ODBC 2.x" where `DoDD()` applies them unconditionally; "add the missing post-connect guard" where it deliberately has none. It cuts the other way too — `BufferLength = 0` *is* a length probe there, and raising that as a question found a real divergence. A sub-rule with its own casualty: read the caller, not just the validator, since msodbcsql normalizes on entry — one finding was retracted by its own author after missing that `SQLBindParameter` folds `SQL_DOUBLE` to `SQL_FLOAT` before validating.

**A test that still passes when you break the thing it names guards nothing.** Nine instances, and the cheapest check in the file: mutate the constant, operator or condition the change is about and confirm the test fails. A limb-reassembly test survived changing its own `<< (i * 32)` to `<< (i * 16)` with all 539 tests green. Temporal tests were built in nanoseconds and asserted against a converter dividing by 1e9 — self-consistently wrong while the driver ran 100x off against a real server. Others passed on `Err(ConnectionClosed)` rather than the behavior in their name, or passed with *and* without the guard they were added for.

Smaller recurring ones: verify a bot's source and spec assertions rather than its confidence (three withdrawn, plus two wrong "this also appears at line X" lists); check that a "breaking" change is observable outside an unpublished pre-1.0 workspace; treat a pre-existing crate-wide gap as a legitimate deferral; pair every new setter arm with its getter.

This also **corrects** the CHANGELOG guidance rather than just adding to it. Still not required — but the related finding that *is* real is a behavior fix buried in a refactor or deletion PR that the description never mentions.

### 4. From the review round (`e85ecfab`, `13a9b310`)

- **The skill is now GitHub-only.** It previously advertised Azure DevOps PRs while running hardcoded GitHub API calls for both, and the two providers number PRs independently — an ADO review would have silently read an unrelated GitHub PR sharing the number. `e85ecfab` added an ADO branch; `13a9b310` removed it once we confirmed PR workflow has moved fully to GitHub. Both commits are kept rather than squashed so the review trail stays honest. Work-item linkage and the coverage `paths-ignore` note remain — neither is PR workflow.
- **The coverage report is not always generated.** `pr-code-coverage.yml` mirrors the ADO path excludes, so a PR touching only `.github/**`, `docs/**` or the root markdown files never produces one, and fork PRs need a maintainer `/coverage`. This PR is itself such a PR. Both references are now conditional, with the exclusion list written down.
- `git fetch origin main` before deriving `BASE`, since fetching only the pull ref leaves a long-lived checkout comparing against a stale base.
- Step 5 picks the crate the diff touches instead of always running `mssql-tds`, which validates nothing in an odbc-, JS- or Python-only change.
- A hunk header bounds one hunk, not the diff — the old wording would have sent anchorable findings to the top-level body.

### Also included

- **Reviewing Alongside Other Reviewers** — verify the proposed fix as well as the diagnosis, and check whether a thread was already answered before escalating severity.
- **Automation carve-out** on the confirm-before-posting rule, so unattended review runs are not blocked. Keyed on explicit authorization rather than the agent's own read of the context, with guardrails: `COMMENT` only — never `APPROVE`, which can satisfy branch protection — no merging, and the unattended run disclosed in the body.
- Step 2 checks the PR out into a dedicated worktree and diffs against `git merge-base`, since PRs here are commonly stacked and often carry a merge from `main`.
- Posting mechanics move to a sibling `posting.md` to keep `SKILL.md` skimmable — it is judgment-free procedure, and long skills get skimmed.

## Verification

Documentation only — no code, no build impact. Every command added to the skill was run against #360 while writing it, including the three-endpoint table above. Each mined rule cites instances from the PRs it came from rather than a single anecdote. The review round's claims were each checked against the workflow files and the PR template before being acted on.

## Related Issues

Fixes #377

## Checklist

- [x] New/changed functionality has tests — n/a, documentation only
- [x] Public API changes are documented — no public API change
