### PR TITLE
Record false-negative review classes in the code-review skill

### DIFF
--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -244,6 +244,12 @@ the rule exists and do not need re-deriving. Last reviewed 2026-08.
   ```bash
   gh issue list --state all --search "row decode perf"
   ```
+- **"This allocates redundantly": read the signature first.** `String::from_utf8_lossy`
+  returns `Cow<'_, str>` and borrows on the valid path — it allocates only to repair
+  malformed input, so "drop the throwaway `String`" is a no-op. Nor are the lossy
+  converters symmetric: `from_utf16_lossy` takes `&[u16]`, has no borrowing form, and
+  genuinely allocates, so one is not precedent for the other. A redundant *scan* is
+  often the real cost, and is a different finding. Retracted twice on one PR.
 - **Repo conventions**: a real convention finding cites the file and line that
   mandates it. Verify against `.github/PULL_REQUEST_TEMPLATE.md`,
   `CONTRIBUTING.md` / `AGENTS.md` / `.github/copilot-instructions.md`, and actual
@@ -262,6 +268,30 @@ the rule exists and do not need re-deriving. Last reviewed 2026-08.
   example, already tracked by a TODO in `disconnect.rs` — is a legitimate deferral,
   because fixing it in one path and not the others is worse than scheduling it as its
   own change.
+
+## Where Reviews Have Failed to Look
+
+The counterpart to the list above: not findings that were raised and were wrong, but
+places a careful pass never examined. Each entry names the spot, not the PR.
+
+- **A documented residual failure still needs its blast radius traced.** When a PR
+  accepts "this now fails later as `HY000` instead of `22001`", the review question is
+  not only which SQLSTATE surfaces but what the failure *costs* — connection,
+  statement, or transaction. In `mssql-tds` that turns on whether `PacketWriter` has
+  flushed: `SqlType::serialize` writes the RPC type metadata preamble before
+  `TdsValueSerializer::serialize_value` (`datatypes/sqltypes.rs`), so bytes exist in
+  the writer, but nothing reaches the wire until `handle_overflow_if_needed` observes
+  `position() >= max_payload_size` (`io/packet_writer.rs`). Below that threshold the
+  message is abandoned by dropping the writer; above it, recovery needs
+  `cancel_current_message` plus consuming the server's DONE token, as that method's
+  own doc comment states. A test written with a short value pins only the benign
+  regime and leaves the risky one uncovered.
+- **Worked examples in `docs/*.md` are checkable claims, not commentary.** Byte
+  counts, code points and expansion arithmetic in a design doc are load-bearing for
+  whoever picks up the deferred work, and cost seconds to verify. One PR shipped
+  "eight-byte numeric character reference ... 24 bytes" for `&#9749;` (U+2615), which
+  is seven characters and 21 — a figure carried over from the five-digit `&#26085;`
+  (U+65E5) example nearby.
 
 ## Reviewing Alongside Other Reviewers
 

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -288,10 +288,10 @@ places a careful pass never examined. Each entry names the spot, not the PR.
   regime and leaves the risky one uncovered.
 - **Worked examples in `docs/*.md` are checkable claims, not commentary.** Byte
   counts, code points and expansion arithmetic in a design doc are load-bearing for
-  whoever picks up the deferred work, and cost seconds to verify. One PR shipped
-  "eight-byte numeric character reference ... 24 bytes" for `&#9749;` (U+2615), which
-  is seven characters and 21 — a figure carried over from the five-digit `&#26085;`
-  (U+65E5) example nearby.
+  whoever picks up the deferred work, and cost seconds to verify. One revision called
+  `&#9749;` (U+2615) an "eight-byte numeric character reference" and totalled three of
+  them as 24 bytes offered to a `varchar(3)`; it is seven bytes, so 21. The 8 belonged
+  to the five-digit `&#26085;` (U+65E5) example nearby.
 
 ## Reviewing Alongside Other Reviewers
 


### PR DESCRIPTION
## Description

Documentation-only change to `.github/skills/code-review/SKILL.md`. Adds three entries drawn from a two-round review of #385.

1. **New bullet in `## Verify Before You Claim`** — the `Cow`/allocation retraction. `String::from_utf8_lossy` borrows on the valid path, so "remove the throwaway `String`" is a no-op, and `from_utf16_lossy` is not precedent for it.
2. **New section, `## Where Reviews Have Failed to Look`** — the counterpart to the existing ledger: places a careful pass never examined, as distinct from findings that were raised and were wrong. It holds two entries:
   - A documented residual failure still needs its blast radius traced. Records the durable repo fact that failure recoverability in `mssql-tds` is flush-dependent — the RPC type metadata preamble is written in `SqlType::serialize` before `TdsValueSerializer::serialize_value`, but nothing reaches the wire until `handle_overflow_if_needed` sees `position() >= max_payload_size`.
   - Worked examples in `docs/*.md` are checkable claims, not commentary.

Placement is immediately after `Verify Before You Claim` and before `Reviewing Alongside Other Reviewers`, so the two ledgers sit together while keeping their contracts distinct.

Every code reference in entry 2 was verified against `mssql-tds` at the branch point (`b0966c96`) rather than taken from the issue text, and stable function names are cited in place of line numbers. The arithmetic in entry 3 was checked independently: `&#9749;` (U+2615) is seven ASCII bytes and `&#26085;` (U+65E5) is eight, so three copies of the former are 21 bytes, not 24. Per Copilot's review, that entry attributes the faulty figure to an earlier revision — #385's current diff already carries the corrected wording.

## Related Issues

Fixes #406

## Checklist

- [x] `cargo bfmt` passes — no Rust changed
- [x] `cargo bclippy` passes — no Rust changed
- [x] `cargo btest` passes — no Rust changed
- [x] New/changed functionality has tests — n/a, documentation only
- [x] Public API changes are documented — n/a, no API change
