### PR TITLE
Fix mssql-odbc build by using the renamed WARN_STRING_TRUNCATION

### DIFF
--- a/mssql-odbc/src/api/util.rs
+++ b/mssql-odbc/src/api/util.rs
@@ -6,7 +6,7 @@ use std::slice;
 use crate::api::odbc_types::{
     SQL_NTS, SQL_SUCCESS, SQL_SUCCESS_WITH_INFO, SqlInteger, SqlReturn, SqlSmallInt, SqlWChar,
 };
-use crate::api::sqlstate::{ERR_STRING_RIGHT_TRUNCATION, post_diag};
+use crate::api::sqlstate::{WARN_STRING_TRUNCATION, post_diag};
 use crate::error::HasDiagnostics;
 
 /// Bit 0 of the COLMETADATA flags word marks a column nullable (`fNullable`).
@@ -181,7 +181,7 @@ pub(crate) unsafe fn write_wide_attr(
     // rather than wrapping into a huge capacity.
     let capacity = usize::try_from(buffer_length).unwrap_or(0) / size_of::<SqlWChar>();
     if unsafe { copy_with_nul(value_ptr, capacity, &utf16) } {
-        post_diag(state, ERR_STRING_RIGHT_TRUNCATION);
+        post_diag(state, WARN_STRING_TRUNCATION);
         return SQL_SUCCESS_WITH_INFO;
     }
     SQL_SUCCESS


### PR DESCRIPTION
## Description

**Build-break fix — please prioritize.** `main` does not compile at tip (`a4727140`); `mssql-odbc` fails with `E0432: unresolved import crate::api::sqlstate::ERR_STRING_RIGHT_TRUNCATION`.

This is a semantic merge conflict between two PRs that were each green in isolation:

- #385 (`a5c4170c`) renamed `ERR_STRING_RIGHT_TRUNCATION` → `WARN_STRING_TRUNCATION` in `mssql-odbc/src/api/sqlstate.rs` and updated every reference that existed at that time.
- #348 (`a4727140`, current `main` tip) added `mssql-odbc/src/api/util.rs`, which still used the old name. It branched before the rename, so git saw no textual conflict.

`util.rs` is compiled (`mssql-odbc/src/api/mod.rs` declares `pub(crate) mod util;`), so this is a hard failure, not a dead-code warning.

The fix updates the two references in `util.rs` to the current constant name. Pure rename, no behavior change: both constants carried identical payloads (`state: SQLSTATE_01004`, `text: "String data, right truncation"`). The existing doc comment in `util.rs` already describes the behavior as "Truncation posts `01004` and returns `SQL_SUCCESS_WITH_INFO`", which matches `WARN_STRING_TRUNCATION`. I grepped the repo for other stale references and found none.

### Overlap with #376

PR #376 currently carries this same one-line fix, applied while resolving its merge with `main` because that branch could not otherwise build. Whichever lands first, the other should drop or absorb the change on its next sync. Flagging so reviewers are not surprised by the duplication.

## Related Issues

Fixes #411

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes (`cargo clippy -p mssql-odbc --all-targets --all-features -- -D warnings`)
- [x] `cargo btest` passes (`cargo nextest run -p mssql-odbc --all-features` — 1056 passed, 1 skipped)
- [x] New/changed functionality has tests — n/a, existing coverage exercises this path; the change is a compile-fix rename
- [x] Public API changes are documented — n/a, `pub(crate)` constant, no public surface change