### PR TITLE
Pin PRINT-after-assignment info surfacing with an e2e test [AB#47535]

### DIFF
--- a/mssql-odbc/tests/e2e/tests/exec_direct_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/exec_direct_test.cpp
@@ -183,6 +183,33 @@ TEST_F(ExecDirectLiveTest, InfoMessagesSurfaceAsDiagnostics) {
     EXPECT_EQ(SQL_NO_DATA, rc);
 }
 
+// AB#47535: a PRINT reached only after variable assignments must still surface
+// its message on SQLExecDirect itself. The assignments carry a SQLSELECT-tagged
+// DONE_COUNT; when those were treated as update counts the batch stopped on the
+// assignment and SQLExecDirect returned plain SQL_SUCCESS, so callers that only
+// read diagnostics on SQL_SUCCESS_WITH_INFO (mssql-python's cursor.messages)
+// saw nothing at all.
+TEST_F(ExecDirectLiveTest, PrintAfterAssignmentsSurfacesOnExecute) {
+    SqlTString sql = ODBCTestUtils::ToSqlTStr(
+        "DECLARE @msg VARCHAR(MAX);"
+        " SET @msg = REPLICATE(CAST('a' AS VARCHAR(MAX)), 2047);"
+        " PRINT @msg;");
+
+    SQLRETURN rc = SQLExecDirect(stmt_, const_cast<SQLTCHAR*>(sql.c_str()), SQL_NTS);
+    ASSERT_EQ(SQL_SUCCESS_WITH_INFO, rc);
+
+    SQLINTEGER native = 0;
+    std::string message = GetDiagMessageForRecord(stmt_, 1, &native);
+    EXPECT_EQ(0, native);
+    EXPECT_NE(std::string::npos, message.find("aaaaaaaaaa"));
+
+    // The assignments produced no navigable result of their own.
+    SQLLEN row_count = 0;
+    ASSERT_SQL_OK(SQLRowCount(stmt_, &row_count), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(-1, row_count);
+    EXPECT_EQ(SQL_NO_DATA, SQLMoreResults(stmt_));
+}
+
 TEST_F(ExecDirectLiveTest, FetchOnFreshStatementReturnsHy010) {
     SQLRETURN rc = SQLFetch(stmt_);
     EXPECT_EQ(SQL_ERROR, rc);

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -6939,6 +6939,52 @@ mod tests {
         assert_eq!(client.last_rows_affected(), -1);
     }
 
+    /// AB#47535: a PRINT reached only *after* variable assignments. The
+    /// assignments' SQLSELECT-tagged DONE_COUNTs must collapse so the very first
+    /// result the caller sees is the PRINT's message-only result. Treating them
+    /// as update counts stops the batch on the DECLARE, so `execute` returns
+    /// `NoRows { rows_affected: Some(1) }` with no message and the ODBC layer
+    /// reports plain `SQL_SUCCESS` — the shape that hid PRINT output from
+    /// `mssql-python`'s `cursor.messages`.
+    ///
+    /// Observed token sequence for
+    /// `DECLARE @msg VARCHAR(MAX); SET @msg = REPLICATE(CAST('a' AS VARCHAR(MAX)), 2047); PRINT @msg;`.
+    #[tokio::test]
+    async fn execute_surfaces_print_after_assignment_counts() {
+        let printed = "a".repeat(2047);
+        let mut client = create_test_client_with_tokens(vec![
+            done_count(CurrentCommand::Select, 1, true),
+            done_count(CurrentCommand::Select, 1, true),
+            info_token(0, 0, &printed),
+            done_no_more(),
+        ]);
+
+        let result = client
+            .execute(
+                "DECLARE @msg VARCHAR(MAX);\
+                 SET @msg = REPLICATE(CAST('a' AS VARCHAR(MAX)), 2047);\
+                 PRINT @msg;"
+                    .to_string(),
+                (),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result,
+            StatementResult::NoRows {
+                rows_affected: None
+            }
+        );
+        assert_eq!(client.last_rows_affected(), -1);
+        assert!(client.take_dml_result_counts().is_empty());
+
+        let messages = client.take_info_messages();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].message, printed);
+        assert_eq!(messages[0].number, 0);
+    }
+
     /// A PRINT on its own statement surfaces as a message-only result (its DONE
     /// carries no count); the following assignment's count is still suppressed.
     #[tokio::test]


### PR DESCRIPTION
## Description

[AB#47535](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47535) reported that `PRINT` output never reached `mssql-python`'s `cursor.messages` — five `test_long_print_message` cases failed with `IndexError` on `cursor.messages[0]`.

The reported batch shape is:

```sql
DECLARE @msg VARCHAR(MAX);
SET @msg = REPLICATE(CAST('a' AS VARCHAR(MAX)), 2047);
PRINT @msg;
```

The assignment statements carry a `SQLSELECT`-tagged `DONE_COUNT`. While those were treated as update counts, the batch stopped on the assignment and never reached the `PRINT`, so `SQLExecDirectW` returned plain `SQL_SUCCESS` with zero diagnostic records. `mssql-python` only reads diagnostics on `SQL_SUCCESS_WITH_INFO` or `SQL_NO_DATA`, so it had nothing to collect. The info-message path itself was never at fault.

**This is already fixed on `main` by #372** (`324880cd`, "Do not treat SQLSELECT-tagged DONE_COUNT as an update count"), which merged after the 20260824.1 build the work item cites. Confirmed by building both sides against a live SQL Server:

| driver build | `SQLExecDirectW` | diag records |
| --- | --- | --- |
| `324880cd^` (pre-fix) | `SQL_SUCCESS` | 0 |
| current `main` | `SQL_SUCCESS_WITH_INFO` | 1 (`01000`, full text) |
| msodbcsql 18 | `SQL_SUCCESS_WITH_INFO` | 1 |

All five reported lengths (2047 / 4000 / 8000 / 8001 / 80000) now match msodbcsql, including SQL Server's 8000-character truncation.

So this PR adds no product change — only the regression tests that were missing. #372's tests cover the row-count side and a `PRINT` after real DML, but not the reported shape: a message-only statement reached *only* through assignments. That is precisely the case that returned `SQL_SUCCESS`, so it gets its own coverage at two levels.

## Tests added

- `ExecDirectLiveTest.PrintAfterAssignmentsSurfacesOnExecute` (e2e) asserts `SQL_SUCCESS_WITH_INFO`, the message on diagnostic record 1, `SQLRowCount == -1` (the assignments produce no navigable result), and `SQL_NO_DATA` from `SQLMoreResults`.
- `execute_surfaces_print_after_assignment_counts` (`mssql-tds`, mock transport) scripts the exact token sequence — two `SQLSELECT`-tagged `DONE_COUNT`s, then the PRINT `INFO`, then `DONE` — and asserts the first result the caller sees is `NoRows { rows_affected: None }` with the printed text drained via `take_info_messages()`. The pre-existing `execute_surfaces_message_but_skips_select_count` covers the reverse ordering (PRINT first, assignment second), so the reported ordering was not pinned at the Rust level. This one needs no live SQL Server.

Both were verified to fail with the `324880cd` guard reverted and pass with it restored:

| test | fix reverted | fix restored |
| --- | --- | --- |
| `PrintAfterAssignmentsSurfacesOnExecute` (e2e, DM-routed) | FAIL — `rc=0` (`SQL_SUCCESS`) | PASS |
| `execute_surfaces_print_after_assignment_counts` (mock) | FAIL — `NoRows { rows_affected: Some(1) }` | PASS |

## Reproduction note

`mssql-python` loads the driver with `dlopen` and calls the `W` entry points directly, with no driver manager in the path, which is how the failure was originally reproduced. An early probe routed through unixODBC appeared clean, but that was an artifact of the probe rather than of the driver manager: the revert experiment above shows the DM-routed e2e test fails on the same assertion, because the driver manager propagates the driver's return code unchanged. Driver-manager routing does not mask this regression.

## Related Issues

https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47535

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes
- [x] New/changed functionality has tests — this PR *is* the tests
- [x] Public API changes are documented — none

## Validation

- Full mssql-odbc e2e suite against a local SQL Server 2022 container: all pass.
- The new e2e test also passes against msodbcsql 18, so its assertions are parity assertions and it needs no `SKIP_IF_COMPARING_MSODBCSQL` guard.
- `cargo nextest run -p mssql-tds --lib -E 'test(/connection::tds_client::tests::execute_/)'`: 37 passed.

The same repro run also shows `RAISERROR(@msg, 16, 1)` reporting SQLSTATE `HY000` where msodbcsql reports `42000`. That is already tracked and diagnosed in [AB#47532](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47532) (severity-tiered fallback in `post_tds_error`), so it is deliberately left alone here.