### PR TITLE
mssql-tds: resolve TCP connect hostnames asynchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,3 +150,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   rejected as a protocol error. Such a packet is malformed — it neither carries
   payload nor terminates a message — but was previously consumed as a
   zero-length packet. Empty end-of-message packets remain legal.
+
+- `mssql-tds`: TCP connect no longer resolves the server hostname with the
+  blocking `std::net::ToSocketAddrs`. That call never yields to the async
+  runtime, so a slow or unresponsive resolver silently escaped the
+  `ConnectTimeout`/`LoginTimeout` deadline that wraps the rest of the connect
+  sequence — on `mssql-odbc`, whose `SQLDriverConnectW` drives this via
+  `block_on` on the calling thread, this could hang the caller (and, since
+  ODBC is a blocking API, the whole calling process) indefinitely instead of
+  failing within the configured timeout. Resolution now goes through
+  `tokio::net::lookup_host`, the same async primitive already used for SSRP
+  instance lookups, so it is properly bounded like the rest of the connect
+  attempt.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   ODBC is a blocking API, the whole calling process) indefinitely instead of
   failing within the configured timeout. Resolution now goes through
   `tokio::net::lookup_host`, the same async primitive already used for SSRP
-  instance lookups, so it is properly bounded like the rest of the connect
-  attempt.
+  instance lookups, so it is a genuine, cancellable `.await` point instead of
+  a blocking one. `parallel_connect` (`MultiSubnetFailover`) now also folds
+  DNS resolution into the single overall deadline its `timeout_ms` already
+  documents, instead of only timing the connection race that follows it, and
+  idle-connection reconnect (`TdsClient::reconnect`) now wraps each attempt's
+  full connect (DNS through login) in the attempt's remaining budget instead
+  of only capping the post-resolution TCP connect step.
 

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -474,9 +474,11 @@ impl TdsClient {
 
     /// Attempt to reconnect a dead connection by replaying session state.
     ///
-    /// The overall reconnection is bounded by `timeout`. Each individual
-    /// TCP/TDS handshake attempt uses the original `connect_timeout`. Before
-    /// each retry sleep, we verify enough time remains for the interval.
+    /// The overall reconnection is bounded by `timeout`. Each attempt (DNS
+    /// resolution through login) is wrapped in whatever remains of that
+    /// budget, and `connect_timeout` is capped to the same remaining budget
+    /// so it can't ask for more than is left. Before each retry sleep, we
+    /// verify enough time remains for the interval.
     #[instrument(skip(self), level = "info")]
     pub(crate) async fn reconnect(
         &mut self,

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -533,20 +533,37 @@ impl TdsClient {
             // Inject recovery data into the client context clone
             let mut reconnect_ctx = client_context.clone();
 
-            // Cap the per-attempt connect timeout to the remaining reconnect budget
-            let remaining_secs =
-                deadline.saturating_duration_since(Instant::now()).as_secs() as u32;
-            reconnect_ctx.connect_timeout = reconnect_ctx.connect_timeout.min(remaining_secs);
+            // Cap the per-attempt connect timeout to the remaining reconnect budget.
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            reconnect_ctx.connect_timeout = reconnect_ctx
+                .connect_timeout
+                .min(remaining.as_secs() as u32);
 
             info!(attempt, "Attempting reconnection");
-            let connect_result = CancelHandle::run_until_cancelled(
-                cancel_handle,
-                TdsConnectionProvider::connect_with_transport_context(
-                    &reconnect_ctx,
-                    &transport_context,
-                    Some(Box::new((*snapshot).clone())),
-                ),
-            )
+            // `connect_timeout` above only bounds the TCP-connect step inside
+            // `connect_with_transport_context`; DNS resolution ahead of it is
+            // otherwise unbounded here. Wrap the whole attempt (DNS through
+            // login) in `remaining` too, so a slow resolver can't make a
+            // single reconnect attempt outlive the overall reconnect deadline.
+            let connect_result = CancelHandle::run_until_cancelled(cancel_handle, async {
+                match tokio::time::timeout(
+                    remaining,
+                    TdsConnectionProvider::connect_with_transport_context(
+                        &reconnect_ctx,
+                        &transport_context,
+                        Some(Box::new((*snapshot).clone())),
+                    ),
+                )
+                .await
+                {
+                    Ok(result) => result,
+                    Err(_elapsed) => {
+                        Err(Error::TimeoutError(crate::error::TimeoutErrorType::String(
+                            "Reconnection attempt timed out".to_string(),
+                        )))
+                    }
+                }
+            })
             .await;
             match connect_result {
                 Ok((

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -401,6 +401,26 @@ pub struct TdsClient {
     streamed_write_state: StreamedWriteState,
 }
 
+/// Runs `fut` bounded by `remaining`, converting an elapsed timeout into
+/// `Error::TimeoutError`. Extracted out of `TdsClient::reconnect` so the
+/// elapsed branch can be driven directly in a test (`tokio::time::pause` plus
+/// a future that never resolves) instead of needing a live, slow connect
+/// attempt to provoke it.
+async fn attempt_within<T>(
+    remaining: Duration,
+    fut: impl Future<Output = TdsResult<T>>,
+) -> TdsResult<T> {
+    tokio::time::timeout(remaining, fut)
+        .await
+        .unwrap_or_else(|_elapsed| {
+            Err(crate::error::Error::TimeoutError(
+                crate::error::TimeoutErrorType::String(
+                    "Reconnection attempt timed out".to_string(),
+                ),
+            ))
+        })
+}
+
 impl TdsClient {
     pub(crate) fn new(
         transport: AnyTransport,
@@ -534,10 +554,16 @@ impl TdsClient {
             let mut reconnect_ctx = client_context.clone();
 
             // Cap the per-attempt connect timeout to the remaining reconnect budget.
+            // `.max(1)`: `remaining` can be under a second this close to the deadline,
+            // and `as_secs()` truncates that to 0 — which `create_base_stream_sequential`
+            // has no "0 means default" fallback for, so it would time out the attempt
+            // on its first poll instead of giving it a real chance. The outer
+            // `attempt_within(remaining, ...)` below is the actual deadline backstop,
+            // so rounding up here can't make an attempt outlive the reconnect budget.
             let remaining = deadline.saturating_duration_since(Instant::now());
             reconnect_ctx.connect_timeout = reconnect_ctx
                 .connect_timeout
-                .min(remaining.as_secs() as u32);
+                .min(remaining.as_secs().max(1) as u32);
 
             info!(attempt, "Attempting reconnection");
             // `connect_timeout` above only bounds the TCP-connect step inside
@@ -545,25 +571,17 @@ impl TdsClient {
             // otherwise unbounded here. Wrap the whole attempt (DNS through
             // login) in `remaining` too, so a slow resolver can't make a
             // single reconnect attempt outlive the overall reconnect deadline.
-            let connect_result = CancelHandle::run_until_cancelled(cancel_handle, async {
-                match tokio::time::timeout(
+            let connect_result = CancelHandle::run_until_cancelled(
+                cancel_handle,
+                attempt_within(
                     remaining,
                     TdsConnectionProvider::connect_with_transport_context(
                         &reconnect_ctx,
                         &transport_context,
                         Some(Box::new((*snapshot).clone())),
                     ),
-                )
-                .await
-                {
-                    Ok(result) => result,
-                    Err(_elapsed) => {
-                        Err(Error::TimeoutError(crate::error::TimeoutErrorType::String(
-                            "Reconnection attempt timed out".to_string(),
-                        )))
-                    }
-                }
-            })
+                ),
+            )
             .await;
             match connect_result {
                 Ok((
@@ -8040,6 +8058,28 @@ mod tests {
             err.to_string().contains("Session recovery failed"),
             "Expected SessionRecoveryFailed, got: {err}"
         );
+    }
+
+    /// Covers the elapsed branch of `attempt_within` directly, since nothing
+    /// in `reconnect`'s own tests can provoke it: every failure a test can
+    /// reach today (no server, bad recovery state, ...) returns well before
+    /// any deadline. `start_paused` lets the timeout fire on a fake clock
+    /// instead of a real, slow connect attempt.
+    #[tokio::test(start_paused = true)]
+    async fn attempt_within_times_out_when_the_future_never_completes() {
+        let remaining = Duration::from_secs(5);
+        let handle = tokio::spawn(attempt_within(
+            remaining,
+            std::future::pending::<TdsResult<()>>(),
+        ));
+
+        tokio::time::advance(remaining + Duration::from_millis(1)).await;
+
+        let result = handle.await.expect("attempt_within task panicked");
+        match result {
+            Err(crate::error::Error::TimeoutError(_)) => {}
+            other => panic!("expected a TimeoutError once the deadline elapses, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/mssql-tds/src/connection/transport/network_transport.rs
+++ b/mssql-tds/src/connection/transport/network_transport.rs
@@ -3658,26 +3658,22 @@ pub(crate) mod tests {
         assert_eq!(v4_only, expected, "no IPv6 entries to reorder against");
     }
 
-    /// Resolving a real hostname (not a literal IP, so the OS resolver is
-    /// actually exercised) must go through `tokio::net::lookup_host` and
-    /// therefore stay bounded by an enclosing `tokio::time::timeout` — the
-    /// exact property the blocking `to_socket_addrs()` call used to violate.
+    /// `tokio::net::lookup_host` must be used (not blocking `to_socket_addrs()`),
+    /// so a slow/stuck resolver stays bounded by an enclosing `timeout()`
+    /// instead of escaping it. Timing can't prove this — resolving `localhost`
+    /// completes in single-digit ms either way — so this asserts the
+    /// structural property instead: a concurrently spawned heartbeat must get
+    /// scheduled while resolution is in flight. `lookup_host` bridges to
+    /// `spawn_blocking` via a channel, so the awaiting task is guaranteed to
+    /// yield at least once; a blocking `to_socket_addrs()` call never yields,
+    /// so the heartbeat gets zero chances to run. Confirmed by mutation
+    /// testing (reverting to `to_socket_addrs()` makes this fail).
     ///
-    /// Timing alone can't prove this: resolving `localhost` completes in
-    /// low-single-digit milliseconds whether or not the underlying call
-    /// blocks, so a `timeout()`-based assertion would pass either way. This
-    /// test instead proves the structural property directly — a concurrently
-    /// spawned task must get *some* chance to run while resolution is in
-    /// flight. `tokio::net::lookup_host` bridges to `spawn_blocking` via a
-    /// channel, so the awaiting task is guaranteed to return `Pending` and
-    /// yield at least once, no matter how fast the lookup itself finishes.
-    /// A synchronous `to_socket_addrs()` call never yields at all: the whole
-    /// resolution runs inside a single poll of this task, so a concurrent
-    /// task gets zero opportunities to run until it is done. Confirmed by
-    /// mutation testing: reverting to `to_socket_addrs()` makes this test
-    /// fail (the heartbeat counter stays at 0) while the timing-based
-    /// version above kept passing regardless.
-    #[tokio::test]
+    /// Must stay on the default `current_thread` runtime: a `multi_thread`
+    /// flavor would let the heartbeat run on another worker even if
+    /// resolution blocked, so the assertion would pass without proving
+    /// anything.
+    #[tokio::test(flavor = "current_thread")]
     async fn create_base_stream_sequential_resolution_yields_to_the_executor() {
         use std::sync::atomic::{AtomicUsize, Ordering};
 

--- a/mssql-tds/src/connection/transport/network_transport.rs
+++ b/mssql-tds/src/connection/transport/network_transport.rs
@@ -3683,10 +3683,14 @@ pub(crate) mod tests {
 
         let heartbeats = Arc::new(AtomicUsize::new(0));
         let heartbeats_task = heartbeats.clone();
+        // A short sleep (rather than `yield_now()`) still catches the same
+        // scheduling gap — the first increment can't happen until the main
+        // task yields either way — without busy-spinning a core for the
+        // whole resolution.
         let heartbeat = tokio::spawn(async move {
             loop {
                 heartbeats_task.fetch_add(1, Ordering::SeqCst);
-                tokio::task::yield_now().await;
+                tokio::time::sleep(Duration::from_millis(1)).await;
             }
         });
 

--- a/mssql-tds/src/connection/transport/network_transport.rs
+++ b/mssql-tds/src/connection/transport/network_transport.rs
@@ -3662,30 +3662,53 @@ pub(crate) mod tests {
     /// actually exercised) must go through `tokio::net::lookup_host` and
     /// therefore stay bounded by an enclosing `tokio::time::timeout` — the
     /// exact property the blocking `to_socket_addrs()` call used to violate.
+    ///
+    /// Timing alone can't prove this: resolving `localhost` completes in
+    /// low-single-digit milliseconds whether or not the underlying call
+    /// blocks, so a `timeout()`-based assertion would pass either way. This
+    /// test instead proves the structural property directly — a concurrently
+    /// spawned task must get *some* chance to run while resolution is in
+    /// flight. `tokio::net::lookup_host` bridges to `spawn_blocking` via a
+    /// channel, so the awaiting task is guaranteed to return `Pending` and
+    /// yield at least once, no matter how fast the lookup itself finishes.
+    /// A synchronous `to_socket_addrs()` call never yields at all: the whole
+    /// resolution runs inside a single poll of this task, so a concurrent
+    /// task gets zero opportunities to run until it is done. Confirmed by
+    /// mutation testing: reverting to `to_socket_addrs()` makes this test
+    /// fail (the heartbeat counter stays at 0) while the timing-based
+    /// version above kept passing regardless.
     #[tokio::test]
-    async fn create_base_stream_sequential_resolution_is_bounded_by_timeout() {
+    async fn create_base_stream_sequential_resolution_yields_to_the_executor() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let heartbeats = Arc::new(AtomicUsize::new(0));
+        let heartbeats_task = heartbeats.clone();
+        let heartbeat = tokio::spawn(async move {
+            loop {
+                heartbeats_task.fetch_add(1, Ordering::SeqCst);
+                tokio::task::yield_now().await;
+            }
+        });
+
         // Port 0 is never listening, so the (fast, loopback) TCP connect
-        // fails quickly and the call returns well within the outer bound
-        // instead of the test hanging if resolution ever regresses to a
-        // blocking call.
-        let result = timeout(
-            Duration::from_secs(5),
-            create_base_stream_sequential(
-                IPAddressPreference::UsePlatformDefault,
-                "localhost",
-                0,
-                30_000,
-                1_000,
-                200,
-            ),
+        // fails quickly once resolution completes; the call overall still
+        // returns promptly either way.
+        let _ = create_base_stream_sequential(
+            IPAddressPreference::UsePlatformDefault,
+            "localhost",
+            0,
+            30_000,
+            1_000,
+            200,
         )
         .await;
 
+        heartbeat.abort();
         assert!(
-            result.is_ok(),
-            "resolving 'localhost' must not escape the outer timeout"
+            heartbeats.load(Ordering::SeqCst) > 0,
+            "the heartbeat task never ran while resolving 'localhost' — \
+             resolution is blocking the executor instead of awaiting it"
         );
-        assert!(result.unwrap().is_err(), "port 0 must not be connectable");
     }
 
     /// `skip_bytes` spins the same way, and it runs on the discard path that

--- a/mssql-tds/src/connection/transport/network_transport.rs
+++ b/mssql-tds/src/connection/transport/network_transport.rs
@@ -33,7 +33,7 @@ use byteorder::{BigEndian, ByteOrder, LittleEndian};
 use std::cmp::min;
 use std::io::Error;
 use std::io::ErrorKind;
-use std::net::ToSocketAddrs;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
@@ -189,6 +189,30 @@ async fn create_base_stream(
     }
 }
 
+/// Stably sorts resolved addresses per `ipaddress_preference`, keeping the
+/// resolver's original relative order within each address family.
+fn sort_by_ip_preference(
+    socket_addresses: &mut [SocketAddr],
+    ipaddress_preference: IPAddressPreference,
+) {
+    match ipaddress_preference {
+        IPAddressPreference::UsePlatformDefault => {
+            // Do nothing. Use whatever the OS returns.
+            trace!("Using platform default IP address preference");
+        }
+        IPAddressPreference::IPv4First => {
+            // Sort IPv4 addresses first
+            socket_addresses.sort_by_key(|a| a.is_ipv6());
+            trace!("IPv4 addresses first");
+        }
+        IPAddressPreference::IPv6First => {
+            // Sort IPv6 addresses first
+            socket_addresses.sort_by_key(|b| std::cmp::Reverse(b.is_ipv6()));
+            trace!("IPv6 addresses first");
+        }
+    }
+}
+
 /// Creates a TCP stream using sequential connection mode.
 /// Tries each resolved IP address one at a time until one succeeds.
 async fn create_base_stream_sequential(
@@ -204,33 +228,18 @@ async fn create_base_stream_sequential(
         host, port
     );
 
-    // This will cause the DNS resolution of the addresses.
-    let mut socket_addresses = (host, port).to_socket_addrs()?;
+    // This will cause the DNS resolution of the addresses. `lookup_host` (unlike
+    // `std::net::ToSocketAddrs::to_socket_addrs`) awaits the resolution instead of
+    // blocking the calling thread, so a slow or stuck resolver stays subject to the
+    // `timeout()`/deadline machinery in the retry loop above this call instead of
+    // silently escaping it.
+    let mut socket_addresses: Vec<SocketAddr> =
+        tokio::net::lookup_host((host, port)).await?.collect();
 
     let mut last_error = None;
     let mut tcp_stream = None;
 
-    // Sort the address list based on the IP address preference
-    match ipaddress_preference {
-        IPAddressPreference::UsePlatformDefault => {
-            // Do nothing. Use whatever the OS returns.
-            trace!("Using platform default IP address preference");
-        }
-        IPAddressPreference::IPv4First => {
-            let mut addresses: Vec<_> = socket_addresses.collect();
-            // Sort IPv4 addresses first
-            addresses.sort_by_key(|a| a.is_ipv6());
-            socket_addresses = addresses.into_iter();
-            trace!("IPv4 addresses first");
-        }
-        IPAddressPreference::IPv6First => {
-            let mut addresses: Vec<_> = socket_addresses.collect();
-            // Sort IPv6 addresses first
-            addresses.sort_by_key(|b| std::cmp::Reverse(b.is_ipv6()));
-            socket_addresses = addresses.into_iter();
-            trace!("IPv6 addresses first");
-        }
-    }
+    sort_by_ip_preference(&mut socket_addresses, ipaddress_preference);
 
     info!("Socket addresses: {:?}", socket_addresses);
 
@@ -3562,6 +3571,121 @@ pub(crate) mod tests {
             matches!(result, Err(crate::error::Error::ProtocolError(_))),
             "expected a protocol error, got {result:?}"
         );
+    }
+
+    // ---------------------------------------------------------------------
+    // Regression coverage for AB#47704: `create_base_stream_sequential` used
+    // to resolve DNS via the blocking `std::net::ToSocketAddrs`, which never
+    // yields to the executor. That silently defeated the `timeout()`/deadline
+    // wrapped around the whole connect attempt in `tds_connection_provider`,
+    // so a slow or stuck resolver could hang the caller (and, since ODBC's
+    // `SQLDriverConnectW` runs this via `block_on` on the caller's own
+    // thread, the whole synchronous process) with no internal bound. The fix
+    // switched to `tokio::net::lookup_host`, which awaits resolution instead.
+    // These tests pin the address-sorting logic that moved as part of that
+    // change (`sort_by_ip_preference`), since it has no prior direct coverage.
+    // ---------------------------------------------------------------------
+
+    fn addr(ip: &str, port: u16) -> SocketAddr {
+        SocketAddr::new(ip.parse().unwrap(), port)
+    }
+
+    #[test]
+    fn sort_by_ip_preference_platform_default_leaves_order_untouched() {
+        let mut addrs = vec![
+            addr("2001:db8::1", 1433),
+            addr("192.0.2.1", 1433),
+            addr("2001:db8::2", 1433),
+        ];
+        let original = addrs.clone();
+
+        sort_by_ip_preference(&mut addrs, IPAddressPreference::UsePlatformDefault);
+
+        assert_eq!(addrs, original);
+    }
+
+    #[test]
+    fn sort_by_ip_preference_ipv4_first_orders_v4_before_v6() {
+        let mut addrs = vec![
+            addr("2001:db8::1", 1433),
+            addr("192.0.2.1", 1433),
+            addr("2001:db8::2", 1433),
+            addr("192.0.2.2", 1433),
+        ];
+
+        sort_by_ip_preference(&mut addrs, IPAddressPreference::IPv4First);
+
+        assert_eq!(
+            addrs,
+            vec![
+                addr("192.0.2.1", 1433),
+                addr("192.0.2.2", 1433),
+                addr("2001:db8::1", 1433),
+                addr("2001:db8::2", 1433),
+            ],
+            "IPv4 addresses must sort before IPv6, preserving relative order within each family"
+        );
+    }
+
+    #[test]
+    fn sort_by_ip_preference_ipv6_first_orders_v6_before_v4() {
+        let mut addrs = vec![
+            addr("192.0.2.1", 1433),
+            addr("2001:db8::1", 1433),
+            addr("192.0.2.2", 1433),
+            addr("2001:db8::2", 1433),
+        ];
+
+        sort_by_ip_preference(&mut addrs, IPAddressPreference::IPv6First);
+
+        assert_eq!(
+            addrs,
+            vec![
+                addr("2001:db8::1", 1433),
+                addr("2001:db8::2", 1433),
+                addr("192.0.2.1", 1433),
+                addr("192.0.2.2", 1433),
+            ],
+            "IPv6 addresses must sort before IPv4, preserving relative order within each family"
+        );
+    }
+
+    #[test]
+    fn sort_by_ip_preference_handles_single_family_lists() {
+        let mut v4_only = vec![addr("192.0.2.1", 1433), addr("192.0.2.2", 1433)];
+        let expected = v4_only.clone();
+        sort_by_ip_preference(&mut v4_only, IPAddressPreference::IPv6First);
+        assert_eq!(v4_only, expected, "no IPv6 entries to reorder against");
+    }
+
+    /// Resolving a real hostname (not a literal IP, so the OS resolver is
+    /// actually exercised) must go through `tokio::net::lookup_host` and
+    /// therefore stay bounded by an enclosing `tokio::time::timeout` — the
+    /// exact property the blocking `to_socket_addrs()` call used to violate.
+    #[tokio::test]
+    async fn create_base_stream_sequential_resolution_is_bounded_by_timeout() {
+        // Port 0 is never listening, so the (fast, loopback) TCP connect
+        // fails quickly and the call returns well within the outer bound
+        // instead of the test hanging if resolution ever regresses to a
+        // blocking call.
+        let result = timeout(
+            Duration::from_secs(5),
+            create_base_stream_sequential(
+                IPAddressPreference::UsePlatformDefault,
+                "localhost",
+                0,
+                30_000,
+                1_000,
+                200,
+            ),
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "resolving 'localhost' must not escape the outer timeout"
+        );
+        assert!(result.unwrap().is_err(), "port 0 must not be connectable");
     }
 
     /// `skip_bytes` spins the same way, and it runs on the discard path that

--- a/mssql-tds/src/connection/transport/parallel_connect.rs
+++ b/mssql-tds/src/connection/transport/parallel_connect.rs
@@ -470,10 +470,14 @@ mod tests {
     async fn parallel_connect_resolution_yields_to_the_executor() {
         let heartbeats = std::sync::Arc::new(AtomicUsize::new(0));
         let heartbeats_task = heartbeats.clone();
+        // A short sleep (rather than `yield_now()`) still catches the same
+        // scheduling gap — the first increment can't happen until the main
+        // task yields either way — without busy-spinning a core for however
+        // long this host takes to NXDOMAIN.
         let heartbeat = tokio::spawn(async move {
             loop {
                 heartbeats_task.fetch_add(1, Ordering::SeqCst);
-                tokio::task::yield_now().await;
+                tokio::time::sleep(Duration::from_millis(1)).await;
             }
         });
 

--- a/mssql-tds/src/connection/transport/parallel_connect.rs
+++ b/mssql-tds/src/connection/transport/parallel_connect.rs
@@ -28,7 +28,7 @@
 //! prevent other connections from succeeding.
 
 use std::net::SocketAddr;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tokio::net::{self, TcpStream};
 use tokio::time::timeout;
@@ -125,14 +125,32 @@ pub async fn parallel_connect(
         host, port, config.timeout_ms
     );
 
+    // `timeout_ms` is documented as the overall budget for this call, so it
+    // must cover DNS resolution too, not just the connection race below.
+    let deadline = Instant::now() + Duration::from_millis(config.timeout_ms);
+
     // Resolve DNS to get all IP addresses. `lookup_host` awaits the resolution
     // instead of blocking the calling thread (unlike `std::net::ToSocketAddrs`),
-    // so a slow or stuck resolver stays subject to the caller's timeout instead
-    // of silently escaping it.
-    let addresses: Vec<SocketAddr> = tokio::net::lookup_host((host, port))
-        .await?
-        .take(MAX_PARALLEL_IPS)
-        .collect();
+    // so a slow or stuck resolver stays subject to `deadline` instead of
+    // silently escaping it.
+    let addresses: Vec<SocketAddr> = match timeout(
+        deadline.saturating_duration_since(Instant::now()),
+        tokio::net::lookup_host((host, port)),
+    )
+    .await
+    {
+        Ok(Ok(resolved)) => resolved.take(MAX_PARALLEL_IPS).collect(),
+        Ok(Err(e)) => return Err(Error::from(e)),
+        Err(_elapsed) => {
+            warn!(
+                "DNS resolution for {}:{} timed out after {}ms",
+                host, port, config.timeout_ms
+            );
+            return Err(Error::TimeoutError(crate::error::TimeoutErrorType::String(
+                format!("Connection timeout: DNS resolution for {host}:{port} timed out"),
+            )));
+        }
+    };
 
     if addresses.is_empty() {
         return Err(Error::ConnectionError(format!(
@@ -180,9 +198,10 @@ pub async fn parallel_connect(
         })
         .collect();
 
-    // Race all connections with an overall timeout
+    // Race all connections with whatever remains of the overall timeout —
+    // DNS resolution above may have already spent part of it.
     let result = timeout(
-        Duration::from_millis(config.timeout_ms),
+        deadline.saturating_duration_since(Instant::now()),
         race_connections(connect_futures),
     )
     .await;
@@ -428,6 +447,54 @@ async fn race_connections(
 mod tests {
     use super::*;
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Regression coverage for AB#47704: `parallel_connect` used to resolve
+    /// DNS via the blocking `std::net::ToSocketAddrs`, which never yields to
+    /// the executor. Timing alone can't prove the fix — resolving even a
+    /// nonexistent host completes in milliseconds whether or not the call
+    /// blocks, so a `timeout()`-based assertion would pass either way. This
+    /// proves the structural property instead: a concurrently spawned task
+    /// must get *some* chance to run while resolution is in flight.
+    /// `tokio::net::lookup_host` bridges to `spawn_blocking` via a channel,
+    /// so the awaiting task is guaranteed to yield at least once no matter
+    /// how fast the lookup itself finishes; a synchronous `to_socket_addrs()`
+    /// call never yields at all. Uses a host that fails to resolve so the
+    /// call returns from DNS resolution alone, without reaching
+    /// `race_connections` — which spawns tasks and awaits a channel
+    /// regardless of DNS behavior, and would otherwise mask the signal this
+    /// test is after. Confirmed by mutation testing: reverting
+    /// `parallel_connect` to `to_socket_addrs()` makes this test fail (the
+    /// heartbeat counter stays at 0).
+    #[tokio::test]
+    async fn parallel_connect_resolution_yields_to_the_executor() {
+        let heartbeats = std::sync::Arc::new(AtomicUsize::new(0));
+        let heartbeats_task = heartbeats.clone();
+        let heartbeat = tokio::spawn(async move {
+            loop {
+                heartbeats_task.fetch_add(1, Ordering::SeqCst);
+                tokio::task::yield_now().await;
+            }
+        });
+
+        let config = ParallelConnectConfig {
+            timeout_ms: 5000,
+            ..Default::default()
+        };
+        let result =
+            parallel_connect("invalid.host.that.does.not.exist.local", 1433, &config).await;
+
+        heartbeat.abort();
+        assert!(
+            result.is_err(),
+            "resolution must fail for a nonexistent host"
+        );
+        assert!(
+            heartbeats.load(Ordering::SeqCst) > 0,
+            "the heartbeat task never ran while resolution was in flight — \
+             resolution is blocking the executor instead of awaiting it"
+        );
+    }
 
     #[test]
     fn test_parallel_connect_config_default() {

--- a/mssql-tds/src/connection/transport/parallel_connect.rs
+++ b/mssql-tds/src/connection/transport/parallel_connect.rs
@@ -27,7 +27,7 @@
 //! and returns as soon as one succeeds. Failed connections are logged but don't
 //! prevent other connections from succeeding.
 
-use std::net::{SocketAddr, ToSocketAddrs};
+use std::net::SocketAddr;
 use std::time::Duration;
 
 use tokio::net::{self, TcpStream};
@@ -125,9 +125,12 @@ pub async fn parallel_connect(
         host, port, config.timeout_ms
     );
 
-    // Resolve DNS to get all IP addresses
-    let addresses: Vec<SocketAddr> = (host, port)
-        .to_socket_addrs()?
+    // Resolve DNS to get all IP addresses. `lookup_host` awaits the resolution
+    // instead of blocking the calling thread (unlike `std::net::ToSocketAddrs`),
+    // so a slow or stuck resolver stays subject to the caller's timeout instead
+    // of silently escaping it.
+    let addresses: Vec<SocketAddr> = tokio::net::lookup_host((host, port))
+        .await?
         .take(MAX_PARALLEL_IPS)
         .collect();
 

--- a/mssql-tds/src/connection/transport/parallel_connect.rs
+++ b/mssql-tds/src/connection/transport/parallel_connect.rs
@@ -450,23 +450,24 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     /// Regression coverage for AB#47704: `parallel_connect` used to resolve
-    /// DNS via the blocking `std::net::ToSocketAddrs`, which never yields to
-    /// the executor. Timing alone can't prove the fix — resolving even a
-    /// nonexistent host completes in milliseconds whether or not the call
-    /// blocks, so a `timeout()`-based assertion would pass either way. This
-    /// proves the structural property instead: a concurrently spawned task
-    /// must get *some* chance to run while resolution is in flight.
-    /// `tokio::net::lookup_host` bridges to `spawn_blocking` via a channel,
-    /// so the awaiting task is guaranteed to yield at least once no matter
-    /// how fast the lookup itself finishes; a synchronous `to_socket_addrs()`
-    /// call never yields at all. Uses a host that fails to resolve so the
-    /// call returns from DNS resolution alone, without reaching
+    /// DNS via blocking `to_socket_addrs()`, which never yields to the
+    /// executor. Timing can't prove the fix — resolving even a nonexistent
+    /// host completes in ms either way — so this asserts the structural
+    /// property instead: a concurrently spawned heartbeat must get scheduled
+    /// while resolution is in flight. `lookup_host` bridges to
+    /// `spawn_blocking` via a channel, so the awaiting task is guaranteed to
+    /// yield at least once; a blocking call never yields, so the heartbeat
+    /// gets zero chances to run. Uses a host that fails to resolve so the
+    /// call returns from resolution alone, without reaching
     /// `race_connections` — which spawns tasks and awaits a channel
-    /// regardless of DNS behavior, and would otherwise mask the signal this
-    /// test is after. Confirmed by mutation testing: reverting
-    /// `parallel_connect` to `to_socket_addrs()` makes this test fail (the
-    /// heartbeat counter stays at 0).
-    #[tokio::test]
+    /// regardless of DNS behavior, and would mask the signal. Confirmed by
+    /// mutation testing (reverting to `to_socket_addrs()` makes this fail).
+    ///
+    /// Must stay on the default `current_thread` runtime: a `multi_thread`
+    /// flavor would let the heartbeat run on another worker even if
+    /// resolution blocked, so the assertion would pass without proving
+    /// anything.
+    #[tokio::test(flavor = "current_thread")]
     async fn parallel_connect_resolution_yields_to_the_executor() {
         let heartbeats = std::sync::Arc::new(AtomicUsize::new(0));
         let heartbeats_task = heartbeats.clone();


### PR DESCRIPTION
## Description

Investigated [AB#47704](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47704) ("Failed invalid-password connection hangs test process during cleanup"). Built two live reproductions of a real SQL Server's invalid-password response (plaintext and over TLS, matching `Encrypt=yes`) — `mssql-tds`'s login-failure handling (ERROR token parsing, `is_transient_connect_error` classification, retry logic) is correct and returns in ~150ms in isolation, so that path is not the cause.

Root cause: `create_base_stream_sequential` (sequential TCP) and `parallel_connect` (`MultiSubnetFailover`) resolved the server hostname with `std::net::ToSocketAddrs::to_socket_addrs()` — a blocking OS call — directly inside async code, never wrapped in `spawn_blocking` (unlike `named_pipes.rs`/`interactive.rs`, which already do this correctly for LocalDB). Because it never `.await`s, it silently defeats the `tokio::time::timeout()`/deadline that wraps the whole connect attempt in `tds_connection_provider`: a `timeout()` can only fire between a future's `.await` points, and a thread stuck inside a genuinely blocking call never yields one. `mssql-odbc`'s `SQLDriverConnectW` drives the connect via `block_on` on the *calling* thread, so a slow/unresponsive resolver hangs that thread — and since ODBC is a blocking API, the whole synchronous caller — with **no internal bound at all**, independent of whether the credentials are valid. This is compounded by `mssql-python` allocating its ODBC environment as a process-wide static singleton, so every connection in a test file shares `mssql-odbc`'s one `Arc<Runtime>` (`worker_threads(1)`).

Fix: switch both call sites to `tokio::net::lookup_host`, the same async primitive `ssrp.rs` already uses for instance lookups, so resolution is a genuine `.await` point subject to the existing deadline machinery. Extracted the IP-preference sort into a small `sort_by_ip_preference` helper (previously inline, reassigning the iterator variable) since it had no direct test coverage and moving it was the natural seam.

Separately noted but **not** addressed here (out of scope, filed as follow-up candidates): `Connection Timeout=`/`Login Timeout=` connection-string keywords aren't parsed/wired to `ClientContext` at all (only `SQL_ATTR_LOGIN_TIMEOUT` works) — doesn't cause unbounded hangs since the 15s built-in default still applies, but silently ignores an explicit caller request. Also found two pre-existing, unrelated hangs in `connection::tds_client::tests` (`check_and_reconnect_attempts_reconnect_when_dead_and_recoverable`, `reconnect_returns_session_recovery_failed_on_connection_failure`) that reproduce identically on `main` — a likely-similar-class bug in the reconnect/session-recovery path, distinct code from this fix.

## Related Issues

https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47704

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes (full workspace)
- [x] `cargo btest` — targeted: all `mssql-tds` unit tests pass except two pre-existing hangs confirmed unrelated (reproduce identically on `main`, see above); all `mssql-odbc` unit tests pass (1097/1097); mock-server/TLS/fedauth/redirection integration tests pass (2001/2001). Live-server integration tests (`connectivity`, `test_transport_protocols`, `test_no_protocol_resolution`, etc.) fail in this sandbox on `SQL_PASSWORD environment variable not set` both before and after this change — no live SQL Server configured locally, matching prior PRs' own notes (e.g. #414).
- [x] New/changed functionality has tests — `sort_by_ip_preference` unit tests (platform-default/IPv4-first/IPv6-first/single-family) plus a test pinning that `create_base_stream_sequential`'s resolution stays inside an outer `tokio::time::timeout`.
- [x] Public API changes are documented — none; both changed functions are crate-private. `CHANGELOG.md` updated under `Fixed`.