### PR TITLE
Correct the regression gate and improvement-verification cap in perf-lab MONITORING.md

### DIFF
--- a/mssql-tds-bench/perf-lab/MONITORING.md
+++ b/mssql-tds-bench/perf-lab/MONITORING.md
@@ -23,11 +23,14 @@ artifact and rendered on the run's Summary tab.
 The gate is already noise-hardened: a benchmark slower than the threshold
 (`BENCH_REGRESSION_RATIO`, default `1.05` = 5%) trips it, is then re-measured 4×
 interleaved, and is only confirmed when it trips in ≥3 of those 4 re-runs.
-Apparent *improvements* get the same treatment at the same magnitude
-(`BENCH_IMPROVEMENT_VERIFY_RATIO` defaults to the regression threshold), so an
-unreproduced win is reported as an artifact rather than a gain. Take the verdict
-line at face value; do not re-litigate a cleared benchmark from the first-pass
-numbers.
+Apparent *improvements* qualify for the same treatment at the same magnitude
+(`BENCH_IMPROVEMENT_VERIFY_RATIO` defaults to the regression threshold), but only
+the largest `BENCH_IMPROVEMENT_VERIFY_MAX` of them (default 3) are actually
+re-measured; any beyond that cap keep unverified first-pass numbers, and the
+summary reports how many it skipped. Treat only a *reproduced* win as real: one
+that was re-measured and did not reproduce is an artifact, and one that fell
+outside the cap is simply unverified. Take the verdict line at face value; do not
+re-litigate a cleared benchmark from the first-pass numbers.
 
 The Windows step log mangles the summary's UTF-8 (emoji, `±`, `µ`). The raw
 critcmp block is still readable, and the emoji bars are a pure function of Δ%, so

--- a/mssql-tds-bench/perf-lab/MONITORING.md
+++ b/mssql-tds-bench/perf-lab/MONITORING.md
@@ -20,11 +20,14 @@ on perf VM" step log, fenced by `===== summary.md =====` markers, so triage need
 no artifact download. The same file is also published in the `perf-results`
 artifact and rendered on the run's Summary tab.
 
-The gate is already noise-hardened: a benchmark ≥10% slower trips it, is then
-re-measured 4× interleaved, and is only confirmed when it trips in ≥3 of those 4
-re-runs. Apparent *improvements* ≥10% get the same treatment, so an unreproduced
-win is reported as an artifact rather than a gain. Take the verdict line at face
-value; do not re-litigate a cleared benchmark from the first-pass numbers.
+The gate is already noise-hardened: a benchmark slower than the threshold
+(`BENCH_REGRESSION_RATIO`, default `1.05` = 5%) trips it, is then re-measured 4×
+interleaved, and is only confirmed when it trips in ≥3 of those 4 re-runs.
+Apparent *improvements* get the same treatment at the same magnitude
+(`BENCH_IMPROVEMENT_VERIFY_RATIO` defaults to the regression threshold), so an
+unreproduced win is reported as an artifact rather than a gain. Take the verdict
+line at face value; do not re-litigate a cleared benchmark from the first-pass
+numbers.
 
 The Windows step log mangles the summary's UTF-8 (emoji, `±`, `µ`). The raw
 critcmp block is still readable, and the emoji bars are a pure function of Δ%, so
@@ -41,23 +44,26 @@ the table can be reconstructed from it when quoting Windows results elsewhere.
   validation, missing bench binaries, or invalid `BENCH_*` settings) — re-queue
   only if the phase looks transient; otherwise fix the code or config. Escalate
   if a retry also fails.
-- **Green** — check for verified improvements and for sub-gate drift, then apply
-  the lock-in rules below.
+- **Green** — check for verified improvements and for quorum-cleared drift, then
+  apply the lock-in rules below.
 
 ## Advancing the baseline
 
 Advancing makes the candidate's numbers the new floor: a later change that gives
 the gains back trips the gate instead of silently settling at the old level. That
 cuts both ways — a bump that carries an unaddressed slowdown legitimizes it, and
-the next 10% gate is then measured from the degraded point.
+the next gate is then measured from the degraded point.
 
 Bump only when **all** of the following hold:
 
 1. Both platforms are green at the **same** commit.
 2. That commit is an ancestor of GitHub `main`.
 3. At least one *verified* improvement (reproduced in ≥ quorum) on either platform.
-4. No benchmark on **either** platform is more than **5%** slower than baseline —
-   tighter than the 10% gate, so drift is investigated rather than absorbed.
+4. No benchmark on **either** platform is more than **5%** slower than baseline.
+   This is the gate's own magnitude, but applied with no quorum: a benchmark that
+   trips in only 1–2 of the 4 re-runs is cleared by the gate, yet its published
+   Δ% (the median of those re-runs) can still sit above 5%. Criterion 4 declines
+   to bake that drift into the floor, so it is investigated rather than absorbed.
 
 When (1)–(3) hold but (4) does not, report the win and the drift together; the
 drift is the finding, and the bump waits for it to be explained or fixed.


### PR DESCRIPTION
## Description

`mssql-tds-bench/perf-lab/MONITORING.md` documented a 10% regression gate, but the harness has enforced 5% since #367 (`run-benchmarks.sh:325`, `run-benchmarks.ps1:483`).

The two PRs were in flight concurrently: #367 (gate 10% → 5%) opened 8-24 21:20 UTC and merged 8-25 19:27 UTC, while #369 (which added `MONITORING.md`) opened 8-24 22:11 UTC and merged 8-25 22:30 UTC. #367 correctly updated `docs/perf-testing-plan.md`; `MONITORING.md` did not exist on its branch, so it was written against a pre-#367 view of the gate and merged three hours later still describing the old value. Documentation-only — no harness behavior changes.

This matters because `MONITORING.md` is the authoritative policy for weekly perf-lab triage, so a wrong threshold there misinforms every run's triage.

### Three things beyond a find-and-replace

**Thresholds are now named, not restated.** The stale text hardcoded bare percentages. This change references `BENCH_REGRESSION_RATIO` and `BENCH_IMPROVEMENT_VERIFY_RATIO` instead, so the next threshold change is greppable from the runbook and less likely to drift again. It also makes explicit that the improvement threshold *inherits* from the regression threshold (`IMP_THR="${BENCH_IMPROVEMENT_VERIFY_RATIO:-$THR}"`, and `$impThr = $thr` on Windows) — that inheritance is why the "improvements ≥10%" sentence was stale as a side effect of #367 rather than independently.

**Lock-in criterion 4 needed a rewrite, not a number swap.** It was justified as being "tighter than the 10% gate," deliberately catching sub-gate drift. At a 5% gate that rationale is gone and the sentence contradicted itself.

The criterion is not redundant, though, so it should not simply be deleted: the gate confirms a regression only at a ≥3-of-4 quorum, whereas criterion 4 reads the published Δ% with no quorum at all. A benchmark that trips in 1–2 of the 4 re-runs is cleared by the gate, yet the median the summary publishes is `(v2 + v3) / 2` over the sorted re-runs — and with `v3` above the threshold that median can still land above 5% (e.g. re-runs of 1.04 / 1.049 / 1.06 / 1.07 clear the gate at 2-of-4 but publish +5.45%). Criterion 4 catches exactly that, so it is now justified by the missing quorum rather than by a tighter number.

**The improvement-verification cap was undocumented** (found in review). The runbook said apparent improvements get the same treatment as regressions, which overstated the guarantee: only the largest `BENCH_IMPROVEMENT_VERIFY_MAX` of them (default 3) are actually re-measured, and the rest keep unverified first-pass numbers — `run-benchmarks.sh:372`/`:381` and `run-benchmarks.ps1:496`/`:499`. The harness emits the skipped count itself and calls the remainder "unverified" (`:606`), so the runbook was contradicting the summary it teaches people to read. The text now names the cap and separates the two cases the old sentence collapsed: a win that was re-measured and did not reproduce is an artifact, whereas one that fell outside the cap is merely unverified. This also makes clear that an improvement outside the cap can never satisfy lock-in criterion 3, which requires a *verified* one.

I also updated the "Green" triage bullet, which told the reader to look for "sub-gate drift" — no longer the right description now that criterion 4 sits at the gate's own magnitude. It now says "quorum-cleared drift."

## Changes

`mssql-tds-bench/perf-lab/MONITORING.md` only:

| Was | Now |
|---|---|
| "a benchmark ≥10% slower trips it" | Names `BENCH_REGRESSION_RATIO`, default `1.05` = 5% |
| "Apparent *improvements* ≥10% get the same treatment" | Names `BENCH_IMPROVEMENT_VERIFY_RATIO` and the `BENCH_IMPROVEMENT_VERIFY_MAX` cap; distinguishes unreproduced from unverified |
| "sub-gate drift" | "quorum-cleared drift" |
| "the next 10% gate" | "the next gate" |
| "tighter than the 10% gate" | Rewritten around the absent quorum |

## Validation

- Swept `mssql-tds-bench/` and `docs/` for `10%`, `1.10`, and both `BENCH_*` ratio vars. The only remaining hits are `docs/perf-testing-plan.md:181` ("a 5-10% regression that is never challenged") and `:183` ("first-pass noise reaches 8-10%") — prose ranges about noise characteristics, not statements of the gate, so both are correct as-is and deliberately untouched.
- Confirmed against `run-benchmarks.sh:325`/`:330` and `run-benchmarks.ps1:483`/`:490` that both platforms default the improvement ratio to the regression ratio, and against `:372`/`:381` and `:496`/`:499` that both cap the verify set at 3 by default.
- Verified the median claim in criterion 4 against `median_stdin` and the `MEDIANS_FILE` loop (`run-benchmarks.sh:465-484`): the median is taken over the 4 re-runs with the first pass excluded, which is what makes an above-threshold median on a cleared benchmark possible. The harness's own comment at `:472` reasons about the same interaction.
- No markdown linter is configured in the repo. `cargo bfmt`/`bclippy`/`btest` are not applicable to a docs-only change and were not run.

## Related Issues

Fixes #388

## Checklist

- [x] `cargo bfmt` passes — N/A: documentation-only, no Rust changed
- [x] `cargo bclippy` passes — N/A: documentation-only, no Rust changed
- [x] `cargo btest` passes — N/A: documentation-only, no Rust changed
- [x] New/changed functionality has tests — N/A: no functionality changed; verified by reading the harness against the corrected text
- [x] Public API changes are documented — N/A: no public API changes
