### PR TITLE
Stop the SQL host job when PR validation is canceled

### DIFF
--- a/.pipeline/docs/arm-sql-host-design.md
+++ b/.pipeline/docs/arm-sql-host-design.md
@@ -275,11 +275,13 @@ full multi-distro ARM test matrices still run on merge.
 | `Test_alpine_arm64`               | non-PR (merge) | full musl matrix (Alpine 3.18–3.21)         |
 
 `Sql_Host_build_arm` is a PR-only instance of `sql-host-template.yml` added to
-the Build stage (`jobCondition: eq(Build.Reason, 'PullRequest')`). It runs
-concurrently with `Build_Linux_ARM` (no `dependsOn`) and the two rendezvous
-via the same `sql-ready-build_arm` / `build_arm` sentinel pair used by the
-test stages. On merge the host job is skipped and the ARM build's test pass
-does not run (its steps are PR-gated), so no x64 agent is idled.
+the Build stage (`jobCondition: and(not(canceled()), eq(Build.Reason,
+'PullRequest'))`). The cancellation guard stops the host when the run is
+cancelled without suppressing it after unrelated failures. It runs concurrently
+with `Build_Linux_ARM` (no `dependsOn`) and the two rendezvous via the same
+`sql-ready-build_arm` / `build_arm` sentinel pair used by the test stages. On
+merge the host job is skipped and the ARM build's test pass does not run (its
+steps are PR-gated), so no x64 agent is idled.
 
 Python integration tests stay `--skip-integration` on ARM: the Python test
 harness builds `Server={host}` with no port, so it cannot target the SQL

--- a/.pipeline/templates/sql-host-template.yml
+++ b/.pipeline/templates/sql-host-template.yml
@@ -56,8 +56,8 @@ parameters:
     type: string
     default: 'imageOverride -equals RUST-UBUSLIM'
   - name: jobCondition
-    # Job-level condition. Defaults to succeeded(); callers that only need the
-    # SQL host on PRs (e.g. the Build stage) pass a Build.Reason check.
+    # Job-level condition. Defaults to succeeded(); custom conditions must retain
+    # a status check so cancellation does not leave the SQL host running.
     type: string
     default: succeeded()
 

--- a/.pipeline/templates/sql-host-template.yml
+++ b/.pipeline/templates/sql-host-template.yml
@@ -56,8 +56,8 @@ parameters:
     type: string
     default: 'imageOverride -equals RUST-UBUSLIM'
   - name: jobCondition
-    # Job-level condition. Defaults to succeeded(); custom conditions must retain
-    # a status check so cancellation does not leave the SQL host running.
+    # Job-level condition. Defaults to succeeded(); custom conditions must evaluate
+    # to false when the pipeline is canceled so the SQL host does not remain running.
     type: string
     default: succeeded()
 

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -104,7 +104,7 @@ stages:
       instanceId: build_arm
       expectedSentinels: build_arm,build_win_arm
       sqlImageTag: ${{ parameters.sqlImageTag }}
-      jobCondition: eq(variables['Build.Reason'], 'PullRequest')
+      jobCondition: and(not(canceled()), eq(variables['Build.Reason'], 'PullRequest'))
   - job: Build_Windows
     displayName: Build Windows
     pool:


### PR DESCRIPTION
## Description

Add a cancellation status check to the PR-only SQL host job condition. The job now stops when its pipeline run is canceled while retaining the Build stage's fail-open behavior after unrelated failures.

Document that custom SQL host conditions must evaluate false when the pipeline is canceled and update the ARM SQL host design description.

## Related Issues

Fixes #403

## Testing

- Parsed all 42 YAML files under `.pipeline` with PyYAML.
- Verified `git diff --check` passes.
- Verified the changed files have no VS Code diagnostics.
- A live cancellation test has not been run; draft PR validation will confirm pipeline compilation.

## Breaking Changes / Migration Notes

None.

## Checklist

- [ ] `cargo bfmt` passes (not run; YAML and documentation only)
- [ ] `cargo bclippy` passes (not run; YAML and documentation only)
- [ ] `cargo btest` passes (not run; YAML and documentation only)
- [ ] New/changed functionality has tests
- [x] Public API changes are documented (not applicable; no public API change)