### PR TITLE
Add three-way ODBC performance benchmarks

### DIFF
--- a/.pipeline/odbc-perf-baseline-linux-pipeline.yml
+++ b/.pipeline/odbc-perf-baseline-linux-pipeline.yml
@@ -23,3 +23,21 @@ extends:
     testScriptArgs: none
     testResultsSubDir: results
     testTimeoutMinutes: 180
+    steps:
+      - bash: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          path = Path("$(Build.ArtifactStagingDirectory)/results/comparison.json")
+          data = json.loads(path.read_text(encoding="utf-8"))
+          regressions = [
+              benchmark["name"]
+              for benchmark in data["benchmarks"]
+              if benchmark["regression"]
+          ]
+          if regressions:
+              raise SystemExit(f"confirmed ODBC regressions: {regressions}")
+          PY
+        displayName: Enforce ODBC regression gate

--- a/.pipeline/odbc-perf-baseline-linux-pipeline.yml
+++ b/.pipeline/odbc-perf-baseline-linux-pipeline.yml
@@ -1,0 +1,25 @@
+# Fixed-baseline ODBC performance pipeline (dedicated perf lab)
+#
+# Builds the C++ benchmark harness once, builds candidate and pinned-baseline
+# mssql-odbc libraries, installs pinned Microsoft ODBC 18, and runs the same
+# harness through unixODBC against all three drivers on one dedicated host.
+
+trigger: none
+pr: none
+
+resources:
+  repositories:
+    - repository: PerfTemplates
+      type: git
+      name: InternalDriverTools/PerfTest
+      ref: refs/heads/main
+
+extends:
+  template: v1/Perf.Test.Job.yml@PerfTemplates
+  parameters:
+    platform: linux
+    testRootDir: $(Build.SourcesDirectory)/mssql-rs
+    testScript: mssql-odbc-bench/perf-lab/run-benchmarks.sh
+    testScriptArgs: none
+    testResultsSubDir: results
+    testTimeoutMinutes: 180

--- a/.pipeline/odbc-perf-baseline-windows-pipeline.yml
+++ b/.pipeline/odbc-perf-baseline-windows-pipeline.yml
@@ -1,0 +1,25 @@
+# Fixed-baseline ODBC performance pipeline - WINDOWS (dedicated perf lab)
+#
+# Windows counterpart to odbc-perf-baseline-linux-pipeline.yml. It compares
+# candidate and pinned-baseline mssql-odbc with pinned Microsoft ODBC 18. The
+# platforms have independent measurements and must not share regression ratios.
+
+trigger: none
+pr: none
+
+resources:
+  repositories:
+    - repository: PerfTemplates
+      type: git
+      name: InternalDriverTools/PerfTest
+      ref: refs/heads/main
+
+extends:
+  template: v1/Perf.Test.Job.yml@PerfTemplates
+  parameters:
+    platform: windows
+    testRootDir: $(Build.SourcesDirectory)/mssql-rs
+    testScript: mssql-odbc-bench/perf-lab/run-benchmarks.ps1
+    testScriptArgs: none
+    testResultsSubDir: results
+    testTimeoutMinutes: 180

--- a/.pipeline/odbc-perf-baseline-windows-pipeline.yml
+++ b/.pipeline/odbc-perf-baseline-windows-pipeline.yml
@@ -28,6 +28,9 @@ extends:
           $ErrorActionPreference = 'Stop'
           $path = '$(Build.ArtifactStagingDirectory)\results\comparison.json'
           $data = Get-Content -Raw -LiteralPath $path | ConvertFrom-Json
+          if ($null -eq $data.benchmarks) {
+              throw "comparison.json has no 'benchmarks' array: $path"
+          }
           $regressions = @($data.benchmarks | Where-Object { $_.regression } |
               ForEach-Object { $_.name })
           if ($regressions.Count -gt 0) {

--- a/.pipeline/odbc-perf-baseline-windows-pipeline.yml
+++ b/.pipeline/odbc-perf-baseline-windows-pipeline.yml
@@ -23,3 +23,14 @@ extends:
     testScriptArgs: none
     testResultsSubDir: results
     testTimeoutMinutes: 180
+    steps:
+      - pwsh: |
+          $ErrorActionPreference = 'Stop'
+          $path = '$(Build.ArtifactStagingDirectory)\results\comparison.json'
+          $data = Get-Content -Raw -LiteralPath $path | ConvertFrom-Json
+          $regressions = @($data.benchmarks | Where-Object { $_.regression } |
+              ForEach-Object { $_.name })
+          if ($regressions.Count -gt 0) {
+              throw "Confirmed ODBC regressions: $($regressions -join ', ')"
+          }
+        displayName: Enforce ODBC regression gate

--- a/.pipeline/odbc-perf-baseline-windows-pipeline.yml
+++ b/.pipeline/odbc-perf-baseline-windows-pipeline.yml
@@ -31,8 +31,16 @@ extends:
           if ($null -eq $data.benchmarks) {
               throw "comparison.json has no 'benchmarks' array: $path"
           }
-          $regressions = @($data.benchmarks | Where-Object { $_.regression } |
-              ForEach-Object { $_.name })
+          $regressions = @(foreach ($benchmark in $data.benchmarks) {
+              foreach ($key in 'name', 'regression') {
+                  if ($null -eq $benchmark.PSObject.Properties[$key]) {
+                      throw "comparison.json benchmark entry has no '$key': $path"
+                  }
+              }
+              if ($benchmark.regression) {
+                  $benchmark.name
+              }
+          })
           if ($regressions.Count -gt 0) {
               throw "Confirmed ODBC regressions: $($regressions -join ', ')"
           }

--- a/.pipeline/scripts/compare-odbc-benchmarks.py
+++ b/.pipeline/scripts/compare-odbc-benchmarks.py
@@ -490,6 +490,19 @@ def diverging_bar_table(results, change_key, ratio_key, mark_confirmed=False):
     return lines
 
 
+def add_section_spacing(lines):
+    """Keep Azure DevOps from visually collapsing adjacent report sections."""
+    spaced = []
+    for line in lines:
+        if line.startswith("### "):
+            while spaced and spaced[-1] == "":
+                spaced.pop()
+            spaced.extend(["", "<br>", "", line])
+        else:
+            spaced.append(line)
+    return spaced
+
+
 def confirmation_section(
     results,
     threshold,
@@ -835,7 +848,7 @@ def summary_markdown(
             "The gate is based on median complete-result wall time. Throughput "
             "counters come from the candidate samples."
         )
-    return "\n".join(lines) + "\n"
+    return "\n".join(add_section_spacing(lines)) + "\n"
 
 
 def parse_args():

--- a/.pipeline/scripts/compare-odbc-benchmarks.py
+++ b/.pipeline/scripts/compare-odbc-benchmarks.py
@@ -223,6 +223,13 @@ def format_speedup(ratio):
     return f"{1.0 / ratio:.2f}x"
 
 
+def format_time_multiple(ratio):
+    """State how many times as long the candidate took when it is slower."""
+    if ratio >= 1.0:
+        return f"{ratio:.2f}x as long"
+    return f"{1.0 / ratio:.2f}x less time"
+
+
 def format_wall_time_change(change_percent):
     """Name the wall-time direction explicitly; 'percent faster' is ambiguous."""
     if change_percent < -0.005:
@@ -617,7 +624,23 @@ def summary_markdown(
             "mssql-odbc baseline."
         )
 
-    lines = ["# ODBC performance comparison", "", f"**{verdict}**", ""]
+    lines = [
+        "# ODBC performance comparison",
+        "",
+        "This report contains two separate comparisons:",
+        "",
+        "1. **Regression gate — candidate vs pinned mssql-odbc baseline.** "
+        "This compares the current Rust driver with the pinned older Rust driver "
+        "and can fail the run.",
+    ]
+    if reference_paths:
+        lines.append(
+            f"2. **Reference gap — candidate vs {reference_label}.** This shows "
+            "the performance gap to the production Microsoft driver. "
+            "**Informational means it does not fail this regression run; it does "
+            "not mean the difference is insignificant.**"
+        )
+    lines.extend(["", f"**Regression-gate verdict: {verdict}**", ""])
     if reference_paths:
         lines.extend(
             [
@@ -625,7 +648,8 @@ def summary_markdown(
                 "",
                 (
                     f"| Benchmark | Pinned mssql-odbc baseline | "
-                    f"{reference_label} | Candidate | Candidate rows/s | "
+                    f"{reference_label} (non-gating reference) | Candidate | "
+                    "Candidate rows/s | "
                     "Candidate cells/s |"
                 ),
                 "|---|---:|---:|---:|---:|---:|",
@@ -673,18 +697,29 @@ def summary_markdown(
         lines.extend(
             [
                 "",
-                f"### Candidate vs {reference_label}",
+                f"### Reference gap: candidate vs {reference_label} (non-gating)",
                 "",
                 (
                     "_🟩 lower wall time · 🟥 higher wall time · "
                     f"1 square ≈ {BAR_PERCENT_PER_SQUARE:.0f} percentage points · "
                     f"capped at {BAR_MAX_SQUARES} squares. Speedup factor is "
-                    f"{reference_label} wall time / candidate wall time. This "
-                    "comparison is informational and never gates the run._"
+                    f"{reference_label} wall time / candidate wall time._"
                 ),
                 "",
             ]
         )
+        lines.append(
+            "**How to read this table:** red means the candidate took longer than "
+            "the Microsoft driver—not that it regressed from the pinned Rust "
+            "baseline. For this run:"
+        )
+        for result in results:
+            lines.append(
+                f"- `{result['name']}`: candidate took "
+                f"**{format_time_multiple(result['candidate_vs_reference_ratio'])}** "
+                f"({format_wall_time_change(result['candidate_vs_reference_change_percent'])})."
+            )
+        lines.append("")
         lines.extend(
             diverging_bar_table(
                 results,
@@ -792,7 +827,8 @@ def summary_markdown(
         lines.append(
             f"Only candidate vs pinned mssql-odbc baseline controls the "
             f"{(threshold - 1.0) * 100:.0f}% regression gate, and only after "
-            "confirmation. Microsoft ODBC results are informational."
+            f"confirmation. The {reference_label} comparison quantifies the "
+            "non-gating reference gap."
         )
     else:
         lines.append(

--- a/.pipeline/scripts/compare-odbc-benchmarks.py
+++ b/.pipeline/scripts/compare-odbc-benchmarks.py
@@ -919,6 +919,10 @@ def parse_confirmations(raw):
 
 def validate_args(args):
     """Reject settings that would silently publish an unusable verdict."""
+    if args.fail_on_regression and args.no_fail_on_regression:
+        raise ValueError(
+            "--fail-on-regression and --no-fail-on-regression are mutually exclusive"
+        )
     if not math.isfinite(args.regression_ratio) or args.regression_ratio <= 1.0:
         raise ValueError("--regression-ratio must be a finite value greater than 1")
     if args.improvement_ratio is not None and (

--- a/.pipeline/scripts/compare-odbc-benchmarks.py
+++ b/.pipeline/scripts/compare-odbc-benchmarks.py
@@ -1,12 +1,27 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-"""Compare raw Google Benchmark samples from ODBC driver builds."""
+"""Repo policy and reporting wrapper around Google Benchmark's own comparator.
+
+Google Benchmark v1.9.1 ships ``tools/compare.py`` and ``gbench.report``; the
+fetched copy in the CMake build tree owns the pairwise math. Pass
+``--gbench-compare`` and this script only supplies what the official tool does
+not: exact benchmark-set validation, the combined three-way report, custom
+throughput counters and pins, the regression gate, targeted confirmation
+overrides, and Azure DevOps Markdown.
+
+The Mann-Whitney U test is disabled explicitly (``--no-utest``). The lab runs
+five repetitions, which is below the nine that Google Benchmark documents as the
+minimum for a meaningful U test, so its p-values would be reported without being
+trustworthy. Reproduction is established by the targeted confirmation rounds
+instead.
+"""
 
 import argparse
 import json
 import math
 import statistics
+import subprocess
 import sys
 from pathlib import Path
 
@@ -21,6 +36,9 @@ TIME_TO_SECONDS = {
 RATE_FIELDS = ("rows_per_second", "cells_per_second", "logical_bytes_per_second")
 BAR_PERCENT_PER_SQUARE = 5.0
 BAR_MAX_SQUARES = 20
+DEFAULT_REGRESSION_RATIO = 1.05
+DEFAULT_IMPROVEMENT_MAX = 3
+GEOMEAN_ENTRY = "OVERALL_GEOMEAN"
 
 
 def read_samples(path):
@@ -60,6 +78,123 @@ def load_samples(paths):
         joined = ", ".join(str(path) for path in paths)
         raise ValueError(f"{joined}: no raw benchmark iteration samples found")
     return grouped
+
+
+def merge_scenario_documents(paths, destination):
+    """Join per-scenario JSON into the single document the official tool expects.
+
+    The harness runs one scenario per process, so every file restarts
+    ``family_index`` at zero. Renumbering by first appearance keeps the merged
+    document shaped like a single multi-family run and keeps the merge
+    reproducible for a given input order.
+    """
+    context = None
+    records = []
+    families = {}
+    for path in paths:
+        with path.open(encoding="utf-8-sig") as stream:
+            document = json.load(stream)
+        if context is None:
+            context = document.get("context", {})
+        for record in document.get("benchmarks", []):
+            name = record.get("run_name") or record.get("name")
+            if not name:
+                raise ValueError(f"{path}: benchmark record has no usable name")
+            merged = dict(record)
+            merged["family_index"] = families.setdefault(name, len(families))
+            records.append(merged)
+    if not records:
+        joined = ", ".join(str(path) for path in paths)
+        raise ValueError(f"{joined}: no benchmark records found")
+    destination.write_text(
+        json.dumps({"context": context or {}, "benchmarks": records}, indent=1) + "\n",
+        encoding="utf-8",
+    )
+    return destination
+
+
+def run_official_compare(compare_script, baseline_path, candidate_path, output_dir, slug):
+    """Run Google Benchmark's comparator and keep its text and JSON output."""
+    dump_path = output_dir / f"gbench-{slug}.json"
+    text_path = output_dir / f"gbench-{slug}.txt"
+    command = [
+        sys.executable,
+        str(compare_script),
+        "--no-color",
+        "--no-utest",
+        "--dump_to_json",
+        str(dump_path),
+        "benchmarks",
+        str(baseline_path),
+        str(candidate_path),
+    ]
+    completed = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    text_path.write_text(completed.stdout + completed.stderr, encoding="utf-8")
+    if completed.returncode != 0:
+        raise ValueError(
+            f"{compare_script}: official comparison failed "
+            f"(exit {completed.returncode}); see {text_path.name}"
+        )
+    with dump_path.open(encoding="utf-8") as stream:
+        return json.load(stream)
+
+
+def official_medians(diff_report, source):
+    """Take medians and ratios from the official report instead of recomputing.
+
+    Google Benchmark emits a ``_median`` aggregate whenever a run has more than
+    one repetition, and the official report carries its ratio as ``time``
+    (candidate/baseline - 1). A single-repetition run has no aggregate, so fall
+    back to the per-repetition entries the same report already paired up.
+    """
+    medians = {}
+    fallback = {}
+    for entry in diff_report:
+        name = entry.get("name", "")
+        if name == GEOMEAN_ENTRY:
+            continue
+        measurements = entry.get("measurements") or []
+        if not measurements:
+            continue
+        unit = TIME_TO_SECONDS.get(entry.get("time_unit"))
+        if unit is None:
+            raise ValueError(f"{source}: '{name}' has an unusable time_unit")
+        if entry.get("run_type") == "aggregate":
+            aggregate = entry.get("aggregate_name") or ""
+            if aggregate != "median":
+                continue
+            suffix = f"_{aggregate}"
+            if not name.endswith(suffix):
+                raise ValueError(f"{source}: aggregate '{name}' has an unexpected name")
+            medians[name[: -len(suffix)]] = {
+                "baseline_seconds": float(measurements[0]["real_time"]) * unit,
+                "candidate_seconds": float(measurements[0]["real_time_other"]) * unit,
+                "ratio": 1.0 + float(measurements[0]["time"]),
+            }
+        else:
+            fallback[name] = {
+                "baseline_seconds": statistics.median(
+                    float(item["real_time"]) for item in measurements
+                )
+                * unit,
+                "candidate_seconds": statistics.median(
+                    float(item["real_time_other"]) for item in measurements
+                )
+                * unit,
+                "ratio": statistics.median(
+                    1.0 + float(item["time"]) for item in measurements
+                ),
+            }
+    for name, value in fallback.items():
+        medians.setdefault(name, value)
+    if not medians:
+        raise ValueError(f"{source}: official report contained no comparable benchmarks")
+    return medians
 
 
 def describe_inputs(paths):
@@ -119,49 +254,119 @@ def require_matching_benchmarks(baseline, other, other_name):
         )
 
 
-def compare(baseline, candidate, threshold, reference=None):
-    """Compare median complete-result wall time and attach candidate throughput."""
+def medians_from_samples(baseline, candidate):
+    """Compute the pairwise medians used when the official comparator is absent."""
+    medians = {}
+    for name, base_samples in baseline.items():
+        base_seconds = median_field(base_samples, "real_seconds")
+        candidate_seconds = median_field(candidate[name], "real_seconds")
+        if base_seconds <= 0 or candidate_seconds <= 0:
+            raise ValueError(f"{name}: benchmark duration must be greater than zero")
+        medians[name] = {
+            "baseline_seconds": base_seconds,
+            "candidate_seconds": candidate_seconds,
+            "ratio": candidate_seconds / base_seconds,
+        }
+    return medians
+
+
+def require_official_coverage(medians, expected, source):
+    """The official report must cover the exact validated set, or the gate is blind."""
+    missing = sorted(set(expected) - set(medians))
+    if missing:
+        raise ValueError(f"{source}: official report is missing benchmarks {missing}")
+
+
+def compare(
+    baseline,
+    candidate,
+    threshold,
+    reference=None,
+    baseline_medians=None,
+    reference_medians=None,
+    improvement_ratio=None,
+    confirmations=None,
+    confirm_runs=None,
+    confirm_quorum=None,
+):
+    """Compare median wall time, then let confirmation rounds own the verdict."""
     require_matching_benchmarks(baseline, candidate, "candidate")
     if reference is not None:
         require_matching_benchmarks(baseline, reference, "reference")
+
+    if baseline_medians is None:
+        baseline_medians = medians_from_samples(baseline, candidate)
+    require_official_coverage(baseline_medians, baseline, "baseline vs candidate")
+    if reference is not None and reference_medians is None:
+        reference_medians = medians_from_samples(reference, candidate)
+    if reference_medians is not None:
+        require_official_coverage(reference_medians, baseline, "reference vs candidate")
+
+    improvement_ratio = improvement_ratio or threshold
+    confirmations = confirmations or {}
+    unknown = sorted(set(confirmations) - set(baseline))
+    if unknown:
+        raise ValueError(f"confirmation results name unknown benchmarks: {unknown}")
 
     results = []
     for name in sorted(baseline):
         base_samples = baseline[name]
         candidate_samples = candidate[name]
-        base_seconds = median_field(base_samples, "real_seconds")
-        candidate_seconds = median_field(candidate_samples, "real_seconds")
-        if base_seconds <= 0 or candidate_seconds <= 0:
+        pair = baseline_medians[name]
+        initial_ratio = pair["ratio"]
+        if not math.isfinite(initial_ratio) or initial_ratio <= 0:
             raise ValueError(f"{name}: benchmark duration must be greater than zero")
-        ratio = candidate_seconds / base_seconds
-        rates = {
-            field: median_field(candidate_samples, field) for field in RATE_FIELDS
-        }
+        initial_regression = initial_ratio >= threshold
+        initial_improvement = initial_ratio <= 1.0 / improvement_ratio
+        confirmation = confirmations.get(name)
+        headline_ratio = (
+            confirmation["ratio"] if confirmation is not None else initial_ratio
+        )
+        if confirm_runs is not None:
+            regression = (
+                confirmation is not None
+                and confirmation["regression_hits"] >= confirm_quorum
+            )
+        else:
+            regression = initial_regression
         result = {
             "name": name,
             "baseline_samples": len(base_samples),
             "candidate_samples": len(candidate_samples),
-            "baseline_median_seconds": base_seconds,
-            "candidate_median_seconds": candidate_seconds,
-            "candidate_ratio": ratio,
-            "change_percent": (ratio - 1.0) * 100.0,
-            "regression": ratio >= threshold,
-            **rates,
+            "baseline_median_seconds": pair["baseline_seconds"],
+            "candidate_median_seconds": pair["candidate_seconds"],
+            "candidate_ratio": headline_ratio,
+            "change_percent": (headline_ratio - 1.0) * 100.0,
+            "initial_ratio": initial_ratio,
+            "initial_change_percent": (initial_ratio - 1.0) * 100.0,
+            "initial_regression": initial_regression,
+            "initial_improvement": initial_improvement,
+            "regression": regression,
+            **{field: median_field(candidate_samples, field) for field in RATE_FIELDS},
         }
+        if confirmation is not None:
+            result.update(
+                {
+                    "confirmation_hits": confirmation["hits"],
+                    "confirmation_regression_hits": confirmation["regression_hits"],
+                    "confirmation_runs": confirm_runs,
+                    "confirmation_ratio": confirmation["ratio"],
+                    "confirmed": confirmation["hits"] >= confirm_quorum,
+                    "confirmed_regression": regression,
+                }
+            )
         if reference is not None:
             reference_samples = reference[name]
-            reference_seconds = median_field(reference_samples, "real_seconds")
-            if reference_seconds <= 0:
+            reference_pair = reference_medians[name]
+            reference_ratio = reference_pair["ratio"]
+            if not math.isfinite(reference_ratio) or reference_ratio <= 0:
                 raise ValueError(f"{name}: benchmark duration must be greater than zero")
-            reference_ratio = candidate_seconds / reference_seconds
             result.update(
                 {
                     "reference_samples": len(reference_samples),
-                    "reference_median_seconds": reference_seconds,
+                    "reference_median_seconds": reference_pair["baseline_seconds"],
                     "candidate_vs_reference_ratio": reference_ratio,
-                    "candidate_vs_reference_change_percent": (
-                        reference_ratio - 1.0
-                    )
+                    "candidate_vs_reference_change_percent": (reference_ratio - 1.0)
                     * 100.0,
                     **{
                         f"reference_{field}": median_field(reference_samples, field)
@@ -170,7 +375,41 @@ def compare(baseline, candidate, threshold, reference=None):
                 }
             )
         results.append(result)
+    if confirm_runs is not None:
+        # An initial regression with no confirmation data would otherwise clear the
+        # gate silently, which is the one failure mode this flow must not have.
+        missing = sorted(
+            result["name"]
+            for result in results
+            if result["initial_regression"] and "confirmation_hits" not in result
+        )
+        if missing:
+            raise ValueError(f"confirmation results are missing for {missing}")
     return results
+
+
+def confirmation_plan(results, improvement_max):
+    """List what the runner must re-measure: every regression, capped improvements.
+
+    Regressions are self-limiting because they fail the run, but a single hot-path
+    change can turn every benchmark green at once, and each verified entry costs a
+    full set of paired re-runs. Keep the largest apparent wins and report the rest
+    unverified.
+    """
+    plan = [
+        ("regression", result["name"], result["initial_ratio"])
+        for result in results
+        if result["initial_regression"]
+    ]
+    improvements = sorted(
+        (result for result in results if result["initial_improvement"]),
+        key=lambda result: result["initial_ratio"],
+    )
+    kept = improvements[:improvement_max]
+    plan.extend(
+        ("improvement", result["name"], result["initial_ratio"]) for result in kept
+    )
+    return plan, len(improvements) - len(kept)
 
 
 def comparison_text(results, reference_label=None):
@@ -190,7 +429,7 @@ def comparison_text(results, reference_label=None):
                 f"{result['baseline_median_seconds'] * 1000:12.2f} "
                 f"{result['reference_median_seconds'] * 1000:14.2f} "
                 f"{result['candidate_median_seconds'] * 1000:14.2f} "
-                f"{result['change_percent']:+9.2f}% "
+                f"{result['initial_change_percent']:+9.2f}% "
                 f"{result['candidate_vs_reference_change_percent']:+12.2f}%"
             )
         return "\n".join(lines) + "\n"
@@ -205,12 +444,12 @@ def comparison_text(results, reference_label=None):
             f"{result['name'][:68]:68} "
             f"{result['baseline_median_seconds'] * 1000:12.2f} "
             f"{result['candidate_median_seconds'] * 1000:14.2f} "
-            f"{result['change_percent']:+9.2f}%"
+            f"{result['initial_change_percent']:+9.2f}%"
         )
     return "\n".join(lines) + "\n"
 
 
-def diverging_bar_table(results, change_key, ratio_key):
+def diverging_bar_table(results, change_key, ratio_key, mark_confirmed=False):
     """Render lower wall time left/green and higher wall time right/red."""
     lines = [
         "| Benchmark | lower wall time ◄ | Wall-time change | ► higher wall time | Speedup factor |",
@@ -221,10 +460,127 @@ def diverging_bar_table(results, change_key, ratio_key):
         squares = bar_squares(change)
         lower = "🟩" * squares if change < -0.05 else ""
         higher = "🟥" * squares if change > 0.05 else ""
+        mark = ""
+        if mark_confirmed and "confirmation_ratio" in result:
+            if result.get("confirmed_regression"):
+                status = "confirmed regression"
+                hits = result["confirmation_regression_hits"]
+            elif result.get("confirmed"):
+                status = "verified improvement"
+                hits = result["confirmation_hits"]
+            else:
+                status = "not confirmed"
+                hits = result["confirmation_hits"]
+            mark = (
+                f" ⟳ ({hits}/"
+                f"{result['confirmation_runs']}; {status})"
+            )
         lines.append(
-            f"| `{result['name']}` | {lower} | "
+            f"| `{result['name']}`{mark} | {lower} | "
             f"{format_wall_time_change(change)} | {higher} | "
             f"{format_speedup(result[ratio_key])} |"
+        )
+    return lines
+
+
+def confirmation_section(
+    results,
+    threshold,
+    improvement_ratio,
+    repetitions,
+    confirm_runs,
+    confirm_quorum,
+    skipped,
+):
+    """Explain what the initial pass flagged and what the re-runs actually held."""
+    lines = []
+    initial_regressions = [r for r in results if r["initial_regression"]]
+    initial_improvements = [r for r in results if r["initial_improvement"]]
+    confirmed = [r for r in results if r.get("confirmed_regression")]
+    verified = [
+        r
+        for r in results
+        if r.get("confirmed") and r["initial_improvement"] and not r["regression"]
+    ]
+    cleared_regressions = [
+        r
+        for r in initial_regressions
+        if "confirmation_hits" in r and not r["regression"]
+    ]
+    cleared_improvements = [
+        r
+        for r in initial_improvements
+        if "confirmation_hits" in r and not r["confirmed"] and not r["regression"]
+    ]
+    improvement_percent = (1.0 - 1.0 / improvement_ratio) * 100
+    sample_description = (
+        f"{repetitions}-sample" if repetitions is not None else "raw-sample"
+    )
+
+    lines.extend(["", "### Initial pass vs confirmation", ""])
+    lines.append(
+        f"The initial {sample_description} median flagged **{len(initial_regressions)} "
+        f"regression(s)** and **{len(initial_improvements)} large apparent "
+        "improvement(s)**."
+    )
+    if confirm_runs is None:
+        lines.extend(["", "_No confirmation rounds were run for this comparison._"])
+        return lines
+    lines.append("")
+    lines.append(
+        f"Each flagged benchmark was then re-measured with the candidate and the "
+        f"pinned mssql-odbc baseline back-to-back for **{confirm_runs} confirmation "
+        f"rounds**. A result counts only when it reproduces in at least "
+        f"**{confirm_quorum} of {confirm_runs}** rounds. The headline wall-time "
+        f"change for a re-measured benchmark (⟳) is the median of those "
+        f"{confirm_runs} confirmation ratios; the initial pass that triggered the "
+        "re-measurement is deliberately excluded so the outlier under test does "
+        "not vote on its own verdict."
+    )
+    lines.append("")
+    lines.append(
+        f"**{len(confirmed)} confirmed regression(s)** and "
+        f"**{len(verified)} verified improvement(s)**; "
+        f"{len(cleared_regressions)} initial regression(s) and "
+        f"{len(cleared_improvements)} apparent improvement(s) did "
+        "not reproduce and are treated as transient noise."
+    )
+    if skipped:
+        lines.append("")
+        lines.append(
+            f"_{skipped} further benchmark(s) had at least "
+            f"{improvement_percent:.2f}% lower wall time but were outside the "
+            "re-measurement cap; they keep their initial numbers, unverified._"
+        )
+    if not (initial_regressions or initial_improvements):
+        return lines
+
+    lines.extend(
+        [
+            "",
+            "| Benchmark | Flagged as | Initial change | Initial direction reproduced | Regression rounds | Confirmed change |",
+            "|---|:--:|--:|:--:|:--:|--:|",
+        ]
+    )
+    for result in sorted(
+        initial_regressions + initial_improvements, key=lambda item: item["name"]
+    ):
+        kind = "regression" if result["initial_regression"] else "improvement"
+        hits = result.get("confirmation_hits")
+        rounds = "—" if hits is None else f"{hits}/{confirm_runs}"
+        regression_hits = result.get("confirmation_regression_hits")
+        regression_rounds = (
+            "—" if regression_hits is None else f"{regression_hits}/{confirm_runs}"
+        )
+        confirmed_change = (
+            "—"
+            if "confirmation_ratio" not in result
+            else format_wall_time_change((result["confirmation_ratio"] - 1.0) * 100.0)
+        )
+        lines.append(
+            f"| `{result['name']}` | {kind} | "
+            f"{format_wall_time_change(result['initial_change_percent'])} | "
+            f"{rounds} | {regression_rounds} | {confirmed_change} |"
         )
     return lines
 
@@ -232,6 +588,7 @@ def diverging_bar_table(results, change_key, ratio_key):
 def summary_markdown(
     results,
     threshold,
+    improvement_ratio,
     baseline_paths,
     candidate_paths,
     reference_paths=None,
@@ -239,18 +596,23 @@ def summary_markdown(
     baseline_commit=None,
     reference_version=None,
     repetitions=None,
+    confirm_runs=None,
+    confirm_quorum=None,
+    improvements_skipped=0,
+    official_compare=False,
 ):
     """Build the single rich report uploaded by the shared PerfTest template."""
     regressions = [result for result in results if result["regression"]]
+    gated = "confirmed " if confirm_runs is not None else ""
     if regressions:
         verdict = (
-            f"❌ {len(regressions)} benchmark(s) had at least "
+            f"❌ {len(regressions)} {gated}benchmark(s) had at least "
             f"{(threshold - 1.0) * 100:.0f}% higher wall time than the pinned "
             "mssql-odbc baseline."
         )
     else:
         verdict = (
-            f"✅ No benchmark had at least "
+            f"✅ No {gated}benchmark had at least "
             f"{(threshold - 1.0) * 100:.0f}% higher wall time than the pinned "
             "mssql-odbc baseline."
         )
@@ -284,18 +646,30 @@ def summary_markdown(
         lines.extend(
             [
                 "",
+                "_Medians measured in the initial pass. Re-measured benchmarks "
+                "carry their confirmation median into the chart below._",
+            ]
+        )
+        lines.extend(
+            [
+                "",
                 "### Candidate vs pinned mssql-odbc baseline",
                 "",
                 (
                     "_🟩 lower wall time · 🟥 higher wall time · "
                     f"1 square ≈ {BAR_PERCENT_PER_SQUARE:.0f} percentage points · "
-                    f"capped at {BAR_MAX_SQUARES} squares. Speedup factor is "
-                    "baseline wall time / candidate wall time._"
+                    f"capped at {BAR_MAX_SQUARES} squares · ⟳ re-measured (median "
+                    "of the confirmation rounds). Speedup factor is baseline wall "
+                    "time / candidate wall time._"
                 ),
                 "",
             ]
         )
-        lines.extend(diverging_bar_table(results, "change_percent", "candidate_ratio"))
+        lines.extend(
+            diverging_bar_table(
+                results, "change_percent", "candidate_ratio", mark_confirmed=True
+            )
+        )
         lines.extend(
             [
                 "",
@@ -305,7 +679,8 @@ def summary_markdown(
                     "_🟩 lower wall time · 🟥 higher wall time · "
                     f"1 square ≈ {BAR_PERCENT_PER_SQUARE:.0f} percentage points · "
                     f"capped at {BAR_MAX_SQUARES} squares. Speedup factor is "
-                    f"{reference_label} wall time / candidate wall time._"
+                    f"{reference_label} wall time / candidate wall time. This "
+                    "comparison is informational and never gates the run._"
                 ),
                 "",
             ]
@@ -320,23 +695,54 @@ def summary_markdown(
     else:
         lines.extend(
             [
-                "| Benchmark | Baseline median | Candidate median | Wall-time change | Speedup factor | Candidate rows/s | Candidate cells/s |",
-                "|---|---:|---:|---|---:|---:|---:|",
+                "| Benchmark | Baseline median | Candidate median | Initial change | Headline change | Speedup factor | Candidate rows/s | Candidate cells/s |",
+                "|---|---:|---:|---|---|---:|---:|---:|",
             ]
         )
         for result in results:
+            mark = ""
+            if "confirmation_ratio" in result:
+                if result.get("confirmed_regression"):
+                    status = "confirmed regression"
+                    hits = result["confirmation_regression_hits"]
+                elif result.get("confirmed"):
+                    status = "verified improvement"
+                    hits = result["confirmation_hits"]
+                else:
+                    status = "not confirmed"
+                    hits = result["confirmation_hits"]
+                mark = (
+                    f" ⟳ ({hits}/"
+                    f"{result['confirmation_runs']}; {status})"
+                )
             lines.append(
-                "| `{name}` | {base:.2f} ms | {candidate:.2f} ms | "
-                "{change} | {speedup} | {rows} | {cells} |".format(
+                "| `{name}`{mark} | {base:.2f} ms | {candidate:.2f} ms | "
+                "{initial_change} | {headline_change} | {speedup} | {rows} | "
+                "{cells} |".format(
                     name=result["name"],
+                    mark=mark,
                     base=result["baseline_median_seconds"] * 1000,
                     candidate=result["candidate_median_seconds"] * 1000,
-                    change=format_wall_time_change(result["change_percent"]),
+                    initial_change=format_wall_time_change(
+                        result["initial_change_percent"]
+                    ),
+                    headline_change=format_wall_time_change(result["change_percent"]),
                     speedup=format_speedup(result["candidate_ratio"]),
                     rows=format_rate(result["rows_per_second"]),
                     cells=format_rate(result["cells_per_second"]),
                 )
             )
+    lines.extend(
+        confirmation_section(
+            results,
+            threshold,
+            improvement_ratio,
+            repetitions,
+            confirm_runs,
+            confirm_quorum,
+            improvements_skipped,
+        )
+    )
     if repetitions is None:
         sample_counts = {result["candidate_samples"] for result in results}
         repetitions = sample_counts.pop() if len(sample_counts) == 1 else None
@@ -357,6 +763,15 @@ def summary_markdown(
             "The tables compare the median complete-result wall time from the raw "
             "iteration samples."
         )
+    if official_compare:
+        lines.append("")
+        lines.append(
+            "Ratios and medians come from Google Benchmark's own "
+            "`tools/compare.py`; its pairwise text and JSON output is retained "
+            "alongside this report. The Mann-Whitney U test is disabled because "
+            "the run uses fewer repetitions than the nine Google Benchmark "
+            "documents as meaningful for it."
+        )
     lines.extend(
         [
             "",
@@ -375,9 +790,9 @@ def summary_markdown(
     lines.append("")
     if reference_paths:
         lines.append(
-            f"Only candidate vs pinned mssql-odbc baseline controls the optional "
-            f"{(threshold - 1.0) * 100:.0f}% regression gate. Microsoft ODBC "
-            "results are informational."
+            f"Only candidate vs pinned mssql-odbc baseline controls the "
+            f"{(threshold - 1.0) * 100:.0f}% regression gate, and only after "
+            "confirmation. Microsoft ODBC results are informational."
         )
     else:
         lines.append(
@@ -388,7 +803,7 @@ def summary_markdown(
 
 
 def parse_args():
-    """Define additive metadata flags without changing the legacy two-way contract."""
+    """Define additive policy flags without changing the legacy two-way contract."""
     parser = argparse.ArgumentParser()
     parser.add_argument("--baseline", required=True, type=Path, action="append")
     parser.add_argument("--candidate", required=True, type=Path, action="append")
@@ -398,46 +813,192 @@ def parse_args():
     parser.add_argument("--reference-version")
     parser.add_argument("--repetitions", type=int)
     parser.add_argument("--output-dir", required=True, type=Path)
-    parser.add_argument("--regression-ratio", type=float, default=1.10)
+    parser.add_argument(
+        "--regression-ratio", type=float, default=DEFAULT_REGRESSION_RATIO
+    )
+    parser.add_argument("--improvement-ratio", type=float)
+    parser.add_argument("--improvement-max", type=int, default=DEFAULT_IMPROVEMENT_MAX)
+    parser.add_argument("--gbench-compare", type=Path)
+    parser.add_argument("--plan-out", type=Path)
+    parser.add_argument("--ratios-out", type=Path)
+    # The perf template attaches Markdown from the results tree, so the screening
+    # and per-round invocations skip summary.md and leave one report to attach.
+    parser.add_argument("--no-summary", action="store_true")
+    parser.add_argument("--confirm-runs", type=int)
+    parser.add_argument("--confirm-quorum", type=int)
+    parser.add_argument(
+        "--confirmation",
+        nargs=4,
+        action="append",
+        metavar=("NAME", "DIRECTION_HITS", "REGRESSION_HITS", "RATIO"),
+        default=[],
+    )
+    # The gate is on by default; --fail-on-regression stays accepted so existing
+    # callers keep working, and --no-fail-on-regression is the way to opt out.
     parser.add_argument("--fail-on-regression", action="store_true")
+    parser.add_argument("--no-fail-on-regression", action="store_true")
     return parser.parse_args()
+
+
+def parse_confirmations(raw):
+    """Turn repeated direction/regression hit counts and ratios into a lookup."""
+    confirmations = {}
+    for name, hits, regression_hits, ratio in raw:
+        if name in confirmations:
+            raise ValueError(f"duplicate confirmation result for '{name}'")
+        try:
+            parsed_hits = int(hits)
+            parsed_regression_hits = int(regression_hits)
+            parsed_ratio = float(ratio)
+        except ValueError:
+            raise ValueError(
+                f"confirmation for '{name}' needs integer direction/regression "
+                f"hit counts and a numeric ratio (got '{hits}', "
+                f"'{regression_hits}', '{ratio}')"
+            ) from None
+        if parsed_hits < 0 or parsed_regression_hits < 0:
+            raise ValueError(f"confirmation hits for '{name}' must not be negative")
+        if not math.isfinite(parsed_ratio) or parsed_ratio <= 0:
+            raise ValueError(f"confirmation ratio for '{name}' must be positive")
+        confirmations[name] = {
+            "hits": parsed_hits,
+            "regression_hits": parsed_regression_hits,
+            "ratio": parsed_ratio,
+        }
+    return confirmations
+
+
+def validate_args(args):
+    """Reject settings that would silently publish an unusable verdict."""
+    if not math.isfinite(args.regression_ratio) or args.regression_ratio <= 1.0:
+        raise ValueError("--regression-ratio must be a finite value greater than 1")
+    if args.improvement_ratio is not None and (
+        not math.isfinite(args.improvement_ratio) or args.improvement_ratio <= 1.0
+    ):
+        raise ValueError("--improvement-ratio must be a finite value greater than 1")
+    if args.improvement_max < 0:
+        raise ValueError("--improvement-max must not be negative")
+    if args.reference and not args.reference_label.strip():
+        raise ValueError("--reference-label must not be empty")
+    if args.repetitions is not None and args.repetitions < 1:
+        raise ValueError("--repetitions must be a positive integer")
+    if args.confirm_runs is not None and args.confirm_runs < 1:
+        raise ValueError("--confirm-runs must be a positive integer")
+    if args.confirmation and args.confirm_runs is None:
+        raise ValueError("--confirmation requires --confirm-runs")
+    if args.confirm_runs is not None:
+        if args.confirm_quorum is None:
+            args.confirm_quorum = args.confirm_runs // 2 + 1
+        if not 1 <= args.confirm_quorum <= args.confirm_runs:
+            raise ValueError("--confirm-quorum must be between 1 and --confirm-runs")
+    elif args.confirm_quorum is not None:
+        raise ValueError("--confirm-quorum requires --confirm-runs")
+
+
+def official_pairwise(args, output_dir):
+    """Delegate both pairwise comparisons to Google Benchmark's own tool."""
+    if args.gbench_compare is None:
+        return None, None
+    if not args.gbench_compare.is_file():
+        raise ValueError(f"--gbench-compare not found: {args.gbench_compare}")
+    merged_baseline = merge_scenario_documents(
+        args.baseline, output_dir / "gbench-merged-baseline.json"
+    )
+    merged_candidate = merge_scenario_documents(
+        args.candidate, output_dir / "gbench-merged-candidate.json"
+    )
+    baseline_medians = official_medians(
+        run_official_compare(
+            args.gbench_compare,
+            merged_baseline,
+            merged_candidate,
+            output_dir,
+            "baseline-vs-candidate",
+        ),
+        "baseline vs candidate",
+    )
+    reference_medians = None
+    if args.reference:
+        merged_reference = merge_scenario_documents(
+            args.reference, output_dir / "gbench-merged-reference.json"
+        )
+        reference_medians = official_medians(
+            run_official_compare(
+                args.gbench_compare,
+                merged_reference,
+                merged_candidate,
+                output_dir,
+                "reference-vs-candidate",
+            ),
+            "reference vs candidate",
+        )
+    return baseline_medians, reference_medians
 
 
 def main():
     """Write log, Markdown, and JSON artifacts from one validated comparison."""
     args = parse_args()
-    if not math.isfinite(args.regression_ratio) or args.regression_ratio <= 1.0:
-        raise ValueError("--regression-ratio must be a finite value greater than 1")
-    if args.reference and not args.reference_label.strip():
-        raise ValueError("--reference-label must not be empty")
-    if args.repetitions is not None and args.repetitions < 1:
-        raise ValueError("--repetitions must be a positive integer")
+    validate_args(args)
+    confirmations = parse_confirmations(args.confirmation)
+    if args.confirm_runs is not None:
+        excessive_hits = sorted(
+            name
+            for name, confirmation in confirmations.items()
+            if confirmation["hits"] > args.confirm_runs
+            or confirmation["regression_hits"] > args.confirm_runs
+        )
+        if excessive_hits:
+            raise ValueError(
+                f"confirmation hits exceed --confirm-runs for {excessive_hits}"
+            )
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    baseline_medians, reference_medians = official_pairwise(args, args.output_dir)
 
     baseline = load_samples(args.baseline)
     candidate = load_samples(args.candidate)
     reference = load_samples(args.reference) if args.reference else None
-    results = compare(baseline, candidate, args.regression_ratio, reference)
+    results = compare(
+        baseline,
+        candidate,
+        args.regression_ratio,
+        reference,
+        baseline_medians,
+        reference_medians,
+        args.improvement_ratio,
+        confirmations,
+        args.confirm_runs,
+        args.confirm_quorum,
+    )
+    plan, improvements_skipped = confirmation_plan(results, args.improvement_max)
 
-    args.output_dir.mkdir(parents=True, exist_ok=True)
     reference_label = args.reference_label.strip() if reference else None
     text = comparison_text(results, reference_label)
     (args.output_dir / "comparison.txt").write_text(text, encoding="utf-8")
-    (args.output_dir / "summary.md").write_text(
-        summary_markdown(
-            results,
-            args.regression_ratio,
-            args.baseline,
-            args.candidate,
-            args.reference,
-            reference_label,
-            args.baseline_commit,
-            args.reference_version,
-            args.repetitions,
-        ),
-        encoding="utf-8",
-    )
+    if not args.no_summary:
+        (args.output_dir / "summary.md").write_text(
+            summary_markdown(
+                results,
+                args.regression_ratio,
+                args.improvement_ratio or args.regression_ratio,
+                args.baseline,
+                args.candidate,
+                args.reference,
+                reference_label,
+                args.baseline_commit,
+                args.reference_version,
+                args.repetitions,
+                args.confirm_runs,
+                args.confirm_quorum,
+                improvements_skipped,
+                args.gbench_compare is not None,
+            ),
+            encoding="utf-8",
+        )
     output = {
         "regression_ratio": args.regression_ratio,
+        "improvement_ratio": args.improvement_ratio or args.regression_ratio,
+        "improvements_skipped": improvements_skipped,
         "benchmarks": results,
     }
     if reference_label is not None:
@@ -448,13 +1009,32 @@ def main():
         output["reference_version"] = args.reference_version
     if args.repetitions is not None:
         output["repetitions"] = args.repetitions
+    if args.confirm_runs is not None:
+        output["confirm_runs"] = args.confirm_runs
+        output["confirm_quorum"] = args.confirm_quorum
     (args.output_dir / "comparison.json").write_text(
         json.dumps(output, indent=2) + "\n",
         encoding="utf-8",
     )
+    if args.plan_out is not None:
+        args.plan_out.parent.mkdir(parents=True, exist_ok=True)
+        args.plan_out.write_text(
+            "".join(f"{kind}\t{name}\t{ratio:.6f}\n" for kind, name, ratio in plan),
+            encoding="utf-8",
+        )
+    if args.ratios_out is not None:
+        args.ratios_out.parent.mkdir(parents=True, exist_ok=True)
+        args.ratios_out.write_text(
+            "".join(
+                f"{result['name']}\t{result['initial_ratio']:.6f}\n"
+                for result in results
+            ),
+            encoding="utf-8",
+        )
     sys.stdout.write(text)
 
-    if args.fail_on_regression and any(result["regression"] for result in results):
+    gate_enabled = not args.no_fail_on_regression
+    if gate_enabled and any(result["regression"] for result in results):
         return 2
     return 0
 

--- a/.pipeline/scripts/compare-odbc-benchmarks.py
+++ b/.pipeline/scripts/compare-odbc-benchmarks.py
@@ -1,0 +1,467 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Compare raw Google Benchmark samples from ODBC driver builds."""
+
+import argparse
+import json
+import math
+import statistics
+import sys
+from pathlib import Path
+
+
+TIME_TO_SECONDS = {
+    "ns": 1e-9,
+    "us": 1e-6,
+    "ms": 1e-3,
+    "s": 1.0,
+}
+
+RATE_FIELDS = ("rows_per_second", "cells_per_second", "logical_bytes_per_second")
+BAR_PERCENT_PER_SQUARE = 5.0
+BAR_MAX_SQUARES = 20
+
+
+def read_samples(path):
+    """Read only raw iteration records so aggregate rows cannot skew the median."""
+    with path.open(encoding="utf-8-sig") as stream:
+        document = json.load(stream)
+    grouped = {}
+    for record in document.get("benchmarks", []):
+        if record.get("aggregate_name") is not None:
+            continue
+        if record.get("run_type", "iteration") != "iteration":
+            continue
+
+        name = record.get("run_name") or record.get("name")
+        unit = record.get("time_unit")
+        if not name or unit not in TIME_TO_SECONDS:
+            raise ValueError(f"{path}: benchmark record has no usable name/time_unit")
+
+        sample = {
+            "real_seconds": float(record["real_time"]) * TIME_TO_SECONDS[unit],
+        }
+        for field in RATE_FIELDS:
+            value = record.get(field)
+            if isinstance(value, (int, float)) and math.isfinite(value):
+                sample[field] = float(value)
+        grouped.setdefault(name, []).append(sample)
+    return grouped
+
+
+def load_samples(paths):
+    """Merge scenario files into one benchmark-keyed sample set."""
+    grouped = {}
+    for path in paths:
+        for name, samples in read_samples(path).items():
+            grouped.setdefault(name, []).extend(samples)
+    if not grouped:
+        joined = ", ".join(str(path) for path in paths)
+        raise ValueError(f"{joined}: no raw benchmark iteration samples found")
+    return grouped
+
+
+def describe_inputs(paths):
+    """Render artifact basenames without leaking agent-specific directories."""
+    return ", ".join(f"`{path.name}`" for path in paths)
+
+
+def median_field(samples, field):
+    """Return a median only when the benchmark emitted the requested counter."""
+    values = [sample[field] for sample in samples if field in sample]
+    return statistics.median(values) if values else None
+
+
+def format_rate(value):
+    """Keep high-volume throughput columns compact enough for the Summary tab."""
+    if value is None:
+        return "-"
+    for scale, suffix in ((1e9, "G"), (1e6, "M"), (1e3, "K")):
+        if abs(value) >= scale:
+            return f"{value / scale:.2f}{suffix}"
+    return f"{value:.2f}"
+
+
+def format_speedup(ratio):
+    """Express comparator/candidate wall time as a direction-neutral speedup factor."""
+    return f"{1.0 / ratio:.2f}x"
+
+
+def format_wall_time_change(change_percent):
+    """Name the wall-time direction explicitly; 'percent faster' is ambiguous."""
+    if change_percent < -0.005:
+        return f"{abs(change_percent):.2f}% lower wall time"
+    if change_percent > 0.005:
+        return f"{change_percent:.2f}% higher wall time"
+    return "0.00% wall-time change"
+
+
+def bar_squares(change_percent):
+    """Scale large ODBC deltas to a readable chart instead of flooding the report."""
+    if abs(change_percent) < 0.05:
+        return 0
+    rounded = math.floor(abs(change_percent) / BAR_PERCENT_PER_SQUARE + 0.5)
+    return min(BAR_MAX_SQUARES, rounded)
+
+
+def require_matching_benchmarks(baseline, other, other_name):
+    """Reject partial comparisons because missing workloads can hide regressions."""
+    baseline_names = set(baseline)
+    other_names = set(other)
+    if baseline_names != other_names:
+        missing_other = sorted(baseline_names - other_names)
+        missing_baseline = sorted(other_names - baseline_names)
+        raise ValueError(
+            "benchmark sets differ: "
+            f"missing from {other_name}={missing_other}, "
+            f"missing from baseline={missing_baseline}"
+        )
+
+
+def compare(baseline, candidate, threshold, reference=None):
+    """Compare median complete-result wall time and attach candidate throughput."""
+    require_matching_benchmarks(baseline, candidate, "candidate")
+    if reference is not None:
+        require_matching_benchmarks(baseline, reference, "reference")
+
+    results = []
+    for name in sorted(baseline):
+        base_samples = baseline[name]
+        candidate_samples = candidate[name]
+        base_seconds = median_field(base_samples, "real_seconds")
+        candidate_seconds = median_field(candidate_samples, "real_seconds")
+        if base_seconds <= 0 or candidate_seconds <= 0:
+            raise ValueError(f"{name}: benchmark duration must be greater than zero")
+        ratio = candidate_seconds / base_seconds
+        rates = {
+            field: median_field(candidate_samples, field) for field in RATE_FIELDS
+        }
+        result = {
+            "name": name,
+            "baseline_samples": len(base_samples),
+            "candidate_samples": len(candidate_samples),
+            "baseline_median_seconds": base_seconds,
+            "candidate_median_seconds": candidate_seconds,
+            "candidate_ratio": ratio,
+            "change_percent": (ratio - 1.0) * 100.0,
+            "regression": ratio >= threshold,
+            **rates,
+        }
+        if reference is not None:
+            reference_samples = reference[name]
+            reference_seconds = median_field(reference_samples, "real_seconds")
+            if reference_seconds <= 0:
+                raise ValueError(f"{name}: benchmark duration must be greater than zero")
+            reference_ratio = candidate_seconds / reference_seconds
+            result.update(
+                {
+                    "reference_samples": len(reference_samples),
+                    "reference_median_seconds": reference_seconds,
+                    "candidate_vs_reference_ratio": reference_ratio,
+                    "candidate_vs_reference_change_percent": (
+                        reference_ratio - 1.0
+                    )
+                    * 100.0,
+                    **{
+                        f"reference_{field}": median_field(reference_samples, field)
+                        for field in RATE_FIELDS
+                    },
+                }
+            )
+        results.append(result)
+    return results
+
+
+def comparison_text(results, reference_label=None):
+    """Produce a compact plain-text artifact suited to step logs and downloads."""
+    if reference_label is not None:
+        lines = [
+            f"Benchmark comparison (baseline / {reference_label} / candidate)",
+            "",
+            (
+                f"{'benchmark':56} {'base ms':>12} {'reference ms':>14} "
+                f"{'candidate ms':>14} {'vs base':>10} {'vs reference':>13}"
+            ),
+        ]
+        for result in results:
+            lines.append(
+                f"{result['name'][:56]:56} "
+                f"{result['baseline_median_seconds'] * 1000:12.2f} "
+                f"{result['reference_median_seconds'] * 1000:14.2f} "
+                f"{result['candidate_median_seconds'] * 1000:14.2f} "
+                f"{result['change_percent']:+9.2f}% "
+                f"{result['candidate_vs_reference_change_percent']:+12.2f}%"
+            )
+        return "\n".join(lines) + "\n"
+
+    lines = [
+        "Benchmark comparison (baseline -> candidate)",
+        "",
+        f"{'benchmark':68} {'base ms':>12} {'candidate ms':>14} {'change':>10}",
+    ]
+    for result in results:
+        lines.append(
+            f"{result['name'][:68]:68} "
+            f"{result['baseline_median_seconds'] * 1000:12.2f} "
+            f"{result['candidate_median_seconds'] * 1000:14.2f} "
+            f"{result['change_percent']:+9.2f}%"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def diverging_bar_table(results, change_key, ratio_key):
+    """Render lower wall time left/green and higher wall time right/red."""
+    lines = [
+        "| Benchmark | lower wall time ◄ | Wall-time change | ► higher wall time | Speedup factor |",
+        "|---|--:|:--:|:--|--:|",
+    ]
+    for result in sorted(results, key=lambda item: item[change_key]):
+        change = result[change_key]
+        squares = bar_squares(change)
+        lower = "🟩" * squares if change < -0.05 else ""
+        higher = "🟥" * squares if change > 0.05 else ""
+        lines.append(
+            f"| `{result['name']}` | {lower} | "
+            f"{format_wall_time_change(change)} | {higher} | "
+            f"{format_speedup(result[ratio_key])} |"
+        )
+    return lines
+
+
+def summary_markdown(
+    results,
+    threshold,
+    baseline_paths,
+    candidate_paths,
+    reference_paths=None,
+    reference_label=None,
+    baseline_commit=None,
+    reference_version=None,
+    repetitions=None,
+):
+    """Build the single rich report uploaded by the shared PerfTest template."""
+    regressions = [result for result in results if result["regression"]]
+    if regressions:
+        verdict = (
+            f"❌ {len(regressions)} benchmark(s) had at least "
+            f"{(threshold - 1.0) * 100:.0f}% higher wall time than the pinned "
+            "mssql-odbc baseline."
+        )
+    else:
+        verdict = (
+            f"✅ No benchmark had at least "
+            f"{(threshold - 1.0) * 100:.0f}% higher wall time than the pinned "
+            "mssql-odbc baseline."
+        )
+
+    lines = ["# ODBC performance comparison", "", f"**{verdict}**", ""]
+    if reference_paths:
+        lines.extend(
+            [
+                "### Median complete-result wall time",
+                "",
+                (
+                    f"| Benchmark | Pinned mssql-odbc baseline | "
+                    f"{reference_label} | Candidate | Candidate rows/s | "
+                    "Candidate cells/s |"
+                ),
+                "|---|---:|---:|---:|---:|---:|",
+            ]
+        )
+        for result in results:
+            lines.append(
+                "| `{name}` | {base:.2f} ms | {reference:.2f} ms | "
+                "{candidate:.2f} ms | {rows} | {cells} |".format(
+                    name=result["name"],
+                    base=result["baseline_median_seconds"] * 1000,
+                    reference=result["reference_median_seconds"] * 1000,
+                    candidate=result["candidate_median_seconds"] * 1000,
+                    rows=format_rate(result["rows_per_second"]),
+                    cells=format_rate(result["cells_per_second"]),
+                )
+            )
+        lines.extend(
+            [
+                "",
+                "### Candidate vs pinned mssql-odbc baseline",
+                "",
+                (
+                    "_🟩 lower wall time · 🟥 higher wall time · "
+                    f"1 square ≈ {BAR_PERCENT_PER_SQUARE:.0f} percentage points · "
+                    f"capped at {BAR_MAX_SQUARES} squares. Speedup factor is "
+                    "baseline wall time / candidate wall time._"
+                ),
+                "",
+            ]
+        )
+        lines.extend(diverging_bar_table(results, "change_percent", "candidate_ratio"))
+        lines.extend(
+            [
+                "",
+                f"### Candidate vs {reference_label}",
+                "",
+                (
+                    "_🟩 lower wall time · 🟥 higher wall time · "
+                    f"1 square ≈ {BAR_PERCENT_PER_SQUARE:.0f} percentage points · "
+                    f"capped at {BAR_MAX_SQUARES} squares. Speedup factor is "
+                    f"{reference_label} wall time / candidate wall time._"
+                ),
+                "",
+            ]
+        )
+        lines.extend(
+            diverging_bar_table(
+                results,
+                "candidate_vs_reference_change_percent",
+                "candidate_vs_reference_ratio",
+            )
+        )
+    else:
+        lines.extend(
+            [
+                "| Benchmark | Baseline median | Candidate median | Wall-time change | Speedup factor | Candidate rows/s | Candidate cells/s |",
+                "|---|---:|---:|---|---:|---:|---:|",
+            ]
+        )
+        for result in results:
+            lines.append(
+                "| `{name}` | {base:.2f} ms | {candidate:.2f} ms | "
+                "{change} | {speedup} | {rows} | {cells} |".format(
+                    name=result["name"],
+                    base=result["baseline_median_seconds"] * 1000,
+                    candidate=result["candidate_median_seconds"] * 1000,
+                    change=format_wall_time_change(result["change_percent"]),
+                    speedup=format_speedup(result["candidate_ratio"]),
+                    rows=format_rate(result["rows_per_second"]),
+                    cells=format_rate(result["cells_per_second"]),
+                )
+            )
+    if repetitions is None:
+        sample_counts = {result["candidate_samples"] for result in results}
+        repetitions = sample_counts.pop() if len(sample_counts) == 1 else None
+    lines.extend(
+        [
+            "",
+            "### Method and artifacts",
+            "",
+        ]
+    )
+    if repetitions is not None:
+        lines.append(
+            f"Each driver/workload was measured with **{repetitions} repetitions**; "
+            "the tables compare the median complete-result wall time."
+        )
+    else:
+        lines.append(
+            "The tables compare the median complete-result wall time from the raw "
+            "iteration samples."
+        )
+    lines.extend(
+        [
+            "",
+            f"- Pinned mssql-odbc baseline commit: `{baseline_commit or 'not provided'}`",
+            f"- Baseline samples: {describe_inputs(baseline_paths)}",
+            f"- Candidate samples: {describe_inputs(candidate_paths)}",
+        ]
+    )
+    if reference_paths:
+        lines.extend(
+            [
+                f"- Microsoft ODBC Driver version: `{reference_version or reference_label}`",
+                f"- Microsoft samples: {describe_inputs(reference_paths)}",
+            ]
+        )
+    lines.append("")
+    if reference_paths:
+        lines.append(
+            f"Only candidate vs pinned mssql-odbc baseline controls the optional "
+            f"{(threshold - 1.0) * 100:.0f}% regression gate. Microsoft ODBC "
+            "results are informational."
+        )
+    else:
+        lines.append(
+            "The gate is based on median complete-result wall time. Throughput "
+            "counters come from the candidate samples."
+        )
+    return "\n".join(lines) + "\n"
+
+
+def parse_args():
+    """Define additive metadata flags without changing the legacy two-way contract."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--baseline", required=True, type=Path, action="append")
+    parser.add_argument("--candidate", required=True, type=Path, action="append")
+    parser.add_argument("--reference", type=Path, action="append")
+    parser.add_argument("--reference-label", default="Reference")
+    parser.add_argument("--baseline-commit")
+    parser.add_argument("--reference-version")
+    parser.add_argument("--repetitions", type=int)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--regression-ratio", type=float, default=1.10)
+    parser.add_argument("--fail-on-regression", action="store_true")
+    return parser.parse_args()
+
+
+def main():
+    """Write log, Markdown, and JSON artifacts from one validated comparison."""
+    args = parse_args()
+    if not math.isfinite(args.regression_ratio) or args.regression_ratio <= 1.0:
+        raise ValueError("--regression-ratio must be a finite value greater than 1")
+    if args.reference and not args.reference_label.strip():
+        raise ValueError("--reference-label must not be empty")
+    if args.repetitions is not None and args.repetitions < 1:
+        raise ValueError("--repetitions must be a positive integer")
+
+    baseline = load_samples(args.baseline)
+    candidate = load_samples(args.candidate)
+    reference = load_samples(args.reference) if args.reference else None
+    results = compare(baseline, candidate, args.regression_ratio, reference)
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    reference_label = args.reference_label.strip() if reference else None
+    text = comparison_text(results, reference_label)
+    (args.output_dir / "comparison.txt").write_text(text, encoding="utf-8")
+    (args.output_dir / "summary.md").write_text(
+        summary_markdown(
+            results,
+            args.regression_ratio,
+            args.baseline,
+            args.candidate,
+            args.reference,
+            reference_label,
+            args.baseline_commit,
+            args.reference_version,
+            args.repetitions,
+        ),
+        encoding="utf-8",
+    )
+    output = {
+        "regression_ratio": args.regression_ratio,
+        "benchmarks": results,
+    }
+    if reference_label is not None:
+        output["reference_label"] = reference_label
+    if args.baseline_commit is not None:
+        output["baseline_commit"] = args.baseline_commit
+    if args.reference_version is not None:
+        output["reference_version"] = args.reference_version
+    if args.repetitions is not None:
+        output["repetitions"] = args.repetitions
+    (args.output_dir / "comparison.json").write_text(
+        json.dumps(output, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    sys.stdout.write(text)
+
+    if args.fail_on_regression and any(result["regression"] for result in results):
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except (OSError, ValueError, KeyError, json.JSONDecodeError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/.pipeline/scripts/containerized-odbc-e2e.sh
+++ b/.pipeline/scripts/containerized-odbc-e2e.sh
@@ -29,28 +29,15 @@ apt-get install -y --no-install-recommends cmake unixodbc-dev
 # The reference driver for comparison mode. The upstream version defaults to a
 # pinned value but can be overridden by the msodbcsqlVersion pipeline variable
 # (passed as ODBC_E2E_MSODBCSQL_VERSION), so a new release can't silently change
-# what the parity table compares against. apt pins the full <upstream>-<revision>
-# package; the Debian revision suffix is appended here.
-MSODBCSQL_VERSION="${ODBC_E2E_MSODBCSQL_VERSION:-18.6.2.1}-1"
+# what the parity table compares against. The shared installer appends and pins
+# the Debian package revision.
+MSODBCSQL_VERSION="${ODBC_E2E_MSODBCSQL_VERSION:-18.6.2.1}"
 
 compare_args=()
 case "$(printf '%s' "${ODBC_E2E_COMPARE:-0}" | tr '[:upper:]' '[:lower:]')" in
     1|true|yes)
-        apt-get install -y --no-install-recommends curl gnupg ca-certificates
-        # Install the signing key into its own keyring and scope it to just the
-        # Microsoft repo via signed-by, rather than trusting it for every apt
-        # source on the box (a global trusted.gpg.d drop-in would do that).
-        install -d -m 0755 /usr/share/keyrings
-        curl -fsSL https://packages.microsoft.com/keys/microsoft.asc \
-            -o /usr/share/keyrings/microsoft.asc
-        curl -fsSL "https://packages.microsoft.com/config/ubuntu/$(. /etc/os-release && echo "$VERSION_ID")/prod.list" \
-            -o /etc/apt/sources.list.d/mssql-release.list
-        sed -i 's#^deb \[#deb [signed-by=/usr/share/keyrings/microsoft.asc #' \
-            /etc/apt/sources.list.d/mssql-release.list
-        grep -q 'signed-by=/usr/share/keyrings/microsoft.asc' /etc/apt/sources.list.d/mssql-release.list \
-            || { echo "Error: failed to scope the Microsoft apt key to its repo" >&2; exit 1; }
-        apt-get update
-        ACCEPT_EULA=Y apt-get install -y --no-install-recommends "msodbcsql18=$MSODBCSQL_VERSION"
+        /workspace/.pipeline/scripts/install-msodbcsql.sh \
+            "$MSODBCSQL_VERSION"
         # msodbcsql18 registers itself as [ODBC Driver 18 for SQL Server] in
         # /etc/odbcinst.ini, which is run_e2e.sh's default --msodbcsql-ini.
         compare_args+=(--compare-with-msodbcsql)

--- a/.pipeline/scripts/install-msodbcsql.ps1
+++ b/.pipeline/scripts/install-msodbcsql.ps1
@@ -60,7 +60,7 @@ if (Test-Path $key) {
         $have = Normalize-Version $info.ProductVersion
         if ($have -and $have -eq $want) {
             Write-Host "Version check passed: registered driver matches the pinned $Version; skipping install."
-            exit 0
+            return
         } elseif ($have) {
             Write-Warning "Registered '$name' is version $($info.ProductVersion) (normalized $have) but the pipeline pins $Version (normalized $want); upgrading the pre-installed driver to the pinned version."
         } else {
@@ -106,13 +106,17 @@ if (-not (Test-Path $key)) {
 # fall through and attempt an upgrade, a persistent mismatch is a real failure
 # (the upgrade did not take) rather than an uncontrollable pre-existing driver.
 $dll = (Get-ItemProperty -Path $key -Name 'Driver' -ErrorAction SilentlyContinue).Driver
-if ($dll -and (Test-Path $dll)) {
-    $info = (Get-Item $dll).VersionInfo
-    $want = Normalize-Version $Version
-    $have = Normalize-Version $info.ProductVersion
-    Write-Host "Post-install '$name' -> $dll (ProductVersion=$($info.ProductVersion))"
-    if ($have -and $have -ne $want) {
-        throw "After install/upgrade, '$name' is version $($info.ProductVersion) (normalized $have) but the pipeline pins $Version (normalized $want); the upgrade did not take effect."
-    }
+if (-not $dll -or -not (Test-Path $dll)) {
+    throw "Install reported success but '$name' has no usable Driver DLL path."
+}
+$info = (Get-Item $dll).VersionInfo
+$want = Normalize-Version $Version
+$have = Normalize-Version $info.ProductVersion
+Write-Host "Post-install '$name' -> $dll (ProductVersion=$($info.ProductVersion))"
+if (-not $have) {
+    throw "Installed '$name' has no readable ProductVersion at $dll."
+}
+if ($have -ne $want) {
+    throw "After install/upgrade, '$name' is version $($info.ProductVersion) (normalized $have) but the pipeline pins $Version (normalized $want); the upgrade did not take effect."
 }
 Write-Host "Installed and registered '$name' ($Version)."

--- a/.pipeline/scripts/install-msodbcsql.sh
+++ b/.pipeline/scripts/install-msodbcsql.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# Installs and verifies one exact Microsoft ODBC Driver 18 package on Ubuntu.
+
+set -euo pipefail
+
+VERSION="${1:-18.6.2.1}"
+if ! [[ "$VERSION" =~ ^[0-9]+(\.[0-9]+){3}$ ]]; then
+    echo "ERROR: invalid msodbcsql version: $VERSION" >&2
+    exit 1
+fi
+PACKAGE_VERSION="${VERSION}-1"
+
+if [ ! -r /etc/os-release ]; then
+    echo "ERROR: /etc/os-release is unavailable" >&2
+    exit 1
+fi
+# shellcheck disable=SC1091
+source /etc/os-release
+if [ "${ID:-}" != "ubuntu" ] || [ -z "${VERSION_ID:-}" ]; then
+    echo "ERROR: the pinned msodbcsql installer requires Ubuntu" >&2
+    exit 1
+fi
+
+sudo_command=()
+if [ "$(id -u)" -ne 0 ]; then
+    command -v sudo >/dev/null 2>&1 ||
+        { echo "ERROR: sudo is required to install msodbcsql" >&2; exit 1; }
+    sudo_command=(sudo)
+fi
+
+temp_dir="$(mktemp -d)"
+cleanup() {
+    # Repository metadata and signing keys are staged only long enough to install;
+    # removing them avoids leaking one run's mutable files into a reused host.
+    rm -rf "$temp_dir"
+}
+trap cleanup EXIT
+
+echo ">>> Installing Microsoft ODBC Driver $VERSION..."
+"${sudo_command[@]}" apt-get update -y
+"${sudo_command[@]}" env DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y --no-install-recommends curl ca-certificates
+
+curl -fsSL https://packages.microsoft.com/keys/microsoft.asc \
+    -o "$temp_dir/microsoft.asc"
+curl -fsSL "https://packages.microsoft.com/config/ubuntu/$VERSION_ID/prod.list" \
+    -o "$temp_dir/mssql-release.list"
+"${sudo_command[@]}" install -d -m 0755 /usr/share/keyrings
+"${sudo_command[@]}" install -m 0644 "$temp_dir/microsoft.asc" \
+    /usr/share/keyrings/microsoft.asc
+# Scope trust to the key installed above. Newer Ubuntu lists may already name a
+# different microsoft-prod.gpg path, so normalize that path instead of accepting a
+# signed-by entry whose file this reusable installer did not create.
+if grep -q 'signed-by=' "$temp_dir/mssql-release.list"; then
+    sed -Ei \
+        's#signed-by=[^] ]+#signed-by=/usr/share/keyrings/microsoft.asc#g' \
+        "$temp_dir/mssql-release.list"
+else
+    sed -i 's#^deb \[#deb [signed-by=/usr/share/keyrings/microsoft.asc #' \
+        "$temp_dir/mssql-release.list"
+fi
+grep -q 'signed-by=/usr/share/keyrings/microsoft.asc' \
+    "$temp_dir/mssql-release.list" ||
+    { echo "ERROR: failed to scope the Microsoft apt key" >&2; exit 1; }
+"${sudo_command[@]}" install -m 0644 "$temp_dir/mssql-release.list" \
+    /etc/apt/sources.list.d/mssql-release.list
+
+"${sudo_command[@]}" apt-get update -y
+"${sudo_command[@]}" env DEBIAN_FRONTEND=noninteractive ACCEPT_EULA=Y \
+    apt-get install -y --no-install-recommends --allow-downgrades \
+    "msodbcsql18=$PACKAGE_VERSION"
+
+installed_version="$(dpkg-query -W -f='${Version}' msodbcsql18)"
+if [ "$installed_version" != "$PACKAGE_VERSION" ]; then
+    echo "ERROR: installed msodbcsql18 $installed_version; expected $PACKAGE_VERSION" >&2
+    exit 1
+fi
+echo ">>> Installed Microsoft ODBC Driver $VERSION ($installed_version)."

--- a/.pipeline/scripts/test_compare_odbc_benchmarks.py
+++ b/.pipeline/scripts/test_compare_odbc_benchmarks.py
@@ -1,0 +1,522 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Offline tests for the ODBC benchmark comparator's policy and reporting.
+
+The comparator decides whether a perf run passes, so the parts worth testing are
+the ones that can be wrong without anything crashing: a benchmark silently
+dropped from one leg, a confirmed regression that fails to gate, an unconfirmed
+one that gates anyway, and a report that omits a whole workload family.
+
+Everything here is synthetic - no SQL Server, no ODBC driver, no Google Benchmark
+build. Google Benchmark's own ``tools/compare.py`` is exercised only when a
+checkout and NumPy/SciPy happen to be present; the default path uses the
+comparator's built-in medians so the suite runs anywhere.
+
+Run with ``python -m unittest discover .pipeline/scripts``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMPARATOR = REPO_ROOT / ".pipeline" / "scripts" / "compare-odbc-benchmarks.py"
+
+# The C++ workload catalog. Written out rather than imported so a rename in the
+# harness shows up here as a failing expectation instead of being silently
+# mirrored.
+BENCHMARKS = (
+    "fetch/narrow_2m_c15_fixed/bound_rowset_1000",
+    "fetch/wide_10k_c600_fixed/bound_rowset_1000",
+    "fetch/rowset_100k_c15_fixed/bound_rowset_1",
+    "fetch/rowset_100k_c15_fixed/bound_rowset_64",
+    "fetch/rowset_100k_c15_fixed/bound_rowset_1000",
+    "fetch/rowset_100k_c15_fixed/bind_cycle_rowset_64",
+    "fetch/rowset_20k_c15_fixed/bind_cycle_rowset_1",
+    "fetch/varwidth_100k_c7_nullable/bound_rowset_1000",
+    "fetch/varwidth_100k_c7_nullable/bound_rowset_64",
+    "getdata/rowwise_20k_c15_fixed/inline_values",
+    "getdata/rowwise_1k_c3_lob_max/chunked_8192",
+    "getdata/rowwise_20k_c16_mixed_lob/whole_result_rowwise",
+    "getdata/rowwise_20k_c4_variant/probe_colattribute",
+)
+
+GETDATA_BENCHMARKS = tuple(
+    name for name in BENCHMARKS if name.startswith("getdata/")
+)
+
+NAME_SUFFIX = "/iterations:1/manual_time"
+REPETITIONS = 5
+
+
+def run_name(benchmark_id):
+    """Google Benchmark's manual-timing run name, which is the comparison key."""
+    return benchmark_id + NAME_SUFFIX
+
+
+def make_document(benchmark_ids, milliseconds, rows=1000):
+    """Build a Google Benchmark document with the shape both harnesses emit.
+
+    ``milliseconds`` maps a benchmark id to its per-repetition time; a scalar
+    applies to every id. Aggregates are included because a real run has them and
+    the comparator prefers them.
+    """
+    benchmarks = []
+    for family_index, benchmark_id in enumerate(benchmark_ids):
+        name = run_name(benchmark_id)
+        value = (
+            milliseconds[benchmark_id]
+            if isinstance(milliseconds, dict)
+            else milliseconds
+        )
+        for repetition_index in range(REPETITIONS):
+            benchmarks.append(
+                {
+                    "name": name,
+                    "family_index": family_index,
+                    "per_family_instance_index": 0,
+                    "run_name": name,
+                    "run_type": "iteration",
+                    "repetitions": REPETITIONS,
+                    "repetition_index": repetition_index,
+                    "threads": 1,
+                    "iterations": 1,
+                    "real_time": value,
+                    "cpu_time": value,
+                    "time_unit": "ms",
+                    "rows": float(rows),
+                    "cells": float(rows * 15),
+                    "rows_per_second": rows / (value / 1000.0),
+                    "cells_per_second": rows * 15 / (value / 1000.0),
+                    "logical_bytes_per_second": rows * 100 / (value / 1000.0),
+                }
+            )
+        benchmarks.append(
+            {
+                "name": f"{name}_median",
+                "family_index": family_index,
+                "per_family_instance_index": 0,
+                "run_name": name,
+                "run_type": "aggregate",
+                "repetitions": REPETITIONS,
+                "threads": 1,
+                "aggregate_name": "median",
+                "aggregate_unit": "time",
+                "iterations": REPETITIONS,
+                "real_time": value,
+                "cpu_time": value,
+                "time_unit": "ms",
+            }
+        )
+    return {"context": {"host_name": "synthetic"}, "benchmarks": benchmarks}
+
+
+class ComparatorTestCase(unittest.TestCase):
+    """Shared plumbing: write synthetic legs and invoke the comparator."""
+
+    def setUp(self):
+        if not COMPARATOR.is_file():
+            self.skipTest(f"comparator not found at {COMPARATOR}")
+        self._temp = tempfile.TemporaryDirectory()
+        self.root = Path(self._temp.name)
+        self.addCleanup(self._temp.cleanup)
+
+    def write(self, name, document):
+        path = self.root / name
+        path.write_text(json.dumps(document), encoding="utf-8")
+        return path
+
+    def compare(self, arguments, output_dir=None):
+        """Run the comparator and return (exit code, stdout+stderr, output dir)."""
+        output_dir = output_dir or (self.root / "out")
+        completed = subprocess.run(
+            [sys.executable, str(COMPARATOR), *arguments, "--output-dir", str(output_dir)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return completed.returncode, completed.stdout + completed.stderr, output_dir
+
+    def three_way(self, baseline_ms, candidate_ms, reference_ms, ids=BENCHMARKS):
+        """Write one full three-driver pass and return its comparator arguments."""
+        baseline = self.write("baseline.json", make_document(ids, baseline_ms))
+        candidate = self.write("candidate.json", make_document(ids, candidate_ms))
+        reference = self.write("reference.json", make_document(ids, reference_ms))
+        return [
+            "--baseline",
+            str(baseline),
+            "--candidate",
+            str(candidate),
+            "--reference",
+            str(reference),
+            "--reference-label",
+            "Microsoft ODBC 18.6.2.1",
+            "--reference-version",
+            "18.6.2.1",
+            "--baseline-commit",
+            "0" * 40,
+            "--repetitions",
+            str(REPETITIONS),
+        ]
+
+
+class ThreeWayReportTests(ComparatorTestCase):
+    """The whole workload catalog must reach the report and the gate."""
+
+    def test_clean_run_passes_and_reports_every_benchmark(self):
+        code, _, out = self.compare(self.three_way(100.0, 100.0, 40.0))
+        self.assertEqual(code, 0)
+        summary = (out / "summary.md").read_text(encoding="utf-8")
+        for benchmark_id in BENCHMARKS:
+            self.assertIn(f"`{run_name(benchmark_id)}`", summary)
+        report = json.loads((out / "comparison.json").read_text(encoding="utf-8"))
+        self.assertEqual(len(report["benchmarks"]), len(BENCHMARKS))
+
+    def test_getdata_rows_carry_throughput_and_the_reference_column(self):
+        code, _, out = self.compare(self.three_way(100.0, 100.0, 40.0))
+        self.assertEqual(code, 0)
+        report = json.loads((out / "comparison.json").read_text(encoding="utf-8"))
+        getdata_rows = [
+            row
+            for row in report["benchmarks"]
+            if row["name"].startswith("getdata/")
+        ]
+        self.assertEqual(len(getdata_rows), len(GETDATA_BENCHMARKS))
+        for row in getdata_rows:
+            self.assertGreater(row["rows_per_second"], 0)
+            self.assertGreater(row["cells_per_second"], 0)
+            self.assertIn("candidate_vs_reference_ratio", row)
+            self.assertAlmostEqual(row["candidate_vs_reference_ratio"], 2.5, places=6)
+
+    def test_microsoft_gap_is_reported_but_never_gates(self):
+        # Candidate is 5x the Microsoft reference and identical to the baseline:
+        # informational, so the run still passes.
+        code, _, out = self.compare(self.three_way(100.0, 100.0, 20.0))
+        self.assertEqual(code, 0)
+        summary = (out / "summary.md").read_text(encoding="utf-8")
+        self.assertIn("Informational means it does not fail this regression run", summary)
+        self.assertIn("✅", summary)
+
+
+class GateAndConfirmationTests(ComparatorTestCase):
+    """The gate is the whole point: it has to fire on a confirmed regression and
+    stay quiet on one that did not reproduce."""
+
+    def regressed_candidate(self, benchmark_id, ratio=1.30):
+        candidate = {name: 100.0 for name in BENCHMARKS}
+        candidate[benchmark_id] = 100.0 * ratio
+        return candidate
+
+    def test_initial_regression_without_confirmation_data_is_rejected(self):
+        target = BENCHMARKS[0]
+        arguments = self.three_way(100.0, self.regressed_candidate(target), 40.0)
+        code, output, _ = self.compare(arguments + ["--confirm-runs", "4"])
+        self.assertEqual(code, 1)
+        self.assertIn("confirmation results are missing", output)
+
+    def test_confirmed_regression_fails_the_run(self):
+        target = BENCHMARKS[2]
+        arguments = self.three_way(100.0, self.regressed_candidate(target), 40.0)
+        code, _, out = self.compare(
+            arguments
+            + [
+                "--confirm-runs",
+                "4",
+                "--confirm-quorum",
+                "3",
+                "--confirmation",
+                run_name(target),
+                "4",
+                "4",
+                "1.28",
+            ]
+        )
+        self.assertEqual(code, 2)
+        summary = (out / "summary.md").read_text(encoding="utf-8")
+        self.assertIn("❌", summary)
+        self.assertIn("confirmed regression", summary)
+
+    def test_unconfirmed_regression_clears_the_gate(self):
+        target = BENCHMARKS[2]
+        arguments = self.three_way(100.0, self.regressed_candidate(target), 40.0)
+        code, _, out = self.compare(
+            arguments
+            + [
+                "--confirm-runs",
+                "4",
+                "--confirm-quorum",
+                "3",
+                "--confirmation",
+                run_name(target),
+                "1",
+                "1",
+                "1.01",
+            ]
+        )
+        self.assertEqual(code, 0)
+        summary = (out / "summary.md").read_text(encoding="utf-8")
+        self.assertIn("✅", summary)
+        self.assertIn("not confirmed", summary)
+
+    def test_a_getdata_regression_gates_exactly_like_a_bound_fetch_one(self):
+        target = GETDATA_BENCHMARKS[0]
+        arguments = self.three_way(100.0, self.regressed_candidate(target), 40.0)
+        code, _, out = self.compare(
+            arguments
+            + [
+                "--confirm-runs",
+                "4",
+                "--confirm-quorum",
+                "3",
+                "--confirmation",
+                run_name(target),
+                "3",
+                "3",
+                "1.27",
+            ]
+        )
+        self.assertEqual(code, 2)
+        summary = (out / "summary.md").read_text(encoding="utf-8")
+        self.assertIn(f"`{run_name(target)}`", summary)
+        self.assertIn("confirmed regression", summary)
+
+    def test_apparent_improvement_that_reverses_still_fails(self):
+        # Flagged as an improvement by the initial pass, then regressed in three
+        # of four confirmation rounds. Regression hits are counted independently
+        # of the initial direction precisely so this cannot slip through.
+        target = BENCHMARKS[4]
+        candidate = {name: 100.0 for name in BENCHMARKS}
+        candidate[target] = 50.0
+        arguments = self.three_way(100.0, candidate, 40.0)
+        code, _, out = self.compare(
+            arguments
+            + [
+                "--confirm-runs",
+                "4",
+                "--confirm-quorum",
+                "3",
+                "--confirmation",
+                run_name(target),
+                "0",
+                "3",
+                "1.20",
+            ]
+        )
+        self.assertEqual(code, 2)
+        summary = (out / "summary.md").read_text(encoding="utf-8")
+        self.assertIn("confirmed regression", summary)
+
+    def test_gate_can_be_disabled_without_changing_the_report(self):
+        target = BENCHMARKS[2]
+        arguments = self.three_way(100.0, self.regressed_candidate(target), 40.0)
+        confirmation = [
+            "--confirm-runs",
+            "4",
+            "--confirm-quorum",
+            "3",
+            "--confirmation",
+            run_name(target),
+            "4",
+            "4",
+            "1.28",
+        ]
+        code, _, out = self.compare(
+            arguments + confirmation + ["--no-fail-on-regression"],
+            output_dir=self.root / "ungated",
+        )
+        self.assertEqual(code, 0)
+        self.assertIn("❌", (out / "summary.md").read_text(encoding="utf-8"))
+
+
+class PlanTests(ComparatorTestCase):
+    """The plan is what the runner re-measures, so an id missing from it is a
+    benchmark that silently skips confirmation."""
+
+    def test_plan_lists_regressions_and_caps_improvements(self):
+        candidate = {name: 100.0 for name in BENCHMARKS}
+        candidate[BENCHMARKS[0]] = 130.0
+        for benchmark_id in BENCHMARKS[8:13]:
+            candidate[benchmark_id] = 50.0
+        arguments = self.three_way(100.0, candidate, 40.0)
+        plan_path = self.root / "plan.txt"
+        code, _, _ = self.compare(
+            arguments
+            + ["--plan-out", str(plan_path), "--no-summary", "--no-fail-on-regression"]
+        )
+        self.assertEqual(code, 0)
+        entries = [
+            line.split("\t")
+            for line in plan_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        kinds = [entry[0] for entry in entries]
+        names = [entry[1] for entry in entries]
+        self.assertEqual(kinds.count("regression"), 1)
+        # Five apparent improvements, capped at the default three.
+        self.assertEqual(kinds.count("improvement"), 3)
+        self.assertIn(run_name(BENCHMARKS[0]), names)
+
+    def test_ratios_output_covers_every_benchmark(self):
+        arguments = self.three_way(100.0, 100.0, 40.0)
+        ratios_path = self.root / "ratios.txt"
+        code, _, _ = self.compare(
+            arguments
+            + ["--ratios-out", str(ratios_path), "--no-summary"]
+        )
+        self.assertEqual(code, 0)
+        names = [
+            line.split("\t")[0]
+            for line in ratios_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        self.assertEqual(sorted(names), sorted(run_name(x) for x in BENCHMARKS))
+
+
+class MismatchTests(ComparatorTestCase):
+    """A partial comparison can hide a regression, so it must be refused."""
+
+    def test_candidate_missing_a_benchmark_is_rejected(self):
+        baseline = self.write("baseline.json", make_document(BENCHMARKS, 100.0))
+        candidate = self.write(
+            "candidate.json", make_document(BENCHMARKS[:-1], 100.0)
+        )
+        code, output, _ = self.compare(
+            ["--baseline", str(baseline), "--candidate", str(candidate)]
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("benchmark sets differ", output)
+
+    def test_reference_missing_a_whole_family_is_rejected(self):
+        baseline = self.write("baseline.json", make_document(BENCHMARKS, 100.0))
+        candidate = self.write("candidate.json", make_document(BENCHMARKS, 100.0))
+        reference = self.write(
+            "reference.json",
+            make_document(
+                tuple(n for n in BENCHMARKS if not n.startswith("getdata/")), 40.0
+            ),
+        )
+        code, output, _ = self.compare(
+            [
+                "--baseline",
+                str(baseline),
+                "--candidate",
+                str(candidate),
+                "--reference",
+                str(reference),
+            ]
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("benchmark sets differ", output)
+
+    def test_confirmation_for_an_unknown_benchmark_is_rejected(self):
+        arguments = self.three_way(100.0, 100.0, 40.0)
+        code, output, _ = self.compare(
+            arguments
+            + [
+                "--confirm-runs",
+                "4",
+                "--confirmation",
+                "fetch/does_not_exist/bound_rowset_1000",
+                "4",
+                "4",
+                "1.2",
+            ]
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("unknown benchmarks", output)
+
+    def test_confirmation_hits_above_the_round_count_are_rejected(self):
+        arguments = self.three_way(100.0, 100.0, 40.0)
+        code, output, _ = self.compare(
+            arguments
+            + [
+                "--confirm-runs",
+                "4",
+                "--confirmation",
+                run_name(BENCHMARKS[0]),
+                "9",
+                "9",
+                "1.2",
+            ]
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("exceed --confirm-runs", output)
+
+
+class LegacyTwoWayTests(ComparatorTestCase):
+    """The per-round confirmation comparison still runs without a reference leg,
+    so the two-way contract has to keep working."""
+
+    def test_two_way_report_is_produced(self):
+        baseline = self.write("baseline.json", make_document(BENCHMARKS, 100.0))
+        candidate = self.write("candidate.json", make_document(BENCHMARKS, 90.0))
+        code, _, out = self.compare(
+            [
+                "--baseline",
+                str(baseline),
+                "--candidate",
+                str(candidate),
+                "--repetitions",
+                str(REPETITIONS),
+            ]
+        )
+        self.assertEqual(code, 0)
+        summary = (out / "summary.md").read_text(encoding="utf-8")
+        self.assertIn("Baseline median", summary)
+        self.assertNotIn("Reference gap", summary)
+        self.assertIn("10.00% lower wall time", summary)
+
+    def test_two_way_gate_still_fires(self):
+        baseline = self.write("baseline.json", make_document(BENCHMARKS, 100.0))
+        candidate = self.write("candidate.json", make_document(BENCHMARKS, 130.0))
+        code, _, _ = self.compare(
+            ["--baseline", str(baseline), "--candidate", str(candidate)]
+        )
+        self.assertEqual(code, 2)
+
+
+class OfficialComparatorTests(ComparatorTestCase):
+    """Same policy, but with Google Benchmark's own tool doing the pairwise math.
+
+    Skipped unless a fetched v1.9.1 checkout and its NumPy/SciPy imports are both
+    available, because that is a build artifact rather than a repo file.
+    """
+
+    def setUp(self):
+        super().setUp()
+        candidates = list(REPO_ROOT.glob("target/**/googlebenchmark-src/tools/compare.py"))
+        if not candidates:
+            self.skipTest("no fetched Google Benchmark checkout in target/")
+        self.gbench_compare = candidates[0]
+        probe = subprocess.run(
+            [sys.executable, "-c", "import numpy, scipy"],
+            capture_output=True,
+            check=False,
+        )
+        if probe.returncode != 0:
+            self.skipTest("NumPy/SciPy not importable for gbench's comparator")
+
+    def test_official_medians_cover_the_whole_set(self):
+        arguments = self.three_way(100.0, 110.0, 40.0)
+        code, output, out = self.compare(
+            arguments
+            + ["--gbench-compare", str(self.gbench_compare), "--no-fail-on-regression"]
+        )
+        self.assertEqual(code, 0, output)
+        report = json.loads((out / "comparison.json").read_text(encoding="utf-8"))
+        self.assertEqual(len(report["benchmarks"]), len(BENCHMARKS))
+        for row in report["benchmarks"]:
+            self.assertAlmostEqual(row["initial_ratio"], 1.1, places=3)
+        self.assertTrue((out / "gbench-baseline-vs-candidate.json").is_file())
+        self.assertTrue((out / "gbench-reference-vs-candidate.txt").is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.pipeline/scripts/test_compare_odbc_benchmarks.py
+++ b/.pipeline/scripts/test_compare_odbc_benchmarks.py
@@ -449,6 +449,14 @@ class MismatchTests(ComparatorTestCase):
         self.assertEqual(code, 1)
         self.assertIn("exceed --confirm-runs", output)
 
+    def test_conflicting_gate_flags_are_rejected(self):
+        arguments = self.three_way(100.0, 100.0, 40.0)
+        code, output, _ = self.compare(
+            arguments + ["--fail-on-regression", "--no-fail-on-regression"]
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("mutually exclusive", output)
+
 
 class LegacyTwoWayTests(ComparatorTestCase):
     """The per-round confirmation comparison still runs without a reference leg,

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -77,6 +77,11 @@ stages:
       displayName: Check duplicate PR head commit
       env:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    - bash: |
+        set -euo pipefail
+        python3 -m unittest discover -s .pipeline/scripts \
+          -p 'test_compare_odbc_benchmarks.py' -v
+      displayName: Test ODBC benchmark comparison policy
 
 - stage: Build
   displayName: Build Stage

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -77,12 +77,6 @@ stages:
       displayName: Check duplicate PR head commit
       env:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    - bash: |
-        set -euo pipefail
-        python3 -m unittest discover -s .pipeline/scripts \
-          -p 'test_compare_odbc_benchmarks.py' -v
-      displayName: Test ODBC benchmark comparison policy
-
 - stage: Build
   displayName: Build Stage
   dependsOn:
@@ -110,6 +104,18 @@ stages:
       expectedSentinels: build_arm,build_win_arm
       sqlImageTag: ${{ parameters.sqlImageTag }}
       jobCondition: and(not(canceled()), eq(variables['Build.Reason'], 'PullRequest'))
+  - job: Test_Benchmark_Policy
+    displayName: Test ODBC benchmark comparison policy
+    pool:
+      name: ${{ parameters.utilPoolName }}
+      demands:
+        - imageOverride -equals RUST-UBUSLIM
+    steps:
+      - bash: |
+          set -euo pipefail
+          python3 -m unittest discover -s .pipeline/scripts \
+            -p 'test_compare_odbc_benchmarks.py' -v
+        displayName: Run comparator policy tests
   - job: Build_Windows
     displayName: Build Windows
     pool:

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -104,18 +104,6 @@ stages:
       expectedSentinels: build_arm,build_win_arm
       sqlImageTag: ${{ parameters.sqlImageTag }}
       jobCondition: and(not(canceled()), eq(variables['Build.Reason'], 'PullRequest'))
-  - job: Test_Benchmark_Policy
-    displayName: Test ODBC benchmark comparison policy
-    pool:
-      name: ${{ parameters.utilPoolName }}
-      demands:
-        - imageOverride -equals RUST-UBUSLIM
-    steps:
-      - bash: |
-          set -euo pipefail
-          python3 -m unittest discover -s .pipeline/scripts \
-            -p 'test_compare_odbc_benchmarks.py' -v
-        displayName: Run comparator policy tests
   - job: Build_Windows
     displayName: Build Windows
     pool:
@@ -262,6 +250,11 @@ stages:
       - template: cargo-authenticate-template.yml
         parameters:
           osType: Linux
+      - bash: |
+          set -euo pipefail
+          python3 -m unittest discover -s .pipeline/scripts \
+            -p 'test_compare_odbc_benchmarks.py' -v
+        displayName: Test ODBC benchmark comparison policy
       - template: build-template-container.yml
         parameters:
           architecture: x64

--- a/docs/perf-testing-plan.md
+++ b/docs/perf-testing-plan.md
@@ -382,14 +382,46 @@ change specifically to `mssql-tds`.
 
 Dedicated Linux and Windows PerfTest pipelines run five repetitions of each
 workload against the pinned `mssql-odbc` commit, Microsoft ODBC Driver 18.6.2.1,
-and the candidate. Their uploaded `summary.md` leads with the optional gate
-verdict and three median complete-result wall times, followed by separate
-colored diverging-bar tables for candidate vs Rust baseline and candidate vs
-Microsoft ODBC. The bars use about five percentage points per square (capped at
-20), while each row retains the exact lower/higher wall-time percentage and
-speedup factor. Only candidate vs the pinned Rust baseline can fail the optional
-gate; Microsoft is an informational reference. The scripts also echo the report
-to the step log and retain raw JSON, context, and comparison artifacts.
+and the candidate. Their uploaded `summary.md` leads with the gate verdict and
+three median complete-result wall times, followed by separate colored
+diverging-bar tables for candidate vs Rust baseline and candidate vs Microsoft
+ODBC. The bars use about five percentage points per square (capped at 20), while
+each row retains the exact lower/higher wall-time percentage and speedup factor.
+Only candidate vs the pinned Rust baseline can fail the gate; Microsoft is an
+informational reference. The scripts also echo the report to the step log and
+retain raw JSON, context, and comparison artifacts.
+
+The gate uses the same 5% threshold and the same auto-confirm contract as the
+fixed-baseline `mssql-tds` runner. The initial five-sample median only screens:
+it selects the candidate-vs-baseline regressions and up to three of the largest
+apparent improvements, which are then re-measured with the candidate and the
+pinned baseline back-to-back for four confirmation rounds, alternating which
+driver runs first. A result counts only when it reproduces in at least three of
+those four rounds, and the headline change is the median of the four confirmation
+ratios — the initial pass that triggered the re-measurement is excluded so the
+outlier under test does not vote on its own verdict. Regression-direction hits
+are counted independently, so an apparent improvement that reverses into a
+3-of-4 regression still fails the run by default.
+
+The pairwise math is Google Benchmark's own `tools/compare.py` and
+`gbench.report` from the pinned v1.9.1 checkout in the CMake build tree, run once
+per comparison pair with its text and JSON output retained.
+`compare-odbc-benchmarks.py` stays a thin wrapper for the repo-specific policy:
+exact benchmark-set validation, the combined three-way report, custom counters
+and pins, the gate, the confirmation overrides, and the Azure DevOps Markdown.
+The Mann-Whitney U test is disabled explicitly because five repetitions are well
+below the nine that Google Benchmark documents as meaningful for it; the
+confirmation rounds establish reproduction instead.
+
+Both runners apply the same noise controls as the `mssql-tds` lab: a SQL Server
+configuration snapshot from the shared `sql-config-dump.sql`, CPU
+frequency/utilization telemetry bracketing the initial pass and every
+confirmation round, optional client CPU pinning, and platform-specific
+large-buffer tuning (glibc mmap/trim thresholds on Linux; debug-heap opt-out,
+priority class, and power scheme on Windows, all restored afterwards).
+Connection-churn network tuning is deliberately not applied: this harness opens
+one connection and reuses it for every measured retrieval, so there is no
+ephemeral-port or TIME_WAIT pressure to relieve.
 
 The resulting layered strategy is:
 
@@ -397,6 +429,6 @@ The resulting layered strategy is:
   protocol/codec/parsing regressions to source. *(This plan.)*
 - **Layer 2 — mssql-odbc (cdylib via ODBC DM):** end-to-end result-fetch
   benchmarks via the fixed C++ harness → candidate/baseline driver comparison
-  and optional Rust-vs-native ODBC comparison.
+  and informational Rust-vs-native ODBC comparison.
 - **Cross-cutting — longitudinal trend of main:** catches dependency/toolchain drift that
   Layer 1's isolation hides.

--- a/docs/perf-testing-plan.md
+++ b/docs/perf-testing-plan.md
@@ -255,7 +255,7 @@ binaries keep the per-binary interleaving effective (see §2).
 - Bulk insert (default 10,000 rows, override via `BENCH_BULK_ROWS`) via the `BulkCopy` builder, over batch sizes 500 / 5,000.
 
 ### mssql-tds-specific
-- Packet-size sensitivity (4096 / 8192 / 32768) on large reads — measures reassembly overhead.
+- Packet-size sensitivity (4096 / 8192 / 32767) on large reads — measures reassembly overhead.
 - Zero-copy `next_row` row-iteration throughput at large row counts.
 
 ---
@@ -391,6 +391,35 @@ Only candidate vs the pinned Rust baseline can fail the gate; Microsoft is an
 informational reference. The scripts also echo the report to the step log and
 retain raw JSON, context, and comparison artifacts.
 
+The workload catalog is shaped by what `mssql-python` actually does to the
+driver, not by what is convenient to write:
+
+- **Bound rowsets at 1, 64, and 1000.** `Cursor.arraysize` defaults to 1, so an
+  unconfigured `fetchmany()` binds a one-row rowset; `fetchall()` caps its
+  computed batch at 1000. A round 1024 is a size no consumer asks for.
+- **A bind/fetch/unbind lifecycle workload.** `fetchmany()` does not bind once
+  and drain — every call re-describes, rebinds, sets the row-array size, fetches
+  one rowset, resets the size, and unbinds. Paired against the plain bound
+  workload on the same table and cadence, it isolates that per-call cost.
+- **Row-at-a-time `SQLGetData`.** One LOB or `sql_variant` column moves the
+  *whole* result off the bound path, so there are four such workloads: ordinary
+  inline values, `MAX` text past one 8192-byte chunk (three continuation calls
+  per value), a small `MAX` column dragging fifteen fixed columns with it, and
+  the `sql_variant` probe → `SQLColAttribute(SQL_CA_SS_VARIANT_TYPE)` → typed
+  read sequence.
+- **Nullable inline variable width, separate from MAX/PLP.** They are different
+  driver paths — one fills a bound buffer, the other streams — so they are
+  measured separately. `VARBINARY` is deliberately absent: binary delivery is
+  still unimplemented in `mssql-odbc` (AB#47239), so including it would fail two
+  legs and pass the third.
+
+Every workload is a C++ call into the driver through the ODBC Driver Manager.
+`mssql-python` is a workload-shape reference only — the source of the rowset
+sizes, the bind/unbind cadence, and the `SQLGetData` sequences. Its own
+performance, including Arrow conversion, is out of scope, and no Python package
+is loaded inside a measurement. That keeps a change attributable to the driver
+without an interpreter, a pybind11 layer, and an Arrow builder in the path.
+
 The gate uses the same 5% threshold and the same auto-confirm contract as the
 fixed-baseline `mssql-tds` runner. The initial five-sample median only screens:
 it selects the candidate-vs-baseline regressions and up to three of the largest
@@ -401,7 +430,9 @@ those four rounds, and the headline change is the median of the four confirmatio
 ratios — the initial pass that triggered the re-measurement is excluded so the
 outlier under test does not vote on its own verdict. Regression-direction hits
 are counted independently, so an apparent improvement that reverses into a
-3-of-4 regression still fails the run by default.
+3-of-4 regression still fails the run by default. Confirmation re-measures whole
+scenarios rather than single benchmarks, so a flagged id costs one paired re-run
+of its own leg per round.
 
 The pairwise math is Google Benchmark's own `tools/compare.py` and
 `gbench.report` from the pinned v1.9.1 checkout in the CMake build tree, run once
@@ -411,7 +442,11 @@ exact benchmark-set validation, the combined three-way report, custom counters
 and pins, the gate, the confirmation overrides, and the Azure DevOps Markdown.
 The Mann-Whitney U test is disabled explicitly because five repetitions are well
 below the nine that Google Benchmark documents as meaningful for it; the
-confirmation rounds establish reproduction instead.
+confirmation rounds establish reproduction instead. Its policy is covered offline
+by `.pipeline/scripts/test_compare_odbc_benchmarks.py`, which drives the whole
+workload catalog through synthetic legs: three-way and legacy two-way reports,
+mismatched benchmark sets, confirmed and unconfirmed regressions, an apparent
+improvement that reverses, and the plan/ratio outputs the runners consume.
 
 Both runners apply the same noise controls as the `mssql-tds` lab: a SQL Server
 configuration snapshot from the shared `sql-config-dump.sql`, CPU

--- a/docs/perf-testing-plan.md
+++ b/docs/perf-testing-plan.md
@@ -255,7 +255,7 @@ binaries keep the per-binary interleaving effective (see §2).
 - Bulk insert (default 10,000 rows, override via `BENCH_BULK_ROWS`) via the `BulkCopy` builder, over batch sizes 500 / 5,000.
 
 ### mssql-tds-specific
-- Packet-size sensitivity (4096 / 8192 / 32767) on large reads — measures reassembly overhead.
+- Packet-size sensitivity (4096 / 8192 / 16192) on large reads — measures reassembly overhead.
 - Zero-copy `next_row` row-iteration throughput at large row counts.
 
 ---

--- a/docs/perf-testing-plan.md
+++ b/docs/perf-testing-plan.md
@@ -255,7 +255,7 @@ binaries keep the per-binary interleaving effective (see §2).
 - Bulk insert (default 10,000 rows, override via `BENCH_BULK_ROWS`) via the `BulkCopy` builder, over batch sizes 500 / 5,000.
 
 ### mssql-tds-specific
-- Packet-size sensitivity (4096 / 8192 / 16192) on large reads — measures reassembly overhead.
+- Packet-size sensitivity (4096 / 8192 / 32768) on large reads — measures reassembly overhead.
 - Zero-copy `next_row` row-iteration throughput at large row counts.
 
 ---
@@ -380,6 +380,12 @@ workload constant. That answers whether the shipped driver artifact regressed.
 The source-isolated Criterion harness above remains the tool for attributing a
 change specifically to `mssql-tds`.
 
+The initial ODBC baseline is the production `main` commit on which this harness
+was introduced. Because the benchmark PR changes no production driver files,
+candidate and baseline begin with identical `mssql-odbc`/`mssql-tds` trees; only
+the candidate supplies the new harness and pipeline. Future baseline advances
+are explicit, reviewed edits to `baseline-commit.txt`.
+
 Dedicated Linux and Windows PerfTest pipelines run five repetitions of each
 workload against the pinned `mssql-odbc` commit, Microsoft ODBC Driver 18.6.2.1,
 and the candidate. Their uploaded `summary.md` leads with the gate verdict and
@@ -403,8 +409,8 @@ driver, not by what is convenient to write:
   workload on the same table and cadence, it isolates that per-call cost.
 - **Row-at-a-time `SQLGetData`.** One LOB or `sql_variant` column moves the
   *whole* result off the bound path, so there are four such workloads: ordinary
-  inline values, `MAX` text past one 8192-byte chunk (three continuation calls
-  per value), a small `MAX` column dragging fifteen fixed columns with it, and
+  inline values, `MAX` text past one 8192-byte chunk (three calls total, including
+  two continuation calls, per non-NULL value), a small `MAX` column dragging fifteen fixed columns with it, and
   the `sql_variant` probe → `SQLColAttribute(SQL_CA_SS_VARIANT_TYPE)` → typed
   read sequence.
 - **Nullable inline variable width, separate from MAX/PLP.** They are different

--- a/docs/perf-testing-plan.md
+++ b/docs/perf-testing-plan.md
@@ -365,25 +365,38 @@ held constant), store results across builds, and watch for drift — catching sl
 from dependency/toolchain changes that the isolated mode hides. Three modes in total:
 (1) existing PR-vs-target, (2) new isolated pinned-commit baseline, (3) trend of main.
 
-### Future: perf testing mssql-odbc (Rust ODBC driver)
+### mssql-odbc end-to-end benchmarks
 
-Criterion benchmarks Rust functions compiled into the same test binary (in-process,
-Rust-native). The future `mssql-odbc` will be a `cdylib` exposing the C ABI
-(`SQLConnect`, `SQLExecDirect`, `SQLFetch`, …), normally consumed through an ODBC Driver
-Manager (unixODBC / Windows DM). The representative path is *through the driver manager*,
-the way a real ODBC app uses it.
+[`mssql-odbc-bench`](../mssql-odbc-bench) is a fixed C++ harness that calls the
+ODBC C API through the platform Driver Manager, matching the path a real
+application uses. Google Benchmark supplies cross-platform wall-clock sampling
+and JSON output; the workload itself uses raw ODBC calls, so the same executable
+can run unchanged against the candidate driver, a pinned Rust baseline, or
+`msodbcsql`.
 
-A Rust bench *could* load the driver via FFI (e.g., `odbc-api`) with Criterion as the
-timing engine, but that loses cross-driver comparability and doesn't measure the real
-consumer path. The cross-driver spec already prescribes a **C/C++ ODBC harness**
-(`QueryPerformanceCounter` / `clock_gettime`) for ODBC. Sharing that harness with
-`msodbcsql` enables an apples-to-apples **Rust mssql-odbc vs native msodbcsql** comparison.
+The ODBC comparison swaps the complete `mssql-odbc` shared library, including
+its statically linked `mssql-tds`, while holding the harness and database
+workload constant. That answers whether the shipped driver artifact regressed.
+The source-isolated Criterion harness above remains the tool for attributing a
+change specifically to `mssql-tds`.
 
-This points to a layered strategy:
+Dedicated Linux and Windows PerfTest pipelines run five repetitions of each
+workload against the pinned `mssql-odbc` commit, Microsoft ODBC Driver 18.6.2.1,
+and the candidate. Their uploaded `summary.md` leads with the optional gate
+verdict and three median complete-result wall times, followed by separate
+colored diverging-bar tables for candidate vs Rust baseline and candidate vs
+Microsoft ODBC. The bars use about five percentage points per square (capped at
+20), while each row retains the exact lower/higher wall-time percentage and
+speedup factor. Only candidate vs the pinned Rust baseline can fail the optional
+gate; Microsoft is an informational reference. The scripts also echo the report
+to the step log and retain raw JSON, context, and comparison artifacts.
+
+The resulting layered strategy is:
 
 - **Layer 1 — mssql-tds (Rust lib):** Criterion component/micro benchmarks → attributes
   protocol/codec/parsing regressions to source. *(This plan.)*
-- **Layer 2 — mssql-odbc (cdylib via ODBC DM):** end-to-end benchmarks via the C/C++ ODBC
-  harness shared with msodbcsql → Rust-vs-native ODBC comparison. *(Future.)*
+- **Layer 2 — mssql-odbc (cdylib via ODBC DM):** end-to-end result-fetch
+  benchmarks via the fixed C++ harness → candidate/baseline driver comparison
+  and optional Rust-vs-native ODBC comparison.
 - **Cross-cutting — longitudinal trend of main:** catches dependency/toolchain drift that
   Layer 1's isolation hides.

--- a/mssql-odbc-bench/CMakeLists.txt
+++ b/mssql-odbc-bench/CMakeLists.txt
@@ -1,0 +1,67 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+cmake_minimum_required(VERSION 3.20)
+project(mssql_odbc_bench LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+include(FetchContent)
+
+set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
+set(BENCHMARK_ENABLE_INSTALL OFF CACHE BOOL "" FORCE)
+set(BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE BOOL "" FORCE)
+FetchContent_Declare(
+    googlebenchmark
+    GIT_REPOSITORY https://github.com/google/benchmark.git
+    GIT_TAG v1.9.1
+    GIT_SHALLOW TRUE
+)
+FetchContent_MakeAvailable(googlebenchmark)
+
+if(WIN32)
+    set(ODBC_DM_LIBRARIES odbc32)
+else()
+    find_path(ODBC_INCLUDE_DIR sql.h)
+    find_library(ODBC_DM_LIBRARY NAMES odbc REQUIRED)
+    if(NOT ODBC_INCLUDE_DIR)
+        message(FATAL_ERROR "Could not find sql.h; install the unixODBC development package")
+    endif()
+    set(ODBC_DM_LIBRARIES ${ODBC_DM_LIBRARY})
+endif()
+
+add_library(mssql_odbc_bench_common STATIC
+    src/odbc_bench.cpp
+)
+target_include_directories(mssql_odbc_bench_common
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        $<$<BOOL:${ODBC_INCLUDE_DIR}>:${ODBC_INCLUDE_DIR}>
+)
+target_compile_definitions(mssql_odbc_bench_common PUBLIC ODBCVER=0x0380)
+if(WIN32)
+    target_compile_definitions(mssql_odbc_bench_common PUBLIC UNICODE _UNICODE NOMINMAX)
+endif()
+target_link_libraries(mssql_odbc_bench_common PUBLIC ${ODBC_DM_LIBRARIES})
+
+if(MSVC)
+    target_compile_options(mssql_odbc_bench_common PRIVATE /W4 /permissive-)
+else()
+    target_compile_options(mssql_odbc_bench_common PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+
+add_executable(mssql_odbc_bench
+    src/benchmark_main.cpp
+)
+target_link_libraries(mssql_odbc_bench
+    PRIVATE
+        mssql_odbc_bench_common
+        benchmark::benchmark
+)
+
+add_executable(mssql_odbc_bench_admin
+    src/admin_main.cpp
+)
+target_link_libraries(mssql_odbc_bench_admin PRIVATE mssql_odbc_bench_common)

--- a/mssql-odbc-bench/CMakeLists.txt
+++ b/mssql-odbc-bench/CMakeLists.txt
@@ -16,8 +16,7 @@ set(BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE BOOL "" FORCE)
 FetchContent_Declare(
     googlebenchmark
     GIT_REPOSITORY https://github.com/google/benchmark.git
-    GIT_TAG v1.9.1
-    GIT_SHALLOW TRUE
+    GIT_TAG c58e6d0710581e3a08d65c349664128a8d9a2461 # v1.9.1
 )
 FetchContent_MakeAvailable(googlebenchmark)
 

--- a/mssql-odbc-bench/README.md
+++ b/mssql-odbc-bench/README.md
@@ -199,7 +199,9 @@ execution and fetching, so there is no port pressure to relieve.
 ### Report
 
 The shared PerfTest template uploads `results/summary.md` to the Azure DevOps
-Summary tab. It starts with the gate verdict and a three-median wall-time table,
+Summary tab. It starts by distinguishing the regression-gating Rust-baseline
+comparison from the non-gating Microsoft-driver reference gap, then shows the
+gate verdict and a three-median wall-time table,
 then shows separate candidate-vs-baseline and candidate-vs-Microsoft diverging
 bar tables, then an initial-vs-confirmed section listing what was flagged, how
 many rounds reproduced it, and the confirmed change. Green means lower wall time
@@ -207,7 +209,9 @@ and red means higher wall time. One square represents about five percentage
 points, capped at 20 squares so the expected 60-95% ODBC differences stay
 readable. Every row also states the exact wall-time change and
 comparator/candidate speedup factor; `⟳` marks a re-measured benchmark. The
-runner echoes the same report to the step log.
+Microsoft section explains that “informational” means it cannot fail this run,
+not that the gap is insignificant. The runner echoes the same report to the step
+log.
 
 ### Perf-lab environment
 

--- a/mssql-odbc-bench/README.md
+++ b/mssql-odbc-bench/README.md
@@ -175,8 +175,9 @@ four measure that path.
   separates the call shape from the cadence.
 - `getdata/rowwise_1k_c3_lob_max/chunked_8192` — `NVARCHAR(MAX)` of 9,000-9,999
   characters and `VARCHAR(MAX)` of 20,000-20,999 bytes. Both are past one
-  8192-byte chunk, so each value needs three continuation calls; preflight fails
-  the run if a value arrives in fewer, because then the loop under test never ran.
+  8192-byte chunk, so each non-NULL value needs three calls total (the initial
+  call plus two continuations); preflight fails the run if a value arrives in
+  fewer, because then the loop under test never ran.
 - `getdata/rowwise_20k_c16_mixed_lob/whole_result_rowwise` — the 15-column fixed
   pattern plus one *small* `NVARCHAR(MAX)`. The payload is tiny on purpose: what
   this measures is one PLP column moving all sixteen onto the row-at-a-time path.
@@ -259,6 +260,11 @@ comparison drivers; only
 the candidate-versus-mssql-odbc-baseline result participates in the regression
 gate. Raw Google Benchmark JSON and every comparison artifact are written to
 the repository-level `results` directory.
+
+The initial baseline pin is the production `main` commit where this benchmark
+harness is introduced. This PR changes no production driver files, so its first
+candidate and baseline have identical `mssql-odbc` and `mssql-tds` sources.
+Future baseline advances are reviewed changes to `baseline-commit.txt`.
 
 ### Gate and confirmation
 

--- a/mssql-odbc-bench/README.md
+++ b/mssql-odbc-bench/README.md
@@ -125,21 +125,98 @@ commit in `perf-lab/baseline-commit.txt`, and Microsoft ODBC Driver 18 from the
 version in `perf-lab/msodbcsql-version.txt`. Candidate and baseline order is
 reversed between workloads, with Microsoft ODBC between them. The result
 summary reports candidate changes relative to both comparison drivers; only
-the candidate-versus-mssql-odbc-baseline result participates in the optional
-regression gate. Raw Google Benchmark JSON and the median comparison are
-written to the repository-level `results` directory.
+the candidate-versus-mssql-odbc-baseline result participates in the regression
+gate. Raw Google Benchmark JSON and every comparison artifact are written to
+the repository-level `results` directory.
+
+### Gate and confirmation
+
+The default regression threshold is **5%** (`1.05`), matching the fixed-baseline
+`mssql-tds` runner, and a confirmed regression **fails the run by default**.
+
+The initial five-sample median is a screening pass, not the verdict. It selects
+the candidate-vs-baseline regressions plus at most three of the largest apparent
+improvements, and the runner then re-measures exactly those benchmarks with the
+candidate and the pinned baseline back-to-back for **four confirmation rounds**.
+The runners alternate which driver runs first to cancel stable position effects.
+A result counts only when it reproduces in at least **3 of 4** rounds. The
+headline wall-time change for a re-measured benchmark is the median of those
+four confirmation ratios; the initial pass that triggered the re-measurement is
+excluded so the outlier under test does not vote on its own verdict. Regression
+hits are tracked independently from the initial direction, so an apparent
+improvement that reverses into a 3-of-4 regression still fails the gate. Microsoft
+ODBC stays informational and never gates.
+
+The harness filters by scenario rather than by benchmark id, so the runner maps
+each flagged benchmark back to its scenario and runs one process covering all
+selected scenarios. Confirmation raw JSON, ratios, and per-round comparisons are
+kept under `results/confirm/round<N>/`; the pre-confirmation comparison is kept
+under `results/initial/`. Only the final report is written as `summary.md`.
+
+### Comparison engine
+
+Pairwise comparison is done by Google Benchmark's own `tools/compare.py` and
+`gbench.report`, taken from the pinned v1.9.1 checkout in the CMake build tree,
+so the tool and the harness stay on the same version. It is run twice — Rust
+baseline vs candidate and Microsoft vs candidate — and both its text and JSON
+outputs are retained. `.pipeline/scripts/compare-odbc-benchmarks.py` remains a
+thin policy/report wrapper: exact benchmark-set validation, the combined
+three-way report, custom throughput counters and pins, the gate, the
+confirmation overrides, and the Azure DevOps Markdown.
+
+The Mann-Whitney U test is disabled explicitly (`--no-utest`). Google Benchmark
+documents nine repetitions as the minimum for a meaningful U test and the lab
+runs five, so its p-values would be published without being trustworthy;
+reproduction is established by the confirmation rounds instead. The official
+Python code imports NumPy and SciPy at module scope even with `--no-utest`, so
+both runners provision them into a private virtualenv under `target/` when the
+host interpreter lacks them.
+
+### Noise controls
+
+Both runners capture a SQL Server configuration snapshot with sqlcmd (the shared
+`mssql-tds-bench/perf-lab/sql-config-dump.sql`) to `results/sql-config.txt`, and
+bracket the initial pass and every confirmation round with CPU
+frequency/utilization samples in `results/cpu-telemetry.csv`. Both honor
+`PERF_CLIENT_CPUS`/`BENCH_CPUS` for client CPU pinning.
+
+Large-buffer allocation is tuned per platform because each retrieval allocates
+bound rowset buffers for up to 600 columns by 1024 rows. Linux raises
+`MALLOC_MMAP_THRESHOLD_` and disables heap trimming so those buffers are reused
+instead of being re-mmapped and re-faulted every repetition. Windows has no
+environment-level equivalent, so it keeps the child off the debug heap
+(`_NO_DEBUG_HEAP`), raises the process priority class (inherited by every
+benchmark leg), and requests the High performance power scheme; priority and
+power scheme are restored when the run ends, as are process affinity and the
+prior `_NO_DEBUG_HEAP` environment state.
+
+Connection-churn network tuning is deliberately **not** applied. The
+`mssql-tds` runner widens the ephemeral port range and enables TIME_WAIT reuse
+for its `concurrent_connects` benchmark; this harness opens one connection in
+`OdbcSession`, holds it for the whole process, and measures only statement
+execution and fetching, so there is no port pressure to relieve.
+
+### Report
 
 The shared PerfTest template uploads `results/summary.md` to the Azure DevOps
 Summary tab. It starts with the gate verdict and a three-median wall-time table,
 then shows separate candidate-vs-baseline and candidate-vs-Microsoft diverging
-bar tables. Green means lower wall time and red means higher wall time. One
-square represents about five percentage points, capped at 20 squares so the
-expected 60-95% ODBC differences stay readable. Every row also states the exact
-wall-time change and comparator/candidate speedup factor. The runner echoes the
-same report to the step log and retains raw JSON, context, text comparison, and
-JSON comparison artifacts.
+bar tables, then an initial-vs-confirmed section listing what was flagged, how
+many rounds reproduced it, and the confirmed change. Green means lower wall time
+and red means higher wall time. One square represents about five percentage
+points, capped at 20 squares so the expected 60-95% ODBC differences stay
+readable. Every row also states the exact wall-time change and
+comparator/candidate speedup factor; `⟳` marks a re-measured benchmark. The
+runner echoes the same report to the step log.
 
-The perf-lab scripts default to five repetitions and report regressions without
-failing the run while initial variance is established. Set
-`ODBC_BENCH_REPETITIONS` to change the sample count and
-`ODBC_BENCH_FAIL_ON_REGRESSION=1` to make the 10% comparison threshold a gate.
+### Perf-lab environment
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `ODBC_BENCH_REPETITIONS` | `5` | Samples per driver/workload |
+| `ODBC_BENCH_REGRESSION_RATIO` | `1.05` | Regression threshold |
+| `ODBC_BENCH_IMPROVEMENT_VERIFY_RATIO` | regression ratio | Threshold for verifying apparent wins |
+| `ODBC_BENCH_IMPROVEMENT_VERIFY_MAX` | `3` | Cap on re-measured improvements |
+| `ODBC_BENCH_CONFIRM_RUNS` | `4` | Confirmation rounds |
+| `ODBC_BENCH_CONFIRM_QUORUM` | majority (`3`) | Rounds required to confirm |
+| `ODBC_BENCH_FAIL_ON_REGRESSION` | `1` | Set `0` to publish the report without gating |

--- a/mssql-odbc-bench/README.md
+++ b/mssql-odbc-bench/README.md
@@ -1,0 +1,145 @@
+# Standalone ODBC fetch benchmarks
+
+This C++17 harness calls the platform ODBC Driver Manager (`odbc32` on Windows,
+unixODBC on Linux). The selected registered driver is loaded by the Driver
+Manager; the harness never links to the Rust driver.
+
+## Prerequisites
+
+- CMake 3.20+ and a C++17 compiler
+- Windows SDK ODBC headers, or the unixODBC runtime and development package
+- Git and network access while CMake fetches pinned Google Benchmark v1.9.1
+- SQL Server 2022+ with database compatibility level 160 (`GENERATE_SERIES`)
+- Permission to create and drop tables in the configured database
+
+## Environment
+
+| Variable | Default/fallback | Purpose |
+|---|---|---|
+| `ODBC_BENCH_DRIVER` | required | Registered ODBC driver name |
+| `ODBC_BENCH_SERVER` | `SQL_SERVER`, then required | Server name/address |
+| `ODBC_BENCH_DATABASE` | `tempdb` | Shared benchmark database |
+| `ODBC_BENCH_UID` | `sa` | SQL login |
+| `ODBC_BENCH_PWD` | `SQL_PASSWORD`, then required | SQL login password |
+| `ODBC_BENCH_TRUST_CERT` | `Yes` | `TrustServerCertificate` value |
+| `ODBC_BENCH_ENCRYPT` | `Mandatory` | `Encrypt` value |
+| `ODBC_BENCH_PACKET_SIZE` | `32768` | TDS packet size, 512–32768 |
+| `ODBC_BENCH_PACKET_SIZE_KEYWORD` | `PacketSize` | `PacketSize` or Microsoft driver spelling `Packet Size` |
+| `ODBC_BENCH_SCENARIO` | all | Run only `narrow` or `wide` |
+
+Missing required values, connection errors, absent/invalid tables, ODBC
+warnings during retrieval, and correctness failures make the process fail.
+There is no disconnected or skipped workload mode.
+
+## Build
+
+Linux:
+
+```bash
+cmake -S mssql-odbc-bench -B mssql-odbc-bench/build -DCMAKE_BUILD_TYPE=Release
+cmake --build mssql-odbc-bench/build --parallel
+```
+
+Windows (Developer PowerShell):
+
+```powershell
+cmake -S mssql-odbc-bench -B mssql-odbc-bench\build -G "Visual Studio 17 2022" -A x64
+cmake --build mssql-odbc-bench\build --config Release
+```
+
+## Set up, run, and clean up
+
+Set the environment once, then create both permanent heaps:
+
+```bash
+./mssql-odbc-bench/build/mssql_odbc_bench_admin setup
+```
+
+```powershell
+.\mssql-odbc-bench\build\Release\mssql_odbc_bench_admin.exe setup
+```
+
+Run a driver leg with standard Google Benchmark JSON output:
+
+```bash
+./mssql-odbc-bench/build/mssql_odbc_bench \
+  --benchmark_repetitions=10 \
+  --benchmark_out=candidate.json \
+  --benchmark_out_format=json
+```
+
+```powershell
+.\mssql-odbc-bench\build\Release\mssql_odbc_bench.exe `
+  --benchmark_repetitions=10 `
+  --benchmark_out=candidate.json `
+  --benchmark_out_format=json
+```
+
+Change only `ODBC_BENCH_DRIVER` and the output path for other driver legs. Every
+leg reads the same tables:
+
+- `dbo.mssql_odbc_bench_narrow_2m_c15_mixed_fixed`
+- `dbo.mssql_odbc_bench_wide_10k_c600_mixed_fixed`
+
+After both legs:
+
+```bash
+./mssql-odbc-bench/build/mssql_odbc_bench_admin cleanup
+```
+
+```powershell
+.\mssql-odbc-bench\build\Release\mssql_odbc_bench_admin.exe cleanup
+```
+
+## Workloads
+
+- `fetch/narrow_2m_c15_mixed_fixed/rowset_1024`: 2,000,000 rows and one
+  15-column pattern.
+- `fetch/wide_10k_c600_mixed_fixed/rowset_1024`: 10,000 rows and 40 repeats of
+  the same pattern.
+
+The pattern is `BIT`, `TINYINT`, `SMALLINT`, `INT`, `BIGINT`, `REAL`,
+`FLOAT(53)`, `DECIMAL(18,4)`, `DATE`, `TIME(7)`, `DATETIME2(7)`,
+`DATETIMEOFFSET(7)`, `UNIQUEIDENTIFIER`, `CHAR(8)`, `NCHAR(8)`. Every column is
+fixed-length and `NOT NULL`; the generated wide row is below SQL Server's
+8,060-byte limit.
+
+Each Google Benchmark sample is one full result-set retrieval
+(`Iterations(1)`). `--benchmark_repetitions` controls the sample count.
+Steady-clock timing starts immediately before `SQLExecDirect` and ends after
+the final `SQLFetchScroll` returns `SQL_NO_DATA` and the row count is checked.
+It includes `SQLNumResultCols`, every `SQLDescribeCol`, every `SQLBindCol`, and
+all rowset fetches. Connection, buffer allocation, statement attributes,
+setup, untimed full-data preflight, cursor close, and unbind are excluded.
+
+JSON results include rows, cells, logical bytes, and execute,
+metadata-plus-bind, and fetch phase counters, plus rows/s, cells/s, and logical
+bytes/s. Preflight checks all indicators, row identity/coverage, an
+order-independent checksum, and representative values for every generated type.
+
+## Dedicated perf lab
+
+`perf-lab/run-benchmarks.sh` and `perf-lab/run-benchmarks.ps1` build the harness
+once, then measure three drivers side by side: the candidate, the mssql-odbc
+commit in `perf-lab/baseline-commit.txt`, and Microsoft ODBC Driver 18 from the
+version in `perf-lab/msodbcsql-version.txt`. Candidate and baseline order is
+reversed between workloads, with Microsoft ODBC between them. The result
+summary reports candidate changes relative to both comparison drivers; only
+the candidate-versus-mssql-odbc-baseline result participates in the optional
+regression gate. Raw Google Benchmark JSON and the median comparison are
+written to the repository-level `results` directory.
+
+The shared PerfTest template uploads `results/summary.md` to the Azure DevOps
+Summary tab. It starts with the gate verdict and a three-median wall-time table,
+then shows separate candidate-vs-baseline and candidate-vs-Microsoft diverging
+bar tables. Green means lower wall time and red means higher wall time. One
+square represents about five percentage points, capped at 20 squares so the
+expected 60-95% ODBC differences stay readable. Every row also states the exact
+wall-time change and comparator/candidate speedup factor. The runner echoes the
+same report to the step log and retains raw JSON, context, text comparison, and
+JSON comparison artifacts.
+
+The perf-lab scripts default to five repetitions and report regressions without
+failing the run while initial variance is established. Set
+`ODBC_BENCH_REPETITIONS` to change the sample count and
+`ODBC_BENCH_FAIL_ON_REGRESSION=1` to make the 10% comparison threshold a gate.

--- a/mssql-odbc-bench/README.md
+++ b/mssql-odbc-bench/README.md
@@ -306,8 +306,9 @@ documents nine repetitions as the minimum for a meaningful U test and the lab
 runs five, so its p-values would be published without being trustworthy;
 reproduction is established by the confirmation rounds instead. The official
 Python code imports NumPy and SciPy at module scope even with `--no-utest`, so
-both runners provision them into a private virtualenv under `target/` when the
-host interpreter lacks them.
+both runners provision pinned NumPy 2.4.6 and SciPy 1.18.0 into a private
+virtualenv under `target/` when the host interpreter lacks them, and record those
+versions in `results/odbc-context.txt`.
 
 ### Noise controls
 

--- a/mssql-odbc-bench/README.md
+++ b/mssql-odbc-bench/README.md
@@ -306,7 +306,7 @@ documents nine repetitions as the minimum for a meaningful U test and the lab
 runs five, so its p-values would be published without being trustworthy;
 reproduction is established by the confirmation rounds instead. The official
 Python code imports NumPy and SciPy at module scope even with `--no-utest`, so
-both runners provision pinned NumPy 2.4.6 and SciPy 1.18.0 into a private
+both runners provision pinned NumPy 2.2.6 and SciPy 1.15.3 into a private
 virtualenv under `target/` when the host interpreter lacks them, and record those
 versions in `results/odbc-context.txt`.
 

--- a/mssql-odbc-bench/README.md
+++ b/mssql-odbc-bench/README.md
@@ -217,14 +217,15 @@ part of the cost the consumer actually pays.
 
 Connection, buffer allocation, statement attributes set before execution, setup,
 the untimed full-data preflight, cursor close, and the final unbind are all
-outside the boundary. The `metadata_bind_ms` phase counter is therefore zero for
-`bind_cycle_*`, where describe and bind are inside the fetch loop rather than
-ahead of it; `fetch_ms` carries that work.
+outside the boundary. The `metadata_bind_ms` phase counter is omitted entirely
+for `bind_cycle_*`, where describe and bind are inside the fetch loop rather
+than ahead of it; `fetch_ms` carries that work.
 
 JSON results include rows, cells, logical bytes, `SQLGetData` call count, and
-execute, metadata-plus-bind, and fetch phase counters, plus rows/s, cells/s, and
-logical bytes/s. Logical bytes are the generator's own byte total, so all three
-drivers are credited with identical payload regardless of representation.
+execute, metadata-plus-bind (absent for `bind_cycle_*`), and fetch phase
+counters, plus rows/s, cells/s, and logical bytes/s. Logical bytes are the
+generator's own byte total, so all three drivers are credited with identical
+payload regardless of representation.
 
 Preflight checks all indicators, row identity/coverage, an order-independent
 checksum, representative values for every generated type, the exact generated

--- a/mssql-odbc-bench/README.md
+++ b/mssql-odbc-bench/README.md
@@ -23,13 +23,14 @@ Manager; the harness never links to the Rust driver.
 | `ODBC_BENCH_PWD` | `SQL_PASSWORD`, then required | SQL login password |
 | `ODBC_BENCH_TRUST_CERT` | `Yes` | `TrustServerCertificate` value |
 | `ODBC_BENCH_ENCRYPT` | `Mandatory` | `Encrypt` value |
-| `ODBC_BENCH_PACKET_SIZE` | `32768` | TDS packet size, 512–32768 |
+| `ODBC_BENCH_PACKET_SIZE` | `32767` | TDS packet size, 512–32767; set through both ODBC attribute and connection keyword, then read back |
 | `ODBC_BENCH_PACKET_SIZE_KEYWORD` | `PacketSize` | `PacketSize` or Microsoft driver spelling `Packet Size` |
-| `ODBC_BENCH_SCENARIO` | all | Run only `narrow` or `wide` |
+| `ODBC_BENCH_SCENARIO` | all | Run only `narrow`, `wide`, `rowset`, `varwidth`, or `getdata` |
 
 Missing required values, connection errors, absent/invalid tables, ODBC
 warnings during retrieval, and correctness failures make the process fail.
-There is no disconnected or skipped workload mode.
+There is no disconnected or skipped workload mode. An unknown scenario is
+rejected at startup rather than producing an empty result file.
 
 ## Build
 
@@ -49,7 +50,7 @@ cmake --build mssql-odbc-bench\build --config Release
 
 ## Set up, run, and clean up
 
-Set the environment once, then create both permanent heaps:
+Set the environment once, then create the benchmark tables:
 
 ```bash
 ./mssql-odbc-bench/build/mssql_odbc_bench_admin setup
@@ -78,8 +79,18 @@ Run a driver leg with standard Google Benchmark JSON output:
 Change only `ODBC_BENCH_DRIVER` and the output path for other driver legs. Every
 leg reads the same tables:
 
-- `dbo.mssql_odbc_bench_narrow_2m_c15_mixed_fixed`
-- `dbo.mssql_odbc_bench_wide_10k_c600_mixed_fixed`
+- `dbo.mssql_odbc_bench_fixed_2m_c15`
+- `dbo.mssql_odbc_bench_fixed_10k_c600`
+- `dbo.mssql_odbc_bench_fixed_100k_c15`
+- `dbo.mssql_odbc_bench_fixed_20k_c15`
+- `dbo.mssql_odbc_bench_varwidth_100k_c7`
+- `dbo.mssql_odbc_bench_lobmax_1k_c3`
+- `dbo.mssql_odbc_bench_mixedlob_20k_c16`
+- `dbo.mssql_odbc_bench_variant_20k_c4`
+
+`mssql_odbc_bench_admin print-sql` prints the exact DDL, generator, and
+projection SQL for the whole catalog without connecting, which is the offline way
+to review or replay what setup sends.
 
 After both legs:
 
@@ -93,10 +104,17 @@ After both legs:
 
 ## Workloads
 
-- `fetch/narrow_2m_c15_mixed_fixed/rowset_1024`: 2,000,000 rows and one
-  15-column pattern.
-- `fetch/wide_10k_c600_mixed_fixed/rowset_1024`: 10,000 rows and 40 repeats of
-  the same pattern.
+Thirteen measurements over eight tables, all of them C++ calls into the driver.
+Every id encodes the data shape, the row and column counts, and the access shape,
+and is identical on all three driver legs. The shapes are drawn from what
+`mssql-python` asks a driver to do; nothing here runs Python.
+
+### `narrow` and `wide` — bound fetch at the fetchall cadence
+
+- `fetch/narrow_2m_c15_fixed/bound_rowset_1000`: 2,000,000 rows, one 15-column
+  pattern.
+- `fetch/wide_10k_c600_fixed/bound_rowset_1000`: 10,000 rows, 40 repeats of the
+  same pattern.
 
 The pattern is `BIT`, `TINYINT`, `SMALLINT`, `INT`, `BIGINT`, `REAL`,
 `FLOAT(53)`, `DECIMAL(18,4)`, `DATE`, `TIME(7)`, `DATETIME2(7)`,
@@ -104,27 +122,140 @@ The pattern is `BIT`, `TINYINT`, `SMALLINT`, `INT`, `BIGINT`, `REAL`,
 fixed-length and `NOT NULL`; the generated wide row is below SQL Server's
 8,060-byte limit.
 
+### `rowset` — the rowset sizes a consumer actually asks for
+
+The row-array sizes are 1, 64, and 1000 rather than a round 1024, because those
+are the cadences `mssql-python` produces: `Cursor.arraysize` defaults to **1**, so
+an unconfigured `fetchmany()` binds a one-row rowset; applications that raise it
+land in the tens; and `fetchall()` caps its computed batch at **1000**
+(`FetchAll_wrap` in `ddbc_bindings.cpp`).
+
+- `fetch/rowset_100k_c15_fixed/bound_rowset_1`
+- `fetch/rowset_100k_c15_fixed/bound_rowset_64`
+- `fetch/rowset_100k_c15_fixed/bound_rowset_1000`
+
+The same 100,000 rows in all three, so only the cadence differs.
+
+`fetchmany()` does not bind once and drain: every call re-describes the columns,
+rebinds them, sets the row-array size, fetches one rowset, resets the size to 1,
+and unbinds. Two workloads model that complete lifecycle:
+
+- `fetch/rowset_100k_c15_fixed/bind_cycle_rowset_64` — same table and cadence as
+  `bound_rowset_64`, so the pair isolates the per-call bind/unbind cost.
+- `fetch/rowset_20k_c15_fixed/bind_cycle_rowset_1` — the default `arraysize`, one
+  full lifecycle per row. A smaller table because this shape issues dozens of
+  ODBC calls per row.
+
+### `varwidth` — nullable inline variable width
+
+- `fetch/varwidth_100k_c7_nullable/bound_rowset_1000`
+- `fetch/varwidth_100k_c7_nullable/bound_rowset_64`
+
+An `INT` identity plus `VARCHAR(64|256|1024)` and `NVARCHAR(64|256|1024)`, all
+nullable. Length varies per row (`1 + row_id % max`), and each column goes NULL
+on a different one row in seven, so per-column indicators are checked rather than
+assumed. Kept deliberately separate from `MAX`/PLP: inline variable width is a
+bound-buffer path, PLP is not.
+
+**No `VARBINARY` column.** `mssql-odbc` implements only the zero-length
+`SQL_C_BINARY` length probe; delivering binary data into a real buffer is still
+`HYC00` (AB#47239, see `mssql-odbc/docs/typed-columnar-fetch-plan.md`), and
+binary-to-character hex is not implemented either. A `VARBINARY` column would
+fail the candidate and baseline legs while the Microsoft leg passed, which is a
+broken comparison rather than a measurement.
+
+### `getdata` — row-at-a-time `SQLGetData`
+
+A LOB or `sql_variant` column makes `mssql-python` abandon bound fetching for the
+**whole** result and read every column of every row with `SQLGetData`, so these
+four measure that path.
+
+- `getdata/rowwise_20k_c15_fixed/inline_values` — ordinary fixed inline values
+  read one cell at a time. Same columns as `bound_rowset_1`, so the pair
+  separates the call shape from the cadence.
+- `getdata/rowwise_1k_c3_lob_max/chunked_8192` — `NVARCHAR(MAX)` of 9,000-9,999
+  characters and `VARCHAR(MAX)` of 20,000-20,999 bytes. Both are past one
+  8192-byte chunk, so each value needs three continuation calls; preflight fails
+  the run if a value arrives in fewer, because then the loop under test never ran.
+- `getdata/rowwise_20k_c16_mixed_lob/whole_result_rowwise` — the 15-column fixed
+  pattern plus one *small* `NVARCHAR(MAX)`. The payload is tiny on purpose: what
+  this measures is one PLP column moving all sixteen onto the row-at-a-time path.
+- `getdata/rowwise_20k_c4_variant/probe_colattribute` — `sql_variant` columns read
+  through the exact sequence `mssql-python` uses: a zero-length `SQL_C_BINARY`
+  probe, then `SQLColAttribute(SQL_CA_SS_VARIANT_TYPE)`, then the typed read. One
+  variant column is nullable so the probe's `SQL_NULL_DATA` arm is exercised too.
+
+  The probe passes a valid pointer with `BufferLength` 0 rather than `NULL`.
+  `mssql-python` passes `NULL` and gets away with it because it `dlopen`s the
+  driver and calls its exports directly; this harness goes through the Driver
+  Manager, which rejects a `NULL` target with `HY009` before the driver sees the
+  call. Both drivers treat the two forms identically.
+
+  Only base types whose reported C type is unambiguous are used. `mssql-odbc`
+  deliberately reports `SQL_C_CHAR` where msodbcsql reports `SQL_C_NUMERIC` for
+  decimal/money variants, and a benchmark that depended on that difference would
+  not be the same work on both drivers.
+
+## Measurement boundaries
+
 Each Google Benchmark sample is one full result-set retrieval
 (`Iterations(1)`). `--benchmark_repetitions` controls the sample count.
-Steady-clock timing starts immediately before `SQLExecDirect` and ends after
-the final `SQLFetchScroll` returns `SQL_NO_DATA` and the row count is checked.
-It includes `SQLNumResultCols`, every `SQLDescribeCol`, every `SQLBindCol`, and
-all rowset fetches. Connection, buffer allocation, statement attributes,
-setup, untimed full-data preflight, cursor close, and unbind are excluded.
+Steady-clock timing starts immediately before `SQLExecDirect` and ends after the
+result is exhausted and the row count is checked. What is inside depends on the
+access shape:
 
-JSON results include rows, cells, logical bytes, and execute,
-metadata-plus-bind, and fetch phase counters, plus rows/s, cells/s, and logical
-bytes/s. Preflight checks all indicators, row identity/coverage, an
-order-independent checksum, and representative values for every generated type.
+| Access shape | Inside the timed region |
+|---|---|
+| `bound_rowset_*` | `SQLExecDirect`, `SQLNumResultCols`, every `SQLDescribeCol`, every `SQLBindCol`, all `SQLFetchScroll` calls |
+| `bind_cycle_*` | the same, but describe + bind + row-array set + fetch + row-array reset + `SQLFreeStmt(SQL_UNBIND)` repeated once per rowset |
+| `getdata/*` | `SQLExecDirect`, the initial describe, then per row: `SQLFetch`, and per column a `SQLDescribeCol` plus its `SQLGetData` calls (including LOB continuations and the variant probe/`SQLColAttribute` pair) |
+
+The per-cell `SQLDescribeCol` in the row-at-a-time shape is not an accident: it
+mirrors `SQLGetData_wrap`, which re-describes every column on every row, so it is
+part of the cost the consumer actually pays.
+
+Connection, buffer allocation, statement attributes set before execution, setup,
+the untimed full-data preflight, cursor close, and the final unbind are all
+outside the boundary. The `metadata_bind_ms` phase counter is therefore zero for
+`bind_cycle_*`, where describe and bind are inside the fetch loop rather than
+ahead of it; `fetch_ms` carries that work.
+
+JSON results include rows, cells, logical bytes, `SQLGetData` call count, and
+execute, metadata-plus-bind, and fetch phase counters, plus rows/s, cells/s, and
+logical bytes/s. Logical bytes are the generator's own byte total, so all three
+drivers are credited with identical payload regardless of representation.
+
+Preflight checks all indicators, row identity/coverage, an order-independent
+checksum, representative values for every generated type, the exact generated
+length of every variable-width and `MAX` value, the LOB continuation count, and
+the `sql_variant` probe/type/value sequence.
+
+## Scope
+
+Every measurement here is a C++ call into the mssql-odbc driver through the
+platform ODBC Driver Manager. `mssql-python` is referenced only as a workload-shape
+reference: it is where the rowset sizes, the bind/unbind cadence, and the
+row-at-a-time `SQLGetData` sequences come from. Its own performance — the
+interpreter, the pybind11 layer, and the Arrow conversion — is out of scope, and
+no Python package is loaded inside any measurement.
+
+The one Python in this lab is reporting tooling: Google Benchmark's `compare.py`
+and `.pipeline/scripts/compare-odbc-benchmarks.py`, which run after the
+measurements and never touch the driver.
+
+```bash
+python -m unittest discover .pipeline/scripts -p 'test_compare*.py'
+```
 
 ## Dedicated perf lab
 
 `perf-lab/run-benchmarks.sh` and `perf-lab/run-benchmarks.ps1` build the harness
 once, then measure three drivers side by side: the candidate, the mssql-odbc
 commit in `perf-lab/baseline-commit.txt`, and Microsoft ODBC Driver 18 from the
-version in `perf-lab/msodbcsql-version.txt`. Candidate and baseline order is
-reversed between workloads, with Microsoft ODBC between them. The result
-summary reports candidate changes relative to both comparison drivers; only
+version in `perf-lab/msodbcsql-version.txt`. Each runs one leg per scenario per
+driver and alternates candidate and baseline order per scenario, with Microsoft
+ODBC between them. The result summary reports candidate changes relative to both
+comparison drivers; only
 the candidate-versus-mssql-odbc-baseline result participates in the regression
 gate. Raw Google Benchmark JSON and every comparison artifact are written to
 the repository-level `results` directory.
@@ -148,10 +279,10 @@ improvement that reverses into a 3-of-4 regression still fails the gate. Microso
 ODBC stays informational and never gates.
 
 The harness filters by scenario rather than by benchmark id, so the runner maps
-each flagged benchmark back to its scenario and runs one process covering all
-selected scenarios. Confirmation raw JSON, ratios, and per-round comparisons are
-kept under `results/confirm/round<N>/`; the pre-confirmation comparison is kept
-under `results/initial/`. Only the final report is written as `summary.md`.
+each flagged benchmark back to its scenario and re-runs those scenarios only.
+Confirmation raw JSON, ratios, and per-round comparisons are kept under
+`results/confirm/round<N>/`; the pre-confirmation comparison is kept under
+`results/initial/`. Only the final report is written as `summary.md`.
 
 ### Comparison engine
 
@@ -181,7 +312,7 @@ frequency/utilization samples in `results/cpu-telemetry.csv`. Both honor
 `PERF_CLIENT_CPUS`/`BENCH_CPUS` for client CPU pinning.
 
 Large-buffer allocation is tuned per platform because each retrieval allocates
-bound rowset buffers for up to 600 columns by 1024 rows. Linux raises
+bound rowset buffers for up to 600 columns by 1000 rows. Linux raises
 `MALLOC_MMAP_THRESHOLD_` and disables heap trimming so those buffers are reused
 instead of being re-mmapped and re-faulted every repetition. Windows has no
 environment-level equivalent, so it keeps the child off the debug heap

--- a/mssql-odbc-bench/README.md
+++ b/mssql-odbc-bench/README.md
@@ -23,7 +23,7 @@ Manager; the harness never links to the Rust driver.
 | `ODBC_BENCH_PWD` | `SQL_PASSWORD`, then required | SQL login password |
 | `ODBC_BENCH_TRUST_CERT` | `Yes` | `TrustServerCertificate` value |
 | `ODBC_BENCH_ENCRYPT` | `Mandatory` | `Encrypt` value |
-| `ODBC_BENCH_PACKET_SIZE` | `32767` | TDS packet size, 512–32767; set through both ODBC attribute and connection keyword, then read back |
+| `ODBC_BENCH_PACKET_SIZE` | `16192` | Cross-platform encrypted-lab value honored exactly by Microsoft ODBC 18.6.2.1 and both Rust builds; set through both ODBC attribute and connection keyword, then read back |
 | `ODBC_BENCH_PACKET_SIZE_KEYWORD` | `PacketSize` | `PacketSize` or Microsoft driver spelling `Packet Size` |
 | `ODBC_BENCH_SCENARIO` | all | Run only `narrow`, `wide`, `rowset`, `varwidth`, or `getdata` |
 

--- a/mssql-odbc-bench/include/odbc_bench.hpp
+++ b/mssql-odbc-bench/include/odbc_bench.hpp
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+#include <sql.h>
+#include <sqlext.h>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace mssql::odbc::bench {
+
+inline constexpr std::size_t kRowArraySize = 1024;
+
+/// Connection and workload selection shared by the admin and timed executables.
+///
+/// Keeping this environment-driven lets the same binaries compare three drivers
+/// without recompilation while the runner controls every connection attribute.
+struct Config {
+    std::string driver;
+    std::string server;
+    std::string database;
+    std::string uid;
+    std::string pwd;
+    std::string trust_certificate;
+    std::string encrypt;
+    std::string packet_size;
+    std::string packet_size_keyword;
+    std::string scenario;
+
+    /// Read and validate the cross-platform perf-lab environment contract.
+    static Config from_environment();
+
+    /// Build a braced ODBC string so credentials and names remain single values.
+    std::string connection_string() const;
+};
+
+/// Defines one stable SQL shape whose name is also the comparison key.
+///
+/// The pattern repetition count changes result width without changing the type mix.
+struct WorkloadSpec {
+    const char* benchmark_name;
+    const char* scenario;
+    const char* table_name;
+    std::uint64_t row_count;
+    std::size_t pattern_repetitions;
+
+    /// Return the exact projected width used to size buffers and verify metadata.
+    std::size_t column_count() const;
+};
+
+/// Return the fixed workload catalog used by setup, validation, and measurement.
+const std::array<WorkloadSpec, 2>& workloads();
+
+/// Owns one ODBC handle chain so every workload uses the same connection lifecycle.
+class OdbcSession {
+public:
+    /// Connect using ODBC 3.8 and allocate the reusable statement handle.
+    explicit OdbcSession(const Config& config);
+    ~OdbcSession();
+
+    OdbcSession(const OdbcSession&) = delete;
+    OdbcSession& operator=(const OdbcSession&) = delete;
+
+    /// Expose the statement only to the runner that controls its complete lifecycle.
+    SQLHSTMT statement() const;
+
+    /// Execute setup/cleanup SQL and drain every result before reusing the statement.
+    void execute_non_query(const std::string& sql);
+
+    /// Verify setup row counts through the same driver path used by the benchmark.
+    std::uint64_t query_count(const std::string& qualified_table);
+
+private:
+    /// Release child-before-parent and remain safe during partial construction.
+    void release() noexcept;
+
+    SQLHENV env_ = SQL_NULL_HENV;
+    SQLHDBC dbc_ = SQL_NULL_HDBC;
+    SQLHSTMT stmt_ = SQL_NULL_HSTMT;
+};
+
+/// Recreate deterministic tables and verify their row counts before timing begins.
+void setup_benchmark_tables(OdbcSession& session);
+
+/// Remove benchmark-owned tables so shared perf databases do not accumulate state.
+void cleanup_benchmark_tables(OdbcSession& session);
+
+/// Separates the end-to-end timing boundary from diagnostic phase timings.
+///
+/// Regression decisions use total_seconds; phase values help explain a change.
+struct RetrievalMetrics {
+    std::uint64_t rows = 0;
+    std::uint64_t cells = 0;
+    std::uint64_t logical_bytes = 0;
+    double total_seconds = 0.0;
+    double execute_seconds = 0.0;
+    double metadata_bind_seconds = 0.0;
+    double fetch_seconds = 0.0;
+};
+
+/// Binds one workload once per retrieval and validates that timed work stays correct.
+class WorkloadRunner {
+public:
+    /// Materialize the workload's column descriptors and row-array buffers.
+    WorkloadRunner(OdbcSession& session, const WorkloadSpec& spec);
+    ~WorkloadRunner();
+
+    WorkloadRunner(const WorkloadRunner&) = delete;
+    WorkloadRunner& operator=(const WorkloadRunner&) = delete;
+
+    /// Return the catalog entry used as the stable Google Benchmark identity.
+    const WorkloadSpec& spec() const;
+
+    /// Report payload volume independent of driver-specific physical representation.
+    std::uint64_t logical_bytes_per_row() const;
+
+    /// Exercise a full untimed fetch and validate rowsets, indicators, and values.
+    void preflight();
+
+    /// Measure execution through complete result consumption with validation disabled.
+    RetrievalMetrics retrieve();
+
+private:
+    /// Hide ODBC headers and mutable fetch state from benchmark registration code.
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace mssql::odbc::bench

--- a/mssql-odbc-bench/include/odbc_bench.hpp
+++ b/mssql-odbc-bench/include/odbc_bench.hpp
@@ -201,6 +201,9 @@ struct RetrievalMetrics {
     std::uint64_t get_data_calls = 0;
     double total_seconds = 0.0;
     double execute_seconds = 0.0;
+    /// Time between execute and the start of fetching. Negative when the workload
+    /// has no one-time metadata phase (`bind_cycle_*` re-describes and re-binds
+    /// inside the fetch loop), in which case no counter is emitted.
     double metadata_bind_seconds = 0.0;
     double fetch_seconds = 0.0;
 };

--- a/mssql-odbc-bench/include/odbc_bench.hpp
+++ b/mssql-odbc-bench/include/odbc_bench.hpp
@@ -14,11 +14,30 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <ostream>
 #include <string>
 
 namespace mssql::odbc::bench {
 
-inline constexpr std::size_t kRowArraySize = 1024;
+/// Row-array sizes the bound workloads exercise.
+///
+/// These are not round numbers picked for symmetry: each one is a cadence the
+/// only supported consumer actually produces. `mssql-python`'s `Cursor.arraysize`
+/// defaults to 1, so an unconfigured `fetchmany()` binds a one-row rowset;
+/// applications that raise it land in the tens; and `fetchall()` caps its
+/// computed batch at 1000 rows (`FetchAll_wrap` in `ddbc_bindings.cpp`). The
+/// harness previously hard-coded 1024, which is a size no consumer asks for.
+inline constexpr std::size_t kFetchManyDefaultRowset = 1;
+inline constexpr std::size_t kFetchManyCadenceRowset = 64;
+inline constexpr std::size_t kFetchAllRowset = 1000;
+
+/// Largest rowset any workload binds, used to size the shared row buffers.
+inline constexpr std::size_t kMaxRowsetSize = kFetchAllRowset;
+
+/// Buffer size `mssql-python` hands to every `SQLGetData` LOB continuation call
+/// (`DAE_CHUNK_SIZE`). Matching it is what makes the chunked workload measure
+/// the same number of driver round trips the consumer would cause.
+inline constexpr std::size_t kLobChunkBytes = 8192;
 
 /// Connection and workload selection shared by the admin and timed executables.
 ///
@@ -43,22 +62,91 @@ struct Config {
     std::string connection_string() const;
 };
 
-/// Defines one stable SQL shape whose name is also the comparison key.
+/// Column families a benchmark table can be built from.
 ///
-/// The pattern repetition count changes result width without changing the type mix.
-struct WorkloadSpec {
-    const char* benchmark_name;
-    const char* scenario;
+/// The shape decides schema generation, the deterministic value generator, and
+/// the preflight validator together, so a table can never be filled by one rule
+/// and checked by another.
+enum class TableShape {
+    /// Repeated fixed-width `NOT NULL` pattern; every value is inline and
+    /// bindable, so it isolates conversion and rowset cost from length handling.
+    fixed_pattern,
+    /// Nullable inline `VARCHAR`/`NVARCHAR` with realistic length variation.
+    /// Deliberately holds no `MAX` column: inline variable width and PLP are
+    /// different driver paths and are measured separately.
+    variable_width,
+    /// `NVARCHAR(MAX)`/`VARCHAR(MAX)` values large enough that one value cannot
+    /// be delivered in a single 8192-byte `SQLGetData` call.
+    lob_max,
+    /// The fixed pattern plus one small `NVARCHAR(MAX)` column. One MAX column
+    /// is enough to make `mssql-python` abandon bound fetching for the *whole*
+    /// result, so this measures the dispatch, not the LOB payload.
+    mixed_lob,
+    /// `sql_variant` columns, which require the zero-length `SQL_C_BINARY` probe
+    /// plus `SQLColAttribute(SQL_CA_SS_VARIANT_TYPE)` before any value is read.
+    sql_variant,
+};
+
+/// How a workload consumes its result set.
+enum class AccessMode {
+    /// Bind once, then `SQLFetchScroll` until `SQL_NO_DATA`. This is the
+    /// steady-state block-fetch path.
+    bound_drain,
+    /// Rebind, fetch one rowset, reset the row-array size, and unbind — once per
+    /// rowset. This is exactly what `mssql-python`'s `fetchmany()` does on every
+    /// call, and at `arraysize = 1` the bind/unbind pair dominates the cost.
+    bound_bind_cycle,
+    /// `SQLFetch` with a one-row rowset and `SQLGetData` per column, which is the
+    /// path a LOB or `sql_variant` column forces the entire result onto.
+    row_wise_get_data,
+};
+
+/// One deterministic table: the setup executable creates exactly this catalog.
+struct TableSpec {
     const char* table_name;
+    TableShape shape;
     std::uint64_t row_count;
+    /// Repeats of the 15-column fixed pattern; ignored by the other shapes.
     std::size_t pattern_repetitions;
 
     /// Return the exact projected width used to size buffers and verify metadata.
     std::size_t column_count() const;
+
+    /// Zero-based index of the `INT` column carrying the row identity, which the
+    /// preflight coverage check reads.
+    std::size_t row_id_column() const;
+
+    /// Driver-independent payload volume for one full retrieval, derived from the
+    /// same generator formulas that fill the table. Computing it up front keeps
+    /// per-cell accounting out of the timed loop for the variable-length shapes.
+    std::uint64_t logical_bytes_total() const;
 };
 
-/// Return the fixed workload catalog used by setup, validation, and measurement.
-const std::array<WorkloadSpec, 2>& workloads();
+/// Defines one stable measurement whose name is also the comparison key.
+///
+/// The name encodes table shape, row count, column count, and access shape, so a
+/// benchmark id stays meaningful in a report that no longer has the catalog next
+/// to it — and stays identical across the candidate, baseline, and Microsoft legs.
+struct WorkloadSpec {
+    const char* benchmark_name;
+    const char* scenario;
+    const TableSpec* table;
+    AccessMode access;
+    /// Row-array size for the bound modes; always 1 for `row_wise_get_data`.
+    std::size_t rowset_size;
+};
+
+/// Number of distinct tables the admin executable creates.
+inline constexpr std::size_t kTableCount = 8;
+
+/// Number of measured workloads in the catalog.
+inline constexpr std::size_t kWorkloadCount = 13;
+
+/// Return the fixed table catalog used by setup, cleanup, and validation.
+const std::array<TableSpec, kTableCount>& tables();
+
+/// Return the fixed workload catalog used by validation and measurement.
+const std::array<WorkloadSpec, kWorkloadCount>& workloads();
 
 /// Owns one ODBC handle chain so every workload uses the same connection lifecycle.
 class OdbcSession {
@@ -94,6 +182,13 @@ void setup_benchmark_tables(OdbcSession& session);
 /// Remove benchmark-owned tables so shared perf databases do not accumulate state.
 void cleanup_benchmark_tables(OdbcSession& session);
 
+/// Print the exact DDL, generator, and projection SQL for the whole catalog.
+///
+/// This needs no connection, so the generated T-SQL can be reviewed or replayed
+/// against a server without provisioning the perf lab first — which is the only
+/// way to check the generators offline, since they are assembled in C++.
+void print_benchmark_sql(std::ostream& output);
+
 /// Separates the end-to-end timing boundary from diagnostic phase timings.
 ///
 /// Regression decisions use total_seconds; phase values help explain a change.
@@ -101,13 +196,16 @@ struct RetrievalMetrics {
     std::uint64_t rows = 0;
     std::uint64_t cells = 0;
     std::uint64_t logical_bytes = 0;
+    /// `SQLGetData` calls issued, including LOB continuations and variant probes.
+    /// Zero for the bound modes, where the driver moves whole rowsets instead.
+    std::uint64_t get_data_calls = 0;
     double total_seconds = 0.0;
     double execute_seconds = 0.0;
     double metadata_bind_seconds = 0.0;
     double fetch_seconds = 0.0;
 };
 
-/// Binds one workload once per retrieval and validates that timed work stays correct.
+/// Drives one workload and validates that the timed work stays correct.
 class WorkloadRunner {
 public:
     /// Materialize the workload's column descriptors and row-array buffers.
@@ -119,9 +217,6 @@ public:
 
     /// Return the catalog entry used as the stable Google Benchmark identity.
     const WorkloadSpec& spec() const;
-
-    /// Report payload volume independent of driver-specific physical representation.
-    std::uint64_t logical_bytes_per_row() const;
 
     /// Exercise a full untimed fetch and validate rowsets, indicators, and values.
     void preflight();

--- a/mssql-odbc-bench/perf-lab/baseline-commit.txt
+++ b/mssql-odbc-bench/perf-lab/baseline-commit.txt
@@ -1,0 +1,10 @@
+# Performance baseline commit for mssql-odbc.
+#
+# The perf-lab benchmarks compare the complete driver built from the current
+# commit with the complete driver built from the commit below. Advancing this
+# pointer requires a pull request, so every baseline move is reviewed and
+# recorded.
+#
+# Exactly one full 40-character commit SHA on its own line. Lines starting with
+# '#' and blank lines are ignored.
+6ab0d5b91f83296a979371d039a71a3d314b214b

--- a/mssql-odbc-bench/perf-lab/baseline-commit.txt
+++ b/mssql-odbc-bench/perf-lab/baseline-commit.txt
@@ -1,10 +1,10 @@
 # Performance baseline commit for mssql-odbc.
 #
-# The perf-lab benchmarks compare the complete driver built from the current
-# commit with the complete driver built from the commit below. Advancing this
-# pointer requires a pull request, so every baseline move is reviewed and
-# recorded.
+# The initial pin is the production main commit on which the benchmark harness
+# was introduced. PR #417 changes no production driver sources, so this bootstrap
+# makes the first candidate and baseline production trees identical. Future
+# advances require a pull request, so every baseline move is reviewed and recorded.
 #
 # Exactly one full 40-character commit SHA on its own line. Lines starting with
 # '#' and blank lines are ignored.
-6ab0d5b91f83296a979371d039a71a3d314b214b
+bc4b2dc80b111c388ac8000b90f1c35290d735a0

--- a/mssql-odbc-bench/perf-lab/msodbcsql-version.txt
+++ b/mssql-odbc-bench/perf-lab/msodbcsql-version.txt
@@ -1,0 +1,5 @@
+# Microsoft ODBC Driver 18 version used as the dedicated-lab reference.
+#
+# Linux installs the exact Debian package <version>-1. Windows uses the pinned
+# MSI URL and SHA-256 in .pipeline/scripts/install-msodbcsql.ps1.
+18.6.2.1

--- a/mssql-odbc-bench/perf-lab/run-benchmarks.ps1
+++ b/mssql-odbc-bench/perf-lab/run-benchmarks.ps1
@@ -500,7 +500,7 @@ if (-not $env:ODBC_BENCH_UID) {
 if (-not $env:ODBC_BENCH_PWD) { $env:ODBC_BENCH_PWD = $env:SQL_PASSWORD }
 if (-not $env:ODBC_BENCH_TRUST_CERT) { $env:ODBC_BENCH_TRUST_CERT = 'Yes' }
 if (-not $env:ODBC_BENCH_ENCRYPT) { $env:ODBC_BENCH_ENCRYPT = 'Mandatory' }
-if (-not $env:ODBC_BENCH_PACKET_SIZE) { $env:ODBC_BENCH_PACKET_SIZE = '32767' }
+if (-not $env:ODBC_BENCH_PACKET_SIZE) { $env:ODBC_BENCH_PACKET_SIZE = '16192' }
 
 New-Item -ItemType Directory -Force -Path $ResultsDir | Out-Null
 

--- a/mssql-odbc-bench/perf-lab/run-benchmarks.ps1
+++ b/mssql-odbc-bench/perf-lab/run-benchmarks.ps1
@@ -938,6 +938,7 @@ try {
         Write-Host '>>> Removing ODBC benchmark tables...'
         $env:ODBC_BENCH_DRIVER = $CandidateDriverName
         $env:ODBC_BENCH_SCENARIO = ''
+        $env:ODBC_BENCH_PACKET_SIZE_KEYWORD = 'PacketSize'
         $previousPreference = $ErrorActionPreference
         $ErrorActionPreference = 'Continue'
         try {

--- a/mssql-odbc-bench/perf-lab/run-benchmarks.ps1
+++ b/mssql-odbc-bench/perf-lab/run-benchmarks.ps1
@@ -337,15 +337,14 @@ function Initialize-BenchmarkPython {
 
 function Invoke-BenchmarkLeg {
     # Keep one raw JSON file per driver/scenario and use the packet-size spelling
-    # accepted by that driver. An empty scenario runs every workload in one process.
+    # accepted by that driver.
     param(
         [Parameter(Mandatory)][AllowEmptyString()][string]$Scenario,
         [Parameter(Mandatory)][string]$Driver,
         [Parameter(Mandatory)][string]$Output
     )
 
-    $label = if ($Scenario) { $Scenario } else { 'all scenarios' }
-    Write-Host ">>> Running $label with $Driver..."
+    Write-Host ">>> Running $Scenario with $Driver..."
     $env:ODBC_BENCH_DRIVER = $Driver
     $env:ODBC_BENCH_SCENARIO = $Scenario
     # Windows Microsoft ODBC accepts the spaced spelling; the Rust driver and the
@@ -380,8 +379,8 @@ function Invoke-Comparator {
 }
 
 function Get-BenchmarkScenario {
-    # The harness filters by scenario, not by benchmark id, so map each flagged
-    # benchmark back to the scenario file it came out of.
+    # Confirmation re-runs whole scenarios, not single benchmarks, so each flagged
+    # id has to be mapped back to the leg it came out of.
     param([Parameter(Mandatory)][string]$Name, [Parameter(Mandatory)][hashtable]$ScenarioFiles)
 
     foreach ($scenario in $ScenarioFiles.Keys) {
@@ -462,6 +461,11 @@ $BaselineTargetDir = Join-Path $RepoRoot 'target\odbc-baseline'
 $CandidateDriverName = 'MSSQL Rust ODBC Perf Candidate'
 $BaselineDriverName = 'MSSQL Rust ODBC Perf Baseline'
 $script:MicrosoftDriverName = 'ODBC Driver 18 for SQL Server'
+
+# Scenario catalog. The C++ harness filters its workloads by scenario, and every
+# downstream step - ordering, comparison, confirmation - iterates this list, so a
+# new scenario needs no other change here.
+$Scenarios = @('narrow', 'wide', 'rowset', 'varwidth', 'getdata')
 $script:OdbcInstRoot = 'HKLM:\Software\ODBC\ODBCINST.INI'
 $script:DriversRegKey = "$script:OdbcInstRoot\ODBC Drivers"
 $script:Repetitions = Get-PositiveIntEnv -Name 'ODBC_BENCH_REPETITIONS' -Default 5
@@ -496,7 +500,7 @@ if (-not $env:ODBC_BENCH_UID) {
 if (-not $env:ODBC_BENCH_PWD) { $env:ODBC_BENCH_PWD = $env:SQL_PASSWORD }
 if (-not $env:ODBC_BENCH_TRUST_CERT) { $env:ODBC_BENCH_TRUST_CERT = 'Yes' }
 if (-not $env:ODBC_BENCH_ENCRYPT) { $env:ODBC_BENCH_ENCRYPT = 'Mandatory' }
-if (-not $env:ODBC_BENCH_PACKET_SIZE) { $env:ODBC_BENCH_PACKET_SIZE = '32768' }
+if (-not $env:ODBC_BENCH_PACKET_SIZE) { $env:ODBC_BENCH_PACKET_SIZE = '32767' }
 
 New-Item -ItemType Directory -Force -Path $ResultsDir | Out-Null
 
@@ -505,7 +509,7 @@ $script:TelemetryCsv = Join-Path $ResultsDir 'cpu-telemetry.csv'
     Set-Content -Path $script:TelemetryCsv -Encoding utf8
 
 # --- Large-buffer and scheduling controls (Windows equivalents) ---
-# Each retrieval allocates bound rowset buffers for up to 600 columns by 1024
+# Each retrieval allocates bound rowset buffers for up to 600 columns by 1000
 # rows. glibc's MALLOC_MMAP_THRESHOLD_/MALLOC_TRIM_THRESHOLD_ used by the Linux
 # runner have no Windows counterpart that a parent process can set, so the
 # Windows side targets the same goal - stable large-allocation cost and stable
@@ -690,6 +694,8 @@ try {
         "microsoft_driver_product_version=$($MicrosoftDriverInfo.ProductVersion)",
         "microsoft_driver_path=$MicrosoftDriver",
         "microsoft_driver_sha256=$MicrosoftDriverSha256",
+        "packet_size=$($env:ODBC_BENCH_PACKET_SIZE)",
+        "packet_size_verified_by_harness=true",
         "repetitions=$script:Repetitions",
         "regression_ratio=$(Format-Invariant $RegressionRatio 'F4')",
         "confirm_runs=$ConfirmRuns",
@@ -752,29 +758,37 @@ try {
         Write-Warning "Could not set the High performance power scheme: $($_.Exception.Message)"
     }
 
-    $candidateNarrow = Join-Path $ResultsDir 'odbc-candidate-narrow.json'
-    $baselineNarrow = Join-Path $ResultsDir 'odbc-baseline-narrow.json'
-    $candidateWide = Join-Path $ResultsDir 'odbc-candidate-wide.json'
-    $baselineWide = Join-Path $ResultsDir 'odbc-baseline-wide.json'
-    $microsoftNarrow = Join-Path $ResultsDir 'odbc-microsoft-narrow.json'
-    $microsoftWide = Join-Path $ResultsDir 'odbc-microsoft-wide.json'
+    $candidateFiles = @{}
+    $baselineFiles = @{}
+    $microsoftFiles = @{}
+    foreach ($scenario in $Scenarios) {
+        $candidateFiles[$scenario] = Join-Path $ResultsDir "odbc-candidate-$scenario.json"
+        $baselineFiles[$scenario] = Join-Path $ResultsDir "odbc-baseline-$scenario.json"
+        $microsoftFiles[$scenario] = Join-Path $ResultsDir "odbc-microsoft-$scenario.json"
+    }
 
     Write-CpuSample 'initial-start'
-    Invoke-BenchmarkLeg -Scenario 'narrow' -Driver $CandidateDriverName -Output $candidateNarrow
-    Invoke-BenchmarkLeg -Scenario 'narrow' -Driver $script:MicrosoftDriverName -Output $microsoftNarrow
-    Invoke-BenchmarkLeg -Scenario 'narrow' -Driver $BaselineDriverName -Output $baselineNarrow
-    Invoke-BenchmarkLeg -Scenario 'wide' -Driver $BaselineDriverName -Output $baselineWide
-    Invoke-BenchmarkLeg -Scenario 'wide' -Driver $script:MicrosoftDriverName -Output $microsoftWide
-    Invoke-BenchmarkLeg -Scenario 'wide' -Driver $CandidateDriverName -Output $candidateWide
+    for ($index = 0; $index -lt $Scenarios.Count; $index++) {
+        $scenario = $Scenarios[$index]
+        # Alternate which Rust driver runs first per scenario, with Microsoft ODBC
+        # between them, so a stable position effect does not favour one side.
+        if ($index % 2 -eq 0) {
+            Invoke-BenchmarkLeg -Scenario $scenario -Driver $CandidateDriverName -Output $candidateFiles[$scenario]
+            Invoke-BenchmarkLeg -Scenario $scenario -Driver $script:MicrosoftDriverName -Output $microsoftFiles[$scenario]
+            Invoke-BenchmarkLeg -Scenario $scenario -Driver $BaselineDriverName -Output $baselineFiles[$scenario]
+        } else {
+            Invoke-BenchmarkLeg -Scenario $scenario -Driver $BaselineDriverName -Output $baselineFiles[$scenario]
+            Invoke-BenchmarkLeg -Scenario $scenario -Driver $script:MicrosoftDriverName -Output $microsoftFiles[$scenario]
+            Invoke-BenchmarkLeg -Scenario $scenario -Driver $CandidateDriverName -Output $candidateFiles[$scenario]
+        }
+    }
     Write-CpuSample 'initial-end'
 
-    $threeWayArguments = @(
-        '--baseline', $baselineNarrow,
-        '--baseline', $baselineWide,
-        '--candidate', $candidateNarrow,
-        '--candidate', $candidateWide,
-        '--reference', $microsoftNarrow,
-        '--reference', $microsoftWide,
+    $threeWayArguments = @()
+    foreach ($scenario in $Scenarios) { $threeWayArguments += @('--baseline', $baselineFiles[$scenario]) }
+    foreach ($scenario in $Scenarios) { $threeWayArguments += @('--candidate', $candidateFiles[$scenario]) }
+    foreach ($scenario in $Scenarios) { $threeWayArguments += @('--reference', $microsoftFiles[$scenario]) }
+    $threeWayArguments += @(
         '--reference-label', "Microsoft ODBC $MicrosoftVersion",
         '--baseline-commit', $BaselineCommit,
         '--reference-version', $MicrosoftVersion,
@@ -797,7 +811,8 @@ try {
         throw "Initial ODBC benchmark comparison failed (exit $initialExit)"
     }
 
-    $scenarioFiles = @{ narrow = $candidateNarrow; wide = $candidateWide }
+    $scenarioFiles = @{}
+    foreach ($scenario in $Scenarios) { $scenarioFiles[$scenario] = $candidateFiles[$scenario] }
     $plan = @()
     foreach ($line in Get-Content -LiteralPath $PlanFile) {
         if (-not $line.Trim()) { continue }
@@ -813,37 +828,36 @@ try {
 
     $confirmationArguments = @()
     if ($plan.Count -gt 0) {
-        # One process covers both scenarios; only narrow those legs when the other
-        # workload has nothing to confirm.
-        $selected = @($plan | ForEach-Object { $_.Scenario } | Sort-Object -Unique)
-        $confirmScenario = if ($selected.Count -eq 1) { $selected[0] } else { '' }
+        # Confirmation re-measures whole scenarios, so only the legs that actually
+        # produced a flagged benchmark are re-run.
+        $confirmScenarios = @($plan | ForEach-Object { $_.Scenario } | Sort-Object -Unique)
 
-        Write-Host ((">>> Auto-confirm: re-measuring {0} benchmark(s) over {1} round(s); " +
-                "a result counts only when it reproduces in >= {2} of {1}.") -f
-            $plan.Count, $ConfirmRuns, $ConfirmQuorum)
+        Write-Host ((">>> Auto-confirm: re-measuring {0} benchmark(s) across {1} scenario(s) " +
+                "over {2} round(s); a result counts only when it reproduces in >= {3} of {2}.") -f
+            $plan.Count, $confirmScenarios.Count, $ConfirmRuns, $ConfirmQuorum)
         $roundRatios = @()
         for ($round = 1; $round -le $ConfirmRuns; $round++) {
             $roundDir = Join-Path $ConfirmDir "round$round"
             New-Item -ItemType Directory -Force -Path $roundDir | Out-Null
             Write-Host ">>> Confirmation round $round/$ConfirmRuns..."
             Write-CpuSample "confirm$round-start"
-            # Keep each pair adjacent, and alternate which side runs first so a
-            # stable position effect cancels across the default four rounds.
-            if ($round % 2 -eq 1) {
-                Invoke-BenchmarkLeg -Scenario $confirmScenario -Driver $CandidateDriverName `
-                    -Output (Join-Path $roundDir 'candidate.json')
-                Invoke-BenchmarkLeg -Scenario $confirmScenario -Driver $BaselineDriverName `
-                    -Output (Join-Path $roundDir 'baseline.json')
-            } else {
-                Invoke-BenchmarkLeg -Scenario $confirmScenario -Driver $BaselineDriverName `
-                    -Output (Join-Path $roundDir 'baseline.json')
-                Invoke-BenchmarkLeg -Scenario $confirmScenario -Driver $CandidateDriverName `
-                    -Output (Join-Path $roundDir 'candidate.json')
+            $roundArguments = @()
+            foreach ($scenario in $confirmScenarios) {
+                $roundCandidate = Join-Path $roundDir "candidate-$scenario.json"
+                $roundBaseline = Join-Path $roundDir "baseline-$scenario.json"
+                # Keep each pair adjacent, and alternate which side runs first so a
+                # stable position effect cancels across the default four rounds.
+                if ($round % 2 -eq 1) {
+                    Invoke-BenchmarkLeg -Scenario $scenario -Driver $CandidateDriverName -Output $roundCandidate
+                    Invoke-BenchmarkLeg -Scenario $scenario -Driver $BaselineDriverName -Output $roundBaseline
+                } else {
+                    Invoke-BenchmarkLeg -Scenario $scenario -Driver $BaselineDriverName -Output $roundBaseline
+                    Invoke-BenchmarkLeg -Scenario $scenario -Driver $CandidateDriverName -Output $roundCandidate
+                }
+                $roundArguments += @('--baseline', $roundBaseline, '--candidate', $roundCandidate)
             }
             Write-CpuSample "confirm$round-end"
-            $roundArguments = @(
-                '--baseline', (Join-Path $roundDir 'baseline.json'),
-                '--candidate', (Join-Path $roundDir 'candidate.json'),
+            $roundArguments += @(
                 '--repetitions', [string]$script:Repetitions,
                 '--regression-ratio', (Format-Invariant $RegressionRatio),
                 '--improvement-ratio', (Format-Invariant $ImprovementRatio),
@@ -924,7 +938,24 @@ try {
         Write-Host '>>> Removing ODBC benchmark tables...'
         $env:ODBC_BENCH_DRIVER = $CandidateDriverName
         $env:ODBC_BENCH_SCENARIO = ''
-        Invoke-CleanupNative -Description 'Benchmark table cleanup' -Command { & $AdminExe cleanup }
+        $previousPreference = $ErrorActionPreference
+        $ErrorActionPreference = 'Continue'
+        try {
+            & $AdminExe cleanup
+            if ($LASTEXITCODE -ne 0) {
+                Write-Warning 'Candidate cleanup failed; retrying with Microsoft ODBC'
+                $env:ODBC_BENCH_DRIVER = $script:MicrosoftDriverName
+                $env:ODBC_BENCH_PACKET_SIZE_KEYWORD = 'Packet Size'
+                & $AdminExe cleanup
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Warning 'Benchmark table cleanup failed with both drivers'
+                }
+            }
+        } catch {
+            Write-Warning "Benchmark table cleanup failed: $($_.Exception.Message)"
+        } finally {
+            $ErrorActionPreference = $previousPreference
+        }
     }
     if ($BaselineRegistrationAttempted) {
         try { Restore-DriverRegistration -State $BaselineState } catch { Write-Warning $_ }

--- a/mssql-odbc-bench/perf-lab/run-benchmarks.ps1
+++ b/mssql-odbc-bench/perf-lab/run-benchmarks.ps1
@@ -325,7 +325,8 @@ function Initialize-BenchmarkPython {
         }
         # Send pip's output to the host so only the interpreter path is returned.
         & $venvPython -m pip install --quiet --upgrade pip *> $null
-        & $venvPython -m pip install --quiet numpy scipy | Out-Host
+        & $venvPython -m pip install --quiet `
+            "numpy==$script:NumpyVersion" "scipy==$script:ScipyVersion" | Out-Host
         if ($LASTEXITCODE -ne 0) {
             return $null
         }
@@ -461,6 +462,8 @@ $BaselineTargetDir = Join-Path $RepoRoot 'target\odbc-baseline'
 $CandidateDriverName = 'MSSQL Rust ODBC Perf Candidate'
 $BaselineDriverName = 'MSSQL Rust ODBC Perf Baseline'
 $script:MicrosoftDriverName = 'ODBC Driver 18 for SQL Server'
+$script:NumpyVersion = '2.4.6'
+$script:ScipyVersion = '1.18.0'
 
 # Scenario catalog. The C++ harness filters its workloads by scenario, and every
 # downstream step - ordering, comparison, confirmation - iterates this list, so a
@@ -702,6 +705,8 @@ try {
         "confirm_quorum=$ConfirmQuorum",
         "gbench_compare=$(if ($GbenchArguments.Count) { $GbenchCompare } else { 'disabled' })",
         "bench_python=$script:BenchPython",
+        "numpy_version=$script:NumpyVersion",
+        "scipy_version=$script:ScipyVersion",
         "timestamp_utc=$([DateTime]::UtcNow.ToString('o'))",
         $RustcVersion,
         $CargoVersion,

--- a/mssql-odbc-bench/perf-lab/run-benchmarks.ps1
+++ b/mssql-odbc-bench/perf-lab/run-benchmarks.ps1
@@ -462,8 +462,8 @@ $BaselineTargetDir = Join-Path $RepoRoot 'target\odbc-baseline'
 $CandidateDriverName = 'MSSQL Rust ODBC Perf Candidate'
 $BaselineDriverName = 'MSSQL Rust ODBC Perf Baseline'
 $script:MicrosoftDriverName = 'ODBC Driver 18 for SQL Server'
-$script:NumpyVersion = '2.4.6'
-$script:ScipyVersion = '1.18.0'
+$script:NumpyVersion = '2.2.6'
+$script:ScipyVersion = '1.15.3'
 
 # Scenario catalog. The C++ harness filters its workloads by scenario, and every
 # downstream step - ordering, comparison, confirmation - iterates this list, so a

--- a/mssql-odbc-bench/perf-lab/run-benchmarks.ps1
+++ b/mssql-odbc-bench/perf-lab/run-benchmarks.ps1
@@ -1,0 +1,517 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# Dedicated Windows perf-lab runner for the mssql-odbc result-set benchmarks.
+
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Native {
+    # Normalize native failures into PowerShell exceptions so the outer finally
+    # block always restores driver registrations and temporary worktrees.
+    param([Parameter(Mandatory)][scriptblock]$Command)
+
+    $previousPreference = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        & $Command
+        if ($LASTEXITCODE -ne 0) {
+            throw "Native command failed (exit $LASTEXITCODE): $Command"
+        }
+    } finally {
+        $ErrorActionPreference = $previousPreference
+    }
+}
+
+function Invoke-CleanupNative {
+    # Cleanup is best effort because the original benchmark failure must remain the
+    # run's primary error.
+    param([Parameter(Mandatory)][scriptblock]$Command, [Parameter(Mandatory)][string]$Description)
+
+    $previousPreference = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        & $Command
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "$Description failed with exit code $LASTEXITCODE"
+        }
+    } catch {
+        Write-Warning "$Description failed: $($_.Exception.Message)"
+    } finally {
+        $ErrorActionPreference = $previousPreference
+    }
+}
+
+function Get-PositiveIntEnv {
+    # Parse tuning knobs consistently instead of letting each call site accept a
+    # different set of malformed values.
+    param([Parameter(Mandatory)][string]$Name, [Parameter(Mandatory)][int]$Default)
+
+    $raw = [Environment]::GetEnvironmentVariable($Name)
+    if ([string]::IsNullOrEmpty($raw)) {
+        return $Default
+    }
+
+    $parsed = 0
+    if (-not [int]::TryParse(
+            $raw,
+            [System.Globalization.NumberStyles]::None,
+            [System.Globalization.CultureInfo]::InvariantCulture,
+            [ref]$parsed
+        ) -or $parsed -lt 1) {
+        throw "$Name must be a positive integer"
+    }
+    return $parsed
+}
+
+function ConvertTo-AffinityMask {
+    # Translate the Linux-style CPU list used by the perf lab into the mask required
+    # by Windows ProcessorAffinity.
+    param([string]$CpuList)
+
+    if ([string]::IsNullOrWhiteSpace($CpuList)) {
+        return $null
+    }
+
+    [long]$mask = 0
+    foreach ($part in ($CpuList -split ',')) {
+        $value = $part.Trim()
+        if ($value -match '^(\d+)-(\d+)$') {
+            $first = [int]$Matches[1]
+            $last = [int]$Matches[2]
+            if ($first -gt $last) {
+                $swap = $first
+                $first = $last
+                $last = $swap
+            }
+            for ($cpu = $first; $cpu -le $last; $cpu++) {
+                $mask = $mask -bor ([long]1 -shl $cpu)
+            }
+        } elseif ($value -match '^\d+$') {
+            $mask = $mask -bor ([long]1 -shl [int]$value)
+        } else {
+            throw "Invalid CPU list token '$value'"
+        }
+    }
+    if ($mask -eq 0) {
+        return $null
+    }
+    return $mask
+}
+
+function Get-RegistryValueState {
+    # Preserve absence separately from an empty value so restoration is exact.
+    param([Parameter(Mandatory)][string]$Path, [Parameter(Mandatory)][string]$Name)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return [pscustomobject]@{ Exists = $false; Value = $null }
+    }
+    $item = Get-ItemProperty -LiteralPath $Path
+    $property = $item.PSObject.Properties[$Name]
+    if ($null -eq $property) {
+        return [pscustomobject]@{ Exists = $false; Value = $null }
+    }
+    return [pscustomobject]@{ Exists = $true; Value = $property.Value }
+}
+
+function Save-DriverRegistration {
+    # Snapshot every registry value the temporary benchmark registration can touch.
+    param([Parameter(Mandatory)][string]$Name)
+
+    $keyPath = "$script:OdbcInstRoot\$Name"
+    return [pscustomobject]@{
+        Name = $Name
+        KeyPath = $keyPath
+        KeyExisted = Test-Path -LiteralPath $keyPath
+        Driver = Get-RegistryValueState -Path $keyPath -Name 'Driver'
+        Setup = Get-RegistryValueState -Path $keyPath -Name 'Setup'
+        ListEntry = Get-RegistryValueState -Path $script:DriversRegKey -Name $Name
+    }
+}
+
+function Set-DriverRegistration {
+    # Register candidate and baseline builds under private names without replacing
+    # the machine's Microsoft ODBC registration.
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$DriverPath
+    )
+
+    $keyPath = "$script:OdbcInstRoot\$Name"
+    New-Item -Path $keyPath -Force | Out-Null
+    Set-ItemProperty -LiteralPath $keyPath -Name 'Driver' -Value $DriverPath
+    Set-ItemProperty -LiteralPath $keyPath -Name 'Setup' -Value $DriverPath
+    New-Item -Path $script:DriversRegKey -Force | Out-Null
+    Set-ItemProperty -LiteralPath $script:DriversRegKey -Name $Name -Value 'Installed'
+    Write-Host ">>> Registered '$Name': $DriverPath"
+}
+
+function Restore-RegistryValue {
+    # Restore both the prior value and the prior existence state.
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)]$State
+    )
+
+    if ($State.Exists) {
+        Set-ItemProperty -LiteralPath $Path -Name $Name -Value $State.Value
+    } elseif (Test-Path -LiteralPath $Path) {
+        Remove-ItemProperty -LiteralPath $Path -Name $Name -ErrorAction SilentlyContinue
+    }
+}
+
+function Restore-DriverRegistration {
+    # Return shared perf hosts to their pre-run registry state.
+    param([Parameter(Mandatory)]$State)
+
+    if ($State.KeyExisted) {
+        Restore-RegistryValue -Path $State.KeyPath -Name 'Driver' -State $State.Driver
+        Restore-RegistryValue -Path $State.KeyPath -Name 'Setup' -State $State.Setup
+    } else {
+        Remove-Item -LiteralPath $State.KeyPath -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    Restore-RegistryValue -Path $script:DriversRegKey -Name $State.Name -State $State.ListEntry
+    Write-Host ">>> Restored registration for '$($State.Name)'"
+}
+
+function Find-CMake {
+    # Hosted Windows agents do not consistently expose Visual Studio's CMake on PATH.
+    $command = Get-Command cmake -ErrorAction SilentlyContinue
+    if ($command) {
+        return $command.Source
+    }
+
+    $candidates = @(
+        "$env:ProgramFiles\CMake\bin\cmake.exe",
+        "$env:ProgramFiles\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe",
+        "$env:ProgramFiles\Microsoft Visual Studio\2022\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe",
+        "$env:ProgramFiles\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe"
+    )
+    foreach ($candidate in $candidates) {
+        if (Test-Path -LiteralPath $candidate) {
+            return $candidate
+        }
+    }
+    throw 'CMake not found'
+}
+
+function Build-Driver {
+    # Isolated Cargo targets prevent candidate artifacts from contaminating the
+    # detached baseline build.
+    param(
+        [Parameter(Mandatory)][string]$SourceRoot,
+        [Parameter(Mandatory)][string]$TargetDir,
+        [Parameter(Mandatory)][string]$Label
+    )
+
+    Write-Host ">>> Building $Label mssql-odbc driver..."
+    $previousTarget = $env:CARGO_TARGET_DIR
+    $env:CARGO_TARGET_DIR = $TargetDir
+    Push-Location $SourceRoot
+    try {
+        Invoke-Native { cargo build -p mssql-odbc --release }
+    } finally {
+        Pop-Location
+        if ($null -eq $previousTarget) {
+            Remove-Item Env:CARGO_TARGET_DIR -ErrorAction SilentlyContinue
+        } else {
+            $env:CARGO_TARGET_DIR = $previousTarget
+        }
+    }
+}
+
+function Invoke-BenchmarkLeg {
+    # Keep one raw JSON file per driver/scenario and use the packet-size spelling
+    # accepted by that driver.
+    param(
+        [Parameter(Mandatory)][string]$Scenario,
+        [Parameter(Mandatory)][string]$Driver,
+        [Parameter(Mandatory)][string]$Output
+    )
+
+    Write-Host ">>> Running $Scenario with $Driver..."
+    $env:ODBC_BENCH_DRIVER = $Driver
+    $env:ODBC_BENCH_SCENARIO = $Scenario
+    $env:ODBC_BENCH_PACKET_SIZE_KEYWORD = if ($Driver -eq $MicrosoftDriverName) {
+        'Packet Size'
+    } else {
+        'PacketSize'
+    }
+    $arguments = @(
+        "--benchmark_repetitions=$script:Repetitions",
+        "--benchmark_out=$Output",
+        '--benchmark_out_format=json'
+    )
+    Invoke-Native { & $script:BenchExe @arguments }
+}
+
+$RepoRoot = (Get-Location).Path
+$ResultsDir = Join-Path $RepoRoot 'results'
+$BaselineFile = Join-Path $RepoRoot 'mssql-odbc-bench\perf-lab\baseline-commit.txt'
+$ReferenceVersionFile = Join-Path $RepoRoot 'mssql-odbc-bench\perf-lab\msodbcsql-version.txt'
+$HarnessBuildDir = Join-Path $RepoRoot 'target\odbc-bench'
+$CandidateTargetDir = Join-Path $RepoRoot 'target\odbc-candidate'
+$BaselineTargetDir = Join-Path $RepoRoot 'target\odbc-baseline'
+$CandidateDriverName = 'MSSQL Rust ODBC Perf Candidate'
+$BaselineDriverName = 'MSSQL Rust ODBC Perf Baseline'
+$MicrosoftDriverName = 'ODBC Driver 18 for SQL Server'
+$script:OdbcInstRoot = 'HKLM:\Software\ODBC\ODBCINST.INI'
+$script:DriversRegKey = "$script:OdbcInstRoot\ODBC Drivers"
+$script:Repetitions = Get-PositiveIntEnv -Name 'ODBC_BENCH_REPETITIONS' -Default 5
+
+if (-not $env:SQL_SERVER) {
+    throw 'SQL_SERVER not set'
+}
+if (-not $env:SQL_PASSWORD) {
+    throw 'SQL_PASSWORD not set'
+}
+
+if (-not $env:ODBC_BENCH_SERVER) { $env:ODBC_BENCH_SERVER = $env:SQL_SERVER }
+if (-not $env:ODBC_BENCH_DATABASE) { $env:ODBC_BENCH_DATABASE = 'tempdb' }
+if (-not $env:ODBC_BENCH_UID) {
+    $env:ODBC_BENCH_UID = if ($env:DB_USERNAME) { $env:DB_USERNAME } else { 'sa' }
+}
+if (-not $env:ODBC_BENCH_PWD) { $env:ODBC_BENCH_PWD = $env:SQL_PASSWORD }
+if (-not $env:ODBC_BENCH_TRUST_CERT) { $env:ODBC_BENCH_TRUST_CERT = 'Yes' }
+if (-not $env:ODBC_BENCH_ENCRYPT) { $env:ODBC_BENCH_ENCRYPT = 'Mandatory' }
+if (-not $env:ODBC_BENCH_PACKET_SIZE) { $env:ODBC_BENCH_PACKET_SIZE = '32768' }
+
+New-Item -ItemType Directory -Force -Path $ResultsDir | Out-Null
+
+if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) {
+    Write-Host '>>> Installing Rust toolchain...'
+    & (Join-Path $RepoRoot '.pipeline\scripts\InstallRustup.ps1')
+}
+$env:PATH = "$env:USERPROFILE\.cargo\bin;$env:PATH"
+if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) {
+    throw 'cargo not found after Rust setup'
+}
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    throw 'git not found'
+}
+$CMake = Find-CMake
+$PythonCommand = Get-Command python -ErrorAction SilentlyContinue
+if (-not $PythonCommand) {
+    $PythonCommand = Get-Command python3 -ErrorAction SilentlyContinue
+}
+if (-not $PythonCommand) {
+    throw 'Python 3 not found'
+}
+$Python = $PythonCommand.Source
+
+if (-not (Test-Path -LiteralPath $BaselineFile)) {
+    throw "Baseline file not found: $BaselineFile"
+}
+$BaselineCommit = (Get-Content -LiteralPath $BaselineFile |
+    Where-Object { $_ -notmatch '^\s*(#|$)' } |
+    Select-Object -First 1).Trim()
+if ($BaselineCommit -notmatch '^[0-9a-fA-F]{40}$') {
+    throw "Invalid baseline commit in $BaselineFile"
+}
+& git rev-parse --verify --quiet "$BaselineCommit^{commit}" *> $null
+if ($LASTEXITCODE -ne 0) {
+    throw "Baseline commit $BaselineCommit is absent from the checkout"
+}
+
+if (-not (Test-Path -LiteralPath $ReferenceVersionFile)) {
+    throw "Reference version file not found: $ReferenceVersionFile"
+}
+$MicrosoftVersion = (Get-Content -LiteralPath $ReferenceVersionFile |
+    Where-Object { $_ -notmatch '^\s*(#|$)' } |
+    Select-Object -First 1).Trim()
+if ($MicrosoftVersion -notmatch '^[0-9]+(\.[0-9]+){3}$') {
+    throw "Invalid Microsoft ODBC version in $ReferenceVersionFile"
+}
+& (Join-Path $RepoRoot '.pipeline\scripts\install-msodbcsql.ps1') `
+    -Version $MicrosoftVersion
+$MicrosoftKey = "$script:OdbcInstRoot\$MicrosoftDriverName"
+if (-not (Test-Path -LiteralPath $MicrosoftKey)) {
+    throw "'$MicrosoftDriverName' was not registered after installation"
+}
+$MicrosoftDriver = (Get-ItemProperty -LiteralPath $MicrosoftKey -Name 'Driver').Driver
+if (-not $MicrosoftDriver -or -not (Test-Path -LiteralPath $MicrosoftDriver)) {
+    throw "Registered Microsoft ODBC driver path is invalid: $MicrosoftDriver"
+}
+$MicrosoftDriverInfo = (Get-Item -LiteralPath $MicrosoftDriver).VersionInfo
+$MicrosoftDriverSha256 = (Get-FileHash -LiteralPath $MicrosoftDriver -Algorithm SHA256).Hash
+
+$BaselineTempDir = Join-Path ([System.IO.Path]::GetTempPath()) "odbc-perf-$([System.Guid]::NewGuid().ToString('N'))"
+$BaselineTree = Join-Path $BaselineTempDir 'worktree'
+$CandidateState = $null
+$BaselineState = $null
+$CandidateRegistrationAttempted = $false
+$BaselineRegistrationAttempted = $false
+$TableCleanupArmed = $false
+$script:BenchExe = ''
+$AdminExe = ''
+$HarnessRuntimeDir = Join-Path $HarnessBuildDir 'Release'
+
+try {
+    Write-Host '>>> Building the fixed C++ benchmark harness...'
+    try {
+        Invoke-Native {
+            & $CMake -S (Join-Path $RepoRoot 'mssql-odbc-bench') `
+                -B $HarnessBuildDir -G 'Visual Studio 17 2022' -A x64
+        }
+    } catch {
+        $gxx = Get-Command g++ -ErrorAction SilentlyContinue
+        $ninja = Get-Command ninja -ErrorAction SilentlyContinue
+        if (-not $gxx -or -not $ninja) {
+            throw
+        }
+        Write-Host '>>> Visual Studio C++ tools unavailable; using MinGW and Ninja...'
+        Remove-Item -LiteralPath $HarnessBuildDir -Recurse -Force -ErrorAction SilentlyContinue
+        $HarnessRuntimeDir = $HarnessBuildDir
+        $env:PATH = "$([System.IO.Path]::GetDirectoryName($gxx.Source));$env:PATH"
+        Invoke-Native {
+            & $CMake -S (Join-Path $RepoRoot 'mssql-odbc-bench') `
+                -B $HarnessBuildDir -G Ninja -DCMAKE_BUILD_TYPE=Release `
+                "-DCMAKE_CXX_COMPILER=$($gxx.Source)"
+        }
+    }
+    Invoke-Native { & $CMake --build $HarnessBuildDir --config Release --parallel }
+
+    Build-Driver -SourceRoot $RepoRoot -TargetDir $CandidateTargetDir -Label 'candidate'
+
+    New-Item -ItemType Directory -Force -Path $BaselineTempDir | Out-Null
+    Write-Host ">>> Adding baseline worktree for $BaselineCommit..."
+    Invoke-Native { git worktree add --detach $BaselineTree $BaselineCommit }
+    Build-Driver -SourceRoot $BaselineTree -TargetDir $BaselineTargetDir -Label 'baseline'
+
+    $CandidateDriver = Join-Path $CandidateTargetDir 'release\msodbcsql18.dll'
+    $BaselineDriver = Join-Path $BaselineTargetDir 'release\msodbcsql18.dll'
+    $script:BenchExe = Join-Path $HarnessRuntimeDir 'mssql_odbc_bench.exe'
+    $AdminExe = Join-Path $HarnessRuntimeDir 'mssql_odbc_bench_admin.exe'
+    foreach ($requiredFile in @(
+            $CandidateDriver,
+            $BaselineDriver,
+            $MicrosoftDriver,
+            $script:BenchExe,
+            $AdminExe
+        )) {
+        if (-not (Test-Path -LiteralPath $requiredFile)) {
+            throw "Expected build output not found: $requiredFile"
+        }
+    }
+
+    $CandidateState = Save-DriverRegistration -Name $CandidateDriverName
+    $CandidateRegistrationAttempted = $true
+    Set-DriverRegistration -Name $CandidateDriverName -DriverPath $CandidateDriver
+    $BaselineState = Save-DriverRegistration -Name $BaselineDriverName
+    $BaselineRegistrationAttempted = $true
+    Set-DriverRegistration -Name $BaselineDriverName -DriverPath $BaselineDriver
+
+    $context = @(
+        "candidate_commit=$(& git rev-parse HEAD)",
+        "baseline_commit=$BaselineCommit",
+        "microsoft_driver_version=$MicrosoftVersion",
+        "microsoft_driver_product_version=$($MicrosoftDriverInfo.ProductVersion)",
+        "microsoft_driver_path=$MicrosoftDriver",
+        "microsoft_driver_sha256=$MicrosoftDriverSha256",
+        "repetitions=$script:Repetitions",
+        "timestamp_utc=$([DateTime]::UtcNow.ToString('o'))",
+        (& rustc -Vv | Out-String).TrimEnd(),
+        (& cargo -V | Out-String).TrimEnd(),
+        (& $CMake --version | Out-String).TrimEnd()
+    ) -join "`n"
+    $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText(
+        (Join-Path $ResultsDir 'odbc-context.txt'),
+        $context + "`n",
+        $utf8NoBom
+    )
+
+    Write-Host '>>> Creating deterministic benchmark tables...'
+    $TableCleanupArmed = $true
+    $env:ODBC_BENCH_DRIVER = $CandidateDriverName
+    $env:ODBC_BENCH_SCENARIO = ''
+    Invoke-Native { & $AdminExe setup }
+
+    $cpuList = if ($env:BENCH_CPUS) { $env:BENCH_CPUS } else { $env:PERF_CLIENT_CPUS }
+    $affinity = ConvertTo-AffinityMask -CpuList $cpuList
+    if ($null -ne $affinity) {
+        try {
+            (Get-Process -Id $PID).ProcessorAffinity = [IntPtr]$affinity
+            Write-Host ">>> Pinned benchmark processes to CPUs: $cpuList"
+        } catch {
+            Write-Warning "Could not set benchmark CPU affinity: $($_.Exception.Message)"
+        }
+    }
+
+    $candidateNarrow = Join-Path $ResultsDir 'odbc-candidate-narrow.json'
+    $baselineNarrow = Join-Path $ResultsDir 'odbc-baseline-narrow.json'
+    $candidateWide = Join-Path $ResultsDir 'odbc-candidate-wide.json'
+    $baselineWide = Join-Path $ResultsDir 'odbc-baseline-wide.json'
+    $microsoftNarrow = Join-Path $ResultsDir 'odbc-microsoft-narrow.json'
+    $microsoftWide = Join-Path $ResultsDir 'odbc-microsoft-wide.json'
+
+    Invoke-BenchmarkLeg -Scenario 'narrow' -Driver $CandidateDriverName -Output $candidateNarrow
+    Invoke-BenchmarkLeg -Scenario 'narrow' -Driver $MicrosoftDriverName -Output $microsoftNarrow
+    Invoke-BenchmarkLeg -Scenario 'narrow' -Driver $BaselineDriverName -Output $baselineNarrow
+    Invoke-BenchmarkLeg -Scenario 'wide' -Driver $BaselineDriverName -Output $baselineWide
+    Invoke-BenchmarkLeg -Scenario 'wide' -Driver $MicrosoftDriverName -Output $microsoftWide
+    Invoke-BenchmarkLeg -Scenario 'wide' -Driver $CandidateDriverName -Output $candidateWide
+
+    $compareArguments = @(
+        (Join-Path $RepoRoot '.pipeline\scripts\compare-odbc-benchmarks.py'),
+        '--baseline', $baselineNarrow,
+        '--baseline', $baselineWide,
+        '--candidate', $candidateNarrow,
+        '--candidate', $candidateWide,
+        '--reference', $microsoftNarrow,
+        '--reference', $microsoftWide,
+        '--reference-label', "Microsoft ODBC $MicrosoftVersion",
+        '--baseline-commit', $BaselineCommit,
+        '--reference-version', $MicrosoftVersion,
+        '--repetitions', [string]$script:Repetitions,
+        '--output-dir', $ResultsDir,
+        '--regression-ratio',
+        $(if ($env:ODBC_BENCH_REGRESSION_RATIO) { $env:ODBC_BENCH_REGRESSION_RATIO } else { '1.10' })
+    )
+    if ($env:ODBC_BENCH_FAIL_ON_REGRESSION -eq '1') {
+        $compareArguments += '--fail-on-regression'
+    }
+    # Exit 2 means the report was written and the optional gate tripped. Preserve
+    # it until after the report reaches the step log.
+    $previousPreference = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        & $Python @compareArguments
+        $compareExitCode = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $previousPreference
+    }
+    if ($compareExitCode -ne 0 -and $compareExitCode -ne 2) {
+        throw "ODBC benchmark comparison failed (exit $compareExitCode)"
+    }
+
+    Write-Host ''
+    Write-Host '===== summary.md ====='
+    Get-Content -LiteralPath (Join-Path $ResultsDir 'summary.md') | ForEach-Object { Write-Host $_ }
+    Write-Host '===== end summary.md ====='
+    Write-Host ">>> ODBC benchmark results written to $ResultsDir"
+    if ($compareExitCode -eq 2) {
+        throw 'ODBC benchmark regression gate failed; see summary.md above'
+    }
+} finally {
+    if ($TableCleanupArmed -and (Test-Path -LiteralPath $AdminExe)) {
+        Write-Host '>>> Removing ODBC benchmark tables...'
+        $env:ODBC_BENCH_DRIVER = $CandidateDriverName
+        $env:ODBC_BENCH_SCENARIO = ''
+        Invoke-CleanupNative -Description 'Benchmark table cleanup' -Command { & $AdminExe cleanup }
+    }
+    if ($BaselineRegistrationAttempted) {
+        try { Restore-DriverRegistration -State $BaselineState } catch { Write-Warning $_ }
+    }
+    if ($CandidateRegistrationAttempted) {
+        try { Restore-DriverRegistration -State $CandidateState } catch { Write-Warning $_ }
+    }
+    if (Test-Path -LiteralPath $BaselineTree) {
+        Invoke-CleanupNative -Description 'Baseline worktree removal' -Command {
+            git worktree remove --force $BaselineTree
+        }
+    }
+    if (Test-Path -LiteralPath $BaselineTempDir) {
+        Remove-Item -LiteralPath $BaselineTempDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/mssql-odbc-bench/perf-lab/run-benchmarks.ps1
+++ b/mssql-odbc-bench/perf-lab/run-benchmarks.ps1
@@ -63,6 +63,71 @@ function Get-PositiveIntEnv {
     return $parsed
 }
 
+function Get-RatioEnv {
+    # Ratios are passed through to the comparator, which owns their validation;
+    # parse here only to keep the runner's own arithmetic culture-invariant.
+    param([Parameter(Mandatory)][string]$Name, [Parameter(Mandatory)][double]$Default)
+
+    $raw = [Environment]::GetEnvironmentVariable($Name)
+    if ([string]::IsNullOrEmpty($raw)) {
+        return $Default
+    }
+    $parsed = 0.0
+    if (-not [double]::TryParse(
+            $raw,
+            [System.Globalization.NumberStyles]::Float,
+            [System.Globalization.CultureInfo]::InvariantCulture,
+            [ref]$parsed
+        ) -or $parsed -le 1.0) {
+        throw "$Name must be a number greater than 1"
+    }
+    return $parsed
+}
+
+function Format-Invariant {
+    param([Parameter(Mandatory)][double]$Value, [string]$Format = 'F6')
+
+    return $Value.ToString($Format, [System.Globalization.CultureInfo]::InvariantCulture)
+}
+
+function Get-CpuSample {
+    # Effective MHz = base MHz * %perf/100 (%perf exceeds 100 under turbo).
+    # Temperature is normally unavailable in an Azure guest, so it stays optional.
+    $perf = $null; $freq = $null; $busy = $null; $temp = $null
+    try {
+        $samples = (Get-Counter -Counter @(
+                '\Processor Information(_Total)\% Processor Performance',
+                '\Processor Information(_Total)\Processor Frequency',
+                '\Processor Information(_Total)\% Processor Time') -ErrorAction Stop).CounterSamples
+        $perf = [math]::Round($samples[0].CookedValue, 1)
+        $freq = [math]::Round($samples[1].CookedValue, 0)
+        $busy = [math]::Round($samples[2].CookedValue, 1)
+    } catch { }
+    $effective = if (($null -ne $perf) -and ($null -ne $freq)) {
+        [math]::Round($freq * $perf / 100.0, 0)
+    } else {
+        $null
+    }
+    return [pscustomobject]@{
+        PctPerf = $perf; BaseMHz = $freq; EffMHz = $effective; Busy = $busy; TempC = $temp
+    }
+}
+
+function Write-CpuSample {
+    # Bracket every measured pass so a confirmation round that disagrees with the
+    # initial pass can be checked against the machine's own frequency/load.
+    param([Parameter(Mandatory)][string]$Label)
+
+    $sample = Get-CpuSample
+    if ($script:TelemetryCsv) {
+        ('{0:o},{1},{2},{3},{4},{5},{6}' -f (Get-Date), $Label, $sample.PctPerf,
+            $sample.BaseMHz, $sample.EffMHz, $sample.Busy, $sample.TempC) |
+            Add-Content -Path $script:TelemetryCsv -Encoding utf8
+    }
+    Write-Host (">>> cpu[{0}] effFreq={1}MHz base={2}MHz %perf={3} busy={4}% temp={5}" -f
+        $Label, $sample.EffMHz, $sample.BaseMHz, $sample.PctPerf, $sample.Busy, $sample.TempC)
+}
+
 function ConvertTo-AffinityMask {
     # Translate the Linux-style CPU list used by the perf lab into the mask required
     # by Windows ProcessorAffinity.
@@ -220,19 +285,72 @@ function Build-Driver {
     }
 }
 
+function Find-Sqlcmd {
+    $command = Get-Command sqlcmd -ErrorAction SilentlyContinue
+    if ($command) {
+        return $command.Source
+    }
+    $probe = 'C:\Program Files\Microsoft SQL Server\Client SDK\ODBC\Tools\Binn\SQLCMD.EXE'
+    if (Test-Path -LiteralPath $probe) {
+        return $probe
+    }
+    return $null
+}
+
+function Initialize-BenchmarkPython {
+    # gbench/report.py imports NumPy and SciPy at module scope even with
+    # --no-utest, so Google Benchmark's comparator cannot run without them. Prefer
+    # an interpreter that already has them; otherwise build a private virtualenv
+    # so nothing is installed into the perf host's system Python.
+    param([Parameter(Mandatory)][string]$Python, [Parameter(Mandatory)][string]$VenvRoot)
+
+    # Missing imports are an expected probe result. PowerShell 5.1 can promote a
+    # native command's redirected stderr to a terminating error under Stop, so use
+    # the exit code while this function runs native Python commands.
+    $previousPreference = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        & $Python -c 'import numpy, scipy' *> $null
+        if ($LASTEXITCODE -eq 0) {
+            return $Python
+        }
+
+        Write-Host ">>> Provisioning NumPy/SciPy for Google Benchmark's comparator..."
+        $venvPython = Join-Path $VenvRoot 'Scripts\python.exe'
+        if (-not (Test-Path -LiteralPath $venvPython)) {
+            & $Python -m venv $VenvRoot *> $null
+            if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $venvPython)) {
+                return $null
+            }
+        }
+        # Send pip's output to the host so only the interpreter path is returned.
+        & $venvPython -m pip install --quiet --upgrade pip *> $null
+        & $venvPython -m pip install --quiet numpy scipy | Out-Host
+        if ($LASTEXITCODE -ne 0) {
+            return $null
+        }
+        return $venvPython
+    } finally {
+        $ErrorActionPreference = $previousPreference
+    }
+}
+
 function Invoke-BenchmarkLeg {
     # Keep one raw JSON file per driver/scenario and use the packet-size spelling
-    # accepted by that driver.
+    # accepted by that driver. An empty scenario runs every workload in one process.
     param(
-        [Parameter(Mandatory)][string]$Scenario,
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Scenario,
         [Parameter(Mandatory)][string]$Driver,
         [Parameter(Mandatory)][string]$Output
     )
 
-    Write-Host ">>> Running $Scenario with $Driver..."
+    $label = if ($Scenario) { $Scenario } else { 'all scenarios' }
+    Write-Host ">>> Running $label with $Driver..."
     $env:ODBC_BENCH_DRIVER = $Driver
     $env:ODBC_BENCH_SCENARIO = $Scenario
-    $env:ODBC_BENCH_PACKET_SIZE_KEYWORD = if ($Driver -eq $MicrosoftDriverName) {
+    # Windows Microsoft ODBC accepts the spaced spelling; the Rust driver and the
+    # Linux runner use PacketSize.
+    $env:ODBC_BENCH_PACKET_SIZE_KEYWORD = if ($Driver -eq $script:MicrosoftDriverName) {
         'Packet Size'
     } else {
         'PacketSize'
@@ -245,19 +363,123 @@ function Invoke-BenchmarkLeg {
     Invoke-Native { & $script:BenchExe @arguments }
 }
 
+function Invoke-Comparator {
+    # Exit 2 means the report was written and the gate tripped, so it has to reach
+    # the caller instead of becoming a terminating error. The comparator's own
+    # output goes straight to the host so only the exit code is returned.
+    param([Parameter(Mandatory)][string[]]$Arguments)
+
+    $previousPreference = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        & $script:BenchPython $script:CompareScript @Arguments | Out-Host
+        return $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $previousPreference
+    }
+}
+
+function Get-BenchmarkScenario {
+    # The harness filters by scenario, not by benchmark id, so map each flagged
+    # benchmark back to the scenario file it came out of.
+    param([Parameter(Mandatory)][string]$Name, [Parameter(Mandatory)][hashtable]$ScenarioFiles)
+
+    foreach ($scenario in $ScenarioFiles.Keys) {
+        if (Select-String -LiteralPath $ScenarioFiles[$scenario] `
+                -SimpleMatch -Pattern """run_name"": ""$Name""" -Quiet) {
+            return $scenario
+        }
+    }
+    throw "Cannot map benchmark '$Name' to a scenario"
+}
+
+function Get-ConfirmationTally {
+    # Hits count rounds that reproduce the initial direction; the median covers the
+    # confirmation rounds only.
+    param(
+        [Parameter(Mandatory)][string]$Kind,
+        [Parameter(Mandatory)][double[]]$Ratios,
+        [Parameter(Mandatory)][double]$RegressionRatio,
+        [Parameter(Mandatory)][double]$ImprovementRatio
+    )
+
+    $hits = 0
+    $regressionHits = 0
+    foreach ($ratio in $Ratios) {
+        if ($ratio -ge $RegressionRatio) { $regressionHits++ }
+        if ($Kind -eq 'regression') {
+            if ($ratio -ge $RegressionRatio) { $hits++ }
+        } elseif ($ratio -le (1.0 / $ImprovementRatio)) {
+            $hits++
+        }
+    }
+    $sorted = @($Ratios | Sort-Object)
+    $count = $sorted.Count
+    $median = if ($count % 2 -eq 1) {
+        $sorted[($count - 1) / 2]
+    } else {
+        ($sorted[$count / 2 - 1] + $sorted[$count / 2]) / 2
+    }
+    return [pscustomobject]@{
+        Hits = $hits; RegressionHits = $regressionHits; Median = $median
+    }
+}
+
+function Read-RatioFile {
+    param([Parameter(Mandatory)][string]$Path)
+
+    $ratios = @{}
+    foreach ($line in Get-Content -LiteralPath $Path) {
+        if (-not $line.Trim()) { continue }
+        $fields = $line -split "`t"
+        if ($fields.Count -lt 2) { continue }
+        $value = 0.0
+        if ([double]::TryParse(
+                $fields[1],
+                [System.Globalization.NumberStyles]::Float,
+                [System.Globalization.CultureInfo]::InvariantCulture,
+                [ref]$value
+            )) {
+            $ratios[$fields[0]] = $value
+        }
+    }
+    return $ratios
+}
+
 $RepoRoot = (Get-Location).Path
 $ResultsDir = Join-Path $RepoRoot 'results'
+$InitialDir = Join-Path $ResultsDir 'initial'
+$ConfirmDir = Join-Path $ResultsDir 'confirm'
+$PlanFile = Join-Path $ResultsDir 'confirm-plan.txt'
 $BaselineFile = Join-Path $RepoRoot 'mssql-odbc-bench\perf-lab\baseline-commit.txt'
 $ReferenceVersionFile = Join-Path $RepoRoot 'mssql-odbc-bench\perf-lab\msodbcsql-version.txt'
+# One shared snapshot query for both perf labs; do not fork a second copy.
+$SqlConfigSql = Join-Path $RepoRoot 'mssql-tds-bench\perf-lab\sql-config-dump.sql'
+$script:CompareScript = Join-Path $RepoRoot '.pipeline\scripts\compare-odbc-benchmarks.py'
 $HarnessBuildDir = Join-Path $RepoRoot 'target\odbc-bench'
 $CandidateTargetDir = Join-Path $RepoRoot 'target\odbc-candidate'
 $BaselineTargetDir = Join-Path $RepoRoot 'target\odbc-baseline'
 $CandidateDriverName = 'MSSQL Rust ODBC Perf Candidate'
 $BaselineDriverName = 'MSSQL Rust ODBC Perf Baseline'
-$MicrosoftDriverName = 'ODBC Driver 18 for SQL Server'
+$script:MicrosoftDriverName = 'ODBC Driver 18 for SQL Server'
 $script:OdbcInstRoot = 'HKLM:\Software\ODBC\ODBCINST.INI'
 $script:DriversRegKey = "$script:OdbcInstRoot\ODBC Drivers"
 $script:Repetitions = Get-PositiveIntEnv -Name 'ODBC_BENCH_REPETITIONS' -Default 5
+# Confirmation defaults match the fixed-baseline mssql-tds runner: four targeted
+# re-runs, reproduction required in a majority (3 of 4).
+$ConfirmRuns = Get-PositiveIntEnv -Name 'ODBC_BENCH_CONFIRM_RUNS' -Default 4
+$ConfirmQuorum = Get-PositiveIntEnv -Name 'ODBC_BENCH_CONFIRM_QUORUM' `
+    -Default ([int][math]::Floor($ConfirmRuns / 2) + 1)
+if ($ConfirmQuorum -gt $ConfirmRuns) {
+    throw 'ODBC_BENCH_CONFIRM_QUORUM must not exceed ODBC_BENCH_CONFIRM_RUNS'
+}
+$ImprovementMax = Get-PositiveIntEnv -Name 'ODBC_BENCH_IMPROVEMENT_VERIFY_MAX' -Default 3
+$RegressionRatio = Get-RatioEnv -Name 'ODBC_BENCH_REGRESSION_RATIO' -Default 1.05
+$ImprovementRatio = Get-RatioEnv -Name 'ODBC_BENCH_IMPROVEMENT_VERIFY_RATIO' `
+    -Default $RegressionRatio
+# A confirmed candidate-vs-pinned-baseline regression fails the run by default;
+# set ODBC_BENCH_FAIL_ON_REGRESSION=0 to publish the report without gating.
+$GateEnabled = $env:ODBC_BENCH_FAIL_ON_REGRESSION -ne '0'
 
 if (-not $env:SQL_SERVER) {
     throw 'SQL_SERVER not set'
@@ -278,6 +500,34 @@ if (-not $env:ODBC_BENCH_PACKET_SIZE) { $env:ODBC_BENCH_PACKET_SIZE = '32768' }
 
 New-Item -ItemType Directory -Force -Path $ResultsDir | Out-Null
 
+$script:TelemetryCsv = Join-Path $ResultsDir 'cpu-telemetry.csv'
+'timestamp,label,pct_processor_performance,base_freq_mhz,eff_freq_mhz,cpu_busy_pct,temp_c' |
+    Set-Content -Path $script:TelemetryCsv -Encoding utf8
+
+# --- Large-buffer and scheduling controls (Windows equivalents) ---
+# Each retrieval allocates bound rowset buffers for up to 600 columns by 1024
+# rows. glibc's MALLOC_MMAP_THRESHOLD_/MALLOC_TRIM_THRESHOLD_ used by the Linux
+# runner have no Windows counterpart that a parent process can set, so the
+# Windows side targets the same goal - stable large-allocation cost and stable
+# clocks - with the controls that do exist: keep the child off the debug heap
+# (which adds per-allocation bookkeeping to exactly these multi-MB buffers), run
+# at High priority so the fetch loop is not preempted by agent housekeeping, and
+# ask for the High performance power scheme so the CPU frequency this run
+# records stays flat. Priority and power scheme are restored in the finally
+# block; both are best effort.
+$PreviousNoDebugHeapExists = Test-Path Env:_NO_DEBUG_HEAP
+$PreviousNoDebugHeap = $env:_NO_DEBUG_HEAP
+$PreviousPriority = $null
+$PreviousPowerScheme = $null
+$PreviousAffinity = $null
+
+# --- No connection-churn network tuning here (deliberate) ---
+# mssql-tds-bench widens the ephemeral port range and enables TIME_WAIT reuse
+# because its concurrent_connects benchmark opens tens of thousands of
+# short-lived TCP connections. This harness opens ONE connection in OdbcSession,
+# holds it for the whole process, and measures only statement execution and
+# fetching, so there is no port pressure to relieve.
+
 if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) {
     Write-Host '>>> Installing Rust toolchain...'
     & (Join-Path $RepoRoot '.pipeline\scripts\InstallRustup.ps1')
@@ -297,7 +547,7 @@ if (-not $PythonCommand) {
 if (-not $PythonCommand) {
     throw 'Python 3 not found'
 }
-$Python = $PythonCommand.Source
+$script:BenchPython = $PythonCommand.Source
 
 if (-not (Test-Path -LiteralPath $BaselineFile)) {
     throw "Baseline file not found: $BaselineFile"
@@ -308,10 +558,7 @@ $BaselineCommit = (Get-Content -LiteralPath $BaselineFile |
 if ($BaselineCommit -notmatch '^[0-9a-fA-F]{40}$') {
     throw "Invalid baseline commit in $BaselineFile"
 }
-& git rev-parse --verify --quiet "$BaselineCommit^{commit}" *> $null
-if ($LASTEXITCODE -ne 0) {
-    throw "Baseline commit $BaselineCommit is absent from the checkout"
-}
+Invoke-Native { git rev-parse --verify --quiet "$BaselineCommit^{commit}" *> $null }
 
 if (-not (Test-Path -LiteralPath $ReferenceVersionFile)) {
     throw "Reference version file not found: $ReferenceVersionFile"
@@ -324,9 +571,9 @@ if ($MicrosoftVersion -notmatch '^[0-9]+(\.[0-9]+){3}$') {
 }
 & (Join-Path $RepoRoot '.pipeline\scripts\install-msodbcsql.ps1') `
     -Version $MicrosoftVersion
-$MicrosoftKey = "$script:OdbcInstRoot\$MicrosoftDriverName"
+$MicrosoftKey = "$script:OdbcInstRoot\$script:MicrosoftDriverName"
 if (-not (Test-Path -LiteralPath $MicrosoftKey)) {
-    throw "'$MicrosoftDriverName' was not registered after installation"
+    throw "'$script:MicrosoftDriverName' was not registered after installation"
 }
 $MicrosoftDriver = (Get-ItemProperty -LiteralPath $MicrosoftKey -Name 'Driver').Driver
 if (-not $MicrosoftDriver -or -not (Test-Path -LiteralPath $MicrosoftDriver)) {
@@ -334,6 +581,21 @@ if (-not $MicrosoftDriver -or -not (Test-Path -LiteralPath $MicrosoftDriver)) {
 }
 $MicrosoftDriverInfo = (Get-Item -LiteralPath $MicrosoftDriver).VersionInfo
 $MicrosoftDriverSha256 = (Get-FileHash -LiteralPath $MicrosoftDriver -Algorithm SHA256).Hash
+
+# --- SQL Server configuration snapshot (validate the instance is tuned) ---
+# Memory, MAXDOP, cost threshold, affinity, tempdb placement, recovery, and trace
+# flags. Best-effort: a missing snapshot must not cost a whole lab run.
+$SqlcmdExe = Find-Sqlcmd
+if ($SqlcmdExe -and (Test-Path -LiteralPath $SqlConfigSql)) {
+    Write-Host '>>> Capturing SQL Server configuration snapshot...'
+    Invoke-CleanupNative -Description 'SQL config snapshot' -Command {
+        & $SqlcmdExe -S $env:ODBC_BENCH_SERVER -U $env:ODBC_BENCH_UID `
+            -P $env:ODBC_BENCH_PWD -C -b -y 0 -Y 30 -i $SqlConfigSql |
+            Tee-Object -FilePath (Join-Path $ResultsDir 'sql-config.txt')
+    }
+} else {
+    Write-Host '>>> Skipping SQL config snapshot (sqlcmd or query file not found).'
+}
 
 $BaselineTempDir = Join-Path ([System.IO.Path]::GetTempPath()) "odbc-perf-$([System.Guid]::NewGuid().ToString('N'))"
 $BaselineTree = Join-Path $BaselineTempDir 'worktree'
@@ -347,6 +609,7 @@ $AdminExe = ''
 $HarnessRuntimeDir = Join-Path $HarnessBuildDir 'Release'
 
 try {
+    $env:_NO_DEBUG_HEAP = '1'
     Write-Host '>>> Building the fixed C++ benchmark harness...'
     try {
         Invoke-Native {
@@ -370,6 +633,21 @@ try {
         }
     }
     Invoke-Native { & $CMake --build $HarnessBuildDir --config Release --parallel }
+
+    # The pinned Google Benchmark v1.9.1 checkout ships the comparator we report
+    # with; using the copy from this build tree keeps the tool and the harness on
+    # the same version.
+    $GbenchCompare = Join-Path $HarnessBuildDir '_deps\googlebenchmark-src\tools\compare.py'
+    if (-not (Test-Path -LiteralPath $GbenchCompare)) {
+        throw "Google Benchmark comparator not found: $GbenchCompare"
+    }
+    $GbenchArguments = @('--gbench-compare', $GbenchCompare)
+    $StatsPython = Initialize-BenchmarkPython -Python $script:BenchPython `
+        -VenvRoot (Join-Path $RepoRoot 'target\odbc-bench-venv')
+    if (-not $StatsPython) {
+        throw "NumPy/SciPy are required by Google Benchmark's compare.py"
+    }
+    $script:BenchPython = $StatsPython
 
     Build-Driver -SourceRoot $RepoRoot -TargetDir $CandidateTargetDir -Label 'candidate'
 
@@ -401,18 +679,27 @@ try {
     $BaselineRegistrationAttempted = $true
     Set-DriverRegistration -Name $BaselineDriverName -DriverPath $BaselineDriver
 
+    $CandidateCommit = (Invoke-Native { git rev-parse HEAD } | Out-String).Trim()
+    $RustcVersion = (Invoke-Native { rustc -Vv } | Out-String).TrimEnd()
+    $CargoVersion = (Invoke-Native { cargo -V } | Out-String).TrimEnd()
+    $CMakeVersion = (Invoke-Native { & $CMake --version } | Out-String).TrimEnd()
     $context = @(
-        "candidate_commit=$(& git rev-parse HEAD)",
+        "candidate_commit=$CandidateCommit",
         "baseline_commit=$BaselineCommit",
         "microsoft_driver_version=$MicrosoftVersion",
         "microsoft_driver_product_version=$($MicrosoftDriverInfo.ProductVersion)",
         "microsoft_driver_path=$MicrosoftDriver",
         "microsoft_driver_sha256=$MicrosoftDriverSha256",
         "repetitions=$script:Repetitions",
+        "regression_ratio=$(Format-Invariant $RegressionRatio 'F4')",
+        "confirm_runs=$ConfirmRuns",
+        "confirm_quorum=$ConfirmQuorum",
+        "gbench_compare=$(if ($GbenchArguments.Count) { $GbenchCompare } else { 'disabled' })",
+        "bench_python=$script:BenchPython",
         "timestamp_utc=$([DateTime]::UtcNow.ToString('o'))",
-        (& rustc -Vv | Out-String).TrimEnd(),
-        (& cargo -V | Out-String).TrimEnd(),
-        (& $CMake --version | Out-String).TrimEnd()
+        $RustcVersion,
+        $CargoVersion,
+        $CMakeVersion
     ) -join "`n"
     $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
     [System.IO.File]::WriteAllText(
@@ -431,11 +718,38 @@ try {
     $affinity = ConvertTo-AffinityMask -CpuList $cpuList
     if ($null -ne $affinity) {
         try {
+            $PreviousAffinity = (Get-Process -Id $PID).ProcessorAffinity
             (Get-Process -Id $PID).ProcessorAffinity = [IntPtr]$affinity
             Write-Host ">>> Pinned benchmark processes to CPUs: $cpuList"
         } catch {
+            $PreviousAffinity = $null
             Write-Warning "Could not set benchmark CPU affinity: $($_.Exception.Message)"
         }
+    }
+    # Child processes inherit this process's priority class, so raising it here
+    # covers every benchmark leg.
+    try {
+        $PreviousPriority = (Get-Process -Id $PID).PriorityClass
+        (Get-Process -Id $PID).PriorityClass = 'High'
+        Write-Host '>>> Benchmark processes raised to High priority'
+    } catch {
+        $PreviousPriority = $null
+        Write-Warning "Could not raise benchmark priority: $($_.Exception.Message)"
+    }
+    try {
+        $activeScheme = (& powercfg /getactivescheme | Out-String)
+        if ($activeScheme -match '([0-9a-fA-F-]{36})') {
+            $PreviousPowerScheme = $Matches[1]
+            & powercfg /setactive 8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c *> $null
+            if ($LASTEXITCODE -eq 0) {
+                Write-Host '>>> Active power scheme set to High performance'
+            } else {
+                $PreviousPowerScheme = $null
+            }
+        }
+    } catch {
+        $PreviousPowerScheme = $null
+        Write-Warning "Could not set the High performance power scheme: $($_.Exception.Message)"
     }
 
     $candidateNarrow = Join-Path $ResultsDir 'odbc-candidate-narrow.json'
@@ -445,15 +759,16 @@ try {
     $microsoftNarrow = Join-Path $ResultsDir 'odbc-microsoft-narrow.json'
     $microsoftWide = Join-Path $ResultsDir 'odbc-microsoft-wide.json'
 
+    Write-CpuSample 'initial-start'
     Invoke-BenchmarkLeg -Scenario 'narrow' -Driver $CandidateDriverName -Output $candidateNarrow
-    Invoke-BenchmarkLeg -Scenario 'narrow' -Driver $MicrosoftDriverName -Output $microsoftNarrow
+    Invoke-BenchmarkLeg -Scenario 'narrow' -Driver $script:MicrosoftDriverName -Output $microsoftNarrow
     Invoke-BenchmarkLeg -Scenario 'narrow' -Driver $BaselineDriverName -Output $baselineNarrow
     Invoke-BenchmarkLeg -Scenario 'wide' -Driver $BaselineDriverName -Output $baselineWide
-    Invoke-BenchmarkLeg -Scenario 'wide' -Driver $MicrosoftDriverName -Output $microsoftWide
+    Invoke-BenchmarkLeg -Scenario 'wide' -Driver $script:MicrosoftDriverName -Output $microsoftWide
     Invoke-BenchmarkLeg -Scenario 'wide' -Driver $CandidateDriverName -Output $candidateWide
+    Write-CpuSample 'initial-end'
 
-    $compareArguments = @(
-        (Join-Path $RepoRoot '.pipeline\scripts\compare-odbc-benchmarks.py'),
+    $threeWayArguments = @(
         '--baseline', $baselineNarrow,
         '--baseline', $baselineWide,
         '--candidate', $candidateNarrow,
@@ -464,23 +779,134 @@ try {
         '--baseline-commit', $BaselineCommit,
         '--reference-version', $MicrosoftVersion,
         '--repetitions', [string]$script:Repetitions,
+        '--regression-ratio', (Format-Invariant $RegressionRatio),
+        '--improvement-ratio', (Format-Invariant $ImprovementRatio),
+        '--improvement-max', [string]$ImprovementMax
+    ) + $GbenchArguments
+
+    # --- Initial pass: five-sample medians pick what deserves re-measurement ---
+    # The initial verdict never gates on its own; it only produces the plan.
+    Write-Host '>>> Comparing the initial three-driver pass...'
+    $initialExit = Invoke-Comparator -Arguments ($threeWayArguments + @(
+            '--output-dir', $InitialDir,
+            '--plan-out', $PlanFile,
+            '--no-summary',
+            '--no-fail-on-regression'
+        ))
+    if ($initialExit -ne 0) {
+        throw "Initial ODBC benchmark comparison failed (exit $initialExit)"
+    }
+
+    $scenarioFiles = @{ narrow = $candidateNarrow; wide = $candidateWide }
+    $plan = @()
+    foreach ($line in Get-Content -LiteralPath $PlanFile) {
+        if (-not $line.Trim()) { continue }
+        $fields = $line -split "`t"
+        $entry = [pscustomobject]@{
+            Kind = $fields[0]
+            Name = $fields[1]
+            Scenario = Get-BenchmarkScenario -Name $fields[1] -ScenarioFiles $scenarioFiles
+        }
+        Write-Host ">>> Initial pass flagged $($entry.Kind): $($entry.Name) (ratio $($fields[2]))"
+        $plan += $entry
+    }
+
+    $confirmationArguments = @()
+    if ($plan.Count -gt 0) {
+        # One process covers both scenarios; only narrow those legs when the other
+        # workload has nothing to confirm.
+        $selected = @($plan | ForEach-Object { $_.Scenario } | Sort-Object -Unique)
+        $confirmScenario = if ($selected.Count -eq 1) { $selected[0] } else { '' }
+
+        Write-Host ((">>> Auto-confirm: re-measuring {0} benchmark(s) over {1} round(s); " +
+                "a result counts only when it reproduces in >= {2} of {1}.") -f
+            $plan.Count, $ConfirmRuns, $ConfirmQuorum)
+        $roundRatios = @()
+        for ($round = 1; $round -le $ConfirmRuns; $round++) {
+            $roundDir = Join-Path $ConfirmDir "round$round"
+            New-Item -ItemType Directory -Force -Path $roundDir | Out-Null
+            Write-Host ">>> Confirmation round $round/$ConfirmRuns..."
+            Write-CpuSample "confirm$round-start"
+            # Keep each pair adjacent, and alternate which side runs first so a
+            # stable position effect cancels across the default four rounds.
+            if ($round % 2 -eq 1) {
+                Invoke-BenchmarkLeg -Scenario $confirmScenario -Driver $CandidateDriverName `
+                    -Output (Join-Path $roundDir 'candidate.json')
+                Invoke-BenchmarkLeg -Scenario $confirmScenario -Driver $BaselineDriverName `
+                    -Output (Join-Path $roundDir 'baseline.json')
+            } else {
+                Invoke-BenchmarkLeg -Scenario $confirmScenario -Driver $BaselineDriverName `
+                    -Output (Join-Path $roundDir 'baseline.json')
+                Invoke-BenchmarkLeg -Scenario $confirmScenario -Driver $CandidateDriverName `
+                    -Output (Join-Path $roundDir 'candidate.json')
+            }
+            Write-CpuSample "confirm$round-end"
+            $roundArguments = @(
+                '--baseline', (Join-Path $roundDir 'baseline.json'),
+                '--candidate', (Join-Path $roundDir 'candidate.json'),
+                '--repetitions', [string]$script:Repetitions,
+                '--regression-ratio', (Format-Invariant $RegressionRatio),
+                '--improvement-ratio', (Format-Invariant $ImprovementRatio),
+                '--output-dir', $roundDir,
+                '--ratios-out', (Join-Path $roundDir 'ratios.txt'),
+                '--no-summary',
+                '--no-fail-on-regression'
+            ) + $GbenchArguments
+            $previousPreference = $ErrorActionPreference
+            $ErrorActionPreference = 'Continue'
+            try {
+                & $script:BenchPython $script:CompareScript @roundArguments *>&1 |
+                    Out-File -FilePath (Join-Path $roundDir 'comparison.log') -Encoding utf8
+                $roundExit = $LASTEXITCODE
+            } finally {
+                $ErrorActionPreference = $previousPreference
+            }
+            if ($roundExit -ne 0) {
+                throw "Confirmation round $round comparison failed (exit $roundExit)"
+            }
+            $roundRatios += , (Read-RatioFile -Path (Join-Path $roundDir 'ratios.txt'))
+        }
+
+        foreach ($entry in $plan) {
+            $observed = @()
+            foreach ($table in $roundRatios) {
+                if ($table.ContainsKey($entry.Name)) {
+                    $observed += $table[$entry.Name]
+                }
+            }
+            if ($observed.Count -ne $ConfirmRuns) {
+                throw ("Expected $ConfirmRuns confirmation ratios for '$($entry.Name)'; " +
+                    "found $($observed.Count)")
+            }
+            # Median of the confirmation rounds only. The initial pass is excluded
+            # on purpose: a benchmark is re-measured because that pass was extreme,
+            # so letting it vote again would let the outlier under test decide its
+            # own verdict and could contradict a quorum that cleared it.
+            $tally = Get-ConfirmationTally -Kind $entry.Kind -Ratios $observed `
+                -RegressionRatio $RegressionRatio -ImprovementRatio $ImprovementRatio
+            Write-Host (((">>> {0}: reproduced {1}/{2} in the initial direction, " +
+                    "regressed {3}/{2}, confirmation median {4}") -f
+                    $entry.Name, $tally.Hits, $ConfirmRuns, $tally.RegressionHits,
+                    (Format-Invariant $tally.Median)))
+            $confirmationArguments += @(
+                '--confirmation', $entry.Name, [string]$tally.Hits,
+                [string]$tally.RegressionHits,
+                (Format-Invariant $tally.Median)
+            )
+        }
+    }
+
+    $finalArguments = $threeWayArguments + @(
         '--output-dir', $ResultsDir,
-        '--regression-ratio',
-        $(if ($env:ODBC_BENCH_REGRESSION_RATIO) { $env:ODBC_BENCH_REGRESSION_RATIO } else { '1.10' })
-    )
-    if ($env:ODBC_BENCH_FAIL_ON_REGRESSION -eq '1') {
-        $compareArguments += '--fail-on-regression'
+        '--confirm-runs', [string]$ConfirmRuns,
+        '--confirm-quorum', [string]$ConfirmQuorum
+    ) + $confirmationArguments
+    if (-not $GateEnabled) {
+        $finalArguments += '--no-fail-on-regression'
     }
-    # Exit 2 means the report was written and the optional gate tripped. Preserve
-    # it until after the report reaches the step log.
-    $previousPreference = $ErrorActionPreference
-    $ErrorActionPreference = 'Continue'
-    try {
-        & $Python @compareArguments
-        $compareExitCode = $LASTEXITCODE
-    } finally {
-        $ErrorActionPreference = $previousPreference
-    }
+    # Exit 2 means the report was written and the gate tripped. Preserve it until
+    # after the report reaches the step log.
+    $compareExitCode = Invoke-Comparator -Arguments $finalArguments
     if ($compareExitCode -ne 0 -and $compareExitCode -ne 2) {
         throw "ODBC benchmark comparison failed (exit $compareExitCode)"
     }
@@ -505,6 +931,22 @@ try {
     }
     if ($CandidateRegistrationAttempted) {
         try { Restore-DriverRegistration -State $CandidateState } catch { Write-Warning $_ }
+    }
+    if ($PreviousPowerScheme) {
+        Invoke-CleanupNative -Description 'Power scheme restore' -Command {
+            & powercfg /setactive $PreviousPowerScheme
+        }
+    }
+    if ($PreviousPriority) {
+        try { (Get-Process -Id $PID).PriorityClass = $PreviousPriority } catch { Write-Warning $_ }
+    }
+    if ($null -ne $PreviousAffinity) {
+        try { (Get-Process -Id $PID).ProcessorAffinity = $PreviousAffinity } catch { Write-Warning $_ }
+    }
+    if ($PreviousNoDebugHeapExists) {
+        $env:_NO_DEBUG_HEAP = $PreviousNoDebugHeap
+    } else {
+        Remove-Item Env:_NO_DEBUG_HEAP -ErrorAction SilentlyContinue
     }
     if (Test-Path -LiteralPath $BaselineTree) {
         Invoke-CleanupNative -Description 'Baseline worktree removal' -Command {

--- a/mssql-odbc-bench/perf-lab/run-benchmarks.ps1
+++ b/mssql-odbc-bench/perf-lab/run-benchmarks.ps1
@@ -703,7 +703,7 @@ try {
         "regression_ratio=$(Format-Invariant $RegressionRatio 'F4')",
         "confirm_runs=$ConfirmRuns",
         "confirm_quorum=$ConfirmQuorum",
-        "gbench_compare=$(if ($GbenchArguments.Count) { $GbenchCompare } else { 'disabled' })",
+        "gbench_compare=$GbenchCompare",
         "bench_python=$script:BenchPython",
         "numpy_version=$script:NumpyVersion",
         "scipy_version=$script:ScipyVersion",

--- a/mssql-odbc-bench/perf-lab/run-benchmarks.sh
+++ b/mssql-odbc-bench/perf-lab/run-benchmarks.sh
@@ -26,8 +26,8 @@ BASELINE_TARGET_DIR="$REPO_ROOT/target/odbc-baseline"
 CANDIDATE_DRIVER_NAME="MSSQL Rust ODBC Perf Candidate"
 BASELINE_DRIVER_NAME="MSSQL Rust ODBC Perf Baseline"
 MICROSOFT_DRIVER_NAME="ODBC Driver 18 for SQL Server"
-NUMPY_VERSION="2.4.6"
-SCIPY_VERSION="1.18.0"
+NUMPY_VERSION="2.2.6"
+SCIPY_VERSION="1.15.3"
 
 # Scenario catalog. The C++ harness filters its workloads by scenario, and every
 # downstream step - ordering, comparison, confirmation - iterates this list, so a

--- a/mssql-odbc-bench/perf-lab/run-benchmarks.sh
+++ b/mssql-odbc-bench/perf-lab/run-benchmarks.sh
@@ -256,14 +256,10 @@ run_leg() {
     local scenario="$1"
     local driver="$2"
     local output="$3"
-    local packet_size_keyword="PacketSize"
-    if [ "$driver" = "$MICROSOFT_DRIVER_NAME" ]; then
-        packet_size_keyword="Packet Size"
-    fi
     echo ">>> Running $scenario with $driver..."
     ODBC_BENCH_DRIVER="$driver" \
         ODBC_BENCH_SCENARIO="$scenario" \
-        ODBC_BENCH_PACKET_SIZE_KEYWORD="$packet_size_keyword" \
+        ODBC_BENCH_PACKET_SIZE_KEYWORD="PacketSize" \
         "${BENCH_PREFIX[@]}" "$BENCH_EXE" \
         "--benchmark_repetitions=$REPETITIONS" \
         "--benchmark_out=$output" \

--- a/mssql-odbc-bench/perf-lab/run-benchmarks.sh
+++ b/mssql-odbc-bench/perf-lab/run-benchmarks.sh
@@ -26,6 +26,8 @@ BASELINE_TARGET_DIR="$REPO_ROOT/target/odbc-baseline"
 CANDIDATE_DRIVER_NAME="MSSQL Rust ODBC Perf Candidate"
 BASELINE_DRIVER_NAME="MSSQL Rust ODBC Perf Baseline"
 MICROSOFT_DRIVER_NAME="ODBC Driver 18 for SQL Server"
+NUMPY_VERSION="2.4.6"
+SCIPY_VERSION="1.18.0"
 
 # Scenario catalog. The C++ harness filters its workloads by scenario, and every
 # downstream step - ordering, comparison, confirmation - iterates this list, so a
@@ -237,7 +239,8 @@ ensure_python_stats() {
         return 1
     fi
     "$venv/bin/python" -m pip install --quiet --upgrade pip >/dev/null 2>&1 || true
-    "$venv/bin/python" -m pip install --quiet numpy scipy || return 1
+    "$venv/bin/python" -m pip install --quiet \
+        "numpy==$NUMPY_VERSION" "scipy==$SCIPY_VERSION" || return 1
     BENCH_PYTHON="$venv/bin/python"
 }
 
@@ -414,7 +417,9 @@ fi
     echo "regression_ratio=$REGRESSION_RATIO"
     echo "confirm_runs=$CONFIRM_RUNS"
     echo "confirm_quorum=$CONFIRM_QUORUM"
-    echo "gbench_compare=${GBENCH_ARGS[1]:-disabled}"
+    echo "gbench_compare=${GBENCH_ARGS[1]}"
+    echo "numpy_version=$NUMPY_VERSION"
+    echo "scipy_version=$SCIPY_VERSION"
     echo "bench_python=$BENCH_PYTHON"
     echo "malloc_mmap_threshold=$MALLOC_MMAP_THRESHOLD_"
     echo "malloc_trim_threshold=$MALLOC_TRIM_THRESHOLD_"
@@ -635,7 +640,7 @@ final_args=(
     --confirm-quorum "$CONFIRM_QUORUM"
     "${CONFIRMATION_ARGS[@]}"
 )
-if [ "$FAIL_ON_REGRESSION" != "1" ]; then
+if [ "$FAIL_ON_REGRESSION" = "0" ]; then
     final_args+=(--no-fail-on-regression)
 fi
 # Exit 2 means the comparison completed and the gate tripped. Delay that exit

--- a/mssql-odbc-bench/perf-lab/run-benchmarks.sh
+++ b/mssql-odbc-bench/perf-lab/run-benchmarks.sh
@@ -6,12 +6,20 @@
 
 set -euo pipefail
 set -E
+export LC_ALL=C
 trap 'rc=$?; echo "ERROR: ${BASH_SOURCE[0]}:${LINENO}: ${BASH_COMMAND} exited ${rc}" >&2' ERR
 
 REPO_ROOT="$(pwd)"
 RESULTS_DIR="$REPO_ROOT/results"
+INITIAL_DIR="$RESULTS_DIR/initial"
+CONFIRM_DIR="$RESULTS_DIR/confirm"
+PLAN_FILE="$RESULTS_DIR/confirm-plan.txt"
+TELEMETRY_CSV="$RESULTS_DIR/cpu-telemetry.csv"
 BASELINE_FILE="$REPO_ROOT/mssql-odbc-bench/perf-lab/baseline-commit.txt"
 REFERENCE_VERSION_FILE="$REPO_ROOT/mssql-odbc-bench/perf-lab/msodbcsql-version.txt"
+# One shared snapshot query for both perf labs; do not fork a second copy.
+SQL_CONFIG_SQL="$REPO_ROOT/mssql-tds-bench/perf-lab/sql-config-dump.sql"
+COMPARE_SCRIPT="$REPO_ROOT/.pipeline/scripts/compare-odbc-benchmarks.py"
 HARNESS_BUILD_DIR="$REPO_ROOT/target/odbc-bench"
 CANDIDATE_TARGET_DIR="$REPO_ROOT/target/odbc-candidate"
 BASELINE_TARGET_DIR="$REPO_ROOT/target/odbc-baseline"
@@ -57,6 +65,54 @@ trap cleanup EXIT
 
 mkdir -p "$RESULTS_DIR"
 
+# Bracketed CPU frequency/utilization samples around every measured pass. If a
+# confirmation round disagrees with the initial pass, this is what says whether
+# the machine changed underneath the measurement or the driver did.
+echo "timestamp,label,avg_cur_freq_mhz,cpu_busy_pct,temp_c" > "$TELEMETRY_CSV"
+cpu_busy_percent() {
+    # /proc/stat is cumulative since boot, so a single read reports a lifetime
+    # average. Take a short delta instead so the number describes this pass.
+    local first second
+    first=$(awk '/^cpu /{ t = 0; for (i = 2; i <= NF; i++) t += $i; print t, $5; exit }' /proc/stat) ||
+        return 1
+    sleep 0.2
+    second=$(awk '/^cpu /{ t = 0; for (i = 2; i <= NF; i++) t += $i; print t, $5; exit }' /proc/stat) ||
+        return 1
+    awk -v a="$first" -v b="$second" 'BEGIN {
+        split(a, before, " ");
+        split(b, after, " ");
+        total = after[1] - before[1];
+        idle = after[2] - before[2];
+        if (total <= 0) exit 1;
+        printf "%.1f", (total - idle) * 100 / total
+    }'
+}
+
+cpu_sample() {
+    local label="$1" sum=0 count=0 file value freq_mhz="" busy="" zone reading temp_c=""
+    for file in /sys/devices/system/cpu/cpu[0-9]*/cpufreq/scaling_cur_freq; do
+        [ -r "$file" ] || continue
+        value=$(cat "$file" 2>/dev/null) || continue
+        sum=$((sum + value))
+        count=$((count + 1))
+    done
+    if [ "$count" -gt 0 ]; then
+        freq_mhz=$((sum / count / 1000))
+    fi
+    if [ -r /proc/stat ]; then
+        busy=$(cpu_busy_percent 2>/dev/null) || busy=""
+    fi
+    for zone in /sys/class/thermal/thermal_zone*/temp; do
+        [ -r "$zone" ] || continue
+        reading=$(cat "$zone" 2>/dev/null) || continue
+        temp_c=$((reading / 1000))
+        break
+    done
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ),${label},${freq_mhz},${busy},${temp_c}" \
+        >> "$TELEMETRY_CSV"
+    echo ">>> cpu[${label}] avgFreq=${freq_mhz}MHz busy=${busy}% temp=${temp_c}C"
+}
+
 : "${SQL_SERVER:?SQL_SERVER not set}"
 : "${SQL_PASSWORD:?SQL_PASSWORD not set}"
 
@@ -68,18 +124,65 @@ export ODBC_BENCH_TRUST_CERT="${ODBC_BENCH_TRUST_CERT:-Yes}"
 export ODBC_BENCH_ENCRYPT="${ODBC_BENCH_ENCRYPT:-Mandatory}"
 export ODBC_BENCH_PACKET_SIZE="${ODBC_BENCH_PACKET_SIZE:-32768}"
 
-REPETITIONS="${ODBC_BENCH_REPETITIONS:-5}"
-case "$REPETITIONS" in
-    ''|*[!0-9]*)
-        echo "ERROR: ODBC_BENCH_REPETITIONS must be a positive integer" >&2
+# --- Allocator tuning (steadier large rowset buffers) ---
+# Each retrieval allocates the bound rowset buffers for up to 600 columns by
+# 1024 rows, which is far past glibc's dynamic mmap threshold. Left alone, every
+# repetition re-mmaps and re-faults those pages, which is both slower and much
+# noisier than the driver difference we are trying to measure. Raise the mmap
+# threshold so the buffers come from the heap and stop trimming so they are
+# reused. The mmap threshold must be raised explicitly: setting only the trim
+# threshold disables glibc's dynamic mmap threshold and forces every large
+# allocation through mmap.
+export MALLOC_MMAP_THRESHOLD_="${MALLOC_MMAP_THRESHOLD_:-134217728}"  # 128 MB
+export MALLOC_TRIM_THRESHOLD_="${MALLOC_TRIM_THRESHOLD_:--1}"          # never trim
+
+# --- No connection-churn network tuning here (deliberate) ---
+# mssql-tds-bench widens the ephemeral port range and enables TIME_WAIT reuse
+# because its concurrent_connects benchmark opens tens of thousands of
+# short-lived TCP connections. This harness opens ONE connection in OdbcSession,
+# holds it for the whole process, and measures only statement execution and
+# fetching, so there is no port pressure to relieve. The CPU/server diagnostics
+# and the large-buffer allocator control above do apply and are enabled.
+
+read_positive_int() {
+    # Parse tuning knobs once, in base 10, so "08" is neither an octal literal
+    # error nor silently a different number than the PowerShell runner reads.
+    local name="$1" value="$2" minimum="$3"
+    case "$value" in
+        ''|*[!0-9]*)
+            echo "ERROR: $name must be a positive integer (got: '$value')" >&2
+            exit 1
+            ;;
+    esac
+    value=$((10#$value))
+    if [ "$value" -lt "$minimum" ]; then
+        echo "ERROR: $name must be >= $minimum (got: $value)" >&2
         exit 1
-        ;;
-esac
-REPETITIONS=$((10#$REPETITIONS))
-if [ "$REPETITIONS" -lt 1 ]; then
-    echo "ERROR: ODBC_BENCH_REPETITIONS must be at least 1" >&2
+    fi
+    printf '%s' "$value"
+}
+
+REPETITIONS="$(read_positive_int ODBC_BENCH_REPETITIONS "${ODBC_BENCH_REPETITIONS:-5}" 1)"
+# Confirmation defaults match the fixed-baseline mssql-tds runner: four targeted
+# re-runs, reproduction required in a majority (3 of 4).
+CONFIRM_RUNS="$(read_positive_int ODBC_BENCH_CONFIRM_RUNS "${ODBC_BENCH_CONFIRM_RUNS:-4}" 1)"
+CONFIRM_QUORUM="$(
+    read_positive_int ODBC_BENCH_CONFIRM_QUORUM \
+        "${ODBC_BENCH_CONFIRM_QUORUM:-$((CONFIRM_RUNS / 2 + 1))}" 1
+)"
+if [ "$CONFIRM_QUORUM" -gt "$CONFIRM_RUNS" ]; then
+    echo "ERROR: ODBC_BENCH_CONFIRM_QUORUM must not exceed ODBC_BENCH_CONFIRM_RUNS" >&2
     exit 1
 fi
+IMPROVEMENT_MAX="$(
+    read_positive_int ODBC_BENCH_IMPROVEMENT_VERIFY_MAX \
+        "${ODBC_BENCH_IMPROVEMENT_VERIFY_MAX:-3}" 1
+)"
+REGRESSION_RATIO="${ODBC_BENCH_REGRESSION_RATIO:-1.05}"
+IMPROVEMENT_RATIO="${ODBC_BENCH_IMPROVEMENT_VERIFY_RATIO:-$REGRESSION_RATIO}"
+# A confirmed candidate-vs-pinned-baseline regression fails the run by default;
+# set ODBC_BENCH_FAIL_ON_REGRESSION=0 to publish the report without gating.
+FAIL_ON_REGRESSION="${ODBC_BENCH_FAIL_ON_REGRESSION:-1}"
 
 ensure_packages() {
     # Perf images vary by pool, so install only tools the harness cannot run without.
@@ -93,6 +196,9 @@ ensure_packages() {
     [ -f /usr/include/sql.h ] || missing+=(unixodbc-dev)
     [ -f /usr/include/openssl/ssl.h ] || missing+=(libssl-dev)
     [ -f /etc/ssl/certs/ca-certificates.crt ] || missing+=(ca-certificates)
+    # Google Benchmark's comparator imports NumPy and SciPy unconditionally, so a
+    # private virtualenv needs to be creatable even when it is never used.
+    python3 -c 'import ensurepip, venv' >/dev/null 2>&1 || missing+=(python3-venv)
     [ ${#missing[@]} -eq 0 ] && return
 
     local sudo_command=()
@@ -103,6 +209,25 @@ ensure_packages() {
         apt-get install -y --no-install-recommends "${missing[@]}"
 }
 ensure_packages
+
+BENCH_PYTHON="$(command -v python3)"
+ensure_python_stats() {
+    # gbench/report.py imports numpy and scipy at module scope even with
+    # --no-utest, so the official comparator cannot run without them. Prefer an
+    # interpreter that already has them; otherwise build a private virtualenv so
+    # nothing is installed into the perf host's system Python.
+    if "$BENCH_PYTHON" -c 'import numpy, scipy' >/dev/null 2>&1; then
+        return 0
+    fi
+    local venv="$REPO_ROOT/target/odbc-bench-venv"
+    echo ">>> Provisioning NumPy/SciPy for Google Benchmark's comparator..."
+    if [ ! -x "$venv/bin/python" ] && ! python3 -m venv "$venv"; then
+        return 1
+    fi
+    "$venv/bin/python" -m pip install --quiet --upgrade pip >/dev/null 2>&1 || true
+    "$venv/bin/python" -m pip install --quiet numpy scipy || return 1
+    BENCH_PYTHON="$venv/bin/python"
+}
 
 if ! command -v cargo >/dev/null 2>&1; then
     echo ">>> Installing Rust toolchain..."
@@ -160,11 +285,46 @@ fi
 MICROSOFT_DRIVER="${microsoft_driver_paths[0]}"
 MICROSOFT_DRIVER_SHA256="$(sha256sum "$MICROSOFT_DRIVER" | cut -d' ' -f1)"
 
+# --- SQL Server configuration snapshot (validate the instance is tuned) ---
+# Memory, MAXDOP, cost threshold, affinity, tempdb placement, recovery, and
+# trace flags. Best-effort: sqlcmd is not guaranteed on a perf image, and a
+# missing snapshot must not cost a whole lab run.
+sqlcmd_bin="$(command -v sqlcmd || true)"
+if [ -z "$sqlcmd_bin" ] && [ -x /opt/mssql-tools18/bin/sqlcmd ]; then
+    sqlcmd_bin=/opt/mssql-tools18/bin/sqlcmd
+fi
+if [ -z "$sqlcmd_bin" ] && [ -x /opt/mssql-tools/bin/sqlcmd ]; then
+    sqlcmd_bin=/opt/mssql-tools/bin/sqlcmd
+fi
+if [ -n "$sqlcmd_bin" ] && [ -f "$SQL_CONFIG_SQL" ]; then
+    echo ">>> Capturing SQL Server configuration snapshot..."
+    "$sqlcmd_bin" -S "$ODBC_BENCH_SERVER" -U "$ODBC_BENCH_UID" -P "$ODBC_BENCH_PWD" \
+        -C -b -y 0 -Y 30 -i "$SQL_CONFIG_SQL" |
+        tee "$RESULTS_DIR/sql-config.txt" ||
+        echo ">>> SQL config snapshot skipped (query failed)."
+else
+    echo ">>> Skipping SQL config snapshot (sqlcmd or query file not found)."
+fi
+
 echo ">>> Building the fixed C++ benchmark harness..."
 cmake -S "$REPO_ROOT/mssql-odbc-bench" \
     -B "$HARNESS_BUILD_DIR" \
     -DCMAKE_BUILD_TYPE=Release
 cmake --build "$HARNESS_BUILD_DIR" --config Release --parallel
+
+# The pinned Google Benchmark v1.9.1 checkout ships the comparator we report
+# with; using the copy from this build tree keeps the tool and the harness on
+# the same version.
+GBENCH_COMPARE="$HARNESS_BUILD_DIR/_deps/googlebenchmark-src/tools/compare.py"
+if [ ! -f "$GBENCH_COMPARE" ]; then
+    echo "ERROR: Google Benchmark comparator not found: $GBENCH_COMPARE" >&2
+    exit 1
+fi
+GBENCH_ARGS=(--gbench-compare "$GBENCH_COMPARE")
+if ! ensure_python_stats; then
+    echo "ERROR: NumPy/SciPy are required by Google Benchmark's compare.py" >&2
+    exit 1
+fi
 
 build_driver() {
     # Separate target directories keep the two Rust driver builds comparable and
@@ -237,6 +397,13 @@ fi
     echo "microsoft_driver_path=$MICROSOFT_DRIVER"
     echo "microsoft_driver_sha256=$MICROSOFT_DRIVER_SHA256"
     echo "repetitions=$REPETITIONS"
+    echo "regression_ratio=$REGRESSION_RATIO"
+    echo "confirm_runs=$CONFIRM_RUNS"
+    echo "confirm_quorum=$CONFIRM_QUORUM"
+    echo "gbench_compare=${GBENCH_ARGS[1]:-disabled}"
+    echo "bench_python=$BENCH_PYTHON"
+    echo "malloc_mmap_threshold=$MALLOC_MMAP_THRESHOLD_"
+    echo "malloc_trim_threshold=$MALLOC_TRIM_THRESHOLD_"
     echo "timestamp_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     uname -a
     rustc -Vv
@@ -252,11 +419,15 @@ ODBC_BENCH_DRIVER="$CANDIDATE_DRIVER_NAME" \
 
 run_leg() {
     # A leg contains one driver/scenario sample file; ordering is interleaved above
-    # to reduce bias from machine or server drift during the run.
+    # to reduce bias from machine or server drift during the run. An empty scenario
+    # runs every workload in one process.
     local scenario="$1"
     local driver="$2"
     local output="$3"
-    echo ">>> Running $scenario with $driver..."
+    echo ">>> Running ${scenario:-all scenarios} with $driver..."
+    # Linux keeps the PacketSize spelling for every driver, including Microsoft
+    # ODBC: on Linux that driver rejects "Packet Size" (01S00) and accepts
+    # "PacketSize" (01S02). Windows uses the "Packet Size" spelling instead.
     ODBC_BENCH_DRIVER="$driver" \
         ODBC_BENCH_SCENARIO="$scenario" \
         ODBC_BENCH_PACKET_SIZE_KEYWORD="PacketSize" \
@@ -273,15 +444,16 @@ BASELINE_WIDE="$RESULTS_DIR/odbc-baseline-wide.json"
 MICROSOFT_NARROW="$RESULTS_DIR/odbc-microsoft-narrow.json"
 MICROSOFT_WIDE="$RESULTS_DIR/odbc-microsoft-wide.json"
 
+cpu_sample "initial-start"
 run_leg narrow "$CANDIDATE_DRIVER_NAME" "$CANDIDATE_NARROW"
 run_leg narrow "$MICROSOFT_DRIVER_NAME" "$MICROSOFT_NARROW"
 run_leg narrow "$BASELINE_DRIVER_NAME" "$BASELINE_NARROW"
 run_leg wide "$BASELINE_DRIVER_NAME" "$BASELINE_WIDE"
 run_leg wide "$MICROSOFT_DRIVER_NAME" "$MICROSOFT_WIDE"
 run_leg wide "$CANDIDATE_DRIVER_NAME" "$CANDIDATE_WIDE"
+cpu_sample "initial-end"
 
-compare_args=(
-    "$REPO_ROOT/.pipeline/scripts/compare-odbc-benchmarks.py"
+three_way_args=(
     --baseline "$BASELINE_NARROW"
     --baseline "$BASELINE_WIDE"
     --candidate "$CANDIDATE_NARROW"
@@ -292,16 +464,156 @@ compare_args=(
     --baseline-commit "$BASELINE_COMMIT"
     --reference-version "$MICROSOFT_VERSION"
     --repetitions "$REPETITIONS"
-    --output-dir "$RESULTS_DIR"
-    --regression-ratio "${ODBC_BENCH_REGRESSION_RATIO:-1.10}"
+    --regression-ratio "$REGRESSION_RATIO"
+    --improvement-ratio "$IMPROVEMENT_RATIO"
+    --improvement-max "$IMPROVEMENT_MAX"
+    "${GBENCH_ARGS[@]}"
 )
-if [ "${ODBC_BENCH_FAIL_ON_REGRESSION:-0}" = "1" ]; then
-    compare_args+=(--fail-on-regression)
+
+# --- Initial pass: five-sample medians pick what deserves re-measurement ---
+# The initial verdict never gates on its own; it only produces the plan.
+echo ">>> Comparing the initial three-driver pass..."
+"$BENCH_PYTHON" "$COMPARE_SCRIPT" \
+    "${three_way_args[@]}" \
+    --output-dir "$INITIAL_DIR" \
+    --plan-out "$PLAN_FILE" \
+    --no-summary \
+    --no-fail-on-regression
+
+scenario_for_benchmark() {
+    # The harness filters by scenario, not by benchmark id, so map each flagged
+    # benchmark back to the scenario file it came out of.
+    local id="$1"
+    if grep -qF "\"run_name\": \"$id\"" "$CANDIDATE_NARROW"; then
+        printf 'narrow'
+    elif grep -qF "\"run_name\": \"$id\"" "$CANDIDATE_WIDE"; then
+        printf 'wide'
+    else
+        echo "ERROR: cannot map benchmark '$id' to a scenario" >&2
+        return 1
+    fi
+}
+
+VERIFY_NAMES=()
+VERIFY_KINDS=()
+select_narrow=0
+select_wide=0
+while IFS=$'\t' read -r plan_kind plan_name plan_ratio; do
+    [ -n "${plan_name:-}" ] || continue
+    VERIFY_KINDS+=("$plan_kind")
+    VERIFY_NAMES+=("$plan_name")
+    echo ">>> Initial pass flagged $plan_kind: $plan_name (ratio $plan_ratio)"
+    plan_scenario="$(scenario_for_benchmark "$plan_name")"
+    case "$plan_scenario" in
+        narrow) select_narrow=1 ;;
+        wide) select_wide=1 ;;
+    esac
+done < "$PLAN_FILE"
+
+CONFIRMATION_ARGS=()
+if [ "${#VERIFY_NAMES[@]}" -gt 0 ]; then
+    # One process covers both scenarios; only narrow those legs when the other
+    # workload has nothing to confirm.
+    if [ "$select_narrow" -eq 1 ] && [ "$select_wide" -eq 1 ]; then
+        CONFIRM_SCENARIO=""
+    elif [ "$select_narrow" -eq 1 ]; then
+        CONFIRM_SCENARIO="narrow"
+    else
+        CONFIRM_SCENARIO="wide"
+    fi
+
+    echo ">>> Auto-confirm: re-measuring ${#VERIFY_NAMES[@]} benchmark(s) over" \
+        "$CONFIRM_RUNS round(s); a result counts only when it reproduces in" \
+        ">= $CONFIRM_QUORUM of $CONFIRM_RUNS."
+    for round in $(seq 1 "$CONFIRM_RUNS"); do
+        round_dir="$CONFIRM_DIR/round$round"
+        mkdir -p "$round_dir"
+        echo ">>> Confirmation round $round/$CONFIRM_RUNS..."
+        cpu_sample "confirm${round}-start"
+        # Keep each pair adjacent, and alternate which side runs first so a stable
+        # position effect cancels across the default four rounds.
+        if [ $((round % 2)) -eq 1 ]; then
+            run_leg "$CONFIRM_SCENARIO" "$CANDIDATE_DRIVER_NAME" "$round_dir/candidate.json"
+            run_leg "$CONFIRM_SCENARIO" "$BASELINE_DRIVER_NAME" "$round_dir/baseline.json"
+        else
+            run_leg "$CONFIRM_SCENARIO" "$BASELINE_DRIVER_NAME" "$round_dir/baseline.json"
+            run_leg "$CONFIRM_SCENARIO" "$CANDIDATE_DRIVER_NAME" "$round_dir/candidate.json"
+        fi
+        cpu_sample "confirm${round}-end"
+        "$BENCH_PYTHON" "$COMPARE_SCRIPT" \
+            --baseline "$round_dir/baseline.json" \
+            --candidate "$round_dir/candidate.json" \
+            --repetitions "$REPETITIONS" \
+            --regression-ratio "$REGRESSION_RATIO" \
+            --improvement-ratio "$IMPROVEMENT_RATIO" \
+            --output-dir "$round_dir" \
+            --ratios-out "$round_dir/ratios.txt" \
+            --no-summary \
+            --no-fail-on-regression \
+            "${GBENCH_ARGS[@]}" > "$round_dir/comparison.log"
+    done
+
+    for index in "${!VERIFY_NAMES[@]}"; do
+        name="${VERIFY_NAMES[$index]}"
+        kind="${VERIFY_KINDS[$index]}"
+        ratios=()
+        for round in $(seq 1 "$CONFIRM_RUNS"); do
+            value="$(
+                awk -F'\t' -v id="$name" '$1 == id { print $2; exit }' \
+                    "$CONFIRM_DIR/round$round/ratios.txt"
+            )"
+            [ -n "$value" ] && ratios+=("$value")
+        done
+        if [ "${#ratios[@]}" -ne "$CONFIRM_RUNS" ]; then
+            echo "ERROR: expected $CONFIRM_RUNS confirmation ratios for '$name';" \
+                "found ${#ratios[@]}" >&2
+            exit 1
+        fi
+        hits="$(
+            printf '%s\n' "${ratios[@]}" |
+                awk -v thr="$REGRESSION_RATIO" -v imp="$IMPROVEMENT_RATIO" -v kind="$kind" '
+                    kind == "regression" { if ($1 + 0 >= thr) count++; next }
+                    { if ($1 + 0 <= 1 / imp) count++ }
+                    END { print count + 0 }'
+        )"
+        regression_hits="$(
+            printf '%s\n' "${ratios[@]}" |
+                awk -v thr="$REGRESSION_RATIO" '
+                    $1 + 0 >= thr { count++ }
+                    END { print count + 0 }'
+        )"
+        # Median of the confirmation rounds only. The initial pass is excluded on
+        # purpose: a benchmark is re-measured because that pass was extreme, so
+        # letting it vote again would let the outlier under test decide its own
+        # verdict and could contradict a quorum that cleared it.
+        median="$(
+            printf '%s\n' "${ratios[@]}" | sort -n |
+                awk '{ v[NR] = $1 + 0 }
+                     END { if (NR % 2) printf "%.6f\n", v[(NR + 1) / 2];
+                           else printf "%.6f\n", (v[NR / 2] + v[NR / 2 + 1]) / 2 }'
+        )"
+        echo ">>> $name: reproduced $hits/$CONFIRM_RUNS in the initial direction," \
+            "regressed $regression_hits/$CONFIRM_RUNS, confirmation median $median"
+        CONFIRMATION_ARGS+=(
+            --confirmation "$name" "$hits" "$regression_hits" "$median"
+        )
+    done
 fi
-# Exit 2 means the comparison completed and the optional gate tripped. Delay that
-# exit until after summary.md is echoed so failed runs remain diagnosable from logs.
+
+final_args=(
+    "${three_way_args[@]}"
+    --output-dir "$RESULTS_DIR"
+    --confirm-runs "$CONFIRM_RUNS"
+    --confirm-quorum "$CONFIRM_QUORUM"
+    "${CONFIRMATION_ARGS[@]}"
+)
+if [ "$FAIL_ON_REGRESSION" != "1" ]; then
+    final_args+=(--no-fail-on-regression)
+fi
+# Exit 2 means the comparison completed and the gate tripped. Delay that exit
+# until after summary.md is echoed so failed runs remain diagnosable from logs.
 set +e
-python3 "${compare_args[@]}"
+"$BENCH_PYTHON" "$COMPARE_SCRIPT" "${final_args[@]}"
 compare_rc=$?
 set -e
 if [ "$compare_rc" -ne 0 ] && [ "$compare_rc" -ne 2 ]; then

--- a/mssql-odbc-bench/perf-lab/run-benchmarks.sh
+++ b/mssql-odbc-bench/perf-lab/run-benchmarks.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# Dedicated Linux perf-lab runner for the mssql-odbc result-set benchmarks.
+
+set -euo pipefail
+set -E
+trap 'rc=$?; echo "ERROR: ${BASH_SOURCE[0]}:${LINENO}: ${BASH_COMMAND} exited ${rc}" >&2' ERR
+
+REPO_ROOT="$(pwd)"
+RESULTS_DIR="$REPO_ROOT/results"
+BASELINE_FILE="$REPO_ROOT/mssql-odbc-bench/perf-lab/baseline-commit.txt"
+REFERENCE_VERSION_FILE="$REPO_ROOT/mssql-odbc-bench/perf-lab/msodbcsql-version.txt"
+HARNESS_BUILD_DIR="$REPO_ROOT/target/odbc-bench"
+CANDIDATE_TARGET_DIR="$REPO_ROOT/target/odbc-candidate"
+BASELINE_TARGET_DIR="$REPO_ROOT/target/odbc-baseline"
+CANDIDATE_DRIVER_NAME="MSSQL Rust ODBC Perf Candidate"
+BASELINE_DRIVER_NAME="MSSQL Rust ODBC Perf Baseline"
+MICROSOFT_DRIVER_NAME="ODBC Driver 18 for SQL Server"
+
+BASELINE_TEMP_DIR=""
+BASELINE_TREE=""
+DRIVER_INI_DIR=""
+ADMIN_EXE=""
+TABLE_CLEANUP_ARMED=0
+
+cleanup() {
+    # Keep failed runs from leaving tables, worktrees, or temporary driver catalogs
+    # that could change the next run's result.
+    local rc=$?
+    trap - ERR
+    set +e
+
+    if [ "$TABLE_CLEANUP_ARMED" -eq 1 ] && [ -x "$ADMIN_EXE" ] &&
+       [ -n "$DRIVER_INI_DIR" ]; then
+        echo ">>> Removing ODBC benchmark tables..."
+        ODBCSYSINI="$DRIVER_INI_DIR" \
+            ODBC_BENCH_DRIVER="$CANDIDATE_DRIVER_NAME" \
+            ODBC_BENCH_SCENARIO="" \
+            "$ADMIN_EXE" cleanup ||
+            echo "WARNING: benchmark table cleanup failed" >&2
+    fi
+
+    if [ -n "$BASELINE_TREE" ]; then
+        git worktree remove --force "$BASELINE_TREE" >/dev/null 2>&1 || true
+    fi
+    if [ -n "$BASELINE_TEMP_DIR" ] && [ -d "$BASELINE_TEMP_DIR" ]; then
+        rm -rf "$BASELINE_TEMP_DIR"
+    fi
+    if [ -n "$DRIVER_INI_DIR" ] && [ -d "$DRIVER_INI_DIR" ]; then
+        rm -rf "$DRIVER_INI_DIR"
+    fi
+    exit "$rc"
+}
+trap cleanup EXIT
+
+mkdir -p "$RESULTS_DIR"
+
+: "${SQL_SERVER:?SQL_SERVER not set}"
+: "${SQL_PASSWORD:?SQL_PASSWORD not set}"
+
+export ODBC_BENCH_SERVER="${ODBC_BENCH_SERVER:-$SQL_SERVER}"
+export ODBC_BENCH_DATABASE="${ODBC_BENCH_DATABASE:-tempdb}"
+export ODBC_BENCH_UID="${ODBC_BENCH_UID:-${DB_USERNAME:-sa}}"
+export ODBC_BENCH_PWD="${ODBC_BENCH_PWD:-$SQL_PASSWORD}"
+export ODBC_BENCH_TRUST_CERT="${ODBC_BENCH_TRUST_CERT:-Yes}"
+export ODBC_BENCH_ENCRYPT="${ODBC_BENCH_ENCRYPT:-Mandatory}"
+export ODBC_BENCH_PACKET_SIZE="${ODBC_BENCH_PACKET_SIZE:-32768}"
+
+REPETITIONS="${ODBC_BENCH_REPETITIONS:-5}"
+case "$REPETITIONS" in
+    ''|*[!0-9]*)
+        echo "ERROR: ODBC_BENCH_REPETITIONS must be a positive integer" >&2
+        exit 1
+        ;;
+esac
+REPETITIONS=$((10#$REPETITIONS))
+if [ "$REPETITIONS" -lt 1 ]; then
+    echo "ERROR: ODBC_BENCH_REPETITIONS must be at least 1" >&2
+    exit 1
+fi
+
+ensure_packages() {
+    # Perf images vary by pool, so install only tools the harness cannot run without.
+    local missing=()
+    command -v git >/dev/null 2>&1 || missing+=(git)
+    command -v curl >/dev/null 2>&1 || missing+=(curl)
+    command -v python3 >/dev/null 2>&1 || missing+=(python3)
+    command -v cmake >/dev/null 2>&1 || missing+=(cmake)
+    command -v c++ >/dev/null 2>&1 || missing+=(build-essential)
+    command -v pkg-config >/dev/null 2>&1 || missing+=(pkg-config)
+    [ -f /usr/include/sql.h ] || missing+=(unixodbc-dev)
+    [ -f /usr/include/openssl/ssl.h ] || missing+=(libssl-dev)
+    [ -f /etc/ssl/certs/ca-certificates.crt ] || missing+=(ca-certificates)
+    [ ${#missing[@]} -eq 0 ] && return
+
+    local sudo_command=()
+    [ "$(id -u)" -ne 0 ] && sudo_command=(sudo)
+    echo ">>> Installing system packages: ${missing[*]}"
+    "${sudo_command[@]}" apt-get update -y
+    "${sudo_command[@]}" env DEBIAN_FRONTEND=noninteractive \
+        apt-get install -y --no-install-recommends "${missing[@]}"
+}
+ensure_packages
+
+if ! command -v cargo >/dev/null 2>&1; then
+    echo ">>> Installing Rust toolchain..."
+    bash "$REPO_ROOT/.pipeline/scripts/install-rustup.sh"
+fi
+# shellcheck disable=SC1091
+[ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
+export PATH="$HOME/.cargo/bin:$PATH"
+command -v cargo >/dev/null 2>&1 ||
+    { echo "ERROR: cargo not found after Rust setup" >&2; exit 1; }
+
+if [ ! -f "$BASELINE_FILE" ]; then
+    echo "ERROR: baseline file not found: $BASELINE_FILE" >&2
+    exit 1
+fi
+BASELINE_COMMIT="$(
+    grep -vE '^[[:space:]]*(#|$)' "$BASELINE_FILE" |
+        head -n1 |
+        tr -d '[:space:]'
+)"
+if ! printf '%s' "$BASELINE_COMMIT" | grep -qE '^[0-9a-fA-F]{40}$'; then
+    echo "ERROR: invalid baseline commit in $BASELINE_FILE" >&2
+    exit 1
+fi
+if ! git rev-parse --verify --quiet "${BASELINE_COMMIT}^{commit}" >/dev/null; then
+    echo "ERROR: baseline commit $BASELINE_COMMIT is absent from the checkout" >&2
+    exit 1
+fi
+
+if [ ! -f "$REFERENCE_VERSION_FILE" ]; then
+    echo "ERROR: reference version file not found: $REFERENCE_VERSION_FILE" >&2
+    exit 1
+fi
+MICROSOFT_VERSION="$(
+    grep -vE '^[[:space:]]*(#|$)' "$REFERENCE_VERSION_FILE" |
+        head -n1 |
+        tr -d '[:space:]'
+)"
+if ! printf '%s' "$MICROSOFT_VERSION" |
+    grep -qE '^[0-9]+(\.[0-9]+){3}$'; then
+    echo "ERROR: invalid Microsoft ODBC version in $REFERENCE_VERSION_FILE" >&2
+    exit 1
+fi
+"$REPO_ROOT/.pipeline/scripts/install-msodbcsql.sh" "$MICROSOFT_VERSION"
+MICROSOFT_PACKAGE_VERSION="$(dpkg-query -W -f='${Version}' msodbcsql18)"
+mapfile -t microsoft_driver_paths < <(
+    dpkg-query -L msodbcsql18 |
+        grep -E '/libmsodbcsql-[0-9.]+\.so\.[0-9.]+$' || true
+)
+if [ "${#microsoft_driver_paths[@]}" -ne 1 ]; then
+    echo "ERROR: expected one installed Microsoft ODBC shared library" >&2
+    printf '  %s\n' "${microsoft_driver_paths[@]}" >&2
+    exit 1
+fi
+MICROSOFT_DRIVER="${microsoft_driver_paths[0]}"
+MICROSOFT_DRIVER_SHA256="$(sha256sum "$MICROSOFT_DRIVER" | cut -d' ' -f1)"
+
+echo ">>> Building the fixed C++ benchmark harness..."
+cmake -S "$REPO_ROOT/mssql-odbc-bench" \
+    -B "$HARNESS_BUILD_DIR" \
+    -DCMAKE_BUILD_TYPE=Release
+cmake --build "$HARNESS_BUILD_DIR" --config Release --parallel
+
+build_driver() {
+    # Separate target directories keep the two Rust driver builds comparable and
+    # prevent Cargo from reusing candidate artifacts for the pinned baseline.
+    local source_root="$1"
+    local target_dir="$2"
+    local label="$3"
+    echo ">>> Building $label mssql-odbc driver..."
+    (
+        cd "$source_root"
+        CARGO_TARGET_DIR="$target_dir" cargo build -p mssql-odbc --release
+    )
+}
+
+build_driver "$REPO_ROOT" "$CANDIDATE_TARGET_DIR" "candidate"
+
+BASELINE_TEMP_DIR="$(mktemp -d)"
+BASELINE_TREE="$BASELINE_TEMP_DIR/worktree"
+echo ">>> Adding baseline worktree for $BASELINE_COMMIT..."
+git worktree add --detach "$BASELINE_TREE" "$BASELINE_COMMIT"
+build_driver "$BASELINE_TREE" "$BASELINE_TARGET_DIR" "baseline"
+
+CANDIDATE_DRIVER="$CANDIDATE_TARGET_DIR/release/libmsodbcsql18.so"
+BASELINE_DRIVER="$BASELINE_TARGET_DIR/release/libmsodbcsql18.so"
+BENCH_EXE="$HARNESS_BUILD_DIR/mssql_odbc_bench"
+ADMIN_EXE="$HARNESS_BUILD_DIR/mssql_odbc_bench_admin"
+for required_file in \
+    "$CANDIDATE_DRIVER" "$BASELINE_DRIVER" "$MICROSOFT_DRIVER" \
+    "$BENCH_EXE" "$ADMIN_EXE"; do
+    if [ ! -f "$required_file" ]; then
+        echo "ERROR: expected build output not found: $required_file" >&2
+        exit 1
+    fi
+done
+
+DRIVER_INI_DIR="$(mktemp -d)"
+cat > "$DRIVER_INI_DIR/odbcinst.ini" <<EOF
+[$CANDIDATE_DRIVER_NAME]
+Description=mssql-odbc candidate performance build
+Driver=$CANDIDATE_DRIVER
+Setup=$CANDIDATE_DRIVER
+UsageCount=1
+
+[$BASELINE_DRIVER_NAME]
+Description=mssql-odbc baseline performance build
+Driver=$BASELINE_DRIVER
+Setup=$BASELINE_DRIVER
+UsageCount=1
+
+[$MICROSOFT_DRIVER_NAME]
+Description=Microsoft ODBC Driver $MICROSOFT_VERSION performance reference
+Driver=$MICROSOFT_DRIVER
+Setup=$MICROSOFT_DRIVER
+UsageCount=1
+EOF
+export ODBCSYSINI="$DRIVER_INI_DIR"
+
+BENCH_PREFIX=()
+BENCH_CPUS="${BENCH_CPUS:-${PERF_CLIENT_CPUS:-}}"
+if [ -n "$BENCH_CPUS" ] && command -v taskset >/dev/null 2>&1; then
+    BENCH_PREFIX=(taskset -c "$BENCH_CPUS")
+    echo ">>> Pinning benchmark processes to CPUs: $BENCH_CPUS"
+fi
+
+{
+    echo "candidate_commit=$(git rev-parse HEAD)"
+    echo "baseline_commit=$BASELINE_COMMIT"
+    echo "microsoft_driver_version=$MICROSOFT_VERSION"
+    echo "microsoft_driver_package=$MICROSOFT_PACKAGE_VERSION"
+    echo "microsoft_driver_path=$MICROSOFT_DRIVER"
+    echo "microsoft_driver_sha256=$MICROSOFT_DRIVER_SHA256"
+    echo "repetitions=$REPETITIONS"
+    echo "timestamp_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    uname -a
+    rustc -Vv
+    cargo -V
+    cmake --version
+} > "$RESULTS_DIR/odbc-context.txt"
+
+echo ">>> Creating deterministic benchmark tables..."
+TABLE_CLEANUP_ARMED=1
+ODBC_BENCH_DRIVER="$CANDIDATE_DRIVER_NAME" \
+    ODBC_BENCH_SCENARIO="" \
+    "$ADMIN_EXE" setup
+
+run_leg() {
+    # A leg contains one driver/scenario sample file; ordering is interleaved above
+    # to reduce bias from machine or server drift during the run.
+    local scenario="$1"
+    local driver="$2"
+    local output="$3"
+    echo ">>> Running $scenario with $driver..."
+    ODBC_BENCH_DRIVER="$driver" \
+        ODBC_BENCH_SCENARIO="$scenario" \
+        ODBC_BENCH_PACKET_SIZE_KEYWORD="PacketSize" \
+        "${BENCH_PREFIX[@]}" "$BENCH_EXE" \
+        "--benchmark_repetitions=$REPETITIONS" \
+        "--benchmark_out=$output" \
+        --benchmark_out_format=json
+}
+
+CANDIDATE_NARROW="$RESULTS_DIR/odbc-candidate-narrow.json"
+BASELINE_NARROW="$RESULTS_DIR/odbc-baseline-narrow.json"
+CANDIDATE_WIDE="$RESULTS_DIR/odbc-candidate-wide.json"
+BASELINE_WIDE="$RESULTS_DIR/odbc-baseline-wide.json"
+MICROSOFT_NARROW="$RESULTS_DIR/odbc-microsoft-narrow.json"
+MICROSOFT_WIDE="$RESULTS_DIR/odbc-microsoft-wide.json"
+
+run_leg narrow "$CANDIDATE_DRIVER_NAME" "$CANDIDATE_NARROW"
+run_leg narrow "$MICROSOFT_DRIVER_NAME" "$MICROSOFT_NARROW"
+run_leg narrow "$BASELINE_DRIVER_NAME" "$BASELINE_NARROW"
+run_leg wide "$BASELINE_DRIVER_NAME" "$BASELINE_WIDE"
+run_leg wide "$MICROSOFT_DRIVER_NAME" "$MICROSOFT_WIDE"
+run_leg wide "$CANDIDATE_DRIVER_NAME" "$CANDIDATE_WIDE"
+
+compare_args=(
+    "$REPO_ROOT/.pipeline/scripts/compare-odbc-benchmarks.py"
+    --baseline "$BASELINE_NARROW"
+    --baseline "$BASELINE_WIDE"
+    --candidate "$CANDIDATE_NARROW"
+    --candidate "$CANDIDATE_WIDE"
+    --reference "$MICROSOFT_NARROW"
+    --reference "$MICROSOFT_WIDE"
+    --reference-label "Microsoft ODBC $MICROSOFT_VERSION"
+    --baseline-commit "$BASELINE_COMMIT"
+    --reference-version "$MICROSOFT_VERSION"
+    --repetitions "$REPETITIONS"
+    --output-dir "$RESULTS_DIR"
+    --regression-ratio "${ODBC_BENCH_REGRESSION_RATIO:-1.10}"
+)
+if [ "${ODBC_BENCH_FAIL_ON_REGRESSION:-0}" = "1" ]; then
+    compare_args+=(--fail-on-regression)
+fi
+# Exit 2 means the comparison completed and the optional gate tripped. Delay that
+# exit until after summary.md is echoed so failed runs remain diagnosable from logs.
+set +e
+python3 "${compare_args[@]}"
+compare_rc=$?
+set -e
+if [ "$compare_rc" -ne 0 ] && [ "$compare_rc" -ne 2 ]; then
+    exit "$compare_rc"
+fi
+
+echo ""
+echo "===== summary.md ====="
+cat "$RESULTS_DIR/summary.md"
+echo "===== end summary.md ====="
+echo ">>> ODBC benchmark results written to $RESULTS_DIR"
+if [ "$compare_rc" -eq 2 ]; then
+    exit 2
+fi

--- a/mssql-odbc-bench/perf-lab/run-benchmarks.sh
+++ b/mssql-odbc-bench/perf-lab/run-benchmarks.sh
@@ -256,10 +256,14 @@ run_leg() {
     local scenario="$1"
     local driver="$2"
     local output="$3"
+    local packet_size_keyword="PacketSize"
+    if [ "$driver" = "$MICROSOFT_DRIVER_NAME" ]; then
+        packet_size_keyword="Packet Size"
+    fi
     echo ">>> Running $scenario with $driver..."
     ODBC_BENCH_DRIVER="$driver" \
         ODBC_BENCH_SCENARIO="$scenario" \
-        ODBC_BENCH_PACKET_SIZE_KEYWORD="PacketSize" \
+        ODBC_BENCH_PACKET_SIZE_KEYWORD="$packet_size_keyword" \
         "${BENCH_PREFIX[@]}" "$BENCH_EXE" \
         "--benchmark_repetitions=$REPETITIONS" \
         "--benchmark_out=$output" \

--- a/mssql-odbc-bench/perf-lab/run-benchmarks.sh
+++ b/mssql-odbc-bench/perf-lab/run-benchmarks.sh
@@ -134,7 +134,7 @@ export ODBC_BENCH_UID="${ODBC_BENCH_UID:-${DB_USERNAME:-sa}}"
 export ODBC_BENCH_PWD="${ODBC_BENCH_PWD:-$SQL_PASSWORD}"
 export ODBC_BENCH_TRUST_CERT="${ODBC_BENCH_TRUST_CERT:-Yes}"
 export ODBC_BENCH_ENCRYPT="${ODBC_BENCH_ENCRYPT:-Mandatory}"
-export ODBC_BENCH_PACKET_SIZE="${ODBC_BENCH_PACKET_SIZE:-32767}"
+export ODBC_BENCH_PACKET_SIZE="${ODBC_BENCH_PACKET_SIZE:-16192}"
 
 # --- Allocator tuning (steadier large rowset buffers) ---
 # Each retrieval allocates the bound rowset buffers for up to 600 columns by

--- a/mssql-odbc-bench/perf-lab/run-benchmarks.sh
+++ b/mssql-odbc-bench/perf-lab/run-benchmarks.sh
@@ -27,6 +27,11 @@ CANDIDATE_DRIVER_NAME="MSSQL Rust ODBC Perf Candidate"
 BASELINE_DRIVER_NAME="MSSQL Rust ODBC Perf Baseline"
 MICROSOFT_DRIVER_NAME="ODBC Driver 18 for SQL Server"
 
+# Scenario catalog. The C++ harness filters its workloads by scenario, and every
+# downstream step - ordering, comparison, confirmation - iterates this list, so a
+# new scenario needs no other change here.
+SCENARIOS=(narrow wide rowset varwidth getdata)
+
 BASELINE_TEMP_DIR=""
 BASELINE_TREE=""
 DRIVER_INI_DIR=""
@@ -43,11 +48,18 @@ cleanup() {
     if [ "$TABLE_CLEANUP_ARMED" -eq 1 ] && [ -x "$ADMIN_EXE" ] &&
        [ -n "$DRIVER_INI_DIR" ]; then
         echo ">>> Removing ODBC benchmark tables..."
-        ODBCSYSINI="$DRIVER_INI_DIR" \
+        if ! ODBCSYSINI="$DRIVER_INI_DIR" \
             ODBC_BENCH_DRIVER="$CANDIDATE_DRIVER_NAME" \
             ODBC_BENCH_SCENARIO="" \
-            "$ADMIN_EXE" cleanup ||
-            echo "WARNING: benchmark table cleanup failed" >&2
+            "$ADMIN_EXE" cleanup; then
+            echo "WARNING: candidate cleanup failed; retrying with Microsoft ODBC" >&2
+            ODBCSYSINI="$DRIVER_INI_DIR" \
+                ODBC_BENCH_DRIVER="$MICROSOFT_DRIVER_NAME" \
+                ODBC_BENCH_SCENARIO="" \
+                ODBC_BENCH_PACKET_SIZE_KEYWORD="PacketSize" \
+                "$ADMIN_EXE" cleanup ||
+                echo "WARNING: benchmark table cleanup failed with both drivers" >&2
+        fi
     fi
 
     if [ -n "$BASELINE_TREE" ]; then
@@ -122,11 +134,11 @@ export ODBC_BENCH_UID="${ODBC_BENCH_UID:-${DB_USERNAME:-sa}}"
 export ODBC_BENCH_PWD="${ODBC_BENCH_PWD:-$SQL_PASSWORD}"
 export ODBC_BENCH_TRUST_CERT="${ODBC_BENCH_TRUST_CERT:-Yes}"
 export ODBC_BENCH_ENCRYPT="${ODBC_BENCH_ENCRYPT:-Mandatory}"
-export ODBC_BENCH_PACKET_SIZE="${ODBC_BENCH_PACKET_SIZE:-32768}"
+export ODBC_BENCH_PACKET_SIZE="${ODBC_BENCH_PACKET_SIZE:-32767}"
 
 # --- Allocator tuning (steadier large rowset buffers) ---
 # Each retrieval allocates the bound rowset buffers for up to 600 columns by
-# 1024 rows, which is far past glibc's dynamic mmap threshold. Left alone, every
+# 1000 rows, which is far past glibc's dynamic mmap threshold. Left alone, every
 # repetition re-mmaps and re-faults those pages, which is both slower and much
 # noisier than the driver difference we are trying to measure. Raise the mmap
 # threshold so the buffers come from the heap and stop trimming so they are
@@ -396,6 +408,8 @@ fi
     echo "microsoft_driver_package=$MICROSOFT_PACKAGE_VERSION"
     echo "microsoft_driver_path=$MICROSOFT_DRIVER"
     echo "microsoft_driver_sha256=$MICROSOFT_DRIVER_SHA256"
+    echo "packet_size=$ODBC_BENCH_PACKET_SIZE"
+    echo "packet_size_verified_by_harness=true"
     echo "repetitions=$REPETITIONS"
     echo "regression_ratio=$REGRESSION_RATIO"
     echo "confirm_runs=$CONFIRM_RUNS"
@@ -418,13 +432,12 @@ ODBC_BENCH_DRIVER="$CANDIDATE_DRIVER_NAME" \
     "$ADMIN_EXE" setup
 
 run_leg() {
-    # A leg contains one driver/scenario sample file; ordering is interleaved above
-    # to reduce bias from machine or server drift during the run. An empty scenario
-    # runs every workload in one process.
+    # A leg contains one driver/scenario sample file; ordering is interleaved
+    # below to reduce bias from machine or server drift during the run.
     local scenario="$1"
     local driver="$2"
     local output="$3"
-    echo ">>> Running ${scenario:-all scenarios} with $driver..."
+    echo ">>> Running $scenario with $driver..."
     # Linux keeps the PacketSize spelling for every driver, including Microsoft
     # ODBC: on Linux that driver rejects "Packet Size" (01S00) and accepts
     # "PacketSize" (01S02). Windows uses the "Packet Size" spelling instead.
@@ -437,29 +450,43 @@ run_leg() {
         --benchmark_out_format=json
 }
 
-CANDIDATE_NARROW="$RESULTS_DIR/odbc-candidate-narrow.json"
-BASELINE_NARROW="$RESULTS_DIR/odbc-baseline-narrow.json"
-CANDIDATE_WIDE="$RESULTS_DIR/odbc-candidate-wide.json"
-BASELINE_WIDE="$RESULTS_DIR/odbc-baseline-wide.json"
-MICROSOFT_NARROW="$RESULTS_DIR/odbc-microsoft-narrow.json"
-MICROSOFT_WIDE="$RESULTS_DIR/odbc-microsoft-wide.json"
+CANDIDATE_FILES=()
+BASELINE_FILES=()
+MICROSOFT_FILES=()
+for scenario in "${SCENARIOS[@]}"; do
+    CANDIDATE_FILES+=("$RESULTS_DIR/odbc-candidate-$scenario.json")
+    BASELINE_FILES+=("$RESULTS_DIR/odbc-baseline-$scenario.json")
+    MICROSOFT_FILES+=("$RESULTS_DIR/odbc-microsoft-$scenario.json")
+done
 
 cpu_sample "initial-start"
-run_leg narrow "$CANDIDATE_DRIVER_NAME" "$CANDIDATE_NARROW"
-run_leg narrow "$MICROSOFT_DRIVER_NAME" "$MICROSOFT_NARROW"
-run_leg narrow "$BASELINE_DRIVER_NAME" "$BASELINE_NARROW"
-run_leg wide "$BASELINE_DRIVER_NAME" "$BASELINE_WIDE"
-run_leg wide "$MICROSOFT_DRIVER_NAME" "$MICROSOFT_WIDE"
-run_leg wide "$CANDIDATE_DRIVER_NAME" "$CANDIDATE_WIDE"
+for index in "${!SCENARIOS[@]}"; do
+    scenario="${SCENARIOS[$index]}"
+    # Alternate which Rust driver runs first per scenario, with Microsoft ODBC
+    # between them, so a stable position effect does not favour one side.
+    if [ $((index % 2)) -eq 0 ]; then
+        run_leg "$scenario" "$CANDIDATE_DRIVER_NAME" "${CANDIDATE_FILES[$index]}"
+        run_leg "$scenario" "$MICROSOFT_DRIVER_NAME" "${MICROSOFT_FILES[$index]}"
+        run_leg "$scenario" "$BASELINE_DRIVER_NAME" "${BASELINE_FILES[$index]}"
+    else
+        run_leg "$scenario" "$BASELINE_DRIVER_NAME" "${BASELINE_FILES[$index]}"
+        run_leg "$scenario" "$MICROSOFT_DRIVER_NAME" "${MICROSOFT_FILES[$index]}"
+        run_leg "$scenario" "$CANDIDATE_DRIVER_NAME" "${CANDIDATE_FILES[$index]}"
+    fi
+done
 cpu_sample "initial-end"
 
-three_way_args=(
-    --baseline "$BASELINE_NARROW"
-    --baseline "$BASELINE_WIDE"
-    --candidate "$CANDIDATE_NARROW"
-    --candidate "$CANDIDATE_WIDE"
-    --reference "$MICROSOFT_NARROW"
-    --reference "$MICROSOFT_WIDE"
+three_way_args=()
+for index in "${!SCENARIOS[@]}"; do
+    three_way_args+=(--baseline "${BASELINE_FILES[$index]}")
+done
+for index in "${!SCENARIOS[@]}"; do
+    three_way_args+=(--candidate "${CANDIDATE_FILES[$index]}")
+done
+for index in "${!SCENARIOS[@]}"; do
+    three_way_args+=(--reference "${MICROSOFT_FILES[$index]}")
+done
+three_way_args+=(
     --reference-label "Microsoft ODBC $MICROSOFT_VERSION"
     --baseline-commit "$BASELINE_COMMIT"
     --reference-version "$MICROSOFT_VERSION"
@@ -481,68 +508,69 @@ echo ">>> Comparing the initial three-driver pass..."
     --no-fail-on-regression
 
 scenario_for_benchmark() {
-    # The harness filters by scenario, not by benchmark id, so map each flagged
-    # benchmark back to the scenario file it came out of.
+    # Confirmation re-runs whole scenarios, not single benchmarks, so each
+    # flagged id has to be mapped back to the leg it came out of.
     local id="$1"
-    if grep -qF "\"run_name\": \"$id\"" "$CANDIDATE_NARROW"; then
-        printf 'narrow'
-    elif grep -qF "\"run_name\": \"$id\"" "$CANDIDATE_WIDE"; then
-        printf 'wide'
-    else
-        echo "ERROR: cannot map benchmark '$id' to a scenario" >&2
-        return 1
-    fi
+    local index
+    for index in "${!SCENARIOS[@]}"; do
+        if grep -qF "\"run_name\": \"$id\"" "${CANDIDATE_FILES[$index]}"; then
+            printf '%s' "${SCENARIOS[$index]}"
+            return 0
+        fi
+    done
+    echo "ERROR: cannot map benchmark '$id' to a scenario" >&2
+    return 1
 }
 
 VERIFY_NAMES=()
 VERIFY_KINDS=()
-select_narrow=0
-select_wide=0
+CONFIRM_SCENARIOS=()
 while IFS=$'\t' read -r plan_kind plan_name plan_ratio; do
     [ -n "${plan_name:-}" ] || continue
     VERIFY_KINDS+=("$plan_kind")
     VERIFY_NAMES+=("$plan_name")
     echo ">>> Initial pass flagged $plan_kind: $plan_name (ratio $plan_ratio)"
     plan_scenario="$(scenario_for_benchmark "$plan_name")"
-    case "$plan_scenario" in
-        narrow) select_narrow=1 ;;
-        wide) select_wide=1 ;;
-    esac
+    already_selected=0
+    for selected in ${CONFIRM_SCENARIOS[@]+"${CONFIRM_SCENARIOS[@]}"}; do
+        [ "$selected" = "$plan_scenario" ] && already_selected=1
+    done
+    [ "$already_selected" -eq 0 ] && CONFIRM_SCENARIOS+=("$plan_scenario")
 done < "$PLAN_FILE"
 
 CONFIRMATION_ARGS=()
 if [ "${#VERIFY_NAMES[@]}" -gt 0 ]; then
-    # One process covers both scenarios; only narrow those legs when the other
-    # workload has nothing to confirm.
-    if [ "$select_narrow" -eq 1 ] && [ "$select_wide" -eq 1 ]; then
-        CONFIRM_SCENARIO=""
-    elif [ "$select_narrow" -eq 1 ]; then
-        CONFIRM_SCENARIO="narrow"
-    else
-        CONFIRM_SCENARIO="wide"
-    fi
-
-    echo ">>> Auto-confirm: re-measuring ${#VERIFY_NAMES[@]} benchmark(s) over" \
-        "$CONFIRM_RUNS round(s); a result counts only when it reproduces in" \
-        ">= $CONFIRM_QUORUM of $CONFIRM_RUNS."
+    echo ">>> Auto-confirm: re-measuring ${#VERIFY_NAMES[@]} benchmark(s) across" \
+        "${#CONFIRM_SCENARIOS[@]} scenario(s) over $CONFIRM_RUNS round(s); a result" \
+        "counts only when it reproduces in >= $CONFIRM_QUORUM of $CONFIRM_RUNS."
     for round in $(seq 1 "$CONFIRM_RUNS"); do
         round_dir="$CONFIRM_DIR/round$round"
         mkdir -p "$round_dir"
         echo ">>> Confirmation round $round/$CONFIRM_RUNS..."
         cpu_sample "confirm${round}-start"
-        # Keep each pair adjacent, and alternate which side runs first so a stable
-        # position effect cancels across the default four rounds.
-        if [ $((round % 2)) -eq 1 ]; then
-            run_leg "$CONFIRM_SCENARIO" "$CANDIDATE_DRIVER_NAME" "$round_dir/candidate.json"
-            run_leg "$CONFIRM_SCENARIO" "$BASELINE_DRIVER_NAME" "$round_dir/baseline.json"
-        else
-            run_leg "$CONFIRM_SCENARIO" "$BASELINE_DRIVER_NAME" "$round_dir/baseline.json"
-            run_leg "$CONFIRM_SCENARIO" "$CANDIDATE_DRIVER_NAME" "$round_dir/candidate.json"
-        fi
+        round_args=()
+        for scenario in "${CONFIRM_SCENARIOS[@]}"; do
+            # Keep each pair adjacent, and alternate which side runs first so a
+            # stable position effect cancels across the default four rounds.
+            if [ $((round % 2)) -eq 1 ]; then
+                run_leg "$scenario" "$CANDIDATE_DRIVER_NAME" \
+                    "$round_dir/candidate-$scenario.json"
+                run_leg "$scenario" "$BASELINE_DRIVER_NAME" \
+                    "$round_dir/baseline-$scenario.json"
+            else
+                run_leg "$scenario" "$BASELINE_DRIVER_NAME" \
+                    "$round_dir/baseline-$scenario.json"
+                run_leg "$scenario" "$CANDIDATE_DRIVER_NAME" \
+                    "$round_dir/candidate-$scenario.json"
+            fi
+            round_args+=(
+                --baseline "$round_dir/baseline-$scenario.json"
+                --candidate "$round_dir/candidate-$scenario.json"
+            )
+        done
         cpu_sample "confirm${round}-end"
         "$BENCH_PYTHON" "$COMPARE_SCRIPT" \
-            --baseline "$round_dir/baseline.json" \
-            --candidate "$round_dir/candidate.json" \
+            "${round_args[@]}" \
             --repetitions "$REPETITIONS" \
             --regression-ratio "$REGRESSION_RATIO" \
             --improvement-ratio "$IMPROVEMENT_RATIO" \

--- a/mssql-odbc-bench/src/admin_main.cpp
+++ b/mssql-odbc-bench/src/admin_main.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "odbc_bench.hpp"
+
+#include <exception>
+#include <iostream>
+#include <string>
+
+// Keep table lifecycle in a separate executable so setup and cleanup cannot enter
+// Google Benchmark's measurement process or timing boundary.
+int main(int argc, char** argv) {
+    if (argc != 2) {
+        std::cerr << "Usage: mssql_odbc_bench_admin <setup|cleanup>\n";
+        return 2;
+    }
+
+    try {
+        const auto config = mssql::odbc::bench::Config::from_environment();
+        mssql::odbc::bench::OdbcSession session(config);
+        const std::string command(argv[1]);
+        if (command == "setup") {
+            mssql::odbc::bench::setup_benchmark_tables(session);
+        } else if (command == "cleanup") {
+            mssql::odbc::bench::cleanup_benchmark_tables(session);
+        } else {
+            std::cerr << "Unknown command '" << command << "'; expected setup or cleanup\n";
+            return 2;
+        }
+    } catch (const std::exception& error) {
+        std::cerr << "ODBC benchmark administration failed: " << error.what() << '\n';
+        return 1;
+    }
+
+    return 0;
+}

--- a/mssql-odbc-bench/src/admin_main.cpp
+++ b/mssql-odbc-bench/src/admin_main.cpp
@@ -11,20 +11,28 @@
 // Google Benchmark's measurement process or timing boundary.
 int main(int argc, char** argv) {
     if (argc != 2) {
-        std::cerr << "Usage: mssql_odbc_bench_admin <setup|cleanup>\n";
+        std::cerr << "Usage: mssql_odbc_bench_admin <setup|cleanup|print-sql>\n";
         return 2;
     }
 
     try {
+        const std::string command(argv[1]);
+        // print-sql is deliberately handled before any connection is made: it is
+        // the offline way to review or replay the generated schema and data.
+        if (command == "print-sql") {
+            mssql::odbc::bench::print_benchmark_sql(std::cout);
+            return 0;
+        }
+
         const auto config = mssql::odbc::bench::Config::from_environment();
         mssql::odbc::bench::OdbcSession session(config);
-        const std::string command(argv[1]);
         if (command == "setup") {
             mssql::odbc::bench::setup_benchmark_tables(session);
         } else if (command == "cleanup") {
             mssql::odbc::bench::cleanup_benchmark_tables(session);
         } else {
-            std::cerr << "Unknown command '" << command << "'; expected setup or cleanup\n";
+            std::cerr << "Unknown command '" << command
+                      << "'; expected setup, cleanup, or print-sql\n";
             return 2;
         }
     } catch (const std::exception& error) {

--- a/mssql-odbc-bench/src/benchmark_main.cpp
+++ b/mssql-odbc-bench/src/benchmark_main.cpp
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "odbc_bench.hpp"
+
+#include <benchmark/benchmark.h>
+
+#include <exception>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+using mssql::odbc::bench::RetrievalMetrics;
+using mssql::odbc::bench::WorkloadRunner;
+
+// Publish wall-time-derived throughput alongside phase timings so the report can
+// compare end-to-end cost while retaining enough context to diagnose a shift.
+void set_counters(benchmark::State& state, const RetrievalMetrics& metrics) {
+    state.counters["rows"] = static_cast<double>(metrics.rows);
+    state.counters["cells"] = static_cast<double>(metrics.cells);
+    state.counters["logical_bytes"] = static_cast<double>(metrics.logical_bytes);
+    state.counters["rows_per_second"] =
+        static_cast<double>(metrics.rows) / metrics.total_seconds;
+    state.counters["cells_per_second"] =
+        static_cast<double>(metrics.cells) / metrics.total_seconds;
+    state.counters["logical_bytes_per_second"] =
+        static_cast<double>(metrics.logical_bytes) / metrics.total_seconds;
+    state.counters["execute_ms"] = metrics.execute_seconds * 1000.0;
+    state.counters["metadata_bind_ms"] = metrics.metadata_bind_seconds * 1000.0;
+    state.counters["fetch_ms"] = metrics.fetch_seconds * 1000.0;
+    state.SetItemsProcessed(static_cast<std::int64_t>(metrics.rows));
+    state.SetBytesProcessed(static_cast<std::int64_t>(metrics.logical_bytes));
+}
+
+}  // namespace
+
+// Register only the selected scenario after an untimed correctness preflight, then
+// let Google Benchmark own repetition and raw JSON emission.
+int main(int argc, char** argv) {
+    benchmark::Initialize(&argc, argv);
+    if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
+        return 2;
+    }
+
+    try {
+        const auto config = mssql::odbc::bench::Config::from_environment();
+        mssql::odbc::bench::OdbcSession session(config);
+        std::vector<std::unique_ptr<WorkloadRunner>> runners;
+        runners.reserve(mssql::odbc::bench::workloads().size());
+
+        for (const auto& spec : mssql::odbc::bench::workloads()) {
+            if (!config.scenario.empty() && config.scenario != spec.scenario) {
+                continue;
+            }
+            auto runner = std::make_unique<WorkloadRunner>(session, spec);
+            runner->preflight();
+            runners.push_back(std::move(runner));
+        }
+
+        std::string benchmark_error;
+        for (auto& runner : runners) {
+            WorkloadRunner* const current = runner.get();
+            benchmark::RegisterBenchmark(
+                current->spec().benchmark_name,
+                [current, &benchmark_error](benchmark::State& state) {
+                    if (!benchmark_error.empty()) {
+                        state.SkipWithError(benchmark_error.c_str());
+                        return;
+                    }
+                    try {
+                        for (auto _ : state) {
+                            (void)_;
+                            const auto metrics = current->retrieve();
+                            state.SetIterationTime(metrics.total_seconds);
+                            set_counters(state, metrics);
+                        }
+                    } catch (const std::exception& error) {
+                        benchmark_error = error.what();
+                        state.SkipWithError(benchmark_error.c_str());
+                    }
+                })
+                ->Iterations(1)
+                ->UseManualTime()
+                ->Unit(benchmark::kMillisecond);
+        }
+
+        benchmark::RunSpecifiedBenchmarks();
+        benchmark::Shutdown();
+        if (!benchmark_error.empty()) {
+            std::cerr << "ODBC benchmark failed: " << benchmark_error << '\n';
+            return 1;
+        }
+    } catch (const std::exception& error) {
+        benchmark::Shutdown();
+        std::cerr << "ODBC benchmark failed: " << error.what() << '\n';
+        return 1;
+    }
+
+    return 0;
+}

--- a/mssql-odbc-bench/src/benchmark_main.cpp
+++ b/mssql-odbc-bench/src/benchmark_main.cpp
@@ -29,7 +29,9 @@ void set_counters(benchmark::State& state, const RetrievalMetrics& metrics) {
     state.counters["logical_bytes_per_second"] =
         static_cast<double>(metrics.logical_bytes) / metrics.total_seconds;
     state.counters["execute_ms"] = metrics.execute_seconds * 1000.0;
-    state.counters["metadata_bind_ms"] = metrics.metadata_bind_seconds * 1000.0;
+    if (metrics.metadata_bind_seconds >= 0.0) {
+        state.counters["metadata_bind_ms"] = metrics.metadata_bind_seconds * 1000.0;
+    }
     state.counters["fetch_ms"] = metrics.fetch_seconds * 1000.0;
     // Zero for the bound modes. On the row-at-a-time workloads it is the number of
     // driver round trips the consumer's access pattern forced, which is the thing

--- a/mssql-odbc-bench/src/benchmark_main.cpp
+++ b/mssql-odbc-bench/src/benchmark_main.cpp
@@ -31,6 +31,10 @@ void set_counters(benchmark::State& state, const RetrievalMetrics& metrics) {
     state.counters["execute_ms"] = metrics.execute_seconds * 1000.0;
     state.counters["metadata_bind_ms"] = metrics.metadata_bind_seconds * 1000.0;
     state.counters["fetch_ms"] = metrics.fetch_seconds * 1000.0;
+    // Zero for the bound modes. On the row-at-a-time workloads it is the number of
+    // driver round trips the consumer's access pattern forced, which is the thing
+    // that actually differs between drivers there.
+    state.counters["get_data_calls"] = static_cast<double>(metrics.get_data_calls);
     state.SetItemsProcessed(static_cast<std::int64_t>(metrics.rows));
     state.SetBytesProcessed(static_cast<std::int64_t>(metrics.logical_bytes));
 }

--- a/mssql-odbc-bench/src/odbc_bench.cpp
+++ b/mssql-odbc-bench/src/odbc_bench.cpp
@@ -30,8 +30,19 @@ namespace {
 
 constexpr SQLSMALLINT kSqlCSSsTime2 = 0x4000;
 constexpr SQLSMALLINT kSqlCSSsTimestampOffset = 0x4001;
+// SQL Server ODBC extension descriptor field carrying a sql_variant value's
+// underlying C type. mssql-python is the only consumer that asks for it, and it
+// is the sole SQLColAttribute field on its fetch path.
+constexpr SQLUSMALLINT kSqlCaSsVariantType = 1215;
 constexpr std::size_t kPatternSize = 15;
 constexpr SQLLEN kIndicatorSentinel = -777;
+// One NULL in every seven rows for a nullable column, offset per column so no two
+// columns go NULL on the same rows. Realistic sparsity without making the payload
+// dominated by NULLs.
+constexpr std::uint64_t kNullPeriod = 7;
+// Repeating source text for every generated string. A pure function of position,
+// so a delivered value can be checked without storing an expected copy.
+constexpr std::string_view kTextCycle = "abcdefghij";
 
 // Mirror the Microsoft SQL Server ODBC extension ABI without depending on
 // platform-specific copies of sqlncli.h.
@@ -84,72 +95,57 @@ enum class ValueKind {
     guid,
     character,
     wide_character,
+    // Inline nullable variable-width text. Length and NULL placement are both
+    // functions of the row id, so the indicator is checked, not just the bytes.
+    var_character,
+    var_wide_character,
+    // PLP columns, never bound: delivered by repeated 8192-byte SQLGetData calls.
+    lob_character,
+    lob_wide_character,
+    // sql_variant values reached through the probe plus SQLColAttribute.
+    variant_integer,
+    variant_bigint,
+    variant_text,
 };
 
-// Keeps SQL generation, binding, payload accounting, and validation on one shared
-// description so the compared drivers receive identical work.
-struct TypeDescriptor {
-    ValueKind kind;
-    const char* sql_type;
-    const char* sql_expression;
-    SQLSMALLINT c_type;
-    std::size_t slot_size;
-    std::uint64_t logical_bytes;
-    SQLLEN expected_indicator;
-};
-
-// Cover common fixed-width conversions plus narrow and wide character paths that
-// stress result-set materialization.
-const std::array<TypeDescriptor, kPatternSize>& type_pattern() {
-    static const std::array<TypeDescriptor, kPatternSize> pattern = {{
-        {ValueKind::bit, "BIT", "CAST(g.[value] % CAST(2 AS BIGINT) AS BIT)",
-         SQL_C_BIT, sizeof(SQLCHAR), 1, sizeof(SQLCHAR)},
-        {ValueKind::tinyint, "TINYINT",
-         "CAST(g.[value] % CAST(251 AS BIGINT) AS TINYINT)", SQL_C_UTINYINT,
-         sizeof(SQLCHAR), 1, sizeof(SQLCHAR)},
-        {ValueKind::smallint, "SMALLINT",
-         "CAST((g.[value] % CAST(60001 AS BIGINT)) - CAST(30000 AS BIGINT) AS SMALLINT)",
-         SQL_C_SSHORT, sizeof(SQLSMALLINT), 2, sizeof(SQLSMALLINT)},
-        {ValueKind::integer, "INT", "CAST(g.[value] AS INT)", SQL_C_SLONG,
-         sizeof(SQLINTEGER), 4, sizeof(SQLINTEGER)},
-        {ValueKind::bigint, "BIGINT", "CAST(g.[value] AS BIGINT)", SQL_C_SBIGINT,
-         sizeof(SQLBIGINT), 8, sizeof(SQLBIGINT)},
-        {ValueKind::real, "REAL",
-         "CAST(g.[value] % CAST(10000 AS BIGINT) AS REAL)", SQL_C_FLOAT,
-         sizeof(float), 4, sizeof(float)},
-        {ValueKind::double_precision, "FLOAT(53)",
-         "CAST(g.[value] % CAST(1000000 AS BIGINT) AS FLOAT(53))", SQL_C_DOUBLE,
-         sizeof(double), 8, sizeof(double)},
-        {ValueKind::decimal, "DECIMAL(18,4)",
-         "CAST(g.[value] AS DECIMAL(18,4))", SQL_C_CHAR, 32, 9, 0},
-        {ValueKind::date, "DATE", "CAST('2024-02-29' AS DATE)", SQL_C_TYPE_DATE,
-         sizeof(SQL_DATE_STRUCT), 3, sizeof(SQL_DATE_STRUCT)},
-        {ValueKind::time, "TIME(7)", "CAST('12:34:56.1234567' AS TIME(7))",
-         kSqlCSSsTime2, sizeof(SqlSsTime2), 5, sizeof(SqlSsTime2)},
-        {ValueKind::datetime2, "DATETIME2(7)",
-         "CAST('2024-02-29T12:34:56.1234567' AS DATETIME2(7))",
-         SQL_C_TYPE_TIMESTAMP, sizeof(SQL_TIMESTAMP_STRUCT), 8,
-         sizeof(SQL_TIMESTAMP_STRUCT)},
-        {ValueKind::datetimeoffset, "DATETIMEOFFSET(7)",
-         "CAST('2024-02-29T12:34:56.1234567+00:00' AS DATETIMEOFFSET(7))",
-         kSqlCSSsTimestampOffset, sizeof(SqlSsTimestampOffset), 10,
-         sizeof(SqlSsTimestampOffset)},
-        {ValueKind::guid, "UNIQUEIDENTIFIER",
-         "CAST('00112233-4455-6677-8899-AABBCCDDEEFF' AS UNIQUEIDENTIFIER)",
-         SQL_C_GUID, sizeof(SqlGuid), 16, sizeof(SqlGuid)},
-        {ValueKind::character, "CHAR(8)", "CAST('ODBCBEN1' AS CHAR(8))",
-         SQL_C_CHAR, 9, 8, 8},
-        {ValueKind::wide_character, "NCHAR(8)",
-         "CAST(N'ODBCWIDE' AS NCHAR(8))", SQL_C_WCHAR, 9 * sizeof(SQLWCHAR), 16,
-         8 * sizeof(SQLWCHAR)},
-    }};
-    return pattern;
+// True for the shapes that must never be bound. mssql-odbc answers a bound PLP
+// column with SQL_ROW_ERROR (AB#47361) and mssql-python never binds one either,
+// so routing them through SQLGetData is both the supported and the realistic path.
+bool is_lob_kind(ValueKind kind) {
+    return kind == ValueKind::lob_character || kind == ValueKind::lob_wide_character;
 }
 
-// Couples a deterministic SQL column name to its shared type contract.
+// True for the shapes that need the zero-length SQL_C_BINARY probe first.
+bool is_variant_kind(ValueKind kind) {
+    return kind == ValueKind::variant_integer || kind == ValueKind::variant_bigint ||
+           kind == ValueKind::variant_text;
+}
+
+// Couples one generated SQL column to everything that must agree about it:
+// its DDL, its deterministic value generator, the C type used to read it, the
+// buffer stride, and the validator. Keeping them on one record is what stops
+// setup and measurement from drifting apart.
 struct ColumnSpec {
     std::string name;
-    const TypeDescriptor* type;
+    ValueKind kind;
+    std::string sql_type;
+    std::string sql_expression;
+    // C type used by SQLBindCol and SQLGetData alike. SQL_C_DEFAULT is never
+    // used: mssql-odbc rejects it at bind time (HY003) and no consumer sends it.
+    SQLSMALLINT c_type = SQL_C_CHAR;
+    std::size_t slot_size = 0;
+    // Constant payload width for the fixed shapes; 0 when length varies per row.
+    std::uint64_t logical_bytes = 0;
+    // Exact indicator every row must report, or 0 when it varies.
+    SQLLEN expected_indicator = 0;
+    // Delivered length for row_id is length_base + (row_id % length_span)
+    // characters. length_span == 0 means the column has no generated length.
+    std::size_t length_base = 0;
+    std::size_t length_span = 0;
+    // Bytes per delivered character (1 for narrow, sizeof(SQLWCHAR) for wide).
+    std::size_t unit_bytes = 1;
+    // 0 for NOT NULL; otherwise the row is NULL when (row_id + phase) % 7 == 0.
+    std::uint64_t null_phase = 0;
 };
 
 // Read environment values without platform-specific ownership leaking to callers.
@@ -356,44 +352,327 @@ std::string column_name(std::size_t ordinal) {
     return buffer;
 }
 
-// Repeat the exact type pattern to create narrow and very-wide workloads.
-std::vector<ColumnSpec> columns_for(const WorkloadSpec& spec) {
-    std::vector<ColumnSpec> columns;
-    columns.reserve(spec.column_count());
-    for (std::size_t repeat = 0; repeat < spec.pattern_repetitions; ++repeat) {
+// Delivered character count for a generated variable-length value.
+std::size_t generated_length(const ColumnSpec& column, std::uint64_t row_id) {
+    if (column.length_span == 0) {
+        return column.length_base;
+    }
+    return column.length_base + static_cast<std::size_t>(row_id % column.length_span);
+}
+
+// Whether the deterministic generator wrote NULL into this cell.
+bool generated_null(const ColumnSpec& column, std::uint64_t row_id) {
+    return column.null_phase != 0 && (row_id + column.null_phase) % kNullPeriod == 0;
+}
+
+// Wrap a value expression in the column's NULL rule so the schema, the data, and
+// the validator share one definition of where the NULLs are.
+std::string apply_null_rule(const ColumnSpec& column, const std::string& expression) {
+    if (column.null_phase == 0) {
+        return expression;
+    }
+    std::ostringstream sql;
+    sql << "CASE WHEN (g.[value] + " << column.null_phase << ") % " << kNullPeriod
+        << " = 0 THEN NULL ELSE " << expression << " END";
+    return sql.str();
+}
+
+// Build the server-side generator for one variable-length text column: take the
+// first N characters of a repeated cycle, where N is a function of the row id.
+std::string text_generator(const ColumnSpec& column, bool wide, bool max_length) {
+    const std::size_t longest = column.length_base + (column.length_span == 0
+                                                          ? 0
+                                                          : column.length_span - 1);
+    const std::size_t repeats = (longest + kTextCycle.size() - 1) / kTextCycle.size();
+    std::ostringstream source;
+    if (wide) {
+        source << "N'" << kTextCycle << '\'';
+    } else {
+        source << '\'' << kTextCycle << '\'';
+    }
+    std::ostringstream sql;
+    sql << "LEFT(REPLICATE(";
+    if (max_length) {
+        // REPLICATE truncates at 8000 bytes / 4000 characters unless its input is
+        // already a MAX type, which is the only way to generate a value that
+        // needs more than one SQLGetData chunk.
+        sql << "CAST(" << source.str() << " AS " << (wide ? "NVARCHAR(MAX)" : "VARCHAR(MAX)")
+            << ')';
+    } else {
+        sql << source.str();
+    }
+    sql << ", " << repeats << "), " << column.length_base;
+    if (column.length_span != 0) {
+        sql << " + CAST(g.[value] % " << column.length_span << " AS INT)";
+    }
+    sql << ')';
+    return sql.str();
+}
+
+// Cover common fixed-width conversions plus narrow and wide character paths that
+// stress result-set materialization.
+struct FixedType {
+    ValueKind kind;
+    const char* sql_type;
+    const char* sql_expression;
+    SQLSMALLINT c_type;
+    std::size_t slot_size;
+    std::uint64_t logical_bytes;
+    SQLLEN expected_indicator;
+};
+
+// The fifteen-column pattern every fixed-width table repeats. Its members pin
+// the C type, the buffer stride, and the exact indicator each column must
+// report, so a driver that silently changed a transfer size is caught in
+// preflight rather than showing up as a throughput difference.
+const std::array<FixedType, kPatternSize>& type_pattern() {
+    static const std::array<FixedType, kPatternSize> pattern = {{
+        {ValueKind::bit, "BIT", "CAST(g.[value] % CAST(2 AS BIGINT) AS BIT)",
+         SQL_C_BIT, sizeof(SQLCHAR), 1, sizeof(SQLCHAR)},
+        {ValueKind::tinyint, "TINYINT",
+         "CAST(g.[value] % CAST(251 AS BIGINT) AS TINYINT)", SQL_C_UTINYINT,
+         sizeof(SQLCHAR), 1, sizeof(SQLCHAR)},
+        {ValueKind::smallint, "SMALLINT",
+         "CAST((g.[value] % CAST(60001 AS BIGINT)) - CAST(30000 AS BIGINT) AS SMALLINT)",
+         SQL_C_SSHORT, sizeof(SQLSMALLINT), 2, sizeof(SQLSMALLINT)},
+        {ValueKind::integer, "INT", "CAST(g.[value] AS INT)", SQL_C_SLONG,
+         sizeof(SQLINTEGER), 4, sizeof(SQLINTEGER)},
+        {ValueKind::bigint, "BIGINT", "CAST(g.[value] AS BIGINT)", SQL_C_SBIGINT,
+         sizeof(SQLBIGINT), 8, sizeof(SQLBIGINT)},
+        {ValueKind::real, "REAL",
+         "CAST(g.[value] % CAST(10000 AS BIGINT) AS REAL)", SQL_C_FLOAT,
+         sizeof(float), 4, sizeof(float)},
+        {ValueKind::double_precision, "FLOAT(53)",
+         "CAST(g.[value] % CAST(1000000 AS BIGINT) AS FLOAT(53))", SQL_C_DOUBLE,
+         sizeof(double), 8, sizeof(double)},
+        {ValueKind::decimal, "DECIMAL(18,4)",
+         "CAST(g.[value] AS DECIMAL(18,4))", SQL_C_CHAR, 32, 9, 0},
+        {ValueKind::date, "DATE", "CAST('2024-02-29' AS DATE)", SQL_C_TYPE_DATE,
+         sizeof(SQL_DATE_STRUCT), 3, sizeof(SQL_DATE_STRUCT)},
+        {ValueKind::time, "TIME(7)", "CAST('12:34:56.1234567' AS TIME(7))",
+         kSqlCSSsTime2, sizeof(SqlSsTime2), 5, sizeof(SqlSsTime2)},
+        {ValueKind::datetime2, "DATETIME2(7)",
+         "CAST('2024-02-29T12:34:56.1234567' AS DATETIME2(7))",
+         SQL_C_TYPE_TIMESTAMP, sizeof(SQL_TIMESTAMP_STRUCT), 8,
+         sizeof(SQL_TIMESTAMP_STRUCT)},
+        {ValueKind::datetimeoffset, "DATETIMEOFFSET(7)",
+         "CAST('2024-02-29T12:34:56.1234567+00:00' AS DATETIMEOFFSET(7))",
+         kSqlCSSsTimestampOffset, sizeof(SqlSsTimestampOffset), 10,
+         sizeof(SqlSsTimestampOffset)},
+        {ValueKind::guid, "UNIQUEIDENTIFIER",
+         "CAST('00112233-4455-6677-8899-AABBCCDDEEFF' AS UNIQUEIDENTIFIER)",
+         SQL_C_GUID, sizeof(SqlGuid), 16, sizeof(SqlGuid)},
+        {ValueKind::character, "CHAR(8)", "CAST('ODBCBEN1' AS CHAR(8))",
+         SQL_C_CHAR, 9, 8, 8},
+        {ValueKind::wide_character, "NCHAR(8)",
+         "CAST(N'ODBCWIDE' AS NCHAR(8))", SQL_C_WCHAR, 9 * sizeof(SQLWCHAR), 16,
+         8 * sizeof(SQLWCHAR)},
+    }};
+    return pattern;
+}
+
+// Append one repeat of the fixed pattern, numbering columns from the current width.
+void append_fixed_pattern(std::vector<ColumnSpec>& columns, std::size_t repetitions) {
+    for (std::size_t repeat = 0; repeat < repetitions; ++repeat) {
         for (const auto& type : type_pattern()) {
-            columns.push_back({column_name(columns.size() + 1), &type});
+            ColumnSpec column;
+            column.name = column_name(columns.size() + 1);
+            column.kind = type.kind;
+            column.sql_type = type.sql_type;
+            column.sql_expression = type.sql_expression;
+            column.c_type = type.c_type;
+            column.slot_size = type.slot_size;
+            column.logical_bytes = type.logical_bytes;
+            column.expected_indicator = type.expected_indicator;
+            columns.push_back(std::move(column));
+        }
+    }
+}
+
+// Build one nullable inline variable-width column: bounded VARCHAR/NVARCHAR only,
+// so it stays on the bindable path and never becomes a PLP column by accident.
+ColumnSpec make_inline_text(std::vector<ColumnSpec>& columns, bool wide,
+                            std::size_t max_length, std::uint64_t null_phase) {
+    ColumnSpec column;
+    column.name = column_name(columns.size() + 1);
+    column.kind = wide ? ValueKind::var_wide_character : ValueKind::var_character;
+    column.unit_bytes = wide ? sizeof(SQLWCHAR) : 1;
+    column.c_type = wide ? SQL_C_WCHAR : SQL_C_CHAR;
+    column.length_base = 1;
+    column.length_span = max_length;
+    column.null_phase = null_phase;
+    // One extra unit for the terminator ODBC always writes.
+    column.slot_size = (max_length + 1) * column.unit_bytes;
+    std::ostringstream type;
+    type << (wide ? "NVARCHAR(" : "VARCHAR(") << max_length << ')';
+    column.sql_type = type.str();
+    column.sql_expression = apply_null_rule(column, text_generator(column, wide, false));
+    return column;
+}
+
+// Build one MAX column whose shortest value still needs more than one 8192-byte
+// SQLGetData call, which is the continuation loop the review asked to measure.
+ColumnSpec make_lob_text(std::vector<ColumnSpec>& columns, bool wide,
+                         std::size_t length_base, std::size_t length_span,
+                         std::uint64_t null_phase) {
+    ColumnSpec column;
+    column.name = column_name(columns.size() + 1);
+    column.kind = wide ? ValueKind::lob_wide_character : ValueKind::lob_character;
+    column.unit_bytes = wide ? sizeof(SQLWCHAR) : 1;
+    column.c_type = wide ? SQL_C_WCHAR : SQL_C_CHAR;
+    column.length_base = length_base;
+    column.length_span = length_span;
+    column.null_phase = null_phase;
+    // Never bound, so the slot is the continuation chunk rather than a row stride.
+    column.slot_size = kLobChunkBytes;
+    column.sql_type = wide ? "NVARCHAR(MAX)" : "VARCHAR(MAX)";
+    column.sql_expression = apply_null_rule(column, text_generator(column, wide, true));
+    return column;
+}
+
+// Build one sql_variant column. Only base types whose SQL_CA_SS_VARIANT_TYPE
+// answer is unambiguous are used: mssql-odbc deliberately reports SQL_C_CHAR
+// where msodbcsql reports SQL_C_NUMERIC for decimal/money variants, and a
+// benchmark that depended on that difference would not be the same work on both.
+ColumnSpec make_variant(std::vector<ColumnSpec>& columns, ValueKind kind,
+                        std::uint64_t null_phase) {
+    ColumnSpec column;
+    column.name = column_name(columns.size() + 1);
+    column.kind = kind;
+    column.sql_type = "SQL_VARIANT";
+    column.null_phase = null_phase;
+    // Widest rendering any accepted variant C type needs, including the character
+    // fallback the driver may legitimately choose for the text arm.
+    column.slot_size = 64;
+    switch (kind) {
+        case ValueKind::variant_integer:
+            column.sql_expression = "CAST(CAST(g.[value] AS INT) AS SQL_VARIANT)";
+            column.logical_bytes = 4;
+            break;
+        case ValueKind::variant_bigint:
+            column.sql_expression = "CAST(CAST(g.[value] AS BIGINT) AS SQL_VARIANT)";
+            column.logical_bytes = 8;
+            break;
+        default:
+            column.sql_expression =
+                "CAST(CAST(N'ODBCVARIANT' AS NVARCHAR(32)) AS SQL_VARIANT)";
+            // Delivered as SQL_C_CHAR, which is what mssql-python requests for a
+            // character variant, so the payload is one byte per ASCII character.
+            column.logical_bytes = 11;
+            break;
+    }
+    column.sql_expression = apply_null_rule(column, column.sql_expression);
+    return column;
+}
+
+// The single source of truth for a table's columns: DDL, generator, binding, and
+// validation are all derived from this one list.
+//
+// VARBINARY is deliberately absent. mssql-odbc implements only the zero-length
+// SQL_C_BINARY length probe; binary *delivery* into a real buffer is still
+// HYC00 (AB#47239, `mssql-odbc/docs/typed-columnar-fetch-plan.md`), and
+// binary-to-character hex rendering is not implemented either. Adding a
+// VARBINARY column would fail the candidate and baseline legs while the
+// Microsoft leg passed, which is a broken comparison rather than a measurement.
+std::vector<ColumnSpec> columns_for(const TableSpec& table) {
+    std::vector<ColumnSpec> columns;
+    switch (table.shape) {
+        case TableShape::fixed_pattern:
+            columns.reserve(table.pattern_repetitions * kPatternSize);
+            append_fixed_pattern(columns, table.pattern_repetitions);
+            break;
+        case TableShape::mixed_lob:
+            append_fixed_pattern(columns, table.pattern_repetitions);
+            // One short MAX column. The payload is tiny on purpose: what this
+            // table measures is that a single PLP column moves the whole result
+            // onto the row-at-a-time path, not the cost of the LOB itself.
+            columns.push_back(make_lob_text(columns, true, 24, 0, 0));
+            break;
+        case TableShape::variable_width: {
+            ColumnSpec identity;
+            identity.name = column_name(1);
+            identity.kind = ValueKind::integer;
+            identity.sql_type = "INT";
+            identity.sql_expression = "CAST(g.[value] AS INT)";
+            identity.c_type = SQL_C_SLONG;
+            identity.slot_size = sizeof(SQLINTEGER);
+            identity.logical_bytes = 4;
+            identity.expected_indicator = sizeof(SQLINTEGER);
+            columns.push_back(std::move(identity));
+            columns.push_back(make_inline_text(columns, false, 64, 1));
+            columns.push_back(make_inline_text(columns, false, 256, 2));
+            columns.push_back(make_inline_text(columns, false, 1024, 3));
+            columns.push_back(make_inline_text(columns, true, 64, 4));
+            columns.push_back(make_inline_text(columns, true, 256, 5));
+            columns.push_back(make_inline_text(columns, true, 1024, 6));
+            break;
+        }
+        case TableShape::lob_max: {
+            ColumnSpec identity;
+            identity.name = column_name(1);
+            identity.kind = ValueKind::integer;
+            identity.sql_type = "INT";
+            identity.sql_expression = "CAST(g.[value] AS INT)";
+            identity.c_type = SQL_C_SLONG;
+            identity.slot_size = sizeof(SQLINTEGER);
+            identity.logical_bytes = 4;
+            identity.expected_indicator = sizeof(SQLINTEGER);
+            columns.push_back(std::move(identity));
+            // 9000-9999 UTF-16 characters is 18000-19998 bytes, so SQL_C_WCHAR
+            // needs three 8192-byte calls; 20000-20999 narrow bytes needs three
+            // as well. Both stay well inside one TDS PLP value.
+            columns.push_back(make_lob_text(columns, true, 9000, 1000, 1));
+            columns.push_back(make_lob_text(columns, false, 20000, 1000, 2));
+            break;
+        }
+        case TableShape::sql_variant: {
+            ColumnSpec identity;
+            identity.name = column_name(1);
+            identity.kind = ValueKind::integer;
+            identity.sql_type = "INT";
+            identity.sql_expression = "CAST(g.[value] AS INT)";
+            identity.c_type = SQL_C_SLONG;
+            identity.slot_size = sizeof(SQLINTEGER);
+            identity.logical_bytes = 4;
+            identity.expected_indicator = sizeof(SQLINTEGER);
+            columns.push_back(std::move(identity));
+            columns.push_back(make_variant(columns, ValueKind::variant_integer, 0));
+            columns.push_back(make_variant(columns, ValueKind::variant_text, 0));
+            // Nullable so the probe's SQL_NULL_DATA arm is exercised too; that is
+            // the branch mssql-python takes before it ever asks for the type.
+            columns.push_back(make_variant(columns, ValueKind::variant_bigint, 3));
+            break;
         }
     }
     return columns;
 }
 
 // Keep benchmark tables isolated under deterministic, explicitly quoted names.
-std::string qualified_table(const WorkloadSpec& spec) {
-    return std::string("[dbo].[") + spec.table_name + ']';
+std::string qualified_table(const TableSpec& table) {
+    return std::string("[dbo].[") + table.table_name + ']';
 }
 
-// Materialize a fixed-width schema that exercises conversion rather than LOB I/O.
-std::string create_table_sql(const WorkloadSpec& spec) {
-    const auto columns = columns_for(spec);
+// Materialize the schema the workload catalog promises.
+std::string create_table_sql(const TableSpec& table) {
+    const auto columns = columns_for(table);
     std::ostringstream sql;
-    sql << "CREATE TABLE " << qualified_table(spec) << " (";
+    sql << "CREATE TABLE " << qualified_table(table) << " (";
     for (std::size_t index = 0; index < columns.size(); ++index) {
         if (index != 0) {
             sql << ',';
         }
-        sql << '[' << columns[index].name << "] " << columns[index].type->sql_type
-            << " NOT NULL";
+        sql << '[' << columns[index].name << "] " << columns[index].sql_type
+            << (columns[index].null_phase == 0 ? " NOT NULL" : " NULL");
     }
     sql << ')';
     return sql.str();
 }
 
 // Generate deterministic values in one server-side statement outside the timed run.
-std::string insert_sql(const WorkloadSpec& spec) {
-    const auto columns = columns_for(spec);
+std::string insert_sql(const TableSpec& table) {
+    const auto columns = columns_for(table);
     std::ostringstream sql;
-    sql << "INSERT INTO " << qualified_table(spec) << " (";
+    sql << "INSERT INTO " << qualified_table(table) << " (";
     for (std::size_t index = 0; index < columns.size(); ++index) {
         if (index != 0) {
             sql << ',';
@@ -405,16 +684,15 @@ std::string insert_sql(const WorkloadSpec& spec) {
         if (index != 0) {
             sql << ',';
         }
-        sql << columns[index].type->sql_expression;
+        sql << columns[index].sql_expression;
     }
-    sql << " FROM GENERATE_SERIES(CAST(1 AS BIGINT), CAST(" << spec.row_count
+    sql << " FROM GENERATE_SERIES(CAST(1 AS BIGINT), CAST(" << table.row_count
         << " AS BIGINT)) AS g OPTION (MAXDOP 1)";
     return sql.str();
 }
 
 // Preserve column order so each bound buffer has a stable semantic contract.
-std::string select_sql(const WorkloadSpec& spec,
-                       const std::vector<ColumnSpec>& columns) {
+std::string select_sql(const TableSpec& table, const std::vector<ColumnSpec>& columns) {
     std::ostringstream sql;
     sql << "SELECT ";
     for (std::size_t index = 0; index < columns.size(); ++index) {
@@ -423,7 +701,7 @@ std::string select_sql(const WorkloadSpec& spec,
         }
         sql << '[' << columns[index].name << ']';
     }
-    sql << " FROM " << qualified_table(spec) << " OPTION (MAXDOP 1)";
+    sql << " FROM " << qualified_table(table) << " OPTION (MAXDOP 1)";
     return sql.str();
 }
 
@@ -434,305 +712,6 @@ std::uint64_t splitmix64(std::uint64_t value) {
     value = (value ^ (value >> 27)) * 0x94D049BB133111EBULL;
     return value ^ (value >> 31);
 }
-
-// Owns one column-wise row-array buffer with alignment valid for every bound C type.
-class ColumnBuffer {
-public:
-    explicit ColumnBuffer(const TypeDescriptor& type)
-        : type_(&type),
-          storage_((type.slot_size * kRowArraySize +
-                    sizeof(std::max_align_t) - 1) /
-                   sizeof(std::max_align_t)),
-          indicators_(kRowArraySize, kIndicatorSentinel) {}
-
-    SQLPOINTER data() {
-        return static_cast<SQLPOINTER>(storage_.data());
-    }
-
-    SQLLEN* indicators() {
-        return indicators_.data();
-    }
-
-    SQLLEN indicator(std::size_t row) const {
-        return indicators_[row];
-    }
-
-    void reset_indicators() {
-        std::fill(indicators_.begin(), indicators_.end(), kIndicatorSentinel);
-    }
-
-    const TypeDescriptor& type() const {
-        return *type_;
-    }
-
-    // Copy rather than reinterpret storage so validation does not assume alignment
-    // beyond the ODBC buffer contract.
-    template <typename T>
-    T read(std::size_t row) const {
-        if (sizeof(T) > type_->slot_size || row >= kRowArraySize) {
-            throw std::logic_error("invalid typed read from column buffer");
-        }
-        T value{};
-        const auto* bytes = reinterpret_cast<const unsigned char*>(storage_.data());
-        std::memcpy(&value, bytes + row * type_->slot_size, sizeof(T));
-        return value;
-    }
-
-    const unsigned char* row_bytes(std::size_t row) const {
-        const auto* bytes = reinterpret_cast<const unsigned char*>(storage_.data());
-        return bytes + row * type_->slot_size;
-    }
-
-private:
-    const TypeDescriptor* type_;
-    std::vector<std::max_align_t> storage_;
-    std::vector<SQLLEN> indicators_;
-};
-
-// Confirm the driver wrote a complete, non-null value before inspecting payload bytes.
-void validate_indicator(const ColumnBuffer& buffer, std::size_t row) {
-    const SQLLEN indicator = buffer.indicator(row);
-    if (indicator == SQL_NULL_DATA) {
-        throw std::runtime_error("preflight found NULL in a NOT NULL workload column");
-    }
-    if (indicator < 0 || indicator == kIndicatorSentinel) {
-        throw std::runtime_error("preflight found an invalid or unwritten indicator");
-    }
-
-    const auto& type = buffer.type();
-    if (type.expected_indicator != 0 && indicator != type.expected_indicator) {
-        std::ostringstream message;
-        message << "preflight indicator mismatch: expected " << type.expected_indicator
-                << ", got " << indicator;
-        throw std::runtime_error(message.str());
-    }
-    if (type.kind == ValueKind::decimal &&
-        (indicator == 0 || static_cast<std::size_t>(indicator) >= type.slot_size)) {
-        throw std::runtime_error("preflight decimal indicator is outside its fixed slot");
-    }
-}
-
-// Attach the row identity to semantic mismatches found during untimed preflight.
-void require_value(bool condition, const char* description, std::uint64_t row_id) {
-    if (!condition) {
-        std::ostringstream message;
-        message << "preflight value mismatch for " << description << " at row id "
-                << row_id;
-        throw std::runtime_error(message.str());
-    }
-}
-
-// Validate both text termination and numeric meaning for DECIMAL-to-character binding.
-void validate_decimal(const ColumnBuffer& buffer, std::size_t row,
-                      std::uint64_t row_id) {
-    const auto length = static_cast<std::size_t>(buffer.indicator(row));
-    const char* text = reinterpret_cast<const char*>(buffer.row_bytes(row));
-    require_value(text[length] == '\0', "DECIMAL terminator", row_id);
-
-    errno = 0;
-    char* end = nullptr;
-    const long double value = std::strtold(text, &end);
-    while (end != nullptr && *end != '\0' &&
-           std::isspace(static_cast<unsigned char>(*end)) != 0) {
-        ++end;
-    }
-    require_value(errno == 0 && end != text && end != nullptr && *end == '\0' &&
-                      value == static_cast<long double>(row_id),
-                  "DECIMAL(18,4)", row_id);
-}
-
-// Check each conversion shape on representative rows without adding work to timing.
-void validate_representative_value(const ColumnBuffer& buffer, std::size_t row,
-                                   std::uint64_t row_id) {
-    switch (buffer.type().kind) {
-        case ValueKind::bit:
-            require_value(buffer.read<SQLCHAR>(row) == row_id % 2, "BIT", row_id);
-            break;
-        case ValueKind::tinyint:
-            require_value(buffer.read<SQLCHAR>(row) == row_id % 251, "TINYINT",
-                          row_id);
-            break;
-        case ValueKind::smallint:
-            require_value(
-                buffer.read<SQLSMALLINT>(row) ==
-                    static_cast<SQLSMALLINT>(
-                        static_cast<std::int64_t>(row_id % 60001) - 30000),
-                "SMALLINT", row_id);
-            break;
-        case ValueKind::integer:
-            require_value(buffer.read<SQLINTEGER>(row) ==
-                              static_cast<SQLINTEGER>(row_id),
-                          "INT", row_id);
-            break;
-        case ValueKind::bigint:
-            require_value(buffer.read<SQLBIGINT>(row) ==
-                              static_cast<SQLBIGINT>(row_id),
-                          "BIGINT", row_id);
-            break;
-        case ValueKind::real:
-            require_value(buffer.read<float>(row) ==
-                              static_cast<float>(row_id % 10000),
-                          "REAL", row_id);
-            break;
-        case ValueKind::double_precision:
-            require_value(buffer.read<double>(row) ==
-                              static_cast<double>(row_id % 1000000),
-                          "FLOAT(53)", row_id);
-            break;
-        case ValueKind::decimal:
-            validate_decimal(buffer, row, row_id);
-            break;
-        case ValueKind::date: {
-            const auto value = buffer.read<SQL_DATE_STRUCT>(row);
-            require_value(value.year == 2024 && value.month == 2 && value.day == 29,
-                          "DATE", row_id);
-            break;
-        }
-        case ValueKind::time: {
-            const auto value = buffer.read<SqlSsTime2>(row);
-            require_value(value.hour == 12 && value.minute == 34 &&
-                              value.second == 56 && value.fraction == 123456700,
-                          "TIME(7)", row_id);
-            break;
-        }
-        case ValueKind::datetime2: {
-            const auto value = buffer.read<SQL_TIMESTAMP_STRUCT>(row);
-            require_value(
-                value.year == 2024 && value.month == 2 && value.day == 29 &&
-                    value.hour == 12 && value.minute == 34 && value.second == 56 &&
-                    value.fraction == 123456700,
-                "DATETIME2(7)", row_id);
-            break;
-        }
-        case ValueKind::datetimeoffset: {
-            const auto value = buffer.read<SqlSsTimestampOffset>(row);
-            require_value(
-                value.year == 2024 && value.month == 2 && value.day == 29 &&
-                    value.hour == 12 && value.minute == 34 && value.second == 56 &&
-                    value.fraction == 123456700 && value.timezone_hour == 0 &&
-                    value.timezone_minute == 0,
-                "DATETIMEOFFSET(7)", row_id);
-            break;
-        }
-        case ValueKind::guid: {
-            const auto value = buffer.read<SqlGuid>(row);
-            const SQLCHAR tail[] = {0x88, 0x99, 0xAA, 0xBB,
-                                    0xCC, 0xDD, 0xEE, 0xFF};
-            require_value(value.data1 == 0x00112233 && value.data2 == 0x4455 &&
-                              value.data3 == 0x6677 &&
-                              std::memcmp(value.data4, tail, sizeof(tail)) == 0,
-                          "UNIQUEIDENTIFIER", row_id);
-            break;
-        }
-        case ValueKind::character:
-            require_value(
-                std::memcmp(buffer.row_bytes(row), "ODBCBEN1", 8) == 0 &&
-                    buffer.row_bytes(row)[8] == 0,
-                "CHAR(8)", row_id);
-            break;
-        case ValueKind::wide_character: {
-            const auto* value =
-                reinterpret_cast<const SQLWCHAR*>(buffer.row_bytes(row));
-            constexpr char expected[] = "ODBCWIDE";
-            bool matches = value[8] == 0;
-            for (std::size_t index = 0; index < 8 && matches; ++index) {
-                matches =
-                    value[index] == static_cast<SQLWCHAR>(expected[index]);
-            }
-            require_value(matches, "NCHAR(8)", row_id);
-            break;
-        }
-    }
-}
-
-// Proves that row-array fetching returns every row exactly once and that every
-// conversion family produces the expected representation before timing is trusted.
-class PreflightValidator {
-public:
-    explicit PreflightValidator(const WorkloadSpec& spec)
-        : spec_(spec),
-          seen_(static_cast<std::size_t>(spec.row_count + 1), false),
-          representatives_({1, 2, 1024, spec.row_count / 2, spec.row_count}),
-          representative_seen_(representatives_.size(), false) {
-        std::sort(representatives_.begin(), representatives_.end());
-        representatives_.erase(
-            std::unique(representatives_.begin(), representatives_.end()),
-            representatives_.end());
-        representative_seen_.assign(representatives_.size(), false);
-        for (std::uint64_t row_id = 1; row_id <= spec_.row_count; ++row_id) {
-            expected_checksum_ += splitmix64(row_id);
-        }
-    }
-
-    // Validate one fetched rowset and fold its identities into the completeness check.
-    void accept(const std::vector<ColumnBuffer>& buffers, SQLULEN rows_fetched) {
-        for (SQLULEN row = 0; row < rows_fetched; ++row) {
-            const auto row_index = static_cast<std::size_t>(row);
-            const SQLINTEGER signed_id = buffers[3].read<SQLINTEGER>(row_index);
-            if (signed_id <= 0 ||
-                static_cast<std::uint64_t>(signed_id) > spec_.row_count) {
-                throw std::runtime_error("preflight found an out-of-range row id");
-            }
-            const auto row_id = static_cast<std::uint64_t>(signed_id);
-            if (seen_[static_cast<std::size_t>(row_id)]) {
-                throw std::runtime_error("preflight found a duplicate row id");
-            }
-            seen_[static_cast<std::size_t>(row_id)] = true;
-            ++accepted_rows_;
-            checksum_ += splitmix64(row_id);
-
-            for (std::size_t repeat = 0; repeat < spec_.pattern_repetitions;
-                 ++repeat) {
-                require_value(
-                    buffers[repeat * kPatternSize + 3].read<SQLINTEGER>(row_index) ==
-                        signed_id,
-                    "repeated INT row id", row_id);
-            }
-
-            for (const auto& buffer : buffers) {
-                validate_indicator(buffer, row_index);
-            }
-
-            const auto representative =
-                std::lower_bound(representatives_.begin(), representatives_.end(),
-                                 row_id);
-            if (representative != representatives_.end() &&
-                *representative == row_id) {
-                const auto representative_index =
-                    static_cast<std::size_t>(representative -
-                                             representatives_.begin());
-                representative_seen_[representative_index] = true;
-                for (const auto& buffer : buffers) {
-                    validate_representative_value(buffer, row_index, row_id);
-                }
-            }
-        }
-    }
-
-    // Reject a run unless counts, checksum, and representative values all completed.
-    std::uint64_t finish() const {
-        if (accepted_rows_ != spec_.row_count) {
-            throw std::runtime_error("preflight row count did not match the workload");
-        }
-        if (checksum_ != expected_checksum_) {
-            throw std::runtime_error("preflight deterministic row checksum did not match");
-        }
-        if (std::find(representative_seen_.begin(), representative_seen_.end(),
-                      false) != representative_seen_.end()) {
-            throw std::runtime_error("preflight did not see every representative row");
-        }
-        return checksum_;
-    }
-
-private:
-    const WorkloadSpec& spec_;
-    std::vector<bool> seen_;
-    std::vector<std::uint64_t> representatives_;
-    std::vector<bool> representative_seen_;
-    std::uint64_t accepted_rows_ = 0;
-    std::uint64_t checksum_ = 0;
-    std::uint64_t expected_checksum_ = 0;
-};
 
 // Use monotonic time because wall-clock adjustments must not affect a benchmark.
 double seconds_between(std::chrono::steady_clock::time_point start,
@@ -747,6 +726,133 @@ SQLPOINTER attribute_value(SQLULEN value) {
 
 }  // namespace
 
+// Derive width from the shared column model so setup and binding cannot drift.
+std::size_t TableSpec::column_count() const {
+    return columns_for(*this).size();
+}
+
+// Every shape except the fixed pattern leads with its INT identity column; the
+// pattern's identity is its fourth entry, and repeats duplicate it.
+std::size_t TableSpec::row_id_column() const {
+    return (shape == TableShape::fixed_pattern || shape == TableShape::mixed_lob) ? 3 : 0;
+}
+
+// Sum the generator's own length rule over every row, so throughput counters
+// describe delivered payload instead of a nominal column width.
+std::uint64_t TableSpec::logical_bytes_total() const {
+    const auto columns = columns_for(*this);
+    std::uint64_t total = 0;
+    for (const auto& column : columns) {
+        const bool constant_width = column.length_span == 0 && column.length_base == 0;
+        if (constant_width && column.null_phase == 0) {
+            total += column.logical_bytes * row_count;
+            continue;
+        }
+        for (std::uint64_t row_id = 1; row_id <= row_count; ++row_id) {
+            if (generated_null(column, row_id)) {
+                continue;
+            }
+            total += constant_width
+                         ? column.logical_bytes
+                         : static_cast<std::uint64_t>(generated_length(column, row_id)) *
+                               column.unit_bytes;
+        }
+    }
+    return total;
+}
+
+// The catalog the admin executable creates and every measurement reads.
+//
+// Row counts are chosen per access shape so one full retrieval stays in the
+// hundreds of milliseconds on all three drivers: a rowset-1 workload issues one
+// driver round trip per row, so it cannot use the same row count as a
+// rowset-1000 one and still finish in comparable time.
+const std::array<TableSpec, kTableCount>& tables() {
+    static const std::array<TableSpec, kTableCount> catalog = {{
+        {"mssql_odbc_bench_fixed_2m_c15", TableShape::fixed_pattern, 2'000'000, 1},
+        {"mssql_odbc_bench_fixed_10k_c600", TableShape::fixed_pattern, 10'000, 40},
+        {"mssql_odbc_bench_fixed_100k_c15", TableShape::fixed_pattern, 100'000, 1},
+        {"mssql_odbc_bench_fixed_20k_c15", TableShape::fixed_pattern, 20'000, 1},
+        {"mssql_odbc_bench_varwidth_100k_c7", TableShape::variable_width, 100'000, 0},
+        {"mssql_odbc_bench_lobmax_1k_c3", TableShape::lob_max, 1'000, 0},
+        {"mssql_odbc_bench_mixedlob_20k_c16", TableShape::mixed_lob, 20'000, 1},
+        {"mssql_odbc_bench_variant_20k_c4", TableShape::sql_variant, 20'000, 0},
+    }};
+    return catalog;
+}
+
+// Look up a catalog table by name so the workload catalog stays declarative and a
+// typo becomes a startup failure instead of a missing benchmark.
+static const TableSpec& table_by_name(const char* name) {
+    for (const auto& table : tables()) {
+        if (std::strcmp(table.table_name, name) == 0) {
+            return table;
+        }
+    }
+    throw std::logic_error("benchmark workload names an unknown table");
+}
+
+// The measured catalog. Ids are stable and carry the shape, so a report row still
+// means something without the catalog beside it, and the candidate, baseline, and
+// Microsoft legs always produce exactly the same set.
+const std::array<WorkloadSpec, kWorkloadCount>& workloads() {
+    static const std::array<WorkloadSpec, kWorkloadCount> specs = {{
+        // Row volume at the fetchall cadence.
+        {"fetch/narrow_2m_c15_fixed/bound_rowset_1000", "narrow",
+         &table_by_name("mssql_odbc_bench_fixed_2m_c15"), AccessMode::bound_drain,
+         kFetchAllRowset},
+        // Per-row conversion and binding breadth, still below the 8060-byte row limit.
+        {"fetch/wide_10k_c600_fixed/bound_rowset_1000", "wide",
+         &table_by_name("mssql_odbc_bench_fixed_10k_c600"), AccessMode::bound_drain,
+         kFetchAllRowset},
+        // The three rowset sizes over identical data, so only the cadence differs.
+        {"fetch/rowset_100k_c15_fixed/bound_rowset_1", "rowset",
+         &table_by_name("mssql_odbc_bench_fixed_100k_c15"), AccessMode::bound_drain,
+         kFetchManyDefaultRowset},
+        {"fetch/rowset_100k_c15_fixed/bound_rowset_64", "rowset",
+         &table_by_name("mssql_odbc_bench_fixed_100k_c15"), AccessMode::bound_drain,
+         kFetchManyCadenceRowset},
+        {"fetch/rowset_100k_c15_fixed/bound_rowset_1000", "rowset",
+         &table_by_name("mssql_odbc_bench_fixed_100k_c15"), AccessMode::bound_drain,
+         kFetchAllRowset},
+        // Same data and cadence as bound_rowset_64, plus the per-call describe,
+        // rebind, and unbind that fetchmany() repeats. The pair isolates that cost.
+        {"fetch/rowset_100k_c15_fixed/bind_cycle_rowset_64", "rowset",
+         &table_by_name("mssql_odbc_bench_fixed_100k_c15"), AccessMode::bound_bind_cycle,
+         kFetchManyCadenceRowset},
+        // The default arraysize: one bind/fetch/unbind lifecycle per row.
+        {"fetch/rowset_20k_c15_fixed/bind_cycle_rowset_1", "rowset",
+         &table_by_name("mssql_odbc_bench_fixed_20k_c15"), AccessMode::bound_bind_cycle,
+         kFetchManyDefaultRowset},
+        // Nullable inline variable width, kept separate from the MAX/PLP path.
+        {"fetch/varwidth_100k_c7_nullable/bound_rowset_1000", "varwidth",
+         &table_by_name("mssql_odbc_bench_varwidth_100k_c7"), AccessMode::bound_drain,
+         kFetchAllRowset},
+        {"fetch/varwidth_100k_c7_nullable/bound_rowset_64", "varwidth",
+         &table_by_name("mssql_odbc_bench_varwidth_100k_c7"), AccessMode::bound_drain,
+         kFetchManyCadenceRowset},
+        // Row-at-a-time SQLGetData over ordinary inline values: the same columns
+        // as bound_rowset_1, so the pair separates the call shape from the cadence.
+        {"getdata/rowwise_20k_c15_fixed/inline_values", "getdata",
+         &table_by_name("mssql_odbc_bench_fixed_20k_c15"), AccessMode::row_wise_get_data,
+         kFetchManyDefaultRowset},
+        // MAX text past one chunk, so every value needs repeated 8192-byte calls.
+        {"getdata/rowwise_1k_c3_lob_max/chunked_8192", "getdata",
+         &table_by_name("mssql_odbc_bench_lobmax_1k_c3"), AccessMode::row_wise_get_data,
+         kFetchManyDefaultRowset},
+        // One small MAX column forcing all 16 columns onto the row-at-a-time path.
+        {"getdata/rowwise_20k_c16_mixed_lob/whole_result_rowwise", "getdata",
+         &table_by_name("mssql_odbc_bench_mixedlob_20k_c16"), AccessMode::row_wise_get_data,
+         kFetchManyDefaultRowset},
+        // The sql_variant sequence: zero-length SQL_C_BINARY probe, then
+        // SQLColAttribute(SQL_CA_SS_VARIANT_TYPE), then the typed read.
+        {"getdata/rowwise_20k_c4_variant/probe_colattribute", "getdata",
+         &table_by_name("mssql_odbc_bench_variant_20k_c4"), AccessMode::row_wise_get_data,
+         kFetchManyDefaultRowset},
+    }};
+    return specs;
+}
+
 // Resolve one explicit configuration contract shared by both executables.
 Config Config::from_environment() {
     Config config;
@@ -759,7 +865,7 @@ Config Config::from_environment() {
         environment_value_or("ODBC_BENCH_TRUST_CERT", "Yes");
     config.encrypt = environment_value_or("ODBC_BENCH_ENCRYPT", "Mandatory");
     config.packet_size =
-        environment_value_or("ODBC_BENCH_PACKET_SIZE", "32768");
+        environment_value_or("ODBC_BENCH_PACKET_SIZE", "32767");
     config.packet_size_keyword =
         environment_value_or("ODBC_BENCH_PACKET_SIZE_KEYWORD", "PacketSize");
     config.scenario = environment_value("ODBC_BENCH_SCENARIO");
@@ -790,19 +896,28 @@ Config Config::from_environment() {
         throw std::runtime_error("ODBC_BENCH_PACKET_SIZE must be an integer");
     }
     const unsigned long packet_size = std::stoul(config.packet_size);
-    if (packet_size < 512 || packet_size > 32768) {
+    if (packet_size < 512 || packet_size > 32767) {
         throw std::runtime_error(
-            "ODBC_BENCH_PACKET_SIZE must be between 512 and 32768");
+            "ODBC_BENCH_PACKET_SIZE must be between 512 and 32767");
     }
     if (config.packet_size_keyword != "PacketSize" &&
         config.packet_size_keyword != "Packet Size") {
         throw std::runtime_error(
             "ODBC_BENCH_PACKET_SIZE_KEYWORD must be PacketSize or Packet Size");
     }
-    if (!config.scenario.empty() && config.scenario != "narrow" &&
-        config.scenario != "wide") {
-        throw std::runtime_error(
-            "ODBC_BENCH_SCENARIO must be narrow, wide, or unset");
+    if (!config.scenario.empty()) {
+        // Reject an unknown scenario instead of silently registering nothing: a
+        // leg that measures zero benchmarks would fail the comparator's
+        // benchmark-set check much further downstream.
+        const bool known = std::any_of(
+            workloads().begin(), workloads().end(), [&config](const WorkloadSpec& spec) {
+                return config.scenario == spec.scenario;
+            });
+        if (!known) {
+            throw std::runtime_error(
+                "ODBC_BENCH_SCENARIO must be one of narrow, wide, rowset, varwidth, "
+                "getdata, or unset");
+        }
     }
     return config;
 }
@@ -823,25 +938,6 @@ std::string Config::connection_string() const {
     return connection.str();
 }
 
-// Derive width from the type pattern to prevent setup and binding from drifting.
-std::size_t WorkloadSpec::column_count() const {
-    return pattern_repetitions * kPatternSize;
-}
-
-// The narrow workload stresses row volume; the wide workload stresses per-row
-// conversion and binding breadth while staying below SQL Server's row-size limit.
-const std::array<WorkloadSpec, 2>& workloads() {
-    static const std::array<WorkloadSpec, 2> specs = {{
-        {"fetch/narrow_2m_c15_mixed_fixed/rowset_1024",
-         "narrow",
-         "mssql_odbc_bench_narrow_2m_c15_mixed_fixed", 2'000'000, 1},
-        {"fetch/wide_10k_c600_mixed_fixed/rowset_1024",
-         "wide",
-         "mssql_odbc_bench_wide_10k_c600_mixed_fixed", 10'000, 40},
-    }};
-    return specs;
-}
-
 // Build a complete handle chain once so connection setup is outside measurements.
 OdbcSession::OdbcSession(const Config& config) {
     try {
@@ -859,10 +955,29 @@ OdbcSession::OdbcSession(const Config& config) {
         require_exact_success(rc, "SQLAllocHandle(SQL_HANDLE_DBC)", SQL_HANDLE_ENV,
                               env_);
 
+        const auto requested_packet_size =
+            static_cast<SQLUINTEGER>(std::stoul(config.packet_size));
+        rc = SQLSetConnectAttr(dbc_, SQL_ATTR_PACKET_SIZE,
+                               attribute_value(requested_packet_size), 0);
+        require_exact_success(rc, "SQLSetConnectAttr(SQL_ATTR_PACKET_SIZE)",
+                              SQL_HANDLE_DBC, dbc_);
+
         auto connection = to_sql_string(config.connection_string());
         rc = SQLDriverConnect(dbc_, nullptr, connection.data(), SQL_NTS, nullptr, 0,
                               nullptr, SQL_DRIVER_NOPROMPT);
         require_connection_success(rc, dbc_);
+
+        SQLUINTEGER negotiated_packet_size = 0;
+        rc = SQLGetConnectAttr(dbc_, SQL_ATTR_PACKET_SIZE, &negotiated_packet_size,
+                               sizeof(negotiated_packet_size), nullptr);
+        require_exact_success(rc, "SQLGetConnectAttr(SQL_ATTR_PACKET_SIZE)",
+                              SQL_HANDLE_DBC, dbc_);
+        if (negotiated_packet_size != requested_packet_size) {
+            std::ostringstream message;
+            message << "driver reports packet size " << negotiated_packet_size
+                    << "; requested " << requested_packet_size;
+            throw std::runtime_error(message.str());
+        }
 
         rc = SQLAllocHandle(SQL_HANDLE_STMT, dbc_, &stmt_);
         require_exact_success(rc, "SQLAllocHandle(SQL_HANDLE_STMT)", SQL_HANDLE_DBC,
@@ -963,8 +1078,7 @@ std::uint64_t OdbcSession::query_count(const std::string& table) {
 
 // Drop in reverse catalog order to keep cleanup safe if dependencies are added later.
 void cleanup_benchmark_tables(OdbcSession& session) {
-    for (auto iterator = workloads().rbegin(); iterator != workloads().rend();
-         ++iterator) {
+    for (auto iterator = tables().rbegin(); iterator != tables().rend(); ++iterator) {
         session.execute_non_query("DROP TABLE IF EXISTS " + qualified_table(*iterator));
     }
     std::cout << "Benchmark tables removed\n";
@@ -973,21 +1087,482 @@ void cleanup_benchmark_tables(OdbcSession& session) {
 // Recreate and count each table before any timed process can consume it.
 void setup_benchmark_tables(OdbcSession& session) {
     cleanup_benchmark_tables(session);
-    for (const auto& spec : workloads()) {
-        std::cout << "Creating " << qualified_table(spec) << " with " << spec.row_count
-                  << " rows and " << spec.column_count() << " columns\n";
-        session.execute_non_query(create_table_sql(spec));
-        session.execute_non_query(insert_sql(spec));
-        const auto actual_rows = session.query_count(qualified_table(spec));
-        if (actual_rows != spec.row_count) {
+    for (const auto& table : tables()) {
+        std::cout << "Creating " << qualified_table(table) << " with " << table.row_count
+                  << " rows and " << table.column_count() << " columns\n";
+        session.execute_non_query(create_table_sql(table));
+        session.execute_non_query(insert_sql(table));
+        const auto actual_rows = session.query_count(qualified_table(table));
+        if (actual_rows != table.row_count) {
             std::ostringstream message;
-            message << qualified_table(spec) << " contains " << actual_rows
-                    << " rows; expected " << spec.row_count;
+            message << qualified_table(table) << " contains " << actual_rows
+                    << " rows; expected " << table.row_count;
             throw std::runtime_error(message.str());
         }
     }
     std::cout << "Benchmark setup complete\n";
 }
+
+// Emit the whole catalog as replayable T-SQL, batch-separated so it can be piped
+// straight into sqlcmd. The statements are byte-identical to what setup sends.
+void print_benchmark_sql(std::ostream& output) {
+    for (const auto& table : tables()) {
+        output << "-- table " << table.table_name << ": " << table.row_count
+               << " rows, " << table.column_count() << " columns\n";
+        output << "DROP TABLE IF EXISTS " << qualified_table(table) << ";\nGO\n";
+        output << create_table_sql(table) << ";\nGO\n";
+        output << insert_sql(table) << ";\nGO\n";
+    }
+    for (const auto& workload : workloads()) {
+        output << "-- workload " << workload.benchmark_name << " (scenario "
+               << workload.scenario << ", rowset " << workload.rowset_size << ")\n";
+        output << select_sql(*workload.table, columns_for(*workload.table))
+               << ";\nGO\n";
+    }
+}
+
+namespace {
+
+// SQLGetData's chunked and probe forms legitimately answer SQL_SUCCESS_WITH_INFO:
+// 01004 is how a driver says "more of this value remains", and a zero-length
+// probe can only answer that way. The strict rule stays in force everywhere
+// else; rejecting it here would reject the protocol these workloads measure.
+void require_succeeded(SQLRETURN rc, const char* operation, SQLHSTMT stmt) {
+    if (rc != SQL_SUCCESS && rc != SQL_SUCCESS_WITH_INFO) {
+        throw_odbc_error(operation, rc, SQL_HANDLE_STMT, stmt);
+    }
+}
+
+// Fold whatever SQL_CA_SS_VARIANT_TYPE reports onto the C type the value is read
+// with. Both the signed/unsigned and the concise/verbose spellings are accepted
+// because the answer comes from the driver, and a benchmark that only understood
+// one spelling would fail on the other driver rather than measure it.
+//
+// SQL_C_WCHAR folds to SQL_C_CHAR deliberately: mssql-python does the same,
+// because requesting SQL_C_WCHAR after the binary probe fails on unixODBC.
+SQLSMALLINT variant_read_c_type(SQLLEN reported) {
+    switch (reported) {
+        case SQL_C_BIT:
+            return SQL_C_BIT;
+        case SQL_C_TINYINT:
+        case SQL_C_STINYINT:
+        case SQL_C_UTINYINT:
+            return SQL_C_STINYINT;
+        case SQL_C_SHORT:
+        case SQL_C_SSHORT:
+        case SQL_C_USHORT:
+            return SQL_C_SSHORT;
+        case SQL_C_LONG:
+        case SQL_C_SLONG:
+        case SQL_C_ULONG:
+            return SQL_C_SLONG;
+        case SQL_C_SBIGINT:
+        case SQL_C_UBIGINT:
+            return SQL_C_SBIGINT;
+        case SQL_C_FLOAT:
+            return SQL_C_FLOAT;
+        case SQL_C_DOUBLE:
+            return SQL_C_DOUBLE;
+        case SQL_C_GUID:
+            return SQL_C_GUID;
+        case SQL_C_TYPE_DATE:
+            return SQL_C_TYPE_DATE;
+        case SQL_C_TYPE_TIMESTAMP:
+            return SQL_C_TYPE_TIMESTAMP;
+        default:
+            return SQL_C_CHAR;
+    }
+}
+
+// Owns one column-wise row-array buffer with alignment valid for every bound C type.
+class ColumnBuffer {
+public:
+    ColumnBuffer(const ColumnSpec& column, std::size_t rows)
+        : column_(&column),
+          rows_(rows),
+          storage_((column.slot_size * rows + sizeof(std::max_align_t) - 1) /
+                   sizeof(std::max_align_t)),
+          indicators_(rows, kIndicatorSentinel) {}
+
+    SQLPOINTER data() {
+        return static_cast<SQLPOINTER>(storage_.data());
+    }
+
+    SQLLEN* indicators() {
+        return indicators_.data();
+    }
+
+    SQLLEN indicator(std::size_t row) const {
+        return indicators_[row];
+    }
+
+    // Row-wise reads write their own indicator because SQLGetData reports it per
+    // call rather than into the bound array.
+    void set_indicator(std::size_t row, SQLLEN value) {
+        indicators_[row] = value;
+    }
+
+    void reset_indicators() {
+        std::fill(indicators_.begin(), indicators_.end(), kIndicatorSentinel);
+    }
+
+    const ColumnSpec& column() const {
+        return *column_;
+    }
+
+    // Slots allocated, which is the workload's rowset size for the bound modes
+    // and 1 for the row-at-a-time one.
+    std::size_t rows() const {
+        return rows_;
+    }
+
+    // Copy rather than reinterpret storage so validation does not assume alignment
+    // beyond the ODBC buffer contract.
+    template <typename T>
+    T read(std::size_t row) const {
+        if (sizeof(T) > column_->slot_size || row >= rows_) {
+            throw std::logic_error("invalid typed read from column buffer");
+        }
+        T value{};
+        const auto* bytes = reinterpret_cast<const unsigned char*>(storage_.data());
+        std::memcpy(&value, bytes + row * column_->slot_size, sizeof(T));
+        return value;
+    }
+
+    const unsigned char* row_bytes(std::size_t row) const {
+        const auto* bytes = reinterpret_cast<const unsigned char*>(storage_.data());
+        return bytes + row * column_->slot_size;
+    }
+
+private:
+    const ColumnSpec* column_;
+    std::size_t rows_;
+    std::vector<std::max_align_t> storage_;
+    std::vector<SQLLEN> indicators_;
+};
+
+// Attach the row identity to semantic mismatches found during untimed preflight.
+void require_value(bool condition, const char* description, std::uint64_t row_id) {
+    if (!condition) {
+        std::ostringstream message;
+        message << "preflight value mismatch for " << description << " at row id "
+                << row_id;
+        throw std::runtime_error(message.str());
+    }
+}
+
+// Confirm the driver wrote a complete value of the length the generator promised,
+// and that NULL appears exactly where the generator put it.
+void validate_indicator(const ColumnBuffer& buffer, std::size_t row,
+                        std::uint64_t row_id) {
+    const auto& column = buffer.column();
+    const SQLLEN indicator = buffer.indicator(row);
+    if (indicator == SQL_NULL_DATA) {
+        require_value(generated_null(column, row_id), "unexpected NULL", row_id);
+        return;
+    }
+    require_value(!generated_null(column, row_id), "missing NULL", row_id);
+    if (indicator < 0 || indicator == kIndicatorSentinel) {
+        throw std::runtime_error("preflight found an invalid or unwritten indicator");
+    }
+
+    if (column.expected_indicator != 0 && indicator != column.expected_indicator) {
+        std::ostringstream message;
+        message << "preflight indicator mismatch: expected " << column.expected_indicator
+                << ", got " << indicator;
+        throw std::runtime_error(message.str());
+    }
+    if (column.length_span != 0 || column.length_base != 0) {
+        const auto expected = static_cast<SQLLEN>(
+            static_cast<std::uint64_t>(generated_length(column, row_id)) *
+            column.unit_bytes);
+        require_value(indicator == expected, "generated value length", row_id);
+    }
+    if (column.kind == ValueKind::decimal &&
+        (indicator == 0 || static_cast<std::size_t>(indicator) >= column.slot_size)) {
+        throw std::runtime_error("preflight decimal indicator is outside its fixed slot");
+    }
+}
+
+// Validate both text termination and numeric meaning for DECIMAL-to-character binding.
+void validate_decimal(const ColumnBuffer& buffer, std::size_t row,
+                      std::uint64_t row_id) {
+    const auto length = static_cast<std::size_t>(buffer.indicator(row));
+    const char* text = reinterpret_cast<const char*>(buffer.row_bytes(row));
+    require_value(text[length] == '\0', "DECIMAL terminator", row_id);
+
+    errno = 0;
+    char* end = nullptr;
+    const long double value = std::strtold(text, &end);
+    while (end != nullptr && *end != '\0' &&
+           std::isspace(static_cast<unsigned char>(*end)) != 0) {
+        ++end;
+    }
+    require_value(errno == 0 && end != text && end != nullptr && *end == '\0' &&
+                      value == static_cast<long double>(row_id),
+                  "DECIMAL(18,4)", row_id);
+}
+
+// Every generated string is a prefix of the repeating cycle, so the expected byte
+// at any position is a pure function of that position.
+bool matches_text_cycle_narrow(const unsigned char* bytes, std::size_t characters) {
+    for (std::size_t index = 0; index < characters; ++index) {
+        if (bytes[index] != static_cast<unsigned char>(kTextCycle[index % kTextCycle.size()])) {
+            return false;
+        }
+    }
+    return bytes[characters] == 0;
+}
+
+// The wide form copies through an aligned buffer first: a bound SQLWCHAR array
+// is only guaranteed to be aligned at the start of the row slot.
+bool matches_text_cycle_wide(const unsigned char* bytes, std::size_t characters) {
+    std::vector<SQLWCHAR> value(characters + 1);
+    std::memcpy(value.data(), bytes, (characters + 1) * sizeof(SQLWCHAR));
+    for (std::size_t index = 0; index < characters; ++index) {
+        if (value[index] !=
+            static_cast<SQLWCHAR>(kTextCycle[index % kTextCycle.size()])) {
+            return false;
+        }
+    }
+    return value[characters] == 0;
+}
+
+// Check each conversion shape on representative rows without adding work to timing.
+void validate_representative_value(const ColumnBuffer& buffer, std::size_t row,
+                                   std::uint64_t row_id) {
+    const auto& column = buffer.column();
+    if (buffer.indicator(row) == SQL_NULL_DATA) {
+        return;
+    }
+    switch (column.kind) {
+        case ValueKind::bit:
+            require_value(buffer.read<SQLCHAR>(row) == row_id % 2, "BIT", row_id);
+            break;
+        case ValueKind::tinyint:
+            require_value(buffer.read<SQLCHAR>(row) == row_id % 251, "TINYINT",
+                          row_id);
+            break;
+        case ValueKind::smallint:
+            require_value(
+                buffer.read<SQLSMALLINT>(row) ==
+                    static_cast<SQLSMALLINT>(
+                        static_cast<std::int64_t>(row_id % 60001) - 30000),
+                "SMALLINT", row_id);
+            break;
+        case ValueKind::integer:
+            require_value(buffer.read<SQLINTEGER>(row) ==
+                              static_cast<SQLINTEGER>(row_id),
+                          "INT", row_id);
+            break;
+        case ValueKind::bigint:
+            require_value(buffer.read<SQLBIGINT>(row) ==
+                              static_cast<SQLBIGINT>(row_id),
+                          "BIGINT", row_id);
+            break;
+        case ValueKind::real:
+            require_value(buffer.read<float>(row) ==
+                              static_cast<float>(row_id % 10000),
+                          "REAL", row_id);
+            break;
+        case ValueKind::double_precision:
+            require_value(buffer.read<double>(row) ==
+                              static_cast<double>(row_id % 1000000),
+                          "FLOAT(53)", row_id);
+            break;
+        case ValueKind::decimal:
+            validate_decimal(buffer, row, row_id);
+            break;
+        case ValueKind::date: {
+            const auto value = buffer.read<SQL_DATE_STRUCT>(row);
+            require_value(value.year == 2024 && value.month == 2 && value.day == 29,
+                          "DATE", row_id);
+            break;
+        }
+        case ValueKind::time: {
+            const auto value = buffer.read<SqlSsTime2>(row);
+            require_value(value.hour == 12 && value.minute == 34 &&
+                              value.second == 56 && value.fraction == 123456700,
+                          "TIME(7)", row_id);
+            break;
+        }
+        case ValueKind::datetime2: {
+            const auto value = buffer.read<SQL_TIMESTAMP_STRUCT>(row);
+            require_value(
+                value.year == 2024 && value.month == 2 && value.day == 29 &&
+                    value.hour == 12 && value.minute == 34 && value.second == 56 &&
+                    value.fraction == 123456700,
+                "DATETIME2(7)", row_id);
+            break;
+        }
+        case ValueKind::datetimeoffset: {
+            const auto value = buffer.read<SqlSsTimestampOffset>(row);
+            require_value(
+                value.year == 2024 && value.month == 2 && value.day == 29 &&
+                    value.hour == 12 && value.minute == 34 && value.second == 56 &&
+                    value.fraction == 123456700 && value.timezone_hour == 0 &&
+                    value.timezone_minute == 0,
+                "DATETIMEOFFSET(7)", row_id);
+            break;
+        }
+        case ValueKind::guid: {
+            const auto value = buffer.read<SqlGuid>(row);
+            const SQLCHAR tail[] = {0x88, 0x99, 0xAA, 0xBB,
+                                    0xCC, 0xDD, 0xEE, 0xFF};
+            require_value(value.data1 == 0x00112233 && value.data2 == 0x4455 &&
+                              value.data3 == 0x6677 &&
+                              std::memcmp(value.data4, tail, sizeof(tail)) == 0,
+                          "UNIQUEIDENTIFIER", row_id);
+            break;
+        }
+        case ValueKind::character:
+            require_value(
+                std::memcmp(buffer.row_bytes(row), "ODBCBEN1", 8) == 0 &&
+                    buffer.row_bytes(row)[8] == 0,
+                "CHAR(8)", row_id);
+            break;
+        case ValueKind::wide_character: {
+            const auto* value =
+                reinterpret_cast<const SQLWCHAR*>(buffer.row_bytes(row));
+            constexpr char expected[] = "ODBCWIDE";
+            bool matches = value[8] == 0;
+            for (std::size_t index = 0; index < 8 && matches; ++index) {
+                matches =
+                    value[index] == static_cast<SQLWCHAR>(expected[index]);
+            }
+            require_value(matches, "NCHAR(8)", row_id);
+            break;
+        }
+        case ValueKind::var_character:
+            require_value(matches_text_cycle_narrow(buffer.row_bytes(row),
+                                                    generated_length(column, row_id)),
+                          "VARCHAR(n)", row_id);
+            break;
+        case ValueKind::var_wide_character:
+            require_value(matches_text_cycle_wide(buffer.row_bytes(row),
+                                                  generated_length(column, row_id)),
+                          "NVARCHAR(n)", row_id);
+            break;
+        case ValueKind::lob_character:
+        case ValueKind::lob_wide_character:
+        case ValueKind::variant_integer:
+        case ValueKind::variant_bigint:
+        case ValueKind::variant_text:
+            // Validated where they are read: their payload never lands in a row
+            // slot, so there is nothing here to inspect.
+            break;
+    }
+}
+
+// Proves that fetching returns every row exactly once and that every conversion
+// family produces the expected representation before timing is trusted.
+class PreflightValidator {
+public:
+    PreflightValidator(const TableSpec& table, std::size_t row_id_column)
+        : table_(table),
+          row_id_column_(row_id_column),
+          seen_(static_cast<std::size_t>(table.row_count + 1), false) {
+        // Cover the ends, the interior, and both sides of a 1000-row rowset
+        // boundary, so an off-by-one at a batch edge cannot hide.
+        representatives_ = {1, 2, kFetchAllRowset, kFetchAllRowset + 1,
+                            table.row_count / 2, table.row_count};
+        std::sort(representatives_.begin(), representatives_.end());
+        representatives_.erase(
+            std::unique(representatives_.begin(), representatives_.end()),
+            representatives_.end());
+        representatives_.erase(
+            std::remove_if(representatives_.begin(), representatives_.end(),
+                           [&table](std::uint64_t row_id) {
+                               return row_id == 0 || row_id > table.row_count;
+                           }),
+            representatives_.end());
+        representative_seen_.assign(representatives_.size(), false);
+        for (std::uint64_t row_id = 1; row_id <= table_.row_count; ++row_id) {
+            expected_checksum_ += splitmix64(row_id);
+        }
+    }
+
+    // Fold one row's identity into the completeness check and return its row id so
+    // the caller can validate anything that never reaches a row slot.
+    std::uint64_t accept_row(const std::vector<ColumnBuffer>& buffers,
+                             std::size_t row_index) {
+        const SQLINTEGER signed_id =
+            buffers[row_id_column_].read<SQLINTEGER>(row_index);
+        if (signed_id <= 0 ||
+            static_cast<std::uint64_t>(signed_id) > table_.row_count) {
+            throw std::runtime_error("preflight found an out-of-range row id");
+        }
+        const auto row_id = static_cast<std::uint64_t>(signed_id);
+        if (seen_[static_cast<std::size_t>(row_id)]) {
+            throw std::runtime_error("preflight found a duplicate row id");
+        }
+        seen_[static_cast<std::size_t>(row_id)] = true;
+        ++accepted_rows_;
+        checksum_ += splitmix64(row_id);
+
+        for (const auto& buffer : buffers) {
+            if (is_lob_kind(buffer.column().kind) ||
+                is_variant_kind(buffer.column().kind)) {
+                continue;
+            }
+            validate_indicator(buffer, row_index, row_id);
+        }
+
+        if (is_representative(row_id)) {
+            for (const auto& buffer : buffers) {
+                validate_representative_value(buffer, row_index, row_id);
+            }
+        }
+        return row_id;
+    }
+
+    // Validate one bound rowset by folding each of its rows in turn.
+    void accept_rowset(const std::vector<ColumnBuffer>& buffers, SQLULEN rows_fetched) {
+        for (SQLULEN row = 0; row < rows_fetched; ++row) {
+            (void)accept_row(buffers, static_cast<std::size_t>(row));
+        }
+    }
+
+    // Record that a chosen row was seen, so finish() can insist the expensive
+    // per-value checks actually ran instead of being skipped by a short result.
+    bool is_representative(std::uint64_t row_id) {
+        const auto entry = std::lower_bound(representatives_.begin(),
+                                            representatives_.end(), row_id);
+        if (entry == representatives_.end() || *entry != row_id) {
+            return false;
+        }
+        representative_seen_[static_cast<std::size_t>(entry - representatives_.begin())] =
+            true;
+        return true;
+    }
+
+    // Reject a run unless counts, checksum, and representative values all completed.
+    std::uint64_t finish() const {
+        if (accepted_rows_ != table_.row_count) {
+            throw std::runtime_error("preflight row count did not match the workload");
+        }
+        if (checksum_ != expected_checksum_) {
+            throw std::runtime_error("preflight deterministic row checksum did not match");
+        }
+        if (std::find(representative_seen_.begin(), representative_seen_.end(),
+                      false) != representative_seen_.end()) {
+            throw std::runtime_error("preflight did not see every representative row");
+        }
+        return checksum_;
+    }
+
+private:
+    const TableSpec& table_;
+    std::size_t row_id_column_;
+    std::vector<bool> seen_;
+    std::vector<std::uint64_t> representatives_;
+    std::vector<bool> representative_seen_;
+    std::uint64_t accepted_rows_ = 0;
+    std::uint64_t checksum_ = 0;
+    std::uint64_t expected_checksum_ = 0;
+};
+
+}  // namespace
 
 // Holds mutable ODBC fetch state behind the stable public runner interface.
 class WorkloadRunner::Impl {
@@ -995,37 +1570,68 @@ public:
     Impl(OdbcSession& session, const WorkloadSpec& spec)
         : session_(session),
           spec_(spec),
-          columns_(columns_for(spec)),
-          query_(to_sql_string(select_sql(spec, columns_))) {
-        buffers_.reserve(columns_.size());
-        for (const auto& column : columns_) {
-            buffers_.emplace_back(*column.type);
-            logical_bytes_per_row_ += column.type->logical_bytes;
+          columns_(columns_for(*spec.table)),
+          query_(to_sql_string(select_sql(*spec.table, columns_))),
+          logical_bytes_(spec.table->logical_bytes_total()) {
+        const bool row_wise = spec_.access == AccessMode::row_wise_get_data;
+        const std::size_t slots = row_wise ? 1 : spec_.rowset_size;
+        if (spec_.rowset_size == 0 || spec_.rowset_size > kMaxRowsetSize) {
+            throw std::logic_error("workload rowset size is outside the supported range");
         }
-        if (logical_bytes_per_row_ >= 8060) {
+        buffers_.reserve(columns_.size());
+        std::uint64_t fixed_row_bytes = 0;
+        for (const auto& column : columns_) {
+            if (!row_wise && (is_lob_kind(column.kind) || is_variant_kind(column.kind))) {
+                // Binding either shape is not merely slower, it is unsupported:
+                // mssql-odbc answers a bound PLP column with SQL_ROW_ERROR
+                // (AB#47361), and a variant needs the probe before its type is
+                // even known. Both belong to a row-at-a-time workload.
+                throw std::logic_error(
+                    "LOB and sql_variant columns cannot be bound; use row-wise access");
+            }
+            buffers_.emplace_back(column, slots);
+            fixed_row_bytes += column.logical_bytes;
+        }
+        variant_types_.assign(columns_.size(), 0);
+        lob_bytes_.assign(columns_.size(), 0);
+        lob_calls_.assign(columns_.size(), 0);
+        chunk_.resize(kLobChunkBytes);
+        if (row_wise) {
+            // The row-wise reader validates a LOB or variant value as it reads it,
+            // which needs the row id, and ODBC only allows SQLGetData to move
+            // forward through the columns. A shape that put either kind before its
+            // identity column would validate against row id 0 forever.
+            const std::size_t identity = spec_.table->row_id_column();
+            for (std::size_t index = 0; index <= identity && index < columns_.size();
+                 ++index) {
+                if (is_lob_kind(columns_[index].kind) ||
+                    is_variant_kind(columns_[index].kind)) {
+                    throw std::logic_error(
+                        "LOB and sql_variant columns must follow the identity column");
+                }
+            }
+        }
+        if (spec_.table->shape == TableShape::fixed_pattern && fixed_row_bytes >= 8060) {
             throw std::logic_error(
                 "generated fixed-width row is not below SQL Server's 8060-byte limit");
         }
     }
 
+    // Return the catalog entry the benchmark registration names this run after.
     const WorkloadSpec& spec() const {
         return spec_;
     }
 
-    std::uint64_t logical_bytes_per_row() const {
-        return logical_bytes_per_row_;
-    }
-
     // Run the identical retrieval path with validation enabled and timing ignored.
     void preflight() {
-        PreflightValidator validator(spec_);
-        (void)run(&validator);
+        PreflightValidator validator(*spec_.table, spec_.table->row_id_column());
+        const auto metrics = run(&validator);
         const auto checksum = validator.finish();
         std::ostringstream message;
         message << "Preflight passed for " << spec_.benchmark_name << ": "
-                << spec_.row_count << " rows, " << spec_.column_count()
-                << " columns, checksum=0x" << std::hex << std::setw(16)
-                << std::setfill('0') << checksum;
+                << metrics.rows << " rows, " << columns_.size() << " columns, "
+                << metrics.get_data_calls << " SQLGetData calls, checksum=0x"
+                << std::hex << std::setw(16) << std::setfill('0') << checksum;
         std::cerr << message.str() << '\n';
     }
 
@@ -1035,148 +1641,410 @@ public:
     }
 
 private:
-    // Configure column-wise arrays before execution so the measured operation uses
-    // the same 1,024-row batch shape on every driver.
-    void prepare_statement() {
-        // Microsoft ODBC leaves this unchanged on terminal SQL_NO_DATA.
-        rows_fetched_ = 0;
-        require_exact_success(
-            SQLSetStmtAttr(session_.statement(), SQL_ATTR_ROW_BIND_TYPE,
-                           attribute_value(SQL_BIND_BY_COLUMN), 0),
-            "SQLSetStmtAttr(SQL_ATTR_ROW_BIND_TYPE)", SQL_HANDLE_STMT,
-            session_.statement());
-        require_exact_success(
-            SQLSetStmtAttr(session_.statement(), SQL_ATTR_ROW_ARRAY_SIZE,
-                           attribute_value(kRowArraySize), 0),
-            "SQLSetStmtAttr(SQL_ATTR_ROW_ARRAY_SIZE)", SQL_HANDLE_STMT,
-            session_.statement());
-        require_exact_success(
-            SQLSetStmtAttr(session_.statement(), SQL_ATTR_ROWS_FETCHED_PTR,
-                           &rows_fetched_, 0),
-            "SQLSetStmtAttr(SQL_ATTR_ROWS_FETCHED_PTR)", SQL_HANDLE_STMT,
-            session_.statement());
+    // One statement handle is shared by every workload in the process, so each
+    // run() is responsible for leaving it in a clean, known state.
+    SQLHSTMT stmt() const {
+        return session_.statement();
     }
 
-    // Include metadata discovery and binding in the end-to-end boundary while
-    // checking that each driver exposes the expected result shape.
-    void describe_and_bind() {
-        SQLSMALLINT result_columns = 0;
+    // Column-wise binding is the only layout mssql-python uses and the only one
+    // mssql-odbc implements, so it is set once and never varied.
+    void set_bind_type() {
         require_exact_success(
-            SQLNumResultCols(session_.statement(), &result_columns),
-            "SQLNumResultCols", SQL_HANDLE_STMT, session_.statement());
-        if (result_columns != static_cast<SQLSMALLINT>(columns_.size())) {
+            SQLSetStmtAttr(stmt(), SQL_ATTR_ROW_BIND_TYPE,
+                           attribute_value(SQL_BIND_BY_COLUMN), 0),
+            "SQLSetStmtAttr(SQL_ATTR_ROW_BIND_TYPE)", SQL_HANDLE_STMT, stmt());
+    }
+
+    // Install the rowset shape. `track` mirrors mssql-python, which points
+    // SQL_ATTR_ROWS_FETCHED_PTR at its own counter for a batch and clears it
+    // again afterwards so no stale pointer survives the call.
+    void set_rowset(SQLULEN size, bool track) {
+        rows_fetched_ = 0;
+        require_exact_success(
+            SQLSetStmtAttr(stmt(), SQL_ATTR_ROW_ARRAY_SIZE, attribute_value(size), 0),
+            "SQLSetStmtAttr(SQL_ATTR_ROW_ARRAY_SIZE)", SQL_HANDLE_STMT, stmt());
+        require_exact_success(
+            SQLSetStmtAttr(stmt(), SQL_ATTR_ROWS_FETCHED_PTR,
+                           track ? &rows_fetched_ : nullptr, 0),
+            "SQLSetStmtAttr(SQL_ATTR_ROWS_FETCHED_PTR)", SQL_HANDLE_STMT, stmt());
+    }
+
+    // Ask the driver for the result shape. Every access mode issues these calls,
+    // but only preflight compares the answers, so measurement and validation
+    // perform the same driver work.
+    void describe_columns(bool validate) {
+        SQLSMALLINT result_columns = 0;
+        require_exact_success(SQLNumResultCols(stmt(), &result_columns),
+                              "SQLNumResultCols", SQL_HANDLE_STMT, stmt());
+        if (validate && result_columns != static_cast<SQLSMALLINT>(columns_.size())) {
             std::ostringstream message;
             message << "result has " << result_columns << " columns; expected "
                     << columns_.size();
             throw std::runtime_error(message.str());
         }
-
         for (std::size_t index = 0; index < columns_.size(); ++index) {
-            SQLTCHAR name[32] = {};
-            SQLSMALLINT name_length = 0;
-            SQLSMALLINT data_type = 0;
-            SQLULEN column_size = 0;
-            SQLSMALLINT decimal_digits = 0;
-            SQLSMALLINT nullable = SQL_NULLABLE_UNKNOWN;
-            require_exact_success(
-                SQLDescribeCol(
-                    session_.statement(), static_cast<SQLUSMALLINT>(index + 1), name,
-                    static_cast<SQLSMALLINT>(std::size(name)), &name_length,
-                    &data_type, &column_size, &decimal_digits, &nullable),
-                "SQLDescribeCol", SQL_HANDLE_STMT, session_.statement());
+            describe_column(index, validate);
+        }
+    }
 
-            const auto& expected_name = columns_[index].name;
-            bool name_matches =
-                name_length == static_cast<SQLSMALLINT>(expected_name.size());
-            for (std::size_t name_index = 0;
-                 name_index < expected_name.size() && name_matches; ++name_index) {
-                name_matches =
-                    name[name_index] ==
-                    static_cast<SQLTCHAR>(
-                        static_cast<unsigned char>(expected_name[name_index]));
-            }
-            if (!name_matches || nullable != SQL_NO_NULLS || data_type == 0 ||
-                column_size == 0) {
-                throw std::runtime_error(
-                    "SQLDescribeCol returned unexpected workload metadata");
-            }
-            (void)decimal_digits;
+    // Describe one column, comparing the answer against the catalog only when
+    // validating, so measurement and preflight make identical driver calls.
+    void describe_column(std::size_t index, bool validate) {
+        SQLTCHAR name[32] = {};
+        SQLSMALLINT name_length = 0;
+        SQLSMALLINT data_type = 0;
+        SQLULEN column_size = 0;
+        SQLSMALLINT decimal_digits = 0;
+        SQLSMALLINT nullable = SQL_NULLABLE_UNKNOWN;
+        require_exact_success(
+            SQLDescribeCol(stmt(), static_cast<SQLUSMALLINT>(index + 1), name,
+                           static_cast<SQLSMALLINT>(std::size(name)), &name_length,
+                           &data_type, &column_size, &decimal_digits, &nullable),
+            "SQLDescribeCol", SQL_HANDLE_STMT, stmt());
+        if (!validate) {
+            return;
+        }
 
+        const auto& column = columns_[index];
+        bool name_matches = name_length == static_cast<SQLSMALLINT>(column.name.size());
+        for (std::size_t position = 0; position < column.name.size() && name_matches;
+             ++position) {
+            name_matches =
+                name[position] ==
+                static_cast<SQLTCHAR>(static_cast<unsigned char>(column.name[position]));
+        }
+        const bool nullability_matches =
+            column.null_phase == 0 ? nullable == SQL_NO_NULLS : nullable == SQL_NULLABLE;
+        if (!name_matches || !nullability_matches || data_type == 0) {
+            throw std::runtime_error(
+                "SQLDescribeCol returned unexpected workload metadata");
+        }
+        (void)decimal_digits;
+        (void)column_size;
+    }
+
+    // Bind every column to its row-array slot. BufferLength is the slot stride,
+    // which is what places the next row's value inside the caller's storage.
+    void bind_columns() {
+        for (std::size_t index = 0; index < columns_.size(); ++index) {
             auto& buffer = buffers_[index];
             require_exact_success(
-                SQLBindCol(
-                    session_.statement(), static_cast<SQLUSMALLINT>(index + 1),
-                    buffer.type().c_type, buffer.data(),
-                    static_cast<SQLLEN>(buffer.type().slot_size),
-                    buffer.indicators()),
-                "SQLBindCol", SQL_HANDLE_STMT, session_.statement());
+                SQLBindCol(stmt(), static_cast<SQLUSMALLINT>(index + 1),
+                           buffer.column().c_type, buffer.data(),
+                           static_cast<SQLLEN>(buffer.column().slot_size),
+                           buffer.indicators()),
+                "SQLBindCol", SQL_HANDLE_STMT, stmt());
         }
+    }
+
+    // Drop every binding. mssql-python calls this after each fetchmany(), and
+    // leaving one behind would let a later leg fetch into a stale buffer.
+    void unbind_columns() {
+        require_exact_success(SQLFreeStmt(stmt(), SQL_UNBIND),
+                              "SQLFreeStmt(SQL_UNBIND)", SQL_HANDLE_STMT, stmt());
     }
 
     // Require successful cleanup because stale bindings would contaminate later legs.
     void cleanup_statement() {
-        require_exact_success(SQLCloseCursor(session_.statement()), "SQLCloseCursor",
-                              SQL_HANDLE_STMT, session_.statement());
-        require_exact_success(SQLFreeStmt(session_.statement(), SQL_UNBIND),
-                              "SQLFreeStmt(SQL_UNBIND)", SQL_HANDLE_STMT,
-                              session_.statement());
+        require_exact_success(SQLCloseCursor(stmt()), "SQLCloseCursor",
+                              SQL_HANDLE_STMT, stmt());
+        unbind_columns();
     }
 
     // Best-effort reset preserves the original ODBC error during stack unwinding.
     void cleanup_statement_noexcept() noexcept {
-        SQLFreeStmt(session_.statement(), SQL_CLOSE);
-        SQLFreeStmt(session_.statement(), SQL_UNBIND);
+        SQLFreeStmt(stmt(), SQL_CLOSE);
+        SQLFreeStmt(stmt(), SQL_UNBIND);
     }
 
-    // Measure from SQL execution through terminal SQL_NO_DATA. This is the regression
-    // boundary; setup, connection, and preflight are deliberately outside it.
-    RetrievalMetrics run(PreflightValidator* validator) {
-        prepare_statement();
-        try {
-            const auto start = std::chrono::steady_clock::now();
-            require_exact_success(
-                SQLExecDirect(session_.statement(), query_.data(), SQL_NTS),
-                "SQLExecDirect", SQL_HANDLE_STMT, session_.statement());
-            const auto after_execute = std::chrono::steady_clock::now();
-
-            describe_and_bind();
-            const auto after_bind = std::chrono::steady_clock::now();
-
-            std::uint64_t rows = 0;
-            for (;;) {
-                if (validator != nullptr) {
-                    for (auto& buffer : buffers_) {
-                        buffer.reset_indicators();
-                    }
+    // Drain one PLP value the way mssql-python's FetchLobColumnData does: repeated
+    // fixed 8192-byte SQLGetData calls, each answered with SQL_SUCCESS_WITH_INFO
+    // until the final one returns SQL_SUCCESS. The accumulating buffer is reused
+    // across values rather than reallocated per value; the consumer allocates a
+    // fresh one, and paying that allocator cost on every value would measure the
+    // allocator rather than the driver.
+    void read_lob_column(std::size_t index, bool validate, std::uint64_t row_id) {
+        const auto& column = columns_[index];
+        lob_bytes_[index] = 0;
+        lob_calls_[index] = 0;
+        lob_payload_.clear();
+        for (;;) {
+            SQLLEN indicator = kIndicatorSentinel;
+            const SQLRETURN rc =
+                SQLGetData(stmt(), static_cast<SQLUSMALLINT>(index + 1), column.c_type,
+                           chunk_.data(), static_cast<SQLLEN>(kLobChunkBytes),
+                           &indicator);
+            ++lob_calls_[index];
+            ++get_data_calls_;
+            // A driver may end the value with SQL_NO_DATA instead of a final
+            // SQL_SUCCESS. mssql-python would raise there; the benchmark accepts
+            // it so a legal ending cannot be reported as a failed measurement.
+            if (rc == SQL_NO_DATA) {
+                break;
+            }
+            require_succeeded(rc, "SQLGetData(LOB chunk)", stmt());
+            if (indicator == SQL_NULL_DATA) {
+                if (validate) {
+                    require_value(generated_null(column, row_id),
+                                  "unexpected NULL LOB", row_id);
                 }
-                rows_fetched_ = 0;
-                const SQLRETURN rc =
-                    SQLFetchScroll(session_.statement(), SQL_FETCH_NEXT, 0);
-                if (rc == SQL_NO_DATA) {
-                    if (rows_fetched_ != 0) {
-                        throw std::runtime_error(
-                            "SQLFetchScroll reported SQL_NO_DATA with rows fetched");
-                    }
-                    break;
-                }
-                require_exact_success(rc, "SQLFetchScroll", SQL_HANDLE_STMT,
-                                      session_.statement());
-                if (rows_fetched_ == 0 || rows_fetched_ > kRowArraySize ||
-                    rows_fetched_ > spec_.row_count ||
-                    rows > spec_.row_count - rows_fetched_) {
-                    throw std::runtime_error(
-                        "SQLFetchScroll returned an invalid rowset size");
-                }
-                if (validator != nullptr) {
-                    validator->accept(buffers_, rows_fetched_);
-                }
-                rows += rows_fetched_;
+                buffers_[index].set_indicator(0, SQL_NULL_DATA);
+                return;
             }
 
-            if (rows != spec_.row_count) {
+            // A driver that knows the remaining length reports it; one streaming
+            // an unbounded PLP value reports SQL_NO_TOTAL. Either way a value
+            // longer than the buffer means the call filled it.
+            std::size_t payload = kLobChunkBytes;
+            if (indicator >= 0 && static_cast<std::size_t>(indicator) < kLobChunkBytes) {
+                payload = static_cast<std::size_t>(indicator);
+            }
+            // The driver writes a terminator inside the buffer, so a filled chunk
+            // carries fewer payload bytes than it is long. Trimming trailing NUL
+            // units recovers the exact payload, as mssql-python's
+            // FetchLobColumnData does; it is exact here because the generated
+            // text contains no embedded NUL.
+            payload -= payload % column.unit_bytes;
+            while (payload >= column.unit_bytes &&
+                   chunk_[payload - 1] == 0 &&
+                   (column.unit_bytes == 1 || chunk_[payload - 2] == 0)) {
+                payload -= column.unit_bytes;
+            }
+            if (payload > 0) {
+                lob_payload_.insert(lob_payload_.end(), chunk_.begin(),
+                                    chunk_.begin() + static_cast<std::ptrdiff_t>(payload));
+            }
+            if (rc == SQL_SUCCESS) {
+                break;
+            }
+            if (payload == 0) {
+                throw std::runtime_error(
+                    "SQLGetData reported more LOB data but delivered no bytes");
+            }
+        }
+
+        lob_bytes_[index] = lob_payload_.size();
+        buffers_[index].set_indicator(0, static_cast<SQLLEN>(lob_payload_.size()));
+        if (validate) {
+            validate_lob_value(index, row_id);
+        }
+    }
+
+    // Check the drained value's length, its content, and that draining it really
+    // needed more than one chunk where the workload says it should.
+    void validate_lob_value(std::size_t index, std::uint64_t row_id) {
+        const auto& column = columns_[index];
+        require_value(!generated_null(column, row_id), "missing NULL LOB", row_id);
+        const std::size_t characters = generated_length(column, row_id);
+        const std::size_t expected_bytes = characters * column.unit_bytes;
+        require_value(lob_payload_.size() == expected_bytes, "LOB payload length",
+                      row_id);
+        if (column.kind == ValueKind::lob_wide_character) {
+            std::vector<SQLWCHAR> value(characters);
+            std::memcpy(value.data(), lob_payload_.data(), expected_bytes);
+            for (std::size_t position = 0; position < characters; ++position) {
+                require_value(value[position] == static_cast<SQLWCHAR>(
+                                                     kTextCycle[position % kTextCycle.size()]),
+                              "NVARCHAR(MAX) content", row_id);
+            }
+        } else {
+            for (std::size_t position = 0; position < characters; ++position) {
+                require_value(lob_payload_[position] ==
+                                  static_cast<unsigned char>(
+                                      kTextCycle[position % kTextCycle.size()]),
+                              "VARCHAR(MAX) content", row_id);
+            }
+        }
+        // A single-call value would mean the continuation loop this workload
+        // exists to measure never ran, so it is a validation failure, not a
+        // faster result.
+        const std::size_t expected_calls = expected_bytes / kLobChunkBytes + 1;
+        if (expected_calls > 1) {
+            require_value(lob_calls_[index] >= expected_calls,
+                          "LOB continuation call count", row_id);
+        }
+    }
+
+    // Reproduce mssql-python's sql_variant sequence exactly: a zero-length
+    // SQL_C_BINARY probe (which both detects NULL and makes the driver resolve the
+    // value's type), then SQLColAttribute(SQL_CA_SS_VARIANT_TYPE), then the read.
+    void read_variant_column(std::size_t index, bool validate, std::uint64_t row_id) {
+        const auto ordinal = static_cast<SQLUSMALLINT>(index + 1);
+        SQLLEN probe_indicator = kIndicatorSentinel;
+        // The probe is zero-length, but the buffer pointer is real. mssql-python
+        // passes NULL here and gets away with it because it dlopens the driver and
+        // calls its exports directly; this harness goes through the Driver
+        // Manager, which rejects a NULL TargetValuePtr with HY009 before the
+        // driver ever sees the call. A valid pointer with BufferLength 0 is the
+        // same request as far as both drivers are concerned — mssql-odbc gates its
+        // probe on `buffer_length == 0` alone, and msodbcsql treats it as an
+        // ordinary length probe.
+        require_succeeded(
+            SQLGetData(stmt(), ordinal, SQL_C_BINARY, probe_sink_.data(), 0,
+                       &probe_indicator),
+            "SQLGetData(sql_variant probe)", stmt());
+        ++get_data_calls_;
+        if (probe_indicator == SQL_NULL_DATA) {
+            buffers_[index].set_indicator(0, SQL_NULL_DATA);
+            variant_types_[index] = 0;
+            if (validate) {
+                require_value(generated_null(columns_[index], row_id),
+                              "unexpected NULL sql_variant", row_id);
+            }
+            return;
+        }
+
+        SQLLEN reported_type = 0;
+        require_succeeded(SQLColAttribute(stmt(), ordinal, kSqlCaSsVariantType, nullptr,
+                                          0, nullptr, &reported_type),
+                          "SQLColAttribute(SQL_CA_SS_VARIANT_TYPE)", stmt());
+        const SQLSMALLINT read_type = variant_read_c_type(reported_type);
+        variant_types_[index] = read_type;
+
+        auto& buffer = buffers_[index];
+        SQLLEN indicator = kIndicatorSentinel;
+        require_succeeded(
+            SQLGetData(stmt(), ordinal, read_type, buffer.data(),
+                       static_cast<SQLLEN>(buffer.column().slot_size), &indicator),
+            "SQLGetData(sql_variant value)", stmt());
+        ++get_data_calls_;
+        buffer.set_indicator(0, indicator);
+        if (validate) {
+            validate_variant_value(index, row_id);
+        }
+    }
+
+    // Compare the delivered value against the generator, accepting either the
+    // typed or the character rendering. Which one a driver picks is a documented
+    // parity difference, but the value it stands for must be the same.
+    void validate_variant_value(std::size_t index, std::uint64_t row_id) {
+        const auto& buffer = buffers_[index];
+        const auto& column = buffer.column();
+        require_value(!generated_null(column, row_id), "missing NULL sql_variant",
+                      row_id);
+        require_value(buffer.indicator(0) > 0, "sql_variant indicator", row_id);
+        const SQLSMALLINT read_type = variant_types_[index];
+        if (column.kind == ValueKind::variant_text) {
+            const auto length = static_cast<std::size_t>(buffer.indicator(0));
+            const char* text = reinterpret_cast<const char*>(buffer.row_bytes(0));
+            require_value(length == 11 && std::memcmp(text, "ODBCVARIANT", 11) == 0,
+                          "sql_variant NVARCHAR value", row_id);
+            return;
+        }
+
+        std::int64_t value = 0;
+        if (read_type == SQL_C_SLONG) {
+            value = buffer.read<SQLINTEGER>(0);
+        } else if (read_type == SQL_C_SBIGINT) {
+            value = static_cast<std::int64_t>(buffer.read<SQLBIGINT>(0));
+        } else if (read_type == SQL_C_CHAR) {
+            const char* text = reinterpret_cast<const char*>(buffer.row_bytes(0));
+            errno = 0;
+            char* end = nullptr;
+            value = static_cast<std::int64_t>(std::strtoll(text, &end, 10));
+            require_value(errno == 0 && end != text && end != nullptr && *end == '\0',
+                          "sql_variant character rendering", row_id);
+        } else {
+            require_value(false, "unexpected sql_variant C type", row_id);
+        }
+        require_value(value == static_cast<std::int64_t>(row_id),
+                      "sql_variant integer value", row_id);
+    }
+
+    // Read one column of the current row. Every column of a result that contains a
+    // LOB or a sql_variant travels this path, which is why the ordinary inline
+    // columns are read here too rather than being bound.
+    void read_row_wise_column(std::size_t index, bool validate, std::uint64_t row_id) {
+        const auto& column = columns_[index];
+        // mssql-python re-describes every column on every row inside
+        // SQLGetData_wrap, so the metadata call is part of the consumer-visible
+        // cost of this path and belongs inside the measurement.
+        describe_column(index, validate);
+        if (is_lob_kind(column.kind)) {
+            read_lob_column(index, validate, row_id);
+            return;
+        }
+        if (is_variant_kind(column.kind)) {
+            read_variant_column(index, validate, row_id);
+            return;
+        }
+
+        auto& buffer = buffers_[index];
+        SQLLEN indicator = kIndicatorSentinel;
+        require_succeeded(
+            SQLGetData(stmt(), static_cast<SQLUSMALLINT>(index + 1), column.c_type,
+                       buffer.data(), static_cast<SQLLEN>(column.slot_size), &indicator),
+            "SQLGetData", stmt());
+        ++get_data_calls_;
+        buffer.set_indicator(0, indicator);
+    }
+
+    // Sum the delivered payload for one row without re-walking the data. Used only
+    // to confirm the row-wise path actually delivered something for every column;
+    // reported throughput uses the generator's own byte total so that all three
+    // drivers are credited with identical payload regardless of representation.
+    std::uint64_t row_payload_bytes() const {
+        std::uint64_t total = 0;
+        for (std::size_t index = 0; index < buffers_.size(); ++index) {
+            const auto indicator = buffers_[index].indicator(0);
+            if (indicator == SQL_NULL_DATA) {
+                continue;
+            }
+            total += is_lob_kind(columns_[index].kind)
+                         ? lob_bytes_[index]
+                         : static_cast<std::uint64_t>(indicator);
+        }
+        return total;
+    }
+
+    // Measure from SQL execution through terminal SQL_NO_DATA. This is the
+    // regression boundary; connection, buffer allocation, setup, untimed
+    // preflight, cursor close, and unbind are all deliberately outside it.
+    RetrievalMetrics run(PreflightValidator* validator) {
+        const bool validate = validator != nullptr;
+        get_data_calls_ = 0;
+        set_bind_type();
+        // Every mode starts from an explicit rowset state so one workload cannot
+        // inherit the shape another left on the shared statement handle.
+        if (spec_.access == AccessMode::bound_drain) {
+            set_rowset(static_cast<SQLULEN>(spec_.rowset_size), true);
+        } else {
+            // Row-wise fetching and the bind-cycle's between-call state are both a
+            // one-row rowset with no fetched-row counter, which is exactly the
+            // state mssql-python restores after every fetchmany().
+            set_rowset(1, false);
+        }
+
+        try {
+            const auto start = std::chrono::steady_clock::now();
+            require_exact_success(SQLExecDirect(stmt(), query_.data(), SQL_NTS),
+                                  "SQLExecDirect", SQL_HANDLE_STMT, stmt());
+            const auto after_execute = std::chrono::steady_clock::now();
+
+            std::uint64_t rows = 0;
+            std::chrono::steady_clock::time_point after_bind = after_execute;
+            switch (spec_.access) {
+                case AccessMode::bound_drain:
+                    describe_columns(validate);
+                    bind_columns();
+                    after_bind = std::chrono::steady_clock::now();
+                    rows = drain_bound(validator);
+                    break;
+                case AccessMode::bound_bind_cycle:
+                    rows = drain_bind_cycle(validator);
+                    break;
+                case AccessMode::row_wise_get_data:
+                    describe_columns(validate);
+                    after_bind = std::chrono::steady_clock::now();
+                    rows = drain_row_wise(validator);
+                    break;
+            }
+
+            if (rows != spec_.table->row_count) {
                 std::ostringstream message;
                 message << "retrieval fetched " << rows << " rows; expected "
-                        << spec_.row_count;
+                        << spec_.table->row_count;
                 throw std::runtime_error(message.str());
             }
             const auto end = std::chrono::steady_clock::now();
@@ -1184,11 +2052,11 @@ private:
             RetrievalMetrics metrics;
             metrics.rows = rows;
             metrics.cells = rows * static_cast<std::uint64_t>(columns_.size());
-            metrics.logical_bytes = rows * logical_bytes_per_row_;
+            metrics.logical_bytes = logical_bytes_;
+            metrics.get_data_calls = get_data_calls_;
             metrics.total_seconds = seconds_between(start, end);
             metrics.execute_seconds = seconds_between(start, after_execute);
-            metrics.metadata_bind_seconds =
-                seconds_between(after_execute, after_bind);
+            metrics.metadata_bind_seconds = seconds_between(after_execute, after_bind);
             metrics.fetch_seconds = seconds_between(after_bind, end);
 
             cleanup_statement();
@@ -1199,13 +2067,123 @@ private:
         }
     }
 
+    // Bind once, then fetch rowsets until the cursor is exhausted.
+    std::uint64_t drain_bound(PreflightValidator* validator) {
+        std::uint64_t rows = 0;
+        for (;;) {
+            const SQLULEN fetched = fetch_one_rowset(validator, rows);
+            if (fetched == 0) {
+                break;
+            }
+            rows += fetched;
+        }
+        return rows;
+    }
+
+    // Repeat the complete describe/bind/fetch/reset/unbind lifecycle that
+    // mssql-python's fetchmany() performs on every call, so the pair with the
+    // matching bound_drain workload isolates exactly that per-call cost.
+    std::uint64_t drain_bind_cycle(PreflightValidator* validator) {
+        const bool validate = validator != nullptr;
+        std::uint64_t rows = 0;
+        for (;;) {
+            describe_columns(validate);
+            bind_columns();
+            set_rowset(static_cast<SQLULEN>(spec_.rowset_size), true);
+            const SQLULEN fetched = fetch_one_rowset(validator, rows);
+            set_rowset(1, false);
+            unbind_columns();
+            if (fetched == 0) {
+                break;
+            }
+            rows += fetched;
+        }
+        return rows;
+    }
+
+    // One SQLFetchScroll, validated for rowset sanity. Returns 0 at end of cursor.
+    SQLULEN fetch_one_rowset(PreflightValidator* validator, std::uint64_t rows_so_far) {
+        if (validator != nullptr) {
+            for (auto& buffer : buffers_) {
+                buffer.reset_indicators();
+            }
+        }
+        // Microsoft ODBC leaves this unchanged on terminal SQL_NO_DATA.
+        rows_fetched_ = 0;
+        const SQLRETURN rc = SQLFetchScroll(stmt(), SQL_FETCH_NEXT, 0);
+        if (rc == SQL_NO_DATA) {
+            if (rows_fetched_ != 0) {
+                throw std::runtime_error(
+                    "SQLFetchScroll reported SQL_NO_DATA with rows fetched");
+            }
+            return 0;
+        }
+        require_exact_success(rc, "SQLFetchScroll", SQL_HANDLE_STMT, stmt());
+        if (rows_fetched_ == 0 || rows_fetched_ > spec_.rowset_size ||
+            rows_fetched_ > spec_.table->row_count ||
+            rows_so_far > spec_.table->row_count - rows_fetched_) {
+            throw std::runtime_error("SQLFetchScroll returned an invalid rowset size");
+        }
+        if (validator != nullptr) {
+            validator->accept_rowset(buffers_, rows_fetched_);
+        }
+        return rows_fetched_;
+    }
+
+    // SQLFetch plus SQLGetData per column, which is what a LOB or sql_variant
+    // column forces on the entire result.
+    std::uint64_t drain_row_wise(PreflightValidator* validator) {
+        const bool validate = validator != nullptr;
+        std::uint64_t rows = 0;
+        for (;;) {
+            const SQLRETURN rc = SQLFetch(stmt());
+            if (rc == SQL_NO_DATA) {
+                break;
+            }
+            require_exact_success(rc, "SQLFetch", SQL_HANDLE_STMT, stmt());
+            if (rows >= spec_.table->row_count) {
+                throw std::runtime_error("SQLFetch returned more rows than the table holds");
+            }
+
+            // ODBC allows SQLGetData in column order only, and the constructor
+            // has already checked that the identity column precedes every column
+            // whose validation needs the row id.
+            std::uint64_t row_id = 0;
+            for (std::size_t index = 0; index < columns_.size(); ++index) {
+                read_row_wise_column(index, validate, row_id);
+                if (index == spec_.table->row_id_column()) {
+                    row_id = static_cast<std::uint64_t>(
+                        buffers_[index].read<SQLINTEGER>(0));
+                }
+            }
+            if (validate) {
+                (void)validator->accept_row(buffers_, 0);
+                if (row_payload_bytes() == 0) {
+                    throw std::runtime_error(
+                        "preflight row delivered no payload from any column");
+                }
+            }
+            ++rows;
+        }
+        return rows;
+    }
+
     OdbcSession& session_;
     const WorkloadSpec& spec_;
     std::vector<ColumnSpec> columns_;
     std::vector<ColumnBuffer> buffers_;
     SqlString query_;
     SQLULEN rows_fetched_ = 0;
-    std::uint64_t logical_bytes_per_row_ = 0;
+    std::uint64_t logical_bytes_ = 0;
+    std::uint64_t get_data_calls_ = 0;
+    std::vector<SQLSMALLINT> variant_types_;
+    std::vector<std::uint64_t> lob_bytes_;
+    std::vector<std::uint64_t> lob_calls_;
+    std::vector<unsigned char> chunk_;
+    std::vector<unsigned char> lob_payload_;
+    // Non-null destination for the zero-length sql_variant probe; nothing is ever
+    // written into it.
+    std::array<unsigned char, 8> probe_sink_{};
 };
 
 // Allocate descriptors once per catalog workload; each iteration still rebinds.
@@ -1217,11 +2195,6 @@ WorkloadRunner::~WorkloadRunner() = default;
 // Preserve the stable benchmark name selected by the shared workload catalog.
 const WorkloadSpec& WorkloadRunner::spec() const {
     return impl_->spec();
-}
-
-// Expose driver-independent payload volume for throughput reporting.
-std::uint64_t WorkloadRunner::logical_bytes_per_row() const {
-    return impl_->logical_bytes_per_row();
 }
 
 // Validate correctness through the same implementation used by timed retrieval.

--- a/mssql-odbc-bench/src/odbc_bench.cpp
+++ b/mssql-odbc-bench/src/odbc_bench.cpp
@@ -1,0 +1,1237 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "odbc_bench.hpp"
+
+#include <algorithm>
+#include <cerrno>
+#include <chrono>
+#include <cctype>
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <iterator>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#ifndef SQL_OV_ODBC3_80
+#define SQL_OV_ODBC3_80 380UL
+#endif
+
+namespace mssql::odbc::bench {
+namespace {
+
+constexpr SQLSMALLINT kSqlCSSsTime2 = 0x4000;
+constexpr SQLSMALLINT kSqlCSSsTimestampOffset = 0x4001;
+constexpr std::size_t kPatternSize = 15;
+constexpr SQLLEN kIndicatorSentinel = -777;
+
+// Mirror the Microsoft SQL Server ODBC extension ABI without depending on
+// platform-specific copies of sqlncli.h.
+struct SqlSsTime2 {
+    SQLUSMALLINT hour;
+    SQLUSMALLINT minute;
+    SQLUSMALLINT second;
+    SQLUINTEGER fraction;
+};
+
+struct SqlSsTimestampOffset {
+    SQLSMALLINT year;
+    SQLUSMALLINT month;
+    SQLUSMALLINT day;
+    SQLUSMALLINT hour;
+    SQLUSMALLINT minute;
+    SQLUSMALLINT second;
+    SQLUINTEGER fraction;
+    SQLSMALLINT timezone_hour;
+    SQLSMALLINT timezone_minute;
+};
+
+struct SqlGuid {
+    SQLUINTEGER data1;
+    SQLUSMALLINT data2;
+    SQLUSMALLINT data3;
+    SQLCHAR data4[8];
+};
+
+// These sizes are interoperability checks: a mismatch would make bound rows
+// incomparable across the Rust and Microsoft drivers.
+static_assert(sizeof(SqlSsTime2) == 12);
+static_assert(sizeof(SqlSsTimestampOffset) == 20);
+static_assert(sizeof(SqlGuid) == 16);
+
+// Selects the semantic validator independently from the ODBC C storage type.
+enum class ValueKind {
+    bit,
+    tinyint,
+    smallint,
+    integer,
+    bigint,
+    real,
+    double_precision,
+    decimal,
+    date,
+    time,
+    datetime2,
+    datetimeoffset,
+    guid,
+    character,
+    wide_character,
+};
+
+// Keeps SQL generation, binding, payload accounting, and validation on one shared
+// description so the compared drivers receive identical work.
+struct TypeDescriptor {
+    ValueKind kind;
+    const char* sql_type;
+    const char* sql_expression;
+    SQLSMALLINT c_type;
+    std::size_t slot_size;
+    std::uint64_t logical_bytes;
+    SQLLEN expected_indicator;
+};
+
+// Cover common fixed-width conversions plus narrow and wide character paths that
+// stress result-set materialization.
+const std::array<TypeDescriptor, kPatternSize>& type_pattern() {
+    static const std::array<TypeDescriptor, kPatternSize> pattern = {{
+        {ValueKind::bit, "BIT", "CAST(g.[value] % CAST(2 AS BIGINT) AS BIT)",
+         SQL_C_BIT, sizeof(SQLCHAR), 1, sizeof(SQLCHAR)},
+        {ValueKind::tinyint, "TINYINT",
+         "CAST(g.[value] % CAST(251 AS BIGINT) AS TINYINT)", SQL_C_UTINYINT,
+         sizeof(SQLCHAR), 1, sizeof(SQLCHAR)},
+        {ValueKind::smallint, "SMALLINT",
+         "CAST((g.[value] % CAST(60001 AS BIGINT)) - CAST(30000 AS BIGINT) AS SMALLINT)",
+         SQL_C_SSHORT, sizeof(SQLSMALLINT), 2, sizeof(SQLSMALLINT)},
+        {ValueKind::integer, "INT", "CAST(g.[value] AS INT)", SQL_C_SLONG,
+         sizeof(SQLINTEGER), 4, sizeof(SQLINTEGER)},
+        {ValueKind::bigint, "BIGINT", "CAST(g.[value] AS BIGINT)", SQL_C_SBIGINT,
+         sizeof(SQLBIGINT), 8, sizeof(SQLBIGINT)},
+        {ValueKind::real, "REAL",
+         "CAST(g.[value] % CAST(10000 AS BIGINT) AS REAL)", SQL_C_FLOAT,
+         sizeof(float), 4, sizeof(float)},
+        {ValueKind::double_precision, "FLOAT(53)",
+         "CAST(g.[value] % CAST(1000000 AS BIGINT) AS FLOAT(53))", SQL_C_DOUBLE,
+         sizeof(double), 8, sizeof(double)},
+        {ValueKind::decimal, "DECIMAL(18,4)",
+         "CAST(g.[value] AS DECIMAL(18,4))", SQL_C_CHAR, 32, 9, 0},
+        {ValueKind::date, "DATE", "CAST('2024-02-29' AS DATE)", SQL_C_TYPE_DATE,
+         sizeof(SQL_DATE_STRUCT), 3, sizeof(SQL_DATE_STRUCT)},
+        {ValueKind::time, "TIME(7)", "CAST('12:34:56.1234567' AS TIME(7))",
+         kSqlCSSsTime2, sizeof(SqlSsTime2), 5, sizeof(SqlSsTime2)},
+        {ValueKind::datetime2, "DATETIME2(7)",
+         "CAST('2024-02-29T12:34:56.1234567' AS DATETIME2(7))",
+         SQL_C_TYPE_TIMESTAMP, sizeof(SQL_TIMESTAMP_STRUCT), 8,
+         sizeof(SQL_TIMESTAMP_STRUCT)},
+        {ValueKind::datetimeoffset, "DATETIMEOFFSET(7)",
+         "CAST('2024-02-29T12:34:56.1234567+00:00' AS DATETIMEOFFSET(7))",
+         kSqlCSSsTimestampOffset, sizeof(SqlSsTimestampOffset), 10,
+         sizeof(SqlSsTimestampOffset)},
+        {ValueKind::guid, "UNIQUEIDENTIFIER",
+         "CAST('00112233-4455-6677-8899-AABBCCDDEEFF' AS UNIQUEIDENTIFIER)",
+         SQL_C_GUID, sizeof(SqlGuid), 16, sizeof(SqlGuid)},
+        {ValueKind::character, "CHAR(8)", "CAST('ODBCBEN1' AS CHAR(8))",
+         SQL_C_CHAR, 9, 8, 8},
+        {ValueKind::wide_character, "NCHAR(8)",
+         "CAST(N'ODBCWIDE' AS NCHAR(8))", SQL_C_WCHAR, 9 * sizeof(SQLWCHAR), 16,
+         8 * sizeof(SQLWCHAR)},
+    }};
+    return pattern;
+}
+
+// Couples a deterministic SQL column name to its shared type contract.
+struct ColumnSpec {
+    std::string name;
+    const TypeDescriptor* type;
+};
+
+// Read environment values without platform-specific ownership leaking to callers.
+std::string environment_value(const char* name) {
+#ifdef _WIN32
+    char* value = nullptr;
+    std::size_t length = 0;
+    if (_dupenv_s(&value, &length, name) != 0 || value == nullptr) {
+        return {};
+    }
+    std::string result(value);
+    std::free(value);
+    return result;
+#else
+    const char* value = std::getenv(name);
+    return value == nullptr ? std::string{} : std::string(value);
+#endif
+}
+
+// Apply defaults only when the variable is absent or empty.
+std::string environment_value_or(const char* name, const char* fallback) {
+    auto value = environment_value(name);
+    return value.empty() ? std::string(fallback) : value;
+}
+
+// Accept the benchmark-specific variable first, then the shared pipeline spelling.
+std::string first_environment_value(const char* primary, const char* fallback) {
+    auto value = environment_value(primary);
+    return value.empty() ? environment_value(fallback) : value;
+}
+
+// Escape closing braces according to ODBC connection-string grammar.
+std::string brace_connection_value(std::string_view value) {
+    std::string result;
+    result.reserve(value.size() + 2);
+    result.push_back('{');
+    for (const char character : value) {
+        result.push_back(character);
+        if (character == '}') {
+            result.push_back('}');
+        }
+    }
+    result.push_back('}');
+    return result;
+}
+
+using SqlString = std::basic_string<SQLTCHAR>;
+
+#ifdef UNICODE
+// Append a Unicode scalar using the UTF-16 representation SQLTCHAR expects.
+void append_code_point(SqlString& output, std::uint32_t code_point) {
+    if (code_point <= 0xFFFF) {
+        output.push_back(static_cast<SQLTCHAR>(code_point));
+        return;
+    }
+    code_point -= 0x10000;
+    output.push_back(static_cast<SQLTCHAR>(0xD800 + (code_point >> 10)));
+    output.push_back(static_cast<SQLTCHAR>(0xDC00 + (code_point & 0x3FF)));
+}
+
+// Validate UTF-8 while converting pipeline-provided text to the ODBC wide API.
+SqlString to_sql_string(std::string_view input) {
+    SqlString output;
+    output.reserve(input.size());
+    for (std::size_t index = 0; index < input.size();) {
+        const auto first = static_cast<unsigned char>(input[index]);
+        std::uint32_t code_point = 0;
+        std::size_t count = 0;
+        if (first <= 0x7F) {
+            code_point = first;
+            count = 1;
+        } else if ((first & 0xE0) == 0xC0) {
+            code_point = first & 0x1F;
+            count = 2;
+        } else if ((first & 0xF0) == 0xE0) {
+            code_point = first & 0x0F;
+            count = 3;
+        } else if ((first & 0xF8) == 0xF0) {
+            code_point = first & 0x07;
+            count = 4;
+        } else {
+            throw std::runtime_error("environment contains invalid UTF-8");
+        }
+
+        if (index + count > input.size()) {
+            throw std::runtime_error("environment contains truncated UTF-8");
+        }
+        for (std::size_t offset = 1; offset < count; ++offset) {
+            const auto next = static_cast<unsigned char>(input[index + offset]);
+            if ((next & 0xC0) != 0x80) {
+                throw std::runtime_error("environment contains invalid UTF-8");
+            }
+            code_point = (code_point << 6) | (next & 0x3F);
+        }
+
+        const bool overlong = (count == 2 && code_point < 0x80) ||
+                              (count == 3 && code_point < 0x800) ||
+                              (count == 4 && code_point < 0x10000);
+        if (overlong || code_point > 0x10FFFF ||
+            (code_point >= 0xD800 && code_point <= 0xDFFF)) {
+            throw std::runtime_error("environment contains invalid UTF-8");
+        }
+        append_code_point(output, code_point);
+        index += count;
+    }
+    return output;
+}
+#else
+// The narrow build intentionally passes the UTF-8 byte sequence unchanged.
+SqlString to_sql_string(std::string_view input) {
+    return SqlString(reinterpret_cast<const SQLTCHAR*>(input.data()), input.size());
+}
+#endif
+
+// Reduce diagnostics to log-safe ASCII; benchmark SQLSTATEs and messages are
+// expected to be ASCII and no diagnostic text participates in measurement.
+std::string from_sql_string(const SQLTCHAR* input, std::size_t length) {
+#ifdef UNICODE
+    std::string output;
+    output.reserve(length);
+    for (std::size_t index = 0; index < length; ++index) {
+        const auto value = static_cast<std::uint32_t>(input[index]);
+        output.push_back(value <= 0x7F ? static_cast<char>(value) : '?');
+    }
+    return output;
+#else
+    return std::string(reinterpret_cast<const char*>(input), length);
+#endif
+}
+
+// Collect the full ODBC diagnostic chain so a failed perf run remains actionable.
+std::string diagnostics(SQLSMALLINT handle_type, SQLHANDLE handle) {
+    if (handle == SQL_NULL_HANDLE) {
+        return "(no diagnostic handle)";
+    }
+
+    std::ostringstream output;
+    bool found = false;
+    for (SQLSMALLINT record = 1; record <= 32; ++record) {
+        SQLTCHAR state[8] = {};
+        SQLINTEGER native_error = 0;
+        SQLTCHAR message[2048] = {};
+        SQLSMALLINT message_length = 0;
+        const SQLRETURN rc =
+            SQLGetDiagRec(handle_type, handle, record, state, &native_error, message,
+                          static_cast<SQLSMALLINT>(std::size(message)), &message_length);
+        if (rc == SQL_NO_DATA) {
+            break;
+        }
+        if (rc != SQL_SUCCESS && rc != SQL_SUCCESS_WITH_INFO) {
+            break;
+        }
+        if (found) {
+            output << " | ";
+        }
+        const auto diagnostic_length = static_cast<std::size_t>(
+            std::clamp<int>(message_length, 0,
+                            static_cast<int>(std::size(message) - 1)));
+        output << '[' << from_sql_string(state, 5) << "] "
+               << from_sql_string(message, diagnostic_length)
+               << " (native=" << native_error << ')';
+        found = true;
+    }
+    return found ? output.str() : "(no diagnostic)";
+}
+
+// Turn an ODBC return code into one exception carrying operation and driver details.
+[[noreturn]] void throw_odbc_error(const char* operation, SQLRETURN rc,
+                                   SQLSMALLINT handle_type, SQLHANDLE handle) {
+    std::ostringstream message;
+    message << operation << " returned " << static_cast<long>(rc) << ": "
+            << diagnostics(handle_type, handle);
+    throw std::runtime_error(message.str());
+}
+
+// Timed operations reject SUCCESS_WITH_INFO because truncation or conversion
+// warnings would make throughput numbers invalid.
+void require_exact_success(SQLRETURN rc, const char* operation,
+                           SQLSMALLINT handle_type, SQLHANDLE handle) {
+    if (rc != SQL_SUCCESS) {
+        throw_odbc_error(operation, rc, handle_type, handle);
+    }
+}
+
+// Connection warnings are logged but accepted because TLS and server policy can
+// produce benign diagnostics before any measured work.
+void require_connection_success(SQLRETURN rc, SQLHDBC dbc) {
+    if (rc != SQL_SUCCESS && rc != SQL_SUCCESS_WITH_INFO) {
+        throw_odbc_error("SQLDriverConnect", rc, SQL_HANDLE_DBC, dbc);
+    }
+    if (rc == SQL_SUCCESS_WITH_INFO) {
+        std::cerr << "SQLDriverConnect completed with diagnostics: "
+                  << diagnostics(SQL_HANDLE_DBC, dbc) << '\n';
+    }
+}
+
+// Generate short stable names that can be checked after SQLDescribeCol.
+std::string column_name(std::size_t ordinal) {
+    char buffer[16] = {};
+    const int written = std::snprintf(buffer, sizeof(buffer), "c%03zu", ordinal);
+    if (written <= 0 || static_cast<std::size_t>(written) >= sizeof(buffer)) {
+        throw std::runtime_error("failed to generate benchmark column name");
+    }
+    return buffer;
+}
+
+// Repeat the exact type pattern to create narrow and very-wide workloads.
+std::vector<ColumnSpec> columns_for(const WorkloadSpec& spec) {
+    std::vector<ColumnSpec> columns;
+    columns.reserve(spec.column_count());
+    for (std::size_t repeat = 0; repeat < spec.pattern_repetitions; ++repeat) {
+        for (const auto& type : type_pattern()) {
+            columns.push_back({column_name(columns.size() + 1), &type});
+        }
+    }
+    return columns;
+}
+
+// Keep benchmark tables isolated under deterministic, explicitly quoted names.
+std::string qualified_table(const WorkloadSpec& spec) {
+    return std::string("[dbo].[") + spec.table_name + ']';
+}
+
+// Materialize a fixed-width schema that exercises conversion rather than LOB I/O.
+std::string create_table_sql(const WorkloadSpec& spec) {
+    const auto columns = columns_for(spec);
+    std::ostringstream sql;
+    sql << "CREATE TABLE " << qualified_table(spec) << " (";
+    for (std::size_t index = 0; index < columns.size(); ++index) {
+        if (index != 0) {
+            sql << ',';
+        }
+        sql << '[' << columns[index].name << "] " << columns[index].type->sql_type
+            << " NOT NULL";
+    }
+    sql << ')';
+    return sql.str();
+}
+
+// Generate deterministic values in one server-side statement outside the timed run.
+std::string insert_sql(const WorkloadSpec& spec) {
+    const auto columns = columns_for(spec);
+    std::ostringstream sql;
+    sql << "INSERT INTO " << qualified_table(spec) << " (";
+    for (std::size_t index = 0; index < columns.size(); ++index) {
+        if (index != 0) {
+            sql << ',';
+        }
+        sql << '[' << columns[index].name << ']';
+    }
+    sql << ") SELECT ";
+    for (std::size_t index = 0; index < columns.size(); ++index) {
+        if (index != 0) {
+            sql << ',';
+        }
+        sql << columns[index].type->sql_expression;
+    }
+    sql << " FROM GENERATE_SERIES(CAST(1 AS BIGINT), CAST(" << spec.row_count
+        << " AS BIGINT)) AS g OPTION (MAXDOP 1)";
+    return sql.str();
+}
+
+// Preserve column order so each bound buffer has a stable semantic contract.
+std::string select_sql(const WorkloadSpec& spec,
+                       const std::vector<ColumnSpec>& columns) {
+    std::ostringstream sql;
+    sql << "SELECT ";
+    for (std::size_t index = 0; index < columns.size(); ++index) {
+        if (index != 0) {
+            sql << ',';
+        }
+        sql << '[' << columns[index].name << ']';
+    }
+    sql << " FROM " << qualified_table(spec) << " OPTION (MAXDOP 1)";
+    return sql.str();
+}
+
+// Mix row IDs into an order-independent checksum that detects loss and duplication.
+std::uint64_t splitmix64(std::uint64_t value) {
+    value += 0x9E3779B97F4A7C15ULL;
+    value = (value ^ (value >> 30)) * 0xBF58476D1CE4E5B9ULL;
+    value = (value ^ (value >> 27)) * 0x94D049BB133111EBULL;
+    return value ^ (value >> 31);
+}
+
+// Owns one column-wise row-array buffer with alignment valid for every bound C type.
+class ColumnBuffer {
+public:
+    explicit ColumnBuffer(const TypeDescriptor& type)
+        : type_(&type),
+          storage_((type.slot_size * kRowArraySize +
+                    sizeof(std::max_align_t) - 1) /
+                   sizeof(std::max_align_t)),
+          indicators_(kRowArraySize, kIndicatorSentinel) {}
+
+    SQLPOINTER data() {
+        return static_cast<SQLPOINTER>(storage_.data());
+    }
+
+    SQLLEN* indicators() {
+        return indicators_.data();
+    }
+
+    SQLLEN indicator(std::size_t row) const {
+        return indicators_[row];
+    }
+
+    void reset_indicators() {
+        std::fill(indicators_.begin(), indicators_.end(), kIndicatorSentinel);
+    }
+
+    const TypeDescriptor& type() const {
+        return *type_;
+    }
+
+    // Copy rather than reinterpret storage so validation does not assume alignment
+    // beyond the ODBC buffer contract.
+    template <typename T>
+    T read(std::size_t row) const {
+        if (sizeof(T) > type_->slot_size || row >= kRowArraySize) {
+            throw std::logic_error("invalid typed read from column buffer");
+        }
+        T value{};
+        const auto* bytes = reinterpret_cast<const unsigned char*>(storage_.data());
+        std::memcpy(&value, bytes + row * type_->slot_size, sizeof(T));
+        return value;
+    }
+
+    const unsigned char* row_bytes(std::size_t row) const {
+        const auto* bytes = reinterpret_cast<const unsigned char*>(storage_.data());
+        return bytes + row * type_->slot_size;
+    }
+
+private:
+    const TypeDescriptor* type_;
+    std::vector<std::max_align_t> storage_;
+    std::vector<SQLLEN> indicators_;
+};
+
+// Confirm the driver wrote a complete, non-null value before inspecting payload bytes.
+void validate_indicator(const ColumnBuffer& buffer, std::size_t row) {
+    const SQLLEN indicator = buffer.indicator(row);
+    if (indicator == SQL_NULL_DATA) {
+        throw std::runtime_error("preflight found NULL in a NOT NULL workload column");
+    }
+    if (indicator < 0 || indicator == kIndicatorSentinel) {
+        throw std::runtime_error("preflight found an invalid or unwritten indicator");
+    }
+
+    const auto& type = buffer.type();
+    if (type.expected_indicator != 0 && indicator != type.expected_indicator) {
+        std::ostringstream message;
+        message << "preflight indicator mismatch: expected " << type.expected_indicator
+                << ", got " << indicator;
+        throw std::runtime_error(message.str());
+    }
+    if (type.kind == ValueKind::decimal &&
+        (indicator == 0 || static_cast<std::size_t>(indicator) >= type.slot_size)) {
+        throw std::runtime_error("preflight decimal indicator is outside its fixed slot");
+    }
+}
+
+// Attach the row identity to semantic mismatches found during untimed preflight.
+void require_value(bool condition, const char* description, std::uint64_t row_id) {
+    if (!condition) {
+        std::ostringstream message;
+        message << "preflight value mismatch for " << description << " at row id "
+                << row_id;
+        throw std::runtime_error(message.str());
+    }
+}
+
+// Validate both text termination and numeric meaning for DECIMAL-to-character binding.
+void validate_decimal(const ColumnBuffer& buffer, std::size_t row,
+                      std::uint64_t row_id) {
+    const auto length = static_cast<std::size_t>(buffer.indicator(row));
+    const char* text = reinterpret_cast<const char*>(buffer.row_bytes(row));
+    require_value(text[length] == '\0', "DECIMAL terminator", row_id);
+
+    errno = 0;
+    char* end = nullptr;
+    const long double value = std::strtold(text, &end);
+    while (end != nullptr && *end != '\0' &&
+           std::isspace(static_cast<unsigned char>(*end)) != 0) {
+        ++end;
+    }
+    require_value(errno == 0 && end != text && end != nullptr && *end == '\0' &&
+                      value == static_cast<long double>(row_id),
+                  "DECIMAL(18,4)", row_id);
+}
+
+// Check each conversion shape on representative rows without adding work to timing.
+void validate_representative_value(const ColumnBuffer& buffer, std::size_t row,
+                                   std::uint64_t row_id) {
+    switch (buffer.type().kind) {
+        case ValueKind::bit:
+            require_value(buffer.read<SQLCHAR>(row) == row_id % 2, "BIT", row_id);
+            break;
+        case ValueKind::tinyint:
+            require_value(buffer.read<SQLCHAR>(row) == row_id % 251, "TINYINT",
+                          row_id);
+            break;
+        case ValueKind::smallint:
+            require_value(
+                buffer.read<SQLSMALLINT>(row) ==
+                    static_cast<SQLSMALLINT>(
+                        static_cast<std::int64_t>(row_id % 60001) - 30000),
+                "SMALLINT", row_id);
+            break;
+        case ValueKind::integer:
+            require_value(buffer.read<SQLINTEGER>(row) ==
+                              static_cast<SQLINTEGER>(row_id),
+                          "INT", row_id);
+            break;
+        case ValueKind::bigint:
+            require_value(buffer.read<SQLBIGINT>(row) ==
+                              static_cast<SQLBIGINT>(row_id),
+                          "BIGINT", row_id);
+            break;
+        case ValueKind::real:
+            require_value(buffer.read<float>(row) ==
+                              static_cast<float>(row_id % 10000),
+                          "REAL", row_id);
+            break;
+        case ValueKind::double_precision:
+            require_value(buffer.read<double>(row) ==
+                              static_cast<double>(row_id % 1000000),
+                          "FLOAT(53)", row_id);
+            break;
+        case ValueKind::decimal:
+            validate_decimal(buffer, row, row_id);
+            break;
+        case ValueKind::date: {
+            const auto value = buffer.read<SQL_DATE_STRUCT>(row);
+            require_value(value.year == 2024 && value.month == 2 && value.day == 29,
+                          "DATE", row_id);
+            break;
+        }
+        case ValueKind::time: {
+            const auto value = buffer.read<SqlSsTime2>(row);
+            require_value(value.hour == 12 && value.minute == 34 &&
+                              value.second == 56 && value.fraction == 123456700,
+                          "TIME(7)", row_id);
+            break;
+        }
+        case ValueKind::datetime2: {
+            const auto value = buffer.read<SQL_TIMESTAMP_STRUCT>(row);
+            require_value(
+                value.year == 2024 && value.month == 2 && value.day == 29 &&
+                    value.hour == 12 && value.minute == 34 && value.second == 56 &&
+                    value.fraction == 123456700,
+                "DATETIME2(7)", row_id);
+            break;
+        }
+        case ValueKind::datetimeoffset: {
+            const auto value = buffer.read<SqlSsTimestampOffset>(row);
+            require_value(
+                value.year == 2024 && value.month == 2 && value.day == 29 &&
+                    value.hour == 12 && value.minute == 34 && value.second == 56 &&
+                    value.fraction == 123456700 && value.timezone_hour == 0 &&
+                    value.timezone_minute == 0,
+                "DATETIMEOFFSET(7)", row_id);
+            break;
+        }
+        case ValueKind::guid: {
+            const auto value = buffer.read<SqlGuid>(row);
+            const SQLCHAR tail[] = {0x88, 0x99, 0xAA, 0xBB,
+                                    0xCC, 0xDD, 0xEE, 0xFF};
+            require_value(value.data1 == 0x00112233 && value.data2 == 0x4455 &&
+                              value.data3 == 0x6677 &&
+                              std::memcmp(value.data4, tail, sizeof(tail)) == 0,
+                          "UNIQUEIDENTIFIER", row_id);
+            break;
+        }
+        case ValueKind::character:
+            require_value(
+                std::memcmp(buffer.row_bytes(row), "ODBCBEN1", 8) == 0 &&
+                    buffer.row_bytes(row)[8] == 0,
+                "CHAR(8)", row_id);
+            break;
+        case ValueKind::wide_character: {
+            const auto* value =
+                reinterpret_cast<const SQLWCHAR*>(buffer.row_bytes(row));
+            constexpr char expected[] = "ODBCWIDE";
+            bool matches = value[8] == 0;
+            for (std::size_t index = 0; index < 8 && matches; ++index) {
+                matches =
+                    value[index] == static_cast<SQLWCHAR>(expected[index]);
+            }
+            require_value(matches, "NCHAR(8)", row_id);
+            break;
+        }
+    }
+}
+
+// Proves that row-array fetching returns every row exactly once and that every
+// conversion family produces the expected representation before timing is trusted.
+class PreflightValidator {
+public:
+    explicit PreflightValidator(const WorkloadSpec& spec)
+        : spec_(spec),
+          seen_(static_cast<std::size_t>(spec.row_count + 1), false),
+          representatives_({1, 2, 1024, spec.row_count / 2, spec.row_count}),
+          representative_seen_(representatives_.size(), false) {
+        std::sort(representatives_.begin(), representatives_.end());
+        representatives_.erase(
+            std::unique(representatives_.begin(), representatives_.end()),
+            representatives_.end());
+        representative_seen_.assign(representatives_.size(), false);
+        for (std::uint64_t row_id = 1; row_id <= spec_.row_count; ++row_id) {
+            expected_checksum_ += splitmix64(row_id);
+        }
+    }
+
+    // Validate one fetched rowset and fold its identities into the completeness check.
+    void accept(const std::vector<ColumnBuffer>& buffers, SQLULEN rows_fetched) {
+        for (SQLULEN row = 0; row < rows_fetched; ++row) {
+            const auto row_index = static_cast<std::size_t>(row);
+            const SQLINTEGER signed_id = buffers[3].read<SQLINTEGER>(row_index);
+            if (signed_id <= 0 ||
+                static_cast<std::uint64_t>(signed_id) > spec_.row_count) {
+                throw std::runtime_error("preflight found an out-of-range row id");
+            }
+            const auto row_id = static_cast<std::uint64_t>(signed_id);
+            if (seen_[static_cast<std::size_t>(row_id)]) {
+                throw std::runtime_error("preflight found a duplicate row id");
+            }
+            seen_[static_cast<std::size_t>(row_id)] = true;
+            ++accepted_rows_;
+            checksum_ += splitmix64(row_id);
+
+            for (std::size_t repeat = 0; repeat < spec_.pattern_repetitions;
+                 ++repeat) {
+                require_value(
+                    buffers[repeat * kPatternSize + 3].read<SQLINTEGER>(row_index) ==
+                        signed_id,
+                    "repeated INT row id", row_id);
+            }
+
+            for (const auto& buffer : buffers) {
+                validate_indicator(buffer, row_index);
+            }
+
+            const auto representative =
+                std::lower_bound(representatives_.begin(), representatives_.end(),
+                                 row_id);
+            if (representative != representatives_.end() &&
+                *representative == row_id) {
+                const auto representative_index =
+                    static_cast<std::size_t>(representative -
+                                             representatives_.begin());
+                representative_seen_[representative_index] = true;
+                for (const auto& buffer : buffers) {
+                    validate_representative_value(buffer, row_index, row_id);
+                }
+            }
+        }
+    }
+
+    // Reject a run unless counts, checksum, and representative values all completed.
+    std::uint64_t finish() const {
+        if (accepted_rows_ != spec_.row_count) {
+            throw std::runtime_error("preflight row count did not match the workload");
+        }
+        if (checksum_ != expected_checksum_) {
+            throw std::runtime_error("preflight deterministic row checksum did not match");
+        }
+        if (std::find(representative_seen_.begin(), representative_seen_.end(),
+                      false) != representative_seen_.end()) {
+            throw std::runtime_error("preflight did not see every representative row");
+        }
+        return checksum_;
+    }
+
+private:
+    const WorkloadSpec& spec_;
+    std::vector<bool> seen_;
+    std::vector<std::uint64_t> representatives_;
+    std::vector<bool> representative_seen_;
+    std::uint64_t accepted_rows_ = 0;
+    std::uint64_t checksum_ = 0;
+    std::uint64_t expected_checksum_ = 0;
+};
+
+// Use monotonic time because wall-clock adjustments must not affect a benchmark.
+double seconds_between(std::chrono::steady_clock::time_point start,
+                       std::chrono::steady_clock::time_point end) {
+    return std::chrono::duration<double>(end - start).count();
+}
+
+// Encode integer statement attributes using the pointer-sized ODBC ABI convention.
+SQLPOINTER attribute_value(SQLULEN value) {
+    return reinterpret_cast<SQLPOINTER>(static_cast<std::uintptr_t>(value));
+}
+
+}  // namespace
+
+// Resolve one explicit configuration contract shared by both executables.
+Config Config::from_environment() {
+    Config config;
+    config.driver = environment_value("ODBC_BENCH_DRIVER");
+    config.server = first_environment_value("ODBC_BENCH_SERVER", "SQL_SERVER");
+    config.database = environment_value_or("ODBC_BENCH_DATABASE", "tempdb");
+    config.uid = environment_value_or("ODBC_BENCH_UID", "sa");
+    config.pwd = first_environment_value("ODBC_BENCH_PWD", "SQL_PASSWORD");
+    config.trust_certificate =
+        environment_value_or("ODBC_BENCH_TRUST_CERT", "Yes");
+    config.encrypt = environment_value_or("ODBC_BENCH_ENCRYPT", "Mandatory");
+    config.packet_size =
+        environment_value_or("ODBC_BENCH_PACKET_SIZE", "32768");
+    config.packet_size_keyword =
+        environment_value_or("ODBC_BENCH_PACKET_SIZE_KEYWORD", "PacketSize");
+    config.scenario = environment_value("ODBC_BENCH_SCENARIO");
+
+    std::vector<std::string> missing;
+    if (config.driver.empty()) {
+        missing.emplace_back("ODBC_BENCH_DRIVER");
+    }
+    if (config.server.empty()) {
+        missing.emplace_back("ODBC_BENCH_SERVER (or SQL_SERVER)");
+    }
+    if (config.pwd.empty()) {
+        missing.emplace_back("ODBC_BENCH_PWD (or SQL_PASSWORD)");
+    }
+    if (!missing.empty()) {
+        std::ostringstream message;
+        message << "missing required connection environment:";
+        for (const auto& name : missing) {
+            message << ' ' << name;
+        }
+        throw std::runtime_error(message.str());
+    }
+
+    if (!std::all_of(config.packet_size.begin(), config.packet_size.end(),
+                     [](unsigned char character) {
+                         return std::isdigit(character) != 0;
+                     })) {
+        throw std::runtime_error("ODBC_BENCH_PACKET_SIZE must be an integer");
+    }
+    const unsigned long packet_size = std::stoul(config.packet_size);
+    if (packet_size < 512 || packet_size > 32768) {
+        throw std::runtime_error(
+            "ODBC_BENCH_PACKET_SIZE must be between 512 and 32768");
+    }
+    if (config.packet_size_keyword != "PacketSize" &&
+        config.packet_size_keyword != "Packet Size") {
+        throw std::runtime_error(
+            "ODBC_BENCH_PACKET_SIZE_KEYWORD must be PacketSize or Packet Size");
+    }
+    if (!config.scenario.empty() && config.scenario != "narrow" &&
+        config.scenario != "wide") {
+        throw std::runtime_error(
+            "ODBC_BENCH_SCENARIO must be narrow, wide, or unset");
+    }
+    return config;
+}
+
+// Keep all three driver legs identical except for the registered driver name and
+// the packet-size keyword spelling each implementation accepts.
+std::string Config::connection_string() const {
+    std::ostringstream connection;
+    connection << "Driver=" << brace_connection_value(driver)
+               << ";Server=" << brace_connection_value(server)
+               << ";Database=" << brace_connection_value(database)
+               << ";UID=" << brace_connection_value(uid)
+               << ";PWD=" << brace_connection_value(pwd)
+               << ";TrustServerCertificate="
+               << brace_connection_value(trust_certificate)
+               << ";Encrypt=" << brace_connection_value(encrypt)
+               << ';' << packet_size_keyword << '=' << packet_size << ';';
+    return connection.str();
+}
+
+// Derive width from the type pattern to prevent setup and binding from drifting.
+std::size_t WorkloadSpec::column_count() const {
+    return pattern_repetitions * kPatternSize;
+}
+
+// The narrow workload stresses row volume; the wide workload stresses per-row
+// conversion and binding breadth while staying below SQL Server's row-size limit.
+const std::array<WorkloadSpec, 2>& workloads() {
+    static const std::array<WorkloadSpec, 2> specs = {{
+        {"fetch/narrow_2m_c15_mixed_fixed/rowset_1024",
+         "narrow",
+         "mssql_odbc_bench_narrow_2m_c15_mixed_fixed", 2'000'000, 1},
+        {"fetch/wide_10k_c600_mixed_fixed/rowset_1024",
+         "wide",
+         "mssql_odbc_bench_wide_10k_c600_mixed_fixed", 10'000, 40},
+    }};
+    return specs;
+}
+
+// Build a complete handle chain once so connection setup is outside measurements.
+OdbcSession::OdbcSession(const Config& config) {
+    try {
+        SQLRETURN rc =
+            SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &env_);
+        require_exact_success(rc, "SQLAllocHandle(SQL_HANDLE_ENV)", SQL_HANDLE_ENV,
+                              env_);
+
+        rc = SQLSetEnvAttr(env_, SQL_ATTR_ODBC_VERSION,
+                           attribute_value(SQL_OV_ODBC3_80), 0);
+        require_exact_success(rc, "SQLSetEnvAttr(SQL_ATTR_ODBC_VERSION)",
+                              SQL_HANDLE_ENV, env_);
+
+        rc = SQLAllocHandle(SQL_HANDLE_DBC, env_, &dbc_);
+        require_exact_success(rc, "SQLAllocHandle(SQL_HANDLE_DBC)", SQL_HANDLE_ENV,
+                              env_);
+
+        auto connection = to_sql_string(config.connection_string());
+        rc = SQLDriverConnect(dbc_, nullptr, connection.data(), SQL_NTS, nullptr, 0,
+                              nullptr, SQL_DRIVER_NOPROMPT);
+        require_connection_success(rc, dbc_);
+
+        rc = SQLAllocHandle(SQL_HANDLE_STMT, dbc_, &stmt_);
+        require_exact_success(rc, "SQLAllocHandle(SQL_HANDLE_STMT)", SQL_HANDLE_DBC,
+                              dbc_);
+    } catch (...) {
+        release();
+        throw;
+    }
+}
+
+// Centralize cleanup so both normal and exceptional paths use the same handle order.
+OdbcSession::~OdbcSession() {
+    release();
+}
+
+// ODBC requires child handles to be released before their parents.
+void OdbcSession::release() noexcept {
+    if (stmt_ != SQL_NULL_HSTMT) {
+        SQLFreeHandle(SQL_HANDLE_STMT, stmt_);
+        stmt_ = SQL_NULL_HSTMT;
+    }
+    if (dbc_ != SQL_NULL_HDBC) {
+        SQLDisconnect(dbc_);
+        SQLFreeHandle(SQL_HANDLE_DBC, dbc_);
+        dbc_ = SQL_NULL_HDBC;
+    }
+    if (env_ != SQL_NULL_HENV) {
+        SQLFreeHandle(SQL_HANDLE_ENV, env_);
+        env_ = SQL_NULL_HENV;
+    }
+}
+
+// The runner owns statement state transitions; other code receives no ownership.
+SQLHSTMT OdbcSession::statement() const {
+    return stmt_;
+}
+
+// Drain all results so the shared statement is clean for the next setup operation.
+void OdbcSession::execute_non_query(const std::string& sql) {
+    auto text = to_sql_string(sql);
+    try {
+        require_exact_success(SQLExecDirect(stmt_, text.data(), SQL_NTS),
+                              "SQLExecDirect", SQL_HANDLE_STMT, stmt_);
+        for (;;) {
+            const SQLRETURN rc = SQLMoreResults(stmt_);
+            if (rc == SQL_NO_DATA) {
+                break;
+            }
+            require_exact_success(rc, "SQLMoreResults", SQL_HANDLE_STMT, stmt_);
+        }
+    } catch (...) {
+        SQLFreeStmt(stmt_, SQL_CLOSE);
+        throw;
+    }
+}
+
+// Check generated table cardinality through bound ODBC fetches, not a side channel.
+std::uint64_t OdbcSession::query_count(const std::string& table) {
+    const std::string sql =
+        "SELECT COUNT_BIG(*) FROM " + table + " OPTION (MAXDOP 1)";
+    auto text = to_sql_string(sql);
+    SQLBIGINT count = -1;
+    SQLLEN indicator = kIndicatorSentinel;
+    try {
+        require_exact_success(SQLExecDirect(stmt_, text.data(), SQL_NTS),
+                              "SQLExecDirect(COUNT_BIG)", SQL_HANDLE_STMT, stmt_);
+        SQLSMALLINT columns = 0;
+        require_exact_success(SQLNumResultCols(stmt_, &columns), "SQLNumResultCols",
+                              SQL_HANDLE_STMT, stmt_);
+        if (columns != 1) {
+            throw std::runtime_error("COUNT_BIG query returned the wrong column count");
+        }
+        require_exact_success(
+            SQLBindCol(stmt_, 1, SQL_C_SBIGINT, &count, sizeof(count), &indicator),
+            "SQLBindCol(COUNT_BIG)", SQL_HANDLE_STMT, stmt_);
+        require_exact_success(SQLFetch(stmt_), "SQLFetch(COUNT_BIG)",
+                              SQL_HANDLE_STMT, stmt_);
+        if (indicator != static_cast<SQLLEN>(sizeof(count)) || count < 0) {
+            throw std::runtime_error("COUNT_BIG query returned an invalid value");
+        }
+        const SQLRETURN final_fetch = SQLFetch(stmt_);
+        if (final_fetch != SQL_NO_DATA) {
+            throw_odbc_error("SQLFetch(COUNT_BIG final)", final_fetch,
+                             SQL_HANDLE_STMT, stmt_);
+        }
+        require_exact_success(SQLCloseCursor(stmt_), "SQLCloseCursor(COUNT_BIG)",
+                              SQL_HANDLE_STMT, stmt_);
+        require_exact_success(SQLFreeStmt(stmt_, SQL_UNBIND),
+                              "SQLFreeStmt(SQL_UNBIND COUNT_BIG)",
+                              SQL_HANDLE_STMT, stmt_);
+    } catch (...) {
+        SQLFreeStmt(stmt_, SQL_CLOSE);
+        SQLFreeStmt(stmt_, SQL_UNBIND);
+        throw;
+    }
+    return static_cast<std::uint64_t>(count);
+}
+
+// Drop in reverse catalog order to keep cleanup safe if dependencies are added later.
+void cleanup_benchmark_tables(OdbcSession& session) {
+    for (auto iterator = workloads().rbegin(); iterator != workloads().rend();
+         ++iterator) {
+        session.execute_non_query("DROP TABLE IF EXISTS " + qualified_table(*iterator));
+    }
+    std::cout << "Benchmark tables removed\n";
+}
+
+// Recreate and count each table before any timed process can consume it.
+void setup_benchmark_tables(OdbcSession& session) {
+    cleanup_benchmark_tables(session);
+    for (const auto& spec : workloads()) {
+        std::cout << "Creating " << qualified_table(spec) << " with " << spec.row_count
+                  << " rows and " << spec.column_count() << " columns\n";
+        session.execute_non_query(create_table_sql(spec));
+        session.execute_non_query(insert_sql(spec));
+        const auto actual_rows = session.query_count(qualified_table(spec));
+        if (actual_rows != spec.row_count) {
+            std::ostringstream message;
+            message << qualified_table(spec) << " contains " << actual_rows
+                    << " rows; expected " << spec.row_count;
+            throw std::runtime_error(message.str());
+        }
+    }
+    std::cout << "Benchmark setup complete\n";
+}
+
+// Holds mutable ODBC fetch state behind the stable public runner interface.
+class WorkloadRunner::Impl {
+public:
+    Impl(OdbcSession& session, const WorkloadSpec& spec)
+        : session_(session),
+          spec_(spec),
+          columns_(columns_for(spec)),
+          query_(to_sql_string(select_sql(spec, columns_))) {
+        buffers_.reserve(columns_.size());
+        for (const auto& column : columns_) {
+            buffers_.emplace_back(*column.type);
+            logical_bytes_per_row_ += column.type->logical_bytes;
+        }
+        if (logical_bytes_per_row_ >= 8060) {
+            throw std::logic_error(
+                "generated fixed-width row is not below SQL Server's 8060-byte limit");
+        }
+    }
+
+    const WorkloadSpec& spec() const {
+        return spec_;
+    }
+
+    std::uint64_t logical_bytes_per_row() const {
+        return logical_bytes_per_row_;
+    }
+
+    // Run the identical retrieval path with validation enabled and timing ignored.
+    void preflight() {
+        PreflightValidator validator(spec_);
+        (void)run(&validator);
+        const auto checksum = validator.finish();
+        std::ostringstream message;
+        message << "Preflight passed for " << spec_.benchmark_name << ": "
+                << spec_.row_count << " rows, " << spec_.column_count()
+                << " columns, checksum=0x" << std::hex << std::setw(16)
+                << std::setfill('0') << checksum;
+        std::cerr << message.str() << '\n';
+    }
+
+    // Run the production measurement path without per-cell validation overhead.
+    RetrievalMetrics retrieve() {
+        return run(nullptr);
+    }
+
+private:
+    // Configure column-wise arrays before execution so the measured operation uses
+    // the same 1,024-row batch shape on every driver.
+    void prepare_statement() {
+        // Microsoft ODBC leaves this unchanged on terminal SQL_NO_DATA.
+        rows_fetched_ = 0;
+        require_exact_success(
+            SQLSetStmtAttr(session_.statement(), SQL_ATTR_ROW_BIND_TYPE,
+                           attribute_value(SQL_BIND_BY_COLUMN), 0),
+            "SQLSetStmtAttr(SQL_ATTR_ROW_BIND_TYPE)", SQL_HANDLE_STMT,
+            session_.statement());
+        require_exact_success(
+            SQLSetStmtAttr(session_.statement(), SQL_ATTR_ROW_ARRAY_SIZE,
+                           attribute_value(kRowArraySize), 0),
+            "SQLSetStmtAttr(SQL_ATTR_ROW_ARRAY_SIZE)", SQL_HANDLE_STMT,
+            session_.statement());
+        require_exact_success(
+            SQLSetStmtAttr(session_.statement(), SQL_ATTR_ROWS_FETCHED_PTR,
+                           &rows_fetched_, 0),
+            "SQLSetStmtAttr(SQL_ATTR_ROWS_FETCHED_PTR)", SQL_HANDLE_STMT,
+            session_.statement());
+    }
+
+    // Include metadata discovery and binding in the end-to-end boundary while
+    // checking that each driver exposes the expected result shape.
+    void describe_and_bind() {
+        SQLSMALLINT result_columns = 0;
+        require_exact_success(
+            SQLNumResultCols(session_.statement(), &result_columns),
+            "SQLNumResultCols", SQL_HANDLE_STMT, session_.statement());
+        if (result_columns != static_cast<SQLSMALLINT>(columns_.size())) {
+            std::ostringstream message;
+            message << "result has " << result_columns << " columns; expected "
+                    << columns_.size();
+            throw std::runtime_error(message.str());
+        }
+
+        for (std::size_t index = 0; index < columns_.size(); ++index) {
+            SQLTCHAR name[32] = {};
+            SQLSMALLINT name_length = 0;
+            SQLSMALLINT data_type = 0;
+            SQLULEN column_size = 0;
+            SQLSMALLINT decimal_digits = 0;
+            SQLSMALLINT nullable = SQL_NULLABLE_UNKNOWN;
+            require_exact_success(
+                SQLDescribeCol(
+                    session_.statement(), static_cast<SQLUSMALLINT>(index + 1), name,
+                    static_cast<SQLSMALLINT>(std::size(name)), &name_length,
+                    &data_type, &column_size, &decimal_digits, &nullable),
+                "SQLDescribeCol", SQL_HANDLE_STMT, session_.statement());
+
+            const auto& expected_name = columns_[index].name;
+            bool name_matches =
+                name_length == static_cast<SQLSMALLINT>(expected_name.size());
+            for (std::size_t name_index = 0;
+                 name_index < expected_name.size() && name_matches; ++name_index) {
+                name_matches =
+                    name[name_index] ==
+                    static_cast<SQLTCHAR>(
+                        static_cast<unsigned char>(expected_name[name_index]));
+            }
+            if (!name_matches || nullable != SQL_NO_NULLS || data_type == 0 ||
+                column_size == 0) {
+                throw std::runtime_error(
+                    "SQLDescribeCol returned unexpected workload metadata");
+            }
+            (void)decimal_digits;
+
+            auto& buffer = buffers_[index];
+            require_exact_success(
+                SQLBindCol(
+                    session_.statement(), static_cast<SQLUSMALLINT>(index + 1),
+                    buffer.type().c_type, buffer.data(),
+                    static_cast<SQLLEN>(buffer.type().slot_size),
+                    buffer.indicators()),
+                "SQLBindCol", SQL_HANDLE_STMT, session_.statement());
+        }
+    }
+
+    // Require successful cleanup because stale bindings would contaminate later legs.
+    void cleanup_statement() {
+        require_exact_success(SQLCloseCursor(session_.statement()), "SQLCloseCursor",
+                              SQL_HANDLE_STMT, session_.statement());
+        require_exact_success(SQLFreeStmt(session_.statement(), SQL_UNBIND),
+                              "SQLFreeStmt(SQL_UNBIND)", SQL_HANDLE_STMT,
+                              session_.statement());
+    }
+
+    // Best-effort reset preserves the original ODBC error during stack unwinding.
+    void cleanup_statement_noexcept() noexcept {
+        SQLFreeStmt(session_.statement(), SQL_CLOSE);
+        SQLFreeStmt(session_.statement(), SQL_UNBIND);
+    }
+
+    // Measure from SQL execution through terminal SQL_NO_DATA. This is the regression
+    // boundary; setup, connection, and preflight are deliberately outside it.
+    RetrievalMetrics run(PreflightValidator* validator) {
+        prepare_statement();
+        try {
+            const auto start = std::chrono::steady_clock::now();
+            require_exact_success(
+                SQLExecDirect(session_.statement(), query_.data(), SQL_NTS),
+                "SQLExecDirect", SQL_HANDLE_STMT, session_.statement());
+            const auto after_execute = std::chrono::steady_clock::now();
+
+            describe_and_bind();
+            const auto after_bind = std::chrono::steady_clock::now();
+
+            std::uint64_t rows = 0;
+            for (;;) {
+                if (validator != nullptr) {
+                    for (auto& buffer : buffers_) {
+                        buffer.reset_indicators();
+                    }
+                }
+                rows_fetched_ = 0;
+                const SQLRETURN rc =
+                    SQLFetchScroll(session_.statement(), SQL_FETCH_NEXT, 0);
+                if (rc == SQL_NO_DATA) {
+                    if (rows_fetched_ != 0) {
+                        throw std::runtime_error(
+                            "SQLFetchScroll reported SQL_NO_DATA with rows fetched");
+                    }
+                    break;
+                }
+                require_exact_success(rc, "SQLFetchScroll", SQL_HANDLE_STMT,
+                                      session_.statement());
+                if (rows_fetched_ == 0 || rows_fetched_ > kRowArraySize ||
+                    rows_fetched_ > spec_.row_count ||
+                    rows > spec_.row_count - rows_fetched_) {
+                    throw std::runtime_error(
+                        "SQLFetchScroll returned an invalid rowset size");
+                }
+                if (validator != nullptr) {
+                    validator->accept(buffers_, rows_fetched_);
+                }
+                rows += rows_fetched_;
+            }
+
+            if (rows != spec_.row_count) {
+                std::ostringstream message;
+                message << "retrieval fetched " << rows << " rows; expected "
+                        << spec_.row_count;
+                throw std::runtime_error(message.str());
+            }
+            const auto end = std::chrono::steady_clock::now();
+
+            RetrievalMetrics metrics;
+            metrics.rows = rows;
+            metrics.cells = rows * static_cast<std::uint64_t>(columns_.size());
+            metrics.logical_bytes = rows * logical_bytes_per_row_;
+            metrics.total_seconds = seconds_between(start, end);
+            metrics.execute_seconds = seconds_between(start, after_execute);
+            metrics.metadata_bind_seconds =
+                seconds_between(after_execute, after_bind);
+            metrics.fetch_seconds = seconds_between(after_bind, end);
+
+            cleanup_statement();
+            return metrics;
+        } catch (...) {
+            cleanup_statement_noexcept();
+            throw;
+        }
+    }
+
+    OdbcSession& session_;
+    const WorkloadSpec& spec_;
+    std::vector<ColumnSpec> columns_;
+    std::vector<ColumnBuffer> buffers_;
+    SqlString query_;
+    SQLULEN rows_fetched_ = 0;
+    std::uint64_t logical_bytes_per_row_ = 0;
+};
+
+// Allocate descriptors once per catalog workload; each iteration still rebinds.
+WorkloadRunner::WorkloadRunner(OdbcSession& session, const WorkloadSpec& spec)
+    : impl_(std::make_unique<Impl>(session, spec)) {}
+
+WorkloadRunner::~WorkloadRunner() = default;
+
+// Preserve the stable benchmark name selected by the shared workload catalog.
+const WorkloadSpec& WorkloadRunner::spec() const {
+    return impl_->spec();
+}
+
+// Expose driver-independent payload volume for throughput reporting.
+std::uint64_t WorkloadRunner::logical_bytes_per_row() const {
+    return impl_->logical_bytes_per_row();
+}
+
+// Validate correctness through the same implementation used by timed retrieval.
+void WorkloadRunner::preflight() {
+    impl_->preflight();
+}
+
+// Return all phase metrics from one complete result-set consumption.
+RetrievalMetrics WorkloadRunner::retrieve() {
+    return impl_->retrieve();
+}
+
+}  // namespace mssql::odbc::bench

--- a/mssql-odbc-bench/src/odbc_bench.cpp
+++ b/mssql-odbc-bench/src/odbc_bench.cpp
@@ -36,6 +36,9 @@ constexpr SQLSMALLINT kSqlCSSsTimestampOffset = 0x4001;
 constexpr SQLUSMALLINT kSqlCaSsVariantType = 1215;
 constexpr std::size_t kPatternSize = 15;
 constexpr SQLLEN kIndicatorSentinel = -777;
+// The encrypted Linux and Windows labs confirmed that Microsoft ODBC 18.6.2.1,
+// the candidate, and the pinned Rust baseline all honor and report 16192 exactly.
+constexpr char kDefaultPacketSize[] = "16192";
 // One NULL in every seven rows for a nullable column, offset per column so no two
 // columns go NULL on the same rows. Realistic sparsity without making the payload
 // dominated by NULLs.
@@ -865,7 +868,7 @@ Config Config::from_environment() {
         environment_value_or("ODBC_BENCH_TRUST_CERT", "Yes");
     config.encrypt = environment_value_or("ODBC_BENCH_ENCRYPT", "Mandatory");
     config.packet_size =
-        environment_value_or("ODBC_BENCH_PACKET_SIZE", "32767");
+        environment_value_or("ODBC_BENCH_PACKET_SIZE", kDefaultPacketSize);
     config.packet_size_keyword =
         environment_value_or("ODBC_BENCH_PACKET_SIZE_KEYWORD", "PacketSize");
     config.scenario = environment_value("ODBC_BENCH_SCENARIO");

--- a/mssql-odbc-bench/src/odbc_bench.cpp
+++ b/mssql-odbc-bench/src/odbc_bench.cpp
@@ -2060,6 +2060,11 @@ private:
             metrics.total_seconds = seconds_between(start, end);
             metrics.execute_seconds = seconds_between(start, after_execute);
             metrics.metadata_bind_seconds = seconds_between(after_execute, after_bind);
+            if (spec_.access == AccessMode::bound_bind_cycle) {
+                // Describe/bind repeats inside the fetch loop for this workload,
+                // so there is no honest one-time metadata phase to report.
+                metrics.metadata_bind_seconds = -1.0;
+            }
             metrics.fetch_seconds = seconds_between(after_bind, end);
 
             cleanup_statement();


### PR DESCRIPTION
## Summary

This is the benchmark and infrastructure PR split from #395. It intentionally excludes the production ODBC/TDS fetch optimizations, which remain separate in #418.

- Add a fixed C++17 ODBC Driver Manager harness for the ODBC result-retrieval patterns used by `microsoft/mssql-python`: bound rowsets 1/64/1000, repeated bind/fetch/unbind cadence, nullable inline variable-width data, and row-wise `SQLGetData` for ordinary, MAX/PLP, and `sql_variant` values. Python itself is not loaded or benchmarked.
- Add dedicated Linux and Windows perf-lab pipelines comparing the candidate with the pinned `mssql-odbc` baseline and Microsoft ODBC Driver 18.6.2.1.
- Publish a rich Summary-tab report with three median wall times, candidate throughput, clearly separated regression-gate/reference comparisons, and confirmation details.
- Screen at 5%, then require 3 of 4 balanced confirmation rounds. Microsoft ODBC is a non-gating reference.
- Pin Google Benchmark v1.9.1 by commit and the reporting environment to NumPy 2.2.6 / SciPy 1.15.3.
- Enforce the final `comparison.json` verdict in repository-owned Linux and Windows pipeline steps.

Work item: [AB#47608](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47608)

Split from: #395

## Bootstrap baseline

The initial baseline is production `main` commit `bc4b2dc80b111c388ac8000b90f1c35290d735a0`, the commit on which this benchmark branch was rebased. This PR changes no production `mssql-odbc` or `mssql-tds` files, so candidate and baseline production blobs are identical; only the candidate supplies the new harness/pipeline. Future baseline advances are reviewed edits to `baseline-commit.txt`.

The common encrypted-lab packet-size default is `16192`, which Microsoft ODBC 18.6.2.1 and both Rust builds accept and report exactly. Earlier packet-negotiation failures in Linux 171011 and Windows 171010 are superseded.

## Live perf-lab validation

The meaningful measurement head is `b67adbf691d03e5752e25908106eb5bd73093e79`. Later commits only clarify documentation or make the Windows artifact schema assertion fail closed; they do not change workloads, timings, dependency pins, comparator results, or gate policy.

- [Linux run 171305 — Summary](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build/results?buildId=171305&view=ms.vss-build-web.run-extensions-tab)
- [Windows run 171304 — Summary](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build/results?buildId=171304&view=ms.vss-build-web.run-extensions-tab)

Both runs:

- exercised all **13 workloads** against all **three drivers**;
- collected the `perf-results` artifact including `summary.md` and raw comparison/context files;
- used the immutable Google Benchmark commit and Python-3.10-compatible pinned NumPy/SciPy environment;
- reported **no confirmed benchmark at least 5% slower than the pinned Rust baseline**;
- passed the repository-owned `Enforce ODBC regression gate` assertion step.

A fresh WSL Ubuntu 22.04 candidate smoke also passed all 13 workloads with exact `16192` readback using a random short-lived SQL login; tables, user, login, container, and temporary files were removed afterward.

## Validation

- 19 comparator tests covering three-way and legacy two-way reports, official Google Benchmark output, mismatch rejection, contradictory gate flags, and confirmation/gating behavior
- Comparator policy tests folded into the existing Linux validation job (no extra agent job)
- Bash syntax and PowerShell parser checks
- Windows x64 C++ harness build with MSVC 14.44.35207
- WSL Ubuntu 22.04 candidate smoke across all 13 workloads
- `cargo bfmt` and `git diff --check`
- Production-tree equality against bootstrap pin; no production optimization files changed
- All review threads resolved