### PR TITLE
Log fuzz crash inputs as base64 for reproducibility

### DIFF
--- a/.pipeline/templates/fuzz-template.yml
+++ b/.pipeline/templates/fuzz-template.yml
@@ -80,6 +80,21 @@ steps:
         echo "Crash files:"
         find artifacts/${{ parameters.fuzzTarget }} -type f -name "crash-*" -exec basename {} \;
         
+        # Emit crash inputs inline as base64 so they can be reproduced from the
+        # build log alone. The published artifact is not always reachable:
+        # downloads can be auth-restricted and retention expires, after which the
+        # crash filename (a SHA1) is not enough to recreate the input.
+        echo "Crash inputs (base64):"
+        find artifacts/${{ parameters.fuzzTarget }} -type f -name "crash-*" | while read -r CRASH; do
+          SIZE=$(wc -c < "$CRASH")
+          echo "----- $(basename "$CRASH") ($SIZE bytes) -----"
+          if [ "$SIZE" -le 4096 ]; then
+            base64 "$CRASH"
+          else
+            echo "(input larger than 4096 bytes; download the published artifact to reproduce)"
+          fi
+        done
+        
         # Set variable to indicate crashes were found
         echo "##vso[task.setvariable variable=FuzzCrashesFound]true"
       else


### PR DESCRIPTION
## Summary

When the GH-Rust Fuzz Test pipeline detects a crash, the build log records only the crash file name (a SHA1). The crashing input bytes live only inside the published pipeline artifact, which is not reliably retrievable — artifact downloads can be auth-restricted and pipeline retention expires. Once the artifact is gone or inaccessible, the SHA1 filename alone cannot recreate the input, so the crash cannot be reproduced or turned into a regression test.

This change makes the crash-handling step in `.pipeline/templates/fuzz-template.yml` echo each crash input as base64 into the build log (bounded to 4096 bytes), so every future fuzz crash is reproducible from the log alone, independent of artifact access or retention.

## Background

This was found while investigating the last fuzz-crash failure in the pipeline: build [164079](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build/results?buildId=164079) (2026-08-01), target `fuzz_token_stream`, crash `crash-80c55599ebe9adee81668324e4c6151894a33fbe` ("libFuzzer: deadly signal").

- There are **no** fuzz-crash failures in the last 24h — the pipeline is green on its 3-hour schedule.
- The Aug-1 panic is **already fixed** on current `main`: reproducing against current HEAD (harness reusing the exact fuzz path with `--cfg fuzzing`, dev profile with overflow-checks + debug-assertions) found **0 panics** across 15.3M random trials (all 256 first-bytes × 60k, lengths 1–48) and a full replay of the committed seed corpus (137/137 inputs).
- The original crash artifact could not be downloaded to attach to the work item (TF400813 via API, AADSTS50173 via `az`) — which is exactly the gap this PR closes.

## Change

- `.pipeline/templates/fuzz-template.yml`: in the crash-found branch of the "Run Fuzzer" step, emit `base64` of each `crash-*` file into the log. YAML validated.

## Testing

- YAML parses cleanly (`yaml.safe_load`).
- Shell logic guards input size (≤ 4096 bytes) and iterates crash files safely; the crash branch already fails the build, so the added logging cannot cause a passing build to fail.

Work item: [AB#47707](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47707)

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>