### PR TITLE
Withdraw a partially sent request instead of dropping it

### DIFF
--- a/mssql-odbc/tests/e2e/tests/char_conversions_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/char_conversions_test.cpp
@@ -104,11 +104,9 @@ protected:
     }
 
     // A round trip on the same connection after a failed execute. A dead
-    // connection fails here (08S01) instead of returning the value.
-    //
-    // Any cursor the caller left open must be closed first: reusing the
-    // statement while one is live is 24000, which says nothing about the
-    // connection and would mask what this is checking.
+    // connection fails here (08S01) instead of returning the value. Any cursor
+    // the caller left open is closed first, since reusing the statement with one
+    // live is 24000 and would mask that.
     void ExpectConnectionStillUsable() {
         SQLCloseCursor(stmt_);
         ASSERT_SQL_OK(SQLFreeStmt(stmt_, SQL_RESET_PARAMS), SQL_HANDLE_STMT, stmt_);
@@ -866,30 +864,21 @@ TEST_F(CharConversionLiveTest, UnmappableCharacterIsSilentlyCorrupted) {
 
 
 // ---------------------------------------------------------------------------
-// A value rejected part-way through a request must cost the request, not the
-// connection. The RPC is flushed in packets as it is built, so a rejection
-// after a flush leaves the server holding an incomplete message; unless it is
-// withdrawn (EOM | IGNORE, then its DONE consumed) the next command is read as
-// a continuation and the server answers 4002 - on a *later* statement than the
-// one that failed. See AB#47687.
+// A value rejected after a packet has flushed leaves the server holding an
+// incomplete message. Unless it is withdrawn (EOM | IGNORE, then its DONE
+// consumed) the next command is read as a continuation and answered 4002 - on a
+// *later* statement than the one that failed. AB#47687.
 //
-// The two drivers reach that state from different points, because they order
-// conversion and sending differently: msodbcsql converts each parameter as the
-// RPC is written (`ParamToSQLType`, "pre-convert ... to catch errors and
-// truncations"), while this driver converts every parameter into RpcParameters
-// before a byte is serialized. So a conversion error strands msodbcsql
-// mid-message but never strands us; only a *serialization*-time rejection does.
-// Both cases are covered below.
-//
-// For the shared mechanism exercised on both drivers at once, see
-// SQLCancelAfterAFlushRetractsTheRequest in execute_test.cpp.
+// The drivers are stranded by different events: msodbcsql converts each
+// parameter as the RPC is written, this driver converts all of them first. So a
+// conversion error strands msodbcsql, and only a serialization-time rejection
+// strands us. One test each below; for the mechanism exercised on both at once,
+// see SQLCancelAfterAFlushRetractsTheRequest in execute_test.cpp.
 // ---------------------------------------------------------------------------
 
-// Strands msodbcsql mid-message: parameter 1 is legal and larger than a packet,
-// and parameter 2 fails its conversion, so `ParamToSQLType` errors with bytes
-// already on the wire (its STATE_BATCH_PARTIALCMDSENT). This driver rejects
-// parameter 2 before serializing anything, so it takes the local-discard branch
-// instead. Both must leave the connection usable, which is what this asserts.
+// Strands msodbcsql: parameter 2 fails `ParamToSQLType` with parameter 1 already
+// on the wire. This driver rejects it before serializing, so it takes the
+// local-discard branch. Both must end with a usable connection.
 TEST_F(CharConversionLiveTest, ConversionFailureAfterAFlushLeavesTheConnectionUsable) {
     ASSERT_SQL_OK(Prepare("SELECT ?, ?"), SQL_HANDLE_STMT, stmt_);
 
@@ -910,14 +899,11 @@ TEST_F(CharConversionLiveTest, ConversionFailureAfterAFlushLeavesTheConnectionUs
     ExpectConnectionStillUsable();
 }
 
-// Strands *this* driver mid-message, which msodbcsql cannot be made to do here:
-// the value passes our UTF-16 unit count at one unit, then expands to the eight
-// bytes of "&#26085;" inside serialize_string and is rejected against
-// varchar(1) - after parameter 1 has already flushed a packet. msodbcsql
-// measures the converted bytes first, substitutes the unmappable character to a
-// single byte, and sends the value without error. The connection invariant is
-// not driver-specific, so this runs under comparison; on msodbcsql it passes
-// without exercising any recovery.
+// Strands this driver: the value passes our UTF-16 unit count at one unit, then
+// expands to the eight bytes of "&#26085;" inside serialize_string and is
+// rejected against varchar(1) - after parameter 1 has flushed. msodbcsql
+// measures the converted bytes first and sends it without error, so under
+// comparison this passes without exercising any recovery.
 TEST_F(CharConversionLiveTest, SerializationFailureAfterAFlushLeavesTheConnectionUsable) {
     if (!DatabaseIsLatin1()) {
         GTEST_SKIP() << "needs a Latin1 collation to make the value unmappable";
@@ -938,8 +924,7 @@ TEST_F(CharConversionLiveTest, SerializationFailureAfterAFlushLeavesTheConnectio
                   SQL_HANDLE_STMT, stmt_);
 
     // Deliberately unasserted: this driver rejects the value, msodbcsql
-    // substitutes it and succeeds. A success leaves a live cursor, which has to
-    // be drained here rather than left for the connection check to trip over.
+    // substitutes it and succeeds, leaving a cursor that must be drained here.
     if (SQLExecute(stmt_) != SQL_ERROR) {
         while (SQLFetch(stmt_) == SQL_SUCCESS) {
         }

--- a/mssql-odbc/tests/e2e/tests/char_conversions_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/char_conversions_test.cpp
@@ -923,12 +923,22 @@ TEST_F(CharConversionLiveTest, SerializationFailureAfterAFlushLeavesTheConnectio
                                    ind, &ind),
                   SQL_HANDLE_STMT, stmt_);
 
-    // Deliberately unasserted: this driver rejects the value, msodbcsql
-    // substitutes it and succeeds, leaving a cursor that must be drained here.
-    if (SQLExecute(stmt_) != SQL_ERROR) {
-        while (SQLFetch(stmt_) == SQL_SUCCESS) {
+    // msodbcsql substitutes the unmappable character and succeeds, leaving a
+    // cursor to drain. On our leg the rejection is the precondition for the
+    // recovery being tested, so assert it - otherwise a regression that stops
+    // failing would leave this test green without exercising any withdrawal.
+    const char* target = std::getenv("ODBC_TEST_TARGET");
+    const bool comparing_msodbcsql = target && std::string(target) == "msodbcsql";
+    const SQLRETURN rc = SQLExecute(stmt_);
+    if (comparing_msodbcsql) {
+        if (rc != SQL_ERROR) {
+            while (SQLFetch(stmt_) == SQL_SUCCESS) {
+            }
+            SQLCloseCursor(stmt_);
         }
-        SQLCloseCursor(stmt_);
+    } else {
+        ASSERT_EQ(SQL_ERROR, rc)
+            << "the over-long value must be rejected during serialization";
     }
 
     ExpectConnectionStillUsable();

--- a/mssql-odbc/tests/e2e/tests/char_conversions_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/char_conversions_test.cpp
@@ -902,9 +902,10 @@ TEST_F(CharConversionLiveTest, ConversionFailureAfterAFlushLeavesTheConnectionUs
 // Strands this driver: the value passes our UTF-16 unit count at one unit, then
 // expands to the eight bytes of "&#26085;" inside serialize_string and is
 // rejected against varchar(1) - after parameter 1 has flushed. msodbcsql
-// measures the converted bytes first and sends it without error, so under
-// comparison this passes without exercising any recovery.
+// measures the converted bytes first and sends it without error, so it never
+// reaches the partial-send state here and the case is skipped on that leg.
 TEST_F(CharConversionLiveTest, SerializationFailureAfterAFlushLeavesTheConnectionUsable) {
+    SKIP_IF_COMPARING_MSODBCSQL();
     if (!DatabaseIsLatin1()) {
         GTEST_SKIP() << "needs a Latin1 collation to make the value unmappable";
     }
@@ -923,23 +924,8 @@ TEST_F(CharConversionLiveTest, SerializationFailureAfterAFlushLeavesTheConnectio
                                    ind, &ind),
                   SQL_HANDLE_STMT, stmt_);
 
-    // msodbcsql substitutes the unmappable character and succeeds, leaving a
-    // cursor to drain. On our leg the rejection is the precondition for the
-    // recovery being tested, so assert it - otherwise a regression that stops
-    // failing would leave this test green without exercising any withdrawal.
-    const char* target = std::getenv("ODBC_TEST_TARGET");
-    const bool comparing_msodbcsql = target && std::string(target) == "msodbcsql";
-    const SQLRETURN rc = SQLExecute(stmt_);
-    if (comparing_msodbcsql) {
-        if (rc != SQL_ERROR) {
-            while (SQLFetch(stmt_) == SQL_SUCCESS) {
-            }
-            SQLCloseCursor(stmt_);
-        }
-    } else {
-        ASSERT_EQ(SQL_ERROR, rc)
-            << "the over-long value must be rejected during serialization";
-    }
+    ASSERT_EQ(SQL_ERROR, SQLExecute(stmt_))
+        << "the over-long value must be rejected during serialization";
 
     ExpectConnectionStillUsable();
 }

--- a/mssql-odbc/tests/e2e/tests/char_conversions_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/char_conversions_test.cpp
@@ -899,7 +899,6 @@ TEST_F(CharConversionLiveTest, UnmappableCharacterIsSilentlyCorrupted) {
     EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
 }
 
-
 // ---------------------------------------------------------------------------
 // A value rejected after a packet has flushed leaves the server holding an
 // incomplete message. Unless it is withdrawn (EOM | IGNORE, then its DONE

--- a/mssql-odbc/tests/e2e/tests/char_conversions_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/char_conversions_test.cpp
@@ -115,18 +115,43 @@ protected:
         return collation.find("Latin1_General") != std::string::npos;
     }
 
-    // A round trip on the same connection after a failed execute. A dead
-    // connection fails here (08S01) instead of returning the value. Any cursor
-    // the caller left open is closed first, since reusing the statement with one
-    // live is 24000 and would mask that.
-    void ExpectConnectionStillUsable() {
+    // The server-side session id, so a test can tell a surviving connection from
+    // a transparently rebuilt one.
+    std::string CurrentSpid() {
+        EXPECT_SQL_OK(Prepare("SELECT CAST(@@SPID AS VARCHAR(16))"), SQL_HANDLE_STMT, stmt_);
+        EXPECT_SQL_OK(SQLExecute(stmt_), SQL_HANDLE_STMT, stmt_);
+        EXPECT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+        const std::string spid = GetColumnChar(1);
+        EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
+        return spid;
+    }
+
+    // A round trip on the same connection after a failed execute. Any cursor the
+    // caller left open is closed first, since reusing the statement with one live
+    // is 24000 and would mask what this checks.
+    //
+    // The SPID is the assertion that matters: session recovery is negotiated by
+    // default, so a driver that killed the connection would reconnect here and
+    // still answer 'alive'. Only an unchanged SPID says the request was retracted
+    // rather than the session rebuilt.
+    void ExpectSameSessionStillUsable(const std::string& expected_spid) {
         SQLCloseCursor(stmt_);
         ASSERT_SQL_OK(SQLFreeStmt(stmt_, SQL_RESET_PARAMS), SQL_HANDLE_STMT, stmt_);
+
+        SQLUINTEGER dead = SQL_CD_TRUE;
+        ASSERT_SQL_OK(
+            SQLGetConnectAttr(dbc_, SQL_ATTR_CONNECTION_DEAD, &dead, SQL_IS_UINTEGER, nullptr),
+            SQL_HANDLE_DBC, dbc_);
+        EXPECT_EQ(SQL_CD_FALSE, dead) << "a retracted request must not cost the connection";
+
         ASSERT_SQL_OK(Prepare("SELECT 'alive'"), SQL_HANDLE_STMT, stmt_);
         ASSERT_SQL_OK(SQLExecute(stmt_), SQL_HANDLE_STMT, stmt_);
         ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
         EXPECT_EQ("alive", GetColumnChar(1));
         EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
+
+        EXPECT_EQ(expected_spid, CurrentSpid())
+            << "the session was rebuilt, so the request cost the connection";
     }
 };
 
@@ -892,6 +917,7 @@ TEST_F(CharConversionLiveTest, UnmappableCharacterIsSilentlyCorrupted) {
 // on the wire. This driver rejects it before serializing, so it takes the
 // local-discard branch. Both must end with a usable connection.
 TEST_F(CharConversionLiveTest, ConversionFailureAfterAFlushLeavesTheConnectionUsable) {
+    const std::string spid = CurrentSpid();
     ASSERT_SQL_OK(Prepare("SELECT ?, ?"), SQL_HANDLE_STMT, stmt_);
 
     // ColumnSize 0 is the `max` spelling, so no length bound applies to this one.
@@ -908,7 +934,7 @@ TEST_F(CharConversionLiveTest, ConversionFailureAfterAFlushLeavesTheConnectionUs
 
     EXPECT_EQ(SQL_ERROR, SQLExecute(stmt_));
 
-    ExpectConnectionStillUsable();
+    ExpectSameSessionStillUsable(spid);
 }
 
 // Strands this driver: the value passes our UTF-16 unit count at one unit, then
@@ -922,6 +948,7 @@ TEST_F(CharConversionLiveTest, SerializationFailureAfterAFlushLeavesTheConnectio
         GTEST_SKIP() << "needs a Latin1 collation to make the value unmappable";
     }
 
+    const std::string spid = CurrentSpid();
     ASSERT_SQL_OK(Prepare("SELECT ?, ?"), SQL_HANDLE_STMT, stmt_);
 
     std::vector<SQLCHAR> big(20000, 'a');
@@ -939,5 +966,5 @@ TEST_F(CharConversionLiveTest, SerializationFailureAfterAFlushLeavesTheConnectio
     ASSERT_EQ(SQL_ERROR, SQLExecute(stmt_))
         << "the over-long value must be rejected during serialization";
 
-    ExpectConnectionStillUsable();
+    ExpectSameSessionStillUsable(spid);
 }

--- a/mssql-odbc/tests/e2e/tests/char_conversions_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/char_conversions_test.cpp
@@ -87,6 +87,37 @@ protected:
         }
         return std::string(reinterpret_cast<const char*>(buf));
     }
+
+    // serialize_string picks the code page from the collation's LCID alone, so
+    // only the LCID has to be Latin1 for U+65E5 to be unmappable. The parameter
+    // carries the *database* collation, which need not match the instance's.
+    bool DatabaseIsLatin1() {
+        EXPECT_SQL_OK(
+            Prepare("SELECT CAST(DATABASEPROPERTYEX(DB_NAME(), 'Collation')"
+                    " AS VARCHAR(128))"),
+            SQL_HANDLE_STMT, stmt_);
+        EXPECT_SQL_OK(SQLExecute(stmt_), SQL_HANDLE_STMT, stmt_);
+        EXPECT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+        const std::string collation = GetColumnChar(1);
+        EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
+        return collation.find("Latin1_General") != std::string::npos;
+    }
+
+    // A round trip on the same connection after a failed execute. A dead
+    // connection fails here (08S01) instead of returning the value.
+    //
+    // Any cursor the caller left open must be closed first: reusing the
+    // statement while one is live is 24000, which says nothing about the
+    // connection and would mask what this is checking.
+    void ExpectConnectionStillUsable() {
+        SQLCloseCursor(stmt_);
+        ASSERT_SQL_OK(SQLFreeStmt(stmt_, SQL_RESET_PARAMS), SQL_HANDLE_STMT, stmt_);
+        ASSERT_SQL_OK(Prepare("SELECT 'alive'"), SQL_HANDLE_STMT, stmt_);
+        ASSERT_SQL_OK(SQLExecute(stmt_), SQL_HANDLE_STMT, stmt_);
+        ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+        EXPECT_EQ("alive", GetColumnChar(1));
+        EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
+    }
 };
 
 // The declared wire type follows ParameterType, not the C type that was bound,
@@ -831,4 +862,89 @@ TEST_F(CharConversionLiveTest, UnmappableCharacterIsSilentlyCorrupted) {
     ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
     EXPECT_EQ("&#26085;", GetColumnChar(1));
     EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
+}
+
+
+// ---------------------------------------------------------------------------
+// A value rejected part-way through a request must cost the request, not the
+// connection. The RPC is flushed in packets as it is built, so a rejection
+// after a flush leaves the server holding an incomplete message; unless it is
+// withdrawn (EOM | IGNORE, then its DONE consumed) the next command is read as
+// a continuation and the server answers 4002 - on a *later* statement than the
+// one that failed. See AB#47687.
+//
+// The two drivers reach that state from different points, because they order
+// conversion and sending differently: msodbcsql converts each parameter as the
+// RPC is written (`ParamToSQLType`, "pre-convert ... to catch errors and
+// truncations"), while this driver converts every parameter into RpcParameters
+// before a byte is serialized. So a conversion error strands msodbcsql
+// mid-message but never strands us; only a *serialization*-time rejection does.
+// Both cases are covered below.
+//
+// For the shared mechanism exercised on both drivers at once, see
+// SQLCancelAfterAFlushRetractsTheRequest in execute_test.cpp.
+// ---------------------------------------------------------------------------
+
+// Strands msodbcsql mid-message: parameter 1 is legal and larger than a packet,
+// and parameter 2 fails its conversion, so `ParamToSQLType` errors with bytes
+// already on the wire (its STATE_BATCH_PARTIALCMDSENT). This driver rejects
+// parameter 2 before serializing anything, so it takes the local-discard branch
+// instead. Both must leave the connection usable, which is what this asserts.
+TEST_F(CharConversionLiveTest, ConversionFailureAfterAFlushLeavesTheConnectionUsable) {
+    ASSERT_SQL_OK(Prepare("SELECT ?, ?"), SQL_HANDLE_STMT, stmt_);
+
+    // ColumnSize 0 is the `max` spelling, so no length bound applies to this one.
+    std::vector<SQLCHAR> big(20000, 'a');
+    SQLLEN big_ind = static_cast<SQLLEN>(big.size());
+    ASSERT_SQL_OK(SQLBindParameter(stmt_, 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 0, 0,
+                                   big.data(), big_ind, &big_ind),
+                  SQL_HANDLE_STMT, stmt_);
+
+    // Ten characters into varchar(4), with a non-blank overflow, so neither
+    // driver may trim it silently.
+    AsciiParam overlong(SQL_C_CHAR, "abcdefghij");
+    ASSERT_SQL_OK(BindAscii(2, overlong, SQL_VARCHAR, 4), SQL_HANDLE_STMT, stmt_);
+
+    EXPECT_EQ(SQL_ERROR, SQLExecute(stmt_));
+
+    ExpectConnectionStillUsable();
+}
+
+// Strands *this* driver mid-message, which msodbcsql cannot be made to do here:
+// the value passes our UTF-16 unit count at one unit, then expands to the eight
+// bytes of "&#26085;" inside serialize_string and is rejected against
+// varchar(1) - after parameter 1 has already flushed a packet. msodbcsql
+// measures the converted bytes first, substitutes the unmappable character to a
+// single byte, and sends the value without error. The connection invariant is
+// not driver-specific, so this runs under comparison; on msodbcsql it passes
+// without exercising any recovery.
+TEST_F(CharConversionLiveTest, SerializationFailureAfterAFlushLeavesTheConnectionUsable) {
+    if (!DatabaseIsLatin1()) {
+        GTEST_SKIP() << "needs a Latin1 collation to make the value unmappable";
+    }
+
+    ASSERT_SQL_OK(Prepare("SELECT ?, ?"), SQL_HANDLE_STMT, stmt_);
+
+    std::vector<SQLCHAR> big(20000, 'a');
+    SQLLEN big_ind = static_cast<SQLLEN>(big.size());
+    ASSERT_SQL_OK(SQLBindParameter(stmt_, 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 0, 0,
+                                   big.data(), big_ind, &big_ind),
+                  SQL_HANDLE_STMT, stmt_);
+
+    SQLWCHAR wide[] = {0x65E5};
+    SQLLEN ind = static_cast<SQLLEN>(sizeof(wide));
+    ASSERT_SQL_OK(SQLBindParameter(stmt_, 2, SQL_PARAM_INPUT, SQL_C_WCHAR, SQL_VARCHAR, 1, 0, wide,
+                                   ind, &ind),
+                  SQL_HANDLE_STMT, stmt_);
+
+    // Deliberately unasserted: this driver rejects the value, msodbcsql
+    // substitutes it and succeeds. A success leaves a live cursor, which has to
+    // be drained here rather than left for the connection check to trip over.
+    if (SQLExecute(stmt_) != SQL_ERROR) {
+        while (SQLFetch(stmt_) == SQL_SUCCESS) {
+        }
+        SQLCloseCursor(stmt_);
+    }
+
+    ExpectConnectionStillUsable();
 }

--- a/mssql-odbc/tests/e2e/tests/char_conversions_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/char_conversions_test.cpp
@@ -92,12 +92,24 @@ protected:
     // only the LCID has to be Latin1 for U+65E5 to be unmappable. The parameter
     // carries the *database* collation, which need not match the instance's.
     bool DatabaseIsLatin1() {
+        // Each step returns early: EXPECT_* is non-fatal, and falling through to
+        // GetColumnChar on an unfetched row reports a collation mismatch instead
+        // of the prepare or fetch that actually failed.
         EXPECT_SQL_OK(
             Prepare("SELECT CAST(DATABASEPROPERTYEX(DB_NAME(), 'Collation')"
                     " AS VARCHAR(128))"),
             SQL_HANDLE_STMT, stmt_);
+        if (::testing::Test::HasFailure()) {
+            return false;
+        }
         EXPECT_SQL_OK(SQLExecute(stmt_), SQL_HANDLE_STMT, stmt_);
+        if (::testing::Test::HasFailure()) {
+            return false;
+        }
         EXPECT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+        if (::testing::Test::HasFailure()) {
+            return false;
+        }
         const std::string collation = GetColumnChar(1);
         EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
         return collation.find("Latin1_General") != std::string::npos;

--- a/mssql-odbc/tests/e2e/tests/execute_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/execute_test.cpp
@@ -448,6 +448,56 @@ TEST_F(PrepareExecuteLiveTest, SQLCancelAbandonsDataAtExecutionSequence) {
     EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
 }
 
+// The same cancel once a chunk has crossed a packet boundary. This is the one
+// place both drivers reach the partial-send state from the same event, so it is
+// the parity case for the retraction itself: msodbcsql's BATCHCTX::Cancel takes
+// its STATE_BATCH_PARTIALCMDSENT arm (EOM | IGNORE, then FlushInputStream), and
+// this driver takes `cancel_streamed_write`. The test above cancels after seven
+// bytes, which never leaves the local buffer, so it only covers the discard
+// branch. See AB#47687.
+TEST_F(PrepareExecuteLiveTest, SQLCancelAfterAFlushRetractsTheRequest) {
+    ASSERT_SQL_OK(Prepare("SELECT ? AS v"), SQL_HANDLE_STMT, stmt_);
+
+    SQLLEN streamed_ind = SQL_DATA_AT_EXEC;
+    SQLCHAR streamed_token = 0;
+    ASSERT_SQL_OK(SQLBindParameter(stmt_, 1, SQL_PARAM_INPUT, SQL_C_CHAR,
+                                   SQL_VARCHAR, 0, 0, &streamed_token, 0,
+                                   &streamed_ind),
+                  SQL_HANDLE_STMT, stmt_);
+
+    ASSERT_EQ(SQL_NEED_DATA, SQLExecute(stmt_));
+    SQLPOINTER value_ptr = nullptr;
+    ASSERT_EQ(SQL_NEED_DATA, SQLParamData(stmt_, &value_ptr));
+
+    // Larger than the default 8000-byte packet, so at least one packet of this
+    // request is on the wire before the cancel.
+    std::vector<char> chunk(20000, 'a');
+    ASSERT_SQL_OK(SQLPutData(stmt_, chunk.data(), static_cast<SQLLEN>(chunk.size())),
+                  SQL_HANDLE_STMT, stmt_);
+
+    ASSERT_SQL_OK(SQLCancel(stmt_), SQL_HANDLE_STMT, stmt_);
+
+    SQLUINTEGER dead = SQL_CD_TRUE;
+    ASSERT_SQL_OK(SQLGetConnectAttr(dbc_, SQL_ATTR_CONNECTION_DEAD, &dead,
+                                    SQL_IS_UINTEGER, nullptr),
+                  SQL_HANDLE_DBC, dbc_);
+    EXPECT_EQ(SQL_CD_FALSE, dead)
+        << "a retracted request must not cost the connection";
+
+    // The withdrawal is only complete once the server's DONE has been consumed.
+    // If it were left unread the next command would pick it up as its own, so
+    // running a fresh statement to completion is what proves the retraction.
+    const char reuse[] = "after-cancel";
+    ASSERT_EQ(SQL_NEED_DATA, SQLExecute(stmt_));
+    ASSERT_EQ(SQL_NEED_DATA, SQLParamData(stmt_, &value_ptr));
+    ASSERT_SQL_OK(SQLPutData(stmt_, const_cast<char*>(reuse), 12),
+                  SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLParamData(stmt_, &value_ptr), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ("after-cancel", GetColumnChar(1));
+    EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
+}
+
 // A data-at-execution parameter may resolve to NULL: the first SQLPutData
 // carries SQL_NULL_DATA and no chunks follow, so the driver emits PLP_NULL.
 // Benefits-from-mock-tds: COALESCE only proves the server saw *a* NULL. A mock

--- a/mssql-odbc/tests/e2e/tests/execute_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/execute_test.cpp
@@ -449,12 +449,10 @@ TEST_F(PrepareExecuteLiveTest, SQLCancelAbandonsDataAtExecutionSequence) {
 }
 
 // The same cancel once a chunk has crossed a packet boundary. This is the one
-// place both drivers reach the partial-send state from the same event, so it is
-// the parity case for the retraction itself: msodbcsql's BATCHCTX::Cancel takes
-// its STATE_BATCH_PARTIALCMDSENT arm (EOM | IGNORE, then FlushInputStream), and
-// this driver takes `cancel_streamed_write`. The test above cancels after seven
-// bytes, which never leaves the local buffer, so it only covers the discard
-// branch. See AB#47687.
+// event that strands *both* drivers, so it is the parity case for the
+// retraction: msodbcsql takes BATCHCTX::Cancel's STATE_BATCH_PARTIALCMDSENT arm
+// and this driver takes `cancel_streamed_write`. The test above cancels after
+// seven bytes, which never leave the local buffer. AB#47687.
 TEST_F(PrepareExecuteLiveTest, SQLCancelAfterAFlushRetractsTheRequest) {
     ASSERT_SQL_OK(Prepare("SELECT ? AS v"), SQL_HANDLE_STMT, stmt_);
 
@@ -469,8 +467,8 @@ TEST_F(PrepareExecuteLiveTest, SQLCancelAfterAFlushRetractsTheRequest) {
     SQLPOINTER value_ptr = nullptr;
     ASSERT_EQ(SQL_NEED_DATA, SQLParamData(stmt_, &value_ptr));
 
-    // Larger than the default 8000-byte packet, so at least one packet of this
-    // request is on the wire before the cancel.
+    // Larger than the default 8000-byte packet, so a packet is on the wire
+    // before the cancel.
     std::vector<char> chunk(20000, 'a');
     ASSERT_SQL_OK(SQLPutData(stmt_, chunk.data(), static_cast<SQLLEN>(chunk.size())),
                   SQL_HANDLE_STMT, stmt_);
@@ -484,9 +482,8 @@ TEST_F(PrepareExecuteLiveTest, SQLCancelAfterAFlushRetractsTheRequest) {
     EXPECT_EQ(SQL_CD_FALSE, dead)
         << "a retracted request must not cost the connection";
 
-    // The withdrawal is only complete once the server's DONE has been consumed.
-    // If it were left unread the next command would pick it up as its own, so
-    // running a fresh statement to completion is what proves the retraction.
+    // An unconsumed DONE would be picked up by this execute, so completing a
+    // second sequence is what proves the withdrawal finished.
     const char reuse[] = "after-cancel";
     ASSERT_EQ(SQL_NEED_DATA, SQLExecute(stmt_));
     ASSERT_EQ(SQL_NEED_DATA, SQLParamData(stmt_, &value_ptr));

--- a/mssql-odbc/tests/e2e/tests/execute_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/execute_test.cpp
@@ -487,7 +487,7 @@ TEST_F(PrepareExecuteLiveTest, SQLCancelAfterAFlushRetractsTheRequest) {
     const char reuse[] = "after-cancel";
     ASSERT_EQ(SQL_NEED_DATA, SQLExecute(stmt_));
     ASSERT_EQ(SQL_NEED_DATA, SQLParamData(stmt_, &value_ptr));
-    ASSERT_SQL_OK(SQLPutData(stmt_, const_cast<char*>(reuse), 12),
+    ASSERT_SQL_OK(SQLPutData(stmt_, const_cast<char*>(reuse), sizeof(reuse) - 1),
                   SQL_HANDLE_STMT, stmt_);
     ASSERT_SQL_OK(SQLParamData(stmt_, &value_ptr), SQL_HANDLE_STMT, stmt_);
     ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -1613,12 +1613,16 @@ impl TdsClient {
                 .await
         }
         .await;
+        let message = packet_writer.suspend();
         if let Err(error) = serialization_result {
-            drop(packet_writer);
-            self.abort_streamed_write().await;
+            drop(rpc);
+            // The prefix runs every materialized parameter through the same
+            // checks as the non-streamed sites, so this is retractable rather
+            // than a reason to discard the connection.
+            self.streamed_write_state = StreamedWriteState::Idle;
+            self.retract_partial_request(message).await;
             return Err(error);
         }
-        let message = packet_writer.suspend();
 
         self.streamed_write_state = StreamedWriteState::Active(Box::new(StreamedWriteContext {
             message,
@@ -1863,6 +1867,25 @@ impl TdsClient {
         if message.nothing_sent() {
             // Not a plain drop: re-arm the RESETCONNECTION bit this message took.
             message.abandon(self.transport.as_writer());
+            self.execution_context.set_has_open_batch(false);
+            return;
+        }
+
+        if message.message_complete() {
+            // The server has the whole request and will answer it, so there is
+            // nothing to withdraw - an `EOM | IGNORE` would open a second message
+            // and leave its DONE for the next command. Cancel with an attention
+            // instead, which is msodbcsql's `STATE_BATCH_CMDSENT` arm. The
+            // transport marks itself dead if the attention goes unacknowledged.
+            //
+            // Dropped rather than abandoned: this message carried its reset bit
+            // all the way out and `note_reset_dispatched` recorded it, so the
+            // acknowledgement is already being tracked. Re-arming would send it
+            // twice.
+            drop(message);
+            let _ = self
+                .send_attention_with_timeout(Duration::from_secs(ATTENTION_TIMEOUT_SECONDS))
+                .await;
             self.execution_context.set_has_open_batch(false);
             return;
         }
@@ -2175,11 +2198,13 @@ impl TdsClient {
                     }
                 }
             }
-            // Terminator or next-parameter header write failed mid-message: drop
-            // the half-written message and abort rather than leave it resumable.
+            // Terminator or next-parameter header write failed mid-message:
+            // withdraw it rather than leaving it resumable or discarding the
+            // connection for a failure that cost only the request.
             Err(e) => {
-                drop(packet_writer);
-                self.abort_streamed_write().await;
+                let message = packet_writer.suspend();
+                self.streamed_write_state = StreamedWriteState::Idle;
+                self.retract_partial_request(message).await;
                 Err(e)
             }
         }
@@ -6447,6 +6472,9 @@ mod tests {
         /// When set, `send` never returns, so a test can drive a write deadline
         /// without a real stalled peer.
         send_should_hang: Arc<std::sync::atomic::AtomicBool>,
+        /// Attentions requested, so a test can tell the cancel-a-sent-request
+        /// path from the withdraw-a-partial-one path.
+        attentions: Arc<std::sync::atomic::AtomicUsize>,
         /// Cached liveness flag toggled by `mark_known_dead`, surfaced through
         /// `connection_known_dead` so tests can assert the fatal-error path.
         known_dead: bool,
@@ -6470,6 +6498,7 @@ mod tests {
                 resume_results: VecDeque::new(),
                 send_should_fail: Arc::new(std::sync::atomic::AtomicBool::new(false)),
                 send_should_hang: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                attentions: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
                 known_dead: false,
                 encryption_setting: NegotiatedEncryptionSetting::NoEncryption,
                 receive_timeouts: Arc::new(std::sync::Mutex::new(Vec::new())),
@@ -6611,6 +6640,10 @@ mod tests {
                 .send_should_fail
                 .load(std::sync::atomic::Ordering::SeqCst)
             {
+                // `NetworkTransport::send` retires the transport on a write
+                // failure; a mock that did not would let tests treat a broken
+                // socket as reusable.
+                self.known_dead = true;
                 return Err(crate::error::Error::ConnectionClosed(
                     "injected send failure".to_string(),
                 ));
@@ -6670,6 +6703,8 @@ mod tests {
             Ok(())
         }
         async fn send_attention_with_timeout(&mut self, _timeout: Duration) -> TdsResult<bool> {
+            self.attentions
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             Ok(false)
         }
         fn is_connection_dead(&self) -> bool {
@@ -10943,7 +10978,7 @@ mod tests {
             StreamedWriteState::Idle
         ));
         assert!(
-            client.is_connection_dead(),
+            client.transport.connection_known_dead(),
             "a failed final send must make the connection non-reusable"
         );
     }
@@ -11613,6 +11648,43 @@ mod tests {
         assert!(
             client.is_connection_dead(),
             "a withdrawal that cannot be written must retire the transport"
+        );
+    }
+
+    /// A budget expiry on the *last* packet leaves the server holding the whole
+    /// request, so there is nothing to withdraw. Sending `EOM | IGNORE` there
+    /// would open a second message and leave its DONE for the next command;
+    /// the request has to be cancelled with an attention instead.
+    #[tokio::test]
+    async fn a_complete_message_is_cancelled_rather_than_withdrawn() {
+        let transport = TestTransport::new();
+        let attentions = Arc::clone(&transport.attentions);
+        let sent = Arc::clone(&transport.sent);
+        let mut client = create_test_client_with_transport(transport);
+
+        let mut writer = PacketWriter::new(
+            PacketType::RpcRequest,
+            client.transport.as_writer(),
+            None,
+            None,
+        );
+        writer.write_async(&[0xABu8; 16]).await.unwrap();
+        writer.finalize().await.unwrap();
+        let message = writer.suspend();
+        assert!(message.message_complete(), "finalize sent the last packet");
+        let sent_before = sent.lock().unwrap().len();
+
+        client.retract_partial_request(message).await;
+
+        assert_eq!(
+            attentions.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "a request the server has in full must be cancelled, not withdrawn"
+        );
+        assert_eq!(
+            sent.lock().unwrap().len(),
+            sent_before,
+            "no second message may be opened to withdraw the first"
         );
     }
 

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -1924,9 +1924,8 @@ impl TdsClient {
         if carried_reset == ResetConnectionMode::None {
             return;
         }
-        let writer = self.transport.as_writer();
-        writer.take_reset_dispatched();
-        writer.set_reset_mode(carried_reset);
+        // Also clears the dispatch record packet 1 left behind.
+        self.transport.as_writer().set_reset_mode(carried_reset);
     }
 
     /// Closes the transport after a request could not be retracted.

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -1864,6 +1864,9 @@ impl TdsClient {
         // which here could swallow the server's answer to the half-written
         // request. msodbcsql's `FIsConnectionDead` is likewise a cached flag.
         if self.transport.connection_known_dead() {
+            // Dead or not, opening this message took the connection's one-shot
+            // reset arm; hand it back rather than swallowing it in a plain drop.
+            message.abandon(self.transport.as_writer());
             return Withdrawal::ConnectionAlreadyDead;
         }
 
@@ -11609,6 +11612,7 @@ mod tests {
     #[tokio::test]
     async fn retract_partial_request_skips_the_withdrawal_on_a_dead_connection() {
         let (mut client, sent) = create_capturing_client(vec![done_no_more()]);
+        client.prepare_reset_connection(false);
         let message = suspend_message_with(&mut client, 10_000).await;
         let sent_before = sent.lock().unwrap().len();
         client.transport.mark_known_dead();
@@ -11619,6 +11623,11 @@ mod tests {
             sent.lock().unwrap().len(),
             sent_before,
             "no withdrawal may be attempted on a dead connection"
+        );
+        assert_eq!(
+            client.transport.as_writer().take_reset_mode(),
+            ResetConnectionMode::Reset,
+            "the skipped message must still hand back the reset arm it took"
         );
     }
 

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -1619,9 +1619,6 @@ impl TdsClient {
             // The prefix runs every materialized parameter through the same
             // checks as the non-streamed sites, so this is retractable rather
             // than a reason to discard the connection.
-            // Not redundant: this function has no entry guard against an already
-            // active stream, and the retraction does not touch the field.
-            self.streamed_write_state = StreamedWriteState::Idle;
             self.retract_partial_request(message).await;
             return Err(error);
         }
@@ -1890,9 +1887,15 @@ impl TdsClient {
             // acknowledgement is already being tracked. Re-arming would send it
             // twice.
             drop(message);
-            let _ = self
+            // `send_attention_and_wait` logs its own timeouts, but the write
+            // failure path returns without logging - and that is the one that
+            // costs a connection.
+            if let Err(error) = self
                 .send_attention_with_timeout(Duration::from_secs(ATTENTION_TIMEOUT_SECONDS))
-                .await;
+                .await
+            {
+                warn!(%error, "Failed to cancel a fully sent request");
+            }
             self.execution_context.set_has_open_batch(false);
             return;
         }

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -1867,25 +1867,63 @@ impl TdsClient {
             return Withdrawal::ConnectionAlreadyDead;
         }
 
+        // Read before `resume` takes it: the server discards an ignored message
+        // whole, so a reset bit already on the wire has to ride a later request.
+        let carried_reset = message.reset_mode();
+
         let mut packet_writer = PacketWriter::resume(
-            message.with_write_timeout(Some(CANCEL_TIMEOUT_SECS)),
+            message
+                .with_write_timeout(Some(CANCEL_TIMEOUT_SECS))
+                .without_cancellation(),
             self.transport.as_writer(),
         );
-        let ignored = packet_writer.cancel_current_message().await;
+        // `PacketWriter` only checks its budget once a write returns, so the
+        // ignore packet needs a deadline of its own. Dropping a write future
+        // mid-flight is safe only because every path out of a failed withdrawal
+        // retires the transport, as `send_attention_and_wait` does.
+        let ignored =
+            tokio::time::timeout(CANCEL_TIMEOUT, packet_writer.cancel_current_message()).await;
         drop(packet_writer);
-        if let Err(error) = ignored {
-            return Withdrawal::Failed(error);
+        match ignored {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => return Withdrawal::Failed(error),
+            Err(_) => {
+                return Withdrawal::Failed(crate::error::Error::TimeoutError(
+                    crate::error::TimeoutErrorType::String(
+                        "Timed out sending the ignore packet".to_string(),
+                    ),
+                ));
+            }
         }
+
+        self.rearm_withdrawn_reset(carried_reset);
 
         // The server acknowledges an ignored message with a DONE. Leaving it
         // unread would desynchronize the next command.
-        let saved = self.remaining_request_timeout.replace(CANCEL_TIMEOUT);
+        let saved_timeout = self.remaining_request_timeout.replace(CANCEL_TIMEOUT);
+        let saved_cancel = self.cancel_handle.take();
         let drained = self.drain_stream().await;
-        self.remaining_request_timeout = saved;
+        self.cancel_handle = saved_cancel;
+        self.remaining_request_timeout = saved_timeout;
         match drained {
             Ok(_) => Withdrawal::Done,
             Err(error) => Withdrawal::Failed(error),
         }
+    }
+
+    /// Hands back the RESETCONNECTION bit a withdrawn message carried away.
+    ///
+    /// Packet #1 recorded the dispatch, but the server discards the whole
+    /// ignored message, reset included. Leaving that record set would make the
+    /// withdrawal's own DONE look like a request that ran without resetting, and
+    /// `observe_response_token` would condemn a connection that is still fine.
+    fn rearm_withdrawn_reset(&mut self, carried_reset: ResetConnectionMode) {
+        if carried_reset == ResetConnectionMode::None {
+            return;
+        }
+        let writer = self.transport.as_writer();
+        writer.take_reset_dispatched();
+        writer.set_reset_mode(carried_reset);
     }
 
     /// Closes the transport after a request could not be retracted.
@@ -6358,6 +6396,9 @@ mod tests {
         /// When set, the next (and every subsequent) `send` fails, simulating a
         /// mid-message wire failure. Shared so a test can flip it after setup.
         send_should_fail: Arc<std::sync::atomic::AtomicBool>,
+        /// When set, `send` never returns, so a test can drive a write deadline
+        /// without a real stalled peer.
+        send_should_hang: Arc<std::sync::atomic::AtomicBool>,
         /// Cached liveness flag toggled by `mark_known_dead`, surfaced through
         /// `connection_known_dead` so tests can assert the fatal-error path.
         known_dead: bool,
@@ -6380,6 +6421,7 @@ mod tests {
                 packet_pos: 0,
                 resume_results: VecDeque::new(),
                 send_should_fail: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                send_should_hang: Arc::new(std::sync::atomic::AtomicBool::new(false)),
                 known_dead: false,
                 encryption_setting: NegotiatedEncryptionSetting::NoEncryption,
                 receive_timeouts: Arc::new(std::sync::Mutex::new(Vec::new())),
@@ -6419,12 +6461,22 @@ mod tests {
             &mut self,
             _context: &ParserContext,
             remaining_request_timeout: Option<Duration>,
-            _cancel_handle: Option<&CancelHandle>,
+            cancel_handle: Option<&CancelHandle>,
         ) -> TdsResult<Tokens> {
             self.receive_timeouts
                 .lock()
                 .unwrap()
                 .push(remaining_request_timeout);
+            // Mirrors the production readers, which run every read under the
+            // handle. Without this a cancelled read looks identical to a healthy
+            // one and tests cannot tell the two apart.
+            if let Some(handle) = cancel_handle
+                && handle.cancel_token.is_cancelled()
+            {
+                return Err(crate::error::Error::OperationCancelledError(
+                    "Request was cancelled".to_string(),
+                ));
+            }
             if let Some(tok) = self.pending_tokens.pop_front() {
                 return Ok(tok);
             }
@@ -6514,6 +6566,12 @@ mod tests {
                 return Err(crate::error::Error::ConnectionClosed(
                     "injected send failure".to_string(),
                 ));
+            }
+            if self
+                .send_should_hang
+                .load(std::sync::atomic::Ordering::SeqCst)
+            {
+                std::future::pending::<()>().await;
             }
             self.sent.lock().unwrap().extend_from_slice(data);
             Ok(())
@@ -11353,11 +11411,21 @@ mod tests {
     /// Opens an RPC message with `payload_len` bytes and suspends it - the state
     /// a send site holds when serialization fails part-way.
     async fn suspend_message_with(client: &mut TdsClient, payload_len: usize) -> SuspendedMessage {
+        suspend_message_under(client, payload_len, None).await
+    }
+
+    /// As [`suspend_message_with`], but the message carries `cancel_handle` the
+    /// way a real request's writer does.
+    async fn suspend_message_under(
+        client: &mut TdsClient,
+        payload_len: usize,
+        cancel_handle: Option<&CancelHandle>,
+    ) -> SuspendedMessage {
         let mut writer = PacketWriter::new(
             PacketType::RpcRequest,
             client.transport.as_writer(),
             None,
-            None,
+            cancel_handle,
         );
         writer
             .write_async(&vec![0xABu8; payload_len])
@@ -11425,6 +11493,78 @@ mod tests {
         assert!(
             !client.is_connection_dead(),
             "a retracted request leaves the connection clean for reuse"
+        );
+    }
+
+    /// Packet #1 recorded the RESETCONNECTION dispatch, but the server discards
+    /// the whole ignored message, reset included. Unless the record is cleared
+    /// and the bit re-armed, the withdrawal's own DONE reads as a request that
+    /// ran without resetting and condemns a healthy connection.
+    #[tokio::test]
+    async fn retracting_hands_back_a_reset_the_server_discarded() {
+        let (mut client, _sent) = create_capturing_client(vec![done_no_more()]);
+        client.prepare_reset_connection(false);
+        let message = suspend_message_with(&mut client, 10_000).await;
+        assert!(!message.nothing_sent(), "the reset must be on the wire");
+
+        client.retract_partial_request(message).await;
+
+        assert!(
+            !client.is_connection_dead(),
+            "withdrawing a reset-carrying request must not condemn the connection"
+        );
+        assert_eq!(
+            client.transport.as_writer().take_reset_mode(),
+            ResetConnectionMode::Reset,
+            "the discarded reset must ride the next request instead"
+        );
+    }
+
+    /// The retraction must not inherit the caller's cancellation. The request is
+    /// already over; a cancelled cleanup would strand the very message it exists
+    /// to withdraw.
+    #[tokio::test]
+    async fn retracting_ignores_a_cancel_fired_against_the_request() {
+        use crate::message::messages::PacketStatusFlags;
+
+        let (mut client, sent) = create_capturing_client(vec![done_no_more()]);
+        let parent = CancelHandle::new();
+        let message = suspend_message_under(&mut client, 10_000, Some(&parent)).await;
+        client.cancel_handle = Some(parent.child_handle());
+        parent.cancel();
+
+        client.retract_partial_request(message).await;
+
+        let wire = sent.lock().unwrap().clone();
+        let last = &wire[wire.len() - PacketWriter::PACKET_HEADER_SIZE..];
+        assert_eq!(
+            last[1],
+            PacketStatusFlags::Eom as u8 | PacketStatusFlags::Ignore as u8,
+            "a fired cancel must not stop the ignore packet"
+        );
+        assert!(
+            !client.is_connection_dead(),
+            "the drain must still run, leaving the connection reusable"
+        );
+    }
+
+    /// `PacketWriter` only checks its budget once a write returns, so a stalled
+    /// peer would block the withdrawal forever. The deadline must fire, and the
+    /// transport must be retired rather than reused - dropping a write future
+    /// mid-flight is only safe because nothing writes to that stream again.
+    #[tokio::test(start_paused = true)]
+    async fn the_ignore_packet_gives_up_on_a_stalled_peer() {
+        let transport = TestTransport::new();
+        let hang = Arc::clone(&transport.send_should_hang);
+        let mut client = create_test_client_with_transport(transport);
+        let message = suspend_message_with(&mut client, 10_000).await;
+
+        hang.store(true, std::sync::atomic::Ordering::SeqCst);
+        client.retract_partial_request(message).await;
+
+        assert!(
+            client.is_connection_dead(),
+            "a withdrawal that cannot be written must retire the transport"
         );
     }
 

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -73,6 +73,7 @@ const CANCEL_TIMEOUT_SECS: u32 = 120;
 /// Derived rather than converted, so the budget cannot degrade to unbounded.
 const CANCEL_TIMEOUT: Duration = Duration::from_secs(CANCEL_TIMEOUT_SECS as u64);
 
+#[derive(Debug)]
 enum Withdrawal {
     /// Ignore packet sent and the server's DONE consumed.
     Done,
@@ -80,6 +81,9 @@ enum Withdrawal {
     ConnectionAlreadyDead,
     /// Neither complete nor retracted; the transport must go.
     Failed(crate::error::Error),
+    /// The ignore write was dropped mid-flight, so the transport must go
+    /// *without* another write on the stream.
+    WriteAbandoned(crate::error::Error),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1384,11 +1388,8 @@ impl TdsClient {
             rpc.create_packet_writer(self.transport.as_writer(), timeout_sec, cancel_handle);
         let serialize_result = rpc.serialize(&mut packet_writer).await;
         let message = packet_writer.suspend();
-        if let Err(e) = serialize_result {
-            drop(rpc);
-            self.retract_partial_request(message).await;
-            return Err(e);
-        }
+        drop(rpc);
+        self.finish_send(serialize_result, message).await?;
 
         self.position_on_first_result().await
     }
@@ -1828,6 +1829,10 @@ impl TdsClient {
                 warn!(%error, "Failed to withdraw a cancelled streamed write");
                 self.abort_streamed_write().await;
             }
+            Withdrawal::WriteAbandoned(error) => {
+                warn!(%error, "Abandoned a cancelled streamed write mid-write");
+                self.retire_without_writing();
+            }
         }
     }
 
@@ -1839,6 +1844,11 @@ impl TdsClient {
     /// [`cancel_streamed_write`](Self::cancel_streamed_write), for the ordinary
     /// (non-data-at-execution) path.
     async fn retract_partial_request(&mut self, message: SuspendedMessage) {
+        // Before anything that drains: a RETURNVALUE read with the capture still
+        // armed would record a handle for a request that never ran.
+        // `cancel_streamed_write` disarms up front for the same reason.
+        self.abort_pending_prepare_capture();
+
         if message.nothing_sent() {
             // Not a plain drop: re-arm the RESETCONNECTION bit this message took.
             message.abandon(self.transport.as_writer());
@@ -1853,6 +1863,10 @@ impl TdsClient {
             Withdrawal::Failed(error) => {
                 warn!(%error, "Failed to withdraw a partially sent request");
                 self.abort_partial_request().await;
+            }
+            Withdrawal::WriteAbandoned(error) => {
+                warn!(%error, "Abandoned a partially sent request mid-write");
+                self.retire_without_writing();
             }
         }
     }
@@ -1881,9 +1895,9 @@ impl TdsClient {
             self.transport.as_writer(),
         );
         // `PacketWriter` only checks its budget once a write returns, so the
-        // ignore packet needs a deadline of its own. Dropping a write future
-        // mid-flight is safe only because every path out of a failed withdrawal
-        // retires the transport, as `send_attention_and_wait` does.
+        // ignore packet needs a deadline of its own. Timing out drops the write
+        // future, which leaves the TLS stream mid-record, so that branch retires
+        // the transport without writing to it again.
         let ignored =
             tokio::time::timeout(CANCEL_TIMEOUT, packet_writer.cancel_current_message()).await;
         drop(packet_writer);
@@ -1891,7 +1905,7 @@ impl TdsClient {
             Ok(Ok(())) => {}
             Ok(Err(error)) => return Withdrawal::Failed(error),
             Err(_) => {
-                return Withdrawal::Failed(crate::error::Error::TimeoutError(
+                return Withdrawal::WriteAbandoned(crate::error::Error::TimeoutError(
                     crate::error::TimeoutErrorType::String(
                         "Timed out sending the ignore packet".to_string(),
                     ),
@@ -1920,6 +1934,11 @@ impl TdsClient {
     /// ignored message, reset included. Leaving that record set would make the
     /// withdrawal's own DONE look like a request that ran without resetting, and
     /// `observe_response_token` would condemn a connection that is still fine.
+    ///
+    /// Deliberately diverges from msodbcsql, which clears `m_fResetConnection`
+    /// as the bit goes out (`SendPacket`, `tds/TdsSend.cpp`) and re-arms only on
+    /// pooled reuse (`odbc/sqlcmisc.cpp`). It has the same hole and never
+    /// notices, having no reset-acknowledgement check to break.
     fn rearm_withdrawn_reset(&mut self, carried_reset: ResetConnectionMode) {
         if carried_reset == ResetConnectionMode::None {
             return;
@@ -1928,17 +1947,45 @@ impl TdsClient {
         self.transport.as_writer().set_reset_mode(carried_reset);
     }
 
+    /// Completes a send, retracting the half-sent message when serialization
+    /// failed so the failure costs the request rather than the connection.
+    ///
+    /// The `drop(rpc)` stays at each call site: `SqlRpc` borrows
+    /// `&self.execution_context`, so that borrow has to end before `&mut self`.
+    async fn finish_send(
+        &mut self,
+        serialize_result: TdsResult<()>,
+        message: SuspendedMessage,
+    ) -> TdsResult<()> {
+        if let Err(e) = serialize_result {
+            self.retract_partial_request(message).await;
+            return Err(e);
+        }
+        Ok(())
+    }
+
     /// Closes the transport after a request could not be retracted.
     /// RESETCONNECTION applies to a later request and cannot terminate an
     /// incomplete one, so the socket is all that is left to discard. Clearing
     /// the open-batch flag lets the next `check_and_reconnect` recover.
     async fn abort_partial_request(&mut self) {
-        self.execution_context.set_has_open_batch(false);
-        self.abort_pending_prepare_capture();
-        self.transport.mark_known_dead();
+        self.retire_without_writing();
         if let Err(error) = self.transport.close_transport().await {
             warn!(%error, "Failed to close transport after a partial request abort");
         }
+    }
+
+    /// Retires the transport without shutting the stream down.
+    ///
+    /// For a write that was dropped mid-flight the stream may still hold a
+    /// half-flushed record, and `close_transport` shuts it down — which on the
+    /// native-tls engine emits a close_notify, one more write on exactly that
+    /// stream. `send_attention_and_wait` avoids it the same way, by marking the
+    /// connection dead and never writing again.
+    fn retire_without_writing(&mut self) {
+        self.execution_context.set_has_open_batch(false);
+        self.abort_pending_prepare_capture();
+        self.transport.mark_known_dead();
     }
 
     /// Marks the streamed parameter currently open for data as SQL NULL.
@@ -2580,11 +2627,8 @@ impl TdsClient {
             rpc.create_packet_writer(self.transport.as_writer(), timeout_sec, cancel_handle);
         let serialize_result = rpc.serialize(&mut packet_writer).await;
         let message = packet_writer.suspend();
-        if let Err(e) = serialize_result {
-            drop(rpc);
-            self.retract_partial_request(message).await;
-            return Err(e);
-        }
+        drop(rpc);
+        self.finish_send(serialize_result, message).await?;
 
         self.position_on_first_result().await
     }
@@ -2732,11 +2776,8 @@ impl TdsClient {
             rpc.create_packet_writer(self.transport.as_writer(), timeout_sec, cancel_handle);
         let serialize_result = rpc.serialize(&mut packet_writer).await;
         let message = packet_writer.suspend();
-        if let Err(e) = serialize_result {
-            drop(rpc);
-            self.retract_partial_request(message).await;
-            return Err(e);
-        }
+        drop(rpc);
+        self.finish_send(serialize_result, message).await?;
 
         // Drain to completion to get output parameters and any server errors.
         let server_errors = self.drain_stream_or_retire().await?;
@@ -2866,11 +2907,8 @@ impl TdsClient {
             rpc.create_packet_writer(self.transport.as_writer(), timeout_sec, cancel_handle);
         let serialize_result = rpc.serialize(&mut packet_writer).await;
         let message = packet_writer.suspend();
-        if let Err(e) = serialize_result {
-            drop(rpc);
-            self.retract_partial_request(message).await;
-            return Err(e);
-        }
+        drop(rpc);
+        self.finish_send(serialize_result, message).await?;
 
         // Drain the result set. A successful unprepare returns no results,
         // but surface any server errors collected during the drain instead of
@@ -3343,13 +3381,8 @@ impl TdsClient {
             rpc.create_packet_writer(self.transport.as_writer(), timeout_sec, cancel_handle);
         let serialize_result = rpc.serialize(&mut packet_writer).await;
         let message = packet_writer.suspend();
-        if let Err(e) = serialize_result {
-            drop(rpc);
-            // Before the retraction, not after: it drains, and a RETURNVALUE read
-            // with the capture still armed would record a handle for an execute
-            // that never ran.
-            self.abort_pending_prepare_capture();
-            self.retract_partial_request(message).await;
+        drop(rpc);
+        if let Err(e) = self.finish_send(serialize_result, message).await {
             self.report_issued_id(issued_id, statement_id);
             return Err(e);
         }
@@ -3523,11 +3556,8 @@ impl TdsClient {
             rpc.create_packet_writer(self.transport.as_writer(), timeout_sec, cancel_handle);
         let serialize_result = rpc.serialize(&mut packet_writer).await;
         let message = packet_writer.suspend();
-        if let Err(e) = serialize_result {
-            drop(rpc);
-            self.retract_partial_request(message).await;
-            return Err(e);
-        }
+        drop(rpc);
+        self.finish_send(serialize_result, message).await?;
 
         self.position_on_first_result().await
     }
@@ -4491,11 +4521,8 @@ impl TdsClient {
             rpc.create_packet_writer(self.transport.as_writer(), timeout_sec, cancel_handle);
         let serialize_result = rpc.serialize(&mut packet_writer).await;
         let message = packet_writer.suspend();
-        if let Err(e) = serialize_result {
-            drop(rpc);
-            self.retract_partial_request(message).await;
-            return Err(e);
-        }
+        drop(rpc);
+        self.finish_send(serialize_result, message).await?;
 
         let mut result = DescribeParameterEncryptionResult::new();
 

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -73,6 +73,15 @@ const CANCEL_TIMEOUT_SECS: u32 = 120;
 /// Derived rather than converted, so the budget cannot degrade to unbounded.
 const CANCEL_TIMEOUT: Duration = Duration::from_secs(CANCEL_TIMEOUT_SECS as u64);
 
+/// Budget for the ignore packet itself, strictly below [`CANCEL_TIMEOUT`].
+///
+/// `PacketWriter` checks this only after a write returns, so it can fire only
+/// while the stream is still intact — which yields the graceful arm, closing the
+/// transport normally. The outer deadline instead drops the write future and
+/// forces retirement without a shutdown, so a merely slow peer should reach this
+/// one first. Only the ordering matters; the exact value does not.
+const CANCEL_WRITE_TIMEOUT_SECS: u32 = CANCEL_TIMEOUT_SECS / 2;
+
 #[derive(Debug)]
 enum Withdrawal {
     /// Ignore packet sent and the server's DONE consumed.
@@ -1872,7 +1881,10 @@ impl TdsClient {
     }
 
     /// Closes an already-sent message with `EOM | IGNORE` and consumes the DONE
-    /// the server answers it with, both under [`CANCEL_TIMEOUT`].
+    /// the server answers it with, each under its own [`CANCEL_TIMEOUT`] — they
+    /// run in sequence, so a withdrawal can hold the caller for twice that.
+    /// msodbcsql is the same shape: `SendPacket(.., DEFAULT_CANCEL_TIMEOUT)`
+    /// followed by `FlushInputStream`.
     async fn withdraw_sent_message(&mut self, message: SuspendedMessage) -> Withdrawal {
         // Cached read, not `is_connection_dead`: that one `try_read`s a byte,
         // which here could swallow the server's answer to the half-written
@@ -1890,14 +1902,14 @@ impl TdsClient {
 
         let mut packet_writer = PacketWriter::resume(
             message
-                .with_write_timeout(Some(CANCEL_TIMEOUT_SECS))
+                .with_write_timeout(Some(CANCEL_WRITE_TIMEOUT_SECS))
                 .without_cancellation(),
             self.transport.as_writer(),
         );
         // `PacketWriter` only checks its budget once a write returns, so the
-        // ignore packet needs a deadline of its own. Timing out drops the write
-        // future, which leaves the TLS stream mid-record, so that branch retires
-        // the transport without writing to it again.
+        // ignore packet needs an outer deadline too. Reaching that one means the
+        // write never came back, so the future is dropped mid-record and the
+        // transport is retired without being written to again.
         let ignored =
             tokio::time::timeout(CANCEL_TIMEOUT, packet_writer.cancel_current_message()).await;
         drop(packet_writer);

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -1319,7 +1319,9 @@ impl TdsClient {
         let batch = SqlBatch::new(sql_command, &self.execution_context);
         let mut packet_writer =
             batch.create_packet_writer(self.transport.as_writer(), timeout, cancel);
-        batch.serialize(&mut packet_writer).await?;
+        let serialize_result = batch.serialize(&mut packet_writer).await;
+        let message = packet_writer.suspend();
+        self.finish_send(serialize_result, message).await?;
         Ok(())
     }
 
@@ -2502,7 +2504,9 @@ impl TdsClient {
         let batch = SqlBatch::new(sql_command, &self.execution_context);
         let mut packet_writer =
             batch.create_packet_writer(self.transport.as_writer(), timeout_sec, cancel_handle);
-        batch.serialize(&mut packet_writer).await?;
+        let serialize_result = batch.serialize(&mut packet_writer).await;
+        let message = packet_writer.suspend();
+        self.finish_send(serialize_result, message).await?;
 
         // Consume the response
         self.consume_done_token().await

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -1619,6 +1619,8 @@ impl TdsClient {
             // The prefix runs every materialized parameter through the same
             // checks as the non-streamed sites, so this is retractable rather
             // than a reason to discard the connection.
+            // Not redundant: this function has no entry guard against an already
+            // active stream, and the retraction does not touch the field.
             self.streamed_write_state = StreamedWriteState::Idle;
             self.retract_partial_request(message).await;
             return Err(error);
@@ -1851,13 +1853,13 @@ impl TdsClient {
         }
     }
 
-    /// Retracts a request whose serialization failed part-way, so the failure
-    /// costs the request rather than the connection.
+    /// Gives up a request whose serialization failed, so the failure costs the
+    /// request rather than the connection.
     ///
-    /// Without it the server holds a truncated message and answers 4002 on the
-    /// *next* command. Same handling as
-    /// [`cancel_streamed_write`](Self::cancel_streamed_write), for the ordinary
-    /// (non-data-at-execution) path.
+    /// How depends on how much of the message reached the server: nothing is
+    /// discarded locally, part is withdrawn with `EOM | IGNORE`, and all of it is
+    /// cancelled with an attention. Without this the server holds a truncated
+    /// message and answers 4002 on the *next* command.
     async fn retract_partial_request(&mut self, message: SuspendedMessage) {
         // Before anything that drains: a RETURNVALUE read with the capture still
         // armed would record a handle for a request that never ran.
@@ -1877,6 +1879,11 @@ impl TdsClient {
             // and leave its DONE for the next command. Cancel with an attention
             // instead, which is msodbcsql's `STATE_BATCH_CMDSENT` arm. The
             // transport marks itself dead if the attention goes unacknowledged.
+            //
+            // Bounded by `ATTENTION_TIMEOUT_SECONDS`, not `CANCEL_TIMEOUT`:
+            // msodbcsql passes its 120s cancel budget here too, but an ACK that
+            // has not arrived in 5s is not coming, and the bulk-load abort takes
+            // the same bound for the same reason.
             //
             // Dropped rather than abandoned: this message carried its reset bit
             // all the way out and `note_reset_dispatched` recorded it, so the
@@ -2203,7 +2210,6 @@ impl TdsClient {
             // connection for a failure that cost only the request.
             Err(e) => {
                 let message = packet_writer.suspend();
-                self.streamed_write_state = StreamedWriteState::Idle;
                 self.retract_partial_request(message).await;
                 Err(e)
             }
@@ -6705,7 +6711,11 @@ mod tests {
         async fn send_attention_with_timeout(&mut self, _timeout: Duration) -> TdsResult<bool> {
             self.attentions
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            Ok(false)
+            // Acknowledged. `Ok(false)` would mean the ACK never came, and
+            // `send_attention_and_wait` retires the transport on every such
+            // outcome - a mock that returned it without doing so would let a test
+            // read a dead connection as a surviving one.
+            Ok(true)
         }
         fn is_connection_dead(&self) -> bool {
             self.closed
@@ -11685,6 +11695,10 @@ mod tests {
             sent.lock().unwrap().len(),
             sent_before,
             "no second message may be opened to withdraw the first"
+        );
+        assert!(
+            !client.transport.connection_known_dead(),
+            "an acknowledged attention leaves the connection reusable"
         );
     }
 

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -63,16 +63,24 @@ const SYNTHETIC_POSITIONAL_PARAM_PREFIX: &str = "ce_pos_";
 /// it, even if the socket is still readable.
 const FATAL_ERROR_SEVERITY: u8 = 20;
 
-/// Wall-clock budget for withdrawing a request, deliberately independent of the
-/// request's own timeout.
+/// Budget for withdrawing a request, independent of the request's own timeout.
 ///
-/// A request may legitimately run without one - ODBC's `SQL_ATTR_QUERY_TIMEOUT`
-/// defaults to 0, which leaves `remaining_request_timeout` as `None` - but
-/// giving up the connection must not inherit that. Without a bound, a server
-/// that never answers the withdrawal blocks the caller forever while it holds
-/// the connection, which is worse than the dead connection being recovered
-/// from. msodbcsql draws the same line with `DEFAULT_CANCEL_TIMEOUT`.
-const CANCEL_TIMEOUT: Duration = Duration::from_secs(120);
+/// `remaining_request_timeout` is `None` whenever `SQL_ATTR_QUERY_TIMEOUT` is 0,
+/// and inheriting that would block the caller forever on a server that never
+/// acknowledges the withdrawal. Matches msodbcsql's `DEFAULT_CANCEL_TIMEOUT`.
+const CANCEL_TIMEOUT_SECS: u32 = 120;
+
+/// Derived rather than converted, so the budget cannot degrade to unbounded.
+const CANCEL_TIMEOUT: Duration = Duration::from_secs(CANCEL_TIMEOUT_SECS as u64);
+
+enum Withdrawal {
+    /// Ignore packet sent and the server's DONE consumed.
+    Done,
+    /// Nothing attempted: no stream left to resynchronize, so not an error.
+    ConnectionAlreadyDead,
+    /// Neither complete nor retracted; the transport must go.
+    Failed(crate::error::Error),
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(in crate::connection) enum CommandTimeoutBudget {
@@ -1812,29 +1820,24 @@ impl TdsClient {
             return;
         }
 
-        if let Err(error) = self.withdraw_sent_message(context.message).await {
-            warn!(%error, "Failed to withdraw a cancelled streamed write");
-            self.abort_streamed_write().await;
-            return;
+        match self.withdraw_sent_message(context.message).await {
+            Withdrawal::Done | Withdrawal::ConnectionAlreadyDead => {
+                self.execution_context.set_has_open_batch(false);
+            }
+            Withdrawal::Failed(error) => {
+                warn!(%error, "Failed to withdraw a cancelled streamed write");
+                self.abort_streamed_write().await;
+            }
         }
-
-        self.execution_context.set_has_open_batch(false);
     }
 
     /// Retracts a request whose serialization failed part-way, so the failure
     /// costs the request rather than the connection.
     ///
-    /// Same state-aware handling as
+    /// Without it the server holds a truncated message and answers 4002 on the
+    /// *next* command. Same handling as
     /// [`cancel_streamed_write`](Self::cancel_streamed_write), for the ordinary
-    /// (non-data-at-execution) path: a message that never reached the network is
-    /// dropped locally, one that did is closed with `EOM | IGNORE` and the DONE
-    /// it is answered with is consumed. Without this the server reads a
-    /// truncated stream and answers 4002 on the *next* command.
-    ///
-    /// Serialization can fail after a flush whenever a value is rejected late -
-    /// a declared length the encoded bytes exceed, or a length field that does
-    /// not fit its wire width - and an earlier parameter has already filled a
-    /// packet.
+    /// (non-data-at-execution) path.
     async fn retract_partial_request(&mut self, message: SuspendedMessage) {
         if message.nothing_sent() {
             // Not a plain drop: re-arm the RESETCONNECTION bit this message took.
@@ -1843,54 +1846,52 @@ impl TdsClient {
             return;
         }
 
-        if let Err(error) = self.withdraw_sent_message(message).await {
-            warn!(%error, "Failed to withdraw a partially sent request");
-            self.abort_partial_request().await;
-            return;
+        match self.withdraw_sent_message(message).await {
+            Withdrawal::Done | Withdrawal::ConnectionAlreadyDead => {
+                self.execution_context.set_has_open_batch(false);
+            }
+            Withdrawal::Failed(error) => {
+                warn!(%error, "Failed to withdraw a partially sent request");
+                self.abort_partial_request().await;
+            }
         }
-
-        self.execution_context.set_has_open_batch(false);
     }
 
     /// Closes an already-sent message with `EOM | IGNORE` and consumes the DONE
     /// the server answers it with, both under [`CANCEL_TIMEOUT`].
-    ///
-    /// Shared by the two retraction paths so neither can inherit the request's
-    /// (possibly absent) timeout and block indefinitely on a server that never
-    /// acknowledges the withdrawal.
-    async fn withdraw_sent_message(&mut self, message: SuspendedMessage) -> TdsResult<()> {
-        // A dead socket cannot carry the withdrawal, and attempting it would
-        // only surface a write error the caller must translate back into the
-        // same abort. msodbcsql skips the same way (`RemoveAllCommands` guards
-        // on `FIsConnectionDead`).
-        if self.transport.is_connection_dead() {
-            return Err(crate::error::Error::ProtocolError(
-                "connection is dead; a partially sent request cannot be withdrawn".to_string(),
-            ));
+    async fn withdraw_sent_message(&mut self, message: SuspendedMessage) -> Withdrawal {
+        // Cached read, not `is_connection_dead`: that one `try_read`s a byte,
+        // which here could swallow the server's answer to the half-written
+        // request. msodbcsql's `FIsConnectionDead` is likewise a cached flag.
+        if self.transport.connection_known_dead() {
+            return Withdrawal::ConnectionAlreadyDead;
         }
 
-        let budget_secs = u32::try_from(CANCEL_TIMEOUT.as_secs()).ok();
         let mut packet_writer = PacketWriter::resume(
-            message.with_write_timeout(budget_secs),
+            message.with_write_timeout(Some(CANCEL_TIMEOUT_SECS)),
             self.transport.as_writer(),
         );
         let ignored = packet_writer.cancel_current_message().await;
         drop(packet_writer);
-        ignored?;
+        if let Err(error) = ignored {
+            return Withdrawal::Failed(error);
+        }
 
         // The server acknowledges an ignored message with a DONE. Leaving it
-        // unread would desynchronize the next command on this connection.
+        // unread would desynchronize the next command.
         let saved = self.remaining_request_timeout.replace(CANCEL_TIMEOUT);
         let drained = self.drain_stream().await;
         self.remaining_request_timeout = saved;
-        drained.map(|_| ())
+        match drained {
+            Ok(_) => Withdrawal::Done,
+            Err(error) => Withdrawal::Failed(error),
+        }
     }
 
-    /// Closes the transport after a partially sent request could not be
-    /// retracted. RESETCONNECTION applies to a later request and cannot
-    /// terminate an incomplete one, so the socket is the only thing left to
-    /// discard. Clearing the open-batch flag lets the next
-    /// [`check_and_reconnect`](Self::check_and_reconnect) recover the session.
+    /// Closes the transport after a request could not be retracted.
+    /// RESETCONNECTION applies to a later request and cannot terminate an
+    /// incomplete one, so the socket is all that is left to discard. Clearing
+    /// the open-batch flag lets the next `check_and_reconnect` recover.
     async fn abort_partial_request(&mut self) {
         self.execution_context.set_has_open_batch(false);
         self.abort_pending_prepare_capture();
@@ -1903,7 +1904,8 @@ impl TdsClient {
     /// Marks the streamed parameter currently open for data as SQL NULL.
     ///
     /// Call this instead of [`write_streamed_chunk`](Self::write_streamed_chunk)
-    /// when a data-at-execution parameter resolves to NULL (the ODBC    /// `SQLPutData(SQL_NULL_DATA)` case). No bytes are written now; when the
+    /// when a data-at-execution parameter resolves to NULL (the ODBC
+    /// `SQLPutData(SQL_NULL_DATA)` case). No bytes are written now; when the
     /// parameter is closed with [`end_streamed_param`](Self::end_streamed_param)
     /// the driver emits `PLP_NULL` instead of an unknown-length opener +
     /// terminator. Mirrors msodbcsql, which writes `VARMAX_LENGTH_NULL` with no
@@ -11348,9 +11350,8 @@ mod tests {
         ));
     }
 
-    /// Opens an RPC message and writes `payload_len` bytes into it, returning it
-    /// suspended — the state a send site is left holding when serialization
-    /// fails part-way through a request.
+    /// Opens an RPC message with `payload_len` bytes and suspends it - the state
+    /// a send site holds when serialization fails part-way.
     async fn suspend_message_with(client: &mut TdsClient, payload_len: usize) -> SuspendedMessage {
         let mut writer = PacketWriter::new(
             PacketType::RpcRequest,
@@ -11365,11 +11366,15 @@ mod tests {
         writer.suspend()
     }
 
-    /// A request that never reached the network is dropped locally: the server
-    /// never learned it existed, so telling it to ignore one would be a lie.
+    /// Dropped locally, and `abandon` rather than `drop` because opening the
+    /// message consumed the connection's pending RESETCONNECTION bit.
     #[tokio::test]
     async fn retract_partial_request_before_first_packet_discards_locally() {
         let (mut client, sent) = create_capturing_client(vec![]);
+        client
+            .transport
+            .as_writer()
+            .set_reset_mode(ResetConnectionMode::Reset);
         let message = suspend_message_with(&mut client, 16).await;
         assert!(message.nothing_sent());
 
@@ -11379,6 +11384,11 @@ mod tests {
             sent.lock().unwrap().is_empty(),
             "a request the server never saw must not be retracted over the wire"
         );
+        assert_eq!(
+            client.transport.as_writer().take_reset_mode(),
+            ResetConnectionMode::Reset,
+            "the abandoned message must hand its reset back to the connection"
+        );
         assert!(
             !client.is_connection_dead(),
             "abandoning an unsent request must leave the connection reusable"
@@ -11386,9 +11396,7 @@ mod tests {
     }
 
     /// Once a packet is on the wire the server is mid-message, so the request is
-    /// closed with EOM | IGNORE and the DONE it answers with is consumed. Without
-    /// this the next command is read as a continuation and the server answers
-    /// 4002.
+    /// closed with EOM | IGNORE and its DONE consumed.
     #[tokio::test]
     async fn retract_partial_request_after_partial_send_ignores_and_drains() {
         use crate::message::messages::PacketStatusFlags;
@@ -11452,16 +11460,15 @@ mod tests {
         );
     }
 
-    /// A dead socket cannot carry the withdrawal. Attempting it would only
-    /// surface a write error that maps back to the same abort, so the guard
-    /// skips straight there — matching msodbcsql's `FIsConnectionDead` check in
-    /// `RemoveAllCommands`.
+    /// The liveness check is the cached flag, never the socket-polling
+    /// `is_connection_dead`: this runs with a half-written message outstanding,
+    /// where a `try_read` probe could swallow the server's answer to it.
     #[tokio::test]
     async fn retract_partial_request_skips_the_withdrawal_on_a_dead_connection() {
         let (mut client, sent) = create_capturing_client(vec![done_no_more()]);
         let message = suspend_message_with(&mut client, 10_000).await;
         let sent_before = sent.lock().unwrap().len();
-        client.transport.close_transport().await.unwrap();
+        client.transport.mark_known_dead();
 
         client.retract_partial_request(message).await;
 
@@ -11470,7 +11477,47 @@ mod tests {
             sent_before,
             "no withdrawal may be attempted on a dead connection"
         );
-        assert!(client.is_connection_dead());
+    }
+
+    /// Drives a real send site, so removing the retraction from
+    /// `execute_sp_executesql` cannot leave the suite green. Parameter 1 flushes
+    /// a packet; parameter 2 is rejected by `serialize_string` after it.
+    #[tokio::test]
+    async fn a_send_site_retracts_when_serialization_fails_after_a_flush() {
+        use crate::message::messages::PacketStatusFlags;
+
+        let (mut client, sent) = create_capturing_client(vec![done_no_more()]);
+        let big = RpcParameter::new(
+            Some("@big".to_string()),
+            StatusFlags::NONE,
+            SqlType::VarcharMax(Some(SqlString::from_utf8_string("a".repeat(20_000)))),
+        );
+        let overlong = RpcParameter::new(
+            Some("@bad".to_string()),
+            StatusFlags::NONE,
+            SqlType::Varchar(
+                Some(SqlString::from_utf8_string("abcdefghij".to_string())),
+                1,
+            ),
+        );
+
+        let result = client
+            .execute_sp_executesql("SELECT @big, @bad".to_string(), vec![big, overlong], ())
+            .await;
+
+        assert!(result.is_err(), "the over-long value must be rejected");
+
+        let wire = sent.lock().unwrap().clone();
+        let last = &wire[wire.len() - PacketWriter::PACKET_HEADER_SIZE..];
+        assert_eq!(
+            last[1],
+            PacketStatusFlags::Eom as u8 | PacketStatusFlags::Ignore as u8,
+            "the half-sent request must be withdrawn, not dropped"
+        );
+        assert!(
+            !client.is_connection_dead(),
+            "a withdrawn request leaves the connection reusable"
+        );
     }
 
     /// The retraction runs on its own budget, so a request that had a timeout

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -63,6 +63,17 @@ const SYNTHETIC_POSITIONAL_PARAM_PREFIX: &str = "ce_pos_";
 /// it, even if the socket is still readable.
 const FATAL_ERROR_SEVERITY: u8 = 20;
 
+/// Wall-clock budget for withdrawing a request, deliberately independent of the
+/// request's own timeout.
+///
+/// A request may legitimately run without one - ODBC's `SQL_ATTR_QUERY_TIMEOUT`
+/// defaults to 0, which leaves `remaining_request_timeout` as `None` - but
+/// giving up the connection must not inherit that. Without a bound, a server
+/// that never answers the withdrawal blocks the caller forever while it holds
+/// the connection, which is worse than the dead connection being recovered
+/// from. msodbcsql draws the same line with `DEFAULT_CANCEL_TIMEOUT`.
+const CANCEL_TIMEOUT: Duration = Duration::from_secs(120);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(in crate::connection) enum CommandTimeoutBudget {
     None,
@@ -1363,7 +1374,13 @@ impl TdsClient {
 
         let mut packet_writer =
             rpc.create_packet_writer(self.transport.as_writer(), timeout_sec, cancel_handle);
-        rpc.serialize(&mut packet_writer).await?;
+        let serialize_result = rpc.serialize(&mut packet_writer).await;
+        let message = packet_writer.suspend();
+        if let Err(e) = serialize_result {
+            drop(rpc);
+            self.retract_partial_request(message).await;
+            return Err(e);
+        }
 
         self.position_on_first_result().await
     }
@@ -1795,20 +1812,8 @@ impl TdsClient {
             return;
         }
 
-        let mut packet_writer = PacketWriter::resume(context.message, self.transport.as_writer());
-        let ignored = packet_writer.cancel_current_message().await;
-        drop(packet_writer);
-
-        if let Err(error) = ignored {
-            warn!(%error, "Failed to send ignore packet for cancelled streamed write");
-            self.abort_streamed_write().await;
-            return;
-        }
-
-        // The server acknowledges an ignored message with a DONE. Leaving it
-        // unread would desynchronize the next command on this connection.
-        if let Err(error) = self.drain_stream().await {
-            warn!(%error, "Failed to drain response to cancelled streamed write");
+        if let Err(error) = self.withdraw_sent_message(context.message).await {
+            warn!(%error, "Failed to withdraw a cancelled streamed write");
             self.abort_streamed_write().await;
             return;
         }
@@ -1816,11 +1821,89 @@ impl TdsClient {
         self.execution_context.set_has_open_batch(false);
     }
 
+    /// Retracts a request whose serialization failed part-way, so the failure
+    /// costs the request rather than the connection.
+    ///
+    /// Same state-aware handling as
+    /// [`cancel_streamed_write`](Self::cancel_streamed_write), for the ordinary
+    /// (non-data-at-execution) path: a message that never reached the network is
+    /// dropped locally, one that did is closed with `EOM | IGNORE` and the DONE
+    /// it is answered with is consumed. Without this the server reads a
+    /// truncated stream and answers 4002 on the *next* command.
+    ///
+    /// Serialization can fail after a flush whenever a value is rejected late -
+    /// a declared length the encoded bytes exceed, or a length field that does
+    /// not fit its wire width - and an earlier parameter has already filled a
+    /// packet.
+    async fn retract_partial_request(&mut self, message: SuspendedMessage) {
+        if message.nothing_sent() {
+            // Not a plain drop: re-arm the RESETCONNECTION bit this message took.
+            message.abandon(self.transport.as_writer());
+            self.execution_context.set_has_open_batch(false);
+            return;
+        }
+
+        if let Err(error) = self.withdraw_sent_message(message).await {
+            warn!(%error, "Failed to withdraw a partially sent request");
+            self.abort_partial_request().await;
+            return;
+        }
+
+        self.execution_context.set_has_open_batch(false);
+    }
+
+    /// Closes an already-sent message with `EOM | IGNORE` and consumes the DONE
+    /// the server answers it with, both under [`CANCEL_TIMEOUT`].
+    ///
+    /// Shared by the two retraction paths so neither can inherit the request's
+    /// (possibly absent) timeout and block indefinitely on a server that never
+    /// acknowledges the withdrawal.
+    async fn withdraw_sent_message(&mut self, message: SuspendedMessage) -> TdsResult<()> {
+        // A dead socket cannot carry the withdrawal, and attempting it would
+        // only surface a write error the caller must translate back into the
+        // same abort. msodbcsql skips the same way (`RemoveAllCommands` guards
+        // on `FIsConnectionDead`).
+        if self.transport.is_connection_dead() {
+            return Err(crate::error::Error::ProtocolError(
+                "connection is dead; a partially sent request cannot be withdrawn".to_string(),
+            ));
+        }
+
+        let budget_secs = u32::try_from(CANCEL_TIMEOUT.as_secs()).ok();
+        let mut packet_writer = PacketWriter::resume(
+            message.with_write_timeout(budget_secs),
+            self.transport.as_writer(),
+        );
+        let ignored = packet_writer.cancel_current_message().await;
+        drop(packet_writer);
+        ignored?;
+
+        // The server acknowledges an ignored message with a DONE. Leaving it
+        // unread would desynchronize the next command on this connection.
+        let saved = self.remaining_request_timeout.replace(CANCEL_TIMEOUT);
+        let drained = self.drain_stream().await;
+        self.remaining_request_timeout = saved;
+        drained.map(|_| ())
+    }
+
+    /// Closes the transport after a partially sent request could not be
+    /// retracted. RESETCONNECTION applies to a later request and cannot
+    /// terminate an incomplete one, so the socket is the only thing left to
+    /// discard. Clearing the open-batch flag lets the next
+    /// [`check_and_reconnect`](Self::check_and_reconnect) recover the session.
+    async fn abort_partial_request(&mut self) {
+        self.execution_context.set_has_open_batch(false);
+        self.abort_pending_prepare_capture();
+        self.transport.mark_known_dead();
+        if let Err(error) = self.transport.close_transport().await {
+            warn!(%error, "Failed to close transport after a partial request abort");
+        }
+    }
+
     /// Marks the streamed parameter currently open for data as SQL NULL.
     ///
     /// Call this instead of [`write_streamed_chunk`](Self::write_streamed_chunk)
-    /// when a data-at-execution parameter resolves to NULL (the ODBC
-    /// `SQLPutData(SQL_NULL_DATA)` case). No bytes are written now; when the
+    /// when a data-at-execution parameter resolves to NULL (the ODBC    /// `SQLPutData(SQL_NULL_DATA)` case). No bytes are written now; when the
     /// parameter is closed with [`end_streamed_param`](Self::end_streamed_param)
     /// the driver emits `PLP_NULL` instead of an unknown-length opener +
     /// terminator. Mirrors msodbcsql, which writes `VARMAX_LENGTH_NULL` with no
@@ -2453,7 +2536,13 @@ impl TdsClient {
 
         let mut packet_writer =
             rpc.create_packet_writer(self.transport.as_writer(), timeout_sec, cancel_handle);
-        rpc.serialize(&mut packet_writer).await?;
+        let serialize_result = rpc.serialize(&mut packet_writer).await;
+        let message = packet_writer.suspend();
+        if let Err(e) = serialize_result {
+            drop(rpc);
+            self.retract_partial_request(message).await;
+            return Err(e);
+        }
 
         self.position_on_first_result().await
     }
@@ -2599,7 +2688,13 @@ impl TdsClient {
 
         let mut packet_writer =
             rpc.create_packet_writer(self.transport.as_writer(), timeout_sec, cancel_handle);
-        rpc.serialize(&mut packet_writer).await?;
+        let serialize_result = rpc.serialize(&mut packet_writer).await;
+        let message = packet_writer.suspend();
+        if let Err(e) = serialize_result {
+            drop(rpc);
+            self.retract_partial_request(message).await;
+            return Err(e);
+        }
 
         // Drain to completion to get output parameters and any server errors.
         let server_errors = self.drain_stream_or_retire().await?;
@@ -2727,7 +2822,13 @@ impl TdsClient {
 
         let mut packet_writer =
             rpc.create_packet_writer(self.transport.as_writer(), timeout_sec, cancel_handle);
-        rpc.serialize(&mut packet_writer).await?;
+        let serialize_result = rpc.serialize(&mut packet_writer).await;
+        let message = packet_writer.suspend();
+        if let Err(e) = serialize_result {
+            drop(rpc);
+            self.retract_partial_request(message).await;
+            return Err(e);
+        }
 
         // Drain the result set. A successful unprepare returns no results,
         // but surface any server errors collected during the drain instead of
@@ -3199,8 +3300,10 @@ impl TdsClient {
         let mut packet_writer =
             rpc.create_packet_writer(self.transport.as_writer(), timeout_sec, cancel_handle);
         let serialize_result = rpc.serialize(&mut packet_writer).await;
-        drop(packet_writer);
+        let message = packet_writer.suspend();
         if let Err(e) = serialize_result {
+            drop(rpc);
+            self.retract_partial_request(message).await;
             self.abort_pending_prepare_capture();
             self.report_issued_id(issued_id, statement_id);
             return Err(e);
@@ -3373,7 +3476,13 @@ impl TdsClient {
 
         let mut packet_writer =
             rpc.create_packet_writer(self.transport.as_writer(), timeout_sec, cancel_handle);
-        rpc.serialize(&mut packet_writer).await?;
+        let serialize_result = rpc.serialize(&mut packet_writer).await;
+        let message = packet_writer.suspend();
+        if let Err(e) = serialize_result {
+            drop(rpc);
+            self.retract_partial_request(message).await;
+            return Err(e);
+        }
 
         self.position_on_first_result().await
     }
@@ -4335,7 +4444,13 @@ impl TdsClient {
         );
         let mut packet_writer =
             rpc.create_packet_writer(self.transport.as_writer(), timeout_sec, cancel_handle);
-        rpc.serialize(&mut packet_writer).await?;
+        let serialize_result = rpc.serialize(&mut packet_writer).await;
+        let message = packet_writer.suspend();
+        if let Err(e) = serialize_result {
+            drop(rpc);
+            self.retract_partial_request(message).await;
+            return Err(e);
+        }
 
         let mut result = DescribeParameterEncryptionResult::new();
 
@@ -6245,6 +6360,10 @@ mod tests {
         /// `connection_known_dead` so tests can assert the fatal-error path.
         known_dead: bool,
         encryption_setting: NegotiatedEncryptionSetting,
+        /// The `remaining_request_timeout` handed to each `receive_token`, so a
+        /// test can assert which budget a read ran under without waiting for one
+        /// to elapse.
+        receive_timeouts: Arc<std::sync::Mutex<Vec<Option<Duration>>>>,
     }
 
     impl TestTransport {
@@ -6261,38 +6380,21 @@ mod tests {
                 send_should_fail: Arc::new(std::sync::atomic::AtomicBool::new(false)),
                 known_dead: false,
                 encryption_setting: NegotiatedEncryptionSetting::NoEncryption,
+                receive_timeouts: Arc::new(std::sync::Mutex::new(Vec::new())),
             }
         }
 
         fn with_tokens(tokens: Vec<Tokens>) -> Self {
             Self {
-                closed: false,
                 pending_tokens: VecDeque::from(tokens),
-                reset_mode: ResetConnectionMode::None,
-                reset_dispatched: false,
-                sent: Arc::new(std::sync::Mutex::new(Vec::new())),
-                packet_data: Vec::new(),
-                packet_pos: 0,
-                resume_results: VecDeque::new(),
-                send_should_fail: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-                known_dead: false,
-                encryption_setting: NegotiatedEncryptionSetting::NoEncryption,
+                ..Self::new()
             }
         }
 
         fn with_packet_data(packet_data: Vec<u8>) -> Self {
             Self {
-                closed: false,
-                pending_tokens: VecDeque::new(),
-                reset_mode: ResetConnectionMode::None,
-                reset_dispatched: false,
-                sent: Arc::new(std::sync::Mutex::new(Vec::new())),
                 packet_data,
-                packet_pos: 0,
-                resume_results: VecDeque::new(),
-                send_should_fail: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-                known_dead: false,
-                encryption_setting: NegotiatedEncryptionSetting::NoEncryption,
+                ..Self::new()
             }
         }
 
@@ -6314,9 +6416,13 @@ mod tests {
         async fn receive_token(
             &mut self,
             _context: &ParserContext,
-            _remaining_request_timeout: Option<Duration>,
+            remaining_request_timeout: Option<Duration>,
             _cancel_handle: Option<&CancelHandle>,
         ) -> TdsResult<Tokens> {
+            self.receive_timeouts
+                .lock()
+                .unwrap()
+                .push(remaining_request_timeout);
             if let Some(tok) = self.pending_tokens.pop_front() {
                 return Ok(tok);
             }
@@ -6749,6 +6855,28 @@ mod tests {
             Vec::new(),
         );
         (client, sent)
+    }
+
+    /// Like [`create_capturing_client`], but shares the timeout each
+    /// `receive_token` was given instead of the bytes written.
+    fn create_timeout_observing_client(
+        tokens: Vec<Tokens>,
+    ) -> (TdsClient, Arc<std::sync::Mutex<Vec<Option<Duration>>>>) {
+        let transport = TestTransport::with_tokens(tokens);
+        let observed = Arc::clone(&transport.receive_timeouts);
+        let transport = AnyTransport::dynamic(transport);
+        let negotiated_settings =
+            crate::handler::handler_factory::create_test_negotiated_settings_internal();
+        let execution_context = crate::connection::execution_context::ExecutionContext::new();
+        let client_context = ClientContext::with_data_source("tcp:localhost,1433");
+        let client = TdsClient::new(
+            transport,
+            negotiated_settings,
+            execution_context,
+            client_context,
+            Vec::new(),
+        );
+        (client, observed)
     }
 
     /// Like [`create_capturing_client`], but also returns a shared flag that,
@@ -11218,6 +11346,177 @@ mod tests {
             client.streamed_write_state,
             StreamedWriteState::Idle
         ));
+    }
+
+    /// Opens an RPC message and writes `payload_len` bytes into it, returning it
+    /// suspended — the state a send site is left holding when serialization
+    /// fails part-way through a request.
+    async fn suspend_message_with(client: &mut TdsClient, payload_len: usize) -> SuspendedMessage {
+        let mut writer = PacketWriter::new(
+            PacketType::RpcRequest,
+            client.transport.as_writer(),
+            None,
+            None,
+        );
+        writer
+            .write_async(&vec![0xABu8; payload_len])
+            .await
+            .unwrap();
+        writer.suspend()
+    }
+
+    /// A request that never reached the network is dropped locally: the server
+    /// never learned it existed, so telling it to ignore one would be a lie.
+    #[tokio::test]
+    async fn retract_partial_request_before_first_packet_discards_locally() {
+        let (mut client, sent) = create_capturing_client(vec![]);
+        let message = suspend_message_with(&mut client, 16).await;
+        assert!(message.nothing_sent());
+
+        client.retract_partial_request(message).await;
+
+        assert!(
+            sent.lock().unwrap().is_empty(),
+            "a request the server never saw must not be retracted over the wire"
+        );
+        assert!(
+            !client.is_connection_dead(),
+            "abandoning an unsent request must leave the connection reusable"
+        );
+    }
+
+    /// Once a packet is on the wire the server is mid-message, so the request is
+    /// closed with EOM | IGNORE and the DONE it answers with is consumed. Without
+    /// this the next command is read as a continuation and the server answers
+    /// 4002.
+    #[tokio::test]
+    async fn retract_partial_request_after_partial_send_ignores_and_drains() {
+        use crate::message::messages::PacketStatusFlags;
+
+        let (mut client, sent) = create_capturing_client(vec![done_no_more()]);
+        let message = suspend_message_with(&mut client, 10_000).await;
+        assert!(
+            !message.nothing_sent(),
+            "a payload larger than one packet must have flushed"
+        );
+
+        client.retract_partial_request(message).await;
+
+        let wire = sent.lock().unwrap().clone();
+        let last = &wire[wire.len() - PacketWriter::PACKET_HEADER_SIZE..];
+        assert_eq!(
+            last[1],
+            PacketStatusFlags::Eom as u8 | PacketStatusFlags::Ignore as u8,
+            "the retracted message must be terminated with an ignore packet"
+        );
+        assert_eq!(
+            u16::from_be_bytes([last[2], last[3]]) as usize,
+            PacketWriter::PACKET_HEADER_SIZE,
+            "the ignore packet carries no payload"
+        );
+        assert!(
+            !client.is_connection_dead(),
+            "a retracted request leaves the connection clean for reuse"
+        );
+    }
+
+    /// If the ignore packet cannot be sent, the request is neither complete nor
+    /// retracted, so the socket is discarded rather than pooled.
+    #[tokio::test]
+    async fn retract_partial_request_falls_back_to_close_when_ignore_fails() {
+        let (mut client, fail) = create_failing_capturing_client(vec![done_no_more()]);
+        let message = suspend_message_with(&mut client, 10_000).await;
+
+        fail.store(true, std::sync::atomic::Ordering::SeqCst);
+        client.retract_partial_request(message).await;
+
+        assert!(
+            client.is_connection_dead(),
+            "a request that could not be retracted must not be reused"
+        );
+    }
+
+    /// The retraction is only complete once the DONE is consumed. If that read
+    /// fails, the next command would pick the DONE up as its own.
+    #[tokio::test]
+    async fn retract_partial_request_falls_back_to_close_when_the_drain_fails() {
+        // No DONE queued: the ignore packet goes out but is never acknowledged.
+        let (mut client, _sent) = create_capturing_client(vec![]);
+        let message = suspend_message_with(&mut client, 10_000).await;
+
+        client.retract_partial_request(message).await;
+
+        assert!(
+            client.is_connection_dead(),
+            "an unacknowledged retraction leaves the stream desynchronized"
+        );
+    }
+
+    /// A dead socket cannot carry the withdrawal. Attempting it would only
+    /// surface a write error that maps back to the same abort, so the guard
+    /// skips straight there — matching msodbcsql's `FIsConnectionDead` check in
+    /// `RemoveAllCommands`.
+    #[tokio::test]
+    async fn retract_partial_request_skips_the_withdrawal_on_a_dead_connection() {
+        let (mut client, sent) = create_capturing_client(vec![done_no_more()]);
+        let message = suspend_message_with(&mut client, 10_000).await;
+        let sent_before = sent.lock().unwrap().len();
+        client.transport.close_transport().await.unwrap();
+
+        client.retract_partial_request(message).await;
+
+        assert_eq!(
+            sent.lock().unwrap().len(),
+            sent_before,
+            "no withdrawal may be attempted on a dead connection"
+        );
+        assert!(client.is_connection_dead());
+    }
+
+    /// The retraction runs on its own budget, so a request that had a timeout
+    /// left does not have it spent by the withdrawal — and one that had none
+    /// still gets a bounded drain rather than blocking forever.
+    #[tokio::test]
+    async fn retracting_does_not_spend_the_request_timeout() {
+        for budget in [None, Some(Duration::from_secs(30))] {
+            let (mut client, _sent) = create_capturing_client(vec![done_no_more()]);
+            let message = suspend_message_with(&mut client, 10_000).await;
+            client.remaining_request_timeout = budget;
+
+            client.retract_partial_request(message).await;
+
+            assert_eq!(
+                client.remaining_request_timeout, budget,
+                "the cancel budget must not leak into the request's"
+            );
+        }
+    }
+
+    /// The drain that consumes the withdrawal's DONE must run under
+    /// [`CANCEL_TIMEOUT`], never under the request's own budget. A request
+    /// without a timeout is the case that matters: inheriting its `None` would
+    /// block forever on a server that never acknowledges the withdrawal, holding
+    /// the connection with no way for the application to intervene.
+    ///
+    /// Asserting the budget the read was *given* is the whole property; that
+    /// `tokio::time::timeout` honours a `Duration` is not this crate's to prove.
+    #[tokio::test]
+    async fn the_withdrawal_drain_runs_under_the_cancel_budget() {
+        for request_budget in [None, Some(Duration::from_secs(3600))] {
+            let (mut client, observed) = create_timeout_observing_client(vec![done_no_more()]);
+            let message = suspend_message_with(&mut client, 10_000).await;
+            client.remaining_request_timeout = request_budget;
+
+            client.retract_partial_request(message).await;
+
+            let seen = observed.lock().unwrap().clone();
+            assert_eq!(seen.len(), 1, "the withdrawal reads exactly one DONE");
+            assert_eq!(
+                seen[0],
+                Some(CANCEL_TIMEOUT),
+                "request budget {request_budget:?} must not reach the withdrawal"
+            );
+        }
     }
 
     /// A parked streamed write owns the connection until it closes. A second

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -3343,8 +3343,11 @@ impl TdsClient {
         let message = packet_writer.suspend();
         if let Err(e) = serialize_result {
             drop(rpc);
-            self.retract_partial_request(message).await;
+            // Before the retraction, not after: it drains, and a RETURNVALUE read
+            // with the capture still armed would record a handle for an execute
+            // that never ran.
             self.abort_pending_prepare_capture();
+            self.retract_partial_request(message).await;
             self.report_issued_id(issued_id, statement_id);
             return Err(e);
         }

--- a/mssql-tds/src/io/packet_writer.rs
+++ b/mssql-tds/src/io/packet_writer.rs
@@ -97,6 +97,11 @@ pub struct PacketWriter<'a> {
     payload_cursor: Cursor<Vec<u8>>,
     packet_size: usize,
     is_first_packet: bool, // Note: Cannot just use packet_id because its value can rollover.
+    /// Set the instant a packet reaches the network. Distinct from
+    /// `is_first_packet`, which is cleared only after the write budget check and
+    /// the first-packet callback, so it still reads `true` on error paths where
+    /// the bytes are already gone.
+    any_packet_flushed: bool,
     start_time: Instant,
     max_timeout_sec: Option<u32>,
     cancel_handle: Option<CancelHandle>,
@@ -127,6 +132,7 @@ pub(crate) struct SuspendedMessage {
     payload_cursor: Cursor<Vec<u8>>,
     packet_size: usize,
     is_first_packet: bool,
+    any_packet_flushed: bool,
     max_timeout_sec: Option<u32>,
     cancel_handle: Option<CancelHandle>,
     reset_mode: ResetConnectionMode,
@@ -137,8 +143,12 @@ impl SuspendedMessage {
     /// `true` while no packet of this message has reached the network yet, so
     /// the request can be abandoned locally without the server ever learning it
     /// existed.
+    ///
+    /// Deliberately not `is_first_packet`: that is cleared only after the write
+    /// budget check and the first-packet callback, so a packet that landed and
+    /// then tripped either would still read as unsent.
     pub(crate) fn nothing_sent(&self) -> bool {
-        self.is_first_packet
+        !self.any_packet_flushed
     }
 
     /// Replaces the write timeout this message inherited from the request that
@@ -222,6 +232,7 @@ impl<'a> PacketWriter<'a> {
             payload_cursor: buffer_cursor,
             packet_size,
             is_first_packet: true,
+            any_packet_flushed: false,
             start_time: Instant::now(),
             max_timeout_sec: effective_timeout,
             cancel_handle: cancel_handle.map(|handle| handle.child_handle()),
@@ -255,6 +266,7 @@ impl<'a> PacketWriter<'a> {
             payload_cursor: self.payload_cursor,
             packet_size: self.packet_size,
             is_first_packet: self.is_first_packet,
+            any_packet_flushed: self.any_packet_flushed,
             max_timeout_sec: self.max_timeout_sec,
             cancel_handle: self.cancel_handle,
             reset_mode: self.reset_mode,
@@ -282,6 +294,7 @@ impl<'a> PacketWriter<'a> {
             payload_cursor: state.payload_cursor,
             packet_size: state.packet_size,
             is_first_packet: state.is_first_packet,
+            any_packet_flushed: state.any_packet_flushed,
             start_time: Instant::now(),
             max_timeout_sec: state.max_timeout_sec,
             cancel_handle: state.cancel_handle,
@@ -391,6 +404,10 @@ impl<'a> PacketWriter<'a> {
         );
 
         send_data_fut.await?;
+
+        // Set before anything that can fail below: once these bytes are on the
+        // wire the server is mid-message, whatever this call returns.
+        self.any_packet_flushed = true;
 
         // The header just written reached the wire, so any reset bit it carried
         // is now the server's to acknowledge. An ignore packet asks the server
@@ -1607,5 +1624,33 @@ pub(crate) mod tests {
         // Two packets were needed; payload reassembles to the full 16 bytes.
         assert!(mock.data.len() > packet_size as usize);
         assert_eq!(reassemble_payload(&mock.data), (0..16).collect::<Vec<u8>>());
+    }
+
+    /// The write budget is checked *after* the packet lands, so this error path
+    /// leaves bytes on the wire. `is_first_packet` is still `true` here - only
+    /// the flushed flag can tell the caller the server is mid-message, and
+    /// getting it wrong means the request is dropped instead of withdrawn.
+    #[test]
+    fn a_packet_that_lands_then_times_out_is_not_nothing_sent() {
+        let mut mock = MockNetworkWriter::new(16);
+        let mut writer = PacketWriter::new(PacketType::RpcRequest, &mut mock, Some(1), None);
+        writer.start_time = Instant::now() - std::time::Duration::from_secs(30);
+
+        let result = block_on(writer.write_async(&[0xABu8; 64]));
+        let message = writer.suspend();
+
+        assert!(result.is_err(), "the overrun budget must surface an error");
+        assert!(
+            !mock.data.is_empty(),
+            "the packet reached the wire before the budget was checked"
+        );
+        assert!(
+            message.is_first_packet,
+            "the first-packet flag is still set on this path"
+        );
+        assert!(
+            !message.nothing_sent(),
+            "a request the server has part of must be withdrawn, not discarded"
+        );
     }
 }

--- a/mssql-tds/src/io/packet_writer.rs
+++ b/mssql-tds/src/io/packet_writer.rs
@@ -311,6 +311,11 @@ impl<'a> PacketWriter<'a> {
     /// answers an ignored message with a DONE token, which the caller must
     /// consume before reusing the connection.
     pub(crate) async fn cancel_current_message(&mut self) -> TdsResult<()> {
+        // The server discards an ignored message whole, so the caller re-arms the
+        // reset instead. Cleared explicitly because a message that failed before
+        // its first packet was accounted for still reports `is_first_packet`, and
+        // the header builder would then hand the bit to the ignore packet.
+        self.reset_mode = ResetConnectionMode::None;
         self.populate_header_and_send(true, true).await
     }
 
@@ -981,6 +986,11 @@ pub(crate) mod tests {
         block_on(writer.write_byte_async(0xAB)).unwrap();
         block_on(writer.cancel_current_message()).unwrap();
 
+        assert_eq!(
+            mock.data[1] & (PacketStatusFlags::ResetConnection as u8),
+            0,
+            "the ignore packet must not carry the reset it asks the server to discard"
+        );
         assert!(!mock.take_reset_dispatched());
     }
 

--- a/mssql-tds/src/io/packet_writer.rs
+++ b/mssql-tds/src/io/packet_writer.rs
@@ -152,6 +152,21 @@ impl SuspendedMessage {
         self
     }
 
+    /// Detaches the request's cancellation from this message.
+    ///
+    /// A retraction runs *because* the request is already over. Letting the
+    /// caller's cancel abort it too would strand the half-sent message the
+    /// retraction exists to withdraw.
+    pub(crate) fn without_cancellation(mut self) -> Self {
+        self.cancel_handle = None;
+        self
+    }
+
+    /// The RESETCONNECTION mode this message took from the connection.
+    pub(crate) fn reset_mode(&self) -> ResetConnectionMode {
+        self.reset_mode
+    }
+
     /// Discards an unsent message, returning any RESETCONNECTION request it was
     /// carrying to `network_writer`.
     ///

--- a/mssql-tds/src/io/packet_writer.rs
+++ b/mssql-tds/src/io/packet_writer.rs
@@ -141,9 +141,19 @@ impl SuspendedMessage {
         self.is_first_packet
     }
 
-    /// Discards an unsent message, returning any RESETCONNECTION request it was
-    /// carrying to `network_writer`.
+    /// Replaces the write timeout this message inherited from the request that
+    /// opened it.
     ///
+    /// Withdrawing a request must be bounded even when the request itself was
+    /// not, so the retraction paths swap in their own budget rather than
+    /// resuming under `None`.
+    pub(crate) fn with_write_timeout(mut self, max_timeout_sec: Option<u32>) -> Self {
+        self.max_timeout_sec = max_timeout_sec;
+        self
+    }
+
+    /// Discards an unsent message, returning any RESETCONNECTION request it was
+    /// carrying to `network_writer`.    ///
     /// [`PacketWriter::new`] consumes the connection's pending reset bit so it
     /// applies to exactly one message. Dropping a message that never reached the
     /// network would therefore swallow the reset: the transport no longer holds
@@ -849,6 +859,23 @@ pub(crate) mod tests {
             writer.get_cursor().position(),
             (PacketWriter::PACKET_HEADER_SIZE + 1) as u64
         );
+    }
+
+    /// A retraction must not inherit the write timeout of the request it is
+    /// withdrawing: that request may have had none, and blocking forever while
+    /// giving up a connection is the failure this bound exists to prevent.
+    #[test]
+    fn with_write_timeout_replaces_the_inherited_budget() {
+        let mut mock = MockNetworkWriter::new(16);
+        let writer = PacketWriter::new(PacketType::RpcRequest, &mut mock, None, None);
+        let message = writer.suspend();
+        assert_eq!(
+            message.max_timeout_sec, None,
+            "a request without a timeout suspends with none"
+        );
+
+        let message = message.with_write_timeout(Some(120));
+        assert_eq!(message.max_timeout_sec, Some(120));
     }
 
     #[test]

--- a/mssql-tds/src/io/packet_writer.rs
+++ b/mssql-tds/src/io/packet_writer.rs
@@ -102,6 +102,11 @@ pub struct PacketWriter<'a> {
     /// the first-packet callback, so it still reads `true` on error paths where
     /// the bytes are already gone.
     any_packet_flushed: bool,
+    /// Whether the final packet of this message reached the network. Like
+    /// `any_packet_flushed`, set with the flush rather than after the checks that
+    /// follow it, so a budget expiry on the last packet cannot make a message the
+    /// server holds in full look incomplete.
+    message_complete: bool,
     start_time: Instant,
     max_timeout_sec: Option<u32>,
     cancel_handle: Option<CancelHandle>,
@@ -133,6 +138,7 @@ pub(crate) struct SuspendedMessage {
     packet_size: usize,
     is_first_packet: bool,
     any_packet_flushed: bool,
+    message_complete: bool,
     max_timeout_sec: Option<u32>,
     cancel_handle: Option<CancelHandle>,
     reset_mode: ResetConnectionMode,
@@ -149,6 +155,13 @@ impl SuspendedMessage {
     /// then tripped either would still read as unsent.
     pub(crate) fn nothing_sent(&self) -> bool {
         !self.any_packet_flushed
+    }
+
+    /// `true` when the final packet reached the network, so the server holds the
+    /// whole request and will answer it. Such a message cannot be withdrawn: an
+    /// `EOM | IGNORE` would open a second one rather than retract this one.
+    pub(crate) fn message_complete(&self) -> bool {
+        self.message_complete
     }
 
     /// Replaces the write timeout this message inherited from the request that
@@ -233,6 +246,7 @@ impl<'a> PacketWriter<'a> {
             packet_size,
             is_first_packet: true,
             any_packet_flushed: false,
+            message_complete: false,
             start_time: Instant::now(),
             max_timeout_sec: effective_timeout,
             cancel_handle: cancel_handle.map(|handle| handle.child_handle()),
@@ -267,6 +281,7 @@ impl<'a> PacketWriter<'a> {
             packet_size: self.packet_size,
             is_first_packet: self.is_first_packet,
             any_packet_flushed: self.any_packet_flushed,
+            message_complete: self.message_complete,
             max_timeout_sec: self.max_timeout_sec,
             cancel_handle: self.cancel_handle,
             reset_mode: self.reset_mode,
@@ -295,6 +310,7 @@ impl<'a> PacketWriter<'a> {
             packet_size: state.packet_size,
             is_first_packet: state.is_first_packet,
             any_packet_flushed: state.any_packet_flushed,
+            message_complete: state.message_complete,
             start_time: Instant::now(),
             max_timeout_sec: state.max_timeout_sec,
             cancel_handle: state.cancel_handle,
@@ -413,6 +429,7 @@ impl<'a> PacketWriter<'a> {
         // Set before anything that can fail below: once these bytes are on the
         // wire the server is mid-message, whatever this call returns.
         self.any_packet_flushed = true;
+        self.message_complete = is_last_packet && !is_ignore_packet;
 
         // The header just written reached the wire, so any reset bit it carried
         // is now the server's to acknowledge. An ignore packet asks the server

--- a/mssql-tds/src/io/packet_writer.rs
+++ b/mssql-tds/src/io/packet_writer.rs
@@ -397,15 +397,11 @@ impl<'a> PacketWriter<'a> {
         // to discard the message, so it is deliberately not recorded — treating
         // it as carrying the reset could condemn a healthy session.
         //
-        // This exemption assumes the ignored message is a single packet. For a
-        // multi-packet message, packet #1 already recorded the dispatch and a
-        // later ignore packet does not undo it: the server discards the whole
-        // message (reset included) while the client still believes the bit
-        // landed, so the next request settles it as "reset done" and an unreset
-        // session can go back to the pool. Latent today — `cancel_current_message`
-        // is the only ignore-packet emitter and is `#[cfg(test)]`-only. If that
-        // changes, the cancel path must clear the dispatch record *and* re-arm
-        // the mode so the bit rides the next request.
+        // Not recording is not enough on its own for a multi-packet message:
+        // packet #1 already recorded the dispatch, a later ignore packet does not
+        // undo it, and the server discards the whole message with the reset in
+        // it. Callers of `cancel_current_message` must hand the bit back —
+        // `TdsClient::rearm_withdrawn_reset` does so for both withdrawal paths.
         if reset_mode != ResetConnectionMode::None && !is_ignore_packet {
             self.network_writer.note_reset_dispatched();
         }

--- a/mssql-tds/src/io/packet_writer.rs
+++ b/mssql-tds/src/io/packet_writer.rs
@@ -153,7 +153,8 @@ impl SuspendedMessage {
     }
 
     /// Discards an unsent message, returning any RESETCONNECTION request it was
-    /// carrying to `network_writer`.    ///
+    /// carrying to `network_writer`.
+    ///
     /// [`PacketWriter::new`] consumes the connection's pending reset bit so it
     /// applies to exactly one message. Dropping a message that never reached the
     /// network would therefore swallow the reset: the transport no longer holds

--- a/mssql-tds/src/io/packet_writer.rs
+++ b/mssql-tds/src/io/packet_writer.rs
@@ -1653,6 +1653,31 @@ pub(crate) mod tests {
         assert_eq!(reassemble_payload(&mock.data), (0..16).collect::<Vec<u8>>());
     }
 
+    /// The budget is checked after the write, so `finalize`'s terminating packet
+    /// is on the wire before it can fail. Such a message needs cancelling, not
+    /// withdrawing: a second `EOM | IGNORE` would leave the server owing two
+    /// responses and the extra DONE for the next command.
+    #[test]
+    fn a_finalized_message_that_times_out_is_still_complete() {
+        let mut mock = MockNetworkWriter::new(16);
+        let mut writer = PacketWriter::new(PacketType::RpcRequest, &mut mock, Some(1), None);
+        block_on(writer.write_async(&[0xABu8; 4])).unwrap();
+        writer.start_time = Instant::now() - std::time::Duration::from_secs(30);
+
+        let result = block_on(writer.finalize());
+        let message = writer.suspend();
+
+        assert!(result.is_err(), "the overrun budget must surface an error");
+        assert!(
+            mock.data[1] & (PacketStatusFlags::Eom as u8) != 0,
+            "the terminating packet reached the wire"
+        );
+        assert!(
+            message.message_complete(),
+            "a terminated message must not be withdrawn as if it were partial"
+        );
+    }
+
     /// The write budget is checked *after* the packet lands, so this error path
     /// leaves bytes on the wire. `is_first_packet` is still `true` here - only
     /// the flushed flag can tell the caller the server is mid-message, and


### PR DESCRIPTION
## Description

A value rejected after a packet has already flushed left the server holding an incomplete message. Dropping the `PacketWriter` discards the local buffer but not the bytes on the wire, so the next command on that connection was read as a continuation and the server answered **4002** — on a *later* statement than the one that failed.

The withdrawal already existed for data-at-execution (`cancel_streamed_write`: `EOM | IGNORE`, then consume the DONE); `nothing_sent` and `abandon` had exactly one caller each. All nine parameter-carrying send sites now share it through `finish_send` → `retract_partial_request`, which picks one of three arms:

| State | Action | msodbcsql |
|---|---|---|
| Nothing flushed | Abandon locally, re-arming the RESETCONNECTION bit the message took | `STATE_BATCH_QUEUINGCMD` |
| Partially sent | Withdraw with `EOM \| IGNORE`, then consume the DONE | `STATE_BATCH_PARTIALCMDSENT` |
| Fully sent | Cancel with an attention — there is nothing to withdraw | `STATE_BATCH_CMDSENT` |

Consolidating the paths is what surfaced the rest of this PR. Five defects, all of which existed on `main` or were reachable the moment the first was fixed:

1. **`nothing_sent()` reported a landed packet as unsent.** The write budget and the first-packet callback are both checked *after* the packet reaches the wire, and `is_first_packet` is cleared only after them. A request overrunning its own `SQL_ATTR_QUERY_TIMEOUT` was therefore discarded locally with the server mid-message — the same 4002, reached through the timeout door. Backed by `any_packet_flushed`, set the instant bytes flush.
2. **A fully sent message was withdrawn rather than cancelled.** The same budget check returns before `eom_pending` and the cursor reset, so a last-packet overrun left the server with the complete message and the retraction opened a *second* one. The drain stopped at the first DONE and left the ignore's DONE for the next command. `message_complete` now routes that case to an attention.
3. **The ignore packet carried the RESETCONNECTION bit.** On the path above `is_first_packet` is still set, so the header builder handed the bit to the `EOM | IGNORE` packet — the bit the exemption beside it deliberately does not record, and which `rearm_withdrawn_reset` re-arms immediately after. Cleared in `cancel_current_message`.
4. **A withdrawn RESETCONNECTION was lost.** Packet 1 recorded the dispatch, but the server discards the whole ignored message, reset included. The withdrawal's own DONE then read as a request that ran without resetting, and `observe_response_token` condemned a healthy connection.
5. **Neither half of the withdrawal was bounded or uncancellable.** `PacketWriter` only checks its budget once a write returns, so the ignore packet had no deadline; and both halves inherited the request's cancellation, so a caller that cancelled mid-serialization also cancelled the cleanup.

### Budgets

The ignore write runs under `CANCEL_WRITE_TIMEOUT_SECS` (60s) and the drain under `CANCEL_TIMEOUT` (120s), **each** its own budget, in sequence. Reaching the inner one means the write completed, so the stream is intact and the transport closes gracefully; reaching the outer one drops the write future mid-record, so the transport is retired *without* a shutdown — `close_transport` would emit a close_notify on the native-tls engine, which is one more write on that stream. `send_attention_and_wait` makes the same bargain.

### Why now

#385 declares real lengths instead of sending everything as `(n)varchar(max)`, which made `serialize_string`'s check reachable and this latent bug with it. P5 ([AB#47369](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47369)) widens it again by giving integers declared lengths.

### Scope

Nine sites are converted: the seven ordinary RPC sends, plus `start_streamed_rpc` and `end_streamed_param`'s write-failure arm. Those last two matter because `serialize_prefix` runs every materialized named parameter through the same check, and mixed materialized + data-at-execution parameters are reachable from `SQLExecDirectW`. The two SQL batch sends go through `finish_send` too, since a multi-packet batch can now fail after a packet lands on a live socket.

`cursor_ops.rs` is **not** converted. Four of its ten sites carry caller-supplied `Vec<RpcParameter>` (`cursor_open_with_params`, `perform_cursor_operation`, `cursor_prepexec`, `cursor_execute`), but `CursorClient`'s only callers in the repo are a unit-test module and the live-server integration test `mssql-tds/tests/test_cursor_ops.rs` — no binding crate reaches it, so it is latent rather than live. Tracked by [AB#47714](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47714). The five `TransactionManagementRequest` sends pass no timeout and never span a packet.

### msodbcsql parity

`BATCHCTX::Cancel` (`tds/TdsSend.cpp`) is the same three-branch design, mapped in the table above. `CRPCRequest::SendRequest` runs it on any failure, its comment naming "a data conversion error", and `RemoveAllCommands` guards on `FIsConnectionDead` — a cached flag rather than a socket probe, which is why the withdrawal reads `connection_known_dead()` and not `is_connection_dead()`.

Three deliberate divergences. The attention arm is bounded by `ATTENTION_TIMEOUT_SECONDS` (5s), not the 120s msodbcsql passes to `SendAttn` and the `FlushInputStream` after it: an acknowledgement that has not arrived in five seconds is not coming, and the bulk-load abort already takes that bound on the identical path. `DEFAULT_CANCEL_TIMEOUT` is a flat 120s there, whereas the write half here is 60s: a peer slow enough to take a minute on the ignore packet is failed by this driver and tolerated by msodbcsql. That is the price of preferring the arm that keeps the stream intact. And msodbcsql never re-arms a withdrawn reset — `SendPacket` clears `m_fResetConnection` as the bit goes out, and the only `ResetConnection(TRUE)` in the tree is pooled reuse — because it has no reset-acknowledgement check to break.

The drivers also reach the partial-send state from different points: msodbcsql converts each parameter as the RPC is written, this driver converts all of them before serializing. So a conversion error strands msodbcsql mid-message but never strands us; only a serialization-time rejection does.

### Tests

Fifteen unit tests cover all three arms, both abort paths, the dead-connection guard, the reset re-arm and its suppression on the ignore packet, an inherited cancel, a stalled peer, a landed-then-timed-out packet, and that each half runs under the cancel budget rather than the request's. Each fix was mutation-checked: reverting it fails its test (the stalled-peer case hangs instead, which is the production symptom).

`TestTransport` had to become faithful twice for those tests to mean anything — `receive_token` now honours the cancel handle, and an injected send failure now retires the transport as `NetworkTransport::send` does. Without the first, a cancelled read was indistinguishable from a healthy one.

`SQLCancelAfterAFlushRetractsTheRequest` is the e2e parity case: a data-at-execution sequence cancelled after a 20000-byte chunk is the one event that strands **both** drivers. Two cases in `char_conversions_test.cpp` cover the conversion/serialization asymmetry; the one that strands us asserts `SQL_ERROR` and carries `SKIP_IF_COMPARING_MSODBCSQL()`. Both `char_conversions_test.cpp` cases compare `@@SPID` across the failing execute — session recovery is negotiated by default, so asserting only that a round trip works would be satisfied by a driver that rebuilt the connection.

The full e2e suite has been run against a live server at this head, including `--compare-with-msodbcsql`, and passes.

## Related Issues

[AB#47687](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47687)

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes
- [x] New/changed functionality has tests
- [x] Public API changes are documented

On `cargo btest`: `--workspace --all-targets` pulls in the `mssql-tds` integration binaries, which need a live SQL Server. Locally every failure is either one of those or one of 7 `certificate_validator` / `win_tls` unit tests that fail identically on clean `main` (missing `tests/test_certificates/*.pem` fixtures). `mssql-odbc` is clean at 1096 and `mssql-tds --lib` at 1976; no failure is in the code or tests this PR adds. CI runs it against a real server.