### PR TITLE
Make macOS SQL Server startup resilient to SQLPAL crashes and Colima flakes

### DIFF
--- a/.pipeline/scripts/README.md
+++ b/.pipeline/scripts/README.md
@@ -81,6 +81,33 @@ Enables Named Pipes and Shared Memory protocols for SQL Server via registry modi
 - Optionally restarts SQL Server service to apply changes
 - Provides detailed configuration status
 
+### start-colima-macos.sh
+Installs Docker + Colima on a hosted macOS agent and boots the VM, retrying on
+the transient lima hostagent boot failures seen in ~3% of runs. Falls back to a
+smaller VM if the larger memory request cannot be satisfied. Retries stop once
+`COLIMA_BUDGET_SECONDS` has elapsed.
+
+**Environment overrides:** `COLIMA_CPU`, `COLIMA_DISK`, `COLIMA_MEMORY_ATTEMPTS`
+(space-separated GiB sizes, one per attempt), `COLIMA_BUDGET_SECONDS`.
+
+### start-sql-server-macos.sh
+Starts the SQL Server test container inside the Colima VM. Retries the image
+pull, recreates the container when SQL Server hits a SQLPAL startup crash
+(~13% of macOS runs), dumps container state plus logs on every failed attempt,
+and exits non-zero when the server never becomes reachable.
+
+The macOS job is capped at 60 minutes, so every retry is bounded by wall clock
+as well as by attempt count: `SETUP_BUDGET_SECONDS` covers the whole step,
+`PULL_BUDGET_SECONDS` carves out the pull phase so a slow registry cannot
+starve the retries, and `READY_TIMEOUT_SECONDS` bounds each container attempt.
+The pipeline step adds a `timeoutInMinutes` backstop over the top.
+
+**Environment:** requires `SQL_PASSWORD`. Overrides: `SQL_IMAGE`,
+`SQL_CONTAINER`, `SQL_MEMORY_LIMIT_MB`, `SETUP_BUDGET_SECONDS` (900),
+`PULL_BUDGET_SECONDS` (480), `READY_TIMEOUT_SECONDS` (180),
+`MAX_START_ATTEMPTS` (3), `PROBE_LOGIN_TIMEOUT_SECONDS` (5),
+`PROBE_INTERVAL_SECONDS` (3).
+
 ## Pipeline Integration
 
 These scripts are referenced in the Azure DevOps pipeline template:

--- a/.pipeline/scripts/README.md
+++ b/.pipeline/scripts/README.md
@@ -83,12 +83,12 @@ Enables Named Pipes and Shared Memory protocols for SQL Server via registry modi
 
 ### start-colima-macos.sh
 Installs Docker + Colima on a hosted macOS agent and boots the VM, retrying on
-the transient lima hostagent boot failures seen in ~3% of runs. Falls back to a
-smaller VM if the larger memory request cannot be satisfied. Retries stop once
-`COLIMA_BUDGET_SECONDS` has elapsed.
+the transient lima hostagent boot failures seen in ~3% of runs. Retries stop
+once `COLIMA_BUDGET_SECONDS` has elapsed. VM size stays at the long-standing
+4 GiB / 4 CPU.
 
-**Environment overrides:** `COLIMA_CPU`, `COLIMA_DISK`, `COLIMA_MEMORY_ATTEMPTS`
-(space-separated GiB sizes, one per attempt), `COLIMA_BUDGET_SECONDS`.
+**Environment overrides:** `COLIMA_CPU`, `COLIMA_MEMORY`, `COLIMA_DISK`,
+`COLIMA_START_ATTEMPTS`, `COLIMA_BUDGET_SECONDS`.
 
 ### start-sql-server-macos.sh
 Starts the SQL Server test container inside the Colima VM. Retries the image
@@ -103,10 +103,9 @@ starve the retries, and `READY_TIMEOUT_SECONDS` bounds each container attempt.
 The pipeline step adds a `timeoutInMinutes` backstop over the top.
 
 **Environment:** requires `SQL_PASSWORD`. Overrides: `SQL_IMAGE`,
-`SQL_CONTAINER`, `SQL_MEMORY_LIMIT_MB`, `SETUP_BUDGET_SECONDS` (900),
-`PULL_BUDGET_SECONDS` (480), `READY_TIMEOUT_SECONDS` (180),
-`MAX_START_ATTEMPTS` (3), `PROBE_LOGIN_TIMEOUT_SECONDS` (5),
-`PROBE_INTERVAL_SECONDS` (3).
+`SQL_CONTAINER`, `SETUP_BUDGET_SECONDS` (900), `PULL_BUDGET_SECONDS` (480),
+`READY_TIMEOUT_SECONDS` (180), `MAX_START_ATTEMPTS` (3),
+`PROBE_LOGIN_TIMEOUT_SECONDS` (5), `PROBE_INTERVAL_SECONDS` (3).
 
 ## Pipeline Integration
 

--- a/.pipeline/scripts/README.md
+++ b/.pipeline/scripts/README.md
@@ -81,14 +81,26 @@ Enables Named Pipes and Shared Memory protocols for SQL Server via registry modi
 - Optionally restarts SQL Server service to apply changes
 - Provides detailed configuration status
 
+### run-bounded.sh
+Sourced helper providing `run_bounded <seconds> <command...>`. macOS ships no
+coreutils `timeout`, so long-running commands are bounded by running them in the
+background and killing them on overrun. Returns 124 on timeout.
+
 ### start-colima-macos.sh
 Installs Docker + Colima on a hosted macOS agent and boots the VM, retrying on
-the transient lima hostagent boot failures seen in ~3% of runs. Retries stop
-once `COLIMA_BUDGET_SECONDS` has elapsed. VM size stays at the long-standing
-4 GiB / 4 CPU.
+the transient lima hostagent boot failures seen in ~3% of runs. VM size stays at
+the long-standing 4 GiB / 4 CPU.
+
+Each `colima start` is bounded by `COLIMA_START_TIMEOUT_SECONDS` so a wedged
+boot still reaches the delete/retry path rather than running until the pipeline
+step timeout. That bound sits above the slowest healthy boot observed over 113
+runs (509s; p95 366s) — the real failures give up within seconds, so a shorter
+bound would only kill slow-but-healthy boots. `COLIMA_BUDGET_SECONDS` then caps
+the retries as a whole.
 
 **Environment overrides:** `COLIMA_CPU`, `COLIMA_MEMORY`, `COLIMA_DISK`,
-`COLIMA_START_ATTEMPTS`, `COLIMA_BUDGET_SECONDS`.
+`COLIMA_START_ATTEMPTS` (3), `COLIMA_START_TIMEOUT_SECONDS` (540),
+`COLIMA_BUDGET_SECONDS` (480).
 
 ### start-sql-server-macos.sh
 Starts the SQL Server test container inside the Colima VM. Retries the image

--- a/.pipeline/scripts/README.md
+++ b/.pipeline/scripts/README.md
@@ -114,9 +114,14 @@ as well as by attempt count: `SETUP_BUDGET_SECONDS` covers the whole step,
 starve the retries, and `READY_TIMEOUT_SECONDS` bounds each container attempt.
 The pipeline step adds a `timeoutInMinutes` backstop over the top.
 
+Every bound is sized above the measured worst case of the *successful* runs, so
+it only ever catches a hang: pulls run p50 292s / p95 478s / max 724s over 112
+runs, and a healthy readiness wait maxes out at 157s over 97 runs. An earlier
+480s pull budget would have killed 4.5% of runs outright.
+
 **Environment:** requires `SQL_PASSWORD`. Overrides: `SQL_IMAGE`,
-`SQL_CONTAINER`, `SETUP_BUDGET_SECONDS` (900), `PULL_BUDGET_SECONDS` (480),
-`READY_TIMEOUT_SECONDS` (180), `MAX_START_ATTEMPTS` (3),
+`SQL_CONTAINER`, `SETUP_BUDGET_SECONDS` (1200), `PULL_BUDGET_SECONDS` (900),
+`READY_TIMEOUT_SECONDS` (240), `MAX_START_ATTEMPTS` (3),
 `PROBE_LOGIN_TIMEOUT_SECONDS` (5), `PROBE_INTERVAL_SECONDS` (3).
 
 ## Pipeline Integration

--- a/.pipeline/scripts/run-bounded.sh
+++ b/.pipeline/scripts/run-bounded.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Sourced helper. macOS ships no coreutils `timeout`, so bound a long-running
+# command by hand: run it in the background and kill it if it overruns.
+#
+# Returns 124 when the limit was hit, otherwise the command's own exit status.
+
+run_bounded() {
+  local limit=$1 pid waited=0
+  shift
+  # Job control gives the child its own process group. Signalling only the direct
+  # child leaves grandchildren (limactl, qemu, docker) alive holding the task's
+  # stdout, which hangs the pipeline step even after the timeout fires.
+  set -m
+  "$@" &
+  pid=$!
+  set +m
+  while kill -0 "$pid" 2>/dev/null; do
+    if [ "$waited" -ge "$limit" ]; then
+      echo "##[warning]'$1' exceeded ${limit}s — terminating"
+      kill -TERM -- "-$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null || true
+      sleep 5
+      kill -KILL -- "-$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+      return 124
+    fi
+    sleep 2
+    waited=$((waited + 2))
+  done
+  wait "$pid"
+}

--- a/.pipeline/scripts/start-colima-macos.sh
+++ b/.pipeline/scripts/start-colima-macos.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Installs Docker + Colima on a Microsoft-hosted macOS agent and boots the VM.
+#
+# Colima's VM boot is flaky on hosted macOS (~3% of runs): the lima hostagent
+# either misses its 5s startup window or never emits the `running` event. Both
+# are transient, so retry from a clean slate instead of failing the job.
+set -euo pipefail
+
+COLIMA_CPU=${COLIMA_CPU:-4}
+COLIMA_DISK=${COLIMA_DISK:-50}
+# GiB to request per attempt. 6 gives SQL Server headroom over the historical 4;
+# the last entry falls back to the known-good size in case a future agent SKU
+# cannot satisfy the larger request.
+COLIMA_MEMORY_ATTEMPTS=${COLIMA_MEMORY_ATTEMPTS:-"6 6 4"}
+# The macOS job only gets 60 minutes, so cap the retries by wall clock rather
+# than letting three boots of an unhealthy agent eat the test budget.
+COLIMA_BUDGET_SECONDS=${COLIMA_BUDGET_SECONDS:-480}
+
+brew update
+brew install docker colima
+
+start_time=$(date +%s)
+attempt=0
+for memory in $COLIMA_MEMORY_ATTEMPTS; do
+  attempt=$((attempt + 1))
+  if [ "$attempt" -gt 1 ] && [ $(($(date +%s) - start_time)) -ge "$COLIMA_BUDGET_SECONDS" ]; then
+    echo "##[warning]colima retry budget (${COLIMA_BUDGET_SECONDS}s) exhausted"
+    break
+  fi
+  echo "##[group]colima start (attempt $attempt, ${memory}GiB)"
+  if colima start --cpu "$COLIMA_CPU" --memory "$memory" --disk "$COLIMA_DISK"; then
+    echo "##[endgroup]"
+    docker context use colima >/dev/null || true
+    docker version
+    docker ps
+    exit 0
+  fi
+  echo "##[endgroup]"
+  echo "##[warning]colima failed to start (attempt $attempt, ${memory}GiB)"
+  tail -50 "$HOME/.colima/_lima/colima/ha.stderr.log" 2>/dev/null || true
+  colima delete --force >/dev/null 2>&1 || true
+  sleep 5
+done
+
+echo "##[error]colima did not start after $attempt attempts"
+exit 1

--- a/.pipeline/scripts/start-colima-macos.sh
+++ b/.pipeline/scripts/start-colima-macos.sh
@@ -6,13 +6,22 @@
 # are transient, so retry from a clean slate instead of failing the job.
 set -euo pipefail
 
+# shellcheck source=.pipeline/scripts/run-bounded.sh
+. "$(dirname "$0")/run-bounded.sh"
+
 COLIMA_CPU=${COLIMA_CPU:-4}
 COLIMA_DISK=${COLIMA_DISK:-50}
-# Stays at the long-standing 4GiB. The startup crashes this script retries are
-# not memory-related (every captured one reports oom=false and dies at LSA load,
-# before the buffer pool is committed), and a larger VM measurably slows boot.
+# Stays at the long-standing 4GiB. The startup crashes the SQL Server script
+# retries are not memory-related (every captured one reports oom=false and dies
+# at LSA load, before the buffer pool is committed), and a larger VM measurably
+# slows boot.
 COLIMA_MEMORY=${COLIMA_MEMORY:-4}
 COLIMA_START_ATTEMPTS=${COLIMA_START_ATTEMPTS:-3}
+# Catches a genuinely wedged `colima start` so it still reaches the delete and
+# retry path instead of running until the pipeline step timeout. Sized above the
+# slowest healthy boot seen over 113 runs (509s; p95 366s) — the observed
+# failures give up within seconds, so anything past this is stuck, not slow.
+COLIMA_START_TIMEOUT_SECONDS=${COLIMA_START_TIMEOUT_SECONDS:-540}
 # The macOS job only gets 60 minutes, so cap the retries by wall clock rather
 # than letting three boots of an unhealthy agent eat the test budget.
 COLIMA_BUDGET_SECONDS=${COLIMA_BUDGET_SECONDS:-480}
@@ -21,13 +30,24 @@ brew update
 brew install docker colima
 
 start_time=$(date +%s)
-for attempt in $(seq 1 "$COLIMA_START_ATTEMPTS"); do
-  if [ "$attempt" -gt 1 ] && [ $(($(date +%s) - start_time)) -ge "$COLIMA_BUDGET_SECONDS" ]; then
-    echo "##[warning]colima retry budget (${COLIMA_BUDGET_SECONDS}s) exhausted"
-    break
+deadline=$((start_time + COLIMA_BUDGET_SECONDS))
+attempts=0
+
+while [ "$attempts" -lt "$COLIMA_START_ATTEMPTS" ]; do
+  limit=$COLIMA_START_TIMEOUT_SECONDS
+  # The first attempt always gets a full slot; later ones take what is left.
+  if [ "$attempts" -gt 0 ]; then
+    left=$((deadline - $(date +%s)))
+    if [ "$left" -le 30 ]; then
+      echo "##[warning]colima retry budget (${COLIMA_BUDGET_SECONDS}s) exhausted after $attempts attempt(s)"
+      break
+    fi
+    [ "$left" -lt "$limit" ] && limit=$left
   fi
-  echo "##[group]colima start (attempt $attempt/$COLIMA_START_ATTEMPTS)"
-  if colima start --cpu "$COLIMA_CPU" --memory "$COLIMA_MEMORY" --disk "$COLIMA_DISK"; then
+
+  attempts=$((attempts + 1))
+  echo "##[group]colima start (attempt $attempts/$COLIMA_START_ATTEMPTS, ${limit}s limit)"
+  if run_bounded "$limit" colima start --cpu "$COLIMA_CPU" --memory "$COLIMA_MEMORY" --disk "$COLIMA_DISK"; then
     echo "##[endgroup]"
     docker context use colima >/dev/null || true
     docker version
@@ -35,11 +55,11 @@ for attempt in $(seq 1 "$COLIMA_START_ATTEMPTS"); do
     exit 0
   fi
   echo "##[endgroup]"
-  echo "##[warning]colima failed to start (attempt $attempt/$COLIMA_START_ATTEMPTS)"
+  echo "##[warning]colima failed to start (attempt $attempts/$COLIMA_START_ATTEMPTS)"
   tail -50 "$HOME/.colima/_lima/colima/ha.stderr.log" 2>/dev/null || true
   colima delete --force >/dev/null 2>&1 || true
   sleep 5
 done
 
-echo "##[error]colima did not start after $COLIMA_START_ATTEMPTS attempts"
+echo "##[error]colima did not start: $attempts of $COLIMA_START_ATTEMPTS configured attempt(s) ran in $(($(date +%s) - start_time))s of a ${COLIMA_BUDGET_SECONDS}s budget"
 exit 1

--- a/.pipeline/scripts/start-colima-macos.sh
+++ b/.pipeline/scripts/start-colima-macos.sh
@@ -8,10 +8,11 @@ set -euo pipefail
 
 COLIMA_CPU=${COLIMA_CPU:-4}
 COLIMA_DISK=${COLIMA_DISK:-50}
-# GiB to request per attempt. 6 gives SQL Server headroom over the historical 4;
-# the last entry falls back to the known-good size in case a future agent SKU
-# cannot satisfy the larger request.
-COLIMA_MEMORY_ATTEMPTS=${COLIMA_MEMORY_ATTEMPTS:-"6 6 4"}
+# Stays at the long-standing 4GiB. The startup crashes this script retries are
+# not memory-related (every captured one reports oom=false and dies at LSA load,
+# before the buffer pool is committed), and a larger VM measurably slows boot.
+COLIMA_MEMORY=${COLIMA_MEMORY:-4}
+COLIMA_START_ATTEMPTS=${COLIMA_START_ATTEMPTS:-3}
 # The macOS job only gets 60 minutes, so cap the retries by wall clock rather
 # than letting three boots of an unhealthy agent eat the test budget.
 COLIMA_BUDGET_SECONDS=${COLIMA_BUDGET_SECONDS:-480}
@@ -20,15 +21,13 @@ brew update
 brew install docker colima
 
 start_time=$(date +%s)
-attempt=0
-for memory in $COLIMA_MEMORY_ATTEMPTS; do
-  attempt=$((attempt + 1))
+for attempt in $(seq 1 "$COLIMA_START_ATTEMPTS"); do
   if [ "$attempt" -gt 1 ] && [ $(($(date +%s) - start_time)) -ge "$COLIMA_BUDGET_SECONDS" ]; then
     echo "##[warning]colima retry budget (${COLIMA_BUDGET_SECONDS}s) exhausted"
     break
   fi
-  echo "##[group]colima start (attempt $attempt, ${memory}GiB)"
-  if colima start --cpu "$COLIMA_CPU" --memory "$memory" --disk "$COLIMA_DISK"; then
+  echo "##[group]colima start (attempt $attempt/$COLIMA_START_ATTEMPTS)"
+  if colima start --cpu "$COLIMA_CPU" --memory "$COLIMA_MEMORY" --disk "$COLIMA_DISK"; then
     echo "##[endgroup]"
     docker context use colima >/dev/null || true
     docker version
@@ -36,11 +35,11 @@ for memory in $COLIMA_MEMORY_ATTEMPTS; do
     exit 0
   fi
   echo "##[endgroup]"
-  echo "##[warning]colima failed to start (attempt $attempt, ${memory}GiB)"
+  echo "##[warning]colima failed to start (attempt $attempt/$COLIMA_START_ATTEMPTS)"
   tail -50 "$HOME/.colima/_lima/colima/ha.stderr.log" 2>/dev/null || true
   colima delete --force >/dev/null 2>&1 || true
   sleep 5
 done
 
-echo "##[error]colima did not start after $attempt attempts"
+echo "##[error]colima did not start after $COLIMA_START_ATTEMPTS attempts"
 exit 1

--- a/.pipeline/scripts/start-sql-server-macos.sh
+++ b/.pipeline/scripts/start-sql-server-macos.sh
@@ -24,6 +24,9 @@
 # stops as soon as there is not enough budget left to complete another attempt.
 set -euo pipefail
 
+# shellcheck source=.pipeline/scripts/run-bounded.sh
+. "$(dirname "$0")/run-bounded.sh"
+
 : "${SQL_PASSWORD:?SQL_PASSWORD must be set}"
 
 SQL_IMAGE=${SQL_IMAGE:-mcr.microsoft.com/mssql/server:2025-latest}
@@ -46,27 +49,6 @@ START_TIME=$(date +%s)
 SETUP_DEADLINE=$((START_TIME + SETUP_BUDGET_SECONDS))
 
 elapsed() { echo $(($(date +%s) - START_TIME)); }
-
-# macOS ships no coreutils `timeout`, so bound long-running commands by hand.
-run_bounded() {
-  local limit=$1 pid waited=0
-  shift
-  "$@" &
-  pid=$!
-  while kill -0 "$pid" 2>/dev/null; do
-    if [ "$waited" -ge "$limit" ]; then
-      echo "##[warning]'$1' exceeded ${limit}s — terminating"
-      kill -TERM "$pid" 2>/dev/null || true
-      sleep 5
-      kill -KILL "$pid" 2>/dev/null || true
-      wait "$pid" 2>/dev/null || true
-      return 124
-    fi
-    sleep 2
-    waited=$((waited + 2))
-  done
-  wait "$pid"
-}
 
 pull_image() {
   local deadline=$((START_TIME + PULL_BUDGET_SECONDS)) attempt=0 left

--- a/.pipeline/scripts/start-sql-server-macos.sh
+++ b/.pipeline/scripts/start-sql-server-macos.sh
@@ -19,9 +19,10 @@
 #
 # Retries are bounded by wall-clock deadlines rather than attempt counts,
 # because the macOS job only gets 60 minutes in total. A failed sqlcmd probe
-# costs ~11s by default and `docker pull` of the SQL image has taken up to 7
-# minutes here, so counting attempts hides very large amounts of time. Retrying
-# stops as soon as there is not enough budget left to complete another attempt.
+# costs ~11s by default and `docker pull` of the SQL image runs p50 292s / max
+# 724s here, so counting attempts hides very large amounts of time. Every bound
+# is sized above the worst case of the *successful* runs so it only catches a
+# hang; retrying stops once there is not enough budget left for another attempt.
 set -euo pipefail
 
 # shellcheck source=.pipeline/scripts/run-bounded.sh
@@ -33,11 +34,13 @@ SQL_IMAGE=${SQL_IMAGE:-mcr.microsoft.com/mssql/server:2025-latest}
 SQL_CONTAINER=${SQL_CONTAINER:-sqlserver}
 
 # Total wall-clock budget for the step (pull plus every container attempt).
-SETUP_BUDGET_SECONDS=${SETUP_BUDGET_SECONDS:-900}
+SETUP_BUDGET_SECONDS=${SETUP_BUDGET_SECONDS:-1200}
 # Sub-budget for the pull phase, so a slow registry cannot starve the retries.
-PULL_BUDGET_SECONDS=${PULL_BUDGET_SECONDS:-480}
-# Per-container-attempt allowance. Healthy startups answer within ~60s.
-READY_TIMEOUT_SECONDS=${READY_TIMEOUT_SECONDS:-180}
+# Sized above the slowest pull seen in 112 runs (724s; p95 478s) — pulls are slow
+# here, not flaky, so a tighter bound just kills healthy runs.
+PULL_BUDGET_SECONDS=${PULL_BUDGET_SECONDS:-900}
+# Per-container-attempt allowance. Slowest healthy startup over 97 runs was 157s.
+READY_TIMEOUT_SECONDS=${READY_TIMEOUT_SECONDS:-240}
 # A container that exits immediately is abandoned in seconds, so cap the
 # attempts too — otherwise the budget alone would allow dozens of restarts.
 MAX_START_ATTEMPTS=${MAX_START_ATTEMPTS:-3}

--- a/.pipeline/scripts/start-sql-server-macos.sh
+++ b/.pipeline/scripts/start-sql-server-macos.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+# Starts the SQL Server test container inside the Colima VM on macOS agents.
+#
+# Two transient failures dominate this step on hosted macOS agents:
+#
+#  1. `docker pull` occasionally fails with "failed to resolve reference" — a
+#     registry/network blip, so the pull is retried.
+#  2. SQL Server itself crashes during startup in roughly 1 in 8 runs. The
+#     container exits with code 1 and the log shows a SQLPAL fatal error
+#     ("[AppLoader] Failed to load LSA: 0xc0070102" or reason 0x2) rather than
+#     an OOM kill. It is a startup race in the emulated VM, and simply
+#     recreating the container clears it.
+#
+# The readiness probe therefore watches container liveness as well as
+# connectivity: once the container has exited there is no point probing for the
+# remaining time, so the whole container is recreated instead. Failing that,
+# the script exits non-zero — the previous inline loop fell through silently,
+# leaving pytest to grind against a dead server until the 60-minute job timeout.
+#
+# Retries are bounded by wall-clock deadlines rather than attempt counts,
+# because the macOS job only gets 60 minutes in total. A failed sqlcmd probe
+# costs ~11s by default and `docker pull` of the SQL image has taken up to 7
+# minutes here, so counting attempts hides very large amounts of time. Retrying
+# stops as soon as there is not enough budget left to complete another attempt.
+set -euo pipefail
+
+: "${SQL_PASSWORD:?SQL_PASSWORD must be set}"
+
+SQL_IMAGE=${SQL_IMAGE:-mcr.microsoft.com/mssql/server:2025-latest}
+SQL_CONTAINER=${SQL_CONTAINER:-sqlserver}
+# SQL Server defaults to 80% of the VM's memory; cap it so the guest kernel and
+# dockerd keep breathing room.
+SQL_MEMORY_LIMIT_MB=${SQL_MEMORY_LIMIT_MB:-2048}
+
+# Total wall-clock budget for the step (pull plus every container attempt).
+SETUP_BUDGET_SECONDS=${SETUP_BUDGET_SECONDS:-900}
+# Sub-budget for the pull phase, so a slow registry cannot starve the retries.
+PULL_BUDGET_SECONDS=${PULL_BUDGET_SECONDS:-480}
+# Per-container-attempt allowance. Healthy startups answer within ~60s.
+READY_TIMEOUT_SECONDS=${READY_TIMEOUT_SECONDS:-180}
+# A container that exits immediately is abandoned in seconds, so cap the
+# attempts too — otherwise the budget alone would allow dozens of restarts.
+MAX_START_ATTEMPTS=${MAX_START_ATTEMPTS:-3}
+# Login timeout per probe; the sqlcmd default of ~9s makes probes expensive.
+PROBE_LOGIN_TIMEOUT_SECONDS=${PROBE_LOGIN_TIMEOUT_SECONDS:-5}
+PROBE_INTERVAL_SECONDS=${PROBE_INTERVAL_SECONDS:-3}
+
+START_TIME=$(date +%s)
+SETUP_DEADLINE=$((START_TIME + SETUP_BUDGET_SECONDS))
+
+elapsed() { echo $(($(date +%s) - START_TIME)); }
+
+# macOS ships no coreutils `timeout`, so bound long-running commands by hand.
+run_bounded() {
+  local limit=$1 pid waited=0
+  shift
+  "$@" &
+  pid=$!
+  while kill -0 "$pid" 2>/dev/null; do
+    if [ "$waited" -ge "$limit" ]; then
+      echo "##[warning]'$1' exceeded ${limit}s — terminating"
+      kill -TERM "$pid" 2>/dev/null || true
+      sleep 5
+      kill -KILL "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+      return 124
+    fi
+    sleep 2
+    waited=$((waited + 2))
+  done
+  wait "$pid"
+}
+
+pull_image() {
+  local deadline=$((START_TIME + PULL_BUDGET_SECONDS)) attempt=0 left
+  while :; do
+    attempt=$((attempt + 1))
+    left=$((deadline - $(date +%s)))
+    if [ "$left" -le 30 ]; then
+      echo "##[error]Unable to pull $SQL_IMAGE within ${PULL_BUDGET_SECONDS}s"
+      return 1
+    fi
+    if run_bounded "$left" docker pull "$SQL_IMAGE"; then
+      echo "Image pulled after $(elapsed)s."
+      return 0
+    fi
+    echo "##[warning]docker pull failed (attempt $attempt)"
+    sleep 10
+  done
+}
+
+dump_diagnostics() {
+  set +e
+  echo "##[group]SQL Server container diagnostics"
+  docker ps -a
+  docker inspect "$SQL_CONTAINER" --format \
+    'status={{.State.Status}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}} error={{.State.Error}}'
+  docker logs --tail 200 "$SQL_CONTAINER"
+  echo "##[endgroup]"
+  set -e
+}
+
+# Returns 0 once the container answers SELECT 1; 1 if it died or stayed
+# unreachable for the whole allowance.
+wait_until_ready() {
+  local limit=$1 deadline probe=0
+  deadline=$(($(date +%s) + limit))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    if [ "$(docker inspect -f '{{.State.Running}}' "$SQL_CONTAINER" 2>/dev/null)" != "true" ]; then
+      echo "  container is no longer running — abandoning this attempt"
+      return 1
+    fi
+    probe=$((probe + 1))
+    if run_bounded 30 docker exec "$SQL_CONTAINER" /opt/mssql-tools18/bin/sqlcmd \
+      -S localhost -U SA -P "$SQL_PASSWORD" \
+      -C -b -l "$PROBE_LOGIN_TIMEOUT_SECONDS" -Q "SELECT 1" >/dev/null 2>&1; then
+      echo "SQL Server is ready after $(elapsed)s (probe $probe)."
+      return 0
+    fi
+    echo "  probe $probe, $((deadline - $(date +%s)))s left for this attempt..."
+    sleep "$PROBE_INTERVAL_SECONDS"
+  done
+  echo "  SQL Server never answered within ${limit}s"
+  return 1
+}
+
+pull_image
+
+attempt=0
+while :; do
+  attempt=$((attempt + 1))
+  left=$((SETUP_DEADLINE - $(date +%s)))
+  if [ "$attempt" -gt "$MAX_START_ATTEMPTS" ]; then
+    echo "##[error]SQL Server did not become ready after $MAX_START_ATTEMPTS attempts ($(elapsed)s used)"
+    exit 1
+  fi
+  if [ "$left" -lt "$READY_TIMEOUT_SECONDS" ]; then
+    echo "##[error]SQL Server not ready and only ${left}s of the ${SETUP_BUDGET_SECONDS}s budget remains after $((attempt - 1)) attempt(s)"
+    exit 1
+  fi
+
+  echo "Starting $SQL_CONTAINER (attempt $attempt/$MAX_START_ATTEMPTS, ${left}s of budget left)..."
+  docker rm --force "$SQL_CONTAINER" >/dev/null 2>&1 || true
+  docker run \
+    --name "$SQL_CONTAINER" \
+    -e ACCEPT_EULA=Y \
+    -e "MSSQL_SA_PASSWORD=$SQL_PASSWORD" \
+    -e "MSSQL_MEMORY_LIMIT_MB=$SQL_MEMORY_LIMIT_MB" \
+    -p 1433:1433 \
+    -d "$SQL_IMAGE"
+
+  echo "Waiting for SQL Server to start..."
+  if wait_until_ready "$READY_TIMEOUT_SECONDS"; then
+    exit 0
+  fi
+
+  dump_diagnostics
+  echo "##[warning]SQL Server failed readiness checks (attempt $attempt/$MAX_START_ATTEMPTS)"
+done

--- a/.pipeline/scripts/start-sql-server-macos.sh
+++ b/.pipeline/scripts/start-sql-server-macos.sh
@@ -28,9 +28,6 @@ set -euo pipefail
 
 SQL_IMAGE=${SQL_IMAGE:-mcr.microsoft.com/mssql/server:2025-latest}
 SQL_CONTAINER=${SQL_CONTAINER:-sqlserver}
-# SQL Server defaults to 80% of the VM's memory; cap it so the guest kernel and
-# dockerd keep breathing room.
-SQL_MEMORY_LIMIT_MB=${SQL_MEMORY_LIMIT_MB:-2048}
 
 # Total wall-clock budget for the step (pull plus every container attempt).
 SETUP_BUDGET_SECONDS=${SETUP_BUDGET_SECONDS:-900}
@@ -145,7 +142,6 @@ while :; do
     --name "$SQL_CONTAINER" \
     -e ACCEPT_EULA=Y \
     -e "MSSQL_SA_PASSWORD=$SQL_PASSWORD" \
-    -e "MSSQL_MEMORY_LIMIT_MB=$SQL_MEMORY_LIMIT_MB" \
     -p 1433:1433 \
     -d "$SQL_IMAGE"
 

--- a/.pipeline/templates/sql-setup-template.yml
+++ b/.pipeline/templates/sql-setup-template.yml
@@ -266,6 +266,6 @@ steps:
 
   - script: bash .pipeline/scripts/start-sql-server-macos.sh
     displayName: 'Start SQL Server (Docker, no TLS certs)'
-    timeoutInMinutes: 17
+    timeoutInMinutes: 22
     env:
       SQL_PASSWORD: $(SQL_PASSWORD)

--- a/.pipeline/templates/sql-setup-template.yml
+++ b/.pipeline/templates/sql-setup-template.yml
@@ -258,47 +258,14 @@ steps:
     displayName: "Update CA certificates on the client"
 
 - ${{ if eq(parameters.buildTarget, 'MacOS') }}:
-  - script: |
-      set -euo pipefail
-      brew install docker colima
-      colima start --cpu 4 --memory 4 --disk 50
-      docker context use colima >/dev/null || true
-      docker version
+  # timeoutInMinutes backstops the scripts' own wall-clock budgets: the macOS
+  # job caps at 60 minutes and SQL setup must not be what exhausts it.
+  - script: bash .pipeline/scripts/start-colima-macos.sh
     displayName: 'Install and start Colima-based Docker'
+    timeoutInMinutes: 12
 
-  - script: |
-      set -euo pipefail
-      docker pull mcr.microsoft.com/mssql/server:2025-latest
-      docker run \
-        --name sqlserver \
-        -e ACCEPT_EULA=Y \
-        -e "MSSQL_SA_PASSWORD=$SQL_PASSWORD" \
-        -p 1433:1433 \
-        -d mcr.microsoft.com/mssql/server:2025-latest
-
-      echo "Waiting for SQL Server to start..."
-      ready=false
-      for i in $(seq 1 30); do
-        if docker exec sqlserver \
-          /opt/mssql-tools18/bin/sqlcmd \
-          -S localhost -U SA -P "$SQL_PASSWORD" \
-          -C -b -Q "SELECT 1" 2>/dev/null; then
-          ready=true
-          break
-        fi
-        echo "  attempt $i/30..."
-        sleep 2
-      done
-
-      if [ "$ready" != true ]; then
-        echo "SQL Server failed readiness checks"
-        set +e
-        docker ps -a
-        docker inspect sqlserver --format \
-          'status={{.State.Status}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}} error={{.State.Error}}'
-        docker logs --tail 500 sqlserver
-        exit 1
-      fi
+  - script: bash .pipeline/scripts/start-sql-server-macos.sh
     displayName: 'Start SQL Server (Docker, no TLS certs)'
+    timeoutInMinutes: 17
     env:
       SQL_PASSWORD: $(SQL_PASSWORD)

--- a/.pipeline/templates/sql-setup-template.yml
+++ b/.pipeline/templates/sql-setup-template.yml
@@ -262,7 +262,7 @@ steps:
   # job caps at 60 minutes and SQL setup must not be what exhausts it.
   - script: bash .pipeline/scripts/start-colima-macos.sh
     displayName: 'Install and start Colima-based Docker'
-    timeoutInMinutes: 12
+    timeoutInMinutes: 13
 
   - script: bash .pipeline/scripts/start-sql-server-macos.sh
     displayName: 'Start SQL Server (Docker, no TLS certs)'

--- a/.pipeline/templates/test-mssql-python-macos-template.yml
+++ b/.pipeline/templates/test-mssql-python-macos-template.yml
@@ -101,7 +101,7 @@ steps:
 # caps at 60 minutes and SQL setup must not be what exhausts it.
 - script: bash .pipeline/scripts/start-colima-macos.sh
   displayName: 'Install and start Colima-based Docker'
-  timeoutInMinutes: 12
+  timeoutInMinutes: 13
 
 # ── 5. Start SQL Server (no TLS certs) ──────────────────────────────────────
 - script: bash .pipeline/scripts/start-sql-server-macos.sh

--- a/.pipeline/templates/test-mssql-python-macos-template.yml
+++ b/.pipeline/templates/test-mssql-python-macos-template.yml
@@ -97,42 +97,16 @@ steps:
     CARGO_REGISTRIES_MSSQL_RS_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_TOKEN)
 
 # ── 4. Start Docker via Colima ───────────────────────────────────────────────
-- script: |
-    brew update
-    brew install docker colima
-
-    colima start --cpu 4 --memory 4 --disk 50
-    docker context use colima >/dev/null || true
-
-    docker version
-    docker ps
+# timeoutInMinutes backstops the scripts' own wall-clock budgets: the macOS job
+# caps at 60 minutes and SQL setup must not be what exhausts it.
+- script: bash .pipeline/scripts/start-colima-macos.sh
   displayName: 'Install and start Colima-based Docker'
+  timeoutInMinutes: 12
 
 # ── 5. Start SQL Server (no TLS certs) ──────────────────────────────────────
-- script: |
-    set -euo pipefail
-
-    docker pull mcr.microsoft.com/mssql/server:2025-latest
-
-    docker run \
-      --name sqlserver \
-      -e ACCEPT_EULA=Y \
-      -e "MSSQL_SA_PASSWORD=${SQL_PASSWORD}" \
-      -p 1433:1433 \
-      -d mcr.microsoft.com/mssql/server:2025-latest
-
-    echo "Waiting for SQL Server to start..."
-    for i in $(seq 1 30); do
-      docker exec sqlserver \
-        /opt/mssql-tools18/bin/sqlcmd \
-        -S localhost \
-        -U SA \
-        -P "$SQL_PASSWORD" \
-        -C -Q "SELECT 1" && break
-      echo "  attempt $i/30..."
-      sleep 2
-    done
+- script: bash .pipeline/scripts/start-sql-server-macos.sh
   displayName: 'Start SQL Server (Docker, no TLS certs)'
+  timeoutInMinutes: 17
   env:
     SQL_PASSWORD: $(SQL_PASSWORD)
 

--- a/.pipeline/templates/test-mssql-python-macos-template.yml
+++ b/.pipeline/templates/test-mssql-python-macos-template.yml
@@ -106,7 +106,7 @@ steps:
 # ── 5. Start SQL Server (no TLS certs) ──────────────────────────────────────
 - script: bash .pipeline/scripts/start-sql-server-macos.sh
   displayName: 'Start SQL Server (Docker, no TLS certs)'
-  timeoutInMinutes: 17
+  timeoutInMinutes: 22
   env:
     SQL_PASSWORD: $(SQL_PASSWORD)
 


### PR DESCRIPTION
## Description

The macOS `Start SQL Server (Docker, no TLS certs)` step is a top flake source in PR validation. Over the last 118 builds of `mssql-rs Pull request validation`:

| Job / step | Failures |
| --- | --- |
| `Test MacOS` → Start SQL Server | 15/118 (~13%) |
| `Build mssql-python macOS (cross-repo)` → Start SQL Server | 15/118 crashed but **reported success** |
| `Install and start Colima-based Docker` | 3/118 |
| `docker pull` | 1/118 (`failed to resolve reference`) |

**Root cause.** SQL Server crashes during startup inside the Colima VM — the container exits with code 1 and the log shows a SQLPAL fatal error (`** ERROR: [AppLoader] Failed to load LSA: 0xc0070102`, or reason `0x2`/`0x6`). It is not an OOM kill (`oom=false` in every captured case). Recreating the container clears it.

**Why the linked build looked like a timeout rather than a SQL failure.** The `mssql-python` macOS copy of the step never checked the result of its readiness loop, so it fell through and exited 0 with a dead container. pytest then retried against that dead server for 24 minutes until the job hit its 60-minute cap, and the failure surfaced as a cancellation. Example: [build 20260825.18](https://sqlclientdrivers.visualstudio.com/public/_build/results?buildId=169802&view=logs&j=48df44f1-3bf3-5cb7-06fa-af3cd35df4c3).

### What changed

Both macOS steps were duplicated inline across two templates and had already drifted apart — only one of them checked readiness, and only one ran `brew update`. They are now shared scripts:

- **`.pipeline/scripts/start-sql-server-macos.sh`** — retries the image pull; aborts a readiness wait as soon as the container has exited rather than probing a corpse for the remaining attempts; recreates the container up to 3 times; dumps `docker ps -a`, `docker inspect` state and `docker logs` on every failed attempt; and **exits non-zero** when the server never becomes reachable.
- **`.pipeline/scripts/start-colima-macos.sh`** — bounds each `colima start` and retries from a clean slate (`colima delete --force`) after the transient lima hostagent boot failures (`hostagent did not start up in 5s`, `did not receive an event with the 'running' status`), tailing `ha.stderr.log` on failure.
- **`.pipeline/scripts/run-bounded.sh`** — shared `run_bounded` helper, since macOS ships no coreutils `timeout`.

**VM size stays at 4 GiB / 4 CPU, deliberately.** The obvious reflex is to give SQL Server more memory, but the evidence does not support it: every captured crash reports `oom=false` and dies at LSA load, before the buffer pool is committed. Measuring it directly, 6 GiB put the Colima boot phase at 404s and 313s against a 4 GiB median of 232s — cost with no demonstrated benefit. The retry is the fix.

### Time-boxing

The macOS job only gets 60 minutes, so retries are bounded by wall clock, not by attempt count. A failed `sqlcmd` probe costs ~11s at the default login timeout, and `docker pull` of the SQL image has taken up to 7 minutes on these agents — counting attempts hides very large amounts of time.

| Bound | Default | Scope |
| --- | --- | --- |
| `SETUP_BUDGET_SECONDS` | 1200s | whole SQL step (pull + all container attempts) |
| `PULL_BUDGET_SECONDS` | 900s | pull phase, carved out of the above so a slow registry cannot starve the retries |
| `READY_TIMEOUT_SECONDS` | 240s | per container attempt |
| `MAX_START_ATTEMPTS` | 3 | a container that exits immediately is abandoned in ~10s, so the budget alone would allow dozens of restarts |
| `sqlcmd -l 5` | 5s | per probe, with a 30s hard kill around the whole `docker exec` |
| `COLIMA_START_TIMEOUT_SECONDS` | 540s | per `colima start` |
| `COLIMA_BUDGET_SECONDS` | 480s | Colima retries as a whole |
| `timeoutInMinutes` | 22 / 13 | pipeline-level backstop over the scripts' own budgets |

**Every bound is sized above the worst case of the *successful* runs**, so it only ever catches a hang rather than a
slow-but-healthy step. That distinction is load-bearing: an initial 480s pull budget looked generous against an
eyeballed "up to 7 minutes", but pulls actually measure p50 292s / p95 478s / **max 724s** over 112 runs, so it would
have failed 4.5% of runs outright — trading a 1-in-8 flake for a new 1-in-22 one. It was caught by this PR's own
validation run and resized. Readiness waits max out at 157s over 97 runs, against a 240s bound.

`COLIMA_START_TIMEOUT_SECONDS` is 540s rather than something tighter because successful Colima boots measure p50 231s / p95 366s / **max 509s** over 113 runs. Bounding by the 480s budget — or anything shorter — would kill slow-but-healthy boots and turn a working run into three failures. The observed failures give up within seconds, so 540s only catches a genuine hang.

`run_bounded` runs the child in its own process group and signals the group. Signalling only the direct child leaves grandchildren (`limactl`, `qemu`) alive holding the task's stdout, which hangs the step past its timeout anyway.

Worst case is a ~20 minute hard cap for SQL setup against a ~6 minute median, in a job whose median is ~26 minutes.

## Related Issues

Fixes #387 — https://github.com/microsoft/mssql-rs/issues/387

## Checklist

- [ ] `cargo bfmt` passes — N/A, no Rust code changed
- [ ] `cargo bclippy` passes — N/A, no Rust code changed
- [ ] `cargo btest` passes — N/A, no Rust code changed
- [ ] New/changed functionality has tests — N/A, pipeline scripts; verified by direct execution (below)
- [ ] Public API changes are documented — N/A, no public API change

### Testing

Both scripts were exercised directly, including the failure paths. SQL scenarios ran against local Docker (`mcr.microsoft.com/mssql/server:2022-latest`); Colima scenarios used a stubbed `colima` binary, since Colima itself is macOS-only.

| Scenario | Result |
| --- | --- |
| SQL: healthy startup | ready at 14s, exit 0 |
| SQL: container crashes on start (bad SA password) | early abort each attempt, 3 attempts, 37s total, exit 1 |
| SQL: container alive but unreachable (`nginx:alpine` stand-in) | 3 × 20s attempts, 72s against a 70s budget, exit 1 |
| Colima: `colima start` hangs | killed at the limit, cleaned up, retried, 0 orphan processes |
| Colima: fails fast ×3 | `3 of 3 configured attempt(s) ran in 21s of a 480s budget` |
| Colima: transient (fails once, then succeeds) | recovers on attempt 2, exit 0 |

`bash -n` passes on all three scripts and both templates still parse as YAML.

**Validation run** (ADO build 20260826.46, on the corrected bounds):

| Job | Colima | Start SQL Server | Job total |
| --- | --- | --- | --- |
| `Test MacOS` | 340s | 356s | 27.8 min |
| `Build mssql-python macOS (cross-repo)` | 112s | 256s | 19.0 min |

Both are at or below their historical medians (`Test MacOS` ~27 min), and neither job needed a retry.

The ADO build itself reports `partiallySucceeded`, from the `mssql-python suite on mssql-odbc driver (cross-repo)` job. That is pre-existing and unrelated: it is the deliberately informational driver-swap suite, it runs on Linux, and it is `succeededWithIssues` on every recent PR build I checked (170060, 170051, 170048, 170000).

### Residual risk

Worth being explicit for review: across three validation runs the crash never reproduced, so **the SQL retry path has not yet executed on a real agent** — it is proven locally and against stubs only. At a ~13% per-run rate the honest signal is the flake rate over the next several merges, not this PR's own green run.

One deliberate behaviour change: `Test MacOS` previously ran `brew install docker colima` with no explicit `brew update`, while the `mssql-python` path did. The shared script always runs it (~1 min), matching the safer of the two originals.

## Breaking changes

None. Pipeline-only change; no driver code, public API, schema or config surface is affected.
