### PR TITLE
mssql-odbc: Fix use-after-free-before-check and double-free-on-retry in handle cleanup

### DIFF
--- a/mssql-odbc/src/api/disconnect.rs
+++ b/mssql-odbc/src/api/disconnect.rs
@@ -84,22 +84,29 @@ fn sql_disconnect_safe(dbc: &DbcHandle) -> SqlReturn {
     // no locks during I/O, so it can race here and access a STMT handle we are about to free.
     // TODO: fix with refcounted handle lifetimes so STMT handles cannot be freed while in use.
     //
-    // Pops (rather than iterating then clearing) so a poisoned STMT mutex
-    // leaves only the not-yet-freed remainder in `state.statements`: a
-    // retried `SQLDisconnect` — a reasonable response to the `SQL_ERROR` this
-    // returns — picks up where this one stopped instead of double-freeing the
-    // statements already dropped this pass (mssql-rs#401). Matches the
-    // descriptor loop directly below, which already does this.
+    // Locking each STMT's own mutex here is pure synchronization, not a read
+    // of its data: by the time `.lock()` returns at all (`Ok` or `Err`), no
+    // other thread can be mid-operation holding it, since a poisoning panic
+    // still fully releases the lock on unwind. A poisoned outcome therefore
+    // doesn't change whether it's safe to free the box, only whether the
+    // STMT's *contents* were left consistent — irrelevant here, since the box
+    // is being dropped whole. Treating it as fatal (returning `SQL_ERROR`
+    // without freeing) would orphan the handle: it would no longer be in
+    // `state.statements` for a retry to find, yet never actually freed either
+    // — reachable by no future call at all (mssql-rs#401 follow-up review).
+    // Tolerating it and freeing anyway, matching `free_stmt`'s own identical
+    // tolerance for its handle's lock, closes that gap outright instead of
+    // just deferring it.
     while let Some(stmt_ptr) = state.statements.pop() {
         // SAFETY: `stmt_ptr` came from `handle_to_raw::<StmtHandle>` and is still
-        // live (the DBC owns it). Acquire the STMT lock to serialize with any
-        // op still holding it, then drop the box.
+        // live (the DBC owns it).
         let stmt = unsafe { handle_from_raw::<StmtHandle>(stmt_ptr) };
-        let Ok(guard) = stmt.inner.lock() else {
-            error!(?stmt_ptr, "SQLDisconnect: stmt mutex poisoned");
-            return SQL_ERROR;
-        };
-        drop(guard);
+        if stmt.inner.lock().is_err() {
+            error!(
+                ?stmt_ptr,
+                "SQLDisconnect: stmt mutex poisoned; freeing anyway"
+            );
+        }
         unsafe { free_handle::<StmtHandle>(stmt_ptr) };
     }
 
@@ -111,20 +118,19 @@ fn sql_disconnect_safe(dbc: &DbcHandle) -> SqlReturn {
     // descriptor-allocation-node list the same way, after its own statement
     // loop (`sqlcconn.cpp:1313-1448`).
     //
-    // Pops (rather than iterating then clearing) so a poisoned DESC mutex
-    // leaves only the not-yet-freed remainder in `state.descriptors`: a
-    // retried `SQLDisconnect` picks up where this one stopped instead of
-    // re-freeing entries this pass already dropped.
+    // Same poison-tolerant shape as the statement loop above, for the same
+    // reason: synchronization only, and treating poison as fatal here would
+    // equally orphan the descriptor rather than actually resolve anything.
     while let Some(desc_ptr) = state.descriptors.pop() {
         // SAFETY: `desc_ptr` came from `handle_to_raw::<DescHandle>` and is
-        // still live (the DBC owns it). Acquire the DESC lock to serialize
-        // with any op still holding it, then drop the box.
+        // still live (the DBC owns it).
         let desc = unsafe { handle_from_raw::<DescHandle>(desc_ptr) };
-        let Ok(guard) = desc.inner.lock() else {
-            error!(?desc_ptr, "SQLDisconnect: desc mutex poisoned");
-            return SQL_ERROR;
-        };
-        drop(guard);
+        if desc.inner.lock().is_err() {
+            error!(
+                ?desc_ptr,
+                "SQLDisconnect: desc mutex poisoned; freeing anyway"
+            );
+        }
         unsafe { free_handle::<DescHandle>(desc_ptr) };
     }
 
@@ -249,17 +255,23 @@ mod tests {
         }
     }
 
-    /// Reproduces mssql-rs#401: a poisoned STMT mutex partway through the
-    /// statement-free loop must leave every *not-yet-processed* statement
-    /// untouched for a retry, not just stop and leave the whole original list
-    /// in place. The pop-then-free shape (matching the descriptor loop
-    /// directly below it) removes each pointer from `state.statements`
-    /// *before* attempting to free it, so a retried `SQLDisconnect` never
-    /// re-walks — and re-frees — a statement this pass already dropped.
+    /// Regression test for a bug in an earlier version of this fix (caught
+    /// by review before merge, mssql-rs#415): treating a poisoned STMT mutex
+    /// as fatal (returning `SQL_ERROR` without freeing) while having already
+    /// popped it off `state.statements` orphaned the statement entirely — no
+    /// longer tracked for a retry to find, yet never actually freed either,
+    /// so no future call could ever reach it again. `SQLDisconnect` must
+    /// instead tolerate a poisoned STMT mutex the same way `free_stmt`
+    /// already tolerates one for its own handle: the lock here exists purely
+    /// to synchronize with any thread still operating on the statement, not
+    /// to read its (possibly inconsistent) contents, so poison doesn't make
+    /// it unsafe to free the box — it succeeds and frees every statement,
+    /// poisoned or not.
     #[test]
-    fn disconnect_retry_after_poisoned_stmt_mutex_does_not_double_free() {
+    fn disconnect_frees_a_statement_even_if_its_mutex_is_poisoned() {
         use crate::api::odbc_types::SQL_HANDLE_STMT;
         use crate::handles::dbc::ConnectionState;
+        use crate::handles::is_live;
 
         let mut env: SqlHandle = SQL_NULL_HANDLE;
         assert_eq!(
@@ -296,37 +308,23 @@ mod tests {
             SQL_SUCCESS
         );
 
-        // Poison stmt2's mutex — the loop pops in LIFO order, so stmt2 (the
-        // more recently pushed) is attempted first and fails immediately,
-        // before stmt1 is ever touched.
+        // Poison stmt2's mutex; stmt1's is left untouched.
         let stmt2_ref = unsafe { handle_from_raw::<StmtHandle>(stmt2) };
         let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let _guard = stmt2_ref.inner.lock().unwrap();
             panic!("poison the stmt lock");
         }));
 
-        assert_eq!(unsafe { sql_disconnect(dbc) }, SQL_ERROR);
-        {
-            let state = dbc_ref.inner.lock().unwrap();
-            // stmt2 was popped off (and so can no longer be double-freed by
-            // a retry) even though its own free could not proceed — a
-            // poisoned mutex can't be safely retried, so leaking it here is
-            // the same accepted trade-off the descriptor loop already makes.
-            // stmt1 was never reached and must still be tracked, untouched.
-            assert_eq!(state.statements, vec![stmt1]);
-            assert_eq!(state.connection_state, ConnectionState::Connected);
-        }
-
-        // Retry: connection_state is still Connected, so this is accepted
-        // and frees stmt1 exactly once. Before this fix, a retry here would
-        // re-walk the *original* two-element list collected before the first
-        // pass failed, re-freeing stmt1 a second time.
+        // Before the fix, this returned SQL_ERROR and left stmt2 neither
+        // tracked nor freed (permanently unreachable). Now it succeeds and
+        // frees both.
         assert_eq!(unsafe { sql_disconnect(dbc) }, SQL_SUCCESS);
         assert!(dbc_ref.inner.lock().unwrap().statements.is_empty());
-
-        // stmt2's box was deliberately never dropped (poisoned mutex —
-        // leaked, not freed); free it directly so this test doesn't leak.
-        unsafe { free_handle::<StmtHandle>(stmt2) };
+        assert!(!is_live(stmt1), "stmt1 (unpoisoned) must be actually freed");
+        assert!(
+            !is_live(stmt2),
+            "stmt2 (poisoned) must be actually freed too, not orphaned"
+        );
 
         unsafe {
             sql_free_handle(SQL_HANDLE_DBC, dbc);

--- a/mssql-odbc/src/api/disconnect.rs
+++ b/mssql-odbc/src/api/disconnect.rs
@@ -83,7 +83,14 @@ fn sql_disconnect_safe(dbc: &DbcHandle) -> SqlReturn {
     // the DBC lock). However, a call that already took the client and is mid-execute() holds
     // no locks during I/O, so it can race here and access a STMT handle we are about to free.
     // TODO: fix with refcounted handle lifetimes so STMT handles cannot be freed while in use.
-    for &stmt_ptr in &state.statements {
+    //
+    // Pops (rather than iterating then clearing) so a poisoned STMT mutex
+    // leaves only the not-yet-freed remainder in `state.statements`: a
+    // retried `SQLDisconnect` — a reasonable response to the `SQL_ERROR` this
+    // returns — picks up where this one stopped instead of double-freeing the
+    // statements already dropped this pass (mssql-rs#401). Matches the
+    // descriptor loop directly below, which already does this.
+    while let Some(stmt_ptr) = state.statements.pop() {
         // SAFETY: `stmt_ptr` came from `handle_to_raw::<StmtHandle>` and is still
         // live (the DBC owns it). Acquire the STMT lock to serialize with any
         // op still holding it, then drop the box.
@@ -95,7 +102,6 @@ fn sql_disconnect_safe(dbc: &DbcHandle) -> SqlReturn {
         drop(guard);
         unsafe { free_handle::<StmtHandle>(stmt_ptr) };
     }
-    state.statements.clear();
 
     // Drop all explicitly-allocated DESC handles, after the statements: an
     // explicit descriptor carries no back-pointer to whichever statements had
@@ -236,6 +242,91 @@ mod tests {
         // before the read) but not on macOS, whose allocator reused it
         // sooner. The connection no longer tracking the descriptor (checked
         // above) is the real, safely-observable contract.
+
+        unsafe {
+            sql_free_handle(SQL_HANDLE_DBC, dbc);
+            sql_free_handle(SQL_HANDLE_ENV, env);
+        }
+    }
+
+    /// Reproduces mssql-rs#401: a poisoned STMT mutex partway through the
+    /// statement-free loop must leave every *not-yet-processed* statement
+    /// untouched for a retry, not just stop and leave the whole original list
+    /// in place. The pop-then-free shape (matching the descriptor loop
+    /// directly below it) removes each pointer from `state.statements`
+    /// *before* attempting to free it, so a retried `SQLDisconnect` never
+    /// re-walks — and re-frees — a statement this pass already dropped.
+    #[test]
+    fn disconnect_retry_after_poisoned_stmt_mutex_does_not_double_free() {
+        use crate::api::odbc_types::SQL_HANDLE_STMT;
+        use crate::handles::dbc::ConnectionState;
+
+        let mut env: SqlHandle = SQL_NULL_HANDLE;
+        assert_eq!(
+            unsafe { sql_alloc_handle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &mut env) },
+            SQL_SUCCESS
+        );
+        assert_eq!(
+            unsafe {
+                sql_set_env_attr(
+                    env,
+                    SQL_ATTR_ODBC_VERSION,
+                    SQL_OV_ODBC3_80 as usize as *mut std::ffi::c_void,
+                    0,
+                )
+            },
+            SQL_SUCCESS
+        );
+        let mut dbc: SqlHandle = SQL_NULL_HANDLE;
+        assert_eq!(
+            unsafe { sql_alloc_handle(SQL_HANDLE_DBC, env, &mut dbc) },
+            SQL_SUCCESS
+        );
+        let dbc_ref = unsafe { handle_from_raw::<DbcHandle>(dbc) };
+        dbc_ref.inner.lock().unwrap().connection_state = ConnectionState::Connected;
+
+        let mut stmt1: SqlHandle = SQL_NULL_HANDLE;
+        assert_eq!(
+            unsafe { sql_alloc_handle(SQL_HANDLE_STMT, dbc, &mut stmt1) },
+            SQL_SUCCESS
+        );
+        let mut stmt2: SqlHandle = SQL_NULL_HANDLE;
+        assert_eq!(
+            unsafe { sql_alloc_handle(SQL_HANDLE_STMT, dbc, &mut stmt2) },
+            SQL_SUCCESS
+        );
+
+        // Poison stmt2's mutex — the loop pops in LIFO order, so stmt2 (the
+        // more recently pushed) is attempted first and fails immediately,
+        // before stmt1 is ever touched.
+        let stmt2_ref = unsafe { handle_from_raw::<StmtHandle>(stmt2) };
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = stmt2_ref.inner.lock().unwrap();
+            panic!("poison the stmt lock");
+        }));
+
+        assert_eq!(unsafe { sql_disconnect(dbc) }, SQL_ERROR);
+        {
+            let state = dbc_ref.inner.lock().unwrap();
+            // stmt2 was popped off (and so can no longer be double-freed by
+            // a retry) even though its own free could not proceed — a
+            // poisoned mutex can't be safely retried, so leaking it here is
+            // the same accepted trade-off the descriptor loop already makes.
+            // stmt1 was never reached and must still be tracked, untouched.
+            assert_eq!(state.statements, vec![stmt1]);
+            assert_eq!(state.connection_state, ConnectionState::Connected);
+        }
+
+        // Retry: connection_state is still Connected, so this is accepted
+        // and frees stmt1 exactly once. Before this fix, a retry here would
+        // re-walk the *original* two-element list collected before the first
+        // pass failed, re-freeing stmt1 a second time.
+        assert_eq!(unsafe { sql_disconnect(dbc) }, SQL_SUCCESS);
+        assert!(dbc_ref.inner.lock().unwrap().statements.is_empty());
+
+        // stmt2's box was deliberately never dropped (poisoned mutex —
+        // leaked, not freed); free it directly so this test doesn't leak.
+        unsafe { free_handle::<StmtHandle>(stmt2) };
 
         unsafe {
             sql_free_handle(SQL_HANDLE_DBC, dbc);

--- a/mssql-odbc/src/api/disconnect.rs
+++ b/mssql-odbc/src/api/disconnect.rs
@@ -85,18 +85,15 @@ fn sql_disconnect_safe(dbc: &DbcHandle) -> SqlReturn {
     // TODO: fix with refcounted handle lifetimes so STMT handles cannot be freed while in use.
     //
     // Locking each STMT's own mutex here is pure synchronization, not a read
-    // of its data: by the time `.lock()` returns at all (`Ok` or `Err`), no
-    // other thread can be mid-operation holding it, since a poisoning panic
-    // still fully releases the lock on unwind. A poisoned outcome therefore
-    // doesn't change whether it's safe to free the box, only whether the
-    // STMT's *contents* were left consistent — irrelevant here, since the box
-    // is being dropped whole. Treating it as fatal (returning `SQL_ERROR`
-    // without freeing) would orphan the handle: it would no longer be in
-    // `state.statements` for a retry to find, yet never actually freed either
-    // — reachable by no future call at all (mssql-rs#401 follow-up review).
-    // Tolerating it and freeing anyway, matching `free_stmt`'s own identical
-    // tolerance for its handle's lock, closes that gap outright instead of
-    // just deferring it.
+    // of its data: a poisoning panic still fully releases the lock on
+    // unwind, so a poisoned outcome doesn't change whether it's safe to free
+    // the box, only whether the STMT's *contents* were left consistent —
+    // irrelevant here, since the box is dropped whole. Treating it as fatal
+    // instead (returning `SQL_ERROR` without freeing) would orphan the
+    // handle: no longer in `state.statements` for a retry to find, yet never
+    // freed either. Tolerating it and freeing anyway, matching `free_stmt`'s
+    // identical tolerance for its own handle's lock, closes that gap instead
+    // of deferring it.
     while let Some(stmt_ptr) = state.statements.pop() {
         // SAFETY: `stmt_ptr` came from `handle_to_raw::<StmtHandle>` and is still
         // live (the DBC owns it).
@@ -255,18 +252,14 @@ mod tests {
         }
     }
 
-    /// Regression test for a bug in an earlier version of this fix (caught
-    /// by review before merge, mssql-rs#415): treating a poisoned STMT mutex
-    /// as fatal (returning `SQL_ERROR` without freeing) while having already
-    /// popped it off `state.statements` orphaned the statement entirely — no
-    /// longer tracked for a retry to find, yet never actually freed either,
-    /// so no future call could ever reach it again. `SQLDisconnect` must
-    /// instead tolerate a poisoned STMT mutex the same way `free_stmt`
-    /// already tolerates one for its own handle: the lock here exists purely
-    /// to synchronize with any thread still operating on the statement, not
-    /// to read its (possibly inconsistent) contents, so poison doesn't make
-    /// it unsafe to free the box — it succeeds and frees every statement,
-    /// poisoned or not.
+    /// `SQLDisconnect` must tolerate a poisoned STMT mutex instead of
+    /// treating it as fatal: the lock exists purely to synchronize with any
+    /// thread still operating on the statement, not to read its (possibly
+    /// inconsistent) contents, so poison doesn't make it unsafe to free the
+    /// box. Matches `free_stmt`'s identical tolerance for its own handle's
+    /// lock — treating it as fatal here instead would orphan the statement:
+    /// no longer tracked in `state.statements` for a retry to find, yet
+    /// never freed either.
     #[test]
     fn disconnect_frees_a_statement_even_if_its_mutex_is_poisoned() {
         use crate::api::odbc_types::SQL_HANDLE_STMT;

--- a/mssql-odbc/src/api/free_handle.rs
+++ b/mssql-odbc/src/api/free_handle.rs
@@ -320,9 +320,14 @@ unsafe fn free_desc(handle: SqlHandle) -> SqlReturn {
     // registered in `dbc_state.descriptors`, by design) fall through to the
     // "live handle missing from parent DBC" branch further down, which is
     // meant to catch a genuine invariant break, not this legitimate case.
+    // `free_errors` runs in the same guarded block as `post_diag`, not after
+    // it: every ODBC entry point must clear stale diagnostics at API entry
+    // before posting a new one, and this branch returns before ever reaching
+    // the `free_errors` call further below.
     if !desc.is_explicit() {
         error!("SQLFreeHandle(DESC): cannot free an implicitly allocated descriptor");
         if let Ok(mut state) = desc.inner.lock() {
+            free_errors(&mut state);
             post_diag(&mut state, ERR_INVALID_USE_OF_AUTO_DESC);
         }
         return SQL_ERROR;
@@ -1005,6 +1010,14 @@ mod tests {
     /// the descriptor handle `SQLFreeHandle` tried (and failed) to free, per
     /// its own spec ("If SQLFreeHandle returns SQL_ERROR, the handle is still
     /// valid"), not on the parent STMT or DBC.
+    ///
+    /// Calls the rejection twice and asserts exactly one diag record after
+    /// each call, not just that the *last* one is HY017: this entry point
+    /// must clear stale diagnostics at API entry like every other one (a
+    /// prior version of this fix regressed exactly this by hoisting the
+    /// rejection above the `free_errors` call — caught in review, not by
+    /// this test, since asserting only `.last()` passes at any record
+    /// count).
     #[test]
     fn free_implicit_desc_is_rejected() {
         use crate::api::sqlstate::SQLSTATE_HY017;
@@ -1017,13 +1030,20 @@ mod tests {
         );
         let ard = unsafe { &*(stmt as *const StmtHandle) }.ard;
 
-        let ret = unsafe { sql_free_handle(SQL_HANDLE_DESC, ard) };
-        assert_eq!(ret, SQL_ERROR);
+        for _ in 0..2 {
+            assert_eq!(unsafe { sql_free_handle(SQL_HANDLE_DESC, ard) }, SQL_ERROR);
 
-        let desc = unsafe { handle_from_raw::<DescHandle>(ard) };
-        let diag = desc.inner.lock().unwrap();
-        assert_eq!(diag.diag_records.last().unwrap().sql_state, SQLSTATE_HY017);
-        drop(diag);
+            let desc = unsafe { handle_from_raw::<DescHandle>(ard) };
+            let diag = desc.inner.lock().unwrap();
+            assert_eq!(
+                diag.diag_records.len(),
+                1,
+                "a fresh rejection must clear any diagnostic left by the previous call, \
+                 not accumulate one record per call"
+            );
+            assert_eq!(diag.diag_records[0].sql_state, SQLSTATE_HY017);
+            drop(diag);
+        }
 
         // The ARD is untouched: the statement (and its implicit descriptors)
         // still free normally.

--- a/mssql-odbc/src/api/free_handle.rs
+++ b/mssql-odbc/src/api/free_handle.rs
@@ -14,7 +14,8 @@ use crate::api::sqlstate::{ERR_INVALID_USE_OF_AUTO_DESC, SQLSTATE_HY000, post_di
 use crate::error::{free_errors, post_sql_error};
 use crate::handles::stmt::STMT_STATE_CURSOR_OPEN;
 use crate::handles::{
-    DbcHandle, DescHandle, EnvHandle, HandleType, StmtHandle, free_handle, handle_from_raw, is_live,
+    DbcHandle, DescHandle, EnvHandle, HandleType, StmtHandle, free_handle, handle_from_raw,
+    live_type,
 };
 use mssql_tds::connection::tds_client::StatementId;
 
@@ -157,17 +158,30 @@ unsafe fn free_dbc(handle: SqlHandle) -> SqlReturn {
 /// cleanup (`sql_disconnect_safe`), returns `SQL_SUCCESS` immediately without
 /// dereferencing it — that cleanup happens behind the Driver Manager's back,
 /// so an application legitimately holding this now-stale handle can still
-/// reach here (mssql-rs#400). If the STMT is somehow not found in the parent
-/// DBC's statement list despite still being live, it was already dropped by
-/// some other path — also returns `SQL_SUCCESS` without calling `free_handle`
-/// a second time.
+/// reach here (mssql-rs#400). Returns `SQL_INVALID_HANDLE`, per spec, if the
+/// handle is live but of some other type. If the STMT is live and correctly
+/// typed but somehow missing from its parent DBC's statement list — an
+/// invariant break rather than an expected path, since "already freed" is
+/// caught above — logs it and still returns `SQL_SUCCESS` rather than
+/// double-freeing or panicking.
 ///
 /// # Safety
 /// `handle` must be a live `StmtHandle` created by `alloc_stmt`.
 unsafe fn free_stmt(handle: SqlHandle) -> SqlReturn {
-    if !is_live(handle) {
-        debug!(?handle, "SQLFreeHandle(STMT): handle already freed, no-op");
-        return SQL_SUCCESS;
+    match live_type(handle) {
+        None => {
+            debug!(?handle, "SQLFreeHandle(STMT): handle already freed, no-op");
+            return SQL_SUCCESS;
+        }
+        Some(HandleType::Stmt) => {}
+        Some(actual) => {
+            error!(
+                ?handle,
+                ?actual,
+                "SQLFreeHandle(STMT): handle is live but not a STMT"
+            );
+            return SQL_INVALID_HANDLE;
+        }
     }
 
     let stmt = unsafe { handle_from_raw::<StmtHandle>(handle) };
@@ -203,7 +217,14 @@ unsafe fn free_stmt(handle: SqlHandle) -> SqlReturn {
             return SQL_ERROR;
         };
         let Some(i) = dbc_state.statements.iter().position(|&p| p == handle) else {
-            // Already dropped by SQLDisconnect - early return.
+            // Live but untracked: not the post-SQLDisconnect case (caught by
+            // `live_type` above), so something removed it from the parent
+            // without freeing it — an invariant break, not an expected path.
+            error!(
+                ?handle,
+                "SQLFreeHandle(STMT): live handle missing from parent DBC"
+            );
+            debug_assert!(false, "live STMT not tracked by its parent DBC");
             return SQL_SUCCESS;
         };
         dbc_state.statements.swap_remove(i);
@@ -226,17 +247,30 @@ unsafe fn free_stmt(handle: SqlHandle) -> SqlReturn {
 /// If the handle was already freed by an earlier `SQLDisconnect` cascading
 /// cleanup (`sql_disconnect_safe`), returns `SQL_SUCCESS` immediately without
 /// dereferencing it — mirrors `free_stmt`'s identical guard and the same
-/// reasoning (mssql-rs#400). If the descriptor is somehow not found in the
-/// parent DBC's descriptor list despite still being live, it was already
-/// dropped by some other path — also returns `SQL_SUCCESS` without calling
-/// `free_handle` a second time.
+/// reasoning (mssql-rs#400). Returns `SQL_INVALID_HANDLE`, per spec, if the
+/// handle is live but of some other type. If the descriptor is live and
+/// correctly typed but somehow missing from its parent DBC's descriptor
+/// list — an invariant break rather than an expected path, since "already
+/// freed" is caught above — logs it and still returns `SQL_SUCCESS` rather
+/// than double-freeing or panicking.
 ///
 /// # Safety
 /// `handle` must be a live `DescHandle` created by `alloc_desc`.
 unsafe fn free_desc(handle: SqlHandle) -> SqlReturn {
-    if !is_live(handle) {
-        debug!(?handle, "SQLFreeHandle(DESC): handle already freed, no-op");
-        return SQL_SUCCESS;
+    match live_type(handle) {
+        None => {
+            debug!(?handle, "SQLFreeHandle(DESC): handle already freed, no-op");
+            return SQL_SUCCESS;
+        }
+        Some(HandleType::Desc) => {}
+        Some(actual) => {
+            error!(
+                ?handle,
+                ?actual,
+                "SQLFreeHandle(DESC): handle is live but not a DESC"
+            );
+            return SQL_INVALID_HANDLE;
+        }
     }
 
     let desc = unsafe { handle_from_raw::<DescHandle>(handle) };
@@ -271,7 +305,14 @@ unsafe fn free_desc(handle: SqlHandle) -> SqlReturn {
     };
 
     let Some(i) = dbc_state.descriptors.iter().position(|&p| p == handle) else {
-        // Already dropped by SQLDisconnect - early return.
+        // Live but untracked: not the post-SQLDisconnect case (caught by
+        // `live_type` above), so something removed it from the parent
+        // without freeing it — an invariant break, not an expected path.
+        error!(
+            ?handle,
+            "SQLFreeHandle(DESC): live handle missing from parent DBC"
+        );
+        debug_assert!(false, "live DESC not tracked by its parent DBC");
         return SQL_SUCCESS;
     };
 
@@ -559,6 +600,43 @@ mod tests {
         unsafe { sql_free_handle(SQL_HANDLE_ENV, env) };
     }
 
+    /// `SQLFreeHandle` dispatches on the caller-supplied `handle_type` with
+    /// no cross-check against the handle it's actually given. Before
+    /// tracking `HandleType` in the live-handle registry, `is_live` only
+    /// confirmed *some* handle was live at this address — so passing a live
+    /// DESC where a STMT was expected still reached
+    /// `handle_from_raw::<StmtHandle>` and reinterpreted a `DescHandle` as a
+    /// `StmtHandle`, no address reuse required. Checking the type recorded
+    /// at allocation time catches this before any dereference, matching the
+    /// ODBC spec's own answer: `SQL_INVALID_HANDLE` for "the handle
+    /// indicated by *Handle* was not a valid handle of the type indicated
+    /// by *HandleType*."
+    #[test]
+    fn free_stmt_on_a_live_desc_handle_returns_invalid_handle() {
+        let (env, dbc) = alloc_env_dbc_connected();
+
+        let mut desc: SqlHandle = ptr::null_mut();
+        assert_eq!(
+            unsafe { sql_alloc_handle(SQL_HANDLE_DESC, dbc, &mut desc) },
+            SQL_SUCCESS
+        );
+
+        assert_eq!(
+            unsafe { sql_free_handle(SQL_HANDLE_STMT, desc) },
+            SQL_INVALID_HANDLE,
+            "a live DESC handle passed as a STMT must be rejected, not reinterpreted"
+        );
+
+        // The DESC itself is untouched by the rejected call and still frees
+        // normally as what it actually is.
+        assert_eq!(
+            unsafe { sql_free_handle(SQL_HANDLE_DESC, desc) },
+            SQL_SUCCESS
+        );
+        unsafe { sql_free_handle(SQL_HANDLE_DBC, dbc) };
+        unsafe { sql_free_handle(SQL_HANDLE_ENV, env) };
+    }
+
     /// Freeing a statement mid data-at-execution must drain the parked
     /// sequence rather than drop the handle with it intact. A dropped
     /// `DaeState` takes the connection's client with it, leaving the DBC with
@@ -687,6 +765,33 @@ mod tests {
         unsafe { sql_free_handle(SQL_HANDLE_ENV, env) };
     }
 
+    /// Mirror of `free_stmt_on_a_live_desc_handle_returns_invalid_handle`
+    /// through `free_desc`'s own type check: a live STMT passed where a DESC
+    /// was expected must be rejected, not reinterpreted as a `DescHandle`.
+    #[test]
+    fn free_desc_on_a_live_stmt_handle_returns_invalid_handle() {
+        let (env, dbc) = alloc_env_dbc_connected();
+
+        let mut stmt: SqlHandle = ptr::null_mut();
+        assert_eq!(
+            unsafe { sql_alloc_handle(SQL_HANDLE_STMT, dbc, &mut stmt) },
+            SQL_SUCCESS
+        );
+
+        assert_eq!(
+            unsafe { sql_free_handle(SQL_HANDLE_DESC, stmt) },
+            SQL_INVALID_HANDLE,
+            "a live STMT handle passed as a DESC must be rejected, not reinterpreted"
+        );
+
+        assert_eq!(
+            unsafe { sql_free_handle(SQL_HANDLE_STMT, stmt) },
+            SQL_SUCCESS
+        );
+        unsafe { sql_free_handle(SQL_HANDLE_DBC, dbc) };
+        unsafe { sql_free_handle(SQL_HANDLE_ENV, env) };
+    }
+
     #[test]
     fn free_desc_unregisters_from_parent_dbc() {
         let (env, dbc) = alloc_env_dbc_connected();
@@ -706,23 +811,17 @@ mod tests {
         unsafe { sql_free_handle(SQL_HANDLE_ENV, env) };
     }
 
-    /// Reproduces the double-free the AB#47436 review identified: after
-    /// `SQLDisconnect` has already freed every outstanding explicit
-    /// descriptor (`sql_disconnect_safe`), an application retrying
-    /// `SQLFreeHandle` on the same, now-stale handle must get `SQL_SUCCESS`
-    /// without freeing anything a second time — mirrors `free_stmt`'s
-    /// identical "already dropped by SQLDisconnect" guard.
-    ///
-    /// Simulates "already removed" by taking the descriptor out of
-    /// `dbc_state.descriptors` directly, without freeing its box, so the
-    /// test itself never dereferences already-freed memory. (That residual
-    /// risk — reading `desc.object_type`/`is_explicit()` before this guard is
-    /// reached, if the box itself were already dropped — is the same one
-    /// `free_stmt` already accepts and is unaffected by this fix; it's
-    /// tracked by the crate's existing refcounted-handle-lifetimes TODO in
-    /// `disconnect.rs`, not something this test exercises.)
+    /// `free_desc`'s "live but untracked by parent" branch documents a
+    /// genuine invariant, not an expected path: once the `live_type` guard
+    /// above already catches the ordinary "freed by `SQLDisconnect`'s
+    /// cascade" case (mssql-rs#400), reaching here while still live and
+    /// correctly typed means something else removed the descriptor from
+    /// `dbc_state.descriptors` without freeing it. No public API can reach
+    /// that state (it would need a panic between `swap_remove` and
+    /// `free_handle`, which `ffi_entry!` swallows), so this test forces it
+    /// directly to exercise the `debug_assert!` that documents it.
     #[test]
-    fn free_desc_already_removed_from_parent_is_a_no_op() {
+    fn free_desc_live_but_untracked_by_parent_fails_in_debug() {
         let (env, dbc) = alloc_env_dbc_connected();
 
         let mut desc: SqlHandle = ptr::null_mut();
@@ -731,17 +830,23 @@ mod tests {
             SQL_SUCCESS
         );
 
-        // Simulate SQLDisconnect having already unregistered (but not yet
-        // dropped) the descriptor.
         let dbc_ref = unsafe { &*(dbc as *const DbcHandle) };
         dbc_ref.inner.lock().unwrap().descriptors.clear();
 
         let ret = unsafe { sql_free_handle(SQL_HANDLE_DESC, desc) };
-        assert_eq!(ret, SQL_SUCCESS);
-
-        // The guard above stopped `free_desc` from dropping the box, so this
-        // test must clean it up itself to avoid leaking.
+        if cfg!(debug_assertions) {
+            assert_eq!(
+                ret, SQL_ERROR,
+                "debug_assert! must fire for a live-but-untracked descriptor"
+            );
+        } else {
+            assert_eq!(ret, SQL_SUCCESS);
+        }
+        // Neither branch drops the box: the debug build panics before
+        // reaching any drop code, and the release build's early return
+        // skips it too — same cleanup either way.
         unsafe { free_handle::<DescHandle>(desc) };
+
         unsafe { sql_free_handle(SQL_HANDLE_DBC, dbc) };
         unsafe { sql_free_handle(SQL_HANDLE_ENV, env) };
     }

--- a/mssql-odbc/src/api/free_handle.rs
+++ b/mssql-odbc/src/api/free_handle.rs
@@ -56,11 +56,27 @@ pub(crate) unsafe fn sql_free_handle(handle_type: SqlSmallInt, handle: SqlHandle
 ///
 /// No mutex is acquired - per the ODBC spec, the DM guarantees the
 /// connection count on this ENV is 0 before calling `SQLFreeEnv`. DM also
-/// ensures no concurrent SQLFreeHandle calls on the same handle.
+/// ensures no concurrent SQLFreeHandle calls on the same handle. Returns
+/// `SQL_INVALID_HANDLE`, per spec, if the handle is live but of some other
+/// type — matches `free_stmt`/`free_desc`'s identical check; unlike those
+/// two, an ENV is never cascade-freed behind the DM's back, so there is no
+/// legitimate stale-handle case here to distinguish from "wrong type."
 ///
 /// # Safety
 /// `handle` must be a live `EnvHandle` created by `alloc_env`.
 unsafe fn free_env(handle: SqlHandle) -> SqlReturn {
+    match live_type(handle) {
+        Some(HandleType::Env) => {}
+        other => {
+            error!(
+                ?handle,
+                ?other,
+                "SQLFreeHandle(ENV): handle is not a live ENV"
+            );
+            return SQL_INVALID_HANDLE;
+        }
+    }
+
     let env = unsafe { handle_from_raw::<EnvHandle>(handle) };
     debug_assert_eq!(
         env.object_type,
@@ -90,11 +106,27 @@ unsafe fn free_env(handle: SqlHandle) -> SqlReturn {
 /// before calling `SQLFreeConnect`, and `SQLDisconnect` drops all child
 /// handles (statements, and their implicit descriptors, plus any explicit
 /// descriptors — `sql_disconnect_safe`). msodbcsql's `SQLFreeConnect` doesn't
-/// lock the connection mutex either.
+/// lock the connection mutex either. Returns `SQL_INVALID_HANDLE`, per spec,
+/// if the handle is live but of some other type — matches `free_stmt`/
+/// `free_desc`'s identical check; unlike those two, a DBC is never
+/// cascade-freed behind the DM's back, so there is no legitimate
+/// stale-handle case here to distinguish from "wrong type."
 ///
 /// # Safety
 /// `handle` must be a live `DbcHandle` created by `alloc_dbc`.
 unsafe fn free_dbc(handle: SqlHandle) -> SqlReturn {
+    match live_type(handle) {
+        Some(HandleType::Dbc) => {}
+        other => {
+            error!(
+                ?handle,
+                ?other,
+                "SQLFreeHandle(DBC): handle is not a live DBC"
+            );
+            return SQL_INVALID_HANDLE;
+        }
+    }
+
     let dbc = unsafe { handle_from_raw::<DbcHandle>(handle) };
     debug_assert_eq!(
         dbc.object_type,
@@ -280,14 +312,24 @@ unsafe fn free_desc(handle: SqlHandle) -> SqlReturn {
         "SQLFreeHandle(DESC): handle is not a DESC"
     );
 
+    // Checked unconditionally, before taking any lock: `is_explicit` reads
+    // only `alloc_type`, set once at construction and never mutated, so this
+    // rejection cannot depend on whether `desc.inner`'s lock is healthy.
+    // Nesting it inside the lock below used to mean a poisoned mutex skipped
+    // this check entirely — silently letting an implicit descriptor (never
+    // registered in `dbc_state.descriptors`, by design) fall through to the
+    // "live handle missing from parent DBC" branch further down, which is
+    // meant to catch a genuine invariant break, not this legitimate case.
+    if !desc.is_explicit() {
+        error!("SQLFreeHandle(DESC): cannot free an implicitly allocated descriptor");
+        if let Ok(mut state) = desc.inner.lock() {
+            post_diag(&mut state, ERR_INVALID_USE_OF_AUTO_DESC);
+        }
+        return SQL_ERROR;
+    }
+
     if let Ok(mut state) = desc.inner.lock() {
         free_errors(&mut state);
-
-        if !desc.is_explicit() {
-            error!("SQLFreeHandle(DESC): cannot free an implicitly allocated descriptor");
-            post_diag(&mut state, ERR_INVALID_USE_OF_AUTO_DESC);
-            return SQL_ERROR;
-        }
     }
 
     let dbc = unsafe { handle_from_raw::<DbcHandle>(desc.parent_dbc) };
@@ -478,6 +520,55 @@ mod tests {
 
         let ret = unsafe { sql_free_handle(SQL_HANDLE_ENV, env) };
         assert_eq!(ret, SQL_SUCCESS);
+    }
+
+    /// The type-confusion fix for `free_stmt`/`free_desc` (`live_type`
+    /// checked before any dereference) has an ENV/DBC counterpart: without
+    /// it, `SQLFreeHandle(SQL_HANDLE_ENV, <live DBC>)` would reach
+    /// `handle_from_raw::<EnvHandle>` and reinterpret a `DbcHandle` as an
+    /// `EnvHandle` — `debug_assert_eq!` on `object_type` can't catch this
+    /// either, since it reads through the already-wrongly-typed reference,
+    /// and `EnvHandle`/`DbcHandle` are neither `#[repr(C)]` nor the same
+    /// size. `free_env` now checks `live_type` first, matching `free_stmt`/
+    /// `free_desc`.
+    #[test]
+    fn free_env_on_a_live_dbc_handle_returns_invalid_handle() {
+        let env = alloc_env();
+
+        let mut dbc: SqlHandle = ptr::null_mut();
+        assert_eq!(
+            unsafe { sql_alloc_handle(SQL_HANDLE_DBC, env, &mut dbc) },
+            SQL_SUCCESS
+        );
+
+        assert_eq!(
+            unsafe { sql_free_handle(SQL_HANDLE_ENV, dbc) },
+            SQL_INVALID_HANDLE,
+            "a live DBC handle passed as an ENV must be rejected, not reinterpreted"
+        );
+
+        // The DBC itself is untouched by the rejected call and still frees
+        // normally as what it actually is.
+        unsafe { sql_free_handle(SQL_HANDLE_DBC, dbc) };
+        unsafe { sql_free_handle(SQL_HANDLE_ENV, env) };
+    }
+
+    /// Mirror of `free_env_on_a_live_dbc_handle_returns_invalid_handle`
+    /// through `free_dbc`'s own type check: a live ENV passed where a DBC
+    /// was expected must be rejected, not reinterpreted as a `DbcHandle`.
+    #[test]
+    fn free_dbc_on_a_live_env_handle_returns_invalid_handle() {
+        let env = alloc_env();
+
+        assert_eq!(
+            unsafe { sql_free_handle(SQL_HANDLE_DBC, env) },
+            SQL_INVALID_HANDLE,
+            "a live ENV handle passed as a DBC must be rejected, not reinterpreted"
+        );
+
+        // The ENV itself is untouched by the rejected call and still frees
+        // normally as what it actually is.
+        unsafe { sql_free_handle(SQL_HANDLE_ENV, env) };
     }
 
     #[test]
@@ -936,6 +1027,60 @@ mod tests {
 
         // The ARD is untouched: the statement (and its implicit descriptors)
         // still free normally.
+        unsafe { sql_free_handle(SQL_HANDLE_STMT, stmt) };
+        unsafe { sql_free_handle(SQL_HANDLE_DBC, dbc) };
+        unsafe { sql_free_handle(SQL_HANDLE_ENV, env) };
+    }
+
+    /// Regression test: `free_implicit_desc_is_rejected` above only exercises
+    /// the healthy-lock path. `is_explicit()` used to be checked *inside*
+    /// `if let Ok(mut state) = desc.inner.lock()`, so a poisoned descriptor
+    /// mutex skipped the whole block — including the HY017 rejection — and
+    /// let an implicit descriptor (never registered in
+    /// `dbc_state.descriptors`, by design) fall through all the way to the
+    /// "live handle missing from parent DBC" branch, incorrectly firing that
+    /// branch's `debug_assert!` in debug builds and silently returning
+    /// `SQL_SUCCESS` for an unfreed, unfreeable handle in release builds.
+    /// `is_explicit()` reads only `alloc_type`, set once at construction and
+    /// never mutated, so the rejection must not depend on lock health at all.
+    ///
+    /// Calls `free_desc` directly rather than through `sql_free_handle`:
+    /// the latter's `ffi_entry!` catches any panic and converts it to the
+    /// same `SQL_ERROR` a correct HY017 rejection also returns, so a return
+    /// code alone can't tell "rejected properly" apart from "panicked on the
+    /// wrongly-firing `debug_assert!`, then caught." Catching the panic here
+    /// instead keeps that distinction visible.
+    #[test]
+    fn free_implicit_desc_is_rejected_even_with_a_poisoned_mutex() {
+        let (env, dbc) = alloc_env_dbc();
+        let mut stmt: SqlHandle = ptr::null_mut();
+        assert_eq!(
+            unsafe { sql_alloc_handle(SQL_HANDLE_STMT, dbc, &mut stmt) },
+            SQL_SUCCESS
+        );
+        let ard = unsafe { &*(stmt as *const StmtHandle) }.ard;
+
+        let ard_ref = unsafe { handle_from_raw::<DescHandle>(ard) };
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = ard_ref.inner.lock().unwrap();
+            panic!("poison the ard lock");
+        }));
+
+        match std::panic::catch_unwind(|| unsafe { free_desc(ard) }) {
+            Ok(ret) => assert_eq!(
+                ret, SQL_ERROR,
+                "an implicit descriptor must be rejected regardless of its own lock's health"
+            ),
+            Err(_) => panic!(
+                "free_desc must reject an implicit descriptor via HY017, not panic on a \
+                 debug_assert! that only fires because its own lock happens to be poisoned"
+            ),
+        }
+
+        // The ARD is untouched: the statement (and its implicit descriptors)
+        // still free normally, poisoned lock and all — matches
+        // `free_stmt`/`free_desc`'s existing tolerance for their own
+        // handle's lock elsewhere in this module.
         unsafe { sql_free_handle(SQL_HANDLE_STMT, stmt) };
         unsafe { sql_free_handle(SQL_HANDLE_DBC, dbc) };
         unsafe { sql_free_handle(SQL_HANDLE_ENV, env) };

--- a/mssql-odbc/src/api/free_handle.rs
+++ b/mssql-odbc/src/api/free_handle.rs
@@ -14,7 +14,7 @@ use crate::api::sqlstate::{ERR_INVALID_USE_OF_AUTO_DESC, SQLSTATE_HY000, post_di
 use crate::error::{free_errors, post_sql_error};
 use crate::handles::stmt::STMT_STATE_CURSOR_OPEN;
 use crate::handles::{
-    DbcHandle, DescHandle, EnvHandle, HandleType, StmtHandle, free_handle, handle_from_raw,
+    DbcHandle, DescHandle, EnvHandle, HandleType, StmtHandle, free_handle, handle_from_raw, is_live,
 };
 use mssql_tds::connection::tds_client::StatementId;
 
@@ -153,13 +153,23 @@ unsafe fn free_dbc(handle: SqlHandle) -> SqlReturn {
 
 /// Mirrors msodbcsql's `SQLFreeStmt(SQL_DROP)` behavior.
 ///
-/// If the STMT is not found in the parent DBC's statement list, it was
-/// already dropped by `SQLDisconnect` — returns `SQL_SUCCESS` without
-/// calling `free_handle`.
+/// If the handle was already freed by an earlier `SQLDisconnect` cascading
+/// cleanup (`sql_disconnect_safe`), returns `SQL_SUCCESS` immediately without
+/// dereferencing it — that cleanup happens behind the Driver Manager's back,
+/// so an application legitimately holding this now-stale handle can still
+/// reach here (mssql-rs#400). If the STMT is somehow not found in the parent
+/// DBC's statement list despite still being live, it was already dropped by
+/// some other path — also returns `SQL_SUCCESS` without calling `free_handle`
+/// a second time.
 ///
 /// # Safety
 /// `handle` must be a live `StmtHandle` created by `alloc_stmt`.
 unsafe fn free_stmt(handle: SqlHandle) -> SqlReturn {
+    if !is_live(handle) {
+        debug!(?handle, "SQLFreeHandle(STMT): handle already freed, no-op");
+        return SQL_SUCCESS;
+    }
+
     let stmt = unsafe { handle_from_raw::<StmtHandle>(handle) };
     debug_assert_eq!(
         stmt.object_type,
@@ -213,13 +223,22 @@ unsafe fn free_stmt(handle: SqlHandle) -> SqlReturn {
 /// several statements at once is a supported case, not an error: every one of
 /// them is reset, not just the first found.
 ///
-/// If the descriptor is not found in the parent DBC's descriptor list, it was
-/// already dropped by `SQLDisconnect` — returns `SQL_SUCCESS` without calling
-/// `free_handle` a second time, mirroring `free_stmt`'s identical guard.
+/// If the handle was already freed by an earlier `SQLDisconnect` cascading
+/// cleanup (`sql_disconnect_safe`), returns `SQL_SUCCESS` immediately without
+/// dereferencing it — mirrors `free_stmt`'s identical guard and the same
+/// reasoning (mssql-rs#400). If the descriptor is somehow not found in the
+/// parent DBC's descriptor list despite still being live, it was already
+/// dropped by some other path — also returns `SQL_SUCCESS` without calling
+/// `free_handle` a second time.
 ///
 /// # Safety
 /// `handle` must be a live `DescHandle` created by `alloc_desc`.
 unsafe fn free_desc(handle: SqlHandle) -> SqlReturn {
+    if !is_live(handle) {
+        debug!(?handle, "SQLFreeHandle(DESC): handle already freed, no-op");
+        return SQL_SUCCESS;
+    }
+
     let desc = unsafe { handle_from_raw::<DescHandle>(handle) };
     debug_assert_eq!(
         desc.object_type,
@@ -501,6 +520,45 @@ mod tests {
         unsafe { sql_free_handle(SQL_HANDLE_ENV, env) };
     }
 
+    /// Reproduces mssql-rs#400: freeing a stale STMT handle a second time —
+    /// standing in for the real scenario, where `SQLDisconnect` cascades-frees
+    /// it first and an application legitimately still holds the handle
+    /// afterward — must return `SQL_SUCCESS` without dereferencing it.
+    ///
+    /// Before the `is_live` guard, this would panic on the `debug_assert_eq!`
+    /// a few lines into `free_stmt`: nothing reallocates the freed memory in
+    /// this single-threaded test, so it still holds the `HandleType::Invalid`
+    /// tombstone `free_handle` stamped on the first free, which doesn't match
+    /// `HandleType::Stmt` — a panic `ffi_entry!` catches and reports as
+    /// `SQL_ERROR`. That return code (not a crash) was the only prior signal
+    /// something had gone wrong; on an allocator that reuses the block
+    /// instead of leaving the tombstone intact (observed on macOS in CI),
+    /// there would have been no signal at all. `is_live` now short-circuits
+    /// before any of that, so this never reaches the assert either way.
+    #[test]
+    fn free_stmt_twice_is_a_no_op_not_a_panic() {
+        let (env, dbc) = alloc_env_dbc();
+
+        let mut stmt: SqlHandle = ptr::null_mut();
+        assert_eq!(
+            unsafe { sql_alloc_handle(SQL_HANDLE_STMT, dbc, &mut stmt) },
+            SQL_SUCCESS
+        );
+
+        assert_eq!(
+            unsafe { sql_free_handle(SQL_HANDLE_STMT, stmt) },
+            SQL_SUCCESS
+        );
+        assert_eq!(
+            unsafe { sql_free_handle(SQL_HANDLE_STMT, stmt) },
+            SQL_SUCCESS,
+            "freeing an already-freed STMT handle must no-op, not panic"
+        );
+
+        unsafe { sql_free_handle(SQL_HANDLE_DBC, dbc) };
+        unsafe { sql_free_handle(SQL_HANDLE_ENV, env) };
+    }
+
     /// Freeing a statement mid data-at-execution must drain the parked
     /// sequence rather than drop the handle with it intact. A dropped
     /// `DaeState` takes the connection's client with it, leaving the DBC with
@@ -597,6 +655,33 @@ mod tests {
 
         let ret = unsafe { sql_free_handle(SQL_HANDLE_DESC, desc) };
         assert_eq!(ret, SQL_SUCCESS);
+
+        unsafe { sql_free_handle(SQL_HANDLE_DBC, dbc) };
+        unsafe { sql_free_handle(SQL_HANDLE_ENV, env) };
+    }
+
+    /// Reproduces mssql-rs#400 for descriptors: same scenario and reasoning
+    /// as `free_stmt_twice_is_a_no_op_not_a_panic`, but through `free_desc`'s
+    /// own `debug_assert_eq!` a few lines in.
+    #[test]
+    fn free_desc_twice_is_a_no_op_not_a_panic() {
+        let (env, dbc) = alloc_env_dbc_connected();
+
+        let mut desc: SqlHandle = ptr::null_mut();
+        assert_eq!(
+            unsafe { sql_alloc_handle(SQL_HANDLE_DESC, dbc, &mut desc) },
+            SQL_SUCCESS
+        );
+
+        assert_eq!(
+            unsafe { sql_free_handle(SQL_HANDLE_DESC, desc) },
+            SQL_SUCCESS
+        );
+        assert_eq!(
+            unsafe { sql_free_handle(SQL_HANDLE_DESC, desc) },
+            SQL_SUCCESS,
+            "freeing an already-freed DESC handle must no-op, not panic"
+        );
 
         unsafe { sql_free_handle(SQL_HANDLE_DBC, dbc) };
         unsafe { sql_free_handle(SQL_HANDLE_ENV, env) };

--- a/mssql-odbc/src/handles/mod.rs
+++ b/mssql-odbc/src/handles/mod.rs
@@ -45,12 +45,40 @@ pub(crate) enum HandleType {
 /// genuine use-after-free once the memory has actually been reused —
 /// observed allocator-dependently on macOS in CI. See mssql-rs#400.
 ///
-/// Deliberately narrower than a full refcounted-handle-lifetime redesign
-/// (tracked separately, `disconnect.rs`'s existing TODO): this only
+/// # Known limitation: address reuse (ABA)
+///
+/// This registry answers "is *some* handle currently allocated at this
+/// address," not "is this *specific* allocation still the one at this
+/// address" — it cannot, since it only ever sees a bare `usize`, with
+/// nothing to distinguish one allocation from a different, later one that
+/// happens to land at the same freed address. So: free handle A, then
+/// allocate a brand-new handle B that the allocator happens to place at
+/// A's old address, and `is_live(A)` reports `true` again — not because A
+/// is somehow still valid, but because the registry cannot tell A and B
+/// apart. A caller still holding stale handle A would then have it
+/// dereferenced as if it were still A, corrupting or freeing B instead
+/// (flagged in review of #415; see
+/// `tests::is_live_cannot_distinguish_a_reused_address_from_the_original_allocation`
+/// for a direct demonstration). This does not make anything *worse* than
+/// before this registry existed — every stale-handle free unconditionally
+/// dereferenced with no check at all — it just means the improvement here
+/// is narrower than "safe against every stale handle": specifically, safe
+/// against the common case where nothing has reallocated at that address
+/// yet, which is what #400's reproduction and the CI failure that
+/// motivated it actually hit.
+///
+/// Actually closing this needs handle identity that survives address
+/// reuse — a generation-tracked indirection layer (handles as small stable
+/// indices into a slot table, not raw pointers) rather than a raw-address
+/// registry. That is squarely the same class of redesign as the existing
+/// refcounted-handle-lifetime TODO (`disconnect.rs`), tracked separately as
+/// mssql-rs#422 rather than attempted here.
+///
+/// Deliberately narrower than that redesign in a second way too: this only
 /// distinguishes "already freed" from "still live," not "live but
 /// concurrently being freed on another thread right now" — that TOCTOU
 /// window is the pre-existing, wider concurrent-use race this crate already
-/// documents and does not attempt to close here.
+/// documents and does not attempt to close here either.
 static LIVE_HANDLES: LazyLock<Mutex<HashSet<usize>>> = LazyLock::new(|| Mutex::new(HashSet::new()));
 
 /// Returns whether `raw` currently refers to a handle that has been
@@ -165,5 +193,42 @@ mod tests {
     fn is_live_is_false_for_an_address_never_allocated() {
         let never_allocated = 0xDEAD_BEEF_usize as *mut c_void;
         assert!(!is_live(never_allocated));
+    }
+
+    /// Documents the registry's known ABA gap (see the doc comment on
+    /// `LIVE_HANDLES`): it tracks addresses, not allocation identity, so it
+    /// cannot tell an original allocation apart from an unrelated later one
+    /// that the allocator happens to place at the same now-freed address.
+    ///
+    /// Real OS-level address reuse can't be forced portably or
+    /// deterministically from a test, so this demonstrates the exact
+    /// consequence directly against the registry: free a handle, insert a
+    /// *different* handle's address into the registry at the same value
+    /// (standing in for the allocator reusing that address), and show
+    /// `is_live` reports the stale original as live again purely because the
+    /// address matches — not because the original allocation is in any way
+    /// still valid.
+    #[test]
+    fn is_live_cannot_distinguish_a_reused_address_from_the_original_allocation() {
+        let original = EnvHandle::new().expect("failed to create EnvHandle for test");
+        let raw = handle_to_raw(Box::new(original));
+
+        unsafe { free_handle::<EnvHandle>(raw) };
+        assert!(!is_live(raw), "freed handle must not be reported live");
+
+        // Stand in for the allocator handing the same address back out for
+        // an unrelated new allocation, without going through
+        // `handle_to_raw` (there is no portable way to force the real
+        // allocator to reuse this exact address deterministically).
+        LIVE_HANDLES
+            .lock()
+            .expect("registry mutex should not be poisoned in this test")
+            .insert(raw as usize);
+
+        assert!(
+            is_live(raw),
+            "registry cannot distinguish a reused address from the stale original: \
+             this is the documented ABA limitation, not a passing safety check"
+        );
     }
 }

--- a/mssql-odbc/src/handles/mod.rs
+++ b/mssql-odbc/src/handles/mod.rs
@@ -12,7 +12,9 @@ pub(crate) use env::EnvHandle;
 pub(crate) use env::OdbcVersion;
 pub(crate) use stmt::StmtHandle;
 
+use std::collections::HashSet;
 use std::ffi::c_void;
+use std::sync::{LazyLock, Mutex};
 
 use tracing::{debug, trace};
 
@@ -29,10 +31,52 @@ pub(crate) enum HandleType {
     Invalid = 0xDEADBEEF,
 }
 
+/// Tracks every currently-allocated handle by raw address, independent of the
+/// handle's own memory. This is what lets a free path confirm a handle is
+/// still live *before* dereferencing it, instead of dereferencing first and
+/// only checking a parent's child list afterward.
+///
+/// Closes a real gap: `SQLDisconnect` cascades-frees every STMT and explicit
+/// DESC on a connection (`sql_disconnect_safe`), which the ODBC Driver
+/// Manager does not observe — an application legitimately holding one of
+/// those now-stale handles can still call `SQLFreeHandle` on it afterward
+/// (confirmed reachable during PR #370's review, not merely hypothetical).
+/// Reading through such a handle before confirming it is still live is a
+/// genuine use-after-free once the memory has actually been reused —
+/// observed allocator-dependently on macOS in CI. See mssql-rs#400.
+///
+/// Deliberately narrower than a full refcounted-handle-lifetime redesign
+/// (tracked separately, `disconnect.rs`'s existing TODO): this only
+/// distinguishes "already freed" from "still live," not "live but
+/// concurrently being freed on another thread right now" — that TOCTOU
+/// window is the pre-existing, wider concurrent-use race this crate already
+/// documents and does not attempt to close here.
+static LIVE_HANDLES: LazyLock<Mutex<HashSet<usize>>> = LazyLock::new(|| Mutex::new(HashSet::new()));
+
+/// Returns whether `raw` currently refers to a handle that has been
+/// allocated (via `handle_to_raw`) and not yet freed (via `free_handle`).
+///
+/// Safe to call on any pointer value, including a stale one whose memory may
+/// already be deallocated or reused: this never dereferences `raw`, so
+/// callers can use it to decide whether dereferencing is safe in the first
+/// place. If the registry lock is itself poisoned, conservatively reports
+/// "not live" — treating an ambiguous handle as already-freed risks a leak,
+/// treating it as live risks a genuine use-after-free.
+pub(crate) fn is_live(raw: *mut c_void) -> bool {
+    LIVE_HANDLES
+        .lock()
+        .map(|live| live.contains(&(raw as usize)))
+        .unwrap_or(false)
+}
+
 /// Converts a heap-allocated handle into an opaque `*mut c_void` for return through FFI.
 /// Ownership transfers to the caller (ODBC Driver Manager).
 pub(crate) fn handle_to_raw<T>(handle: Box<T>) -> *mut c_void {
-    Box::into_raw(handle) as *mut c_void
+    let raw = Box::into_raw(handle) as *mut c_void;
+    if let Ok(mut live) = LIVE_HANDLES.lock() {
+        live.insert(raw as usize);
+    }
+    raw
 }
 
 /// Recovers a reference to a typed handle from an opaque `*mut c_void`.
@@ -75,6 +119,9 @@ pub(crate) unsafe fn handle_from_raw_mut<'a, T>(raw: *mut c_void) -> &'a mut T {
 /// Must only be called once per handle. The pointer is invalid after this call.
 pub(crate) unsafe fn free_handle<T: HasObjectType>(raw: *mut c_void) {
     if !raw.is_null() {
+        if let Ok(mut live) = LIVE_HANDLES.lock() {
+            live.remove(&(raw as usize));
+        }
         let handle = unsafe { &mut *(raw as *mut T) };
         let object_type = *handle.object_type_mut();
         debug!(?raw, ?object_type, "Freeing handle");
@@ -89,4 +136,34 @@ pub(crate) unsafe fn free_handle<T: HasObjectType>(raw: *mut c_void) {
 /// detection
 pub(crate) trait HasObjectType {
     fn object_type_mut(&mut self) -> &mut HandleType;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handle_is_live_after_alloc_and_not_after_free() {
+        let env = EnvHandle::new().expect("failed to create EnvHandle for test");
+        let raw = handle_to_raw(Box::new(env));
+
+        assert!(is_live(raw), "a freshly allocated handle must be live");
+
+        unsafe { free_handle::<EnvHandle>(raw) };
+
+        assert!(
+            !is_live(raw),
+            "a freed handle must no longer be reported live"
+        );
+    }
+
+    /// `is_live` must never dereference its argument: a pointer value that
+    /// was never handed out by `handle_to_raw` at all (as opposed to one that
+    /// was handed out and later freed) is exactly the kind of garbage input
+    /// it has to tolerate without touching the memory it (doesn't) point at.
+    #[test]
+    fn is_live_is_false_for_an_address_never_allocated() {
+        let never_allocated = 0xDEAD_BEEF_usize as *mut c_void;
+        assert!(!is_live(never_allocated));
+    }
 }

--- a/mssql-odbc/src/handles/mod.rs
+++ b/mssql-odbc/src/handles/mod.rs
@@ -90,6 +90,17 @@ static LIVE_HANDLES: LazyLock<Mutex<HashSet<usize>>> = LazyLock::new(|| Mutex::n
 /// place. If the registry lock is itself poisoned, conservatively reports
 /// "not live" — treating an ambiguous handle as already-freed risks a leak,
 /// treating it as live risks a genuine use-after-free.
+///
+/// That leak-over-UAF trade-off is permanent once triggered, not scoped to
+/// one call: a poisoned `std::sync::Mutex` never un-poisons, and
+/// `handle_to_raw` makes the matching choice on the insert side (silently
+/// skips registering new handles rather than panicking), so every handle —
+/// past and future — would report "not live" for the rest of the process,
+/// making `free_stmt`/`free_desc` skip freeing them all. In practice this
+/// needs a panic while holding `LIVE_HANDLES`'s lock, whose critical
+/// sections are a single `HashSet` op each with no user code or I/O that
+/// could panic, so it's realistically very unlikely — documented here so it
+/// isn't rediscovered as a mystery leak later.
 pub(crate) fn is_live(raw: *mut c_void) -> bool {
     LIVE_HANDLES
         .lock()

--- a/mssql-odbc/src/handles/mod.rs
+++ b/mssql-odbc/src/handles/mod.rs
@@ -12,9 +12,9 @@ pub(crate) use env::EnvHandle;
 pub(crate) use env::OdbcVersion;
 pub(crate) use stmt::StmtHandle;
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::ffi::c_void;
-use std::sync::{LazyLock, Mutex};
+use std::sync::{LazyLock, Mutex, MutexGuard};
 
 use tracing::{debug, trace};
 
@@ -31,90 +31,90 @@ pub(crate) enum HandleType {
     Invalid = 0xDEADBEEF,
 }
 
-/// Tracks every currently-allocated handle by raw address, independent of the
-/// handle's own memory. This is what lets a free path confirm a handle is
-/// still live *before* dereferencing it, instead of dereferencing first and
-/// only checking a parent's child list afterward.
+/// Tracks every currently-allocated handle's `HandleType` by raw address,
+/// independent of the handle's own memory. Lets a free path confirm a
+/// handle is still live, and of the expected type, *before* dereferencing
+/// it — instead of dereferencing first and checking a parent's child list,
+/// or the handle's own type tag, afterward.
 ///
-/// Closes a real gap: `SQLDisconnect` cascades-frees every STMT and explicit
-/// DESC on a connection (`sql_disconnect_safe`), which the ODBC Driver
-/// Manager does not observe — an application legitimately holding one of
-/// those now-stale handles can still call `SQLFreeHandle` on it afterward
-/// (confirmed reachable during PR #370's review, not merely hypothetical).
-/// Reading through such a handle before confirming it is still live is a
-/// genuine use-after-free once the memory has actually been reused —
-/// observed allocator-dependently on macOS in CI. See mssql-rs#400.
+/// Closes two real gaps:
+/// - Address liveness: `SQLDisconnect` cascade-frees every STMT and
+///   explicit DESC on a connection (`sql_disconnect_safe`) behind the
+///   Driver Manager's back, so an application legitimately holding one of
+///   those now-stale handles can still call `SQLFreeHandle` on it
+///   afterward. Dereferencing before confirming it's still live is a
+///   genuine use-after-free once the memory is reused. See #400.
+/// - Type confusion: `SQLFreeHandle` dispatches on the caller-supplied
+///   `handle_type` with no cross-check, so a live handle of the wrong type
+///   (e.g. a DESC passed where a STMT was expected) used to reach
+///   `handle_from_raw::<StmtHandle>` and get reinterpreted — no address
+///   reuse required. Recording the type here answers that without the
+///   same dereference-to-check-the-type problem this registry exists to
+///   avoid in the first place.
 ///
 /// # Known limitation: address reuse (ABA)
 ///
-/// This registry answers "is *some* handle currently allocated at this
-/// address," not "is this *specific* allocation still the one at this
-/// address" — it cannot, since it only ever sees a bare `usize`, with
-/// nothing to distinguish one allocation from a different, later one that
-/// happens to land at the same freed address. So: free handle A, then
-/// allocate a brand-new handle B that the allocator happens to place at
-/// A's old address, and `is_live(A)` reports `true` again — not because A
-/// is somehow still valid, but because the registry cannot tell A and B
-/// apart. A caller still holding stale handle A would then have it
-/// dereferenced as if it were still A, corrupting or freeing B instead
-/// (flagged in review of #415; see
+/// Tracking `HandleType` doesn't extend to telling one allocation apart
+/// from a *later, same-typed* one that the allocator places at the same
+/// freed address: free handle A, allocate a new same-typed handle B at A's
+/// old address, and this registry reports A's address as live with the
+/// expected type again — not because A is valid, but because it cannot
+/// distinguish A from B. See
 /// `tests::is_live_cannot_distinguish_a_reused_address_from_the_original_allocation`
-/// for a direct demonstration). This does not make anything *worse* than
-/// before this registry existed — every stale-handle free unconditionally
-/// dereferenced with no check at all — it just means the improvement here
-/// is narrower than "safe against every stale handle": specifically, safe
-/// against the common case where nothing has reallocated at that address
-/// yet, which is what #400's reproduction and the CI failure that
-/// motivated it actually hit.
+/// for a direct demonstration (real OS-level reuse can't be forced
+/// portably/deterministically from a test). Closing this needs handle
+/// identity that survives address reuse — a generation-tracked indirection
+/// layer, the same class of redesign as the pre-existing refcounted-
+/// handle-lifetime TODO in `disconnect.rs` — tracked separately as #422.
 ///
-/// Actually closing this needs handle identity that survives address
-/// reuse — a generation-tracked indirection layer (handles as small stable
-/// indices into a slot table, not raw pointers) rather than a raw-address
-/// registry. That is squarely the same class of redesign as the existing
-/// refcounted-handle-lifetime TODO (`disconnect.rs`), tracked separately as
-/// mssql-rs#422 rather than attempted here.
-///
-/// Deliberately narrower than that redesign in a second way too: this only
-/// distinguishes "already freed" from "still live," not "live but
+/// Also narrower in a second way: this only distinguishes "already freed
+/// or wrong type" from "still live as expected," not "live but
 /// concurrently being freed on another thread right now" — that TOCTOU
-/// window is the pre-existing, wider concurrent-use race this crate already
-/// documents and does not attempt to close here either.
-static LIVE_HANDLES: LazyLock<Mutex<HashSet<usize>>> = LazyLock::new(|| Mutex::new(HashSet::new()));
+/// window is the pre-existing, wider concurrent-use race this crate
+/// already documents and does not attempt to close here.
+static LIVE_HANDLES: LazyLock<Mutex<HashMap<usize, HandleType>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
-/// Returns whether `raw` currently refers to a handle that has been
-/// allocated (via `handle_to_raw`) and not yet freed (via `free_handle`).
-///
-/// Safe to call on any pointer value, including a stale one whose memory may
-/// already be deallocated or reused: this never dereferences `raw`, so
-/// callers can use it to decide whether dereferencing is safe in the first
-/// place. If the registry lock is itself poisoned, conservatively reports
-/// "not live" — treating an ambiguous handle as already-freed risks a leak,
-/// treating it as live risks a genuine use-after-free.
-///
-/// That leak-over-UAF trade-off is permanent once triggered, not scoped to
-/// one call: a poisoned `std::sync::Mutex` never un-poisons, and
-/// `handle_to_raw` makes the matching choice on the insert side (silently
-/// skips registering new handles rather than panicking), so every handle —
-/// past and future — would report "not live" for the rest of the process,
-/// making `free_stmt`/`free_desc` skip freeing them all. In practice this
-/// needs a panic while holding `LIVE_HANDLES`'s lock, whose critical
-/// sections are a single `HashSet` op each with no user code or I/O that
-/// could panic, so it's realistically very unlikely — documented here so it
-/// isn't rediscovered as a mystery leak later.
-pub(crate) fn is_live(raw: *mut c_void) -> bool {
+/// Locks `LIVE_HANDLES`, recovering the guard even if the mutex is
+/// poisoned. Its critical sections are a single `HashMap` operation each,
+/// with no user code, I/O, or user-supplied `Hash` impl to panic mid-update
+/// and leave the map inconsistent, so there is no invariant recovering
+/// could violate here — only a handle-freeing path that would otherwise
+/// break for the rest of the process over a poisoning that can't happen.
+fn live_handles() -> MutexGuard<'static, HashMap<usize, HandleType>> {
     LIVE_HANDLES
         .lock()
-        .map(|live| live.contains(&(raw as usize)))
-        .unwrap_or(false)
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Returns the `HandleType` recorded for `raw` if it currently refers to a
+/// live handle (allocated via `handle_to_raw`, not yet freed via
+/// `free_handle`), or `None` otherwise.
+///
+/// Safe to call on any pointer value, including one never allocated or
+/// already freed, whose memory may be deallocated or reused: this never
+/// dereferences `raw`, so callers can use it to decide whether
+/// dereferencing is safe — and as what type — in the first place.
+pub(crate) fn live_type(raw: *mut c_void) -> Option<HandleType> {
+    live_handles().get(&(raw as usize)).copied()
+}
+
+/// Returns whether `raw` currently refers to a live handle of any type.
+/// Only used by tests today — production call sites need the type check
+/// `live_type` itself provides, so they match on it directly.
+#[cfg(test)]
+pub(crate) fn is_live(raw: *mut c_void) -> bool {
+    live_type(raw).is_some()
 }
 
 /// Converts a heap-allocated handle into an opaque `*mut c_void` for return through FFI.
-/// Ownership transfers to the caller (ODBC Driver Manager).
-pub(crate) fn handle_to_raw<T>(handle: Box<T>) -> *mut c_void {
+/// Ownership transfers to the caller (ODBC Driver Manager). Records the
+/// handle's `HandleType` in `LIVE_HANDLES` before it does, so `live_type`
+/// can answer for it later without a dereference.
+pub(crate) fn handle_to_raw<T: HasObjectType>(mut handle: Box<T>) -> *mut c_void {
+    let object_type = *handle.object_type_mut();
     let raw = Box::into_raw(handle) as *mut c_void;
-    if let Ok(mut live) = LIVE_HANDLES.lock() {
-        live.insert(raw as usize);
-    }
+    live_handles().insert(raw as usize, object_type);
     raw
 }
 
@@ -158,9 +158,7 @@ pub(crate) unsafe fn handle_from_raw_mut<'a, T>(raw: *mut c_void) -> &'a mut T {
 /// Must only be called once per handle. The pointer is invalid after this call.
 pub(crate) unsafe fn free_handle<T: HasObjectType>(raw: *mut c_void) {
     if !raw.is_null() {
-        if let Ok(mut live) = LIVE_HANDLES.lock() {
-            live.remove(&(raw as usize));
-        }
+        live_handles().remove(&(raw as usize));
         let handle = unsafe { &mut *(raw as *mut T) };
         let object_type = *handle.object_type_mut();
         debug!(?raw, ?object_type, "Freeing handle");
@@ -196,6 +194,35 @@ mod tests {
         );
     }
 
+    /// A poisoned `LIVE_HANDLES` mutex must not permanently blind the
+    /// registry: `live_handles()` recovers the guard instead of treating
+    /// poison as fatal, since its critical sections are a single `HashMap`
+    /// op each with no invariant a panic mid-update could leave broken.
+    /// Poisons the lock directly (panicking while holding it, without
+    /// mutating the map), then confirms handle tracking still works
+    /// normally afterward rather than silently going blind for the rest of
+    /// the process.
+    #[test]
+    fn live_handles_registry_recovers_from_a_poisoned_lock() {
+        let _ = std::panic::catch_unwind(|| {
+            let _guard = LIVE_HANDLES.lock().unwrap();
+            panic!("poison the live-handles registry lock");
+        });
+
+        let env = EnvHandle::new().expect("failed to create EnvHandle for test");
+        let raw = handle_to_raw(Box::new(env));
+        assert!(
+            is_live(raw),
+            "a poisoned registry must recover and keep tracking new handles"
+        );
+
+        unsafe { free_handle::<EnvHandle>(raw) };
+        assert!(
+            !is_live(raw),
+            "a poisoned registry must recover and still untrack freed handles"
+        );
+    }
+
     /// `is_live` must never dereference its argument: a pointer value that
     /// was never handed out by `handle_to_raw` at all (as opposed to one that
     /// was handed out and later freed) is exactly the kind of garbage input
@@ -207,18 +234,19 @@ mod tests {
     }
 
     /// Documents the registry's known ABA gap (see the doc comment on
-    /// `LIVE_HANDLES`): it tracks addresses, not allocation identity, so it
-    /// cannot tell an original allocation apart from an unrelated later one
-    /// that the allocator happens to place at the same now-freed address.
+    /// `LIVE_HANDLES`): tracking `HandleType` closes type confusion, but not
+    /// address reuse — it still cannot tell an original allocation apart
+    /// from an unrelated, *same-typed* later one that the allocator places
+    /// at the same now-freed address.
     ///
     /// Real OS-level address reuse can't be forced portably or
     /// deterministically from a test, so this demonstrates the exact
-    /// consequence directly against the registry: free a handle, insert a
-    /// *different* handle's address into the registry at the same value
-    /// (standing in for the allocator reusing that address), and show
-    /// `is_live` reports the stale original as live again purely because the
-    /// address matches — not because the original allocation is in any way
-    /// still valid.
+    /// consequence directly against the registry: free a handle, then
+    /// insert its address back under the same type (standing in for the
+    /// allocator reusing that address for a new, unrelated allocation of
+    /// the same type), and show `live_type` reports the stale original as
+    /// live and correctly-typed again — not because the original
+    /// allocation is in any way still valid.
     #[test]
     fn is_live_cannot_distinguish_a_reused_address_from_the_original_allocation() {
         let original = EnvHandle::new().expect("failed to create EnvHandle for test");
@@ -228,18 +256,23 @@ mod tests {
         assert!(!is_live(raw), "freed handle must not be reported live");
 
         // Stand in for the allocator handing the same address back out for
-        // an unrelated new allocation, without going through
-        // `handle_to_raw` (there is no portable way to force the real
-        // allocator to reuse this exact address deterministically).
-        LIVE_HANDLES
-            .lock()
-            .expect("registry mutex should not be poisoned in this test")
-            .insert(raw as usize);
+        // an unrelated new allocation of the same type, without going
+        // through `handle_to_raw` (there is no portable way to force the
+        // real allocator to reuse this exact address deterministically).
+        live_handles().insert(raw as usize, HandleType::Env);
 
-        assert!(
-            is_live(raw),
-            "registry cannot distinguish a reused address from the stale original: \
+        assert_eq!(
+            live_type(raw),
+            Some(HandleType::Env),
+            "registry cannot distinguish a reused address from the stale original, \
+             even with type tracking, once the new allocation shares the same type: \
              this is the documented ABA limitation, not a passing safety check"
         );
+
+        // Clean up: this test shares `LIVE_HANDLES` with every other test in
+        // the process under plain `cargo test` (not `cargo nextest`, which
+        // gives each test its own process), so leaving `raw` behind would
+        // seed a phantom-live address into state other tests read.
+        live_handles().remove(&(raw as usize));
     }
 }


### PR DESCRIPTION
## Description

Fixes **#400** and **#401**, both filed by David Engel during PR #370's review as narrow, pre-existing follow-ups (explicitly called out as not blocking that PR, since they predate it or were deliberately deferred).

### #400 — `SQLFreeHandle` on a stale STMT/DESC handle dereferenced freed memory before the "already dropped" guard

`free_stmt` and `free_desc` both guarded against a double-free by checking the parent DBC's child list — but only *after* already dereferencing the handle (`debug_assert_eq!` on `object_type`, locking `.inner` for `free_errors`, reading `.parent_dbc`). When `SQLDisconnect` had already cascade-freed the handle behind the Driver Manager's back — an application legitimately holding a stale STMT/DESC handle across disconnect and then calling `SQLFreeHandle` on it is ordinary usage, not DM misuse — every one of those reads was a genuine use-after-free. This usually "worked" because the freed block hadn't been reused yet, but an allocator that reuses it sooner (observed on macOS during PR #370's own CI) breaks even that.

**Fix:** added a lightweight live-handle registry (`handles::live_type`, a process-wide `Mutex<HashMap<usize, HandleType>>` populated in `handle_to_raw` and depopulated in `free_handle` — the two existing choke points every handle already funnels through) that answers "is this raw address still an allocated handle, and of what type" *without ever dereferencing it*. `free_stmt`/`free_desc` now check it before doing anything else, returning `SQL_SUCCESS` immediately on a stale handle. Deliberately narrower than the full refcounted-handle-lifetime redesign `disconnect.rs`'s existing TODO already tracks — this only closes the *sequential* "already fully freed" case, not the separate *concurrent*-use race that TODO covers, nor address-reuse (ABA) — see below.

**Externally visible behavior change:** `SQLFreeHandle` now returns `SQL_INVALID_HANDLE`, per spec, when called with a live handle of the wrong type for all four handle types (ENV/DBC/STMT/DESC) — e.g. `SQLFreeHandle(SQL_HANDLE_STMT, <live DESC>)`. Before this PR, that case reached `handle_from_raw::<WrongType>` and silently reinterpreted the handle's memory as the wrong type (genuine UB, not just a logic error), since neither the affected handle structs are `#[repr(C)]` nor the same size as each other.

### #401 — `SQLDisconnect`'s statement loop could double-free on retry after a poisoned mutex

The statement-free loop in `sql_disconnect_safe` iterated `state.statements` by reference and cleared it only after the loop finished, so a poisoned STMT mutex mid-loop returned `SQL_ERROR` with every already-freed pointer still in the list — a retried `SQLDisconnect` (a reasonable response to `SQL_ERROR`) would re-walk the full original list and double-free. The descriptor loop directly below it already used a pop-then-free shape for exactly this reason; the statement loop just hadn't been updated to match.

**Fix, revised after review:** the initial fix switched the statement loop to the same pop-then-fail-on-poison shape as the descriptor loop, but review correctly flagged that shape as still broken: popping the pointer *before* the lock check means a poisoned mutex leaves the statement permanently orphaned — no longer tracked for a retry to find, yet never freed either, unreachable by any future call. Both loops now instead **tolerate a poisoned mutex and free anyway**: the lock here is pure synchronization (never read after acquiring), and a poisoning panic still fully releases the underlying lock on unwind, so a poisoned outcome doesn't change whether it's safe to free the box. This matches `free_stmt`/`free_desc`'s own existing tolerance for their handle's lock.

### Follow-ups from review, addressed in this PR

- **`LIVE_HANDLES` address-reuse (ABA) limitation.** The registry tracks raw addresses (now with type), not allocation identity, so it cannot distinguish a stale handle from an unrelated new one of the same type the allocator later places at the same freed address. Closing that needs handle identity that survives address reuse (a generation-tracked indirection layer), out of scope here — the same class of redesign as the pre-existing refcounted-handle-lifetime TODO. Documented directly on `LIVE_HANDLES`'s doc comment, added a test demonstrating the exact mechanism, and filed #422 to track a proper fix.
- **Type confusion beyond STMT/DESC.** An earlier revision of this PR closed the type-confusion hole only for `free_stmt`/`free_desc`; review pointed out `free_env`/`free_dbc` had the identical gap. Closed the same way for all four handle types.
- **Implicit-descriptor rejection skipped under a poisoned lock.** `free_desc`'s HY017 rejection for implicit descriptors was originally nested inside `desc.inner.lock()`, so a poisoned mutex on that descriptor skipped the whole check and fell through to unrelated code paths. Hoisted the (lock-free) `is_explicit()` check above the lock so the rejection is unconditional — this itself briefly regressed diagnostic-clearing (caught in follow-up review; every ODBC entry point must clear stale diagnostics before posting a new one) before landing on the final version, which folds `free_errors` into the same guarded block as `post_diag`.
- **Poisoned-registry recovery.** `LIVE_HANDLES`'s lock is recovered via `into_inner()` on poison rather than treating the whole registry as permanently blind — justified because its critical sections are single `HashMap` ops with no user code/I/O that could actually poison it, and this repo already uses the same pattern elsewhere (`auth/msqa.rs`, `auth/entra.rs`). This is a deliberate, narrow exception to `.github/instructions/mssql-odbc.instructions.md`'s general "never recover via `into_inner()`" rule; filed #430 to reconcile the instructions with it.

## Testing

Every fix ships with regression tests I verified **actually catch the bug**: temporarily reverted each fix, confirmed the corresponding test fails with the exact predicted symptom, then restored the fix and confirmed it passes. Highlights:

- `free_stmt_twice_is_a_no_op_not_a_panic` / `free_desc_twice_is_a_no_op_not_a_panic`: call `SQLFreeHandle` twice on the same handle, assert `SQL_SUCCESS` both times.
- `free_stmt_on_a_live_desc_handle_returns_invalid_handle` / `free_desc_on_a_live_stmt_handle_returns_invalid_handle` / `free_env_on_a_live_dbc_handle_returns_invalid_handle` / `free_dbc_on_a_live_env_handle_returns_invalid_handle`: a live handle of the wrong type is rejected with `SQL_INVALID_HANDLE`, not reinterpreted.
- `disconnect_frees_a_statement_even_if_its_mutex_is_poisoned`: poisons one of two statements' mutexes, confirms `SQLDisconnect` still succeeds and both statements are actually freed.
- `free_implicit_desc_is_rejected_even_with_a_poisoned_mutex`: poisons the implicit descriptor's own mutex, confirms the HY017 rejection still happens (calls `free_desc` directly, bypassing `ffi_entry!`'s `catch_unwind`, so a wrongly-firing `debug_assert!` can't be laundered into the same `SQL_ERROR` a correct rejection also returns).
- `free_implicit_desc_is_rejected`: now calls the rejection twice and asserts exactly one diagnostic record each time, guarding the diagnostic-clearing regression above.
- `live_handles_registry_recovers_from_a_poisoned_lock`: poisons the registry's own lock directly, confirms handle tracking still works afterward.
- `is_live_cannot_distinguish_a_reused_address_from_the_original_allocation`: documents the registry's known ABA gap by directly simulating address reuse (real OS-level reuse can't be forced portably/deterministically from a test).

## Validation

- `cargo nextest run -p mssql-odbc --lib` — 1098 passed, 1 skipped (pre-existing, requires a live server).
- `cargo bclippy` (workspace, `-D warnings`) — clean.
- `cargo bfmt` (workspace) — clean.
- Full PR validation pipeline (Linux/Linux ARM/Windows/Windows ARM/macOS builds and tests, Kerberos, mssql-python cross-repo, coverage) — all green.

## Related Issues

Fixes #400
Fixes #401
Relates to #422 (filed from this PR's review, tracking the `LIVE_HANDLES` ABA follow-up)
Relates to #430 (filed from this PR's review, tracking the `into_inner()` instructions carve-out)

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes (`cargo nextest run -p mssql-odbc --lib`: 1098 passed, 1 skipped)
- [x] New/changed functionality has tests
- [x] Public API changes are documented (no *new* public API, but `SQLFreeHandle`'s behavior on a live handle of the wrong type changed from UB to a spec-compliant `SQL_INVALID_HANDLE` — see above)