### PR TITLE
Fix SQLGetData returning uninitialized buffer for SELECT NULL

### DIFF
--- a/mssql-odbc/src/api/get_data.rs
+++ b/mssql-odbc/src/api/get_data.rs
@@ -273,6 +273,17 @@ fn write_captured_column(
     };
 
     if matches!(value, ColumnValues::Null) {
+        // ODBC spec: "If [StrLen_or_IndPtr] is a null pointer, no length or
+        // indicator value is returned. This returns an error when the data
+        // being fetched is NULL" (SQLSTATE 22002). There is nowhere to report
+        // the NULL, and leaving the target buffer untouched would hand the
+        // caller whatever was already there. Mirrors the identical check in
+        // fetch_scroll.rs::deliver_bound for bound columns. Leave the value
+        // resident so a retry with a real indicator can still succeed.
+        if strlen_or_ind_ptr.is_null() {
+            post_diag(stmt_state, ERR_INDICATOR_REQUIRED);
+            return SQL_ERROR;
+        }
         unsafe { write_if_some(strlen_or_ind_ptr, SQL_NULL_DATA) };
         // Only character targets get a terminator; a fixed-width target's
         // buffer is left untouched on NULL.

--- a/mssql-odbc/src/api/get_data.rs
+++ b/mssql-odbc/src/api/get_data.rs
@@ -1539,6 +1539,82 @@ mod tests {
         assert_eq!(ind, std::mem::size_of::<i32>() as SqlLen);
     }
 
+    /// AB#47507 — SQLGetData must return SQLSTATE 22002 ("Indicator variable
+    /// required but not supplied") when the value is NULL and the caller
+    /// supplied no indicator, matching msodbcsql and the bound-column path
+    /// (fetch_scroll.rs::deliver_bound). Before this check existed,
+    /// SQLGetData silently returned SQL_SUCCESS and left the caller's output
+    /// buffer untouched. mssql-python's SQLGetData_wrap relies on the
+    /// ODBC-mandated error to detect NULL for fixed-width C types — it fetches
+    /// SQL_INTEGER et al. with a null indicator and falls back to `None` only
+    /// when SQLGetData fails — so the missing check meant callers read back
+    /// whatever was already on their stack as if it were the column's value.
+    #[test]
+    fn get_data_typed_null_without_indicator_reports_22002() {
+        let h = TestHandles::with_env_dbc_stmt();
+        stmt_with_captured(&h, ColumnValues::Null);
+
+        let mut out: i32 = -1_066_579_696; // poisoned sentinel, must survive untouched
+        let ret = unsafe {
+            sql_get_data(
+                h.stmt,
+                1,
+                SQL_C_SLONG,
+                (&mut out as *mut i32).cast(),
+                4,
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(ret, SQL_ERROR);
+        assert_eq!(out, -1_066_579_696, "NULL must not disturb the data slot");
+        {
+            let sh = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+            let s = sh.inner.lock().unwrap();
+            assert_last_diag(&s.diag_records, ERR_INDICATOR_REQUIRED);
+        }
+
+        // The value was not consumed: a retry with a real indicator still
+        // reports the NULL correctly.
+        let mut ind: SqlLen = -99;
+        let ret = unsafe {
+            sql_get_data(
+                h.stmt,
+                1,
+                SQL_C_SLONG,
+                (&mut out as *mut i32).cast(),
+                4,
+                &mut ind,
+            )
+        };
+        assert_eq!(ret, SQL_SUCCESS);
+        assert_eq!(ind, SQL_NULL_DATA);
+    }
+
+    /// The same rule applies to character targets: a NULL with no indicator is
+    /// still 22002, even though a terminator could otherwise be written.
+    #[test]
+    fn get_data_char_null_without_indicator_reports_22002() {
+        let h = TestHandles::with_env_dbc_stmt();
+        stmt_with_captured(&h, ColumnValues::Null);
+
+        let mut buf = [b'X'; 8];
+        let ret = unsafe {
+            sql_get_data(
+                h.stmt,
+                1,
+                SQL_C_CHAR,
+                buf.as_mut_ptr() as SqlPointer,
+                buf.len() as SqlLen,
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(ret, SQL_ERROR);
+        assert_eq!(buf, [b'X'; 8], "NULL must not disturb the data slot");
+        let sh = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        let s = sh.inner.lock().unwrap();
+        assert_last_diag(&s.diag_records, ERR_INDICATOR_REQUIRED);
+    }
+
     #[test]
     fn get_data_typed_timestamp_target() {
         use crate::api::odbc_types::SqlTimestampStruct;

--- a/mssql-odbc/src/api/get_data.rs
+++ b/mssql-odbc/src/api/get_data.rs
@@ -1550,16 +1550,9 @@ mod tests {
         assert_eq!(ind, std::mem::size_of::<i32>() as SqlLen);
     }
 
-    /// AB#47507 — SQLGetData must return SQLSTATE 22002 ("Indicator variable
-    /// required but not supplied") when the value is NULL and the caller
-    /// supplied no indicator, matching msodbcsql and the bound-column path
-    /// (fetch_scroll.rs::deliver_bound). Before this check existed,
-    /// SQLGetData silently returned SQL_SUCCESS and left the caller's output
-    /// buffer untouched. mssql-python's SQLGetData_wrap relies on the
-    /// ODBC-mandated error to detect NULL for fixed-width C types — it fetches
-    /// SQL_INTEGER et al. with a null indicator and falls back to `None` only
-    /// when SQLGetData fails — so the missing check meant callers read back
-    /// whatever was already on their stack as if it were the column's value.
+    /// AB#47507 regression: a NULL value with no indicator must be SQLSTATE
+    /// 22002, not a silent SQL_SUCCESS that leaves the caller's buffer
+    /// untouched.
     #[test]
     fn get_data_typed_null_without_indicator_reports_22002() {
         let h = TestHandles::with_env_dbc_stmt();

--- a/mssql-odbc/src/api/get_data.rs
+++ b/mssql-odbc/src/api/get_data.rs
@@ -1619,6 +1619,88 @@ mod tests {
         assert_last_diag(&s.diag_records, ERR_INDICATOR_REQUIRED);
     }
 
+    /// PR review follow-up: the 22002 early return must not disturb the
+    /// forward-only row cursor, or a later column in the same row becomes
+    /// unreachable. Drives `SELECT 1, NULL, 2` purely through `StmtState`
+    /// bookkeeping (manually re-seeding `last_captured` between calls the way
+    /// `resume_row_to_column` would), so it pins the accounting invariant
+    /// without needing a live decoder: column 2's 22002 must leave
+    /// `current_row_last_col` at column 1, so the forward-only gate still
+    /// admits column 3 afterward, and column 3 is not mistaken for an
+    /// already-consumed re-request of column 2.
+    #[test]
+    fn get_data_null_without_indicator_does_not_block_later_columns_in_the_row() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let stmt_handle = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        {
+            let mut s = stmt_handle.inner.lock().unwrap();
+            s.set_state(STMT_STATE_CURSOR_OPEN);
+            s.column_metadata = int_columns(3);
+            s.row_positioned = true;
+            s.last_captured = Some((1, ColumnValues::Int(1)));
+        }
+
+        let mut out: i32 = 0;
+        let mut ind: SqlLen = 0;
+        let ret = unsafe {
+            sql_get_data(
+                h.stmt,
+                1,
+                SQL_C_SLONG,
+                (&mut out as *mut i32).cast(),
+                4,
+                &mut ind,
+            )
+        };
+        assert_eq!(ret, SQL_SUCCESS);
+        assert_eq!(out, 1);
+
+        // Column 2 is NULL with no indicator: 22002, and must not advance the
+        // forward-only cursor past column 1.
+        {
+            let mut s = stmt_handle.inner.lock().unwrap();
+            s.last_captured = Some((2, ColumnValues::Null));
+        }
+        let ret = unsafe {
+            sql_get_data(
+                h.stmt,
+                2,
+                SQL_C_SLONG,
+                (&mut out as *mut i32).cast(),
+                4,
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(ret, SQL_ERROR);
+        {
+            let s = stmt_handle.inner.lock().unwrap();
+            assert_eq!(
+                s.current_row_last_col, 1,
+                "a failed NULL column must not advance the forward-only cursor"
+            );
+        }
+
+        // Column 3 is still reachable: the forward-only gate admits it
+        // (current_row_last_col is still 1), and it is not treated as an
+        // already-captured re-request of column 2.
+        {
+            let mut s = stmt_handle.inner.lock().unwrap();
+            s.last_captured = Some((3, ColumnValues::Int(2)));
+        }
+        let ret = unsafe {
+            sql_get_data(
+                h.stmt,
+                3,
+                SQL_C_SLONG,
+                (&mut out as *mut i32).cast(),
+                4,
+                &mut ind,
+            )
+        };
+        assert_eq!(ret, SQL_SUCCESS);
+        assert_eq!(out, 2);
+    }
+
     #[test]
     fn get_data_typed_timestamp_target() {
         use crate::api::odbc_types::SqlTimestampStruct;

--- a/mssql-odbc/tests/e2e/tests/get_data_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/get_data_test.cpp
@@ -252,6 +252,46 @@ TEST_F(GetDataLiveTest, NullColumn) {
     SQLCloseCursor(stmt_);
 }
 
+// AB#47507: a bare SELECT NULL is a nullable INT column with no CAST. When the
+// caller supplies no indicator, SQLGetData must fail with SQLSTATE 22002
+// rather than silently succeed and leave the target buffer untouched. This is
+// the exact regression reported: mssql-python fetches SQL_INTEGER columns via
+// SQL_C_SLONG with a null indicator and relies on the ODBC-mandated error to
+// detect NULL, falling back to None only when SQLGetData fails.
+TEST_F(GetDataLiveTest, NullColumnWithoutIndicatorReturns22002) {
+    ASSERT_SQL_OK(ExecDirect("SELECT NULL"), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+
+    SQLINTEGER value = 7;
+    SQLRETURN rc = SQLGetData(stmt_, 1, SQL_C_SLONG, &value, sizeof(value), nullptr);
+    EXPECT_EQ(SQL_ERROR, rc);
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "22002");
+    EXPECT_EQ(7, value) << "a NULL must not disturb the data slot";
+
+    SQLCloseCursor(stmt_);
+}
+
+// The same rule holds on the PLP arrival path: VARCHAR(MAX) NULL decodes via
+// the distinct SQL_PLP_NULL wire marker and RowWriter::write_null, not the
+// fixed/var-length NULL length prefix NullColumn above exercises. Both paths
+// must converge on the identical SQLGetData guard.
+TEST_F(GetDataLiveTest, PlpNullColumnWithoutIndicatorReturns22002) {
+    ASSERT_SQL_OK(ExecDirect("SELECT CAST(NULL AS VARCHAR(MAX)) AS c1"),
+                  SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+
+    SQLCHAR buf[16];
+    std::memset(buf, 'Z', sizeof(buf));
+    SQLRETURN rc = SQLGetData(stmt_, 1, SQL_C_CHAR, buf, sizeof(buf), nullptr);
+    EXPECT_EQ(SQL_ERROR, rc);
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "22002");
+    EXPECT_TRUE(std::all_of(buf, buf + sizeof(buf),
+                            [](SQLCHAR b) { return b == 'Z'; }))
+        << "a NULL must not disturb the data slot";
+
+    SQLCloseCursor(stmt_);
+}
+
 // A scalar column followed by a PLP column: the scalar is delivered in one shot,
 // then the PLP value streams to completion. Exercises the scalar→PLP transition
 // within a single row.


### PR DESCRIPTION
## Description

`SQLGetData` silently returned `SQL_SUCCESS` and left the caller's output buffer completely untouched when a column value was NULL and the caller passed a null `StrLen_or_IndPtr`. Per the ODBC spec this must be SQLSTATE `22002` ("Indicator variable required but not supplied") — mssql-odbc already implements this rule correctly for the bound-column path (`fetch_scroll.rs::deliver_bound` / `RowIssue::IndicatorRequired`), but the older unbound `SQLGetData` path (`get_data.rs::write_captured_column`) never got the same check.

mssql-python's `SQLGetData_wrap` fetches several fixed-width C types (`SQL_INTEGER`, `SQL_SMALLINT`, `SQL_TINYINT`, `SQL_BIT`, `SQL_REAL`, `SQL_DOUBLE`/`SQL_FLOAT`, `SQL_BIGINT`, `SQL_TYPE_DATE`, `SQL_TIMESTAMP`) with a null indicator and relies on the ODBC-mandated error to detect NULL (falling back to `None` only when `SQLGetData` fails). Without the check, `cursor.execute("SELECT NULL").fetchval()` returned whatever uninitialized memory happened to be on the caller's stack instead of `None` — a different value on every run.

Verified against the actual msodbcsql C++ reference driver source (`Sql/Ntdbms/sqlncli/odbc/sqlcdata.h`): `if (fIsNullData) { if (lpIndValue == NULL) { wError = IDS_22_002; ... } else *lpIndValue = SQL_NULL_DATA; }` — this driver was diverging from parity, not exceeding it.

Commit history is intentionally split so the CI signal is directly attributable:
1. **Add regression tests** — two new unit tests that fail against the pre-fix code, reproducing the bug at the unit level.
2. **Apply the fix** — mirrors `deliver_bound`'s existing `IndicatorRequired` check; turns the new tests (and the affected mssql-python cross-repo tests) green.

## Validation results (before-fix vs. after-fix pipeline runs)

Ran the `mssql-rs Pull request validation` pipeline (definition 2267) once per commit to isolate the fix's effect:

| | Before-fix ([build 169853](https://sqlclientdrivers.visualstudio.com/public/_build/results?buildId=169853)) | After-fix ([build 169854](https://sqlclientdrivers.visualstudio.com/public/_build/results?buildId=169854)) |
|---|---|---|
| `test_fetchval_null_values` | ❌ Failed | ✅ Passed |
| `test_gh610_execute_all_null_params` | ❌ Failed | ✅ Passed |
| `test_ddl_and_dml_rollback` | ❌ Failed | ✅ Passed |
| `mssql-python suite on mssql-odbc driver` (scoped run) | 1540/2076 passed | 1543/2076 passed |
| `Build Stage` (fmt + clippy + nextest, Windows/Linux/macOS/ARM) | n/a (build superseded/cancelled before completion) | ✅ succeeded |

Net effect: exactly **+3 passed / −3 failed**, identical total test count (2076) in both scoped runs — the fix's effect is precisely isolated to the 3 tests this bug caused, with no regressions elsewhere in the suite. The only non-green item in the after-fix build is the `mssql-python suite on mssql-odbc driver` job itself reporting `SucceededWithIssues`, which is by design while the driver is under development (unrelated pre-existing failures, not caused by this change).

## Related Issues

https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47507

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes
- [x] New/changed functionality has tests
- [x] Public API changes are documented (behavioral fix only, no signature change)