### PR TITLE
Pin ColumnSize 0 to a max declaration in the char parameter e2e suite

### DIFF
--- a/mssql-odbc/tests/e2e/tests/char_conversions_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/char_conversions_test.cpp
@@ -506,6 +506,9 @@ TEST_F(CharConversionLiveTest, UnboundedColumnSizeCarriesOversizedValues) {
 // Asserted rather than fixed because msodbcsql 18.6 declares `max` here too and
 // fails identically, so deriving the length from the data instead would be the
 // divergence (AB#47533).
+//
+// Benefits-from-mock-tds: a mock TDS server could assert the RPC parameter was
+// declared varchar(max)/nvarchar(max) directly.
 TEST_F(CharConversionLiveTest, UnboundedColumnSizeIsMaxEvenForASmallValue) {
     const std::pair<SQLSMALLINT, SQLSMALLINT> cases[] = {
         {SQL_C_CHAR, SQL_VARCHAR},

--- a/mssql-odbc/tests/e2e/tests/char_conversions_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/char_conversions_test.cpp
@@ -498,6 +498,33 @@ TEST_F(CharConversionLiveTest, UnboundedColumnSizeCarriesOversizedValues) {
     EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
 }
 
+// ColumnSize 0 is `max` even for a value that would fit a bounded length, so the
+// parameter cannot be cast to sql_variant - sql_variant has no `max` member. The
+// application has to pass a real ColumnSize, which
+// CharParamDeclaresTheParameterType covers.
+//
+// Asserted rather than fixed because msodbcsql 18.6 declares `max` here too and
+// fails identically, so deriving the length from the data instead would be the
+// divergence (AB#47533).
+TEST_F(CharConversionLiveTest, UnboundedColumnSizeIsMaxEvenForASmallValue) {
+    const std::pair<SQLSMALLINT, SQLSMALLINT> cases[] = {
+        {SQL_C_CHAR, SQL_VARCHAR},
+        {SQL_C_WCHAR, SQL_WVARCHAR},
+    };
+    for (const auto& c : cases) {
+        ASSERT_SQL_OK(Prepare("SELECT CAST(? AS SQL_VARIANT)"), SQL_HANDLE_STMT,
+                      stmt_);
+
+        AsciiParam value(c.first, "abc");
+        ASSERT_SQL_OK(BindAscii(1, value, c.second, 0), SQL_HANDLE_STMT, stmt_);
+
+        EXPECT_EQ(SQL_ERROR, SQLExecute(stmt_)) << "sql type " << c.second;
+        EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "22018");
+        EXPECT_SQL_OK(SQLFreeStmt(stmt_, SQL_RESET_PARAMS), SQL_HANDLE_STMT,
+                      stmt_);
+    }
+}
+
 // A zero-length value is an empty string, not a NULL - only SQL_NULL_DATA in the
 // indicator means NULL. The fixed-length targets still pad out to ColumnSize,
 // which is the one case where an empty value has a non-zero DATALENGTH.


### PR DESCRIPTION
## Description

Closes out [AB#47533](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47533), which reported `SQL_WVARCHAR` with `ColumnSize 0` being sent as `nvarchar(max)` and breaking `CAST(? AS sql_variant)`. Investigating it turned up two separate facts, and neither needs a driver change:

**The four failing mssql-python tests already pass.** The `nvarchar(max)` they hit came from the pre-#385 converter, which ignored `ColumnSize` entirely and turned every `SQL_C_WCHAR` value into `NVarcharMax` regardless of `ParameterType`. #385 fixed that. Rebuilt from current `main`, swapped into the cross-repo container, all four pass:

```
tests/test_023_execute_path_parity.py -k "test_native_small_geometry_binds_nvarchar or test_native_unicode_kind_geometry_still_detected"
4 passed, 130 deselected
```

**The `ColumnSize 0` → `max` mapping itself is parity-correct.** A direct unixODBC probe against both drivers on SQL Server 2022:

| binding | msodbcsql 18.6 | mssql-odbc |
| --- | --- | --- |
| `SQL_VARCHAR`, ColumnSize 0, `"hello"` | 22018, `varchar(max)` → sql_variant | identical |
| `SQL_VARCHAR`, ColumnSize 5, `"hello"` | `varchar(5)` | identical |
| `SQL_WVARCHAR`, ColumnSize 0, WKT | 22018, `nvarchar(max)` → sql_variant | identical |
| `SQL_WVARCHAR`, ColumnSize 10, WKT | `nvarchar(20)` | identical |

Same SQLSTATE, same declared type, same `MaxLength`. Deriving the declared length from the data instead would be the divergence, so `variable_length()` stays as it is.

What was actually missing is coverage. `UnboundedColumnSizeCarriesOversizedValues` exercises `ColumnSize 0` only with 9000-byte and 5000-unit payloads, where `max` is the only answer that could work — nothing pinned the small-value case, which is the one that looks like a bug. This PR adds `UnboundedColumnSizeIsMaxEvenForASmallValue`: a 3-character value bound with `ColumnSize 0` against `SQL_VARCHAR` and `SQL_WVARCHAR`, asserting the `22018` that proves the parameter was declared `max`. It runs on both legs of `--compare-with-msodbcsql`, so the parity table now records that `max` is deliberate.

Test only — no driver code changes.

## Related Issues

[AB#47533](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47533)

Fix implemented by #385.

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes — unchanged, no Rust code touched
- [x] New/changed functionality has tests — this PR is the test
- [x] Public API changes are documented — n/a

## Verification

`char_conversions_test` against a local SQL Server 2022, both drivers:

| leg | result |
| --- | --- |
| mssql-odbc | 21 passed |
| msodbcsql 18.6 | 16 passed, 5 skipped (pre-existing `SKIP_IF_COMPARING_MSODBCSQL`) |

The new test passes on both, which is the claim it exists to make.
