### PR TITLE
Derive the SQLSTATE of an unmapped server error from its severity [AB#47532]

### DIFF
--- a/.github/instructions/mssql-odbc.instructions.md
+++ b/.github/instructions/mssql-odbc.instructions.md
@@ -161,9 +161,14 @@ authoritative parity reference for this crate. Its source lives in the
     `mssql_tds::TdsError` bubbling up from the protocol layer. For
     `TdsError::SqlServerError` it fans out to one record per server-reported
     error, mapping each error number to a SQLSTATE via the static
-    `SERVER_ERROR_TO_SQL_STATE_MAP`; for other variants it posts a single
-    record using `default_sqlstate`. Pick `08001` for connect-time
-    failures and `HY000` for execution/fetch failures.
+    `SERVER_ERROR_TO_SQL_STATE_MAP` and falling back to the message's TDS
+    severity class when the number is unmapped (`> 18` → `HY000`, `> 10` →
+    `42000`, else `01000`, matching msodbcsql's `sqlcerr.cpp:1385-1401`); for
+    other variants it posts a single record using `default_sqlstate`. Pick
+    `08001` for connect-time failures and `HY000` for execution/fetch
+    failures. Do not add rows to `SERVER_ERROR_TO_SQL_STATE_MAP` to correct a
+    single error's SQLSTATE — entries there are a permanent compatibility
+    commitment, and the severity fallback already covers unmapped errors.
   Never hand-roll `post_sql_error` over a `TdsError` — you lose the
   per-server-error fan-out and the SQLSTATE mapping.
 - Every ODBC entry point must clear the handle's diagnostic records at API

--- a/mssql-odbc/src/api/sqlstate.rs
+++ b/mssql-odbc/src/api/sqlstate.rs
@@ -31,6 +31,9 @@ pub(crate) const SQLSTATE_22018: [u8; 5] = *b"22018";
 pub(crate) const SQLSTATE_22026: [u8; 5] = *b"22026";
 pub(crate) const SQLSTATE_24000: [u8; 5] = *b"24000";
 pub(crate) const SQLSTATE_25000: [u8; 5] = *b"25000";
+/// Syntax error or access violation — the state a server error carries when it
+/// is the application's statement that is at fault.
+pub(crate) const SQLSTATE_42000: [u8; 5] = *b"42000";
 pub(crate) const SQLSTATE_HY000: [u8; 5] = *b"HY000";
 pub(crate) const SQLSTATE_HY003: [u8; 5] = *b"HY003";
 pub(crate) const SQLSTATE_HY004: [u8; 5] = *b"HY004";
@@ -517,15 +520,48 @@ pub(crate) fn sqlstate_for_sql_error(error_number: u32) -> Option<[u8; 5]> {
         .map(|i| SERVER_ERROR_TO_SQL_STATE_MAP[i].1)
 }
 
+/// Highest TDS severity class that is purely informational — msodbcsql's
+/// `EX_MAXISEVERITY` (`tds.h:603`).
+const SEVERITY_MAX_INFO: i32 = 10;
+/// Highest TDS severity class the user can correct — msodbcsql's
+/// `MAXUSEVERITY` (`tds.h:612`). Above it the failure is a system or resource
+/// condition the application cannot fix by changing its statement.
+const SEVERITY_MAX_USER: i32 = 18;
+
+/// SQLSTATE for a server message whose error number has no entry in
+/// [`SERVER_ERROR_TO_SQL_STATE_MAP`], derived from its TDS severity class.
+///
+/// msodbcsql tiers this fallback rather than using one fixed state
+/// (`PostSQLServerMessageEx`, `sqlcerr.cpp:1385-1401`): severity > 18 →
+/// `IDS_S1_000_01` (`HY000`), > 10 → `IDS_37_000` (`42000`), otherwise
+/// `IDS_01_000_00` (`01000`). The map's own header states the rule
+/// (`sqlcstr.cpp:120`: "Any SQLServer error not here will receive a 37000
+/// SQLState").
+///
+/// The middle tier is what makes an unmapped syntax error or a severity-16
+/// `RAISERROR` a *programming* error rather than a generic one — the
+/// distinction wrappers such as mssql-python use to pick an exception class.
+/// Growing the map instead would fix one error number at a time and violate
+/// its "entries are permanent" contract; the tier fixes every unmapped error.
+fn sqlstate_for_severity(class: i32) -> [u8; 5] {
+    if class > SEVERITY_MAX_USER {
+        SQLSTATE_HY000
+    } else if class > SEVERITY_MAX_INFO {
+        SQLSTATE_42000
+    } else {
+        SQLSTATE_01000
+    }
+}
+
 /// Post one ODBC diagnostic record per server error in `err`.
 ///
 /// For [`TdsError::SqlServerError`], iterates the server-reported errors in
 /// the order TDS delivered them and pushes one
 /// [`DiagRecord`](crate::error::DiagRecord) each. Each record's SQLSTATE
 /// comes from [`sqlstate_for_sql_error`]; any error number not in the map
-/// falls back to `default`. Native error and message are taken straight
-/// from the server-reported error. Any informational/warning messages the
-/// server sent alongside the errors are posted after the error records so a
+/// falls back to [`sqlstate_for_severity`]. Native error and message are taken
+/// straight from the server-reported error. Any informational/warning messages
+/// the server sent alongside the errors are posted after the error records so a
 /// failing call still surfaces the full server diagnostic set (matching
 /// msodbcsql).
 ///
@@ -533,9 +569,10 @@ pub(crate) fn sqlstate_for_sql_error(error_number: u32) -> Option<[u8; 5]> {
 /// timeout, …), pushes a single record with `default`, native error 0, and
 /// the error's `Display` text.
 ///
-/// `default` is the SQLSTATE that best describes the caller's context —
-/// typically `08001` for connect-time failures and `HY000` for general
-/// execution / fetch failures.
+/// `default` therefore describes the caller's context for failures the engine
+/// did *not* raise — typically `08001` for connect-time failures and `HY000`
+/// for general execution / fetch failures. A server error carries its own
+/// severity, so it never uses `default`.
 pub(crate) fn post_tds_error(state: &mut impl HasDiagnostics, err: &TdsError, default: [u8; 5]) {
     if let TdsError::SqlServerError { diagnostics } = err {
         if diagnostics.errors.is_empty() {
@@ -546,7 +583,8 @@ pub(crate) fn post_tds_error(state: &mut impl HasDiagnostics, err: &TdsError, de
             post_sql_error(state, default, 0, err.to_string());
         } else {
             for e in &diagnostics.errors {
-                let sqlstate = sqlstate_for_sql_error(e.number).unwrap_or(default);
+                let sqlstate = sqlstate_for_sql_error(e.number)
+                    .unwrap_or_else(|| sqlstate_for_severity(e.class));
                 let native = i32::try_from(e.number).unwrap_or(i32::MAX);
                 post_sql_error(
                     state,
@@ -581,7 +619,8 @@ pub(crate) fn post_tds_info_messages(
     messages: &[SqlInfoMessage],
 ) -> bool {
     for message in messages {
-        let sqlstate = sqlstate_for_sql_error(message.number).unwrap_or(SQLSTATE_01000);
+        let sqlstate = sqlstate_for_sql_error(message.number)
+            .unwrap_or_else(|| sqlstate_for_severity(message.class));
         let native = i32::try_from(message.number).unwrap_or(i32::MAX);
         post_sql_error(
             state,
@@ -690,7 +729,9 @@ mod tests {
 
     #[test]
     fn post_tds_error_posts_one_record_per_server_error_in_order() {
-        // 18456 → 28000 (mapped); 4060 → fallback (not in our map).
+        // 18456 → 28000 (mapped); 4060 → severity fallback (not in our map).
+        // `sql_error` builds class 14, so the fallback is the middle tier —
+        // `default` (08001 here) applies only to non-server failures.
         let mut s = FakeState::default();
         let err = TdsError::from_sql_errors(vec![
             sql_error(18456, "Login failed."),
@@ -700,8 +741,52 @@ mod tests {
         assert_eq!(s.records.len(), 2);
         assert_eq!(s.records[0].sql_state, *b"28000");
         assert_eq!(s.records[0].native_error, 18456);
-        assert_eq!(s.records[1].sql_state, SQLSTATE_08001); // fallback
+        assert_eq!(s.records[1].sql_state, SQLSTATE_42000);
         assert_eq!(s.records[1].native_error, 4060);
+    }
+
+    #[test]
+    fn severity_tiers_match_msodbcsql_boundaries() {
+        // sqlcerr.cpp:1385-1401 — > MAXUSEVERITY (18), > EX_MAXISEVERITY (10),
+        // else. Exercise both boundaries from either side.
+        assert_eq!(sqlstate_for_severity(0), SQLSTATE_01000);
+        assert_eq!(sqlstate_for_severity(10), SQLSTATE_01000);
+        assert_eq!(sqlstate_for_severity(11), SQLSTATE_42000);
+        assert_eq!(sqlstate_for_severity(16), SQLSTATE_42000);
+        assert_eq!(sqlstate_for_severity(18), SQLSTATE_42000);
+        assert_eq!(sqlstate_for_severity(19), SQLSTATE_HY000);
+        assert_eq!(sqlstate_for_severity(25), SQLSTATE_HY000);
+    }
+
+    #[test]
+    fn unmapped_server_error_takes_sqlstate_from_its_severity() {
+        // The three cases that drove AB#47532: an unmapped syntax error (102,
+        // severity 15), an unmapped conversion error (257, severity 16) and
+        // RAISERROR's generic 50000. None is in the map — nor in msodbcsql's —
+        // yet all must reach 42000 so wrappers classify them as programming
+        // errors rather than operational ones.
+        for (number, class) in [(102u32, 15), (257, 16), (50000, 16)] {
+            assert_eq!(sqlstate_for_sql_error(number), None, "error {number}");
+            let mut s = FakeState::default();
+            let mut e = sql_error(number, "boom");
+            e.class = class;
+            post_tds_error(&mut s, &TdsError::from_sql_errors(vec![e]), SQLSTATE_HY000);
+            assert_eq!(s.records.len(), 1);
+            assert_eq!(s.records[0].sql_state, SQLSTATE_42000, "error {number}");
+        }
+    }
+
+    #[test]
+    fn unmapped_fatal_server_error_stays_hy000() {
+        // Severity above MAXUSEVERITY is not something the application can fix
+        // by rewriting its statement, so it keeps the general error state.
+        let mut s = FakeState::default();
+        let mut e = sql_error(823, "I/O error");
+        e.class = 24;
+        post_tds_error(&mut s, &TdsError::from_sql_errors(vec![e]), SQLSTATE_HY000);
+        assert_eq!(s.records.len(), 1);
+        assert_eq!(s.records[0].sql_state, SQLSTATE_HY000);
+        assert_eq!(s.records[0].native_error, 823);
     }
 
     #[test]

--- a/mssql-odbc/src/api/sqlstate.rs
+++ b/mssql-odbc/src/api/sqlstate.rs
@@ -523,9 +523,8 @@ pub(crate) fn sqlstate_for_sql_error(error_number: u32) -> Option<[u8; 5]> {
 /// Highest TDS severity class that is purely informational — msodbcsql's
 /// `EX_MAXISEVERITY` (`tds.h:603`).
 const SEVERITY_MAX_INFO: i32 = 10;
-/// Highest TDS severity class the user can correct — msodbcsql's
-/// `MAXUSEVERITY` (`tds.h:612`). Above it the failure is a system or resource
-/// condition the application cannot fix by changing its statement.
+/// Upper boundary of msodbcsql's `42000` compatibility tier —
+/// `MAXUSEVERITY` (`tds.h:612`).
 const SEVERITY_MAX_USER: i32 = 18;
 
 /// SQLSTATE for a server message whose error number has no entry in

--- a/mssql-odbc/tests/e2e/tests/exec_direct_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/exec_direct_test.cpp
@@ -115,6 +115,43 @@ TEST_F(ExecDirectLiveTest, InvalidSql) {
     EXPECT_SQL_ERROR(rc);
 }
 
+// AB#47532: a server error with no entry in the error-number→SQLSTATE map takes
+// its state from the TDS severity class, not from a fixed HY000. Severity 11-18
+// is a user-correctable error, so it reports 42000 and wrappers can classify it
+// as a programming error. None of the error numbers below is in the map — nor in
+// msodbcsql's — so these tests only pass through the severity tier.
+TEST_F(ExecDirectLiveTest, SyntaxErrorReports42000) {
+    // Error 102/156, severity 15.
+    SqlTString sql = ODBCTestUtils::ToSqlTStr("SELECT * FROM");
+    SQLRETURN rc = SQLExecDirect(stmt_, const_cast<SQLTCHAR*>(sql.c_str()), SQL_NTS);
+    ASSERT_EQ(SQL_ERROR, rc);
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "42000");
+}
+
+TEST_F(ExecDirectLiveTest, ConversionErrorReports42000) {
+    // Error 257, severity 16 — implicit varchar→varbinary conversion.
+    SqlTString sql = ODBCTestUtils::ToSqlTStr(
+        "DECLARE @b VARBINARY(10); SET @b = 'not binary';");
+    SQLRETURN rc = SQLExecDirect(stmt_, const_cast<SQLTCHAR*>(sql.c_str()), SQL_NTS);
+    ASSERT_EQ(SQL_ERROR, rc);
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "42000");
+}
+
+TEST_F(ExecDirectLiveTest, RaiseErrorSeverity16Reports42000) {
+    // Native 50000 — RAISERROR's generic user-message number. It is deliberately
+    // absent from the map (it carries no fixed semantic), so only severity can
+    // classify it.
+    SqlTString sql = ODBCTestUtils::ToSqlTStr("RAISERROR(N'boom', 16, 1);");
+    SQLRETURN rc = SQLExecDirect(stmt_, const_cast<SQLTCHAR*>(sql.c_str()), SQL_NTS);
+    ASSERT_EQ(SQL_ERROR, rc);
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "42000");
+
+    SQLINTEGER native = 0;
+    std::string message = GetDiagMessageForRecord(stmt_, 1, &native);
+    EXPECT_EQ(50000, native);
+    EXPECT_NE(std::string::npos, message.find("boom"));
+}
+
 // Re-executing on the same STMT requires closing the cursor first.
 // SQLExecDirectW leaves an open cursor for result-bearing queries; the caller
 // must call SQLCloseCursor (or SQLFreeStmt(SQL_CLOSE)) before re-executing.

--- a/mssql-odbc/tests/e2e/tests/exec_direct_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/exec_direct_test.cpp
@@ -116,9 +116,9 @@ TEST_F(ExecDirectLiveTest, InvalidSql) {
 }
 
 // AB#47532: a server error with no entry in the error-number→SQLSTATE map takes
-// its state from the TDS severity class, not from a fixed HY000. Severity 11-18
-// is a user-correctable error, so it reports 42000 and wrappers can classify it
-// as a programming error. None of the error numbers below is in the map — nor in
+// its state from the TDS severity class, not from a fixed HY000. In msodbcsql's
+// compatibility tiers, severity 11-18 reports 42000, which wrappers classify as
+// a programming error. None of the error numbers below is in the map — nor in
 // msodbcsql's — so these tests only pass through the severity tier.
 TEST_F(ExecDirectLiveTest, SyntaxErrorReports42000) {
     // Error 102/156, severity 15.


### PR DESCRIPTION
## Description

A server error whose number is absent from `SERVER_ERROR_TO_SQL_STATE_MAP` fell back to whatever SQLSTATE the calling API had picked for its own context — `HY000` on every execution path. msodbcsql instead tiers that fallback on the TDS severity class (`PostSQLServerMessageEx`, `odbc/sqlcerr.cpp:1385-1401`):

| Severity class | msodbcsql resource | ODBC 3.x SQLSTATE |
| --- | --- | --- |
| `> MAXUSEVERITY` (18) | `IDS_S1_000_01` | `HY000` |
| `> EX_MAXISEVERITY` (10) | `IDS_37_000` | `42000` |
| otherwise | `IDS_01_000_00` | `01000` |

Constants are in `tds.h:602-612`; the state strings in `cli_common/src/clntcomn.cpp:1026,1034,1169`. The map's own header states the rule outright (`odbc/sqlcstr.cpp:120`): *"Any SQLServer error not here will receive a 37000 SQLState"* — `37000` being the ODBC 2.x spelling of `42000`.

Without the middle tier, an unmapped syntax error (102/156, severity 15), an implicit-conversion failure (257, severity 16) and `RAISERROR`'s generic 50000 all reported `HY000`, so mssql-python raised `OperationalError` where msodbcsql produces `ProgrammingError`.

Adding rows to the map would have been the wrong fix: none of these numbers is in msodbcsql's table either — it reaches the right answer purely through the tier. Growing the table would correct one error number at a time while leaving every other unmapped error wrong, and entries there are a permanent compatibility commitment requiring server-team sign-off (`sqlcstr.cpp:126-134`).

### Changes

- New `sqlstate_for_severity(class)` in `mssql-odbc/src/api/sqlstate.rs`, used by both `post_tds_error` and `post_tds_info_messages` when the error-number lookup misses.
- Added the `SQLSTATE_42000` constant.
- `post_tds_error`'s `default` argument now applies only to failures the engine did **not** raise (transport, TLS, protocol) and to a `SqlServerError` that carried no ERROR token. That is what each call site's `08001` / `08007` / `08S01` choice actually describes; a server error carries its own severity and no longer borrows it.
- Documented the rule in `.github/instructions/mssql-odbc.instructions.md`, including an explicit "don't grow the map to fix one SQLSTATE" note, so this doesn't get re-solved the wrong way.

No behavior change for info messages: `INFO` tokens are severity ≤ 10, which the tier maps to the `01000` they already used.

## Related Issues

https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47532

[AB#47532](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47532)

## Testing

**Unit** — new tests cover both tier boundaries from either side, the three driving error numbers (102 / 257 / 50000), and that a severity-24 error still reports `HY000`. `cargo test -p mssql-odbc --lib`: 1073 passed.

**e2e parity** — three new tests in `exec_direct_test.cpp` (`SyntaxErrorReports42000`, `ConversionErrorReports42000`, `RaiseErrorSeverity16Reports42000`). Ran the full suite on both drivers against SQL Server 2022:

```
./run_e2e.sh --skip-build --compare-with-msodbcsql
Summary: 29 parity, 0 divergence(s), 0 shared failure(s), 0 skipped
```

The three new tests pass identically on msodbcsql 18.6, so they are parity assertions rather than mssql-odbc-specific ones.

**Cross-repo (mssql-python on mssql-odbc)** — reproduced the CI job locally by swapping this driver into the mssql-python container, running each module on the baseline driver and again on the patched one, and diffing the failure sets:

| Test | Before | After |
| --- | --- | --- |
| `test_006_exceptions.py::test_syntax_error` | fail | pass |
| `test_006_exceptions.py::test_truncate_error_message` | fail | pass |
| `test_006_exceptions.py::test_data_truncation_error` | fail | pass |
| `test_004_cursor.py::test_gh627_temp_table_null_varbinary_raises` | fail | pass |
| `test_004_cursor.py::test_long_raiserror[2047]` | fail | pass |
| `test_004_cursor.py::test_long_raiserror[4000]` | fail | pass |

`test_004_cursor.py` (523 tests) went from 175 to 172 failures with **zero new failures**; `test_006_exceptions.py` went from 3 failures to 0. `test_data_truncation_error` was not in the work item — it fails on error 2628, also unmapped, and is fixed by the same tier.

`test_003_connection.py` aborts partway through in that container, identically on the baseline driver — pre-existing and unrelated.

## Breaking changes / migration notes

Behavioral, and intended: an unmapped server error of severity 11-18 now reports `42000` instead of the caller's default (`HY000` on execution paths, `08001` on connect, `08007` / `08S01` on the transaction paths). This is the msodbcsql behavior, so applications moving between the two drivers see fewer differences, not more. Applications keying on `HY000` for user-correctable server errors would need to key on `42000` — which is what they already do against msodbcsql. No API or configuration change.

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes — 3435 run, 3407 passed, 28 failed. All 28 are in the untouched `mssql-tds` crate and are environmental: 46 assertions across `test_vector_type` / `test_bulk_copy_vector` / `test_rpc_datatypes` need the `VECTOR` type (my local server is SQL 2022: *"Type VECTOR is not a defined system type"*), and `connectivity` needs an AAD-enabled server. Zero `mssql-odbc` failures.
- [x] New/changed functionality has tests
- [x] Public API changes are documented — none; `sqlstate.rs` is `pub(crate)`.
