### PR TITLE
Retract partially sent cursor RPCs

### DIFF
--- a/mssql-tds/src/connection/cursor_ops.rs
+++ b/mssql-tds/src/connection/cursor_ops.rs
@@ -326,7 +326,10 @@ impl CursorClient for TdsClient {
 
         let mut pw =
             rpc.create_packet_writer(self.transport.as_writer(), timeout_sec, cancel_handle);
-        rpc.serialize(&mut pw).await?;
+        let serialize_result = rpc.serialize(&mut pw).await;
+        let message = pw.suspend();
+        drop(rpc);
+        self.finish_send(serialize_result, message).await?;
 
         self.consume_cursor_open_response().await
     }
@@ -416,7 +419,10 @@ impl CursorClient for TdsClient {
 
         let mut pw =
             rpc.create_packet_writer(self.transport.as_writer(), timeout_sec, cancel_handle);
-        rpc.serialize(&mut pw).await?;
+        let serialize_result = rpc.serialize(&mut pw).await;
+        let message = pw.suspend();
+        drop(rpc);
+        self.finish_send(serialize_result, message).await?;
 
         self.consume_cursor_open_response().await
     }
@@ -469,7 +475,10 @@ impl CursorClient for TdsClient {
 
         let mut pw =
             rpc.create_packet_writer(self.transport.as_writer(), timeout_sec, cancel_handle);
-        rpc.serialize(&mut pw).await?;
+        let serialize_result = rpc.serialize(&mut pw).await;
+        let message = pw.suspend();
+        drop(rpc);
+        self.finish_send(serialize_result, message).await?;
 
         let metadata = self.next_rowset().await?;
         if metadata.is_none() {
@@ -560,7 +569,10 @@ impl CursorClient for TdsClient {
 
         let mut pw =
             rpc.create_packet_writer(self.transport.as_writer(), timeout_sec, cancel_handle);
-        rpc.serialize(&mut pw).await?;
+        let serialize_result = rpc.serialize(&mut pw).await;
+        let message = pw.suspend();
+        drop(rpc);
+        self.finish_send(serialize_result, message).await?;
 
         let server_errors = self.drain_stream_or_retire().await?;
         self.execution_context.set_has_open_batch(false);
@@ -642,7 +654,10 @@ impl CursorClient for TdsClient {
 
         let mut pw =
             rpc.create_packet_writer(self.transport.as_writer(), timeout_sec, cancel_handle);
-        rpc.serialize(&mut pw).await?;
+        let serialize_result = rpc.serialize(&mut pw).await;
+        let message = pw.suspend();
+        drop(rpc);
+        self.finish_send(serialize_result, message).await?;
 
         let server_errors = self.drain_stream_or_retire().await?;
         self.execution_context.set_has_open_batch(false);
@@ -718,7 +733,10 @@ impl CursorClient for TdsClient {
 
         let mut pw =
             rpc.create_packet_writer(self.transport.as_writer(), timeout_sec, cancel_handle);
-        rpc.serialize(&mut pw).await?;
+        let serialize_result = rpc.serialize(&mut pw).await;
+        let message = pw.suspend();
+        drop(rpc);
+        self.finish_send(serialize_result, message).await?;
 
         let server_errors = self.drain_stream_or_retire().await?;
         self.execution_context.set_has_open_batch(false);
@@ -815,7 +833,10 @@ impl CursorClient for TdsClient {
 
         let mut pw =
             rpc.create_packet_writer(self.transport.as_writer(), timeout_sec, cancel_handle);
-        rpc.serialize(&mut pw).await?;
+        let serialize_result = rpc.serialize(&mut pw).await;
+        let message = pw.suspend();
+        drop(rpc);
+        self.finish_send(serialize_result, message).await?;
 
         self.drain_cursor_response().await?;
         let status = self.captured_cursor_status()?;
@@ -903,7 +924,10 @@ impl CursorClient for TdsClient {
 
         let mut pw =
             rpc.create_packet_writer(self.transport.as_writer(), timeout_sec, cancel_handle);
-        rpc.serialize(&mut pw).await?;
+        let serialize_result = rpc.serialize(&mut pw).await;
+        let message = pw.suspend();
+        drop(rpc);
+        self.finish_send(serialize_result, message).await?;
 
         // prepared_handle is plain INPUT (no ReturnValue), so the OUTPUT ordinals
         // match sp_cursoropen: 0=cursor, 1=scrollopt, 2=ccopt, 3=rowcount.
@@ -988,7 +1012,10 @@ impl CursorClient for TdsClient {
 
         let mut pw =
             rpc.create_packet_writer(self.transport.as_writer(), timeout_sec, cancel_handle);
-        rpc.serialize(&mut pw).await?;
+        let serialize_result = rpc.serialize(&mut pw).await;
+        let message = pw.suspend();
+        drop(rpc);
+        self.finish_send(serialize_result, message).await?;
 
         self.drain_cursor_response().await?;
         let status = self.captured_cursor_status()?;
@@ -1046,7 +1073,10 @@ impl CursorClient for TdsClient {
 
         let mut pw =
             rpc.create_packet_writer(self.transport.as_writer(), timeout_sec, cancel_handle);
-        rpc.serialize(&mut pw).await?;
+        let serialize_result = rpc.serialize(&mut pw).await;
+        let message = pw.suspend();
+        drop(rpc);
+        self.finish_send(serialize_result, message).await?;
 
         let server_errors = self.drain_stream_or_retire().await?;
         self.execution_context.set_has_open_batch(false);

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -1996,9 +1996,9 @@ impl TdsClient {
     /// Completes a send, retracting the half-sent message when serialization
     /// failed so the failure costs the request rather than the connection.
     ///
-    /// Every request serialized through a `PacketWriter` must pass its result
-    /// and suspended message here instead of propagating the error directly.
-    /// TODO(AB#47772): enforce this by moving serialization behind one API.
+    /// SQL batch and RPC sends that can fail after bytes reach an otherwise
+    /// usable transport must pass their result and suspended message here.
+    /// TODO(AB#47772): move these sends behind one API.
     ///
     /// The `drop(rpc)` stays at each call site: `SqlRpc` borrows
     /// `&self.execution_context`, so that borrow has to end before `&mut self`.

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -1915,11 +1915,10 @@ impl TdsClient {
         }
     }
 
-    /// Closes an already-sent message with `EOM | IGNORE` and consumes the DONE
-    /// the server answers it with, each under its own [`CANCEL_TIMEOUT`] — they
-    /// run in sequence, so a withdrawal can hold the caller for twice that.
-    /// msodbcsql is the same shape: `SendPacket(.., DEFAULT_CANCEL_TIMEOUT)`
-    /// followed by `FlushInputStream`.
+    /// Closes an already-sent message with `EOM | IGNORE`, allowing 60 seconds
+    /// for the write and then 120 seconds to consume its DONE. A stalled write
+    /// hits the 120-second outer deadline and skips the drain. msodbcsql instead
+    /// allows 120 seconds for each sequential leg.
     async fn withdraw_sent_message(&mut self, message: SuspendedMessage) -> Withdrawal {
         // Cached read, not `is_connection_dead`: that one `try_read`s a byte,
         // which here could swallow the server's answer to the half-written
@@ -1997,9 +1996,13 @@ impl TdsClient {
     /// Completes a send, retracting the half-sent message when serialization
     /// failed so the failure costs the request rather than the connection.
     ///
+    /// Every request serialized through a `PacketWriter` must pass its result
+    /// and suspended message here instead of propagating the error directly.
+    /// TODO(AB#47772): enforce this by moving serialization behind one API.
+    ///
     /// The `drop(rpc)` stays at each call site: `SqlRpc` borrows
     /// `&self.execution_context`, so that borrow has to end before `&mut self`.
-    async fn finish_send(
+    pub(super) async fn finish_send(
         &mut self,
         serialize_result: TdsResult<()>,
         message: SuspendedMessage,
@@ -6439,6 +6442,7 @@ pub trait ResultSet {
 mod tests {
     use super::*;
     use crate::connection::client_context::ClientContext;
+    use crate::connection::cursor_ops::CursorClient;
     use crate::connection::transport::network_transport::TransportSslHandler;
     use crate::connection::transport::tds_transport::TdsTransport;
     use crate::core::{CancelHandle, TdsResult};
@@ -6481,6 +6485,9 @@ mod tests {
         /// When set, `send` never returns, so a test can drive a write deadline
         /// without a real stalled peer.
         send_should_hang: Arc<std::sync::atomic::AtomicBool>,
+        /// Fires after the first successful send, allowing a multi-packet
+        /// request to be cancelled while the server holds its first packet.
+        cancel_after_send: Option<tokio_util::sync::CancellationToken>,
         /// Attentions requested, so a test can tell the cancel-a-sent-request
         /// path from the withdraw-a-partial-one path.
         attentions: Arc<std::sync::atomic::AtomicUsize>,
@@ -6507,6 +6514,7 @@ mod tests {
                 resume_results: VecDeque::new(),
                 send_should_fail: Arc::new(std::sync::atomic::AtomicBool::new(false)),
                 send_should_hang: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                cancel_after_send: None,
                 attentions: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
                 known_dead: false,
                 encryption_setting: NegotiatedEncryptionSetting::NoEncryption,
@@ -6664,6 +6672,9 @@ mod tests {
                 std::future::pending::<()>().await;
             }
             self.sent.lock().unwrap().extend_from_slice(data);
+            if let Some(cancel) = self.cancel_after_send.take() {
+                cancel.cancel();
+            }
             Ok(())
         }
         fn packet_size(&self) -> u32 {
@@ -11801,6 +11812,221 @@ mod tests {
             !client.is_connection_dead(),
             "a withdrawn request leaves the connection reusable"
         );
+    }
+
+    fn partially_serializable_cursor_params() -> Vec<RpcParameter> {
+        vec![
+            RpcParameter::new(
+                Some("@big".to_string()),
+                StatusFlags::NONE,
+                SqlType::VarcharMax(Some(SqlString::from_utf8_string("a".repeat(20_000)))),
+            ),
+            RpcParameter::new(
+                Some("@bad".to_string()),
+                StatusFlags::NONE,
+                SqlType::Varchar(
+                    Some(SqlString::from_utf8_string("abcdefghij".to_string())),
+                    1,
+                ),
+            ),
+        ]
+    }
+
+    fn assert_cursor_send_was_retracted(client: &TdsClient, sent: &Arc<std::sync::Mutex<Vec<u8>>>) {
+        use crate::message::messages::PacketStatusFlags;
+
+        let wire = sent.lock().unwrap().clone();
+        assert!(
+            wire.len() >= PacketWriter::PACKET_HEADER_SIZE,
+            "expected at least one complete TDS packet, got {} bytes",
+            wire.len()
+        );
+        let last = &wire[wire.len() - PacketWriter::PACKET_HEADER_SIZE..];
+        assert_eq!(
+            u16::from_be_bytes([last[2], last[3]]) as usize,
+            PacketWriter::PACKET_HEADER_SIZE,
+            "the withdrawal must end with a header-only TDS packet"
+        );
+        assert_eq!(
+            last[1],
+            PacketStatusFlags::Eom as u8 | PacketStatusFlags::Ignore as u8,
+            "the half-sent cursor RPC must be withdrawn"
+        );
+        assert!(
+            !client.is_connection_dead(),
+            "a withdrawn cursor RPC must leave the connection reusable"
+        );
+    }
+
+    fn assert_overlong_parameter_error(error: crate::error::Error) {
+        assert!(
+            error.to_string().contains("exceeds schema size"),
+            "the caller must receive the original serialization error, got {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cursor_open_with_params_retracts_a_partial_send() {
+        let (mut client, sent) = create_capturing_client(vec![done_no_more()]);
+
+        let error = client
+            .cursor_open_with_params(
+                "SELECT @big, @bad",
+                partially_serializable_cursor_params(),
+                crate::cursor::CursorScrollOption::FORWARD_ONLY,
+                crate::cursor::CursorConcurrency::READONLY,
+                0,
+                None,
+                None,
+            )
+            .await
+            .expect_err("the over-long cursor parameter must fail");
+
+        assert_overlong_parameter_error(error);
+        assert_cursor_send_was_retracted(&client, &sent);
+    }
+
+    #[tokio::test]
+    async fn cursor_open_retracts_when_cancelled_after_a_flush() {
+        let cancel = CancelHandle::new();
+        let mut transport = TestTransport::with_tokens(vec![done_no_more()]);
+        let sent = Arc::clone(&transport.sent);
+        transport.cancel_after_send = Some(cancel.cancel_token.clone());
+        let mut client = create_test_client_with_transport(transport);
+
+        let error = client
+            .cursor_open(
+                &"a".repeat(20_000),
+                crate::cursor::CursorScrollOption::FORWARD_ONLY,
+                crate::cursor::CursorConcurrency::READONLY,
+                0,
+                None,
+                Some(&cancel),
+            )
+            .await
+            .expect_err("cancellation after packet one must stop serialization");
+
+        assert!(matches!(
+            error,
+            crate::error::Error::OperationCancelledError(_)
+        ));
+        assert_cursor_send_was_retracted(&client, &sent);
+    }
+
+    #[tokio::test]
+    async fn cursor_prepare_retracts_when_cancelled_after_a_flush() {
+        let cancel = CancelHandle::new();
+        let mut transport = TestTransport::with_tokens(vec![done_no_more()]);
+        let sent = Arc::clone(&transport.sent);
+        transport.cancel_after_send = Some(cancel.cancel_token.clone());
+        let mut client = create_test_client_with_transport(transport);
+
+        let error = client
+            .cursor_prepare(
+                &"a".repeat(20_000),
+                "",
+                crate::cursor::CursorScrollOption::FORWARD_ONLY,
+                crate::cursor::CursorConcurrency::READONLY,
+                None,
+                Some(&cancel),
+            )
+            .await
+            .expect_err("cancellation after packet one must stop serialization");
+
+        assert!(matches!(
+            error,
+            crate::error::Error::OperationCancelledError(_)
+        ));
+        assert_cursor_send_was_retracted(&client, &sent);
+    }
+
+    #[tokio::test]
+    async fn set_cursor_option_retracts_when_cancelled_after_a_flush() {
+        let cancel = CancelHandle::new();
+        let mut transport = TestTransport::with_tokens(vec![done_no_more()]);
+        let sent = Arc::clone(&transport.sent);
+        transport.cancel_after_send = Some(cancel.cancel_token.clone());
+        let mut client = create_test_client_with_transport(transport);
+
+        let error = client
+            .set_cursor_option(
+                1,
+                crate::cursor::CursorOptionCode::CursorName,
+                crate::cursor::CursorOptionValue::String("a".repeat(20_000)),
+                None,
+                Some(&cancel),
+            )
+            .await
+            .expect_err("cancellation after packet one must stop serialization");
+
+        assert!(matches!(
+            error,
+            crate::error::Error::OperationCancelledError(_)
+        ));
+        assert_cursor_send_was_retracted(&client, &sent);
+    }
+
+    #[tokio::test]
+    async fn perform_cursor_operation_retracts_a_partial_send() {
+        let (mut client, sent) = create_capturing_client(vec![done_no_more()]);
+
+        let error = client
+            .perform_cursor_operation(
+                1,
+                crate::cursor::CursorOperation::UPDATE,
+                1,
+                "",
+                partially_serializable_cursor_params(),
+                None,
+                None,
+            )
+            .await
+            .expect_err("the over-long cursor parameter must fail");
+
+        assert_overlong_parameter_error(error);
+        assert_cursor_send_was_retracted(&client, &sent);
+    }
+
+    #[tokio::test]
+    async fn cursor_prepexec_retracts_a_partial_send() {
+        let (mut client, sent) = create_capturing_client(vec![done_no_more()]);
+
+        let error = client
+            .cursor_prepexec(
+                "SELECT @big, @bad",
+                partially_serializable_cursor_params(),
+                crate::cursor::CursorScrollOption::FORWARD_ONLY,
+                crate::cursor::CursorConcurrency::READONLY,
+                0,
+                None,
+                None,
+            )
+            .await
+            .expect_err("the over-long cursor parameter must fail");
+
+        assert_overlong_parameter_error(error);
+        assert_cursor_send_was_retracted(&client, &sent);
+    }
+
+    #[tokio::test]
+    async fn cursor_execute_retracts_a_partial_send() {
+        let (mut client, sent) = create_capturing_client(vec![done_no_more()]);
+
+        let error = client
+            .cursor_execute(
+                1,
+                partially_serializable_cursor_params(),
+                crate::cursor::CursorScrollOption::FORWARD_ONLY,
+                crate::cursor::CursorConcurrency::READONLY,
+                0,
+                None,
+                None,
+            )
+            .await
+            .expect_err("the over-long cursor parameter must fail");
+
+        assert_overlong_parameter_error(error);
+        assert_cursor_send_was_retracted(&client, &sent);
     }
 
     /// The retraction runs on its own budget, so a request that had a timeout

--- a/mssql-tds/tests/test_cursor_ops.rs
+++ b/mssql-tds/tests/test_cursor_ops.rs
@@ -60,6 +60,48 @@ async fn read_all_rows(
     rows
 }
 
+async fn current_spid(client: &mut mssql_tds::connection::tds_client::TdsClient) -> i16 {
+    client
+        .execute("SELECT @@SPID".to_string(), ())
+        .await
+        .unwrap();
+    let rows = read_all_rows(client).await;
+    match rows.as_slice() {
+        [row] => match row.as_slice() {
+            [ColumnValues::SmallInt(spid)] => *spid,
+            other => panic!("expected one SMALLINT column for @@SPID, got {other:?}"),
+        },
+        other => panic!("expected one row for @@SPID, got {other:?}"),
+    }
+}
+
+fn partially_serializable_cursor_params() -> Vec<RpcParameter> {
+    use mssql_tds::datatypes::sql_string::SqlString;
+
+    vec![
+        RpcParameter::new(
+            Some("@big".to_string()),
+            StatusFlags::NONE,
+            SqlType::VarcharMax(Some(SqlString::from_utf8_string("a".repeat(20_000)))),
+        ),
+        RpcParameter::new(
+            Some("@bad".to_string()),
+            StatusFlags::NONE,
+            SqlType::Varchar(
+                Some(SqlString::from_utf8_string("abcdefghij".to_string())),
+                1,
+            ),
+        ),
+    ]
+}
+
+fn assert_overlong_parameter_error(error: mssql_tds::error::Error) {
+    assert!(
+        error.to_string().contains("exceeds schema size"),
+        "the caller must receive the original serialization error, got {error}"
+    );
+}
+
 // --- Basic Lifecycle Tests ---
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -659,6 +701,167 @@ async fn cursor_open_with_params_success() {
 
     client
         .cursor_close(resp.cursor_id, None, None)
+        .await
+        .unwrap();
+    client.close_connection().await.unwrap();
+}
+
+// Benefits-from-mock-tds: assert that the failed cursor-open RPC ends with
+// EOM | IGNORE and that its DONE is consumed before the SPID query is sent.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cursor_open_with_params_serialization_failure_preserves_session() {
+    let mut client = begin_connection(&build_tcp_datasource()).await;
+    let spid = current_spid(&mut client).await;
+
+    let error = client
+        .cursor_open_with_params(
+            "SELECT @big, @bad",
+            partially_serializable_cursor_params(),
+            CursorScrollOption::FORWARD_ONLY,
+            CursorConcurrency::READONLY,
+            0,
+            None,
+            None,
+        )
+        .await
+        .expect_err("the over-long cursor parameter must fail");
+
+    assert_overlong_parameter_error(error);
+    assert_eq!(
+        current_spid(&mut client).await,
+        spid,
+        "cursor-open recovery must reuse the physical session"
+    );
+    client.close_connection().await.unwrap();
+}
+
+// Benefits-from-mock-tds: assert that the failed sp_cursor RPC ends with
+// EOM | IGNORE and that its DONE is consumed before the SPID query is sent.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cursor_operation_serialization_failure_preserves_session() {
+    let mut client = begin_connection(&build_tcp_datasource()).await;
+    setup_temp_table(&mut client, 3).await;
+    let cursor = client
+        .cursor_open(
+            "SELECT id, name, value FROM #ct ORDER BY id",
+            CursorScrollOption::KEYSET_DRIVEN,
+            CursorConcurrency::OPTCC,
+            0,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    client
+        .cursor_fetch(cursor.cursor_id, FetchDirection::NEXT, 0, 1, None, None)
+        .await
+        .unwrap();
+    assert_eq!(read_all_rows(&mut client).await.len(), 1);
+    let spid = current_spid(&mut client).await;
+
+    let error = client
+        .perform_cursor_operation(
+            cursor.cursor_id,
+            CursorOperation::UPDATE,
+            1,
+            "",
+            partially_serializable_cursor_params(),
+            None,
+            None,
+        )
+        .await
+        .expect_err("the over-long cursor parameter must fail");
+
+    assert_overlong_parameter_error(error);
+    assert_eq!(
+        current_spid(&mut client).await,
+        spid,
+        "cursor-operation recovery must reuse the physical session"
+    );
+    client
+        .cursor_fetch(cursor.cursor_id, FetchDirection::NEXT, 0, 1, None, None)
+        .await
+        .unwrap();
+    assert_eq!(
+        read_all_rows(&mut client).await.len(),
+        1,
+        "the same cursor must remain usable after its RPC is withdrawn"
+    );
+    client
+        .cursor_close(cursor.cursor_id, None, None)
+        .await
+        .unwrap();
+    client.close_connection().await.unwrap();
+}
+
+// Benefits-from-mock-tds: assert that the failed cursor-prepexec RPC ends with
+// EOM | IGNORE and that its DONE is consumed before the SPID query is sent.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cursor_prepexec_serialization_failure_preserves_session() {
+    let mut client = begin_connection(&build_tcp_datasource()).await;
+    let spid = current_spid(&mut client).await;
+
+    let error = client
+        .cursor_prepexec(
+            "SELECT @big, @bad",
+            partially_serializable_cursor_params(),
+            CursorScrollOption::FORWARD_ONLY,
+            CursorConcurrency::READONLY,
+            0,
+            None,
+            None,
+        )
+        .await
+        .expect_err("the over-long cursor parameter must fail");
+
+    assert_overlong_parameter_error(error);
+    assert_eq!(
+        current_spid(&mut client).await,
+        spid,
+        "cursor-prepexec recovery must reuse the physical session"
+    );
+    client.close_connection().await.unwrap();
+}
+
+// Benefits-from-mock-tds: assert that the failed cursor-execute RPC ends with
+// EOM | IGNORE and that its DONE is consumed before the SPID query is sent.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cursor_execute_serialization_failure_preserves_session() {
+    let mut client = begin_connection(&build_tcp_datasource()).await;
+    let prepared = client
+        .cursor_prepare(
+            "SELECT @big, @bad",
+            "@big VARCHAR(MAX), @bad VARCHAR(1)",
+            CursorScrollOption::FORWARD_ONLY,
+            CursorConcurrency::READONLY,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    let spid = current_spid(&mut client).await;
+
+    let error = client
+        .cursor_execute(
+            prepared.prepared_handle,
+            partially_serializable_cursor_params(),
+            CursorScrollOption::FORWARD_ONLY,
+            CursorConcurrency::READONLY,
+            0,
+            None,
+            None,
+        )
+        .await
+        .expect_err("the over-long cursor parameter must fail");
+
+    assert_overlong_parameter_error(error);
+    assert_eq!(
+        current_spid(&mut client).await,
+        spid,
+        "cursor-execute recovery must reuse the physical session"
+    );
+    client
+        .cursor_unprepare(prepared.prepared_handle, None, None)
         .await
         .unwrap();
     client.close_connection().await.unwrap();


### PR DESCRIPTION
## Description

Route all server-cursor RPC sends through the partial-request recovery added in #408. Serialization failures now abandon unsent requests, withdraw partial requests with EOM | IGNORE, or cancel fully sent requests with attention while preserving the original error.

Adds byte-level unit coverage for seven cursor send paths, including cancellation after a packet flush, and live-server coverage for same-session and same-cursor reuse.

## Related Issues

https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47714/

Follow-up: https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47772/

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes
- [x] New/changed functionality has tests
- [x] Public API changes are documented

Live cursor e2e tests pass. The full local unit run has 7 pre-existing failures from missing certificate fixtures.