### PR TITLE
Fix LOGIN7 Unicode lengths and map ODBC APP name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Changed
 
+- `mssql-tds`: LOGIN7 now encodes Unicode field lengths as UTF-16 code units
+  and rejects oversized records instead of producing malformed packets. This
+  fixes login failures with non-ASCII usernames, passwords, database names,
+  hostnames, and application names across all bindings.
+
 - `mssql-tds`: `TdsClient::language()` now returns the language negotiated at
   login (from the server's `ENVCHANGE`) instead of always returning an empty
   string, matching its documentation.
@@ -137,4 +142,3 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   rejected as a protocol error. Such a packet is malformed — it neither carries
   payload nor terminates a message — but was previously consumed as a
   zero-length packet. Empty end-of-message packets remain legal.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- `mssql-odbc`: the `APP` connection-string keyword is now sent as the TDS login
+  application name. It was recognized but ignored, so `APP_NAME()` reported the
+  default `TDSX Rust Client` value without warning that `APP` had been dropped.
+
+- `mssql-tds`: LOGIN7 record sizing now includes the optional change-password
+  value, preventing a caller-supplied value from making the declared packet
+  length shorter than the serialized payload.
+
 - `mssql-tds`: idle connection resiliency (transparent session recovery) now
   works end to end. The client-side gate that authorizes a reconnect is now set
   from the server's `FEATUREEXTACK` acknowledgment — previously it was only ever

--- a/mssql-odbc/docs/connection_string_parser.md
+++ b/mssql-odbc/docs/connection_string_parser.md
@@ -158,6 +158,7 @@ pass both keys directly; mssql-python collapses the group to a single canonical
 | `HostnameInCertificate` | `EncryptionOptions::host_name_in_cert` | verbatim |
 | `ServerCertificate` | `EncryptionOptions::server_certificate` (path) | verbatim path |
 | `ServerSPN` | `ClientContext::server_spn` | verbatim |
+| `APP` | `ClientContext::application_name` | verbatim |
 | `ApplicationIntent` | `ClientContext::application_intent` | `ReadOnly` / `ReadWrite` |
 | `MultiSubnetFailover` | `ClientContext::multi_subnet_failover` | `Yes` / `No` |
 | `IpAddressPreference` | `ClientContext::ipaddress_preference` | `IPv4First` / `IPv6First` / `UsePlatformDefault`; unknown → `IPv4First` |
@@ -195,8 +196,10 @@ Whole-value, case-insensitive, exact match (not prefix, not `y`/`1`):
   mssql-tds. An empty value is a recognized reset.
 
 Pass-through string keys (`Server`/`Addr`/`Address`, `Database`, `UID`, `PWD`,
-`ServerSPN`, `HostnameInCertificate`, `ServerCertificate`) are stored verbatim with
-no value validation, exactly as msodbcsql does.
+`APP`, `ServerSPN`, `HostnameInCertificate`, `ServerCertificate`) are stored verbatim
+with no value validation, exactly as msodbcsql does. (msodbcsql additionally rejects
+an `APP` longer than 128 characters; per-key length caps are an intentional non-goal
+here — see below.)
 
 ## Keys we recognize but do not act on
 

--- a/mssql-odbc/src/api/driver_connect.rs
+++ b/mssql-odbc/src/api/driver_connect.rs
@@ -469,6 +469,9 @@ fn apply_connection_params(context: &mut ClientContext, params: &ConnectionParam
     if let Some(server_spn) = &params.server_spn {
         context.server_spn = Some(server_spn.clone());
     }
+    if let Some(application_name) = &params.application_name {
+        context.application_name = application_name.clone();
+    }
     if let Some(intent) = &params.application_intent {
         context.application_intent = if intent.eq_ignore_ascii_case("readonly") {
             ApplicationIntent::ReadOnly
@@ -1008,13 +1011,28 @@ mod tests {
     }
 
     #[test]
+    fn apply_params_maps_app_to_application_name() {
+        let mut ctx = ClientContext::default();
+        apply_connection_params(
+            &mut ctx,
+            &ConnectionParams {
+                application_name: Some("MSSQL-Python".to_string()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(ctx.application_name, "MSSQL-Python");
+    }
+
+    #[test]
     fn apply_params_leaves_unset_fields_at_defaults() {
         let mut ctx = ClientContext::default();
         let before_packet = ctx.packet_size;
         let before_retry = ctx.connect_retry_count;
+        let before_app_name = ctx.application_name.clone();
         apply_connection_params(&mut ctx, &ConnectionParams::default());
         assert_eq!(ctx.packet_size, before_packet);
         assert_eq!(ctx.connect_retry_count, before_retry);
+        assert_eq!(ctx.application_name, before_app_name);
         assert_eq!(ctx.encryption_options.host_name_in_cert, None);
         assert_eq!(ctx.encryption_options.server_certificate, None);
     }

--- a/mssql-odbc/src/connection/connection_string_parser.rs
+++ b/mssql-odbc/src/connection/connection_string_parser.rs
@@ -48,7 +48,6 @@ const KNOWN_IGNORED_KEYS: &[&str] = &[
     "description",
     "desc",
     "driver",
-    "app",
     "wsid",
     "language",
     "network",
@@ -135,6 +134,7 @@ enum ConnAttrKey {
     Authentication,
     TrustedConnection,
     ServerSpn,
+    App,
     ApplicationIntent,
     MultiSubnetFailover,
     ConnectRetryCount,
@@ -203,6 +203,7 @@ pub(crate) struct ConnectionParams {
     pub(crate) authentication: Option<String>,
     pub(crate) trusted_connection: Option<bool>,
     pub(crate) server_spn: Option<String>,
+    pub(crate) application_name: Option<String>,
     pub(crate) application_intent: Option<String>,
     pub(crate) multi_subnet_failover: Option<bool>,
     pub(crate) connect_retry_count: Option<u32>,
@@ -248,6 +249,9 @@ impl ConnectionParams {
         }
         if let Some(server_spn) = &self.server_spn {
             parts.push(format!("ServerSPN={}", quote_odbc_value(server_spn)));
+        }
+        if let Some(application_name) = &self.application_name {
+            parts.push(format!("APP={}", quote_odbc_value(application_name)));
         }
         if let Some(application_intent) = &self.application_intent {
             parts.push(format!("ApplicationIntent={application_intent}"));
@@ -318,6 +322,7 @@ impl fmt::Debug for ConnectionParams {
             .field("authentication", &self.authentication)
             .field("trusted_connection", &self.trusted_connection)
             .field("server_spn", &self.server_spn)
+            .field("application_name", &self.application_name)
             .field("application_intent", &self.application_intent)
             .field("multi_subnet_failover", &self.multi_subnet_failover)
             .field("connect_retry_count", &self.connect_retry_count)
@@ -373,6 +378,7 @@ const MAPPED_KEYS: &[(&str, ConnAttrKey)] = &[
     ("authentication", ConnAttrKey::Authentication),
     ("trusted_connection", ConnAttrKey::TrustedConnection),
     ("serverspn", ConnAttrKey::ServerSpn),
+    ("app", ConnAttrKey::App),
     ("applicationintent", ConnAttrKey::ApplicationIntent),
     ("multisubnetfailover", ConnAttrKey::MultiSubnetFailover),
     ("connectretrycount", ConnAttrKey::ConnectRetryCount),
@@ -439,6 +445,7 @@ fn assign_value(
             params.trusted_connection = Some(is_yes(value));
         }
         ConnAttrKey::ServerSpn => params.server_spn = Some(value.to_string()),
+        ConnAttrKey::App => params.application_name = Some(value.to_string()),
         ConnAttrKey::ApplicationIntent => {
             validate_attr(lower, value, APPLICATION_INTENT_VALUES)?;
             params.application_intent = Some(value.to_string());
@@ -1290,7 +1297,6 @@ mod tests {
         for key in [
             "Driver",
             "DSN",
-            "APP",
             "WSID",
             "Language",
             "Network",
@@ -1307,6 +1313,23 @@ mod tests {
             assert_eq!(p.server, "h", "key {key}");
             assert_eq!(p.uid, "u", "key {key}");
         }
+    }
+
+    #[test]
+    fn app_maps_to_application_name() {
+        for key in ["APP", "app", "App"] {
+            let s = format!("Server=h;{key}=My App;UID=u;<PW>=p");
+            let (p, warn) = parse_connection_string(&cs(&s)).unwrap();
+            assert!(!warn, "{key} should map cleanly to APP");
+            assert_eq!(p.application_name.as_deref(), Some("My App"), "key {key}");
+        }
+    }
+
+    #[test]
+    fn app_is_absent_when_not_supplied() {
+        let (p, warn) = parse_connection_string(&cs("Server=h;UID=u;<PW>=p")).unwrap();
+        assert!(!warn);
+        assert_eq!(p.application_name, None);
     }
 
     #[test]
@@ -1485,7 +1508,7 @@ mod tests {
     #[test]
     fn fmt_as_odbc_conn_str_includes_new_keys() {
         let (p, _) = parse_connection_string(
-            "Server=h;ApplicationIntent=ReadOnly;MultiSubnetFailover=yes;ConnectRetryCount=2;ConnectRetryInterval=10;KeepAlive=30;KeepAliveInterval=1;PacketSize=4096;IpAddressPreference=IPv4First;ServerSPN=svc;HostnameInCertificate=cn;ServerCertificate=/tmp/c.pem;UID=u",
+            "Server=h;ApplicationIntent=ReadOnly;MultiSubnetFailover=yes;ConnectRetryCount=2;ConnectRetryInterval=10;KeepAlive=30;KeepAliveInterval=1;PacketSize=4096;IpAddressPreference=IPv4First;ServerSPN=svc;APP=MyApp;HostnameInCertificate=cn;ServerCertificate=/tmp/c.pem;UID=u",
         )
         .unwrap();
         let out = p.fmt_as_odbc_conn_str();
@@ -1499,6 +1522,7 @@ mod tests {
             "PacketSize=4096",
             "IpAddressPreference=IPv4First",
             "ServerSPN=svc",
+            "APP=MyApp",
             "HostnameInCertificate=cn",
             "ServerCertificate=/tmp/c.pem",
         ] {

--- a/mssql-odbc/tests/e2e/tests/driver_connect_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/driver_connect_test.cpp
@@ -555,24 +555,13 @@ TEST_F(DriverConnectLiveTest, NewConnectionAttributesParity) {
 // Regression coverage for AB#47534, where APP parsed cleanly but was dropped
 // before the login packet, so the server saw the driver's default name instead.
 TEST_F(DriverConnectLiveTest, AppKeywordReachesServerAppName) {
-    auto& cfg = ODBCTestConfig::Instance();
-    if (!cfg.HasSqlAuth()) {
-        GTEST_SKIP() << "Requires SQL auth (ODBC_TEST_SERVER + ODBC_TEST_UID + "
-                        "ODBC_TEST_PWD); see follow-up issue for capability gating";
-    }
     const std::string kAppName = "AppKeywordE2E";
-    const std::string cs =
-        "Driver={" + cfg.Driver() + "}"
-        ";Server=" + cfg.Server() +
-        ";UID=" + cfg.Uid() +
-        ";PWD=" + cfg.Pwd() +
-        ";TrustServerCertificate=" + cfg.TrustCert() +
-        ";APP=" + kAppName;
+    SqlTString connstr = ODBCTestUtils::BuildConnectionString();
+    connstr += ODBCTestUtils::ToSqlTStr(";APP=" + kAppName);
 
     SQLHDBC hdbc = SQL_NULL_HDBC;
     ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DBC, env_, &hdbc));
 
-    SqlTString connstr = ODBCTestUtils::ToSqlTStr(cs);
     SQLTCHAR outStr[1024] = {};
     SQLSMALLINT outLen = 0;
     SQLRETURN rc = SQLDriverConnect(hdbc, nullptr,

--- a/mssql-odbc/tests/e2e/tests/driver_connect_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/driver_connect_test.cpp
@@ -551,6 +551,56 @@ TEST_F(DriverConnectLiveTest, NewConnectionAttributesParity) {
     }
 }
 
+// APP must reach the server in the TDS login packet, which APP_NAME() reports.
+// Regression coverage for AB#47534, where APP parsed cleanly but was dropped
+// before the login packet, so the server saw the driver's default name instead.
+TEST_F(DriverConnectLiveTest, AppKeywordReachesServerAppName) {
+    auto& cfg = ODBCTestConfig::Instance();
+    if (!cfg.HasSqlAuth()) {
+        GTEST_SKIP() << "Requires SQL auth (ODBC_TEST_SERVER + ODBC_TEST_UID + "
+                        "ODBC_TEST_PWD); see follow-up issue for capability gating";
+    }
+    const std::string kAppName = "AppKeywordE2E";
+    const std::string cs =
+        "Driver={" + cfg.Driver() + "}"
+        ";Server=" + cfg.Server() +
+        ";UID=" + cfg.Uid() +
+        ";PWD=" + cfg.Pwd() +
+        ";TrustServerCertificate=" + cfg.TrustCert() +
+        ";APP=" + kAppName;
+
+    SQLHDBC hdbc = SQL_NULL_HDBC;
+    ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DBC, env_, &hdbc));
+
+    SqlTString connstr = ODBCTestUtils::ToSqlTStr(cs);
+    SQLTCHAR outStr[1024] = {};
+    SQLSMALLINT outLen = 0;
+    SQLRETURN rc = SQLDriverConnect(hdbc, nullptr,
+                                    const_cast<SQLTCHAR*>(connstr.c_str()),
+                                    static_cast<SQLSMALLINT>(connstr.size()),
+                                    outStr, 1024, &outLen, SQL_DRIVER_NOPROMPT);
+    ASSERT_TRUE(SQL_SUCCEEDED(rc)) << "rc=" << rc;
+    EXPECT_FALSE(ODBCTestUtils::HasDiagState(SQL_HANDLE_DBC, hdbc, "01S00"));
+
+    SQLHSTMT hstmt = SQL_NULL_HSTMT;
+    ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_STMT, hdbc, &hstmt));
+
+    SqlTString sql = ODBCTestUtils::ToSqlTStr("SELECT APP_NAME()");
+    ASSERT_TRUE(SQL_SUCCEEDED(
+        SQLExecDirect(hstmt, const_cast<SQLTCHAR*>(sql.c_str()), SQL_NTS)));
+    ASSERT_TRUE(SQL_SUCCEEDED(SQLFetch(hstmt)));
+
+    SQLTCHAR buf[256] = {};
+    SQLLEN ind = 0;
+    ASSERT_TRUE(SQL_SUCCEEDED(
+        SQLGetData(hstmt, 1, SQL_C_TCHAR, buf, sizeof(buf), &ind)));
+    EXPECT_EQ(kAppName, ODBCTestUtils::ToNarrow(SqlTString(buf)));
+
+    SQLFreeHandle(SQL_HANDLE_STMT, hstmt);
+    SQLDisconnect(hdbc);
+    SQLFreeHandle(SQL_HANDLE_DBC, hdbc);
+}
+
 // mssql-odbc rejects an invalid value on a validated connection-string key with
 // HY024 at connect time. The reference msodbcsql driver is laxer: it treats an
 // invalid ApplicationIntent enum as a plain SQL_ERROR without HY024, and a

--- a/mssql-odbc/tests/e2e/tests/driver_connect_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/driver_connect_test.cpp
@@ -556,8 +556,9 @@ TEST_F(DriverConnectLiveTest, NewConnectionAttributesParity) {
 // before the login packet, so the server saw the driver's default name instead.
 TEST_F(DriverConnectLiveTest, AppKeywordReachesServerAppName) {
     const std::string kAppName = "AppKeywordE2E";
-    SqlTString connstr = ODBCTestUtils::BuildConnectionString();
-    connstr += ODBCTestUtils::ToSqlTStr(";APP=" + kAppName);
+    SqlTString connstr =
+        ODBCTestUtils::ToSqlTStr("APP=" + kAppName + ";") +
+        ODBCTestUtils::BuildConnectionString();
 
     SQLHDBC hdbc = SQL_NULL_HDBC;
     ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DBC, env_, &hdbc));

--- a/mssql-tds/src/message/login.rs
+++ b/mssql-tds/src/message/login.rs
@@ -34,6 +34,7 @@ use crate::io::token_stream::{ParserContext, TdsTokenStreamReader};
 use tracing::{Level, debug, event, info, trace};
 
 pub(crate) const FIXED_LOGIN_RECORD_LENGTH: i32 = 94;
+const MAX_LOGIN_RECORD_LENGTH: usize = 128 * 1024 - 1;
 
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub(crate) struct RoutingInfo {
@@ -806,15 +807,15 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
     /// Calculate the length of the login record.
     /// This includes the fixed length of the login record, the length of the variable length fields,
     /// and the length of the feature extension data.
-    fn calculate_login_record_length(&self) -> (i32, i32) {
-        let mut login_record_length = FIXED_LOGIN_RECORD_LENGTH;
+    fn calculate_login_record_length(&self) -> TdsResult<(i32, i32)> {
+        let mut login_record_length = FIXED_LOGIN_RECORD_LENGTH as usize;
         login_record_length += self.model.user_input.len_bytes();
         login_record_length += self.model.transport_context.len_bytes();
         login_record_length += 4; // Feature extension offset size.
 
         // Add SSPI token length if present
         if let Some(sspi_token) = &self.model.sspi_token {
-            login_record_length += sspi_token.len() as i32;
+            login_record_length += sspi_token.len();
         }
 
         // We write the feature extension at the end of the login record. This is not necessary, but makes reading
@@ -822,11 +823,17 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
         // for the feature extension.
         let feature_extension_offset = login_record_length;
         login_record_length += self.features_request.len_bytes();
-        (login_record_length, feature_extension_offset)
+        if login_record_length > MAX_LOGIN_RECORD_LENGTH {
+            return Err(crate::error::Error::ProtocolError(format!(
+                "LOGIN7 record length {login_record_length} exceeds the maximum of {MAX_LOGIN_RECORD_LENGTH} bytes"
+            )));
+        }
+        Ok((login_record_length as i32, feature_extension_offset as i32))
     }
 
     pub(crate) async fn serialize(&mut self) -> TdsResult<()> {
-        let (login_record_length, feature_extension_offset) = self.calculate_login_record_length();
+        let (login_record_length, feature_extension_offset) =
+            self.calculate_login_record_length()?;
         trace!(login_record_length);
         self.payload_writer
             .write_i32_async(login_record_length)
@@ -1051,7 +1058,7 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
     /// Writes the value of the hostname of the client to the login packet.
     async fn write_hostname(&mut self) -> TdsResult<()> {
         if self
-            .write_metadata(utf16_code_units(&self.model.user_input.workstation_id) as i16)
+            .write_metadata(utf16_code_units(&self.model.user_input.workstation_id)?)
             .await?
         {
             self.deferred_actions_indicator
@@ -1067,7 +1074,7 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
             TdsAuthenticationMethod::Password
         ) {
             if self
-                .write_metadata(utf16_code_units(&self.model.user_input.user_name) as i16)
+                .write_metadata(utf16_code_units(&self.model.user_input.user_name)?)
                 .await?
             {
                 self.deferred_actions_indicator
@@ -1084,7 +1091,7 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
     async fn write_password(&mut self) -> TdsResult<()> {
         if self.model.user_input.tds_authentication_method == TdsAuthenticationMethod::Password {
             if self
-                .write_metadata(utf16_code_units(&self.model.user_input.password) as i16)
+                .write_metadata(utf16_code_units(&self.model.user_input.password)?)
                 .await?
             {
                 self.deferred_actions_indicator
@@ -1100,7 +1107,7 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
     /// Writes the value of the application name provided in the client context to the login packet.
     async fn write_app_name(&mut self) -> TdsResult<()> {
         if self
-            .write_metadata(utf16_code_units(&self.model.user_input.application_name) as i16)
+            .write_metadata(utf16_code_units(&self.model.user_input.application_name)?)
             .await?
         {
             self.deferred_actions_indicator
@@ -1113,9 +1120,9 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
     /// Uses get_login_server_name() to get DataSource format (host,port) for TCP connections.
     async fn write_server_name(&mut self) -> TdsResult<()> {
         if self
-            .write_metadata(
-                utf16_code_units(&self.model.transport_context.get_login_server_name()) as i16,
-            )
+            .write_metadata(utf16_code_units(
+                &self.model.transport_context.get_login_server_name(),
+            )?)
             .await?
         {
             self.deferred_actions_indicator
@@ -1127,7 +1134,7 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
     async fn write_feature_ext(&mut self) -> TdsResult<()> {
         // The offset at which to read the feature extension length.
         self.payload_writer
-            .write_i16_async(self.content_next_offset as i16)
+            .write_u16_async(self.current_offset()?)
             .await?;
 
         // Length of the size of feature extension offset data, which is a DWORD.
@@ -1145,7 +1152,7 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
     /// This is also called the Client interface name.
     async fn write_library_name(&mut self) -> TdsResult<()> {
         if self
-            .write_metadata(utf16_code_units(&self.model.user_input.library_name) as i16)
+            .write_metadata(utf16_code_units(&self.model.user_input.library_name)?)
             .await?
         {
             self.deferred_actions_indicator
@@ -1156,7 +1163,7 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
 
     async fn write_language(&mut self) -> TdsResult<()> {
         if self
-            .write_metadata(utf16_code_units(&self.model.user_input.language) as i16)
+            .write_metadata(utf16_code_units(&self.model.user_input.language)?)
             .await?
         {
             self.deferred_actions_indicator
@@ -1168,7 +1175,7 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
     /// Writes the value of the database name, which we are connecting to.
     async fn write_database(&mut self) -> TdsResult<()> {
         if self
-            .write_metadata(utf16_code_units(&self.model.user_input.database) as i16)
+            .write_metadata(utf16_code_units(&self.model.user_input.database)?)
             .await?
         {
             self.deferred_actions_indicator
@@ -1194,15 +1201,15 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
         if sspi_len == 0 {
             // No SSPI token - write offset and zero length
             self.payload_writer
-                .write_i16_async(self.content_next_offset as i16)
+                .write_u16_async(self.current_offset()?)
                 .await?;
-            self.payload_writer.write_i16_async(0).await?;
+            self.payload_writer.write_u16_async(0).await?;
             return Ok(());
         }
 
         // Write offset
         self.payload_writer
-            .write_i16_async(self.content_next_offset as i16)
+            .write_u16_async(self.current_offset()?)
             .await?;
 
         if sspi_len <= 0xFFFF {
@@ -1223,7 +1230,7 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
 
     async fn write_attach_db_file(&mut self) -> TdsResult<()> {
         if self
-            .write_metadata(utf16_code_units(&self.model.user_input.attach_db_file) as i16)
+            .write_metadata(utf16_code_units(&self.model.user_input.attach_db_file)?)
             .await?
         {
             self.deferred_actions_indicator
@@ -1234,7 +1241,7 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
 
     async fn write_change_password(&mut self) -> TdsResult<()> {
         if self
-            .write_metadata(utf16_code_units(&self.model.user_input.change_password) as i16)
+            .write_metadata(utf16_code_units(&self.model.user_input.change_password)?)
             .await?
         {
             self.deferred_actions_indicator
@@ -1257,22 +1264,29 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
         Ok(())
     }
 
-    async fn write_metadata(&mut self, char_length: i16) -> TdsResult<bool> {
+    async fn write_metadata(&mut self, char_length: u16) -> TdsResult<bool> {
+        let offset = self.current_offset()?;
         if char_length == 0 {
-            self.payload_writer
-                .write_i16_async(self.content_next_offset as i16)
-                .await?;
-            self.payload_writer.write_i16_async(0).await?;
+            self.payload_writer.write_u16_async(offset).await?;
+            self.payload_writer.write_u16_async(0).await?;
             return Ok(false);
         }
 
-        self.payload_writer
-            .write_i16_async(self.content_next_offset as i16)
-            .await?;
-        self.payload_writer.write_i16_async(char_length).await?;
+        self.payload_writer.write_u16_async(offset).await?;
+        self.payload_writer.write_u16_async(char_length).await?;
 
-        self.content_next_offset += (char_length * 2) as i32;
+        self.content_next_offset += i32::from(char_length) * 2;
         Ok(true)
+    }
+
+    fn current_offset(&self) -> TdsResult<u16> {
+        u16::try_from(self.content_next_offset).map_err(|_| {
+            crate::error::Error::ProtocolError(format!(
+                "LOGIN7 field offset {} exceeds the maximum of {} bytes",
+                self.content_next_offset,
+                u16::MAX
+            ))
+        })
     }
 }
 
@@ -1305,15 +1319,20 @@ enum LoginDeferredPayload {
 
 /// Trait to calculate the size of the fields for the login records in bytes.
 trait SizedLoginItem {
-    fn len_bytes(&self) -> i32;
+    fn len_bytes(&self) -> usize;
 }
 
-fn utf16_code_units(value: &str) -> usize {
-    value.encode_utf16().count()
+fn utf16_code_units(value: &str) -> TdsResult<u16> {
+    u16::try_from(value.encode_utf16().count()).map_err(|_| {
+        crate::error::Error::ProtocolError(format!(
+            "LOGIN7 string exceeds the maximum of {} UTF-16 code units",
+            u16::MAX
+        ))
+    })
 }
 
 impl SizedLoginItem for TransportContext {
-    fn len_bytes(&self) -> i32 {
+    fn len_bytes(&self) -> usize {
         // Must match what get_login_server_name() returns for consistency
         // with write_server_name() which serializes get_login_server_name()
         self.get_login_server_name().len_bytes()
@@ -1321,16 +1340,16 @@ impl SizedLoginItem for TransportContext {
 }
 
 impl SizedLoginItem for String {
-    fn len_bytes(&self) -> i32 {
-        (utf16_code_units(self) * 2) as i32
+    fn len_bytes(&self) -> usize {
+        self.encode_utf16().count() * 2
     }
 }
 
 impl SizedLoginItem for FeaturesRequest {
-    fn len_bytes(&self) -> i32 {
-        let mut length = 0;
+    fn len_bytes(&self) -> usize {
+        let mut length = 0usize;
         for feature in self.get_requested_features() {
-            length += feature.data_length();
+            length += feature.data_length() as usize;
         }
 
         length += 1; // Feature extension terminator.
@@ -1340,7 +1359,7 @@ impl SizedLoginItem for FeaturesRequest {
 }
 
 impl SizedLoginItem for ClientContext {
-    fn len_bytes(&self) -> i32 {
+    fn len_bytes(&self) -> usize {
         // Do not consider the length of the transport context. That
         // may be overridden by the redirected endpoint.
         let mut client_context_item_length = 0;
@@ -1362,7 +1381,7 @@ impl ClientContext {
     /// For TdsAuthenticationMethod::SSPI, the username and password are not sent (they're empty),
     /// and the SSPI token length is calculated separately in LoginRequestModel.
     /// FedAuth or AccessToken authentication is accounted for, in the Feature extension data.
-    fn calculate_byte_length_for_authentication(&self) -> i32 {
+    fn calculate_byte_length_for_authentication(&self) -> usize {
         let mut length = 0;
         if matches!(
             self.tds_authentication_method,
@@ -1494,6 +1513,66 @@ mod tests {
 
         assert_eq!(app_offset, FIXED_LOGIN_RECORD_LENGTH as u16);
         assert_eq!(app_length, 8);
+    }
+
+    #[test]
+    fn database_metadata_uses_utf16_code_units() {
+        let context = ClientContext {
+            database: "caf\u{e9}".to_string(),
+            connect_retry_count: 0,
+            ..ClientContext::default()
+        };
+        let transport_context = context.transport_context.clone();
+        let model = LoginRequestModel::from_context(&context, false, &transport_context, None);
+        let mut mock = MockNetworkWriter::new(4096);
+        let mut packet_writer = PacketWriter::new(PacketType::Login7, &mut mock, None, None);
+        let mut serializer = Serializer::new(&model, &mut packet_writer);
+
+        block_on(serializer.write_database()).unwrap();
+        assert_eq!(
+            serializer.content_next_offset,
+            FIXED_LOGIN_RECORD_LENGTH + 8
+        );
+
+        let mut payload = packet_writer.get_payload();
+        payload.set_position(PacketWriter::PACKET_HEADER_SIZE as u64);
+        assert_eq!(
+            payload.read_u16::<LittleEndian>().unwrap(),
+            FIXED_LOGIN_RECORD_LENGTH as u16
+        );
+        assert_eq!(payload.read_u16::<LittleEndian>().unwrap(), 4);
+    }
+
+    #[test]
+    fn login_rejects_oversized_string_and_record() {
+        let context = ClientContext {
+            application_name: "a".repeat(usize::from(u16::MAX) + 1),
+            connect_retry_count: 0,
+            ..ClientContext::default()
+        };
+        let transport_context = context.transport_context.clone();
+        let model = LoginRequestModel::from_context(&context, false, &transport_context, None);
+        let mut mock = MockNetworkWriter::new(4096);
+        let mut packet_writer = PacketWriter::new(PacketType::Login7, &mut mock, None, None);
+        let mut serializer = Serializer::new(&model, &mut packet_writer);
+
+        let field_error = block_on(serializer.write_app_name()).unwrap_err();
+        assert!(field_error.to_string().contains("65535 UTF-16 code units"));
+
+        let context = ClientContext {
+            application_name: "a".repeat(65_000),
+            database: "b".repeat(1_000),
+            connect_retry_count: 0,
+            ..ClientContext::default()
+        };
+        let transport_context = context.transport_context.clone();
+        let model = LoginRequestModel::from_context(&context, false, &transport_context, None);
+        let mut mock = MockNetworkWriter::new(4096);
+        let mut packet_writer = PacketWriter::new(PacketType::Login7, &mut mock, None, None);
+        let serializer = Serializer::new(&model, &mut packet_writer);
+
+        let record_error = serializer.calculate_login_record_length().unwrap_err();
+        assert!(record_error.to_string().contains("131071 bytes"));
     }
 
     // ── FeaturesRequest::features() ──

--- a/mssql-tds/src/message/login.rs
+++ b/mssql-tds/src/message/login.rs
@@ -1051,7 +1051,7 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
     /// Writes the value of the hostname of the client to the login packet.
     async fn write_hostname(&mut self) -> TdsResult<()> {
         if self
-            .write_metadata(self.model.user_input.workstation_id.len() as i16)
+            .write_metadata(utf16_code_units(&self.model.user_input.workstation_id) as i16)
             .await?
         {
             self.deferred_actions_indicator
@@ -1067,7 +1067,7 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
             TdsAuthenticationMethod::Password
         ) {
             if self
-                .write_metadata(self.model.user_input.user_name.len() as i16)
+                .write_metadata(utf16_code_units(&self.model.user_input.user_name) as i16)
                 .await?
             {
                 self.deferred_actions_indicator
@@ -1084,7 +1084,7 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
     async fn write_password(&mut self) -> TdsResult<()> {
         if self.model.user_input.tds_authentication_method == TdsAuthenticationMethod::Password {
             if self
-                .write_metadata(self.model.user_input.password.len() as i16)
+                .write_metadata(utf16_code_units(&self.model.user_input.password) as i16)
                 .await?
             {
                 self.deferred_actions_indicator
@@ -1100,7 +1100,7 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
     /// Writes the value of the application name provided in the client context to the login packet.
     async fn write_app_name(&mut self) -> TdsResult<()> {
         if self
-            .write_metadata(self.model.user_input.application_name.len() as i16)
+            .write_metadata(utf16_code_units(&self.model.user_input.application_name) as i16)
             .await?
         {
             self.deferred_actions_indicator
@@ -1113,7 +1113,9 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
     /// Uses get_login_server_name() to get DataSource format (host,port) for TCP connections.
     async fn write_server_name(&mut self) -> TdsResult<()> {
         if self
-            .write_metadata(self.model.transport_context.get_login_server_name().len() as i16)
+            .write_metadata(
+                utf16_code_units(&self.model.transport_context.get_login_server_name()) as i16,
+            )
             .await?
         {
             self.deferred_actions_indicator
@@ -1143,7 +1145,7 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
     /// This is also called the Client interface name.
     async fn write_library_name(&mut self) -> TdsResult<()> {
         if self
-            .write_metadata(self.model.user_input.library_name.len() as i16)
+            .write_metadata(utf16_code_units(&self.model.user_input.library_name) as i16)
             .await?
         {
             self.deferred_actions_indicator
@@ -1154,7 +1156,7 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
 
     async fn write_language(&mut self) -> TdsResult<()> {
         if self
-            .write_metadata(self.model.user_input.language.len() as i16)
+            .write_metadata(utf16_code_units(&self.model.user_input.language) as i16)
             .await?
         {
             self.deferred_actions_indicator
@@ -1166,7 +1168,7 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
     /// Writes the value of the database name, which we are connecting to.
     async fn write_database(&mut self) -> TdsResult<()> {
         if self
-            .write_metadata(self.model.user_input.database.len() as i16)
+            .write_metadata(utf16_code_units(&self.model.user_input.database) as i16)
             .await?
         {
             self.deferred_actions_indicator
@@ -1221,7 +1223,7 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
 
     async fn write_attach_db_file(&mut self) -> TdsResult<()> {
         if self
-            .write_metadata(self.model.user_input.attach_db_file.len() as i16)
+            .write_metadata(utf16_code_units(&self.model.user_input.attach_db_file) as i16)
             .await?
         {
             self.deferred_actions_indicator
@@ -1232,7 +1234,7 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
 
     async fn write_change_password(&mut self) -> TdsResult<()> {
         if self
-            .write_metadata(self.model.user_input.change_password.len() as i16)
+            .write_metadata(utf16_code_units(&self.model.user_input.change_password) as i16)
             .await?
         {
             self.deferred_actions_indicator
@@ -1306,6 +1308,10 @@ trait SizedLoginItem {
     fn len_bytes(&self) -> i32;
 }
 
+fn utf16_code_units(value: &str) -> usize {
+    value.encode_utf16().count()
+}
+
 impl SizedLoginItem for TransportContext {
     fn len_bytes(&self) -> i32 {
         // Must match what get_login_server_name() returns for consistency
@@ -1316,7 +1322,7 @@ impl SizedLoginItem for TransportContext {
 
 impl SizedLoginItem for String {
     fn len_bytes(&self) -> i32 {
-        (self.len() * 2) as i32
+        (utf16_code_units(self) * 2) as i32
     }
 }
 
@@ -1457,6 +1463,14 @@ mod tests {
         features.insert(FeatureExtension::Json, Box::new(JsonFeature::default()));
         features.insert(FeatureExtension::Vector, Box::new(VectorFeature::default()));
         FeaturesRequest { features }
+    }
+
+    #[test]
+    fn application_name_length_uses_utf16_code_units() {
+        let application_name = "MSSQL \u{1f980}".to_string();
+
+        assert_eq!(utf16_code_units(&application_name), 8);
+        assert_eq!(application_name.len_bytes(), 16);
     }
 
     // ── FeaturesRequest::features() ──

--- a/mssql-tds/src/message/login.rs
+++ b/mssql-tds/src/message/login.rs
@@ -824,7 +824,7 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
         let feature_extension_offset = login_record_length;
         login_record_length += self.features_request.len_bytes();
         if login_record_length > MAX_LOGIN_RECORD_LENGTH {
-            return Err(crate::error::Error::ProtocolError(format!(
+            return Err(crate::error::Error::UsageError(format!(
                 "LOGIN7 record length {login_record_length} exceeds the maximum of {MAX_LOGIN_RECORD_LENGTH} bytes"
             )));
         }
@@ -1081,8 +1081,8 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
                     .push(LoginDeferredPayload::UserName);
             }
         } else {
-            self.payload_writer.write_i16_async(0).await?;
-            self.payload_writer.write_i16_async(0).await?;
+            self.payload_writer.write_u16_async(0).await?;
+            self.payload_writer.write_u16_async(0).await?;
         }
         Ok(())
     }
@@ -1098,8 +1098,8 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
                     .push(LoginDeferredPayload::Password);
             }
         } else {
-            self.payload_writer.write_i16_async(0).await?;
-            self.payload_writer.write_i16_async(0).await?;
+            self.payload_writer.write_u16_async(0).await?;
+            self.payload_writer.write_u16_async(0).await?;
         }
         Ok(())
     }
@@ -1281,7 +1281,7 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
 
     fn current_offset(&self) -> TdsResult<u16> {
         u16::try_from(self.content_next_offset).map_err(|_| {
-            crate::error::Error::ProtocolError(format!(
+            crate::error::Error::UsageError(format!(
                 "LOGIN7 field offset {} exceeds the maximum of {} bytes",
                 self.content_next_offset,
                 u16::MAX
@@ -1324,7 +1324,7 @@ trait SizedLoginItem {
 
 fn utf16_code_units(value: &str) -> TdsResult<u16> {
     u16::try_from(value.encode_utf16().count()).map_err(|_| {
-        crate::error::Error::ProtocolError(format!(
+        crate::error::Error::UsageError(format!(
             "LOGIN7 string exceeds the maximum of {} UTF-16 code units",
             u16::MAX
         ))
@@ -1545,6 +1545,20 @@ mod tests {
     }
 
     #[test]
+    fn record_length_accounts_for_change_password() {
+        let base = ClientContext {
+            connect_retry_count: 0,
+            ..ClientContext::default()
+        };
+        let with_change_password = ClientContext {
+            change_password: "abcd".to_string(),
+            ..base.clone()
+        };
+
+        assert_eq!(with_change_password.len_bytes(), base.len_bytes() + 8);
+    }
+
+    #[test]
     fn login_rejects_oversized_string_and_record() {
         let context = ClientContext {
             application_name: "a".repeat(usize::from(u16::MAX) + 1),
@@ -1558,6 +1572,7 @@ mod tests {
         let mut serializer = Serializer::new(&model, &mut packet_writer);
 
         let field_error = block_on(serializer.write_app_name()).unwrap_err();
+        assert!(matches!(field_error, crate::error::Error::UsageError(_)));
         assert!(field_error.to_string().contains("65535 UTF-16 code units"));
 
         let context = ClientContext {
@@ -1573,6 +1588,7 @@ mod tests {
         let serializer = Serializer::new(&model, &mut packet_writer);
 
         let record_error = serializer.calculate_login_record_length().unwrap_err();
+        assert!(matches!(record_error, crate::error::Error::UsageError(_)));
         assert!(record_error.to_string().contains("131071 bytes"));
     }
 

--- a/mssql-tds/src/message/login.rs
+++ b/mssql-tds/src/message/login.rs
@@ -1381,6 +1381,7 @@ impl ClientContext {
 mod tests {
     use super::*;
     use crate::core::Version;
+    use crate::io::packet_writer::tests::MockNetworkWriter;
     use crate::message::features::jsonfeature::JsonFeature;
     use crate::message::features::vectorfeature::VectorFeature;
     use crate::token::fed_auth_info::{FedAuthInfoToken, SspiToken};
@@ -1388,6 +1389,8 @@ mod tests {
     use crate::token::tokens::{
         EnvChangeContainer, EnvChangeToken, EnvChangeTokenSubType, ErrorToken, SqlCollation,
     };
+    use byteorder::{LittleEndian, ReadBytesExt};
+    use futures::executor::block_on;
 
     // ── FeatureExtension::as_u8 ──
 
@@ -1466,11 +1469,31 @@ mod tests {
     }
 
     #[test]
-    fn application_name_length_uses_utf16_code_units() {
-        let application_name = "MSSQL \u{1f980}".to_string();
+    fn application_name_metadata_uses_utf16_code_units() {
+        let context = ClientContext {
+            application_name: "MSSQL \u{1f980}".to_string(),
+            connect_retry_count: 0,
+            ..ClientContext::default()
+        };
+        let transport_context = context.transport_context.clone();
+        let model = LoginRequestModel::from_context(&context, false, &transport_context, None);
+        let mut mock = MockNetworkWriter::new(4096);
+        let mut packet_writer = PacketWriter::new(PacketType::Login7, &mut mock, None, None);
+        let mut serializer = Serializer::new(&model, &mut packet_writer);
 
-        assert_eq!(utf16_code_units(&application_name), 8);
-        assert_eq!(application_name.len_bytes(), 16);
+        block_on(serializer.write_app_name()).unwrap();
+        assert_eq!(
+            serializer.content_next_offset,
+            FIXED_LOGIN_RECORD_LENGTH + 16
+        );
+
+        let mut payload = packet_writer.get_payload();
+        payload.set_position(PacketWriter::PACKET_HEADER_SIZE as u64);
+        let app_offset = payload.read_u16::<LittleEndian>().unwrap();
+        let app_length = payload.read_u16::<LittleEndian>().unwrap();
+
+        assert_eq!(app_offset, FIXED_LOGIN_RECORD_LENGTH as u16);
+        assert_eq!(app_length, 8);
     }
 
     // ── FeaturesRequest::features() ──

--- a/mssql-tds/src/message/login.rs
+++ b/mssql-tds/src/message/login.rs
@@ -1199,7 +1199,8 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
         let sspi_len = self.model.sspi_token.as_ref().map_or(0, |t| t.len());
 
         if sspi_len == 0 {
-            // No SSPI token - write offset and zero length
+            // ibSSPI is ignored when cbSSPI is zero, so avoid a running offset
+            // that may exceed u16 after a long token.
             self.payload_writer.write_u16_async(0).await?;
             self.payload_writer.write_u16_async(0).await?;
             return Ok(());
@@ -1264,6 +1265,7 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
 
     async fn write_metadata(&mut self, char_length: u16) -> TdsResult<bool> {
         if char_length == 0 {
+            // Empty LOGIN7 fields ignore their offsets.
             self.payload_writer.write_u16_async(0).await?;
             self.payload_writer.write_u16_async(0).await?;
             return Ok(false);
@@ -1367,6 +1369,7 @@ impl SizedLoginItem for ClientContext {
         client_context_item_length += self.language.len_bytes();
         client_context_item_length += self.database.len_bytes();
         client_context_item_length += self.attach_db_file.len_bytes();
+        client_context_item_length += self.change_password.len_bytes();
 
         client_context_item_length += self.calculate_byte_length_for_authentication();
         client_context_item_length
@@ -1590,14 +1593,21 @@ mod tests {
         block_on(serializer.write_sspi_short()).unwrap();
         block_on(serializer.write_attach_db_file()).unwrap();
         block_on(serializer.write_change_password()).unwrap();
+        block_on(serializer.write_cb_sspi_long()).unwrap();
 
         assert_eq!(serializer.content_next_offset, 70_094);
         let mut payload = packet_writer.get_payload();
-        payload.set_position((PacketWriter::PACKET_HEADER_SIZE + 4) as u64);
+        payload.set_position(PacketWriter::PACKET_HEADER_SIZE as u64);
+        assert_eq!(
+            payload.read_u16::<LittleEndian>().unwrap(),
+            FIXED_LOGIN_RECORD_LENGTH as u16
+        );
+        assert_eq!(payload.read_u16::<LittleEndian>().unwrap(), u16::MAX);
         assert_eq!(payload.read_u16::<LittleEndian>().unwrap(), 0);
         assert_eq!(payload.read_u16::<LittleEndian>().unwrap(), 0);
         assert_eq!(payload.read_u16::<LittleEndian>().unwrap(), 0);
         assert_eq!(payload.read_u16::<LittleEndian>().unwrap(), 0);
+        assert_eq!(payload.read_u32::<LittleEndian>().unwrap(), 70_000);
     }
 
     // ── FeaturesRequest::features() ──

--- a/mssql-tds/src/message/login.rs
+++ b/mssql-tds/src/message/login.rs
@@ -1138,7 +1138,7 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
             .await?;
 
         // Length of the size of feature extension offset data, which is a DWORD.
-        self.payload_writer.write_i16_async(4).await?;
+        self.payload_writer.write_u16_async(4).await?;
 
         self.content_next_offset += size_of::<i32>() as i32;
 
@@ -1200,9 +1200,7 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
 
         if sspi_len == 0 {
             // No SSPI token - write offset and zero length
-            self.payload_writer
-                .write_u16_async(self.current_offset()?)
-                .await?;
+            self.payload_writer.write_u16_async(0).await?;
             self.payload_writer.write_u16_async(0).await?;
             return Ok(());
         }
@@ -1265,13 +1263,13 @@ impl<'a, 'n, 'context> Serializer<'a, 'n, 'context> {
     }
 
     async fn write_metadata(&mut self, char_length: u16) -> TdsResult<bool> {
-        let offset = self.current_offset()?;
         if char_length == 0 {
-            self.payload_writer.write_u16_async(offset).await?;
+            self.payload_writer.write_u16_async(0).await?;
             self.payload_writer.write_u16_async(0).await?;
             return Ok(false);
         }
 
+        let offset = self.current_offset()?;
         self.payload_writer.write_u16_async(offset).await?;
         self.payload_writer.write_u16_async(char_length).await?;
 
@@ -1573,6 +1571,33 @@ mod tests {
 
         let record_error = serializer.calculate_login_record_length().unwrap_err();
         assert!(record_error.to_string().contains("131071 bytes"));
+    }
+
+    #[test]
+    fn empty_fields_do_not_reject_long_sspi_offset() {
+        let context = ClientContext {
+            connect_retry_count: 0,
+            tds_authentication_method: TdsAuthenticationMethod::SSPI,
+            ..ClientContext::default()
+        };
+        let transport_context = context.transport_context.clone();
+        let mut model = LoginRequestModel::from_context(&context, false, &transport_context, None);
+        model.sspi_token = Some(vec![0; 70_000]);
+        let mut mock = MockNetworkWriter::new(131_072);
+        let mut packet_writer = PacketWriter::new(PacketType::Login7, &mut mock, None, None);
+        let mut serializer = Serializer::new(&model, &mut packet_writer);
+
+        block_on(serializer.write_sspi_short()).unwrap();
+        block_on(serializer.write_attach_db_file()).unwrap();
+        block_on(serializer.write_change_password()).unwrap();
+
+        assert_eq!(serializer.content_next_offset, 70_094);
+        let mut payload = packet_writer.get_payload();
+        payload.set_position((PacketWriter::PACKET_HEADER_SIZE + 4) as u64);
+        assert_eq!(payload.read_u16::<LittleEndian>().unwrap(), 0);
+        assert_eq!(payload.read_u16::<LittleEndian>().unwrap(), 0);
+        assert_eq!(payload.read_u16::<LittleEndian>().unwrap(), 0);
+        assert_eq!(payload.read_u16::<LittleEndian>().unwrap(), 0);
     }
 
     // ── FeaturesRequest::features() ──


### PR DESCRIPTION
## Description

This change fixes malformed LOGIN7 packets for non-ASCII usernames, passwords, database names, hostnames, application names, and other Unicode login fields across every mssql-tds consumer. LOGIN7 field lengths are now encoded as UTF-16 code units, matching the UTF-16LE payload; field offsets use the protocol's unsigned representation; optional change-password data is included in record sizing; and oversized fields or records return a usage error instead of panicking or emitting invalid metadata.

It also maps the ODBC connection-string keyword `APP` to `ClientContext::application_name`. Previously, `APP` was recognized but sat in `KNOWN_IGNORED_KEYS`, so SQL Server saw the mssql-tds default `TDSX Rust Client` rather than the application-supplied value. Because `APP` was recognized, the parser raised no `01S00` warning either, so nothing surfaced the drop.

`APP` now maps to a `ConnectionParams` slot and is wired onto the `ClientContext` in `apply_connection_params`, matching msodbcsql's `KEY_APP` handling (`sqlcconn.cpp`).

The value is stored verbatim. msodbcsql additionally rejects an `APP` longer than 128 characters (`x_rgLookup[KEY_APP].cLimitSize`), but per-key length caps are an intentional non-goal of this parser (already documented under "Intentional non-goals" in `mssql-odbc/docs/connection_string_parser.md`). Instead, the shared serializer now enforces LOGIN7's `USHORT` field bounds and 128 KiB minus one byte record limit for every caller-controlled login field.

## Related Issues

https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47534

## Testing

- New parser and application tests cover mapping `APP` into `ClientContext::application_name` and reconstructed connection strings.
- Byte-level mssql-tds tests verify emitted LOGIN7 metadata and offset advancement for both astral application names and non-ASCII database names.
- Oversize tests verify that fields beyond `u16::MAX` UTF-16 code units and records beyond 128 KiB minus one byte are rejected as usage errors.
- Record-size coverage verifies optional change-password data and long SSPI tokens, including the short-length sentinel and long-length field.
- `DriverConnectLiveTest.AppKeywordReachesServerAppName` now builds on the suite's configured connection string for SQL authentication, integrated authentication, DSN, and connection-string override modes, then verifies `SELECT APP_NAME()`.
- `cargo nextest run -p mssql-tds --lib -E 'test(/message::login/)'` — 39 passed.
- `cargo clippy -p mssql-tds --lib --all-features --frozen -- -D warnings` — passed.

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes (remaining local failures are the known environment-dependent `mssql-tds::connectivity` / TLS-mock tests, unrelated to this change)
- [x] New/changed functionality has tests
- [x] Public API changes are documented