### PR TITLE
Record that the perf gate's auto-confirm quorum does not survive run-to-run variance

### DIFF
--- a/mssql-tds-bench/perf-lab/MONITORING.md
+++ b/mssql-tds-bench/perf-lab/MONITORING.md
@@ -40,27 +40,31 @@ the table can be reconstructed from it when quoting Windows results elsewhere.
 ## What the quorum does not cover
 
 The 4 re-runs are interleaved inside a *single* VM session, so they establish
-that a benchmark is consistently slower **on that machine, on that run**. A
-run-level condition — host hardware, CPU frequency and thermal state, a noisy
-neighbor, SQL Server state — biases all 4 equally, and the benchmark it lands on
-trips 4/4 and is published as a confirmed regression.
+that a benchmark moved **on that machine, on that run**. A run-level condition —
+host hardware, CPU frequency and thermal state, a noisy neighbor, SQL Server
+state — biases all 4 equally, and the benchmark it lands on reproduces 4/4 and is
+published as confirmed. This applies in **both** directions: the same re-measure
+pass covers regressions and large apparent improvements (one `VERIFY_IDS` set,
+one loop), so a session that happens to favor the candidate manufactures a
+*verified improvement* just as readily as an unlucky one manufactures a
+regression.
 
 This is not hypothetical. On 2026-08-31, builds
 [171113](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build/results?buildId=171113)
 and
 [171243](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build/results?buildId=171243)
 confirmed disjoint sets of regressions with no `mssql-tds` source change between
-them: `select_n_rows/10000` (3/4, +12%) and `temporal/decode` (4/4, +10%) in the
-first, `primitives/decode` (4/4, +11%) in the second, each clearing in the other
-run. Both runs measure the same baseline commit, and their `base` columns — a
-repeated measurement of identical code — differ by up to 5.2%, which is the gate
-threshold itself.
+them: `select_n_rows/10000` (+8.5%, 3/4, worst re-run +12%) and `temporal/decode`
+(+6.0%, 4/4, worst +10%) in the first, `primitives/decode` (+8.0%, 4/4, worst
++11%) in the second, each clearing in the other run. Both runs measure the same
+baseline commit, and their `base` columns — a repeated measurement of identical
+code — differ by up to 5.2%, which is the gate threshold itself.
 
 So the quorum rules out per-sample noise, not per-run noise, and a single
-confirmed regression is a *candidate* finding rather than a settled one. Until
+confirmed result is a *candidate* finding rather than a settled one. Until
 [#434](https://github.com/microsoft/mssql-rs/issues/434) narrows the variance,
 compare the two runs' baseline columns before trusting a verdict: when unchanged
-baseline code moves by an amount comparable to the reported regression, the run
+baseline code moves by an amount comparable to the reported change, the run
 is not decisive.
 
 ## Triage
@@ -80,7 +84,8 @@ is not decisive.
   only if the phase looks transient; otherwise fix the code or config. Escalate
   if a retry also fails.
 - **Green** — check for verified improvements and for quorum-cleared drift, then
-  apply the lock-in rules below.
+  apply the lock-in rules below. A verified improvement from a single run is a
+  candidate too, not a settled win; criterion 3 says what it takes to spend one.
 
 ## Advancing the baseline
 
@@ -89,16 +94,32 @@ the gains back trips the gate instead of silently settling at the old level. Tha
 cuts both ways — a bump that carries an unaddressed slowdown legitimizes it, and
 the next gate is then measured from the degraded point.
 
+This is why a false *improvement* is the more expensive error. A false regression
+is self-correcting: someone investigates, finds nothing, and moves on. A false
+improvement is self-perpetuating — it advances the floor to a number that was
+never real, and every later run is then measured against that number, so the
+noise is converted into a permanent regression for whoever comes next. The
+criteria below are therefore stricter about the win than about the run.
+
 Bump only when **all** of the following hold:
 
 1. Both platforms are green at the **same** commit.
 2. That commit is an ancestor of GitHub `main`.
-3. At least one *verified* improvement (reproduced in ≥ quorum) on either platform.
+3. At least one *verified* improvement (reproduced in ≥ quorum) on either
+   platform, **reproduced again in a separate run on a fresh VM**. The
+   improvement-verification re-runs share the single VM session with the
+   regression re-runs — one `VERIFY_IDS` set, one loop — so they carry exactly
+   the limitation described above, and a session biased toward the candidate
+   yields a 4/4 "verified" win from nothing. One session is not evidence for a
+   change that becomes the floor; a win that survives two sessions is.
 4. No benchmark on **either** platform is more than **5%** slower than baseline.
    This is the gate's own magnitude, but applied with no quorum: a benchmark that
    trips in only 1–2 of the 4 re-runs is cleared by the gate, yet its published
    Δ% (the median of those re-runs) can still sit above 5%. Criterion 4 declines
    to bake that drift into the floor, so it is investigated rather than absorbed.
+
+Criteria 3 and 4 are usually satisfiable from the same pair of runs, since
+criterion 3 already calls for a second one — read both from the confirming run.
 
 When (1)–(3) hold but (4) does not, report the win and the drift together; the
 drift is the finding, and the bump waits for it to be explained or fixed. Note

--- a/mssql-tds-bench/perf-lab/MONITORING.md
+++ b/mssql-tds-bench/perf-lab/MONITORING.md
@@ -29,19 +29,51 @@ the largest `BENCH_IMPROVEMENT_VERIFY_MAX` of them (default 3) are actually
 re-measured; any beyond that cap keep unverified first-pass numbers, and the
 summary reports how many it skipped. Treat only a *reproduced* win as real: one
 that was re-measured and did not reproduce is an artifact, and one that fell
-outside the cap is simply unverified. Take the verdict line at face value; do not
-re-litigate a cleared benchmark from the first-pass numbers.
+outside the cap is simply unverified. Within a single run, take the verdict line
+at face value: do not re-litigate a benchmark it cleared from the first-pass
+numbers.
 
 The Windows step log mangles the summary's UTF-8 (emoji, `±`, `µ`). The raw
 critcmp block is still readable, and the emoji bars are a pure function of Δ%, so
 the table can be reconstructed from it when quoting Windows results elsewhere.
 
+## What the quorum does not cover
+
+The 4 re-runs are interleaved inside a *single* VM session, so they establish
+that a benchmark is consistently slower **on that machine, on that run**. A
+run-level condition — host hardware, CPU frequency and thermal state, a noisy
+neighbor, SQL Server state — biases all 4 equally, and the benchmark it lands on
+trips 4/4 and is published as a confirmed regression.
+
+This is not hypothetical. On 2026-08-31, builds
+[171113](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build/results?buildId=171113)
+and
+[171243](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build/results?buildId=171243)
+confirmed disjoint sets of regressions with no `mssql-tds` source change between
+them: `select_n_rows/10000` (3/4, +12%) and `temporal/decode` (4/4, +10%) in the
+first, `primitives/decode` (4/4, +11%) in the second, each clearing in the other
+run. Both runs measure the same baseline commit, and their `base` columns — a
+repeated measurement of identical code — differ by up to 5.2%, which is the gate
+threshold itself.
+
+So the quorum rules out per-sample noise, not per-run noise, and a single
+confirmed regression is a *candidate* finding rather than a settled one. Until
+[#434](https://github.com/microsoft/mssql-rs/issues/434) narrows the variance,
+compare the two runs' baseline columns before trusting a verdict: when unchanged
+baseline code moves by an amount comparable to the reported regression, the run
+is not decisive.
+
 ## Triage
 
 - **Confirmed regression** (the completed summary verdict reports confirmed
-  regressions) — report the confirmed benchmarks with their trip counts and worst
-  ratios, plus the commit range since the last green run on that platform. Do not
-  retry: the quorum has already ruled out noise.
+  regressions) — re-queue the same definition once at the same commit and compare
+  the two verdicts before reporting a regression or naming suspect commits. A
+  benchmark that confirms in both runs is real; one that clears in the second was
+  run-level noise the quorum could not see, and the pair of runs should be
+  reported as inconclusive instead. This costs one run and is far cheaper than
+  the bisect a false confirmation invites. Once a regression survives the second
+  run, report the confirmed benchmarks with their trip counts and worst ratios,
+  plus the commit range since the last green run on that platform.
 - **Infra or harness failure** (no completed summary verdict, or the failing
   phase is VM deploy, SQL setup, toolchain/critcmp install, baseline SHA
   validation, missing bench binaries, or invalid `BENCH_*` settings) — re-queue
@@ -69,7 +101,10 @@ Bump only when **all** of the following hold:
    to bake that drift into the floor, so it is investigated rather than absorbed.
 
 When (1)–(3) hold but (4) does not, report the win and the drift together; the
-drift is the finding, and the bump waits for it to be explained or fixed.
+drift is the finding, and the bump waits for it to be explained or fixed. Note
+that run-to-run variance is itself a common explanation for a criterion-4
+slowdown — check the baseline columns across runs before treating one as a real
+change.
 
 The bump is a pull request editing `baseline-commit.txt` — reviewed, recorded in
 git history, and attributable. See


### PR DESCRIPTION
## Description

Amends the perf-lab triage runbook to record a failure mode we hit on 2026-08-31: the regression gate's auto-confirm quorum does not survive run-to-run VM variance.

The gate re-measures a tripping benchmark 4× and confirms it at ≥3 of 4. Those re-runs are interleaved inside a *single* VM session, so they rule out per-sample noise but not a run-level bias — host hardware, CPU frequency and thermal state, a noisy neighbor, SQL Server state — which shifts all four measurements equally. Whichever benchmark that bias lands on reproduces 4/4 and is published as rock-solid.

Two consecutive Linux runs made this concrete:

| Benchmark | [171113](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build/results?buildId=171113) @`6e7c9e8c` | [171243](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build/results?buildId=171243) @`bc4b2dc8` |
|---|--:|--:|
| `select_n_rows/10000` | **+8.5% · 3/4 · worst re-run +12%** | +1.0% · did not trip |
| `temporal/decode` | **+6.0% · 4/4 · worst +10%** | +3.0% · did not trip |
| `primitives/decode` | +4.0% · did not trip | **+8.0% · 4/4 · worst +11%** |

Disjoint verdicts, and the only commit between the two candidate SHAs is #426, which touches no `mssql-tds` source. The corroborating detail is already in the published output: both runs measure the same baseline commit `ecd8d6cb`, so the `base` column is a repeated measurement of identical code, and it moved by up to **5.2%** (`select_n_rows/10000` 5.8 → 6.1 ms; `bulk_insert/500` +5.1%; `connect_close` -4.9%; `scalars/decode` +4.6%). That is the gate threshold itself.

The runbook previously said *"Do not retry: the quorum has already ruled out noise."* Followed as written, that is what turns an artifact into a bisect across innocent commits — during this triage it produced a suspect list naming #343 and #360, both since exonerated.

### The improvement direction shares the flaw, and is worse

Raised in review, and it widened the change. The harness runs both directions through the same code path — `run-benchmarks.sh:389` unions offenders and improvements into one `VERIFY_IDS` set, and `:438-444` re-measures the whole set in one loop, one session. So a session biased toward the candidate manufactures a 4/4 *verified improvement* just as readily. Criterion 3 accepted exactly that signal as grounds to advance the baseline.

The two errors are not symmetric. A false regression is self-correcting: someone investigates, finds nothing, moves on. A false improvement is self-perpetuating — it advances the floor to a number that was never real, and every later run is measured against that number, so one session's noise becomes a permanent manufactured regression for whoever comes next.

Changes:

- New **"What the quorum does not cover"** section explaining the single-VM limitation in both directions, with the 171113/171243 evidence.
- **Triage** now re-queues once at the same commit and compares verdicts before reporting a regression or naming suspects. Confirms in both runs → real; clears in the second → report as inconclusive. One extra run is much cheaper than a bisect.
- **Criterion 3** now requires a verified improvement to reproduce in a separate run on a fresh VM, with the shared-session reason stated inline, plus the asymmetry rationale above the criteria list.
- A note on criterion 4 that run-to-run variance is a common explanation for an apparent >5% slowdown.
- Moved the Windows UTF-8 note so it stays with "Reading a run".

Harness-side work is tracked in the linked issue; this PR is the runbook half only. The suggestion recorded there is to persist the per-run baseline measurements we already take and throw away — every run re-measures the baseline commit from source, so we are collecting repeated measurements of identical code across many VMs for free. Keeping that history makes variance measurable, and lets the comparison basis become a median of recent baseline measurements rather than today's single sample, which attacks the root cause: most of what we call a regression is the *baseline* half of the comparison moving. That would also remove most of the need for the extra confirmation run this PR mandates, so the policy change here is best read as the interim measure.

## Related Issues

Refs https://github.com/microsoft/mssql-rs/issues/434

## Checklist

- [x] `cargo bfmt` passes — n/a, documentation-only change
- [x] `cargo bclippy` passes — n/a, documentation-only change
- [x] `cargo btest` passes — n/a, documentation-only change
- [x] New/changed functionality has tests — n/a, documentation-only change
- [x] Public API changes are documented — n/a, no API change
