### PR TITLE
Warn unattended reviewers off the ADO MCP server, and fail open

### DIFF
--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -18,7 +18,10 @@ you happen to be reviewing. Skill maintenance is not that author's problem.
 
 1. Read the PR title/description to understand intent. Flag if the description is
    missing or doesn't match the diff. This repo requires a linked GitHub issue or
-   Azure DevOps work item — flag a PR that has neither.
+   Azure DevOps work item — flag a PR that has neither. Resolving an `AB#` reference
+   is worth it when you can: it catches a PR that drifts from what its work item
+   asked, or one still open against a closed item. See step 6 for how to reach ADO
+   without stalling an unattended run.
 2. **Check the PR out locally.** A diff alone is not enough to review this codebase —
    most defects here turn on unchanged code (the other implementer of a trait, the
    caller three layers up, the `#[cfg]` variant of a constant). Use a dedicated
@@ -117,6 +120,34 @@ you happen to be reviewing. Skill maintenance is not that author's problem.
    - notes in the body that it came from an unattended run, so the author knows the
      findings were not checked by a human first.
    - never merges, and never resolves a thread it did not open.
+   - treats every interactive authentication path as unavailable, and prefers a tool
+     that fails loudly over one that waits politely.
+
+   That last point has teeth. **Do not call the Azure DevOps MCP server**
+   (`mcp.dev.azure.com` — `repo_pull_request`, `pipelines_build`, work-item tools) from
+   an unattended run. It authenticates through browser-based OAuth, and once the token
+   lapses it does not fail — it blocks on a browser nobody will open, while the run
+   still reports itself as running. A scheduled reviewer here wedged for sixteen hours
+   that way, within a minute of resolving an `AB#` reference, twice. Enterprise policy
+   sets `bypass-permissions mode DISABLED`, so an agent cannot approve its way past the
+   prompt either. Reach ADO through the `az` CLI, which uses the existing `az login`
+   session:
+
+   ```powershell
+   az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --only-show-errors   # preflight, once per run
+   az boards work-item show --id <n> --org https://dev.azure.com/sqlclientdrivers --only-show-errors -o json
+   ```
+
+   Wrap each call in a timeout and check the exit code — an expired *refresh* token is
+   the failure that would otherwise prompt. First timeout or auth error marks ADO
+   unavailable for the rest of the run; do not retry per PR. Never run `az login` or
+   `az devops login` unattended, which are the commands that open a browser.
+
+   **Fail open.** ADO is context, not a gate: it confirms a PR does what its work item
+   asked. When it is unreachable, take an `AB#<number>` at face value as satisfying the
+   linked-work-item requirement in step 1 and review normally. Report the skipped
+   cross-check in the run log, not in the PR — a reviewer's infrastructure trouble is
+   not the author's problem.
 7. Ground yourself in reference code and public/private documentation/specifications.
    If you don't know the codebase, or which references to use, ask for context before
    reviewing.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -20,8 +20,8 @@ you happen to be reviewing. Skill maintenance is not that author's problem.
    missing or doesn't match the diff. This repo requires a linked GitHub issue or
    Azure DevOps work item — flag a PR that has neither. Resolving an `AB#` reference
    is worth it when you can: it catches a PR that drifts from what its work item
-   asked, or one still open against a closed item. See step 6 for how to reach ADO
-   without stalling an unattended run.
+   asked, or one still open against a closed item. See step 6 for handling ADO in an
+   unattended run.
 2. **Check the PR out locally.** A diff alone is not enough to review this codebase —
    most defects here turn on unchanged code (the other implementer of a trait, the
    caller three layers up, the `#[cfg]` variant of a constant). Use a dedicated
@@ -121,27 +121,11 @@ you happen to be reviewing. Skill maintenance is not that author's problem.
      findings were not checked by a human first.
    - never merges, and never resolves a thread it did not open.
    - treats every interactive authentication path as unavailable, and prefers a tool
-     that fails loudly over one that waits politely.
-
-   That last point has teeth. **Do not call the Azure DevOps MCP server**
-   (`mcp.dev.azure.com` — `repo_pull_request`, `pipelines_build`, work-item tools) from
-   an unattended run. It authenticates through browser-based OAuth, and once the token
-   lapses it does not fail — it blocks on a browser nobody will open, while the run
-   still reports itself as running. A scheduled reviewer here wedged for sixteen hours
-   that way, within a minute of resolving an `AB#` reference, twice. Enterprise policy
-   sets `bypass-permissions mode DISABLED`, so an agent cannot approve its way past the
-   prompt either. Reach ADO through the `az` CLI, which uses the existing `az login`
-   session:
-
-   ```powershell
-   az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --only-show-errors   # preflight, once per run
-   az boards work-item show --id <n> --org https://dev.azure.com/sqlclientdrivers --only-show-errors -o json
-   ```
-
-   Wrap each call in a timeout and check the exit code — an expired *refresh* token is
-   the failure that would otherwise prompt. First timeout or auth error marks ADO
-   unavailable for the rest of the run; do not retry per PR. Never run `az login` or
-   `az devops login` unattended, which are the commands that open a browser.
+     that fails loudly over one that waits politely. The Azure DevOps MCP server is the
+     known trap: its OAuth flow blocks on a browser nobody will open, and the run keeps
+     reporting itself as healthy while it hangs. Use whatever non-interactive ADO access
+     you have instead, bound it with a timeout, and mark ADO unavailable for the rest of
+     the run on the first failure rather than retrying per PR.
 
    **Fail open.** ADO is context, not a gate: it confirms a PR does what its work item
    asked. When it is unreachable, take an `AB#<number>` at face value as satisfying the


### PR DESCRIPTION
## Description

The `code-review` skill left an unattended reviewer no signal that reaching for Azure DevOps could hang the run. The ADO MCP server (`mcp.dev.azure.com`) authenticates through browser-based OAuth, and once its token lapses it does not fail — it blocks on a browser nobody will open, while the run still reports itself as running. A scheduled reviewer against this repo wedged for sixteen hours that way, twice, both times within a minute of resolving an `AB#` reference on #348. Enterprise policy here sets `bypass-permissions mode DISABLED`, so an agent cannot approve its way past the prompt either.

Two changes to `.github/skills/code-review/SKILL.md`:

- **Step 6, "Automated runs"** — a fourth bullet establishing that an unattended run treats every interactive authentication path as unavailable and prefers a tool that fails loudly over one that waits politely, calling out the ADO MCP server as the known trap. The run should use whatever non-interactive ADO access it has, bound it with a timeout, and mark ADO unavailable for the rest of the run on the first failure rather than retrying per PR. Fail open — an unreachable ADO drops the work-item cross-check and nothing else, and the outage is reported in the run log rather than in someone's PR.
- **Step 1** — note that resolving an `AB#` reference is worth doing when possible, since it catches a PR that drifts from what its work item asked or one still open against a closed item, with a pointer to step 6.

### Why no concrete commands

An earlier revision of this PR spelled out an `az` CLI recipe: the ADO resource GUID, the org URL, a per-run `az account get-access-token` preflight, and `az boards work-item show`. That was verified working against this org, but it is a snapshot of one runner's environment on one day. A reviewer running with a PAT, a different MCP configuration, or no `az login` at all would read it as wrong, and it would rot silently — this repo's skill is also read by external contributors who have no ADO access whatsoever. What belongs in the repo is the part only this repo can decide: that the MCP server hangs instead of failing, and that ADO is context rather than a merge gate. How to actually authenticate is left to the agent and its own environment.

Note that #409 quotes a `repo_pull_request` line from the Process section that has since been removed by other work on this skill; the fix adapts to the current text, and the underlying trap is unchanged.

## Related Issues

Fixes #409

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes
- [ ] New/changed functionality has tests
- [x] Public API changes are documented

Docs-only change to a skill markdown file — no Rust touched, so fmt/clippy/test are unaffected and there is nothing to test. No public API change.