### PR TITLE
Pin mssql-tds to the feed index when publishing mssql-mock-tds

### DIFF
--- a/.pipeline/OneBranch/PublishFeeds-Sandbox.yml
+++ b/.pipeline/OneBranch/PublishFeeds-Sandbox.yml
@@ -597,7 +597,7 @@ extends:
             enableJsDeps: false
         - pwsh: .pipeline/scripts/stamp-crate-versions-sandbox.ps1 -ReleaseVersion '${{ parameters.releaseVersion }}' -BuildId '$(Build.BuildId)'
           displayName: 'Stamp crate versions (sandbox, package-only)'
-        - pwsh: .pipeline/scripts/pin-mssql-tds-dep-version.ps1 -Version '$(crateVersion)'
+        - pwsh: .pipeline/scripts/pin-mssql-tds-dep-version.ps1 -Version '$(crateVersion)' -IndexUrl '$(cargoSparseIndex)'
           displayName: 'Pin mssql-tds dependency version'
         - ${{ if eq(parameters.publishCrate, true) }}:
           - pwsh: .pipeline/scripts/cargo-publish-mock.ps1 -Registry '$(cargoRegistry)' -SparseIndexBaseUrl '$(cargoSparseIndex)' -TdsVersion '$(crateVersion)'

--- a/.pipeline/scripts/pin-mssql-tds-dep-version.ps1
+++ b/.pipeline/scripts/pin-mssql-tds-dep-version.ps1
@@ -11,23 +11,49 @@
   stamped version while keeping the path (cargo uses the version on publish and the
   path for local verify builds).
 
+  A version alone is not enough: cargo records a dependency with no registry as
+  coming from crates.io, where mssql-tds does not exist. Consumers of the feed then
+  fail to resolve mssql-mock-tds with "no matching package named `mssql-tds` found,
+  location searched: crates.io index". CI does not hit this because
+  .cargo/config.ci.toml source-replaces crates.io with the feed. So we also pin the
+  feed's own index.
+
 .PARAMETER Version
   The stamped crate version to pin (typically $(crateVersion)).
+
+.PARAMETER IndexUrl
+  Sparse index base URL of the feed being published to (typically
+  $(cargoSparseIndex)). Pass the plain URL, not the ~force-auth variant, so that
+  anonymous readers of a public feed can resolve the dependency.
 #>
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory = $true)][string]$Version
+    [Parameter(Mandatory = $true)][string]$Version,
+    [Parameter(Mandatory = $true)][string]$IndexUrl
 )
 
 $ErrorActionPreference = 'Stop'
 
 if ([string]::IsNullOrWhiteSpace($Version)) { Write-Error 'Version not set'; exit 1 }
+if ([string]::IsNullOrWhiteSpace($IndexUrl)) { Write-Error 'IndexUrl not set'; exit 1 }
+
+# ~force-auth makes the endpoint reject anonymous reads. This URL is baked into the
+# published manifest, so passing it here would silently force every consumer to
+# authenticate, and the breakage only shows up long after the publish succeeds. The
+# other $(cargoSparseIndex) callers merely poll the index, so a wrong URL fails
+# loudly in the same run and needs no equivalent check.
+if ($IndexUrl -match '~force-auth') {
+    Write-Error "IndexUrl must be the plain feed URL, not the ~force-auth variant: $IndexUrl"
+    exit 1
+}
+
+$index = if ($IndexUrl -match '^sparse\+') { $IndexUrl } else { "sparse+$IndexUrl" }
 
 $path = 'mssql-mock-tds/Cargo.toml'
 $c = Get-Content $path -Raw
 $c = $c -replace 'mssql-tds\s*=\s*\{\s*path\s*=\s*"\.\./mssql-tds"',
-                 "mssql-tds = { path = `"../mssql-tds`", version = `"$Version`""
+                 "mssql-tds = { path = `"../mssql-tds`", version = `"$Version`", registry-index = `"$index`""
 Set-Content $path $c -NoNewline
 
-Write-Host "Pinned mssql-tds dependency to version $Version"
+Write-Host "Pinned mssql-tds dependency to version $Version (index: $index)"
 Select-String -Path $path -Pattern 'mssql-tds\s*=' | ForEach-Object { Write-Host $_.Line }

--- a/.pipeline/scripts/pin-mssql-tds-dep-version.ps1
+++ b/.pipeline/scripts/pin-mssql-tds-dep-version.ps1
@@ -37,11 +37,18 @@ $ErrorActionPreference = 'Stop'
 if ([string]::IsNullOrWhiteSpace($Version)) { Write-Error 'Version not set'; exit 1 }
 if ([string]::IsNullOrWhiteSpace($IndexUrl)) { Write-Error 'IndexUrl not set'; exit 1 }
 
-# ~force-auth makes the endpoint reject anonymous reads. This URL is baked into the
-# published manifest, so passing it here would silently force every consumer to
-# authenticate, and the breakage only shows up long after the publish succeeds. The
-# other $(cargoSparseIndex) callers merely poll the index, so a wrong URL fails
-# loudly in the same run and needs no equivalent check.
+# Cargo identifies a source by the literal URL string, so the plain and ~force-auth
+# spellings of this feed are two unrelated sources to it. Whichever one we bake here
+# is where consumers resolve mssql-tds from, and a wrong choice only surfaces long
+# after the publish succeeds -- unlike the other $(cargoSparseIndex) callers, which
+# merely poll the index and fail loudly in the same run.
+#
+# The plain URL is not free: an internal consumer whose alias points at ~force-auth
+# and who also depends on mssql-tds directly gets two copies in the graph, and a
+# confusing "expected `mssql_tds::X`, found `mssql_tds::X`" where a type crosses
+# between them. They can fix that by pointing their own alias at the plain URL.
+# Baking ~force-auth has no such escape hatch: every anonymous read of this public
+# feed would fail to resolve, which is the breakage this pinning exists to prevent.
 if ($IndexUrl -match '~force-auth') {
     Write-Error "IndexUrl must be the plain feed URL, not the ~force-auth variant: $IndexUrl"
     exit 1
@@ -53,6 +60,27 @@ $path = 'mssql-mock-tds/Cargo.toml'
 $c = Get-Content $path -Raw
 $c = $c -replace 'mssql-tds\s*=\s*\{\s*path\s*=\s*"\.\./mssql-tds"',
                  "mssql-tds = { path = `"../mssql-tds`", version = `"$Version`", registry-index = `"$index`""
+
+# -replace changes nothing when the dependency line drifts from the shape above
+# (keys reordered, workspace = true), so without this the script would exit 0 having
+# done nothing and the run would fail much later, in cargo publish -p mssql-mock-tds
+# -- after cargo-publish-mock.ps1 has already put mssql-tds@$Version on the feed.
+# Feed versions are immutable, so that burns the version and the retry cannot
+# succeed. Counting rather than merely testing for presence also catches a second
+# run appending a duplicate set of keys, which TOML rejects.
+$dep = [regex]::Match($c, '(?m)^\s*mssql-tds\s*=\s*\{[^}]*\}')
+if (-not $dep.Success) {
+    Write-Error "No mssql-tds dependency line found in $path"
+    exit 1
+}
+foreach ($key in 'version', 'registry-index') {
+    $n = ([regex]::Matches($dep.Value, "(?<![\w-])$key\s*=")).Count
+    if ($n -ne 1) {
+        Write-Error "Expected exactly one '$key' in the mssql-tds dependency of ${path}, found ${n}: $($dep.Value.Trim())"
+        exit 1
+    }
+}
+
 Set-Content $path $c -NoNewline
 
 Write-Host "Pinned mssql-tds dependency to version $Version (index: $index)"


### PR DESCRIPTION
Fixes #389

## What

Publishing `mssql-mock-tds` to the Azure feed produced a manifest that declares its `mssql-tds` dependency as coming from crates.io, where `mssql-tds` does not exist. Restore fails for every consumer.

`pin-mssql-tds-dep-version.ps1` added a `version` to the path dep (cargo rejects publishing a path dep without one) but no registry. Cargo treats `version` with no registry as **crates.io**.

CI never caught it because `.cargo/config.ci.toml` source-replaces crates.io with the feed, redirecting the lookup back to a place the crate does exist.

## Changes

- `pin-mssql-tds-dep-version.ps1` takes a new required `-IndexUrl` and emits `registry-index = "sparse+<url>"` on the dependency.
- `PublishFeeds-Sandbox.yml` passes the existing `$(cargoSparseIndex)` variable — same value already used for preflight and index polling, so there's one source of truth.
- The script rejects a `~force-auth` URL. That URL gets baked into the published manifest, so using it would silently force every consumer to authenticate against a feed that reads anonymously, and the breakage would only surface long after the publish succeeded. The other `$(cargoSparseIndex)` callers only poll the index, so a wrong URL fails loudly in the same run and needs no equivalent check.

## Verification

All checks run locally against the real feed.

**Before** — fresh project depending on the published `mssql-mock-tds 0.1.0-dev.20260826.169925`:

```
error: no matching package named `mssql-tds` found
location searched: crates.io index
```

**After** — ran the real CI sequence (`stamp-crate-versions-sandbox.ps1` → `pin-mssql-tds-dep-version.ps1` → `cargo package -p mssql-mock-tds`). The packaged manifest now contains:

```toml
[dependencies.mssql-tds]
version = "0.1.0-dev.20260826.169925"
registry-index = "sparse+https://pkgs.dev.azure.com/sqlclientdrivers/public/_packaging/mssql-rs_Public/Cargo/index/"
default-features = false
```

Then consumed that exact packaged crate from a project with **no registry alias and no source replacement** — the configuration that failed before:

```
Locking 185 packages to latest compatible versions
Compiling mssql-tds v0.1.0-dev.20260826.169925 (registry `sparse+https://pkgs.dev.azure.com/.../Cargo/index/`)
Finished `dev` profile in 51.96s
```

Lockfile now records the feed instead of crates.io:

```toml
name = "mssql-tds"
source = "sparse+https://pkgs.dev.azure.com/sqlclientdrivers/public/_packaging/mssql-rs_Public/Cargo/index/"
```

Also verified:
- The `~force-auth` check exits 1 and leaves `Cargo.toml` untouched.
- The healthy URL does **not** trip that check and produces the correct dep line.
- An already-`sparse+`-prefixed URL is not double-prefixed.
- `path` + `version` + `registry-index` coexist fine; local path builds are unaffected.
- https://sqlclientdrivers.visualstudio.com/mssql-rs/_build/results?buildId=170138&view=results 

No Rust code changed, so `bfmt`/`bclippy`/`btest` are unaffected. The repo working tree was restored after each test.

## Not covered

Existing published versions stay broken — the metadata is baked into the feed index and can't be edited. They need republishing under new versions.

Publishing to crates.io is deliberately out of scope. It has a conflicting requirement (crates.io rejects deps sourced from other registries, so `mssql-tds` would need to be published there first) and will be handled separately.