### PR TITLE
Bump mssql-py-core version to 0.1.10

### DIFF
--- a/mssql-py-core/Cargo.toml
+++ b/mssql-py-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mssql-py-core"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 publish = false
 


### PR DESCRIPTION
## Description

Bump the `mssql-py-core` crate version from `0.1.9` to `0.1.10`.

## Related Issues

Fixes #437

## Checklist

- [x] `cargo bfmt` passes — `cargo fmt --manifest-path mssql-py-core/Cargo.toml -- --check` is clean; the crate is excluded from the root workspace.
- [x] `cargo bclippy` passes — N/A: version-only manifest change.
- [x] `cargo btest` passes — N/A: no logic changed.
- [x] New/changed functionality has tests — N/A: version bump only.
- [x] Public API changes are documented — N/A: no API change.