### PR TITLE
Avoid SQLDescribeCol UTF-16 allocations

### DIFF
--- a/mssql-odbc-bench/perf-lab/baseline-commit.txt
+++ b/mssql-odbc-bench/perf-lab/baseline-commit.txt
@@ -1,10 +1,9 @@
 # Performance baseline commit for mssql-odbc.
 #
-# The initial pin is the production main commit on which the benchmark harness
-# was introduced. PR #417 changes no production driver sources, so this bootstrap
-# makes the first candidate and baseline production trees identical. Future
+# PR #417's merge commit is the production parent of the optimization diff. This
+# pin builds the merged benchmark-era driver as the comparison baseline. Future
 # advances require a pull request, so every baseline move is reviewed and recorded.
 #
 # Exactly one full 40-character commit SHA on its own line. Lines starting with
 # '#' and blank lines are ignored.
-bc4b2dc80b111c388ac8000b90f1c35290d735a0
+acb3ed1dd22a2f9277cf14636fb847273a7a454c

--- a/mssql-odbc/Cargo.toml
+++ b/mssql-odbc/Cargo.toml
@@ -32,6 +32,7 @@ url = "2"
 # connection silently reuse a stale cached credential built from a different
 # secret.
 sha2 = "0.11.0"
+# `RowWriter` exposes UUID values without first boxing them as `ColumnValues`.
 uuid = "1"
 
 # `ActiveDirectoryInteractive` delegates the sign-in UI to `mssql-auth.dll`

--- a/mssql-odbc/src/api/describe_col.rs
+++ b/mssql-odbc/src/api/describe_col.rs
@@ -17,7 +17,7 @@ use crate::api::odbc_types::{
 use crate::api::sqlstate::{
     ERR_FUNCTION_SEQUENCE, ERR_INVALID_DESCRIPTOR_INDEX, WARN_STRING_TRUNCATION, post_diag,
 };
-use crate::api::util::{copy_with_nul, write_if_some};
+use crate::api::util::{copy_str_utf16_with_nul, write_if_some};
 use crate::error::free_errors;
 use crate::handles::stmt::STMT_STATE_EXEC_CONTEXT;
 use crate::handles::{HandleType, StmtHandle, handle_from_raw};
@@ -137,11 +137,15 @@ fn sql_describe_col_w_safe(
 
     let meta = &stmt_state.column_metadata[(column_number - 1) as usize];
 
-    let name_utf16: Vec<u16> = meta.column_name.encode_utf16().collect();
-    let name_len = SqlSmallInt::try_from(name_utf16.len()).unwrap_or(SqlSmallInt::MAX);
+    let (name_len, truncated) = unsafe {
+        copy_str_utf16_with_nul(
+            column_name,
+            usize::try_from(buffer_length).unwrap_or(0),
+            &meta.column_name,
+        )
+    };
+    let name_len = SqlSmallInt::try_from(name_len).unwrap_or(SqlSmallInt::MAX);
     unsafe { write_if_some(name_length_ptr, name_len) };
-
-    let truncated = unsafe { copy_with_nul(column_name, buffer_length as usize, &name_utf16) };
 
     unsafe { write_if_some(data_type_ptr, odbc_sql_type(meta)) };
     unsafe { write_if_some(column_size_ptr, column_size(meta)) };

--- a/mssql-odbc/src/api/fetch_scroll.rs
+++ b/mssql-odbc/src/api/fetch_scroll.rs
@@ -17,11 +17,23 @@
 //! long value in chunks across repeated calls, whereas a bound column gets one
 //! shot at a fixed-size buffer and reports `01004` if the value does not fit.
 
+use std::borrow::Cow;
+
 use tracing::{debug, error};
 
-use mssql_tds::connection::tds_client::{CursorColumn, ResultSet};
-use mssql_tds::datatypes::column_values::ColumnValues;
+use mssql_tds::connection::tds_client::{BufferedRowPoll, CursorColumn, ResultSet};
+use mssql_tds::datatypes::column_values::{
+    ColumnValues, SqlDate, SqlDateTime, SqlDateTime2, SqlDateTimeOffset, SqlMoney,
+    SqlSmallDateTime, SqlSmallMoney, SqlTime, SqlXml,
+};
+use mssql_tds::datatypes::decoder::DecimalParts;
+use mssql_tds::datatypes::row_writer::RowWriter;
+use mssql_tds::datatypes::sql_json::SqlJson;
+use mssql_tds::datatypes::sql_string::{EncodingType, SqlString};
+use mssql_tds::datatypes::sql_vector::SqlVector;
+use mssql_tds::datatypes::sqldatatypes::TdsDataType;
 use mssql_tds::error::Error as TdsError;
+use uuid::Uuid;
 
 use super::sqlstate::*;
 use crate::api::exec_common::release_busy_if_row_exhausted;
@@ -32,11 +44,15 @@ use crate::api::odbc_types::{
     SQL_C_STINYINT, SQL_C_TINYINT, SQL_C_TYPE_DATE, SQL_C_TYPE_TIME, SQL_C_TYPE_TIMESTAMP,
     SQL_C_UBIGINT, SQL_C_ULONG, SQL_C_USHORT, SQL_C_UTINYINT, SQL_C_WCHAR, SQL_ERROR,
     SQL_FETCH_NEXT, SQL_INVALID_HANDLE, SQL_NO_DATA, SQL_NULL_DATA, SQL_ROW_ERROR, SQL_ROW_NOROW,
-    SQL_ROW_SUCCESS, SQL_ROW_SUCCESS_WITH_INFO, SQL_SUCCESS, SQL_SUCCESS_WITH_INFO, SqlHandle,
-    SqlLen, SqlPointer, SqlReturn, SqlSmallInt, SqlULen, SqlUSmallInt, SqlWChar,
+    SQL_ROW_SUCCESS, SQL_ROW_SUCCESS_WITH_INFO, SQL_SUCCESS, SQL_SUCCESS_WITH_INFO, SqlDateStruct,
+    SqlGuid, SqlHandle, SqlLen, SqlPointer, SqlReturn, SqlSmallInt, SqlSsTime2Struct,
+    SqlSsTimestampoffsetStruct, SqlTimestampStruct, SqlULen, SqlUSmallInt, SqlWChar,
 };
-use crate::api::util::{copy_with_nul, write_if_some};
+use crate::api::util::{copy_with_nul, resolve_cursor_poll, write_if_some};
 use crate::conversion::error::{ConvError, ConvOk};
+use crate::conversion::fetch_convert::{
+    DateTimeParts, date_parts, datetime2_parts, datetimeoffset_parts, time_parts,
+};
 use crate::error::{free_errors, post_sql_error};
 use crate::handles::stmt::{
     ColumnBinding, STMT_STATE_CURSOR_OPEN, STMT_STATE_FETCH_IN_PROGRESS, StmtState,
@@ -149,6 +165,279 @@ impl RowOutcome {
             _ => RowOutcome::Success,
         }
     }
+}
+
+struct BoundRowWriter<'a> {
+    bindings: &'a [ColumnBinding],
+    next_binding: usize,
+    row_index: usize,
+    bind_offset: usize,
+    outcome: RowOutcome,
+    last_column_read: usize,
+}
+
+// The ODBC call owns the bound buffers for the duration of the synchronous
+// fetch. Moving its decode future between runtime workers cannot make the
+// pointers concurrently accessible.
+unsafe impl Send for BoundRowWriter<'_> {}
+
+impl<'a> BoundRowWriter<'a> {
+    fn new(
+        bindings: &'a [ColumnBinding],
+        row_index: usize,
+        bind_offset: usize,
+    ) -> BoundRowWriter<'a> {
+        BoundRowWriter {
+            bindings,
+            next_binding: 0,
+            row_index,
+            bind_offset,
+            outcome: RowOutcome::Success,
+            last_column_read: 0,
+        }
+    }
+
+    fn take_binding(&mut self, col: usize) -> Option<ColumnBinding> {
+        let ordinal = col + 1;
+        while self
+            .bindings
+            .get(self.next_binding)
+            .is_some_and(|binding| usize::from(binding.column_number) < ordinal)
+        {
+            self.next_binding += 1;
+        }
+        let binding = *self.bindings.get(self.next_binding)?;
+        if usize::from(binding.column_number) != ordinal {
+            return None;
+        }
+        self.next_binding += 1;
+        self.last_column_read = ordinal;
+        Some(binding)
+    }
+
+    fn write_value(&mut self, col: usize, value: ColumnValues) {
+        let Some(binding) = self.take_binding(col) else {
+            return;
+        };
+        let delivered =
+            unsafe { deliver_bound(&binding, self.row_index, self.bind_offset, &value) };
+        self.outcome = self.outcome.merge(delivered);
+    }
+
+    fn write_exact<T, F>(&mut self, col: usize, target_type: SqlSmallInt, value: T, fallback: F)
+    where
+        T: Copy,
+        F: FnOnce() -> ColumnValues,
+    {
+        let Some(binding) = self.take_binding(col) else {
+            return;
+        };
+        let delivered = if binding.target_type == target_type {
+            unsafe { deliver_fixed_bound(&binding, self.row_index, self.bind_offset, value) }
+        } else {
+            unsafe { deliver_bound(&binding, self.row_index, self.bind_offset, &fallback()) }
+        };
+        self.outcome = self.outcome.merge(delivered);
+    }
+
+    fn write_temporal<T, P, C, V>(
+        &mut self,
+        col: usize,
+        target_type: SqlSmallInt,
+        parts: P,
+        convert: C,
+        value: V,
+    ) where
+        T: Copy,
+        P: FnOnce() -> Option<DateTimeParts>,
+        C: FnOnce(DateTimeParts) -> T,
+        V: FnOnce() -> ColumnValues,
+    {
+        let Some(binding) = self.take_binding(col) else {
+            return;
+        };
+        let delivered = if binding.target_type == target_type {
+            match parts() {
+                Some(parts) => unsafe {
+                    deliver_fixed_bound(&binding, self.row_index, self.bind_offset, convert(parts))
+                },
+                None => RowOutcome::Error(RowIssue::Restricted),
+            }
+        } else {
+            unsafe { deliver_bound(&binding, self.row_index, self.bind_offset, &value()) }
+        };
+        self.outcome = self.outcome.merge(delivered);
+    }
+}
+
+impl RowWriter for BoundRowWriter<'_> {
+    fn write_null(&mut self, col: usize) {
+        self.write_value(col, ColumnValues::Null);
+    }
+
+    fn write_bool(&mut self, col: usize, val: bool) {
+        self.write_exact(col, SQL_C_BIT, u8::from(val), || ColumnValues::Bit(val));
+    }
+
+    fn write_u8(&mut self, col: usize, val: u8) {
+        self.write_exact(col, SQL_C_UTINYINT, val, || ColumnValues::TinyInt(val));
+    }
+
+    fn write_i16(&mut self, col: usize, val: i16) {
+        self.write_exact(col, SQL_C_SSHORT, val, || ColumnValues::SmallInt(val));
+    }
+
+    fn write_i32(&mut self, col: usize, val: i32) {
+        self.write_exact(col, SQL_C_SLONG, val, || ColumnValues::Int(val));
+    }
+
+    fn write_i64(&mut self, col: usize, val: i64) {
+        self.write_exact(col, SQL_C_SBIGINT, val, || ColumnValues::BigInt(val));
+    }
+
+    fn write_f32(&mut self, col: usize, val: f32) {
+        self.write_exact(col, SQL_C_FLOAT, val, || ColumnValues::Real(val));
+    }
+
+    fn write_f64(&mut self, col: usize, val: f64) {
+        self.write_exact(col, SQL_C_DOUBLE, val, || ColumnValues::Float(val));
+    }
+
+    fn write_string(&mut self, col: usize, bytes: Cow<'_, [u8]>, encoding: EncodingType) {
+        let Some(binding) = self.take_binding(col) else {
+            return;
+        };
+        let delivered = unsafe {
+            deliver_encoded_string(&binding, self.row_index, self.bind_offset, bytes, encoding)
+        };
+        self.outcome = self.outcome.merge(delivered);
+    }
+
+    fn write_bytes(&mut self, col: usize, bytes: Cow<'_, [u8]>) {
+        self.write_value(col, ColumnValues::Bytes(bytes.into_owned()));
+    }
+
+    fn write_decimal(&mut self, col: usize, val: DecimalParts) {
+        self.write_value(col, ColumnValues::Decimal(val));
+    }
+
+    fn write_numeric(&mut self, col: usize, val: DecimalParts) {
+        self.write_value(col, ColumnValues::Numeric(val));
+    }
+
+    fn write_date(&mut self, col: usize, val: SqlDate) {
+        self.write_temporal(
+            col,
+            SQL_C_TYPE_DATE,
+            || Some(date_parts(&val)),
+            |parts| SqlDateStruct {
+                year: parts.year,
+                month: parts.month,
+                day: parts.day,
+            },
+            || ColumnValues::Date(val.clone()),
+        );
+    }
+
+    fn write_time(&mut self, col: usize, val: SqlTime) {
+        self.write_temporal(
+            col,
+            SQL_C_SS_TIME2,
+            || Some(time_parts(&val)),
+            |parts| SqlSsTime2Struct {
+                hour: parts.hour,
+                minute: parts.minute,
+                second: parts.second,
+                fraction: parts.fraction_ns,
+            },
+            || ColumnValues::Time(val.clone()),
+        );
+    }
+
+    fn write_datetime(&mut self, col: usize, val: SqlDateTime) {
+        self.write_value(col, ColumnValues::DateTime(val));
+    }
+
+    fn write_smalldatetime(&mut self, col: usize, val: SqlSmallDateTime) {
+        self.write_value(col, ColumnValues::SmallDateTime(val));
+    }
+
+    fn write_datetime2(&mut self, col: usize, val: SqlDateTime2) {
+        self.write_temporal(
+            col,
+            SQL_C_TYPE_TIMESTAMP,
+            || Some(datetime2_parts(&val)),
+            |parts| SqlTimestampStruct {
+                year: parts.year,
+                month: parts.month,
+                day: parts.day,
+                hour: parts.hour,
+                minute: parts.minute,
+                second: parts.second,
+                fraction: parts.fraction_ns,
+            },
+            || ColumnValues::DateTime2(val.clone()),
+        );
+    }
+
+    fn write_datetimeoffset(&mut self, col: usize, val: SqlDateTimeOffset) {
+        self.write_temporal(
+            col,
+            SQL_C_SS_TIMESTAMPOFFSET,
+            || datetimeoffset_parts(&val),
+            |parts| SqlSsTimestampoffsetStruct {
+                year: parts.year,
+                month: parts.month,
+                day: parts.day,
+                hour: parts.hour,
+                minute: parts.minute,
+                second: parts.second,
+                fraction: parts.fraction_ns,
+                timezone_hour: parts.tz_hour,
+                timezone_minute: parts.tz_minute,
+            },
+            || ColumnValues::DateTimeOffset(val.clone()),
+        );
+    }
+
+    fn write_money(&mut self, col: usize, val: SqlMoney) {
+        self.write_value(col, ColumnValues::Money(val));
+    }
+
+    fn write_smallmoney(&mut self, col: usize, val: SqlSmallMoney) {
+        self.write_value(col, ColumnValues::SmallMoney(val));
+    }
+
+    fn write_uuid(&mut self, col: usize, val: Uuid) {
+        let (data1, data2, data3, data4) = val.as_fields();
+        self.write_exact(
+            col,
+            SQL_C_GUID,
+            SqlGuid {
+                data1,
+                data2,
+                data3,
+                data4: *data4,
+            },
+            || ColumnValues::Uuid(val),
+        );
+    }
+
+    fn write_xml(&mut self, col: usize, val: SqlXml) {
+        self.write_value(col, ColumnValues::Xml(val));
+    }
+
+    fn write_json(&mut self, col: usize, val: SqlJson) {
+        self.write_value(col, ColumnValues::Json(val));
+    }
+
+    fn write_vector(&mut self, col: usize, val: SqlVector) {
+        self.write_value(col, ColumnValues::Vector(val));
+    }
+
+    fn write_variant_base_type(&mut self, _col: usize, _base: TdsDataType) {}
+
+    fn end_row(&mut self) {}
 }
 
 fn fetch_scroll_safe(
@@ -380,53 +669,102 @@ fn fill_rowset(
     // Read once per fetch, not once per bind, so an application can move the
     // whole rowset between calls by updating the pointed-to value.
     let bind_offset = unsafe { read_bind_offset(row_bind_offset_ptr) };
+    let can_write_complete_rows = bindings
+        .last()
+        .is_some_and(|binding| binding.column_number as usize == column_count)
+        && client.current_result_supports_row_into();
 
-    while rows_filled < row_budget {
-        match dbc.runtime.block_on(client.next_row_cursor()) {
-            Ok(true) => {}
-            Ok(false) => break,
-            Err(e) => {
-                fetch_error = Some(e);
-                break;
-            }
-        }
-
+    for _ in row_slots(row_budget) {
         let mut outcome = RowOutcome::Success;
         let mut columns_read = 0usize;
-        for binding in bindings {
-            let column = binding.column_number as usize;
-            if column == 0 || column > column_count {
-                // msodbcsql skips a binding whose ordinal is past the end of
-                // this result set and reports nothing -- a binding left over
-                // from a wider one is not an error there, so it is not one
-                // here either.
-                continue;
-            }
-            let pulled = dbc.runtime.block_on(client.read_row_column(column - 1));
-            columns_read = column;
-            let result = match pulled {
-                Ok(CursorColumn::Value { value, .. }) => unsafe {
-                    deliver_bound(binding, rows_filled as usize, bind_offset, &value)
-                },
-                // A bound long/LOB column would have to be drained into the
-                // fixed buffer here; that path is owned by SQLGetData today, so
-                // report the row rather than deliver a wrong value (AB#47361).
-                // Abandoning the stream is safe: the next `read_row_column`
-                // finishes off a paused PLP value before it decodes anything.
-                Ok(CursorColumn::PlpStreaming { .. }) => RowOutcome::Error(RowIssue::Unsupported),
-                // Reading ascending and once per column, neither of these is
-                // reachable; treat them as a row error rather than assuming.
-                Ok(CursorColumn::RowEnded) | Ok(CursorColumn::AlreadyConsumed) => {
-                    RowOutcome::Error(RowIssue::Restricted)
+        if can_write_complete_rows {
+            let mut writer = BoundRowWriter::new(bindings, rows_filled as usize, bind_offset);
+            let result = match client.try_next_buffered_row_into(&mut writer) {
+                Ok(BufferedRowPoll::Complete) => Ok(()),
+                Ok(BufferedRowPoll::Partial) => {
+                    dbc.runtime.block_on(client.finish_row_into(&mut writer))
                 }
-                Err(e) => {
-                    fetch_error = Some(e);
-                    RowOutcome::Error(RowIssue::Restricted)
+                Ok(BufferedRowPoll::Exhausted) => break,
+                Ok(BufferedRowPoll::Pending) => {
+                    let cursor_poll = client.try_next_row_cursor();
+                    match resolve_cursor_poll(cursor_poll, || {
+                        dbc.runtime.block_on(client.next_row_cursor())
+                    }) {
+                        Ok(true) => match client.try_finish_row_into(&mut writer) {
+                            Ok(true) => Ok(()),
+                            Ok(false) => dbc.runtime.block_on(client.finish_row_into(&mut writer)),
+                            Err(error) => Err(error),
+                        },
+                        Ok(false) => break,
+                        Err(error) => {
+                            fetch_error = Some(error);
+                            break;
+                        }
+                    }
                 }
+                Err(error) => Err(error),
             };
-            outcome = outcome.merge(result);
-            if fetch_error.is_some() {
-                break;
+            if let Err(error) = result {
+                fetch_error = Some(error);
+                outcome = outcome.merge(RowOutcome::Error(RowIssue::Restricted));
+            } else {
+                columns_read = writer.last_column_read;
+                outcome = outcome.merge(writer.outcome);
+            }
+        } else {
+            let cursor_poll = client.try_next_row_cursor();
+            match resolve_cursor_poll(cursor_poll, || {
+                dbc.runtime.block_on(client.next_row_cursor())
+            }) {
+                Ok(true) => {}
+                Ok(false) => break,
+                Err(error) => {
+                    fetch_error = Some(error);
+                    break;
+                }
+            }
+
+            for binding in bindings {
+                let column = binding.column_number as usize;
+                if column == 0 || column > column_count {
+                    // msodbcsql skips a binding whose ordinal is past the end of
+                    // this result set and reports nothing -- a binding left over
+                    // from a wider one is not an error there, so it is not one
+                    // here either.
+                    continue;
+                }
+                let target = column - 1;
+                let cursor_poll = client.try_read_row_column(target);
+                let pulled = resolve_cursor_poll(cursor_poll, || {
+                    dbc.runtime.block_on(client.read_row_column(target))
+                });
+                columns_read = column;
+                let result = match pulled {
+                    Ok(CursorColumn::Value { value, .. }) => unsafe {
+                        deliver_bound(binding, rows_filled as usize, bind_offset, &value)
+                    },
+                    // A bound long/LOB column would have to be drained into the
+                    // fixed buffer here; that path is owned by SQLGetData today, so
+                    // report the row rather than deliver a wrong value (AB#47361).
+                    // Abandoning the stream is safe: the next `read_row_column`
+                    // finishes off a paused PLP value before it decodes anything.
+                    Ok(CursorColumn::PlpStreaming { .. }) => {
+                        RowOutcome::Error(RowIssue::Unsupported)
+                    }
+                    // Reading ascending and once per column, neither of these is
+                    // reachable; treat them as a row error rather than assuming.
+                    Ok(CursorColumn::RowEnded) | Ok(CursorColumn::AlreadyConsumed) => {
+                        RowOutcome::Error(RowIssue::Restricted)
+                    }
+                    Err(e) => {
+                        fetch_error = Some(e);
+                        RowOutcome::Error(RowIssue::Restricted)
+                    }
+                };
+                outcome = outcome.merge(result);
+                if fetch_error.is_some() {
+                    break;
+                }
             }
         }
         last_column_read = columns_read;
@@ -568,6 +906,10 @@ fn row_budget(max_rows: SqlULen, rows_returned: SqlULen, row_array_size: SqlULen
     row_array_size.min(max_rows.saturating_sub(rows_returned))
 }
 
+fn row_slots(row_budget: SqlULen) -> std::ops::Range<SqlULen> {
+    0..row_budget
+}
+
 /// Writes `SQL_ROW_NOROW` into the unused tail of the row status array.
 fn mark_no_rows(row_status_ptr: *mut SqlUSmallInt, from: SqlULen, row_array_size: SqlULen) {
     if row_status_ptr.is_null() {
@@ -621,6 +963,90 @@ unsafe fn read_bind_offset(ptr: *mut SqlULen) -> usize {
         return 0;
     }
     unsafe { ptr.read_unaligned() }
+}
+
+unsafe fn deliver_encoded_string(
+    binding: &ColumnBinding,
+    row_index: usize,
+    bind_offset: usize,
+    bytes: Cow<'_, [u8]>,
+    encoding: EncodingType,
+) -> RowOutcome {
+    let direct_char = binding.target_type == SQL_C_CHAR
+        && (matches!(encoding, EncodingType::Utf8) && std::str::from_utf8(&bytes).is_ok()
+            || matches!(encoding, EncodingType::LcidBased(_)) && bytes.is_ascii());
+    let direct_wchar = binding.target_type == SQL_C_WCHAR
+        && matches!(encoding, EncodingType::Utf16)
+        && bytes.len().is_multiple_of(2)
+        && std::char::decode_utf16(
+            bytes
+                .chunks_exact(2)
+                .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]])),
+        )
+        .all(|unit| unit.is_ok());
+
+    if !direct_char && !direct_wchar {
+        return unsafe {
+            deliver_bound(
+                binding,
+                row_index,
+                bind_offset,
+                &ColumnValues::String(SqlString::new(bytes.into_owned(), encoding)),
+            )
+        };
+    }
+
+    let stride = element_stride(binding.target_type, binding.buffer_length);
+    let indicator = if binding.strlen_or_ind_ptr.is_null() {
+        std::ptr::null_mut()
+    } else {
+        unsafe {
+            (binding.strlen_or_ind_ptr as *mut u8)
+                .add(bind_offset)
+                .cast::<SqlLen>()
+                .add(row_index)
+        }
+    };
+    let slot =
+        unsafe { (binding.target_value_ptr as *mut u8).add(bind_offset + row_index * stride) };
+
+    if direct_char {
+        unsafe { write_if_some(indicator, bytes.len() as SqlLen) };
+        return if unsafe { copy_with_nul(slot, stride, &bytes) } {
+            RowOutcome::Info(RowIssue::StringTruncated)
+        } else {
+            RowOutcome::Success
+        };
+    }
+
+    let source_len = bytes.len() / 2;
+    unsafe { write_if_some(indicator, bytes.len() as SqlLen) };
+    if slot.is_null() {
+        return RowOutcome::Success;
+    }
+    let buf_elements = char_buf_elements(binding.target_type, stride);
+    if buf_elements == 0 {
+        return if source_len == 0 {
+            RowOutcome::Success
+        } else {
+            RowOutcome::Info(RowIssue::StringTruncated)
+        };
+    }
+    let destination = slot.cast::<SqlWChar>();
+    let copy_len = source_len.min(buf_elements - 1);
+    for (index, chunk) in bytes.chunks_exact(2).take(copy_len).enumerate() {
+        unsafe {
+            destination
+                .add(index)
+                .write_unaligned(u16::from_le_bytes([chunk[0], chunk[1]]))
+        };
+    }
+    unsafe { destination.add(copy_len).write_unaligned(0) };
+    if copy_len < source_len {
+        RowOutcome::Info(RowIssue::StringTruncated)
+    } else {
+        RowOutcome::Success
+    }
 }
 
 /// Writes one column value into its bound buffer slot for row `row_index`.
@@ -717,6 +1143,33 @@ unsafe fn deliver_bound(
             return RowOutcome::Info(RowIssue::StringTruncated);
         }
     }
+    RowOutcome::Success
+}
+
+unsafe fn deliver_fixed_bound<T: Copy>(
+    binding: &ColumnBinding,
+    row_index: usize,
+    bind_offset: usize,
+    value: T,
+) -> RowOutcome {
+    let stride = element_stride(binding.target_type, binding.buffer_length);
+    let indicator = if binding.strlen_or_ind_ptr.is_null() {
+        std::ptr::null_mut()
+    } else {
+        unsafe {
+            (binding.strlen_or_ind_ptr as *mut u8)
+                .add(bind_offset)
+                .cast::<SqlLen>()
+                .add(row_index)
+        }
+    };
+    if !binding.target_value_ptr.is_null() {
+        let slot =
+            unsafe { (binding.target_value_ptr as *mut u8).add(bind_offset + row_index * stride) };
+        unsafe { slot.cast::<T>().write_unaligned(value) };
+    }
+    let size = SqlLen::try_from(std::mem::size_of::<T>()).unwrap_or(SqlLen::MAX);
+    unsafe { write_if_some(indicator, size) };
     RowOutcome::Success
 }
 
@@ -898,6 +1351,14 @@ mod tests {
         // before this, so the budget only has to stay total, not underflow.
         assert_eq!(row_budget(5, 5, 4), 0);
         assert_eq!(row_budget(5, 9, 4), 0);
+    }
+
+    #[test]
+    fn max_rows_bounds_the_whole_row_dispatch_loop() {
+        let budget = row_budget(5, 4, 4);
+        let dispatches = row_slots(budget).count();
+
+        assert_eq!(dispatches, 1);
     }
 
     /// The cap is per result set, so advancing onto a new one must restart the
@@ -1215,6 +1676,71 @@ mod tests {
         }
         assert_eq!(buf, [10, 20, 30, 0]);
         assert_eq!(ind[0], 4);
+    }
+
+    #[test]
+    fn bound_row_writer_delivers_borrowed_character_data() {
+        let mut narrow = [0u8; 8];
+        let mut narrow_ind = [0 as SqlLen; 1];
+        let narrow_binding = binding(
+            1,
+            SQL_C_CHAR,
+            narrow.as_mut_ptr() as SqlPointer,
+            narrow.len() as SqlLen,
+            narrow_ind.as_mut_ptr(),
+        );
+        let mut wide = [0u16; 8];
+        let mut wide_ind = [0 as SqlLen; 1];
+        let wide_binding = binding(
+            2,
+            SQL_C_WCHAR,
+            wide.as_mut_ptr() as SqlPointer,
+            std::mem::size_of_val(&wide) as SqlLen,
+            wide_ind.as_mut_ptr(),
+        );
+        let bindings = [narrow_binding, wide_binding];
+        let mut writer = BoundRowWriter::new(&bindings, 0, 0);
+
+        writer.write_string(0, Cow::Borrowed(b"hello"), EncodingType::Utf8);
+        writer.write_string(1, Cow::Borrowed(b"h\0i\0"), EncodingType::Utf16);
+
+        assert_eq!(&narrow[..6], b"hello\0");
+        assert_eq!(narrow_ind[0], 5);
+        assert_eq!(&wide[..3], &[b'h' as u16, b'i' as u16, 0]);
+        assert_eq!(wide_ind[0], 4);
+        assert!(matches!(writer.outcome, RowOutcome::Success));
+        assert_eq!(writer.last_column_read, 2);
+    }
+
+    #[test]
+    fn bound_row_writer_skips_unbound_columns_without_losing_ordinal() {
+        let mut first = [0i32; 1];
+        let mut third = [0i32; 1];
+        let bindings = [
+            binding(
+                1,
+                SQL_C_SLONG,
+                first.as_mut_ptr() as SqlPointer,
+                0,
+                ptr::null_mut(),
+            ),
+            binding(
+                3,
+                SQL_C_SLONG,
+                third.as_mut_ptr() as SqlPointer,
+                0,
+                ptr::null_mut(),
+            ),
+        ];
+        let mut writer = BoundRowWriter::new(&bindings, 0, 0);
+
+        writer.write_i32(0, 10);
+        writer.write_i32(1, 20);
+        writer.write_i32(2, 30);
+
+        assert_eq!(first[0], 10);
+        assert_eq!(third[0], 30);
+        assert_eq!(writer.last_column_read, 3);
     }
 
     /// NULL is reported through the indicator; the data slot is left alone for

--- a/mssql-odbc/src/api/fetch_scroll.rs
+++ b/mssql-odbc/src/api/fetch_scroll.rs
@@ -131,7 +131,7 @@ impl RowIssue {
 }
 
 /// The per-row outcome recorded in the row status array.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum RowOutcome {
     Success,
     Info(RowIssue),
@@ -674,7 +674,7 @@ fn fill_rowset(
         .is_some_and(|binding| binding.column_number as usize == column_count)
         && client.current_result_supports_row_into();
 
-    for _ in row_slots(row_budget) {
+    dispatch_rows(row_budget, |_| {
         let mut outcome = RowOutcome::Success;
         let mut columns_read = 0usize;
         if can_write_complete_rows {
@@ -684,7 +684,7 @@ fn fill_rowset(
                 Ok(BufferedRowPoll::Partial) => {
                     dbc.runtime.block_on(client.finish_row_into(&mut writer))
                 }
-                Ok(BufferedRowPoll::Exhausted) => break,
+                Ok(BufferedRowPoll::Exhausted) => return false,
                 Ok(BufferedRowPoll::Pending) => {
                     let cursor_poll = client.try_next_row_cursor();
                     match cursor_poll.and_then(|poll| {
@@ -695,10 +695,10 @@ fn fill_rowset(
                             Ok(false) => dbc.runtime.block_on(client.finish_row_into(&mut writer)),
                             Err(error) => Err(error),
                         },
-                        Ok(false) => break,
+                        Ok(false) => return false,
                         Err(error) => {
                             fetch_error = Some(error);
-                            break;
+                            return false;
                         }
                     }
                 }
@@ -717,10 +717,10 @@ fn fill_rowset(
                 .and_then(|poll| poll.resolve(|| dbc.runtime.block_on(client.next_row_cursor())))
             {
                 Ok(true) => {}
-                Ok(false) => break,
+                Ok(false) => return false,
                 Err(error) => {
                     fetch_error = Some(error);
-                    break;
+                    return false;
                 }
             }
 
@@ -773,10 +773,8 @@ fn fill_rowset(
         worst = worst.merge(outcome);
         rows_filled += 1;
 
-        if fetch_error.is_some() {
-            break;
-        }
-    }
+        fetch_error.is_none()
+    });
 
     // A zero-row end of set returns SQL_NO_DATA, which cannot carry
     // SQL_SUCCESS_WITH_INFO, so anything drained here would be posted under a
@@ -906,8 +904,14 @@ fn row_budget(max_rows: SqlULen, rows_returned: SqlULen, row_array_size: SqlULen
     row_array_size.min(max_rows.saturating_sub(rows_returned))
 }
 
-fn row_slots(row_budget: SqlULen) -> std::ops::Range<SqlULen> {
-    0..row_budget
+/// Calls `dispatch` for consecutive row slots until the budget is spent or the
+/// callback reports that no later row should be attempted.
+fn dispatch_rows(row_budget: SqlULen, mut dispatch: impl FnMut(SqlULen) -> bool) {
+    for row in 0..row_budget {
+        if !dispatch(row) {
+            break;
+        }
+    }
 }
 
 /// Writes `SQL_ROW_NOROW` into the unused tail of the row status array.
@@ -965,6 +969,13 @@ unsafe fn read_bind_offset(ptr: *mut SqlULen) -> usize {
     unsafe { ptr.read_unaligned() }
 }
 
+/// Writes already-encoded character data into one bound row slot.
+///
+/// # Safety
+///
+/// The binding's target and indicator pointers, after applying `bind_offset`
+/// and `row_index`, must be valid for their declared slot sizes. The writable
+/// target slot must not overlap `bytes`.
 unsafe fn deliver_encoded_string(
     binding: &ColumnBinding,
     row_index: usize,
@@ -1146,6 +1157,13 @@ unsafe fn deliver_bound(
     RowOutcome::Success
 }
 
+/// Writes one exact fixed-width value and its byte-count indicator.
+///
+/// # Safety
+///
+/// The binding's target pointer, after applying `bind_offset` and `row_index`,
+/// must be null or writable for `T`; its displaced indicator pointer must be
+/// null or writable for one `SqlLen`.
 unsafe fn deliver_fixed_bound<T: Copy>(
     binding: &ColumnBinding,
     row_index: usize,
@@ -1356,9 +1374,15 @@ mod tests {
     #[test]
     fn max_rows_bounds_the_whole_row_dispatch_loop() {
         let budget = row_budget(5, 4, 4);
-        let dispatches = row_slots(budget).count();
+        let mut buffered_rows = vec![10, 20, 30];
+        let mut delivered = Vec::new();
+        dispatch_rows(budget, |_| {
+            delivered.push(buffered_rows.remove(0));
+            true
+        });
 
-        assert_eq!(dispatches, 1);
+        assert_eq!(delivered, vec![10]);
+        assert_eq!(buffered_rows, vec![20, 30]);
     }
 
     /// The cap is per result set, so advancing onto a new one must restart the
@@ -1741,6 +1765,171 @@ mod tests {
         assert_eq!(first[0], 10);
         assert_eq!(third[0], 30);
         assert_eq!(writer.last_column_read, 3);
+    }
+
+    #[test]
+    fn bound_row_writer_matches_established_conversion_path() {
+        macro_rules! check {
+            ($target:expr, $target_rust_type:ty, $column_value:expr, $write:expr) => {{
+                let value = $column_value;
+                let mut direct_data = [0xA5_u8; 256];
+                let mut baseline_data = direct_data;
+                let mut direct_ind = [0xA5_u8; 32];
+                let mut baseline_ind = direct_ind;
+                let direct_binding = binding(
+                    1,
+                    $target,
+                    unsafe { direct_data.as_mut_ptr().add(1) }.cast(),
+                    64,
+                    unsafe { direct_ind.as_mut_ptr().add(1) }.cast(),
+                );
+                let baseline_binding = binding(
+                    1,
+                    $target,
+                    unsafe { baseline_data.as_mut_ptr().add(1) }.cast(),
+                    64,
+                    unsafe { baseline_ind.as_mut_ptr().add(1) }.cast(),
+                );
+                let bindings = [direct_binding];
+                let mut writer = BoundRowWriter::new(&bindings, 1, 1);
+
+                $write(&mut writer);
+                let expected = unsafe { deliver_bound(&baseline_binding, 1, 1, &value) };
+                let slot_offset = 2 + element_stride($target, 64);
+                let direct_value = unsafe {
+                    direct_data
+                        .as_ptr()
+                        .add(slot_offset)
+                        .cast::<$target_rust_type>()
+                        .read_unaligned()
+                };
+                let baseline_value = unsafe {
+                    baseline_data
+                        .as_ptr()
+                        .add(slot_offset)
+                        .cast::<$target_rust_type>()
+                        .read_unaligned()
+                };
+
+                assert_eq!(writer.outcome, expected);
+                assert_eq!(direct_value, baseline_value);
+                assert_eq!(direct_ind, baseline_ind);
+            }};
+        }
+
+        check!(
+            SQL_C_BIT,
+            u8,
+            ColumnValues::Bit(true),
+            |w: &mut BoundRowWriter<'_>| w.write_bool(0, true)
+        );
+        check!(
+            SQL_C_UTINYINT,
+            u8,
+            ColumnValues::TinyInt(0xFE),
+            |w: &mut BoundRowWriter<'_>| w.write_u8(0, 0xFE)
+        );
+        check!(
+            SQL_C_SSHORT,
+            i16,
+            ColumnValues::SmallInt(-1234),
+            |w: &mut BoundRowWriter<'_>| w.write_i16(0, -1234)
+        );
+        check!(
+            SQL_C_SLONG,
+            i32,
+            ColumnValues::Int(-123_456),
+            |w: &mut BoundRowWriter<'_>| w.write_i32(0, -123_456)
+        );
+        check!(
+            SQL_C_SBIGINT,
+            i64,
+            ColumnValues::BigInt(-9_876_543_210),
+            |w: &mut BoundRowWriter<'_>| w.write_i64(0, -9_876_543_210)
+        );
+        check!(
+            SQL_C_FLOAT,
+            f32,
+            ColumnValues::Real(12.5),
+            |w: &mut BoundRowWriter<'_>| w.write_f32(0, 12.5)
+        );
+        check!(
+            SQL_C_DOUBLE,
+            f64,
+            ColumnValues::Float(-42.25),
+            |w: &mut BoundRowWriter<'_>| w.write_f64(0, -42.25)
+        );
+
+        let date = SqlDate::create(738_000).unwrap();
+        check!(
+            SQL_C_TYPE_DATE,
+            SqlDateStruct,
+            ColumnValues::Date(date.clone()),
+            |w: &mut BoundRowWriter<'_>| w.write_date(0, date.clone())
+        );
+        let time = SqlTime {
+            time_nanoseconds: 45_296_123_456_700,
+            scale: 7,
+        };
+        check!(
+            SQL_C_SS_TIME2,
+            SqlSsTime2Struct,
+            ColumnValues::Time(time.clone()),
+            |w: &mut BoundRowWriter<'_>| w.write_time(0, time.clone())
+        );
+        let datetime2 = SqlDateTime2 {
+            days: 738_000,
+            time: time.clone(),
+        };
+        check!(
+            SQL_C_TYPE_TIMESTAMP,
+            SqlTimestampStruct,
+            ColumnValues::DateTime2(datetime2.clone()),
+            |w: &mut BoundRowWriter<'_>| w.write_datetime2(0, datetime2.clone())
+        );
+        let datetimeoffset = SqlDateTimeOffset {
+            datetime2: datetime2.clone(),
+            offset: -420,
+        };
+        check!(
+            SQL_C_SS_TIMESTAMPOFFSET,
+            SqlSsTimestampoffsetStruct,
+            ColumnValues::DateTimeOffset(datetimeoffset.clone()),
+            |w: &mut BoundRowWriter<'_>| w.write_datetimeoffset(0, datetimeoffset.clone())
+        );
+        let uuid = Uuid::from_u128(0x0011_2233_4455_6677_8899_aabb_ccdd_eeff);
+        check!(
+            SQL_C_GUID,
+            SqlGuid,
+            ColumnValues::Uuid(uuid),
+            |w: &mut BoundRowWriter<'_>| w.write_uuid(0, uuid)
+        );
+
+        let decimal = DecimalParts::new(true, 18, 4, 1_234_500);
+        check!(
+            SQL_C_CHAR,
+            [u8; 64],
+            ColumnValues::Decimal(decimal),
+            |w: &mut BoundRowWriter<'_>| w.write_decimal(0, decimal)
+        );
+        check!(
+            SQL_C_CHAR,
+            [u8; 64],
+            ColumnValues::Numeric(decimal),
+            |w: &mut BoundRowWriter<'_>| w.write_numeric(0, decimal)
+        );
+        check!(
+            SQL_C_SBIGINT,
+            i64,
+            ColumnValues::Int(-123_456),
+            |w: &mut BoundRowWriter<'_>| w.write_i32(0, -123_456)
+        );
+        check!(
+            SQL_C_SSHORT,
+            i16,
+            ColumnValues::BigInt(i64::MAX),
+            |w: &mut BoundRowWriter<'_>| w.write_i64(0, i64::MAX)
+        );
     }
 
     /// NULL is reported through the indicator; the data slot is left alone for

--- a/mssql-odbc/src/api/fetch_scroll.rs
+++ b/mssql-odbc/src/api/fetch_scroll.rs
@@ -167,6 +167,10 @@ impl RowOutcome {
     }
 }
 
+/// Writes one decoded TDS row into the application buffers bound by column.
+///
+/// `next_binding` and `last_column_read` survive a packet-boundary continuation,
+/// so the same instance must be passed back when the TDS decoder pauses mid-row.
 struct BoundRowWriter<'a> {
     bindings: &'a [ColumnBinding],
     next_binding: usize,
@@ -182,6 +186,7 @@ struct BoundRowWriter<'a> {
 unsafe impl Send for BoundRowWriter<'_> {}
 
 impl<'a> BoundRowWriter<'a> {
+    /// Starts writing one row at its rowset slot and bind-offset displacement.
     fn new(
         bindings: &'a [ColumnBinding],
         row_index: usize,
@@ -197,6 +202,8 @@ impl<'a> BoundRowWriter<'a> {
         }
     }
 
+    /// Advances the ordered binding cursor to `col`, returning its binding when
+    /// present and skipping unbound columns without losing the wire ordinal.
     fn take_binding(&mut self, col: usize) -> Option<ColumnBinding> {
         let ordinal = col + 1;
         while self
@@ -215,6 +222,7 @@ impl<'a> BoundRowWriter<'a> {
         Some(binding)
     }
 
+    /// Sends a materialized value through the established conversion path.
     fn write_value(&mut self, col: usize, value: ColumnValues) {
         let Some(binding) = self.take_binding(col) else {
             return;
@@ -224,6 +232,8 @@ impl<'a> BoundRowWriter<'a> {
         self.outcome = self.outcome.merge(delivered);
     }
 
+    /// Writes `value` directly when the bound C type is exact, otherwise lazily
+    /// materializes the equivalent `ColumnValues` for normal conversion.
     fn write_exact<T, F>(&mut self, col: usize, target_type: SqlSmallInt, value: T, fallback: F)
     where
         T: Copy,
@@ -240,6 +250,8 @@ impl<'a> BoundRowWriter<'a> {
         self.outcome = self.outcome.merge(delivered);
     }
 
+    /// Converts temporal parts directly into the matching ODBC struct, retaining
+    /// the normal conversion path for other C targets and range failures.
     fn write_temporal<T, P, C, V>(
         &mut self,
         col: usize,

--- a/mssql-odbc/src/api/fetch_scroll.rs
+++ b/mssql-odbc/src/api/fetch_scroll.rs
@@ -1217,7 +1217,8 @@ mod tests {
     use crate::test_support::TestHandles;
     use mssql_tds::datatypes::sql_string::{EncodingType, SqlString};
     use mssql_tds::test_client_support::{
-        col_metadata_empty, done_no_more, int_columns, tds_client_from_tokens,
+        col_metadata_empty, done_no_more, int_columns, tds_client_from_int_rows,
+        tds_client_from_tokens,
     };
 
     fn binding(
@@ -1373,16 +1374,105 @@ mod tests {
 
     #[test]
     fn max_rows_bounds_the_whole_row_dispatch_loop() {
-        let budget = row_budget(5, 4, 4);
-        let mut buffered_rows = vec![10, 20, 30];
-        let mut delivered = Vec::new();
-        dispatch_rows(budget, |_| {
-            delivered.push(buffered_rows.remove(0));
-            true
-        });
+        let h = TestHandles::with_env_dbc_stmt();
+        h.mark_dbc_connected();
+        let mut values = [0_i32; 4];
+        let mut indicators = [0 as SqlLen; 4];
+        let mut statuses = [SQL_ROW_NOROW; 4];
+        let mut rows_fetched = 0;
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        {
+            let mut state = stmt.inner.lock().unwrap();
+            state.set_state(STMT_STATE_CURSOR_OPEN);
+            state.begin_result_set(int_columns(1));
+            state.max_rows = 5;
+            state.rows_returned = 4;
+            state.row_array_size = 4;
+            state.rows_fetched_ptr = &mut rows_fetched;
+            state.row_status_ptr = statuses.as_mut_ptr();
+            state.set_binding(binding(
+                1,
+                SQL_C_SLONG,
+                values.as_mut_ptr().cast(),
+                0,
+                indicators.as_mut_ptr(),
+            ));
+        }
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        let mut client = tds_client_from_int_rows(vec![vec![10], vec![20], vec![30]]);
+        dbc.runtime
+            .block_on(client.execute("SELECT buffered rows".to_string(), ()))
+            .unwrap();
+        {
+            let mut state = dbc.inner.lock().unwrap();
+            state.client = Some(client);
+            state.active_stmt = Some(h.stmt);
+        }
 
-        assert_eq!(delivered, vec![10]);
-        assert_eq!(buffered_rows, vec![20, 30]);
+        assert_eq!(
+            unsafe { sql_fetch_scroll(h.stmt, SQL_FETCH_NEXT, 0) },
+            SQL_SUCCESS
+        );
+        assert_eq!(rows_fetched, 1);
+        assert_eq!(values, [10, 0, 0, 0]);
+        assert_eq!(
+            statuses,
+            [SQL_ROW_SUCCESS, SQL_ROW_NOROW, SQL_ROW_NOROW, SQL_ROW_NOROW]
+        );
+        assert_eq!(stmt.inner.lock().unwrap().rows_returned, 5);
+
+        {
+            let mut state = stmt.inner.lock().unwrap();
+            state.max_rows = 0;
+            state.rows_returned = 0;
+            state.row_array_size = 1;
+        }
+        assert_eq!(
+            unsafe { sql_fetch_scroll(h.stmt, SQL_FETCH_NEXT, 0) },
+            SQL_SUCCESS
+        );
+        assert_eq!(
+            values[0], 20,
+            "the capped fetch consumed only the first row"
+        );
+    }
+
+    #[test]
+    fn partial_binding_uses_the_column_cursor_path() {
+        let h = TestHandles::with_env_dbc_stmt();
+        h.mark_dbc_connected();
+        let mut value = 0_i32;
+        let mut indicator = 0;
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        {
+            let mut state = stmt.inner.lock().unwrap();
+            state.set_state(STMT_STATE_CURSOR_OPEN);
+            state.begin_result_set(int_columns(2));
+            state.set_binding(binding(
+                1,
+                SQL_C_SLONG,
+                (&mut value as *mut i32).cast(),
+                0,
+                &mut indicator,
+            ));
+        }
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        let mut client = tds_client_from_int_rows(vec![vec![10, 20]]);
+        dbc.runtime
+            .block_on(client.execute("SELECT partial binding".to_string(), ()))
+            .unwrap();
+        {
+            let mut state = dbc.inner.lock().unwrap();
+            state.client = Some(client);
+            state.active_stmt = Some(h.stmt);
+        }
+
+        assert_eq!(
+            unsafe { sql_fetch_scroll(h.stmt, SQL_FETCH_NEXT, 0) },
+            SQL_SUCCESS
+        );
+        assert_eq!(value, 10);
+        assert_eq!(indicator, 4);
     }
 
     /// The cap is per result set, so advancing onto a new one must restart the
@@ -1867,6 +1957,12 @@ mod tests {
             ColumnValues::Date(date.clone()),
             |w: &mut BoundRowWriter<'_>| w.write_date(0, date.clone())
         );
+        check!(
+            SQL_C_CHAR,
+            [u8; 64],
+            ColumnValues::Date(date.clone()),
+            |w: &mut BoundRowWriter<'_>| w.write_date(0, date.clone())
+        );
         let time = SqlTime {
             time_nanoseconds: 45_296_123_456_700,
             scale: 7,
@@ -1874,6 +1970,12 @@ mod tests {
         check!(
             SQL_C_SS_TIME2,
             SqlSsTime2Struct,
+            ColumnValues::Time(time.clone()),
+            |w: &mut BoundRowWriter<'_>| w.write_time(0, time.clone())
+        );
+        check!(
+            SQL_C_CHAR,
+            [u8; 64],
             ColumnValues::Time(time.clone()),
             |w: &mut BoundRowWriter<'_>| w.write_time(0, time.clone())
         );
@@ -1887,6 +1989,12 @@ mod tests {
             ColumnValues::DateTime2(datetime2.clone()),
             |w: &mut BoundRowWriter<'_>| w.write_datetime2(0, datetime2.clone())
         );
+        check!(
+            SQL_C_CHAR,
+            [u8; 64],
+            ColumnValues::DateTime2(datetime2.clone()),
+            |w: &mut BoundRowWriter<'_>| w.write_datetime2(0, datetime2.clone())
+        );
         let datetimeoffset = SqlDateTimeOffset {
             datetime2: datetime2.clone(),
             offset: -420,
@@ -1897,10 +2005,22 @@ mod tests {
             ColumnValues::DateTimeOffset(datetimeoffset.clone()),
             |w: &mut BoundRowWriter<'_>| w.write_datetimeoffset(0, datetimeoffset.clone())
         );
+        check!(
+            SQL_C_CHAR,
+            [u8; 64],
+            ColumnValues::DateTimeOffset(datetimeoffset.clone()),
+            |w: &mut BoundRowWriter<'_>| w.write_datetimeoffset(0, datetimeoffset.clone())
+        );
         let uuid = Uuid::from_u128(0x0011_2233_4455_6677_8899_aabb_ccdd_eeff);
         check!(
             SQL_C_GUID,
             SqlGuid,
+            ColumnValues::Uuid(uuid),
+            |w: &mut BoundRowWriter<'_>| w.write_uuid(0, uuid)
+        );
+        check!(
+            SQL_C_CHAR,
+            [u8; 64],
             ColumnValues::Uuid(uuid),
             |w: &mut BoundRowWriter<'_>| w.write_uuid(0, uuid)
         );
@@ -1930,6 +2050,126 @@ mod tests {
             ColumnValues::BigInt(i64::MAX),
             |w: &mut BoundRowWriter<'_>| w.write_i64(0, i64::MAX)
         );
+        check!(
+            SQL_C_SLONG,
+            i32,
+            ColumnValues::Null,
+            |w: &mut BoundRowWriter<'_>| w.write_null(0)
+        );
+        check!(
+            SQL_C_CHAR,
+            [u8; 64],
+            ColumnValues::Bytes(vec![1, 2, 3]),
+            |w: &mut BoundRowWriter<'_>| w.write_bytes(0, Cow::Borrowed(&[1, 2, 3]))
+        );
+        let datetime = SqlDateTime {
+            days: 45_000,
+            time: 12_345,
+        };
+        check!(
+            SQL_C_TYPE_TIMESTAMP,
+            SqlTimestampStruct,
+            ColumnValues::DateTime(datetime.clone()),
+            |w: &mut BoundRowWriter<'_>| w.write_datetime(0, datetime.clone())
+        );
+        let smalldatetime = SqlSmallDateTime {
+            days: 45_000,
+            time: 754,
+        };
+        check!(
+            SQL_C_TYPE_TIMESTAMP,
+            SqlTimestampStruct,
+            ColumnValues::SmallDateTime(smalldatetime.clone()),
+            |w: &mut BoundRowWriter<'_>| w.write_smalldatetime(0, smalldatetime.clone())
+        );
+        let money = SqlMoney {
+            lsb_part: 123_450,
+            msb_part: 0,
+        };
+        check!(
+            SQL_C_CHAR,
+            [u8; 64],
+            ColumnValues::Money(money.clone()),
+            |w: &mut BoundRowWriter<'_>| w.write_money(0, money.clone())
+        );
+        let smallmoney = SqlSmallMoney { int_val: -123_450 };
+        check!(
+            SQL_C_CHAR,
+            [u8; 64],
+            ColumnValues::SmallMoney(smallmoney.clone()),
+            |w: &mut BoundRowWriter<'_>| w.write_smallmoney(0, smallmoney.clone())
+        );
+    }
+
+    #[test]
+    fn bound_row_writer_ignores_values_without_a_matching_binding() {
+        let mut value = 0_i32;
+        let bindings = [binding(
+            1,
+            SQL_C_SLONG,
+            (&mut value as *mut i32).cast(),
+            0,
+            ptr::null_mut(),
+        )];
+        let mut writer = BoundRowWriter::new(&bindings, 0, 0);
+
+        writer.write_i32(1, 42);
+        writer.write_string(2, Cow::Borrowed(b"unused"), EncodingType::Utf8);
+        writer.write_xml(3, SqlXml::from("<unused/>".to_string()));
+        writer.write_json(4, SqlJson::new(b"{}".to_vec()));
+        writer.write_vector(5, SqlVector::try_from_f32(vec![1.0]).unwrap());
+        writer.write_variant_base_type(2, TdsDataType::Int4);
+        writer.end_row();
+
+        assert_eq!(value, 0);
+    }
+
+    #[test]
+    fn bound_row_writer_covers_encoded_string_fallback_and_truncation() {
+        let mut invalid = [0_u8; 8];
+        let invalid_binding = binding(
+            1,
+            SQL_C_CHAR,
+            invalid.as_mut_ptr().cast(),
+            invalid.len() as SqlLen,
+            ptr::null_mut(),
+        );
+        let bindings = [invalid_binding];
+        let mut writer = BoundRowWriter::new(&bindings, 0, 0);
+        writer.write_string(0, Cow::Borrowed(&[0xFF]), EncodingType::Utf8);
+        assert_eq!(
+            writer.outcome,
+            RowOutcome::Error(RowIssue::InvalidCharacter)
+        );
+
+        let mut probe = [0_u16; 1];
+        let mut probe_indicator = 0;
+        let probe_binding = binding(
+            1,
+            SQL_C_WCHAR,
+            probe.as_mut_ptr().cast(),
+            0,
+            &mut probe_indicator,
+        );
+        let bindings = [probe_binding];
+        let mut writer = BoundRowWriter::new(&bindings, 0, 0);
+        writer.write_string(0, Cow::Borrowed(b"h\0"), EncodingType::Utf16);
+        assert_eq!(writer.outcome, RowOutcome::Info(RowIssue::StringTruncated));
+        assert_eq!(probe_indicator, 2);
+
+        let mut truncated = [0_u16; 2];
+        let truncated_binding = binding(
+            1,
+            SQL_C_WCHAR,
+            truncated.as_mut_ptr().cast(),
+            std::mem::size_of_val(&truncated) as SqlLen,
+            ptr::null_mut(),
+        );
+        let bindings = [truncated_binding];
+        let mut writer = BoundRowWriter::new(&bindings, 0, 0);
+        writer.write_string(0, Cow::Borrowed(b"h\0i\0"), EncodingType::Utf16);
+        assert_eq!(truncated, [u16::from(b'h'), 0]);
+        assert_eq!(writer.outcome, RowOutcome::Info(RowIssue::StringTruncated));
     }
 
     /// NULL is reported through the indicator; the data slot is left alone for

--- a/mssql-odbc/src/api/fetch_scroll.rs
+++ b/mssql-odbc/src/api/fetch_scroll.rs
@@ -674,7 +674,7 @@ fn fill_rowset(
         .is_some_and(|binding| binding.column_number as usize == column_count)
         && client.current_result_supports_row_into();
 
-    dispatch_rows(row_budget, |_| {
+    dispatch_rows(row_budget, || {
         let mut outcome = RowOutcome::Success;
         let mut columns_read = 0usize;
         if can_write_complete_rows {
@@ -906,9 +906,9 @@ fn row_budget(max_rows: SqlULen, rows_returned: SqlULen, row_array_size: SqlULen
 
 /// Calls `dispatch` for consecutive row slots until the budget is spent or the
 /// callback reports that no later row should be attempted.
-fn dispatch_rows(row_budget: SqlULen, mut dispatch: impl FnMut(SqlULen) -> bool) {
-    for row in 0..row_budget {
-        if !dispatch(row) {
+fn dispatch_rows(row_budget: SqlULen, mut dispatch: impl FnMut() -> bool) {
+    for _ in 0..row_budget {
+        if !dispatch() {
             break;
         }
     }
@@ -1218,7 +1218,7 @@ mod tests {
     use mssql_tds::datatypes::sql_string::{EncodingType, SqlString};
     use mssql_tds::test_client_support::{
         col_metadata_empty, done_no_more, int_columns, tds_client_from_int_rows,
-        tds_client_from_tokens,
+        tds_client_from_partial_int_rows, tds_client_from_tokens,
     };
 
     fn binding(
@@ -1473,6 +1473,83 @@ mod tests {
         );
         assert_eq!(value, 10);
         assert_eq!(indicator, 4);
+
+        let mut second = 0_i32;
+        let mut second_indicator = 0;
+        assert_eq!(
+            unsafe {
+                crate::api::get_data::sql_get_data(
+                    h.stmt,
+                    2,
+                    SQL_C_SLONG,
+                    (&mut second as *mut i32).cast(),
+                    0,
+                    &mut second_indicator,
+                )
+            },
+            SQL_SUCCESS
+        );
+        assert_eq!(second, 20);
+        assert_eq!(second_indicator, 4);
+    }
+
+    fn assert_partial_buffered_row_delivery(buffered_prefix_columns: usize) {
+        let h = TestHandles::with_env_dbc_stmt();
+        h.mark_dbc_connected();
+        let mut first = [0_i32; 2];
+        let mut second = [0_i32; 2];
+        let mut first_indicators = [0 as SqlLen; 2];
+        let mut second_indicators = [0 as SqlLen; 2];
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        {
+            let mut state = stmt.inner.lock().unwrap();
+            state.set_state(STMT_STATE_CURSOR_OPEN);
+            state.begin_result_set(int_columns(2));
+            state.set_binding(binding(
+                1,
+                SQL_C_SLONG,
+                first.as_mut_ptr().cast(),
+                0,
+                first_indicators.as_mut_ptr(),
+            ));
+            state.set_binding(binding(
+                2,
+                SQL_C_SLONG,
+                second.as_mut_ptr().cast(),
+                0,
+                second_indicators.as_mut_ptr(),
+            ));
+        }
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        let mut client =
+            tds_client_from_partial_int_rows(vec![vec![10, 20]], buffered_prefix_columns);
+        dbc.runtime
+            .block_on(client.execute("SELECT partial buffered row".to_string(), ()))
+            .unwrap();
+        {
+            let mut state = dbc.inner.lock().unwrap();
+            state.client = Some(client);
+            state.active_stmt = Some(h.stmt);
+        }
+
+        assert_eq!(
+            unsafe { sql_fetch_scroll(h.stmt, SQL_FETCH_NEXT, 0) },
+            SQL_SUCCESS
+        );
+        assert_eq!(first[0], 10);
+        assert_eq!(second[0], 20);
+        assert_eq!(first_indicators[0], 4);
+        assert_eq!(second_indicators[0], 4);
+    }
+
+    #[test]
+    fn bound_row_writer_survives_continuation_after_row_header() {
+        assert_partial_buffered_row_delivery(0);
+    }
+
+    #[test]
+    fn bound_row_writer_survives_continuation_after_first_column() {
+        assert_partial_buffered_row_delivery(1);
     }
 
     /// The cap is per result set, so advancing onto a new one must restart the

--- a/mssql-odbc/src/api/fetch_scroll.rs
+++ b/mssql-odbc/src/api/fetch_scroll.rs
@@ -48,7 +48,7 @@ use crate::api::odbc_types::{
     SqlGuid, SqlHandle, SqlLen, SqlPointer, SqlReturn, SqlSmallInt, SqlSsTime2Struct,
     SqlSsTimestampoffsetStruct, SqlTimestampStruct, SqlULen, SqlUSmallInt, SqlWChar,
 };
-use crate::api::util::{copy_with_nul, resolve_cursor_poll, write_if_some};
+use crate::api::util::{copy_with_nul, write_if_some};
 use crate::conversion::error::{ConvError, ConvOk};
 use crate::conversion::fetch_convert::{
     DateTimeParts, date_parts, datetime2_parts, datetimeoffset_parts, time_parts,
@@ -687,8 +687,8 @@ fn fill_rowset(
                 Ok(BufferedRowPoll::Exhausted) => break,
                 Ok(BufferedRowPoll::Pending) => {
                     let cursor_poll = client.try_next_row_cursor();
-                    match resolve_cursor_poll(cursor_poll, || {
-                        dbc.runtime.block_on(client.next_row_cursor())
+                    match cursor_poll.and_then(|poll| {
+                        poll.resolve(|| dbc.runtime.block_on(client.next_row_cursor()))
                     }) {
                         Ok(true) => match client.try_finish_row_into(&mut writer) {
                             Ok(true) => Ok(()),
@@ -713,9 +713,9 @@ fn fill_rowset(
             }
         } else {
             let cursor_poll = client.try_next_row_cursor();
-            match resolve_cursor_poll(cursor_poll, || {
-                dbc.runtime.block_on(client.next_row_cursor())
-            }) {
+            match cursor_poll
+                .and_then(|poll| poll.resolve(|| dbc.runtime.block_on(client.next_row_cursor())))
+            {
                 Ok(true) => {}
                 Ok(false) => break,
                 Err(error) => {
@@ -735,8 +735,8 @@ fn fill_rowset(
                 }
                 let target = column - 1;
                 let cursor_poll = client.try_read_row_column(target);
-                let pulled = resolve_cursor_poll(cursor_poll, || {
-                    dbc.runtime.block_on(client.read_row_column(target))
+                let pulled = cursor_poll.and_then(|poll| {
+                    poll.resolve(|| dbc.runtime.block_on(client.read_row_column(target)))
                 });
                 columns_read = column;
                 let result = match pulled {

--- a/mssql-odbc/src/api/fetch_scroll.rs
+++ b/mssql-odbc/src/api/fetch_scroll.rs
@@ -172,11 +172,17 @@ impl RowOutcome {
 /// `next_binding` and `last_column_read` survive a packet-boundary continuation,
 /// so the same instance must be passed back when the TDS decoder pauses mid-row.
 struct BoundRowWriter<'a> {
+    /// Ordered snapshot of the statement's bound columns.
     bindings: &'a [ColumnBinding],
+    /// Next binding that may match an incoming wire column.
     next_binding: usize,
+    /// Zero-based destination row within each bound column array.
     row_index: usize,
+    /// Byte displacement from `SQL_ATTR_ROW_BIND_OFFSET_PTR`.
     bind_offset: usize,
+    /// Worst conversion outcome observed for this row.
     outcome: RowOutcome,
+    /// Highest bound column ordinal consumed from the row.
     last_column_read: usize,
 }
 
@@ -283,38 +289,47 @@ impl<'a> BoundRowWriter<'a> {
 }
 
 impl RowWriter for BoundRowWriter<'_> {
+    /// Reports NULL through the bound indicator without disturbing fixed-width data.
     fn write_null(&mut self, col: usize) {
         self.write_value(col, ColumnValues::Null);
     }
 
+    /// Writes a `bit` directly when the target is `SQL_C_BIT`.
     fn write_bool(&mut self, col: usize, val: bool) {
         self.write_exact(col, SQL_C_BIT, u8::from(val), || ColumnValues::Bit(val));
     }
 
+    /// Writes a `tinyint` directly when the target is `SQL_C_UTINYINT`.
     fn write_u8(&mut self, col: usize, val: u8) {
         self.write_exact(col, SQL_C_UTINYINT, val, || ColumnValues::TinyInt(val));
     }
 
+    /// Writes a `smallint` directly when the target is `SQL_C_SSHORT`.
     fn write_i16(&mut self, col: usize, val: i16) {
         self.write_exact(col, SQL_C_SSHORT, val, || ColumnValues::SmallInt(val));
     }
 
+    /// Writes an `int` directly when the target is `SQL_C_SLONG`.
     fn write_i32(&mut self, col: usize, val: i32) {
         self.write_exact(col, SQL_C_SLONG, val, || ColumnValues::Int(val));
     }
 
+    /// Writes a `bigint` directly when the target is `SQL_C_SBIGINT`.
     fn write_i64(&mut self, col: usize, val: i64) {
         self.write_exact(col, SQL_C_SBIGINT, val, || ColumnValues::BigInt(val));
     }
 
+    /// Writes a `real` directly when the target is `SQL_C_FLOAT`.
     fn write_f32(&mut self, col: usize, val: f32) {
         self.write_exact(col, SQL_C_FLOAT, val, || ColumnValues::Real(val));
     }
 
+    /// Writes a `float` directly when the target is `SQL_C_DOUBLE`.
     fn write_f64(&mut self, col: usize, val: f64) {
         self.write_exact(col, SQL_C_DOUBLE, val, || ColumnValues::Float(val));
     }
 
+    /// Delivers borrowed wire text directly when its encoding matches the target.
     fn write_string(&mut self, col: usize, bytes: Cow<'_, [u8]>, encoding: EncodingType) {
         let Some(binding) = self.take_binding(col) else {
             return;
@@ -325,18 +340,22 @@ impl RowWriter for BoundRowWriter<'_> {
         self.outcome = self.outcome.merge(delivered);
     }
 
+    /// Materializes binary data for the established conversion path.
     fn write_bytes(&mut self, col: usize, bytes: Cow<'_, [u8]>) {
         self.write_value(col, ColumnValues::Bytes(bytes.into_owned()));
     }
 
+    /// Delivers a decoded `decimal` through the established conversion path.
     fn write_decimal(&mut self, col: usize, val: DecimalParts) {
         self.write_value(col, ColumnValues::Decimal(val));
     }
 
+    /// Delivers a decoded `numeric` through the established conversion path.
     fn write_numeric(&mut self, col: usize, val: DecimalParts) {
         self.write_value(col, ColumnValues::Numeric(val));
     }
 
+    /// Writes a `date` directly into `SQL_DATE_STRUCT` when requested.
     fn write_date(&mut self, col: usize, val: SqlDate) {
         self.write_temporal(
             col,
@@ -351,6 +370,7 @@ impl RowWriter for BoundRowWriter<'_> {
         );
     }
 
+    /// Writes a `time` directly into `SQL_SS_TIME2_STRUCT` when requested.
     fn write_time(&mut self, col: usize, val: SqlTime) {
         self.write_temporal(
             col,
@@ -366,14 +386,17 @@ impl RowWriter for BoundRowWriter<'_> {
         );
     }
 
+    /// Delivers legacy `datetime` through the established temporal converter.
     fn write_datetime(&mut self, col: usize, val: SqlDateTime) {
         self.write_value(col, ColumnValues::DateTime(val));
     }
 
+    /// Delivers `smalldatetime` through the established temporal converter.
     fn write_smalldatetime(&mut self, col: usize, val: SqlSmallDateTime) {
         self.write_value(col, ColumnValues::SmallDateTime(val));
     }
 
+    /// Writes `datetime2` directly into `SQL_TIMESTAMP_STRUCT` when requested.
     fn write_datetime2(&mut self, col: usize, val: SqlDateTime2) {
         self.write_temporal(
             col,
@@ -392,6 +415,7 @@ impl RowWriter for BoundRowWriter<'_> {
         );
     }
 
+    /// Writes directly into `SQL_SS_TIMESTAMPOFFSET_STRUCT` when requested.
     fn write_datetimeoffset(&mut self, col: usize, val: SqlDateTimeOffset) {
         self.write_temporal(
             col,
@@ -412,14 +436,17 @@ impl RowWriter for BoundRowWriter<'_> {
         );
     }
 
+    /// Delivers `money` through the established numeric conversion path.
     fn write_money(&mut self, col: usize, val: SqlMoney) {
         self.write_value(col, ColumnValues::Money(val));
     }
 
+    /// Delivers `smallmoney` through the established numeric conversion path.
     fn write_smallmoney(&mut self, col: usize, val: SqlSmallMoney) {
         self.write_value(col, ColumnValues::SmallMoney(val));
     }
 
+    /// Writes a GUID directly in the ODBC `SQLGUID` field layout when requested.
     fn write_uuid(&mut self, col: usize, val: Uuid) {
         let (data1, data2, data3, data4) = val.as_fields();
         self.write_exact(
@@ -435,20 +462,25 @@ impl RowWriter for BoundRowWriter<'_> {
         );
     }
 
+    /// Delivers XML through the established character conversion path.
     fn write_xml(&mut self, col: usize, val: SqlXml) {
         self.write_value(col, ColumnValues::Xml(val));
     }
 
+    /// Delivers JSON through the established character conversion path.
     fn write_json(&mut self, col: usize, val: SqlJson) {
         self.write_value(col, ColumnValues::Json(val));
     }
 
+    /// Delivers vector data through the established character conversion path.
     fn write_vector(&mut self, col: usize, val: SqlVector) {
         self.write_value(col, ColumnValues::Vector(val));
     }
 
+    /// Bound fetches do not separately expose a `sql_variant` base type.
     fn write_variant_base_type(&mut self, _col: usize, _base: TdsDataType) {}
 
+    /// Row completion is accounted for by the surrounding rowset loop.
     fn end_row(&mut self) {}
 }
 

--- a/mssql-odbc/src/api/get_data.rs
+++ b/mssql-odbc/src/api/get_data.rs
@@ -16,7 +16,7 @@ use super::sqlstate::*;
 use crate::api::exec_common::release_busy_if_row_exhausted;
 use crate::api::odbc_types::SqlWChar;
 use crate::api::type_rules::{canonical_c_type, is_valid_c_type};
-use crate::api::util::{copy_with_nul, resolve_cursor_poll, write_if_some};
+use crate::api::util::{copy_with_nul, write_if_some};
 use crate::error::{free_errors, post_sql_error};
 use crate::handles::stmt::{ActivePlpStream, STMT_STATE_CURSOR_OPEN, StmtState};
 use crate::handles::{HandleType, StmtHandle, handle_from_raw};
@@ -561,9 +561,8 @@ fn resume_row_to_column(
 
     let target = column_number - 1; // 0-based
     let cursor_poll = client.try_read_row_column(target);
-    let cursor_result = resolve_cursor_poll(cursor_poll, || {
-        dbc.runtime.block_on(client.read_row_column(target))
-    });
+    let cursor_result = cursor_poll
+        .and_then(|poll| poll.resolve(|| dbc.runtime.block_on(client.read_row_column(target))));
 
     let Ok(mut dbc_state) = dbc.inner.lock() else {
         error!("SQLGetData: dbc mutex poisoned after row resume");

--- a/mssql-odbc/src/api/get_data.rs
+++ b/mssql-odbc/src/api/get_data.rs
@@ -16,7 +16,7 @@ use super::sqlstate::*;
 use crate::api::exec_common::release_busy_if_row_exhausted;
 use crate::api::odbc_types::SqlWChar;
 use crate::api::type_rules::{canonical_c_type, is_valid_c_type};
-use crate::api::util::{copy_with_nul, write_if_some};
+use crate::api::util::{copy_with_nul, resolve_cursor_poll, write_if_some};
 use crate::error::{free_errors, post_sql_error};
 use crate::handles::stmt::{ActivePlpStream, STMT_STATE_CURSOR_OPEN, StmtState};
 use crate::handles::{HandleType, StmtHandle, handle_from_raw};
@@ -560,7 +560,10 @@ fn resume_row_to_column(
     };
 
     let target = column_number - 1; // 0-based
-    let cursor_result = dbc.runtime.block_on(client.read_row_column(target));
+    let cursor_poll = client.try_read_row_column(target);
+    let cursor_result = resolve_cursor_poll(cursor_poll, || {
+        dbc.runtime.block_on(client.read_row_column(target))
+    });
 
     let Ok(mut dbc_state) = dbc.inner.lock() else {
         error!("SQLGetData: dbc mutex poisoned after row resume");

--- a/mssql-odbc/src/api/get_data.rs
+++ b/mssql-odbc/src/api/get_data.rs
@@ -1469,7 +1469,7 @@ mod tests {
     use crate::error::diag::DiagRecord;
     use crate::handles::DbcHandle;
     use crate::test_support::TestHandles;
-    use mssql_tds::test_client_support::int_columns;
+    use mssql_tds::test_client_support::{int_columns, tds_client_from_int_rows};
 
     /// Assert the most recent diagnostic matches the expected canonical
     /// SQLSTATE and message text (the message is prefixed by the driver, so we
@@ -1900,6 +1900,48 @@ mod tests {
         s.column_metadata = int_columns(2);
         s.row_positioned = true;
         s.last_captured = Some((1, value));
+    }
+
+    #[test]
+    fn get_data_resolves_a_buffered_cursor_column() {
+        let h = TestHandles::with_env_dbc_stmt();
+        h.mark_dbc_connected();
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        {
+            let mut state = stmt.inner.lock().unwrap();
+            state.set_state(STMT_STATE_CURSOR_OPEN);
+            state.column_metadata = int_columns(1);
+            state.row_positioned = true;
+        }
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        let mut client = tds_client_from_int_rows(vec![vec![42]]);
+        dbc.runtime
+            .block_on(client.execute("SELECT buffered row".to_string(), ()))
+            .unwrap();
+        assert!(dbc.runtime.block_on(client.next_row_cursor()).unwrap());
+        {
+            let mut state = dbc.inner.lock().unwrap();
+            state.client = Some(client);
+            state.active_stmt = Some(h.stmt);
+        }
+        let mut value = 0_i32;
+        let mut indicator = 0;
+
+        assert_eq!(
+            unsafe {
+                sql_get_data(
+                    h.stmt,
+                    1,
+                    SQL_C_SLONG,
+                    (&mut value as *mut i32).cast(),
+                    0,
+                    &mut indicator,
+                )
+            },
+            SQL_SUCCESS
+        );
+        assert_eq!(value, 42);
+        assert_eq!(indicator, 4);
     }
 
     /// The byte count a probe reports for each value kind. Variable-length

--- a/mssql-odbc/src/api/util.rs
+++ b/mssql-odbc/src/api/util.rs
@@ -8,6 +8,17 @@ use crate::api::odbc_types::{
 };
 use crate::api::sqlstate::{WARN_STRING_TRUNCATION, post_diag};
 use crate::error::HasDiagnostics;
+use mssql_tds::connection::tds_client::CursorPoll;
+
+pub(crate) fn resolve_cursor_poll<T, E>(
+    poll: Result<CursorPoll<T>, E>,
+    fallback: impl FnOnce() -> Result<T, E>,
+) -> Result<T, E> {
+    match poll? {
+        CursorPoll::Ready(value) => Ok(value),
+        CursorPoll::Pending => fallback(),
+    }
+}
 
 /// Bit 0 of the COLMETADATA flags word marks a column nullable (`fNullable`).
 /// Shared by any RPC-backed result set (`SQLGetTypeInfo`, catalog functions)
@@ -342,10 +353,47 @@ pub(crate) fn rewrite_param_markers(sql: &str) -> (String, usize) {
 #[cfg(test)]
 mod tests {
     use super::{
-        copy_with_nul, read_utf16, read_utf16_attr, read_utf16_long, rewrite_param_markers,
-        write_if_some,
+        copy_with_nul, read_utf16, read_utf16_attr, read_utf16_long, resolve_cursor_poll,
+        rewrite_param_markers, write_if_some,
     };
     use crate::api::odbc_types::{SQL_NTS, SqlInteger, SqlWChar};
+    use mssql_tds::connection::tds_client::CursorPoll;
+
+    #[test]
+    fn cursor_ready_skips_fallback() {
+        let mut calls = 0;
+        let value = resolve_cursor_poll(Ok::<_, ()>(CursorPoll::Ready(7)), || {
+            calls += 1;
+            Ok(9)
+        });
+
+        assert_eq!(value, Ok(7));
+        assert_eq!(calls, 0);
+    }
+
+    #[test]
+    fn cursor_pending_calls_fallback_once() {
+        let mut calls = 0;
+        let value = resolve_cursor_poll(Ok::<_, ()>(CursorPoll::Pending), || {
+            calls += 1;
+            Ok(9)
+        });
+
+        assert_eq!(value, Ok(9));
+        assert_eq!(calls, 1);
+    }
+
+    #[test]
+    fn cursor_error_skips_fallback() {
+        let mut calls = 0;
+        let value = resolve_cursor_poll::<u8, _>(Err("cursor failed"), || {
+            calls += 1;
+            Ok(9)
+        });
+
+        assert_eq!(value, Err("cursor failed"));
+        assert_eq!(calls, 0);
+    }
 
     #[test]
     fn rewrite_no_markers_is_unchanged() {

--- a/mssql-odbc/src/api/util.rs
+++ b/mssql-odbc/src/api/util.rs
@@ -79,6 +79,40 @@ pub(crate) unsafe fn copy_with_nul<T: Copy + Default>(
     copy_len < src.len()
 }
 
+/// Encodes `src` directly into a caller-owned UTF-16 buffer and appends a NUL
+/// when the buffer has room. Returns the full encoded length and whether the
+/// destination truncated it.
+///
+/// A null `dst` is a length-only query and never reports truncation.
+///
+/// # Safety
+/// `dst`, if non-null, must be writable for `buf_len` [`SqlWChar`] values.
+pub(crate) unsafe fn copy_str_utf16_with_nul(
+    dst: *mut SqlWChar,
+    buf_len: usize,
+    src: &str,
+) -> (usize, bool) {
+    if dst.is_null() {
+        return (src.encode_utf16().count(), false);
+    }
+
+    let copy_capacity = buf_len.saturating_sub(1);
+    let mut encoded_len = 0;
+    let mut copied_len = 0;
+    for value in src.encode_utf16() {
+        if copied_len < copy_capacity {
+            unsafe { dst.add(copied_len).write_unaligned(value) };
+            copied_len += 1;
+        }
+        encoded_len += 1;
+    }
+    if buf_len > 0 {
+        unsafe { dst.add(copied_len).write_unaligned(0) };
+    }
+
+    (encoded_len, copied_len < encoded_len)
+}
+
 /// Read a UTF-16 string from a raw pointer and an explicit or NUL-terminated length.
 ///
 /// # Safety
@@ -341,8 +375,8 @@ pub(crate) fn rewrite_param_markers(sql: &str) -> (String, usize) {
 #[cfg(test)]
 mod tests {
     use super::{
-        copy_with_nul, read_utf16, read_utf16_attr, read_utf16_long, rewrite_param_markers,
-        write_if_some,
+        copy_str_utf16_with_nul, copy_with_nul, read_utf16, read_utf16_attr, read_utf16_long,
+        rewrite_param_markers, write_if_some,
     };
     use crate::api::odbc_types::{SQL_NTS, SqlInteger, SqlWChar};
 
@@ -684,6 +718,36 @@ mod tests {
         assert!(truncated);
         assert_eq!(buf[0], 0xD83D);
         assert_eq!(buf[1], 0);
+    }
+
+    #[test]
+    fn copy_str_utf16_with_nul_copies_unicode() {
+        let mut buf = [0xFFFF; 6];
+        let (len, truncated) =
+            unsafe { copy_str_utf16_with_nul(buf.as_mut_ptr(), buf.len(), "a😀b") };
+        assert_eq!(len, 4);
+        assert!(!truncated);
+        assert_eq!(
+            &buf[..5],
+            &[u16::from(b'a'), 0xD83D, 0xDE00, u16::from(b'b'), 0]
+        );
+    }
+
+    #[test]
+    fn copy_str_utf16_with_nul_reports_code_unit_truncation() {
+        let mut buf = [0xFFFF; 3];
+        let (len, truncated) =
+            unsafe { copy_str_utf16_with_nul(buf.as_mut_ptr(), buf.len(), "a😀b") };
+        assert_eq!(len, 4);
+        assert!(truncated);
+        assert_eq!(buf, [u16::from(b'a'), 0xD83D, 0]);
+    }
+
+    #[test]
+    fn copy_str_utf16_with_nul_supports_length_queries() {
+        let (len, truncated) = unsafe { copy_str_utf16_with_nul(std::ptr::null_mut(), 0, "😀") };
+        assert_eq!(len, 2);
+        assert!(!truncated);
     }
 
     // Lock in that the generic helper works for narrow (`SQL_C_CHAR`) buffers,

--- a/mssql-odbc/src/api/util.rs
+++ b/mssql-odbc/src/api/util.rs
@@ -8,18 +8,6 @@ use crate::api::odbc_types::{
 };
 use crate::api::sqlstate::{WARN_STRING_TRUNCATION, post_diag};
 use crate::error::HasDiagnostics;
-use mssql_tds::connection::tds_client::CursorPoll;
-
-pub(crate) fn resolve_cursor_poll<T, E>(
-    poll: Result<CursorPoll<T>, E>,
-    fallback: impl FnOnce() -> Result<T, E>,
-) -> Result<T, E> {
-    match poll? {
-        CursorPoll::Ready(value) => Ok(value),
-        CursorPoll::Pending => fallback(),
-    }
-}
-
 /// Bit 0 of the COLMETADATA flags word marks a column nullable (`fNullable`).
 /// Shared by any RPC-backed result set (`SQLGetTypeInfo`, catalog functions)
 /// that clears it on the ODBC-mandated NOT NULL columns after execution.
@@ -353,47 +341,10 @@ pub(crate) fn rewrite_param_markers(sql: &str) -> (String, usize) {
 #[cfg(test)]
 mod tests {
     use super::{
-        copy_with_nul, read_utf16, read_utf16_attr, read_utf16_long, resolve_cursor_poll,
-        rewrite_param_markers, write_if_some,
+        copy_with_nul, read_utf16, read_utf16_attr, read_utf16_long, rewrite_param_markers,
+        write_if_some,
     };
     use crate::api::odbc_types::{SQL_NTS, SqlInteger, SqlWChar};
-    use mssql_tds::connection::tds_client::CursorPoll;
-
-    #[test]
-    fn cursor_ready_skips_fallback() {
-        let mut calls = 0;
-        let value = resolve_cursor_poll(Ok::<_, ()>(CursorPoll::Ready(7)), || {
-            calls += 1;
-            Ok(9)
-        });
-
-        assert_eq!(value, Ok(7));
-        assert_eq!(calls, 0);
-    }
-
-    #[test]
-    fn cursor_pending_calls_fallback_once() {
-        let mut calls = 0;
-        let value = resolve_cursor_poll(Ok::<_, ()>(CursorPoll::Pending), || {
-            calls += 1;
-            Ok(9)
-        });
-
-        assert_eq!(value, Ok(9));
-        assert_eq!(calls, 1);
-    }
-
-    #[test]
-    fn cursor_error_skips_fallback() {
-        let mut calls = 0;
-        let value = resolve_cursor_poll::<u8, _>(Err("cursor failed"), || {
-            calls += 1;
-            Ok(9)
-        });
-
-        assert_eq!(value, Err("cursor failed"));
-        assert_eq!(calls, 0);
-    }
 
     #[test]
     fn rewrite_no_markers_is_unchanged() {

--- a/mssql-odbc/src/conversion/fetch_convert.rs
+++ b/mssql-odbc/src/conversion/fetch_convert.rs
@@ -31,7 +31,9 @@ use crate::api::type_rules::is_integer_c_type;
 use crate::api::util::write_if_some;
 use crate::conversion::error::{ConvError, ConvOk};
 use crate::conversion::numeric::{NumericSource, narrow_i128, parse_decimal_literal};
-use mssql_tds::datatypes::column_values::ColumnValues;
+use mssql_tds::datatypes::column_values::{
+    ColumnValues, SqlDate, SqlDateTime2, SqlDateTimeOffset, SqlTime,
+};
 use mssql_tds::datatypes::sql_string::{EncodingType, SqlString};
 
 /// Decodes a character column without the panicking paths in
@@ -342,6 +344,70 @@ pub(crate) struct DateTimeParts {
     pub has_tz: bool,
 }
 
+pub(crate) fn date_parts(date: &SqlDate) -> DateTimeParts {
+    let (year, month, day) = civil_from_days_since_0001(i64::from(date.get_days()));
+    DateTimeParts {
+        year,
+        month,
+        day,
+        has_date: true,
+        ..Default::default()
+    }
+}
+
+pub(crate) fn time_parts(time: &SqlTime) -> DateTimeParts {
+    let (hour, minute, second, fraction_ns) = hms_from_ticks_100ns(time.time_nanoseconds);
+    DateTimeParts {
+        hour,
+        minute,
+        second,
+        fraction_ns,
+        scale: time.scale,
+        has_time: true,
+        ..Default::default()
+    }
+}
+
+pub(crate) fn datetime2_parts(datetime: &SqlDateTime2) -> DateTimeParts {
+    let (year, month, day) = civil_from_days_since_0001(i64::from(datetime.days));
+    let mut parts = time_parts(&datetime.time);
+    parts.year = year;
+    parts.month = month;
+    parts.day = day;
+    parts.has_date = true;
+    parts
+}
+
+pub(crate) fn datetimeoffset_parts(datetime: &SqlDateTimeOffset) -> Option<DateTimeParts> {
+    // The wire value is UTC; ODBC returns the local wall clock obtained by
+    // applying the stored offset.
+    let utc_ticks = datetime.datetime2.time.time_nanoseconds as i64
+        + i64::from(datetime.offset) * 60 * 10_000_000;
+    let days = i64::from(datetime.datetime2.days) + utc_ticks.div_euclid(TICKS_PER_DAY);
+    if !(0..=MAX_DAYS_SINCE_0001).contains(&days) {
+        return None;
+    }
+
+    let (year, month, day) = civil_from_days_since_0001(days);
+    let (hour, minute, second, fraction_ns) =
+        hms_from_ticks_100ns(utc_ticks.rem_euclid(TICKS_PER_DAY) as u64);
+    Some(DateTimeParts {
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second,
+        fraction_ns,
+        scale: datetime.datetime2.time.scale,
+        tz_hour: datetime.offset / 60,
+        tz_minute: datetime.offset % 60,
+        has_date: true,
+        has_time: true,
+        has_tz: true,
+    })
+}
+
 /// (year, month, day) from a day count where day 0 = 0001-01-01, using Howard
 /// Hinnant's `civil_from_days` algorithm rebased from its 1970 epoch.
 fn civil_from_days_since_0001(days_since_0001: i64) -> (i16, u16, u16) {
@@ -386,64 +452,10 @@ fn hms_from_ticks_100ns(ticks: u64) -> (u16, u16, u16, u32) {
 pub(crate) fn extract_datetime_parts(value: &ColumnValues) -> Option<DateTimeParts> {
     let mut p = DateTimeParts::default();
     match value {
-        ColumnValues::Date(d) => {
-            let (y, m, day) = civil_from_days_since_0001(i64::from(d.get_days()));
-            p.year = y;
-            p.month = m;
-            p.day = day;
-            p.has_date = true;
-        }
-        ColumnValues::Time(t) => {
-            let (h, mi, s, f) = hms_from_ticks_100ns(t.time_nanoseconds);
-            p.scale = t.scale;
-            p.hour = h;
-            p.minute = mi;
-            p.second = s;
-            p.fraction_ns = f;
-            p.has_time = true;
-        }
-        ColumnValues::DateTime2(dt) => {
-            let (y, m, day) = civil_from_days_since_0001(i64::from(dt.days));
-            let (h, mi, s, f) = hms_from_ticks_100ns(dt.time.time_nanoseconds);
-            p.scale = dt.time.scale;
-            p.year = y;
-            p.month = m;
-            p.day = day;
-            p.hour = h;
-            p.minute = mi;
-            p.second = s;
-            p.fraction_ns = f;
-            p.has_date = true;
-            p.has_time = true;
-        }
-        ColumnValues::DateTimeOffset(dto) => {
-            // The wire value is UTC; `offset` is what must be added to reach the
-            // local wall clock the application wrote, which is what the ODBC
-            // struct and the character rendering report.
-            let utc_ticks = dto.datetime2.time.time_nanoseconds as i64
-                + i64::from(dto.offset) * 60 * 10_000_000;
-            // Euclidean division so a negative offset borrows a day rather than
-            // producing a negative time-of-day.
-            let days = i64::from(dto.datetime2.days) + utc_ticks.div_euclid(TICKS_PER_DAY);
-            if !(0..=MAX_DAYS_SINCE_0001).contains(&days) {
-                return None;
-            }
-            let (y, m, day) = civil_from_days_since_0001(days);
-            let (h, mi, s, f) = hms_from_ticks_100ns(utc_ticks.rem_euclid(TICKS_PER_DAY) as u64);
-            p.scale = dto.datetime2.time.scale;
-            p.year = y;
-            p.month = m;
-            p.day = day;
-            p.hour = h;
-            p.minute = mi;
-            p.second = s;
-            p.fraction_ns = f;
-            p.tz_hour = dto.offset / 60;
-            p.tz_minute = dto.offset % 60;
-            p.has_date = true;
-            p.has_time = true;
-            p.has_tz = true;
-        }
+        ColumnValues::Date(date) => return Some(date_parts(date)),
+        ColumnValues::Time(time) => return Some(time_parts(time)),
+        ColumnValues::DateTime2(datetime) => return Some(datetime2_parts(datetime)),
+        ColumnValues::DateTimeOffset(datetime) => return datetimeoffset_parts(datetime),
         ColumnValues::DateTime(dt) => {
             let (y, m, day) = civil_from_days_since_0001(i64::from(dt.days) + DAYS_0001_TO_1900);
             // `datetime` time is counted in 1/300-second ticks since midnight.

--- a/mssql-odbc/src/conversion/fetch_convert.rs
+++ b/mssql-odbc/src/conversion/fetch_convert.rs
@@ -344,6 +344,7 @@ pub(crate) struct DateTimeParts {
     pub has_tz: bool,
 }
 
+/// Converts a TDS `date` into normalized calendar fields.
 pub(crate) fn date_parts(date: &SqlDate) -> DateTimeParts {
     let (year, month, day) = civil_from_days_since_0001(i64::from(date.get_days()));
     DateTimeParts {
@@ -355,6 +356,7 @@ pub(crate) fn date_parts(date: &SqlDate) -> DateTimeParts {
     }
 }
 
+/// Converts a TDS `time` into normalized clock fields.
 pub(crate) fn time_parts(time: &SqlTime) -> DateTimeParts {
     let (hour, minute, second, fraction_ns) = hms_from_ticks_100ns(time.time_nanoseconds);
     DateTimeParts {
@@ -368,6 +370,7 @@ pub(crate) fn time_parts(time: &SqlTime) -> DateTimeParts {
     }
 }
 
+/// Converts a TDS `datetime2` into normalized calendar and clock fields.
 pub(crate) fn datetime2_parts(datetime: &SqlDateTime2) -> DateTimeParts {
     let (year, month, day) = civil_from_days_since_0001(i64::from(datetime.days));
     let mut parts = time_parts(&datetime.time);
@@ -378,6 +381,9 @@ pub(crate) fn datetime2_parts(datetime: &SqlDateTime2) -> DateTimeParts {
     parts
 }
 
+/// Converts a UTC TDS `datetimeoffset` value to its represented local time.
+///
+/// Returns `None` when applying the offset falls outside the TDS date range.
 pub(crate) fn datetimeoffset_parts(datetime: &SqlDateTimeOffset) -> Option<DateTimeParts> {
     // The wire value is UTC; ODBC returns the local wall clock obtained by
     // applying the stored offset.

--- a/mssql-odbc/src/conversion/fetch_convert.rs
+++ b/mssql-odbc/src/conversion/fetch_convert.rs
@@ -326,21 +326,32 @@ const DAYS_0001_TO_1900: i64 = 693_595;
 /// each target C struct can be filled from a single representation.
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct DateTimeParts {
+    /// Proleptic Gregorian year.
     pub year: i16,
+    /// Calendar month in `1..=12`.
     pub month: u16,
+    /// Calendar day in `1..=31`.
     pub day: u16,
+    /// Hour in `0..=23`.
     pub hour: u16,
+    /// Minute in `0..=59`.
     pub minute: u16,
+    /// Second in `0..=59`.
     pub second: u16,
     /// Fractional seconds in nanoseconds.
     pub fraction_ns: u32,
     /// Declared fractional-seconds scale (0-7) of the source column. Character
     /// rendering pads to exactly this many digits, matching msodbcsql.
     pub scale: u8,
+    /// Signed timezone hour component.
     pub tz_hour: i16,
+    /// Signed timezone minute component.
     pub tz_minute: i16,
+    /// Whether the source carries a date component.
     pub has_date: bool,
+    /// Whether the source carries a time component.
     pub has_time: bool,
+    /// Whether the source carries a timezone offset.
     pub has_tz: bool,
 }
 

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -8158,6 +8158,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn next_row_into_continues_a_partial_buffered_row() {
+        let expected = [0x1234_5678_i32, -42_i32];
+        let second = expected[1].to_le_bytes();
+        let mut first_payload = vec![0xff, TokenType::Row as u8];
+        first_payload.extend_from_slice(&expected[0].to_le_bytes());
+        first_payload.extend_from_slice(&second[..2]);
+        let mut first = TestPacketBuilder::new(crate::message::messages::PacketType::TabularResult);
+        let mut second_packet =
+            TestPacketBuilder::new(crate::message::messages::PacketType::TabularResult);
+        let mut stream = first.continuation().append_bytes(&first_payload).build();
+        stream.extend_from_slice(&second_packet.append_bytes(&second[2..]).build());
+        let mut transport = create_network_transport_with_data(&stream);
+        assert_eq!(transport.read_byte().await.unwrap(), 0xff);
+        let mut client = create_test_client_with_any_transport(AnyTransport::network(transport));
+        client.current_metadata = Some(int_column_metadata(expected.len()));
+        client.current_result_set_has_been_read_till_end = false;
+        let mut writer = crate::datatypes::row_writer::DefaultRowWriter::new(expected.len());
+
+        assert!(client.next_row_into(&mut writer).await.unwrap());
+        assert_eq!(
+            writer.take_row(),
+            expected
+                .into_iter()
+                .map(ColumnValues::Int)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
     async fn buffered_row_poll_parks_only_an_incomplete_row() {
         let expected = [0x1234_5678_i32, -42_i32];
         let second = expected[1].to_le_bytes();
@@ -8284,6 +8313,7 @@ mod tests {
     fn row_writer_finish_is_limited_to_non_plp_results() {
         let mut client = create_test_client();
         assert!(!client.current_result_supports_row_into());
+        assert!(!client.buffered_row_support());
 
         client.current_metadata = Some(int_column_metadata(1));
         assert!(client.current_result_supports_row_into());
@@ -8311,6 +8341,131 @@ mod tests {
         }));
         assert!(!client.current_result_supports_row_into());
         assert!(!client.buffered_row_support());
+        let mut writer = crate::datatypes::row_writer::DefaultRowWriter::new(1);
+        assert_eq!(
+            client.try_next_buffered_row_into(&mut writer).unwrap(),
+            BufferedRowPoll::Pending
+        );
+    }
+
+    #[test]
+    fn buffered_cursor_edge_states_preserve_the_async_fallback_contract() {
+        let mut client = create_test_client();
+        let mut writer = crate::datatypes::row_writer::DefaultRowWriter::new(2);
+
+        assert!(client.try_next_row_cursor().is_err());
+        assert!(client.try_next_buffered_row_into(&mut writer).is_err());
+
+        let metadata = int_column_metadata(2);
+        client.current_metadata = Some(Arc::clone(&metadata));
+        client.current_result_set_has_been_read_till_end = true;
+        assert_eq!(
+            client.try_next_row_cursor().unwrap(),
+            CursorPoll::Ready(false)
+        );
+        assert_eq!(
+            client.try_next_buffered_row_into(&mut writer).unwrap(),
+            BufferedRowPoll::Exhausted
+        );
+
+        client.current_result_set_has_been_read_till_end = false;
+        client.active_row_read_state = ActiveRowReadState::RowPaused(Box::new(RowPauseState {
+            next_column_index: 1,
+            metadata,
+            nbc_null_bitmap: None,
+            decryptor: None,
+        }));
+        assert_eq!(client.try_next_row_cursor().unwrap(), CursorPoll::Pending);
+        assert_eq!(
+            client.try_next_buffered_row_into(&mut writer).unwrap(),
+            BufferedRowPoll::Pending
+        );
+        assert_eq!(
+            client.try_read_row_column(0).unwrap(),
+            CursorPoll::Ready(CursorColumn::AlreadyConsumed)
+        );
+        assert!(client.try_read_row_column(2).is_err());
+        assert_eq!(client.try_read_row_column(1).unwrap(), CursorPoll::Pending);
+        assert!(!client.try_finish_row_into(&mut writer).unwrap());
+
+        let cancellation = CancelHandle::new();
+        client.cancel_handle = Some(cancellation.child_handle());
+        cancellation.cancel();
+        assert!(!client.try_finish_row_into(&mut writer).unwrap());
+        client.cancel_handle = None;
+
+        client.active_row_read_state = ActiveRowReadState::Idle;
+        assert!(client.try_finish_row_into(&mut writer).is_err());
+
+        client.active_row_read_state = ActiveRowReadState::RowPaused(Box::new(RowPauseState {
+            next_column_index: 0,
+            metadata: int_column_metadata(3),
+            nbc_null_bitmap: None,
+            decryptor: None,
+        }));
+        assert_eq!(client.try_read_row_column(1).unwrap(), CursorPoll::Pending);
+    }
+
+    #[tokio::test]
+    async fn finish_row_into_rejects_non_resumable_state() {
+        let mut client = create_test_client();
+        let mut writer = crate::datatypes::row_writer::DefaultRowWriter::new(1);
+
+        assert!(client.finish_row_into(&mut writer).await.is_err());
+        assert!(matches!(
+            client.active_row_read_state,
+            ActiveRowReadState::Idle
+        ));
+    }
+
+    #[tokio::test]
+    async fn finish_row_into_handles_transport_outcomes() {
+        fn paused() -> RowPauseState {
+            RowPauseState {
+                next_column_index: 0,
+                metadata: int_column_metadata(1),
+                nbc_null_bitmap: None,
+                decryptor: None,
+            }
+        }
+
+        let mut complete_transport = TestTransport::new();
+        complete_transport
+            .resume_results
+            .push_back(RowReadResult::RowWritten);
+        let mut complete = create_test_client_with_transport(complete_transport);
+        complete.active_row_read_state = ActiveRowReadState::RowPaused(Box::new(paused()));
+        complete.remaining_request_timeout = Some(Duration::from_secs(1));
+        let mut writer = crate::datatypes::row_writer::DefaultRowWriter::new(1);
+        complete.finish_row_into(&mut writer).await.unwrap();
+        assert!(matches!(
+            complete.active_row_read_state,
+            ActiveRowReadState::Idle
+        ));
+
+        let mut paused_transport = TestTransport::new();
+        paused_transport
+            .resume_results
+            .push_back(RowReadResult::RowPaused(paused()));
+        let mut still_paused = create_test_client_with_transport(paused_transport);
+        still_paused.active_row_read_state = ActiveRowReadState::RowPaused(Box::new(paused()));
+        assert!(still_paused.finish_row_into(&mut writer).await.is_err());
+        assert!(matches!(
+            still_paused.active_row_read_state,
+            ActiveRowReadState::RowPaused(_)
+        ));
+
+        let mut token_transport = TestTransport::new();
+        token_transport
+            .resume_results
+            .push_back(RowReadResult::Token(done_no_more()));
+        let mut token = create_test_client_with_transport(token_transport);
+        token.active_row_read_state = ActiveRowReadState::RowPaused(Box::new(paused()));
+        assert!(token.finish_row_into(&mut writer).await.is_err());
+
+        let mut failed = create_test_client();
+        failed.active_row_read_state = ActiveRowReadState::RowPaused(Box::new(paused()));
+        assert!(failed.finish_row_into(&mut writer).await.is_err());
     }
 
     // ── PLP streaming lifecycle contract tests ──

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -5583,10 +5583,10 @@ impl TdsClient {
         let value = match &self.active_row_read_state {
             ActiveRowReadState::RowPaused(pause_state) => self
                 .transport
-                .try_read_buffered_column(pause_state, target)?,
+                .try_read_buffered_column_with_base(pause_state, target)?,
             ActiveRowReadState::Idle | ActiveRowReadState::PlpPaused(_) => None,
         };
-        let Some(value) = value else {
+        let Some((value, variant_base)) = value else {
             return Ok(CursorPoll::Pending);
         };
         if let Some(start) = start {
@@ -5606,7 +5606,7 @@ impl TdsClient {
         }
         Ok(CursorPoll::Ready(CursorColumn::Value {
             value,
-            variant_base: None,
+            variant_base,
         }))
     }
 
@@ -8097,6 +8097,52 @@ mod tests {
         assert_eq!(
             client.try_read_row_column(1).unwrap(),
             CursorPoll::Ready(CursorColumn::RowEnded)
+        );
+    }
+
+    #[tokio::test]
+    async fn sync_cursor_decodes_buffered_sql_variant_with_base_type() {
+        let column = crate::query::metadata::ColumnMetadata {
+            user_type: 0,
+            flags: 0,
+            type_info: crate::datatypes::sqldatatypes::TypeInfo::var_len(
+                TdsDataType::SsVariant,
+                8009,
+            )
+            .unwrap(),
+            data_type: TdsDataType::SsVariant,
+            column_name: "variant".to_string(),
+            multi_part_name: None,
+            crypto_metadata: None,
+        };
+        let metadata = Arc::new(ColMetadataToken {
+            column_count: 1,
+            columns: vec![column],
+            cek_table: Vec::new(),
+        });
+        let mut payload = vec![0xff, TokenType::Row as u8];
+        payload.extend_from_slice(&6_u32.to_le_bytes());
+        payload.extend_from_slice(&[TdsDataType::Int4 as u8, 0]);
+        payload.extend_from_slice(&42_i32.to_le_bytes());
+        let mut packet =
+            TestPacketBuilder::new(crate::message::messages::PacketType::TabularResult);
+        let mut transport =
+            create_network_transport_with_data(&packet.append_bytes(&payload).build());
+        assert_eq!(transport.read_byte().await.unwrap(), 0xff);
+        let mut client = create_test_client_with_any_transport(AnyTransport::network(transport));
+        client.current_metadata = Some(metadata);
+        client.current_result_set_has_been_read_till_end = false;
+
+        assert_eq!(
+            client.try_next_row_cursor().unwrap(),
+            CursorPoll::Ready(true)
+        );
+        assert_eq!(
+            client.try_read_row_column(0).unwrap(),
+            CursorPoll::Ready(CursorColumn::Value {
+                value: ColumnValues::Int(42),
+                variant_base: Some(TdsDataType::Int4),
+            })
         );
     }
 

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -230,6 +230,31 @@ pub enum CursorColumn {
     RowEnded,
 }
 
+/// Result of a non-blocking pull-cursor attempt.
+#[derive(Debug, PartialEq)]
+pub enum CursorPoll<T> {
+    /// The operation completed entirely from bytes already buffered by the
+    /// transport.
+    Ready(T),
+    /// The existing async cursor method must continue the operation.
+    ///
+    /// No transport bytes or cursor state were consumed by the attempt.
+    Pending,
+}
+
+/// Result of attempting to decode the next row entirely from transport-buffered bytes.
+#[derive(Debug, PartialEq)]
+pub enum BufferedRowPoll {
+    /// A complete row was written.
+    Complete,
+    /// A row prefix was written and the cursor holds the continuation state.
+    Partial,
+    /// No row bytes or cursor state were consumed.
+    Pending,
+    /// The current result set was already exhausted.
+    Exhausted,
+}
+
 /// Where a connection stands in the RESETCONNECTION handshake (MS-TDS
 /// 2.2.3.1.2). The bit is armed on the connection and consumed by the packet
 /// writer, so confirming that the server honored it needs all three states
@@ -299,6 +324,12 @@ struct StreamedWriteContext {
     timeout_sec: Option<u32>,
 }
 
+#[derive(Debug)]
+struct BufferedRowSupport {
+    metadata: Arc<ColMetadataToken>,
+    supported: bool,
+}
+
 /// Active TDS connection to a SQL Server instance.
 ///
 /// Created by [`TdsConnectionProvider::create_client()`](crate::connection_provider::tds_connection_provider::TdsConnectionProvider::create_client).
@@ -321,6 +352,7 @@ pub struct TdsClient {
     /// the metadata it was built for so it is rebuilt when the result set
     /// changes. `None` until the first encrypted result set is seen.
     current_decryptor: Option<MemoizedCellDecryptor>,
+    buffered_row_support: Option<Box<BufferedRowSupport>>,
     count_map: HashMap<CurrentCommand, u64>,
     /// Rows affected by the most recent statement; see [`last_rows_affected`](Self::last_rows_affected).
     last_rows_affected: i64,
@@ -456,6 +488,7 @@ impl TdsClient {
             reset_state: ResetAckState::Idle,
             current_metadata: None,
             current_decryptor: None,
+            buffered_row_support: None,
             count_map: HashMap::new(),
             last_rows_affected: -1,
             dml_result_counts: Vec::new(),
@@ -1036,6 +1069,11 @@ impl TdsClient {
                 t.saturating_sub(elapsed)
             }
         });
+    }
+
+    #[inline]
+    fn request_timeout_start(&self) -> Option<Instant> {
+        self.remaining_request_timeout.map(|_| Instant::now())
     }
 
     /// Pre-execution check: detect a dead connection and attempt session recovery.
@@ -5267,6 +5305,107 @@ impl TdsClient {
         }
     }
 
+    /// Attempts to position the cursor from bytes already buffered by the transport.
+    ///
+    /// Returns [`CursorPoll::Pending`] without consuming bytes or cursor state
+    /// when the current row must first be drained, the next token needs async
+    /// parsing, encryption keys need resolving, or the row header is incomplete.
+    pub fn try_next_row_cursor(&mut self) -> TdsResult<CursorPoll<bool>> {
+        let Some(metadata) = self.current_metadata.as_ref().map(Arc::clone) else {
+            return Err(UsageError(
+                "No metadata found while fetching the next row. Have you called the execute method or was the query supposed to return resultset?".to_string(),
+            ));
+        };
+        if self.current_result_set_has_been_read_till_end {
+            return Ok(CursorPoll::Ready(false));
+        }
+        if !matches!(self.active_row_read_state, ActiveRowReadState::Idle)
+            || self
+                .cancel_handle
+                .as_ref()
+                .is_some_and(|handle| handle.cancel_token.is_cancelled())
+        {
+            return Ok(CursorPoll::Pending);
+        }
+
+        // Resolving a CEK can call an async key-store provider. Keep encrypted
+        // result sets on the existing async path.
+        if !metadata.cek_table.is_empty()
+            || metadata
+                .columns
+                .iter()
+                .any(|column| column.crypto_metadata.is_some())
+        {
+            return Ok(CursorPoll::Pending);
+        }
+
+        let context = ParserContext::ColumnMetadata(metadata, None);
+        let start = self.request_timeout_start();
+        let pause_state = self.transport.try_receive_row_header(&context)?;
+        let Some(pause_state) = pause_state else {
+            return Ok(CursorPoll::Pending);
+        };
+        if let Some(start) = start {
+            self.update_remaining_timeout(start);
+        }
+        self.active_row_read_state = ActiveRowReadState::RowPaused(Box::new(pause_state));
+        Ok(CursorPoll::Ready(true))
+    }
+
+    /// Attempts to decode the next row directly into `writer` from bytes already
+    /// buffered by the transport.
+    ///
+    /// [`BufferedRowPoll::Pending`] is non-destructive. A
+    /// [`BufferedRowPoll::Partial`] result may already have written a row prefix;
+    /// the same writer must be passed to [`Self::finish_row_into`].
+    pub fn try_next_buffered_row_into<W>(&mut self, writer: &mut W) -> TdsResult<BufferedRowPoll>
+    where
+        W: RowWriter + Send + ?Sized,
+    {
+        if self.current_metadata.is_none() {
+            return Err(UsageError(
+                "No metadata found while fetching the next row. Have you called the execute method or was the query supposed to return resultset?".to_string(),
+            ));
+        }
+        if self.current_result_set_has_been_read_till_end {
+            return Ok(BufferedRowPoll::Exhausted);
+        }
+        if !matches!(self.active_row_read_state, ActiveRowReadState::Idle)
+            || self
+                .cancel_handle
+                .as_ref()
+                .is_some_and(|handle| handle.cancel_token.is_cancelled())
+            || !self.buffered_row_support()
+        {
+            return Ok(BufferedRowPoll::Pending);
+        }
+        let metadata = Arc::clone(
+            self.current_metadata
+                .as_ref()
+                .ok_or_else(|| UsageError("Buffered row metadata was cleared".to_string()))?,
+        );
+
+        let context = ParserContext::ColumnMetadata(metadata, None);
+        let start = self.request_timeout_start();
+        let Some(mut pause_state) = self.transport.try_receive_row_header(&context)? else {
+            return Ok(BufferedRowPoll::Pending);
+        };
+        let complete = self
+            .transport
+            .try_read_buffered_row_into(&mut pause_state, writer)?;
+        if let Some(start) = start {
+            self.update_remaining_timeout(start);
+        }
+
+        if complete {
+            writer.end_row();
+            Ok(BufferedRowPoll::Complete)
+        } else {
+            self.active_row_read_state = ActiveRowReadState::RowPaused(Box::new(pause_state));
+            Ok(BufferedRowPoll::Partial)
+        }
+    }
+
     /// Positions the cursor on the next row without decoding any column
     /// (ODBC `SQLFetch`). Returns `Ok(true)` when positioned on a row and
     /// `Ok(false)` when the result set is exhausted.
@@ -5274,7 +5413,8 @@ impl TdsClient {
     /// After this returns `true`, individual columns are pulled with
     /// [`read_row_column`](Self::read_row_column). Any previously positioned row
     /// is drained first; its remaining column bytes are read and discarded rather
-    /// than returned to the caller.
+    /// than returned to the caller. Use this directly, or after
+    /// [`Self::try_next_row_cursor`] returns [`CursorPoll::Pending`].
     #[instrument(skip(self), level = "info")]
     pub async fn next_row_cursor(&mut self) -> TdsResult<bool> {
         // A previous `peek_past_current_row` already read this row's header
@@ -5306,7 +5446,7 @@ impl TdsClient {
         let decryptor = self.resolve_cell_decryptor(&metadata).await?;
         let parser_context = ParserContext::ColumnMetadata(metadata, decryptor);
         loop {
-            let start = Instant::now();
+            let start = self.request_timeout_start();
             let header = self
                 .transport
                 .receive_row_header(
@@ -5315,7 +5455,9 @@ impl TdsClient {
                     self.cancel_handle.as_ref(),
                 )
                 .await?;
-            self.update_remaining_timeout(start);
+            if let Some(start) = start {
+                self.update_remaining_timeout(start);
+            }
 
             match header {
                 RowHeader::Positioned(pause_state) => {
@@ -5362,6 +5504,209 @@ impl TdsClient {
         Ok(has_row)
     }
 
+    /// Attempts to decode the next sequential column from buffered bytes.
+    ///
+    /// Returns [`CursorPoll::Pending`] without consuming bytes or cursor state
+    /// for PLP, encrypted, skipped, unsupported, or incomplete columns. The
+    /// caller then continues with [`Self::read_row_column`].
+    pub fn try_read_row_column(&mut self, target: usize) -> TdsResult<CursorPoll<CursorColumn>> {
+        let (next_column, column_count) = match &self.active_row_read_state {
+            ActiveRowReadState::Idle => return Ok(CursorPoll::Ready(CursorColumn::RowEnded)),
+            ActiveRowReadState::PlpPaused(_) => return Ok(CursorPoll::Pending),
+            ActiveRowReadState::RowPaused(pause_state) => {
+                (pause_state.next_column_index, pause_state.columns().len())
+            }
+        };
+        if self
+            .cancel_handle
+            .as_ref()
+            .is_some_and(|handle| handle.cancel_token.is_cancelled())
+        {
+            return Ok(CursorPoll::Pending);
+        }
+        if target >= column_count {
+            return Err(UsageError(format!(
+                "read_row_column target column {target} is out of range (row has {column_count} columns)"
+            )));
+        }
+        if target < next_column {
+            return Ok(CursorPoll::Ready(CursorColumn::AlreadyConsumed));
+        }
+        if target != next_column {
+            // Skipping intervening columns can require arbitrarily shaped
+            // decoders. The async path remains authoritative for that case.
+            return Ok(CursorPoll::Pending);
+        }
+
+        let start = self.request_timeout_start();
+        let value = match &self.active_row_read_state {
+            ActiveRowReadState::RowPaused(pause_state) => self
+                .transport
+                .try_read_buffered_column(pause_state, target)?,
+            ActiveRowReadState::Idle | ActiveRowReadState::PlpPaused(_) => None,
+        };
+        let Some(value) = value else {
+            return Ok(CursorPoll::Pending);
+        };
+        if let Some(start) = start {
+            self.update_remaining_timeout(start);
+        }
+
+        let ActiveRowReadState::RowPaused(mut pause_state) =
+            std::mem::replace(&mut self.active_row_read_state, ActiveRowReadState::Idle)
+        else {
+            return Err(crate::error::Error::ImplementationError(
+                "buffered column decode lost its row pause state".to_string(),
+            ));
+        };
+        pause_state.next_column_index = target + 1;
+        if pause_state.next_column_index < column_count {
+            self.active_row_read_state = ActiveRowReadState::RowPaused(pause_state);
+        }
+        Ok(CursorPoll::Ready(CursorColumn::Value {
+            value,
+            variant_base: None,
+        }))
+    }
+
+    /// Attempts to finish the positioned row through `writer` from bytes already
+    /// buffered by the transport.
+    ///
+    /// `false` means the buffered prefix was consumed and the same writer must be
+    /// passed to [`Self::finish_row_into`] to decode the remainder.
+    pub fn try_finish_row_into<W>(&mut self, writer: &mut W) -> TdsResult<bool>
+    where
+        W: RowWriter + Send + ?Sized,
+    {
+        if self
+            .cancel_handle
+            .as_ref()
+            .is_some_and(|handle| handle.cancel_token.is_cancelled())
+        {
+            return Ok(false);
+        }
+
+        let start = self.request_timeout_start();
+        let complete = match &mut self.active_row_read_state {
+            ActiveRowReadState::RowPaused(pause_state) => self
+                .transport
+                .try_read_buffered_row_into(pause_state, writer)?,
+            ActiveRowReadState::PlpPaused(_) => return Ok(false),
+            ActiveRowReadState::Idle => {
+                return Err(UsageError(
+                    "try_finish_row_into called without a positioned row".to_string(),
+                ));
+            }
+        };
+        if let Some(start) = start {
+            self.update_remaining_timeout(start);
+        }
+        if complete {
+            self.active_row_read_state = ActiveRowReadState::Idle;
+            writer.end_row();
+        }
+        Ok(complete)
+    }
+
+    /// Returns whether the current result can be consumed as complete rows
+    /// without changing the pull cursor's PLP streaming behavior.
+    pub fn current_result_supports_row_into(&self) -> bool {
+        let Some(metadata) = self.current_metadata.as_ref() else {
+            return false;
+        };
+        if let Some(cached) = self.buffered_row_support.as_ref()
+            && Arc::ptr_eq(metadata, &cached.metadata)
+        {
+            return cached.supported;
+        }
+        Self::metadata_supports_buffered_rows(metadata)
+    }
+
+    fn buffered_row_support(&mut self) -> bool {
+        let Some(metadata) = self.current_metadata.as_ref() else {
+            return false;
+        };
+        if let Some(cached) = self.buffered_row_support.as_ref()
+            && Arc::ptr_eq(metadata, &cached.metadata)
+        {
+            return cached.supported;
+        }
+
+        let supported = Self::metadata_supports_buffered_rows(metadata);
+        self.buffered_row_support = Some(Box::new(BufferedRowSupport {
+            metadata: Arc::clone(metadata),
+            supported,
+        }));
+        supported
+    }
+
+    fn metadata_supports_buffered_rows(metadata: &ColMetadataToken) -> bool {
+        metadata.cek_table.is_empty()
+            && metadata
+                .columns
+                .iter()
+                .all(|column| !column.is_plp() && column.crypto_metadata.is_none())
+    }
+
+    /// Finishes a row partially consumed by [`Self::try_finish_row_into`].
+    pub async fn finish_row_into<W>(&mut self, writer: &mut W) -> TdsResult<()>
+    where
+        W: RowWriter + Send + ?Sized,
+    {
+        let state = std::mem::replace(&mut self.active_row_read_state, ActiveRowReadState::Idle);
+        let pause_state = match state {
+            ActiveRowReadState::RowPaused(pause_state) => pause_state,
+            state => {
+                self.active_row_read_state = state;
+                return Err(UsageError(
+                    "finish_row_into called without a resumable positioned row".to_string(),
+                ));
+            }
+        };
+
+        let start = self.request_timeout_start();
+        let result = self
+            .transport
+            .resume_row_into(
+                *pause_state,
+                self.remaining_request_timeout,
+                self.cancel_handle.as_ref(),
+                ColumnPolicy::DecodeAll,
+                writer,
+            )
+            .await;
+        if let Some(start) = start {
+            self.update_remaining_timeout(start);
+        }
+
+        match result {
+            Ok(RowReadResult::RowWritten) => {
+                writer.end_row();
+                Ok(())
+            }
+            Ok(RowReadResult::RowPaused(pause_state)) => {
+                self.active_row_read_state = ActiveRowReadState::RowPaused(Box::new(pause_state));
+                Err(crate::error::Error::ProtocolError(
+                    "DecodeAll unexpectedly paused while finishing a row".to_string(),
+                ))
+            }
+            Ok(RowReadResult::PlpPaused(pause_state)) => {
+                self.active_row_read_state = ActiveRowReadState::PlpPaused(Box::new(pause_state));
+                Err(crate::error::Error::ProtocolError(
+                    "DecodeAll unexpectedly paused at a PLP value while finishing a row"
+                        .to_string(),
+                ))
+            }
+            Ok(RowReadResult::Token(_)) => Err(crate::error::Error::ProtocolError(
+                "row continuation returned a control token".to_string(),
+            )),
+            Err(error) => {
+                self.abort_pending_prepare_capture();
+                Err(error)
+            }
+        }
+    }
+
     /// Pulls column `target` (0-based) of the currently positioned row,
     /// skipping any intervening columns (ODBC `SQLGetData`). Forward-only:
     /// `target` must be at or after the cursor's next undecoded column.
@@ -5370,15 +5715,18 @@ impl TdsClient {
     /// - [`CursorColumn::Value`] with the decoded value for non-PLP columns,
     /// - [`CursorColumn::PlpStreaming`] when `target` is a PLP column whose
     ///   bytes must be pulled via [`read_active_plp_chunk`](Self::read_active_plp_chunk),
-    /// - [`CursorColumn::AlreadyConsumed`] if `target` was already read/skipped
-    ///   (including after the whole row has been consumed),
+    /// - [`CursorColumn::AlreadyConsumed`] if `target` was already read or skipped
+    ///   while the row remains positioned,
     /// - [`CursorColumn::RowEnded`] when no row is positioned.
+    ///
+    /// Use this directly, or after [`Self::try_read_row_column`] returns
+    /// [`CursorPoll::Pending`].
     ///
     /// # Errors
     ///
     /// Returns `UsageError` when `target` is out of range **and** a row is
     /// still positioned with unread columns (partially read). When no row is
-    /// positioned — including after the final column has been read — an
+    /// positioned -- including after the final column has been read -- an
     /// out-of-range or backward `target` yields [`CursorColumn::RowEnded`]
     /// instead of an error.
     ///
@@ -5394,7 +5742,7 @@ impl TdsClient {
     /// guarantee `read_row_column(0)` yields a value: a zero-column row is
     /// positioned with a column count of 0, so `read_row_column(0)` is
     /// out-of-range and returns `UsageError`.
-    #[instrument(skip(self), level = "info")]
+    // Avoid a span for every SQLGetData column; row and token events retain observability.
     pub async fn read_row_column(&mut self, target: usize) -> TdsResult<CursorColumn> {
         match std::mem::replace(&mut self.active_row_read_state, ActiveRowReadState::Idle) {
             ActiveRowReadState::Idle => Ok(CursorColumn::RowEnded),
@@ -5436,7 +5784,7 @@ impl TdsClient {
         }
 
         let mut capture = DefaultRowWriter::new(1);
-        let start = Instant::now();
+        let start = self.request_timeout_start();
         let result = self
             .transport
             .resume_row_into(
@@ -5447,7 +5795,9 @@ impl TdsClient {
                 &mut capture,
             )
             .await?;
-        self.update_remaining_timeout(start);
+        if let Some(start) = start {
+            self.update_remaining_timeout(start);
+        }
 
         match result {
             RowReadResult::RowPaused(next_pause) => {
@@ -6443,6 +6793,7 @@ mod tests {
     use crate::connection::transport::tds_transport::TdsTransport;
     use crate::core::{CancelHandle, TdsResult};
     use crate::datatypes::row_writer::RowWriter;
+    use crate::io::packet_reader::TdsPacketReader;
     use crate::io::reader_writer::{NetworkReader, NetworkWriter};
     use crate::io::token_stream::{
         ColumnPolicy, ParserContext, RowHeader, RowPauseState, RowReadResult, TdsTokenStreamReader,
@@ -6450,8 +6801,9 @@ mod tests {
     use crate::message::parameters::rpc_parameters::StreamedSqlType;
     use crate::test_client_support::byte_stream::tds_client_over_raw_bytes as client_over_bytes;
     use crate::test_client_support::byte_stream::tds_client_over_raw_bytes_with_column_encryption as client_over_bytes_with_ae;
+    use crate::test_packet_support::{TestPacketBuilder, create_network_transport_with_data};
     use crate::token::tokens::{
-        ColMetadataToken, CurrentCommand, DoneStatus, DoneToken, InfoToken, Tokens,
+        ColMetadataToken, CurrentCommand, DoneStatus, DoneToken, InfoToken, TokenType, Tokens,
     };
     use async_trait::async_trait;
     use std::collections::VecDeque;
@@ -6487,6 +6839,8 @@ mod tests {
         /// Cached liveness flag toggled by `mark_known_dead`, surfaced through
         /// `connection_known_dead` so tests can assert the fatal-error path.
         known_dead: bool,
+        sync_header_available: bool,
+        sync_columns: VecDeque<ColumnValues>,
         encryption_setting: NegotiatedEncryptionSetting,
         /// The `remaining_request_timeout` handed to each `receive_token`, so a
         /// test can assert which budget a read ran under without waiting for one
@@ -6509,6 +6863,8 @@ mod tests {
                 send_should_hang: Arc::new(std::sync::atomic::AtomicBool::new(false)),
                 attentions: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
                 known_dead: false,
+                sync_header_available: false,
+                sync_columns: VecDeque::new(),
                 encryption_setting: NegotiatedEncryptionSetting::NoEncryption,
                 receive_timeouts: Arc::new(std::sync::Mutex::new(Vec::new())),
             }
@@ -6543,6 +6899,33 @@ mod tests {
 
     #[async_trait]
     impl TdsTokenStreamReader for TestTransport {
+        fn try_receive_row_header(
+            &mut self,
+            context: &ParserContext,
+        ) -> TdsResult<Option<RowPauseState>> {
+            if !self.sync_header_available {
+                return Ok(None);
+            }
+            self.sync_header_available = false;
+            let ParserContext::ColumnMetadata(metadata, decryptor) = context else {
+                return Ok(None);
+            };
+            Ok(Some(RowPauseState {
+                next_column_index: 0,
+                metadata: Arc::clone(metadata),
+                nbc_null_bitmap: None,
+                decryptor: decryptor.clone(),
+            }))
+        }
+
+        fn try_read_buffered_column(
+            &mut self,
+            _pause_state: &RowPauseState,
+            _target: usize,
+        ) -> TdsResult<Option<ColumnValues>> {
+            Ok(self.sync_columns.pop_front())
+        }
+
         async fn receive_token(
             &mut self,
             _context: &ParserContext,
@@ -6810,7 +7193,10 @@ mod tests {
     }
 
     fn create_test_client_with_transport(transport: TestTransport) -> TdsClient {
-        let transport = AnyTransport::dynamic(transport);
+        create_test_client_with_any_transport(AnyTransport::dynamic(transport))
+    }
+
+    fn create_test_client_with_any_transport(transport: AnyTransport) -> TdsClient {
         let negotiated_settings =
             crate::handler::handler_factory::create_test_negotiated_settings_internal();
         let execution_context = crate::connection::execution_context::ExecutionContext::new();
@@ -7110,6 +7496,28 @@ mod tests {
 
     fn stale_metadata() -> Arc<ColMetadataToken> {
         Arc::new(ColMetadataToken::default())
+    }
+
+    fn int_column_metadata(column_count: usize) -> Arc<ColMetadataToken> {
+        let columns = (0..column_count)
+            .map(|index| crate::query::metadata::ColumnMetadata {
+                user_type: 0,
+                flags: 0,
+                type_info: crate::datatypes::sqldatatypes::TypeInfo::fixed_len(
+                    crate::datatypes::sqldatatypes::TdsDataType::Int4,
+                )
+                .unwrap(),
+                data_type: crate::datatypes::sqldatatypes::TdsDataType::Int4,
+                column_name: format!("c{index}"),
+                multi_part_name: None,
+                crypto_metadata: None,
+            })
+            .collect();
+        Arc::new(ColMetadataToken {
+            column_count: u16::try_from(column_count).unwrap(),
+            columns,
+            cek_table: vec![],
+        })
     }
 
     fn done_more() -> Tokens {
@@ -7591,6 +7999,228 @@ mod tests {
         let resolved = budget.into_timeout().unwrap();
         assert_eq!(resolved.seconds(), None);
         assert_eq!(resolved.duration(), None);
+    }
+
+    #[test]
+    fn sync_cursor_attempt_reads_buffered_header_and_columns_in_order() {
+        let metadata = int_column_metadata(2);
+        let mut transport = TestTransport::new();
+        transport.sync_header_available = true;
+        transport.sync_columns = VecDeque::from([ColumnValues::Int(10), ColumnValues::Int(20)]);
+        let mut client = create_test_client_with_transport(transport);
+        client.current_metadata = Some(metadata);
+        client.current_result_set_has_been_read_till_end = false;
+
+        assert_eq!(
+            client.try_next_row_cursor().unwrap(),
+            CursorPoll::Ready(true)
+        );
+        assert_eq!(
+            client.try_read_row_column(0).unwrap(),
+            CursorPoll::Ready(CursorColumn::Value {
+                value: ColumnValues::Int(10),
+                variant_base: None,
+            })
+        );
+        assert_eq!(
+            client.try_read_row_column(1).unwrap(),
+            CursorPoll::Ready(CursorColumn::Value {
+                value: ColumnValues::Int(20),
+                variant_base: None,
+            })
+        );
+        assert_eq!(
+            client.try_read_row_column(1).unwrap(),
+            CursorPoll::Ready(CursorColumn::RowEnded)
+        );
+    }
+
+    #[tokio::test]
+    async fn buffered_row_poll_completes_without_parking_cursor_state() {
+        let expected = [0x1234_5678_i32, -42_i32];
+        let mut payload = vec![0xff, TokenType::Row as u8];
+        payload.extend(expected.iter().flat_map(|value| value.to_le_bytes()));
+        let mut packet =
+            TestPacketBuilder::new(crate::message::messages::PacketType::TabularResult);
+        let mut transport =
+            create_network_transport_with_data(&packet.append_bytes(&payload).build());
+        assert_eq!(transport.read_byte().await.unwrap(), 0xff);
+        let mut client = create_test_client_with_any_transport(AnyTransport::network(transport));
+        client.current_metadata = Some(int_column_metadata(expected.len()));
+        client.current_result_set_has_been_read_till_end = false;
+        let mut writer = crate::datatypes::row_writer::DefaultRowWriter::new(expected.len());
+
+        assert_eq!(
+            client.try_next_buffered_row_into(&mut writer).unwrap(),
+            BufferedRowPoll::Complete
+        );
+        assert_eq!(
+            writer.take_row(),
+            expected
+                .into_iter()
+                .map(ColumnValues::Int)
+                .collect::<Vec<_>>()
+        );
+        assert!(matches!(
+            client.active_row_read_state,
+            ActiveRowReadState::Idle
+        ));
+    }
+
+    #[tokio::test]
+    async fn buffered_row_poll_parks_only_an_incomplete_row() {
+        let expected = [0x1234_5678_i32, -42_i32];
+        let second = expected[1].to_le_bytes();
+        let mut first_payload = vec![0xff, TokenType::Row as u8];
+        first_payload.extend_from_slice(&expected[0].to_le_bytes());
+        first_payload.extend_from_slice(&second[..2]);
+        let mut first = TestPacketBuilder::new(crate::message::messages::PacketType::TabularResult);
+        let mut second_packet =
+            TestPacketBuilder::new(crate::message::messages::PacketType::TabularResult);
+        let mut stream = first.continuation().append_bytes(&first_payload).build();
+        stream.extend_from_slice(&second_packet.append_bytes(&second[2..]).build());
+        let mut transport = create_network_transport_with_data(&stream);
+        assert_eq!(transport.read_byte().await.unwrap(), 0xff);
+        let mut client = create_test_client_with_any_transport(AnyTransport::network(transport));
+        client.current_metadata = Some(int_column_metadata(expected.len()));
+        client.current_result_set_has_been_read_till_end = false;
+        let mut writer = crate::datatypes::row_writer::DefaultRowWriter::new(expected.len());
+
+        assert_eq!(
+            client.try_next_buffered_row_into(&mut writer).unwrap(),
+            BufferedRowPoll::Partial
+        );
+        assert!(matches!(
+            client.active_row_read_state,
+            ActiveRowReadState::RowPaused(ref state) if state.next_column_index == 1
+        ));
+        client.finish_row_into(&mut writer).await.unwrap();
+        assert_eq!(
+            writer.take_row(),
+            expected
+                .into_iter()
+                .map(ColumnValues::Int)
+                .collect::<Vec<_>>()
+        );
+        assert!(matches!(
+            client.active_row_read_state,
+            ActiveRowReadState::Idle
+        ));
+    }
+
+    #[test]
+    fn sync_cursor_pending_leaves_cursor_state_untouched() {
+        let mut client = create_test_client();
+        client.current_metadata = Some(int_column_metadata(1));
+        client.current_result_set_has_been_read_till_end = false;
+
+        assert_eq!(client.try_next_row_cursor().unwrap(), CursorPoll::Pending);
+        assert!(matches!(
+            client.active_row_read_state,
+            ActiveRowReadState::Idle
+        ));
+
+        client.active_row_read_state = ActiveRowReadState::RowPaused(Box::new(RowPauseState {
+            next_column_index: 0,
+            metadata: int_column_metadata(1),
+            nbc_null_bitmap: None,
+            decryptor: None,
+        }));
+        assert_eq!(client.try_read_row_column(0).unwrap(), CursorPoll::Pending);
+        assert!(matches!(
+            client.active_row_read_state,
+            ActiveRowReadState::RowPaused(ref state) if state.next_column_index == 0
+        ));
+    }
+
+    #[test]
+    fn sync_cursor_ready_preserves_explicit_zero_timeout() {
+        let metadata = int_column_metadata(1);
+        let mut transport = TestTransport::new();
+        transport.sync_header_available = true;
+        transport.sync_columns.push_back(ColumnValues::Int(42));
+        let mut client = create_test_client_with_transport(transport);
+        client.current_metadata = Some(metadata);
+        client.current_result_set_has_been_read_till_end = false;
+        client.remaining_request_timeout = Some(Duration::ZERO);
+
+        assert_eq!(
+            client.try_next_row_cursor().unwrap(),
+            CursorPoll::Ready(true)
+        );
+        assert_eq!(
+            client.try_read_row_column(0).unwrap(),
+            CursorPoll::Ready(CursorColumn::Value {
+                value: ColumnValues::Int(42),
+                variant_base: None,
+            })
+        );
+        assert_eq!(client.remaining_request_timeout, Some(Duration::ZERO));
+    }
+
+    #[test]
+    fn sync_cursor_defers_cancelled_operations_without_consuming_state() {
+        let metadata = int_column_metadata(1);
+        let mut transport = TestTransport::new();
+        transport.sync_header_available = true;
+        transport.sync_columns.push_back(ColumnValues::Int(42));
+        let mut client = create_test_client_with_transport(transport);
+        client.current_metadata = Some(Arc::clone(&metadata));
+        client.current_result_set_has_been_read_till_end = false;
+        let cancellation = CancelHandle::new();
+        client.cancel_handle = Some(cancellation.child_handle());
+        cancellation.cancel();
+
+        assert_eq!(client.try_next_row_cursor().unwrap(), CursorPoll::Pending);
+        assert!(matches!(
+            client.active_row_read_state,
+            ActiveRowReadState::Idle
+        ));
+
+        client.active_row_read_state = ActiveRowReadState::RowPaused(Box::new(RowPauseState {
+            next_column_index: 0,
+            metadata,
+            nbc_null_bitmap: None,
+            decryptor: None,
+        }));
+        assert_eq!(client.try_read_row_column(0).unwrap(), CursorPoll::Pending);
+        assert!(matches!(
+            client.active_row_read_state,
+            ActiveRowReadState::RowPaused(ref state) if state.next_column_index == 0
+        ));
+    }
+
+    #[test]
+    fn row_writer_finish_is_limited_to_non_plp_results() {
+        let mut client = create_test_client();
+        assert!(!client.current_result_supports_row_into());
+
+        client.current_metadata = Some(int_column_metadata(1));
+        assert!(client.current_result_supports_row_into());
+        assert!(client.buffered_row_support());
+        assert!(client.buffered_row_support());
+
+        let column = crate::query::metadata::ColumnMetadata {
+            user_type: 0,
+            flags: 0,
+            type_info: crate::datatypes::sqldatatypes::TypeInfo::partial_len(
+                crate::datatypes::sqldatatypes::TdsDataType::BigVarBinary,
+                usize::from(u16::MAX),
+                None,
+            )
+            .unwrap(),
+            data_type: crate::datatypes::sqldatatypes::TdsDataType::BigVarBinary,
+            column_name: "payload".to_string(),
+            multi_part_name: None,
+            crypto_metadata: None,
+        };
+        client.current_metadata = Some(Arc::new(ColMetadataToken {
+            column_count: 1,
+            columns: vec![column],
+            cek_table: vec![],
+        }));
+        assert!(!client.current_result_supports_row_into());
+        assert!(!client.buffered_row_support());
     }
 
     // ── PLP streaming lifecycle contract tests ──
@@ -8420,6 +9050,25 @@ mod tests {
     }
 
     // ── deduct_timeout tests ──
+
+    #[test]
+    fn request_timeout_clock_is_skipped_without_budget() {
+        let client = create_test_client();
+        assert!(client.request_timeout_start().is_none());
+    }
+
+    #[test]
+    fn request_timeout_clock_is_kept_for_exhausted_budget() {
+        let mut client = create_test_client();
+        client.remaining_request_timeout = Some(Duration::ZERO);
+
+        let start = client
+            .request_timeout_start()
+            .expect("an explicit zero budget must still be measured");
+        client.update_remaining_timeout(start);
+
+        assert_eq!(client.remaining_request_timeout, Some(Duration::ZERO));
+    }
 
     #[test]
     fn deduct_timeout_subtracts_elapsed() {

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -230,7 +230,10 @@ pub enum CursorColumn {
     RowEnded,
 }
 
-/// Result of a non-blocking pull-cursor attempt.
+/// Result of a non-blocking pull-cursor attempt on concrete [`TdsClient`].
+///
+/// This polling surface is not part of [`ResultSet`]; synchronous bindings use
+/// it directly and continue with the matching async client method on `Pending`.
 #[derive(Debug, PartialEq)]
 pub enum CursorPoll<T> {
     /// The operation completed entirely from bytes already buffered by the
@@ -242,7 +245,22 @@ pub enum CursorPoll<T> {
     Pending,
 }
 
-/// Result of attempting to decode the next row entirely from transport-buffered bytes.
+impl<T> CursorPoll<T> {
+    /// Returns a buffered result immediately or invokes `fallback` once when
+    /// asynchronous continuation is required.
+    pub fn resolve<E>(self, fallback: impl FnOnce() -> Result<T, E>) -> Result<T, E> {
+        match self {
+            Self::Ready(value) => Ok(value),
+            Self::Pending => fallback(),
+        }
+    }
+}
+
+/// Result of a concrete [`TdsClient`] attempt to decode the next row from
+/// transport-buffered bytes.
+///
+/// `Pending` is non-destructive. `Partial` has written a prefix, so callers must
+/// reuse the same writer with [`TdsClient::finish_row_into`].
 #[derive(Debug, PartialEq)]
 pub enum BufferedRowPoll {
     /// A complete row was written.
@@ -5203,11 +5221,13 @@ impl TdsClient {
     /// this returns a [`UsageError`] rather than silently draining and skipping
     /// that row; a fully-consumed or absent row is accepted.
     ///
-    /// Uses `receive_row_into` to decode ROW/NBCROW tokens directly through
-    /// `decode_into`, bypassing the intermediate `RowToken { all_values }`.
-    /// Concrete writers stay concrete through the production transport and
-    /// decode chain. [`ResultSet::next_row_into`] provides the same operation
-    /// through statically dispatched trait calls.
+    /// Buffered, unencrypted, non-PLP rows are decoded synchronously first.
+    /// Incomplete rows continue asynchronously with the same writer; other
+    /// unsupported buffered shapes use `receive_row_into`. All paths bypass the
+    /// intermediate `RowToken { all_values }`. Concrete writers stay concrete
+    /// through the production transport and decode chain.
+    /// [`ResultSet::next_row_into`] provides the same operation through
+    /// statically dispatched trait calls.
     // `#[instrument]` adds enough state to exceed the 4096 B budget once the
     // lazy timeout future is inlined. Successful rows still emit `Row Received`.
     pub async fn next_row_into<W>(&mut self, writer: &mut W) -> TdsResult<bool>
@@ -5242,6 +5262,27 @@ impl TdsClient {
                      advance the cursor with next_row_cursor before using the push row API"
                         .to_string(),
                 ));
+            }
+        }
+
+        match self.try_next_buffered_row_into(writer) {
+            Ok(BufferedRowPoll::Complete) => {
+                info!("Row Received");
+                return Ok(true);
+            }
+            Ok(BufferedRowPoll::Partial) => {
+                if let Err(error) = self.finish_row_into(writer).await {
+                    self.abort_pending_prepare_capture();
+                    return Err(error);
+                }
+                info!("Row Received");
+                return Ok(true);
+            }
+            Ok(BufferedRowPoll::Exhausted) => return Ok(false),
+            Ok(BufferedRowPoll::Pending) => {}
+            Err(error) => {
+                self.abort_pending_prepare_capture();
+                return Err(error);
             }
         }
 
@@ -8002,6 +8043,30 @@ mod tests {
     }
 
     #[test]
+    fn cursor_poll_resolves_ready_without_fallback() {
+        let mut calls = 0;
+        let value = CursorPoll::Ready(7).resolve::<()>(|| {
+            calls += 1;
+            Ok(9)
+        });
+
+        assert_eq!(value, Ok(7));
+        assert_eq!(calls, 0);
+    }
+
+    #[test]
+    fn cursor_poll_resolves_pending_with_one_fallback() {
+        let mut calls = 0;
+        let value = CursorPoll::Pending.resolve::<()>(|| {
+            calls += 1;
+            Ok(9)
+        });
+
+        assert_eq!(value, Ok(9));
+        assert_eq!(calls, 1);
+    }
+
+    #[test]
     fn sync_cursor_attempt_reads_buffered_header_and_columns_in_order() {
         let metadata = int_column_metadata(2);
         let mut transport = TestTransport::new();
@@ -8065,6 +8130,31 @@ mod tests {
             client.active_row_read_state,
             ActiveRowReadState::Idle
         ));
+    }
+
+    #[tokio::test]
+    async fn next_row_into_uses_buffered_dispatch() {
+        let expected = [0x1234_5678_i32, -42_i32];
+        let mut payload = vec![0xff, TokenType::Row as u8];
+        payload.extend(expected.iter().flat_map(|value| value.to_le_bytes()));
+        let mut packet =
+            TestPacketBuilder::new(crate::message::messages::PacketType::TabularResult);
+        let mut transport =
+            create_network_transport_with_data(&packet.append_bytes(&payload).build());
+        assert_eq!(transport.read_byte().await.unwrap(), 0xff);
+        let mut client = create_test_client_with_any_transport(AnyTransport::network(transport));
+        client.current_metadata = Some(int_column_metadata(expected.len()));
+        client.current_result_set_has_been_read_till_end = false;
+        let mut writer = crate::datatypes::row_writer::DefaultRowWriter::new(expected.len());
+
+        assert!(client.next_row_into(&mut writer).await.unwrap());
+        assert_eq!(
+            writer.take_row(),
+            expected
+                .into_iter()
+                .map(ColumnValues::Int)
+                .collect::<Vec<_>>()
+        );
     }
 
     #[tokio::test]

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -342,9 +342,12 @@ struct StreamedWriteContext {
     timeout_sec: Option<u32>,
 }
 
+/// Cached whole-row eligibility paired with the exact metadata allocation it describes.
 #[derive(Debug)]
 struct BufferedRowSupport {
+    /// Metadata allocation whose eligibility was evaluated.
     metadata: Arc<ColMetadataToken>,
+    /// Whether all columns support buffered whole-row decoding.
     supported: bool,
 }
 
@@ -1090,6 +1093,7 @@ impl TdsClient {
     }
 
     #[inline]
+    /// Starts timeout accounting only when the request has a finite budget.
     fn request_timeout_start(&self) -> Option<Instant> {
         self.remaining_request_timeout.map(|_| Instant::now())
     }
@@ -5663,6 +5667,7 @@ impl TdsClient {
         Self::metadata_supports_buffered_rows(metadata)
     }
 
+    /// Returns and caches whole-row eligibility for the current metadata allocation.
     fn buffered_row_support(&mut self) -> bool {
         let Some(metadata) = self.current_metadata.as_ref() else {
             return false;
@@ -5681,6 +5686,7 @@ impl TdsClient {
         supported
     }
 
+    /// Checks whether every column can use the non-streaming, non-encrypted row path.
     fn metadata_supports_buffered_rows(metadata: &ColMetadataToken) -> bool {
         metadata.cek_table.is_empty()
             && metadata

--- a/mssql-tds/src/connection/transport/any_transport.rs
+++ b/mssql-tds/src/connection/transport/any_transport.rs
@@ -146,6 +146,7 @@ impl AnyTransport {
         }
     }
 
+    /// Attempts to position a row using only bytes already buffered by the active transport.
     pub(crate) fn try_receive_row_header(
         &mut self,
         context: &ParserContext,
@@ -159,6 +160,7 @@ impl AnyTransport {
         }
     }
 
+    /// Attempts to decode one buffered column while retaining a `sql_variant` base type.
     pub(crate) fn try_read_buffered_column_with_base(
         &mut self,
         pause_state: &RowPauseState,
@@ -180,6 +182,7 @@ impl AnyTransport {
         }
     }
 
+    /// Writes as much of the current buffered row as the active transport can complete.
     pub(crate) fn try_read_buffered_row_into<W: RowWriter + ?Sized>(
         &mut self,
         pause_state: &mut RowPauseState,

--- a/mssql-tds/src/connection/transport/any_transport.rs
+++ b/mssql-tds/src/connection/transport/any_transport.rs
@@ -159,17 +159,24 @@ impl AnyTransport {
         }
     }
 
-    pub(crate) fn try_read_buffered_column(
+    pub(crate) fn try_read_buffered_column_with_base(
         &mut self,
         pause_state: &RowPauseState,
         target: usize,
-    ) -> TdsResult<Option<ColumnValues>> {
+    ) -> TdsResult<
+        Option<(
+            ColumnValues,
+            Option<crate::datatypes::sqldatatypes::TdsDataType>,
+        )>,
+    > {
         match self {
             Self::Network(transport) => {
-                TdsTokenStreamReader::try_read_buffered_column(transport, pause_state, target)
+                transport.try_read_buffered_column_with_base(pause_state, target)
             }
             #[cfg(any(test, feature = "test-util", fuzzing))]
-            Self::Dynamic(transport) => transport.try_read_buffered_column(pause_state, target),
+            Self::Dynamic(transport) => transport
+                .try_read_buffered_column(pause_state, target)
+                .map(|value| value.map(|value| (value, None))),
         }
     }
 

--- a/mssql-tds/src/connection/transport/any_transport.rs
+++ b/mssql-tds/src/connection/transport/any_transport.rs
@@ -181,7 +181,16 @@ impl AnyTransport {
         match self {
             Self::Network(transport) => transport.try_read_buffered_row_into(pause_state, writer),
             #[cfg(any(test, feature = "test-util", fuzzing))]
-            Self::Dynamic(_) => Ok(false),
+            Self::Dynamic(transport) => {
+                let Some(row) = transport.try_read_buffered_test_row(pause_state)? else {
+                    return Ok(false);
+                };
+                for value in row {
+                    writer.write_i32(pause_state.next_column_index, value);
+                    pause_state.next_column_index += 1;
+                }
+                Ok(true)
+            }
         }
     }
 

--- a/mssql-tds/src/connection/transport/any_transport.rs
+++ b/mssql-tds/src/connection/transport/any_transport.rs
@@ -189,14 +189,15 @@ impl AnyTransport {
             Self::Network(transport) => transport.try_read_buffered_row_into(pause_state, writer),
             #[cfg(any(test, feature = "test-util", fuzzing))]
             Self::Dynamic(transport) => {
-                let Some(row) = transport.try_read_buffered_test_row(pause_state)? else {
+                let Some((row, complete)) = transport.try_read_buffered_test_row(pause_state)?
+                else {
                     return Ok(false);
                 };
                 for value in row {
                     writer.write_i32(pause_state.next_column_index, value);
                     pause_state.next_column_index += 1;
                 }
-                Ok(true)
+                Ok(complete)
             }
         }
     }

--- a/mssql-tds/src/connection/transport/any_transport.rs
+++ b/mssql-tds/src/connection/transport/any_transport.rs
@@ -10,10 +10,12 @@ use futures::future::Either;
 use crate::connection::transport::network_transport::NetworkTransport;
 use crate::connection::transport::tds_transport::TdsTransport;
 use crate::core::{CancelHandle, TdsResult};
+use crate::datatypes::column_values::ColumnValues;
 use crate::datatypes::row_writer::RowWriter;
 use crate::io::reader_writer::NetworkWriter;
 use crate::io::token_stream::{
     ColumnPolicy, ParserContext, PlpPauseState, RowHeader, RowPauseState, RowReadResult,
+    TdsTokenStreamReader,
 };
 use crate::token::tokens::Tokens;
 
@@ -141,6 +143,45 @@ impl AnyTransport {
                     .receive_row_header(context, remaining_request_timeout, cancel_handle)
                     .await
             }
+        }
+    }
+
+    pub(crate) fn try_receive_row_header(
+        &mut self,
+        context: &ParserContext,
+    ) -> TdsResult<Option<RowPauseState>> {
+        match self {
+            Self::Network(transport) => {
+                TdsTokenStreamReader::try_receive_row_header(transport, context)
+            }
+            #[cfg(any(test, feature = "test-util", fuzzing))]
+            Self::Dynamic(transport) => transport.try_receive_row_header(context),
+        }
+    }
+
+    pub(crate) fn try_read_buffered_column(
+        &mut self,
+        pause_state: &RowPauseState,
+        target: usize,
+    ) -> TdsResult<Option<ColumnValues>> {
+        match self {
+            Self::Network(transport) => {
+                TdsTokenStreamReader::try_read_buffered_column(transport, pause_state, target)
+            }
+            #[cfg(any(test, feature = "test-util", fuzzing))]
+            Self::Dynamic(transport) => transport.try_read_buffered_column(pause_state, target),
+        }
+    }
+
+    pub(crate) fn try_read_buffered_row_into<W: RowWriter + ?Sized>(
+        &mut self,
+        pause_state: &mut RowPauseState,
+        writer: &mut W,
+    ) -> TdsResult<bool> {
+        match self {
+            Self::Network(transport) => transport.try_read_buffered_row_into(pause_state, writer),
+            #[cfg(any(test, feature = "test-util", fuzzing))]
+            Self::Dynamic(_) => Ok(false),
         }
     }
 

--- a/mssql-tds/src/connection/transport/buffers.rs
+++ b/mssql-tds/src/connection/transport/buffers.rs
@@ -215,10 +215,17 @@ impl TdsReadBuffer {
         self.buffer_length += new_packet_size - 8;
     }
 
+    /// Returns the remaining allocation from the current position, including
+    /// capacity beyond `buffer_length`. Fixed-width readers use this only after
+    /// `do_we_have_enough_data` proves the requested bytes are valid.
     pub(crate) fn get_slice(&self) -> &[u8] {
         &self.working_buffer[self.buffer_position..]
     }
 
+    /// Returns only bytes received from the wire and not yet consumed.
+    ///
+    /// Sync-first decoders must use this bounded view so unused or stale bytes
+    /// after `buffer_length` cannot make an incomplete value appear complete.
     pub(crate) fn get_buffered_slice(&self) -> &[u8] {
         &self.working_buffer[self.buffer_position..self.buffer_length]
     }

--- a/mssql-tds/src/connection/transport/buffers.rs
+++ b/mssql-tds/src/connection/transport/buffers.rs
@@ -218,6 +218,10 @@ impl TdsReadBuffer {
     pub(crate) fn get_slice(&self) -> &[u8] {
         &self.working_buffer[self.buffer_position..]
     }
+
+    pub(crate) fn get_buffered_slice(&self) -> &[u8] {
+        &self.working_buffer[self.buffer_position..self.buffer_length]
+    }
 }
 
 impl Debug for TdsReadBuffer {

--- a/mssql-tds/src/connection/transport/network_transport.rs
+++ b/mssql-tds/src/connection/transport/network_transport.rs
@@ -15,6 +15,7 @@ use crate::core::{
 use crate::datatypes::column_values::ColumnValues;
 use crate::datatypes::decoder::GenericDecoder;
 use crate::datatypes::row_writer::RowWriter;
+use crate::datatypes::sqldatatypes::TdsDataType;
 use crate::error::Error::{OperationCancelledError, TimeoutError};
 use crate::error::TimeoutErrorType;
 use crate::handler::handler_factory::SessionSettings;
@@ -1801,6 +1802,42 @@ impl NetworkTransport {
         };
         self.tds_read_buffer.consume_bytes(used)?;
         Ok(Some(value))
+    }
+
+    pub(crate) fn try_read_buffered_column_with_base(
+        &mut self,
+        pause_state: &RowPauseState,
+        target: usize,
+    ) -> TdsResult<Option<(ColumnValues, Option<TdsDataType>)>> {
+        if target != pause_state.next_column_index {
+            return Ok(None);
+        }
+        let Some(metadata) = pause_state.metadata.columns.get(target) else {
+            return Ok(None);
+        };
+        if pause_state
+            .nbc_null_bitmap
+            .as_ref()
+            .is_some_and(|bitmap| bitmap[target / 8] & (1 << (target % 8)) != 0)
+        {
+            return Ok(Some((ColumnValues::Null, None)));
+        }
+        if metadata.data_type != TdsDataType::SsVariant {
+            return self
+                .try_read_buffered_column(pause_state, target)
+                .map(|value| value.map(|value| (value, None)));
+        }
+        if pause_state.decryptor.is_some() {
+            return Ok(None);
+        }
+        let decoder = GenericDecoder::default();
+        let Some((base, value, used)) =
+            decoder.try_decode_buffered_variant(self.tds_read_buffer.get_buffered_slice())?
+        else {
+            return Ok(None);
+        };
+        self.tds_read_buffer.consume_bytes(used)?;
+        Ok(Some((value, base)))
     }
 
     pub(crate) fn try_read_buffered_row_into<W: RowWriter + ?Sized>(
@@ -3633,6 +3670,37 @@ pub(crate) mod tests {
                 .unwrap()
         );
         assert_eq!(writer.take_row(), vec![ColumnValues::Null]);
+    }
+
+    #[tokio::test]
+    async fn buffered_variant_column_honors_nbcrow_null_bitmap() {
+        let metadata = Arc::new(ColMetadataToken {
+            column_count: 1,
+            columns: vec![ColumnMetadata {
+                user_type: 0,
+                flags: 0,
+                type_info: TypeInfo::var_len(TdsDataType::SsVariant, 8009).unwrap(),
+                data_type: TdsDataType::SsVariant,
+                column_name: "variant".to_string(),
+                multi_part_name: None,
+                crypto_metadata: None,
+            }],
+            cek_table: Vec::new(),
+        });
+        let pause_state = RowPauseState {
+            next_column_index: 0,
+            metadata,
+            nbc_null_bitmap: Some(Arc::from([1_u8])),
+            decryptor: None,
+        };
+        let mut reader = create_network_transport_with_data(&[]);
+
+        assert_eq!(
+            reader
+                .try_read_buffered_column_with_base(&pause_state, 0)
+                .unwrap(),
+            Some((ColumnValues::Null, None))
+        );
     }
 
     #[tokio::test]

--- a/mssql-tds/src/connection/transport/network_transport.rs
+++ b/mssql-tds/src/connection/transport/network_transport.rs
@@ -1719,6 +1719,7 @@ impl TdsPacketReader for NetworkTransport {
 }
 
 impl NetworkTransport {
+    /// Parses a buffered ROW/NBCROW header without refilling the network buffer.
     pub(crate) fn try_receive_row_header(
         &mut self,
         context: &ParserContext,
@@ -1772,6 +1773,7 @@ impl NetworkTransport {
         }))
     }
 
+    /// Decodes the next ordinary buffered column without consuming on a miss.
     pub(crate) fn try_read_buffered_column(
         &mut self,
         pause_state: &RowPauseState,
@@ -1804,6 +1806,7 @@ impl NetworkTransport {
         Ok(Some(value))
     }
 
+    /// Decodes the next buffered column and preserves its `sql_variant` base type.
     pub(crate) fn try_read_buffered_column_with_base(
         &mut self,
         pause_state: &RowPauseState,
@@ -1840,6 +1843,10 @@ impl NetworkTransport {
         Ok(Some((value, base)))
     }
 
+    /// Decodes consecutive buffered columns directly into `writer`.
+    ///
+    /// Returns `false` after preserving the partially advanced row state when
+    /// the next value needs async continuation.
     pub(crate) fn try_read_buffered_row_into<W: RowWriter + ?Sized>(
         &mut self,
         pause_state: &mut RowPauseState,

--- a/mssql-tds/src/connection/transport/network_transport.rs
+++ b/mssql-tds/src/connection/transport/network_transport.rs
@@ -3537,6 +3537,105 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
+    async fn buffered_cursor_rejects_invalid_context_and_preserves_non_rows() {
+        let mut empty_packet = TestPacketBuilder::new(PacketType::TabularResult);
+        let mut empty = create_network_transport_with_data(&empty_packet.build());
+        empty.read_tds_packet().await.unwrap();
+        assert!(
+            empty
+                .try_receive_row_header(&int4_row_context(1))
+                .unwrap()
+                .is_none()
+        );
+
+        let mut packet = TestPacketBuilder::new(PacketType::TabularResult);
+        let payload = [TokenType::Done as u8];
+        let mut reader = create_network_transport_with_data(&packet.append_bytes(&payload).build());
+        reader.read_tds_packet().await.unwrap();
+
+        assert!(
+            reader
+                .try_receive_row_header(&ParserContext::None(()))
+                .is_err()
+        );
+        assert!(
+            reader
+                .try_receive_row_header(&int4_row_context(1))
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(reader.tds_read_buffer.get_remaining_byte_count(), 1);
+
+        let pause_state = RowPauseState {
+            next_column_index: 1,
+            metadata: match int4_row_context(1) {
+                ParserContext::ColumnMetadata(metadata, _) => metadata,
+                _ => unreachable!(),
+            },
+            nbc_null_bitmap: None,
+            decryptor: None,
+        };
+        assert_eq!(
+            reader.try_read_buffered_column(&pause_state, 1).unwrap(),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn buffered_row_writer_propagates_decoder_errors() {
+        let metadata = Arc::new(ColMetadataToken {
+            column_count: 1,
+            columns: vec![ColumnMetadata {
+                user_type: 0,
+                flags: 0,
+                type_info: TypeInfo::var_len(TdsDataType::IntN, 8).unwrap(),
+                data_type: TdsDataType::IntN,
+                column_name: "value".to_string(),
+                multi_part_name: None,
+                crypto_metadata: None,
+            }],
+            cek_table: Vec::new(),
+        });
+        let mut pause_state = RowPauseState {
+            next_column_index: 0,
+            metadata,
+            nbc_null_bitmap: None,
+            decryptor: None,
+        };
+        let mut packet = TestPacketBuilder::new(PacketType::TabularResult);
+        let mut reader =
+            create_network_transport_with_data(&packet.append_bytes(&[3, 0, 0, 0]).build());
+        reader.read_tds_packet().await.unwrap();
+        let mut writer = DefaultRowWriter::new(1);
+
+        assert!(
+            reader
+                .try_read_buffered_row_into(&mut pause_state, &mut writer)
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn buffered_row_writer_writes_nbcrow_nulls() {
+        let mut packet = TestPacketBuilder::new(PacketType::TabularResult);
+        let payload = [TokenType::NbcRow as u8, 0b0000_0001];
+        let mut reader = create_network_transport_with_data(&packet.append_bytes(&payload).build());
+        reader.read_tds_packet().await.unwrap();
+        let mut pause_state = reader
+            .try_receive_row_header(&int4_row_context(1))
+            .unwrap()
+            .unwrap();
+        let mut writer = DefaultRowWriter::new(1);
+
+        assert!(
+            reader
+                .try_read_buffered_row_into(&mut pause_state, &mut writer)
+                .unwrap()
+        );
+        assert_eq!(writer.take_row(), vec![ColumnValues::Null]);
+    }
+
+    #[tokio::test]
     async fn buffered_nbcrow_reuses_unaliased_bitmap_allocation() {
         let mut packet = TestPacketBuilder::new(PacketType::TabularResult);
         let payload = [

--- a/mssql-tds/src/connection/transport/network_transport.rs
+++ b/mssql-tds/src/connection/transport/network_transport.rs
@@ -12,6 +12,8 @@ use crate::connection_provider::tds_connection_provider::PARSER_REGISTRY;
 use crate::core::{
     CancelHandle, EncryptionOptions, EncryptionSetting, NegotiatedEncryptionSetting, TdsResult,
 };
+use crate::datatypes::column_values::ColumnValues;
+use crate::datatypes::decoder::GenericDecoder;
 use crate::datatypes::row_writer::RowWriter;
 use crate::error::Error::{OperationCancelledError, TimeoutError};
 use crate::error::TimeoutErrorType;
@@ -27,7 +29,7 @@ use crate::io::token_stream::{
 use crate::message::attention::AttentionRequest;
 use crate::message::login_options::TdsVersion;
 use crate::message::messages::{PacketStatusFlags, Request, ResetConnectionMode};
-use crate::token::tokens::{DoneStatus, Tokens};
+use crate::token::tokens::{DoneStatus, TokenType, Tokens};
 use async_trait::async_trait;
 use byteorder::{BigEndian, ByteOrder, LittleEndian};
 use std::cmp::min;
@@ -1716,6 +1718,154 @@ impl TdsPacketReader for NetworkTransport {
 }
 
 impl NetworkTransport {
+    pub(crate) fn try_receive_row_header(
+        &mut self,
+        context: &ParserContext,
+    ) -> TdsResult<Option<RowPauseState>> {
+        let ParserContext::ColumnMetadata(metadata, decryptor) = context else {
+            return Err(crate::error::Error::ProtocolError(
+                "Expected ColumnMetadata in context for row decoding".to_string(),
+            ));
+        };
+        let buffered = self.tds_read_buffer.get_buffered_slice();
+        let Some(&token) = buffered.first() else {
+            return Ok(None);
+        };
+
+        if token == TokenType::Row as u8 {
+            self.tds_read_buffer.consume_bytes(1)?;
+            return Ok(Some(RowPauseState {
+                next_column_index: 0,
+                metadata: Arc::clone(metadata),
+                nbc_null_bitmap: None,
+                decryptor: decryptor.clone(),
+            }));
+        }
+
+        if token != TokenType::NbcRow as u8 {
+            return Ok(None);
+        }
+
+        let bitmap_len = metadata.columns.len().div_ceil(8);
+        let Some(bitmap_bytes) = buffered.get(1..1 + bitmap_len) else {
+            return Ok(None);
+        };
+        let bitmap = if let Some(mut cached) = self.nbc_bitmap_scratch.take()
+            && cached.len() == bitmap_len
+            && let Some(buffer) = Arc::get_mut(&mut cached)
+        {
+            buffer.copy_from_slice(bitmap_bytes);
+            self.nbc_bitmap_scratch = Some(Arc::clone(&cached));
+            cached
+        } else {
+            let bitmap: Arc<[u8]> = Arc::from(bitmap_bytes);
+            self.nbc_bitmap_scratch = Some(Arc::clone(&bitmap));
+            bitmap
+        };
+        self.tds_read_buffer.consume_bytes(1 + bitmap_len)?;
+        Ok(Some(RowPauseState {
+            next_column_index: 0,
+            metadata: Arc::clone(metadata),
+            nbc_null_bitmap: Some(bitmap),
+            decryptor: decryptor.clone(),
+        }))
+    }
+
+    pub(crate) fn try_read_buffered_column(
+        &mut self,
+        pause_state: &RowPauseState,
+        target: usize,
+    ) -> TdsResult<Option<ColumnValues>> {
+        if target != pause_state.next_column_index {
+            return Ok(None);
+        }
+        let Some(metadata) = pause_state.metadata.columns.get(target) else {
+            return Ok(None);
+        };
+        if pause_state
+            .nbc_null_bitmap
+            .as_ref()
+            .is_some_and(|bitmap| bitmap[target / 8] & (1 << (target % 8)) != 0)
+        {
+            return Ok(Some(ColumnValues::Null));
+        }
+        if pause_state.decryptor.is_some() {
+            return Ok(None);
+        }
+
+        let decoder = GenericDecoder::default();
+        let Some((value, used)) =
+            decoder.try_decode_buffered(self.tds_read_buffer.get_buffered_slice(), metadata)?
+        else {
+            return Ok(None);
+        };
+        self.tds_read_buffer.consume_bytes(used)?;
+        Ok(Some(value))
+    }
+
+    pub(crate) fn try_read_buffered_row_into<W: RowWriter + ?Sized>(
+        &mut self,
+        pause_state: &mut RowPauseState,
+        writer: &mut W,
+    ) -> TdsResult<bool> {
+        if pause_state.decryptor.is_some() {
+            return Ok(false);
+        }
+
+        let decoder = GenericDecoder::default();
+        let mut consumed = 0usize;
+        let outcome = {
+            let buffered = self.tds_read_buffer.get_buffered_slice();
+            let mut outcome = Ok(true);
+            while let Some(metadata) = pause_state
+                .metadata
+                .columns
+                .get(pause_state.next_column_index)
+            {
+                let col = pause_state.next_column_index;
+                if pause_state
+                    .nbc_null_bitmap
+                    .as_ref()
+                    .is_some_and(|bitmap| bitmap[col / 8] & (1 << (col % 8)) != 0)
+                {
+                    writer.write_null(col);
+                    pause_state.next_column_index += 1;
+                    continue;
+                }
+
+                let Some(remaining) = buffered.get(consumed..) else {
+                    outcome = Err(crate::error::Error::ProtocolError(
+                        "Buffered row decoder consumed past the available data".to_string(),
+                    ));
+                    break;
+                };
+                match decoder.try_decode_buffered_into(remaining, metadata, col, writer) {
+                    Ok(Some(used)) => {
+                        let Some(next) = consumed.checked_add(used) else {
+                            outcome = Err(crate::error::Error::ProtocolError(
+                                "Buffered row decoder byte count overflowed".to_string(),
+                            ));
+                            break;
+                        };
+                        consumed = next;
+                        pause_state.next_column_index += 1;
+                    }
+                    Ok(None) => {
+                        outcome = Ok(false);
+                        break;
+                    }
+                    Err(error) => {
+                        outcome = Err(error);
+                        break;
+                    }
+                }
+            }
+            outcome
+        };
+        self.tds_read_buffer.consume_bytes(consumed)?;
+        outcome
+    }
+
     pub(crate) async fn receive_token(
         &mut self,
         context: &ParserContext,
@@ -1889,6 +2039,21 @@ impl NetworkTransport {
 
 #[async_trait]
 impl TdsTokenStreamReader for NetworkTransport {
+    fn try_receive_row_header(
+        &mut self,
+        context: &ParserContext,
+    ) -> TdsResult<Option<RowPauseState>> {
+        NetworkTransport::try_receive_row_header(self, context)
+    }
+
+    fn try_read_buffered_column(
+        &mut self,
+        pause_state: &RowPauseState,
+        target: usize,
+    ) -> TdsResult<Option<ColumnValues>> {
+        NetworkTransport::try_read_buffered_column(self, pause_state, target)
+    }
+
     async fn receive_token(
         &mut self,
         context: &ParserContext,
@@ -2047,12 +2212,16 @@ pub(crate) mod tests {
     use crate::connection::transport::network_transport::Stream;
     use crate::connection::transport::ssl_handler::SslHandler;
     use crate::core::EncryptionOptions;
+    use crate::datatypes::row_writer::DefaultRowWriter;
+    use crate::datatypes::sqldatatypes::{TdsDataType, TypeInfo};
     use crate::message::messages::PacketType;
+    use crate::query::metadata::ColumnMetadata;
     use crate::test_packet_support::{
         TestPacketBuilder, build_duplex_transport, create_network_transport_with_chunked_data,
         create_network_transport_with_data, create_network_transport_with_live_peer,
         create_network_transport_with_live_peer_capturing_writes, encode_utf16_le,
     };
+    use crate::token::tokens::ColMetadataToken;
     use bytes::Bytes;
     use futures::SinkExt;
     use futures::StreamExt;
@@ -2063,6 +2232,27 @@ pub(crate) mod tests {
     // The choice of 8192 is large enough for sending data. This stream should have a buffer large enough for send.
     // The test would keep the payload lower than this size to make sure that the duplex stream can handle it.
     pub(crate) const MAX_BUFFER_SIZE: usize = 8192;
+
+    fn int4_row_context(column_count: usize) -> ParserContext {
+        ParserContext::ColumnMetadata(
+            Arc::new(ColMetadataToken {
+                column_count: u16::try_from(column_count).unwrap(),
+                columns: (0..column_count)
+                    .map(|index| ColumnMetadata {
+                        user_type: 0,
+                        flags: 0,
+                        type_info: TypeInfo::fixed_len(TdsDataType::Int4).unwrap(),
+                        data_type: TdsDataType::Int4,
+                        column_name: format!("value{index}"),
+                        multi_part_name: None,
+                        crypto_metadata: None,
+                    })
+                    .collect(),
+                cek_table: vec![],
+            }),
+            None,
+        )
+    }
 
     impl Stream for DuplexStream {
         fn tls_handshake_starting(&mut self) {
@@ -3180,6 +3370,244 @@ pub(crate) mod tests {
         let mut reader = create_network_transport_with_chunked_data(&stream, 3);
 
         assert_eq!(reader.read_uint32().await.unwrap(), 0x4433_2211);
+    }
+
+    #[tokio::test]
+    async fn buffered_cursor_reads_complete_row_header_and_column() {
+        let expected = 0x1234_5678_i32;
+        let mut packet = TestPacketBuilder::new(PacketType::TabularResult);
+        let mut payload = vec![TokenType::Row as u8];
+        payload.extend_from_slice(&expected.to_le_bytes());
+        let mut reader = create_network_transport_with_data(&packet.append_bytes(&payload).build());
+        reader.read_tds_packet().await.unwrap();
+
+        let pause_state = reader
+            .try_receive_row_header(&int4_row_context(1))
+            .unwrap()
+            .expect("complete buffered row header");
+        assert_eq!(
+            reader.try_read_buffered_column(&pause_state, 0).unwrap(),
+            Some(ColumnValues::Int(expected))
+        );
+        assert_eq!(reader.tds_read_buffer.get_remaining_byte_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn buffered_row_writer_finishes_a_complete_row_without_continuation() {
+        let expected = [0x1234_5678_i32, -42_i32];
+        let mut payload = vec![TokenType::Row as u8];
+        payload.extend(expected.iter().flat_map(|value| value.to_le_bytes()));
+        let mut packet = TestPacketBuilder::new(PacketType::TabularResult);
+        let mut reader = create_network_transport_with_data(&packet.append_bytes(&payload).build());
+        reader.read_tds_packet().await.unwrap();
+
+        let mut pause_state = reader
+            .try_receive_row_header(&int4_row_context(expected.len()))
+            .unwrap()
+            .expect("complete buffered row header");
+        let mut writer = DefaultRowWriter::new(expected.len());
+
+        assert!(
+            reader
+                .try_read_buffered_row_into(&mut pause_state, &mut writer)
+                .unwrap()
+        );
+        assert_eq!(
+            writer.take_row(),
+            expected
+                .into_iter()
+                .map(ColumnValues::Int)
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(reader.tds_read_buffer.get_remaining_byte_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn buffered_row_writer_keeps_partial_column_for_async_continuation() {
+        let expected = [0x1234_5678_i32, -42_i32];
+        let second = expected[1].to_le_bytes();
+        let mut first_payload = vec![TokenType::Row as u8];
+        first_payload.extend_from_slice(&expected[0].to_le_bytes());
+        first_payload.extend_from_slice(&second[..2]);
+
+        let mut first = TestPacketBuilder::new(PacketType::TabularResult);
+        let mut second_packet = TestPacketBuilder::new(PacketType::TabularResult);
+        let mut stream = first.continuation().append_bytes(&first_payload).build();
+        stream.extend_from_slice(&second_packet.append_bytes(&second[2..]).build());
+        let mut reader = create_network_transport_with_data(&stream);
+        reader.read_tds_packet().await.unwrap();
+
+        let mut pause_state = reader
+            .try_receive_row_header(&int4_row_context(expected.len()))
+            .unwrap()
+            .expect("complete buffered row header");
+        let mut writer = DefaultRowWriter::new(expected.len());
+
+        assert!(
+            !reader
+                .try_read_buffered_row_into(&mut pause_state, &mut writer)
+                .unwrap()
+        );
+        assert_eq!(pause_state.next_column_index, 1);
+        assert_eq!(
+            reader.tds_read_buffer.get_remaining_byte_count(),
+            2,
+            "the partial second value must remain buffered"
+        );
+
+        let result = reader
+            .resume_row_into(
+                pause_state,
+                None,
+                None,
+                ColumnPolicy::DecodeAll,
+                &mut writer,
+            )
+            .await
+            .unwrap();
+        assert!(matches!(result, RowReadResult::RowWritten));
+        assert_eq!(
+            writer.take_row(),
+            expected
+                .into_iter()
+                .map(ColumnValues::Int)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn buffered_cursor_miss_preserves_bytes_for_async_continuation() {
+        let expected = 0x1234_5678_i32;
+        let value = expected.to_le_bytes();
+        let mut first = TestPacketBuilder::new(PacketType::TabularResult);
+        let mut second = TestPacketBuilder::new(PacketType::TabularResult);
+        let mut first_payload = vec![TokenType::Row as u8];
+        first_payload.extend_from_slice(&value[..2]);
+        let mut stream = first.continuation().append_bytes(&first_payload).build();
+        stream.extend_from_slice(&second.append_bytes(&value[2..]).build());
+        let mut reader = create_network_transport_with_data(&stream);
+        reader.read_tds_packet().await.unwrap();
+
+        let pause_state = reader
+            .try_receive_row_header(&int4_row_context(1))
+            .unwrap()
+            .expect("row header is wholly buffered");
+        assert_eq!(reader.tds_read_buffer.get_remaining_byte_count(), 2);
+        assert_eq!(
+            reader.try_read_buffered_column(&pause_state, 0).unwrap(),
+            None
+        );
+        assert_eq!(
+            reader.tds_read_buffer.get_remaining_byte_count(),
+            2,
+            "a miss must not consume the partial scalar"
+        );
+
+        let mut writer = DefaultRowWriter::new(1);
+        let result = reader
+            .resume_row_into(
+                pause_state,
+                None,
+                None,
+                ColumnPolicy::DecodeOne(0),
+                &mut writer,
+            )
+            .await
+            .unwrap();
+        assert!(matches!(result, RowReadResult::RowWritten));
+        assert_eq!(writer.take_row(), vec![ColumnValues::Int(expected)]);
+    }
+
+    #[tokio::test]
+    async fn buffered_nbcrow_null_column_needs_no_payload_bytes() {
+        let mut packet = TestPacketBuilder::new(PacketType::TabularResult);
+        let payload = [TokenType::NbcRow as u8, 0b0000_0001];
+        let mut reader = create_network_transport_with_data(&packet.append_bytes(&payload).build());
+        reader.read_tds_packet().await.unwrap();
+
+        let pause_state = reader
+            .try_receive_row_header(&int4_row_context(1))
+            .unwrap()
+            .expect("complete NBCROW header");
+        assert_eq!(
+            reader.try_read_buffered_column(&pause_state, 0).unwrap(),
+            Some(ColumnValues::Null)
+        );
+        assert_eq!(reader.tds_read_buffer.get_remaining_byte_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn buffered_nbcrow_reuses_unaliased_bitmap_allocation() {
+        let mut packet = TestPacketBuilder::new(PacketType::TabularResult);
+        let payload = [
+            TokenType::NbcRow as u8,
+            0b0000_0001,
+            0b0000_0010,
+            TokenType::NbcRow as u8,
+            0b0000_0100,
+            0b0000_1000,
+        ];
+        let mut reader = create_network_transport_with_data(&packet.append_bytes(&payload).build());
+        reader.read_tds_packet().await.unwrap();
+        let context = int4_row_context(9);
+
+        let first = reader
+            .try_receive_row_header(&context)
+            .unwrap()
+            .expect("first NBCROW header");
+        let first_bitmap = first.nbc_null_bitmap.as_ref().expect("first bitmap");
+        assert_eq!(first_bitmap.as_ref(), &[0b0000_0001, 0b0000_0010]);
+        let first_allocation = first_bitmap.as_ptr();
+        drop(first);
+
+        let second = reader
+            .try_receive_row_header(&context)
+            .unwrap()
+            .expect("second NBCROW header");
+        let second_bitmap = second.nbc_null_bitmap.as_ref().expect("second bitmap");
+        assert_eq!(second_bitmap.as_ref(), &[0b0000_0100, 0b0000_1000]);
+        assert_eq!(
+            second_bitmap.as_ptr(),
+            first_allocation,
+            "the uniquely owned scratch bitmap should be refilled in place"
+        );
+    }
+
+    #[tokio::test]
+    async fn buffered_nbcrow_bitmap_miss_preserves_header_for_async_continuation() {
+        let mut first = TestPacketBuilder::new(PacketType::TabularResult);
+        let mut second = TestPacketBuilder::new(PacketType::TabularResult);
+        let mut stream = first
+            .continuation()
+            .append_bytes(&[TokenType::NbcRow as u8, 0])
+            .build();
+        stream.extend_from_slice(&second.append_bytes(&[0]).build());
+        let mut reader = create_network_transport_with_data(&stream);
+        reader.read_tds_packet().await.unwrap();
+        let context = int4_row_context(9);
+
+        assert!(reader.try_receive_row_header(&context).unwrap().is_none());
+        assert_eq!(
+            reader.tds_read_buffer.get_remaining_byte_count(),
+            2,
+            "the token and partial bitmap must remain buffered"
+        );
+
+        let header = reader
+            .receive_row_header(&context, None, None)
+            .await
+            .unwrap();
+        let RowHeader::Positioned(pause_state) = header else {
+            panic!("expected an NBCROW position");
+        };
+        assert_eq!(
+            pause_state
+                .nbc_null_bitmap
+                .as_ref()
+                .expect("NBCROW bitmap")
+                .as_ref(),
+            &[0, 0]
+        );
     }
 
     #[tokio::test]

--- a/mssql-tds/src/datatypes/decoder.rs
+++ b/mssql-tds/src/datatypes/decoder.rs
@@ -199,6 +199,7 @@ pub(crate) const fn decimal_metadata_is_valid(precision: u8, scale: u8) -> bool 
 }
 
 #[inline]
+/// Expands a time value at TDS scale `0..=7` into 100-nanosecond ticks.
 const fn scale_time_value(value: u64, scale: u8) -> u64 {
     match scale {
         0 => value * 10_000_000,
@@ -296,7 +297,9 @@ pub(crate) struct GenericDecoder {
 
 /// Non-consuming-on-failure reader for values already buffered by the transport.
 struct BufferedSlice<'a> {
+    /// Received bytes available to the synchronous decoder.
     bytes: &'a [u8],
+    /// Number of bytes tentatively consumed by this decode attempt.
     position: usize,
 }
 

--- a/mssql-tds/src/datatypes/decoder.rs
+++ b/mssql-tds/src/datatypes/decoder.rs
@@ -198,6 +198,20 @@ pub(crate) const fn decimal_metadata_is_valid(precision: u8, scale: u8) -> bool 
     precision > 0 && precision <= MAX_DECIMAL_PRECISION && scale <= precision
 }
 
+#[inline]
+const fn scale_time_value(value: u64, scale: u8) -> u64 {
+    match scale {
+        0 => value * 10_000_000,
+        1 => value * 1_000_000,
+        2 => value * 100_000,
+        3 => value * 10_000,
+        4 => value * 1_000,
+        5 => value * 100,
+        6 => value * 10,
+        _ => value,
+    }
+}
+
 /// Byte width of a `decimal`/`numeric` magnitude: four little-endian 32-bit words.
 pub(crate) const DECIMAL_MAGNITUDE_BYTES: usize = MAX_DECIMAL_INT_PARTS * 4;
 
@@ -278,6 +292,77 @@ impl From<i32> for ColumnValues {
 #[derive(Debug, Default)]
 pub(crate) struct GenericDecoder {
     string_decoder: StringDecoder,
+}
+
+struct BufferedSlice<'a> {
+    bytes: &'a [u8],
+    position: usize,
+}
+
+impl<'a> BufferedSlice<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, position: 0 }
+    }
+
+    fn take<const N: usize>(&mut self) -> Option<[u8; N]> {
+        let end = self.position.checked_add(N)?;
+        let value = self.bytes.get(self.position..end)?.try_into().ok()?;
+        self.position = end;
+        Some(value)
+    }
+
+    fn take_bytes(&mut self, len: usize) -> Option<Vec<u8>> {
+        self.take_slice(len).map(<[u8]>::to_vec)
+    }
+
+    fn take_slice(&mut self, len: usize) -> Option<&'a [u8]> {
+        let end = self.position.checked_add(len)?;
+        let value = self.bytes.get(self.position..end)?;
+        self.position = end;
+        Some(value)
+    }
+
+    fn byte(&mut self) -> Option<u8> {
+        self.take().map(|[value]| value)
+    }
+
+    fn i16(&mut self) -> Option<i16> {
+        self.take().map(i16::from_le_bytes)
+    }
+
+    fn u16(&mut self) -> Option<u16> {
+        self.take().map(u16::from_le_bytes)
+    }
+
+    fn u24(&mut self) -> Option<u32> {
+        let [b0, b1, b2] = self.take()?;
+        Some(u32::from_le_bytes([b0, b1, b2, 0]))
+    }
+
+    fn i32(&mut self) -> Option<i32> {
+        self.take().map(i32::from_le_bytes)
+    }
+
+    fn u32(&mut self) -> Option<u32> {
+        self.take().map(u32::from_le_bytes)
+    }
+
+    fn u40(&mut self) -> Option<u64> {
+        let [b0, b1, b2, b3, b4] = self.take()?;
+        Some(u64::from_le_bytes([b0, b1, b2, b3, b4, 0, 0, 0]))
+    }
+
+    fn i64(&mut self) -> Option<i64> {
+        self.take().map(i64::from_le_bytes)
+    }
+
+    fn f32(&mut self) -> Option<f32> {
+        self.take().map(f32::from_le_bytes)
+    }
+
+    fn f64(&mut self) -> Option<f64> {
+        self.take().map(f64::from_le_bytes)
+    }
 }
 
 #[cfg_attr(not(test), allow(dead_code))]
@@ -596,6 +681,600 @@ impl PlpColumnStream {
 }
 
 impl GenericDecoder {
+    /// Decodes one complete non-PLP column from `bytes` without awaiting.
+    ///
+    /// `None` means the buffered bytes are incomplete or this type still
+    /// requires the async decoder. The caller must consume `used` bytes only
+    /// after receiving `Some`, so a miss is non-destructive.
+    ///
+    /// Each supported arm must remain wire-compatible with [`Self::decode_into`].
+    pub(crate) fn try_decode_buffered(
+        &self,
+        bytes: &[u8],
+        metadata: &ColumnMetadata,
+    ) -> TdsResult<Option<(ColumnValues, usize)>> {
+        if metadata.is_plp() || metadata.crypto_metadata.is_some() {
+            return Ok(None);
+        }
+
+        let mut reader = BufferedSlice::new(bytes);
+        let value = match metadata.data_type {
+            TdsDataType::Int1 => ColumnValues::TinyInt(match reader.byte() {
+                Some(value) => value,
+                None => return Ok(None),
+            }),
+            TdsDataType::Int2 => ColumnValues::SmallInt(match reader.i16() {
+                Some(value) => value,
+                None => return Ok(None),
+            }),
+            TdsDataType::Int4 => ColumnValues::Int(match reader.i32() {
+                Some(value) => value,
+                None => return Ok(None),
+            }),
+            TdsDataType::Int8 => ColumnValues::BigInt(match reader.i64() {
+                Some(value) => value,
+                None => return Ok(None),
+            }),
+            TdsDataType::Flt4 => ColumnValues::Real(match reader.f32() {
+                Some(value) => value,
+                None => return Ok(None),
+            }),
+            TdsDataType::Flt8 => ColumnValues::Float(match reader.f64() {
+                Some(value) => value,
+                None => return Ok(None),
+            }),
+            TdsDataType::Bit => ColumnValues::Bit(match reader.byte() {
+                Some(value) => value == 1,
+                None => return Ok(None),
+            }),
+            TdsDataType::IntN => {
+                let Some(length) = reader.byte() else {
+                    return Ok(None);
+                };
+                match length {
+                    0 => ColumnValues::Null,
+                    1 => ColumnValues::TinyInt(match reader.byte() {
+                        Some(value) => value,
+                        None => return Ok(None),
+                    }),
+                    2 => ColumnValues::SmallInt(match reader.i16() {
+                        Some(value) => value,
+                        None => return Ok(None),
+                    }),
+                    4 => ColumnValues::Int(match reader.i32() {
+                        Some(value) => value,
+                        None => return Ok(None),
+                    }),
+                    8 => ColumnValues::BigInt(match reader.i64() {
+                        Some(value) => value,
+                        None => return Ok(None),
+                    }),
+                    _ => {
+                        return Err(crate::error::Error::ProtocolError(format!(
+                            "Invalid IntN length: {length}"
+                        )));
+                    }
+                }
+            }
+            TdsDataType::FltN => {
+                let Some(length) = reader.byte() else {
+                    return Ok(None);
+                };
+                match length {
+                    0 => ColumnValues::Null,
+                    4 => ColumnValues::Real(match reader.f32() {
+                        Some(value) => value,
+                        None => return Ok(None),
+                    }),
+                    _ => ColumnValues::Float(match reader.f64() {
+                        Some(value) => value,
+                        None => return Ok(None),
+                    }),
+                }
+            }
+            TdsDataType::BitN => {
+                let Some(length) = reader.byte() else {
+                    return Ok(None);
+                };
+                match length {
+                    0 => ColumnValues::Null,
+                    _ => ColumnValues::Bit(match reader.byte() {
+                        Some(value) => value == 1,
+                        None => return Ok(None),
+                    }),
+                }
+            }
+            TdsDataType::Money4 => ColumnValues::SmallMoney(SqlSmallMoney {
+                int_val: match reader.i32() {
+                    Some(value) => value,
+                    None => return Ok(None),
+                },
+            }),
+            TdsDataType::Money => {
+                let Some(msb_part) = reader.i32() else {
+                    return Ok(None);
+                };
+                let Some(lsb_part) = reader.i32() else {
+                    return Ok(None);
+                };
+                ColumnValues::Money(SqlMoney { lsb_part, msb_part })
+            }
+            TdsDataType::MoneyN => {
+                let Some(length) = reader.byte() else {
+                    return Ok(None);
+                };
+                match length {
+                    0 => ColumnValues::Null,
+                    4 => ColumnValues::SmallMoney(SqlSmallMoney {
+                        int_val: match reader.i32() {
+                            Some(value) => value,
+                            None => return Ok(None),
+                        },
+                    }),
+                    8 => {
+                        let Some(msb_part) = reader.i32() else {
+                            return Ok(None);
+                        };
+                        let Some(lsb_part) = reader.i32() else {
+                            return Ok(None);
+                        };
+                        ColumnValues::Money(SqlMoney { lsb_part, msb_part })
+                    }
+                    _ => {
+                        return Err(crate::error::Error::ProtocolError(format!(
+                            "Invalid MoneyN length: {length}"
+                        )));
+                    }
+                }
+            }
+            TdsDataType::DateTim4 => {
+                let Some(days) = reader.u16() else {
+                    return Ok(None);
+                };
+                let Some(time) = reader.u16() else {
+                    return Ok(None);
+                };
+                ColumnValues::SmallDateTime(SqlSmallDateTime { days, time })
+            }
+            TdsDataType::DateTime => {
+                let Some(days) = reader.i32() else {
+                    return Ok(None);
+                };
+                let Some(time) = reader.u32() else {
+                    return Ok(None);
+                };
+                ColumnValues::DateTime(SqlDateTime { days, time })
+            }
+            TdsDataType::DateTimeN => {
+                let Some(length) = reader.byte() else {
+                    return Ok(None);
+                };
+                match length {
+                    0 => ColumnValues::Null,
+                    4 => {
+                        let Some(days) = reader.u16() else {
+                            return Ok(None);
+                        };
+                        let Some(time) = reader.u16() else {
+                            return Ok(None);
+                        };
+                        ColumnValues::SmallDateTime(SqlSmallDateTime { days, time })
+                    }
+                    _ => {
+                        let Some(days) = reader.i32() else {
+                            return Ok(None);
+                        };
+                        let Some(time) = reader.u32() else {
+                            return Ok(None);
+                        };
+                        ColumnValues::DateTime(SqlDateTime { days, time })
+                    }
+                }
+            }
+            TdsDataType::DateN => {
+                let Some(length) = reader.byte() else {
+                    return Ok(None);
+                };
+                match length {
+                    0 => ColumnValues::Null,
+                    _ => ColumnValues::Date(SqlDate::unchecked_create(match reader.u24() {
+                        Some(value) => value,
+                        None => return Ok(None),
+                    })),
+                }
+            }
+            TdsDataType::TimeN | TdsDataType::DateTime2N | TdsDataType::DateTimeOffsetN => {
+                let Some(length) = reader.byte() else {
+                    return Ok(None);
+                };
+                if length == 0 {
+                    ColumnValues::Null
+                } else {
+                    let scale = metadata.get_scale().ok_or_else(|| {
+                        crate::error::Error::ImplementationError(format!(
+                            "{:?} type should have scale",
+                            metadata.data_type
+                        ))
+                    })?;
+                    let trailing = match metadata.data_type {
+                        TdsDataType::TimeN => 0,
+                        TdsDataType::DateTime2N => 3,
+                        TdsDataType::DateTimeOffsetN => 5,
+                        _ => {
+                            return Err(crate::error::Error::ImplementationError(
+                                "unexpected buffered time type".to_string(),
+                            ));
+                        }
+                    };
+                    let time_length = length.checked_sub(trailing).ok_or_else(|| {
+                        crate::error::Error::ProtocolError(format!(
+                            "Invalid {:?} length: {length}",
+                            metadata.data_type
+                        ))
+                    })?;
+                    let scaled = match time_length {
+                        3 => reader.u24().map(u64::from),
+                        4 => reader.u32().map(u64::from),
+                        _ => reader.u40(),
+                    };
+                    let Some(scaled) = scaled else {
+                        return Ok(None);
+                    };
+                    let time = SqlTime {
+                        time_nanoseconds: scale_time_value(scaled, scale),
+                        scale,
+                    };
+                    match metadata.data_type {
+                        TdsDataType::TimeN => ColumnValues::Time(time),
+                        TdsDataType::DateTime2N => {
+                            let Some(days) = reader.u24() else {
+                                return Ok(None);
+                            };
+                            ColumnValues::DateTime2(SqlDateTime2 { days, time })
+                        }
+                        TdsDataType::DateTimeOffsetN => {
+                            let Some(days) = reader.u24() else {
+                                return Ok(None);
+                            };
+                            let Some(offset) = reader.i16() else {
+                                return Ok(None);
+                            };
+                            ColumnValues::DateTimeOffset(SqlDateTimeOffset {
+                                datetime2: SqlDateTime2 { days, time },
+                                offset,
+                            })
+                        }
+                        _ => {
+                            return Err(crate::error::Error::ImplementationError(
+                                "unexpected buffered time type".to_string(),
+                            ));
+                        }
+                    }
+                }
+            }
+            TdsDataType::Guid => {
+                let Some(length) = reader.byte() else {
+                    return Ok(None);
+                };
+                if length == 0 {
+                    ColumnValues::Null
+                } else {
+                    if length != 16 {
+                        return Err(crate::error::Error::ProtocolError(format!(
+                            "Invalid GUID length: expected 16 bytes, got {length}"
+                        )));
+                    }
+                    let Some(bytes) = reader.take::<16>() else {
+                        return Ok(None);
+                    };
+                    ColumnValues::Uuid(uuid::Uuid::from_bytes_le(bytes))
+                }
+            }
+            TdsDataType::NChar
+            | TdsDataType::NVarChar
+            | TdsDataType::BigChar
+            | TdsDataType::BigVarChar
+            | TdsDataType::Char
+            | TdsDataType::VarChar => {
+                let Some(length) = reader.u16() else {
+                    return Ok(None);
+                };
+                if length == u16::MAX {
+                    ColumnValues::Null
+                } else {
+                    let Some(bytes) = reader.take_bytes(usize::from(length)) else {
+                        return Ok(None);
+                    };
+                    ColumnValues::String(SqlString::new(bytes, get_encoding_type(metadata)))
+                }
+            }
+            TdsDataType::BigBinary | TdsDataType::BigVarBinary => {
+                let Some(length) = reader.u16() else {
+                    return Ok(None);
+                };
+                if length == u16::MAX {
+                    ColumnValues::Null
+                } else {
+                    let Some(bytes) = reader.take_bytes(usize::from(length)) else {
+                        return Ok(None);
+                    };
+                    ColumnValues::Bytes(bytes)
+                }
+            }
+            _ => return Ok(None),
+        };
+
+        Ok(Some((value, reader.position)))
+    }
+
+    pub(crate) fn try_decode_buffered_into<W: RowWriter + ?Sized>(
+        &self,
+        bytes: &[u8],
+        metadata: &ColumnMetadata,
+        col: usize,
+        writer: &mut W,
+    ) -> TdsResult<Option<usize>> {
+        if metadata.is_plp() || metadata.crypto_metadata.is_some() {
+            return Ok(None);
+        }
+
+        macro_rules! read {
+            ($reader:ident.$method:ident()) => {
+                match $reader.$method() {
+                    Some(value) => value,
+                    None => return Ok(None),
+                }
+            };
+        }
+
+        let mut reader = BufferedSlice::new(bytes);
+        match metadata.data_type {
+            TdsDataType::Int1 => writer.write_u8(col, read!(reader.byte())),
+            TdsDataType::Int2 => writer.write_i16(col, read!(reader.i16())),
+            TdsDataType::Int4 => writer.write_i32(col, read!(reader.i32())),
+            TdsDataType::Int8 => writer.write_i64(col, read!(reader.i64())),
+            TdsDataType::Flt4 => writer.write_f32(col, read!(reader.f32())),
+            TdsDataType::Flt8 => writer.write_f64(col, read!(reader.f64())),
+            TdsDataType::Bit => writer.write_bool(col, read!(reader.byte()) == 1),
+            TdsDataType::IntN => match read!(reader.byte()) {
+                0 => writer.write_null(col),
+                1 => writer.write_u8(col, read!(reader.byte())),
+                2 => writer.write_i16(col, read!(reader.i16())),
+                4 => writer.write_i32(col, read!(reader.i32())),
+                8 => writer.write_i64(col, read!(reader.i64())),
+                length => {
+                    return Err(crate::error::Error::ProtocolError(format!(
+                        "Invalid IntN length: {length}"
+                    )));
+                }
+            },
+            TdsDataType::FltN => match read!(reader.byte()) {
+                0 => writer.write_null(col),
+                4 => writer.write_f32(col, read!(reader.f32())),
+                _ => writer.write_f64(col, read!(reader.f64())),
+            },
+            TdsDataType::BitN => match read!(reader.byte()) {
+                0 => writer.write_null(col),
+                _ => writer.write_bool(col, read!(reader.byte()) == 1),
+            },
+            TdsDataType::Money4 => writer.write_smallmoney(
+                col,
+                SqlSmallMoney {
+                    int_val: read!(reader.i32()),
+                },
+            ),
+            TdsDataType::Money => {
+                let msb_part = read!(reader.i32());
+                let lsb_part = read!(reader.i32());
+                writer.write_money(col, SqlMoney { lsb_part, msb_part });
+            }
+            TdsDataType::MoneyN => match read!(reader.byte()) {
+                0 => writer.write_null(col),
+                4 => writer.write_smallmoney(
+                    col,
+                    SqlSmallMoney {
+                        int_val: read!(reader.i32()),
+                    },
+                ),
+                8 => {
+                    let msb_part = read!(reader.i32());
+                    let lsb_part = read!(reader.i32());
+                    writer.write_money(col, SqlMoney { lsb_part, msb_part });
+                }
+                length => {
+                    return Err(crate::error::Error::ProtocolError(format!(
+                        "Invalid MoneyN length: {length}"
+                    )));
+                }
+            },
+            TdsDataType::DateTim4 => {
+                let days = read!(reader.u16());
+                let time = read!(reader.u16());
+                writer.write_smalldatetime(col, SqlSmallDateTime { days, time });
+            }
+            TdsDataType::DateTime => {
+                let days = read!(reader.i32());
+                let time = read!(reader.u32());
+                writer.write_datetime(col, SqlDateTime { days, time });
+            }
+            TdsDataType::DateTimeN => match read!(reader.byte()) {
+                0 => writer.write_null(col),
+                4 => {
+                    let days = read!(reader.u16());
+                    let time = read!(reader.u16());
+                    writer.write_smalldatetime(col, SqlSmallDateTime { days, time });
+                }
+                _ => {
+                    let days = read!(reader.i32());
+                    let time = read!(reader.u32());
+                    writer.write_datetime(col, SqlDateTime { days, time });
+                }
+            },
+            TdsDataType::DateN => match read!(reader.byte()) {
+                0 => writer.write_null(col),
+                _ => writer.write_date(col, SqlDate::unchecked_create(read!(reader.u24()))),
+            },
+            TdsDataType::TimeN | TdsDataType::DateTime2N | TdsDataType::DateTimeOffsetN => {
+                let length = read!(reader.byte());
+                if length == 0 {
+                    writer.write_null(col);
+                } else {
+                    let scale = metadata.get_scale().ok_or_else(|| {
+                        crate::error::Error::ImplementationError(format!(
+                            "{:?} type should have scale",
+                            metadata.data_type
+                        ))
+                    })?;
+                    let trailing = match metadata.data_type {
+                        TdsDataType::TimeN => 0,
+                        TdsDataType::DateTime2N => 3,
+                        TdsDataType::DateTimeOffsetN => 5,
+                        _ => {
+                            return Err(crate::error::Error::ImplementationError(
+                                "unexpected buffered time type".to_string(),
+                            ));
+                        }
+                    };
+                    let time_length = length.checked_sub(trailing).ok_or_else(|| {
+                        crate::error::Error::ProtocolError(format!(
+                            "Invalid {:?} length: {length}",
+                            metadata.data_type
+                        ))
+                    })?;
+                    let scaled = match time_length {
+                        3 => read!(reader.u24()).into(),
+                        4 => read!(reader.u32()).into(),
+                        _ => read!(reader.u40()),
+                    };
+                    let time = SqlTime {
+                        time_nanoseconds: scale_time_value(scaled, scale),
+                        scale,
+                    };
+                    match metadata.data_type {
+                        TdsDataType::TimeN => writer.write_time(col, time),
+                        TdsDataType::DateTime2N => writer.write_datetime2(
+                            col,
+                            SqlDateTime2 {
+                                days: read!(reader.u24()),
+                                time,
+                            },
+                        ),
+                        TdsDataType::DateTimeOffsetN => writer.write_datetimeoffset(
+                            col,
+                            SqlDateTimeOffset {
+                                datetime2: SqlDateTime2 {
+                                    days: read!(reader.u24()),
+                                    time,
+                                },
+                                offset: read!(reader.i16()),
+                            },
+                        ),
+                        _ => {
+                            return Err(crate::error::Error::ImplementationError(
+                                "unexpected buffered time type".to_string(),
+                            ));
+                        }
+                    }
+                }
+            }
+            TdsDataType::Guid => {
+                let length = read!(reader.byte());
+                if length == 0 {
+                    writer.write_null(col);
+                } else {
+                    if length != 16 {
+                        return Err(crate::error::Error::ProtocolError(format!(
+                            "Invalid GUID length: expected 16 bytes, got {length}"
+                        )));
+                    }
+                    let Some(bytes) = reader.take::<16>() else {
+                        return Ok(None);
+                    };
+                    writer.write_uuid(col, uuid::Uuid::from_bytes_le(bytes));
+                }
+            }
+            TdsDataType::DecimalN | TdsDataType::NumericN => {
+                let length = read!(reader.byte());
+                let TypeInfoVariant::VarLenPrecisionScale(_, _, precision, scale) =
+                    metadata.type_info.type_info_variant
+                else {
+                    return Err(crate::error::Error::ProtocolError(format!(
+                        "Invalid type info variant for Decimal/Numeric: expected VarLenPrecisionScale, got: {:?}",
+                        metadata.type_info.type_info_variant
+                    )));
+                };
+                if !decimal_metadata_is_valid(precision, scale) {
+                    return Err(crate::error::Error::ProtocolError(format!(
+                        "Invalid decimal precision {precision} / scale {scale}"
+                    )));
+                }
+                if length == 0 {
+                    writer.write_null(col);
+                } else {
+                    let sign = read!(reader.byte());
+                    let magnitude_len = usize::from(length - 1);
+                    let number_of_int_parts = magnitude_len.div_ceil(4);
+                    if number_of_int_parts > MAX_DECIMAL_INT_PARTS {
+                        return Err(crate::error::Error::ProtocolError(format!(
+                            "Decimal int parts {number_of_int_parts} exceeds maximum allowed {MAX_DECIMAL_INT_PARTS} (length was {length})"
+                        )));
+                    }
+                    let Some(source) = reader.take_slice(magnitude_len) else {
+                        return Ok(None);
+                    };
+                    let mut magnitude = [0u8; DECIMAL_MAGNITUDE_BYTES];
+                    magnitude[..magnitude_len].copy_from_slice(source);
+                    let value = DecimalParts::new(
+                        sign == 1,
+                        precision,
+                        scale,
+                        u128::from_le_bytes(magnitude),
+                    );
+                    if metadata.data_type == TdsDataType::DecimalN {
+                        writer.write_decimal(col, value);
+                    } else {
+                        writer.write_numeric(col, value);
+                    }
+                }
+            }
+            TdsDataType::NChar
+            | TdsDataType::NVarChar
+            | TdsDataType::BigChar
+            | TdsDataType::BigVarChar
+            | TdsDataType::Char
+            | TdsDataType::VarChar => {
+                let length = read!(reader.u16());
+                if length == u16::MAX {
+                    writer.write_null(col);
+                } else {
+                    let Some(bytes) = reader.take_slice(usize::from(length)) else {
+                        return Ok(None);
+                    };
+                    writer.write_string(col, Cow::Borrowed(bytes), get_encoding_type(metadata));
+                }
+            }
+            TdsDataType::BigBinary | TdsDataType::BigVarBinary => {
+                let length = read!(reader.u16());
+                if length == u16::MAX {
+                    writer.write_null(col);
+                } else {
+                    let Some(bytes) = reader.take_slice(usize::from(length)) else {
+                        return Ok(None);
+                    };
+                    writer.write_bytes(col, Cow::Borrowed(bytes));
+                }
+            }
+            _ => {
+                let Some((value, used)) = self.try_decode_buffered(bytes, metadata)? else {
+                    return Ok(None);
+                };
+                write_column_value(writer, col, value);
+                return Ok(Some(used));
+            }
+        }
+        Ok(Some(reader.position))
+    }
+
     #[cfg(test)]
     const SHORTLEN_MAXVALUE: usize = 65535;
     const SQL_PLP_NULL: usize = 0xffffffffffffffff;
@@ -878,30 +1557,8 @@ impl GenericDecoder {
             _ => read_sync_first!(reader, try_read_uint40, read_uint40),
         };
 
-        // The value from SQL Server is in scaled units based on the scale:
-        // Scale 0: seconds (need to multiply by 10^7)
-        // Scale 1: tenths of seconds (multiply by 10^6)
-        // Scale 2: hundredths (multiply by 10^5)
-        // Scale 3: milliseconds (multiply by 10^4)
-        // Scale 4: ten-thousandths (multiply by 10^3)
-        // Scale 5: hundred-thousandths (multiply by 10^2)
-        // Scale 6: microseconds (multiply by 10^1)
-        // Scale 7: 100-nanoseconds (multiply by 10^0 = no scaling)
-        // We need to convert to 100-nanosecond units for consistency
-        let time_nanoseconds = match scale {
-            0 => scaled_value * 10_000_000, // Seconds to 100ns
-            1 => scaled_value * 1_000_000,  // Tenths to 100ns
-            2 => scaled_value * 100_000,    // Hundredths to 100ns
-            3 => scaled_value * 10_000,     // Milliseconds to 100ns
-            4 => scaled_value * 1_000,      // Ten-thousandths to 100ns
-            5 => scaled_value * 100,        // Hundred-thousandths to 100ns
-            6 => scaled_value * 10,         // Microseconds to 100ns
-            7 => scaled_value,              // Already in 100ns
-            _ => scaled_value,              // Fallback
-        };
-
         Ok(SqlTime {
-            time_nanoseconds,
+            time_nanoseconds: scale_time_value(scaled_value, scale),
             scale,
         })
     }
@@ -3655,7 +4312,9 @@ mod test {
         use std::borrow::Cow;
 
         use crate::core::TdsResult;
-        use crate::datatypes::column_values::{ColumnValues, SqlDateTime, SqlSmallDateTime};
+        use crate::datatypes::column_values::{
+            ColumnValues, SqlDateTime, SqlMoney, SqlSmallDateTime, SqlTime,
+        };
         use crate::datatypes::decoder::{
             DecimalParts, GenericDecoder, MAX_PLP_SIZE, PlpChunkReadLength, PlpChunkStreamReader,
             PlpColumnStream, SqlTypeDecode,
@@ -3878,6 +4537,114 @@ mod test {
                 multi_part_name: None,
                 crypto_metadata: None,
             }
+        }
+
+        fn buffered_value(bytes: &[u8], metadata: &ColumnMetadata) -> (ColumnValues, usize) {
+            GenericDecoder::default()
+                .try_decode_buffered(bytes, metadata)
+                .unwrap()
+                .expect("complete buffered value")
+        }
+
+        #[test]
+        fn buffered_decode_intn_handles_null_value_and_partial_payload() {
+            let metadata = varlen_metadata(TdsDataType::IntN, 4);
+            assert_eq!(buffered_value(&[0], &metadata), (ColumnValues::Null, 1));
+            assert_eq!(
+                GenericDecoder::default()
+                    .try_decode_buffered(&[4, 0x78, 0x56], &metadata)
+                    .unwrap(),
+                None
+            );
+            assert_eq!(
+                buffered_value(&[4, 0x78, 0x56, 0x34, 0x12], &metadata),
+                (ColumnValues::Int(0x1234_5678), 5)
+            );
+        }
+
+        #[test]
+        fn buffered_decode_money_preserves_wire_word_order() {
+            let metadata = fixed_metadata(TdsDataType::Money, 8);
+            let mut bytes = 7_i32.to_le_bytes().to_vec();
+            bytes.extend_from_slice(&11_i32.to_le_bytes());
+            assert_eq!(
+                buffered_value(&bytes, &metadata),
+                (
+                    ColumnValues::Money(SqlMoney {
+                        lsb_part: 11,
+                        msb_part: 7,
+                    }),
+                    8,
+                )
+            );
+        }
+
+        #[test]
+        fn buffered_decode_time_applies_fractional_scale() {
+            let metadata = ColumnMetadata {
+                user_type: 0,
+                flags: 0,
+                data_type: TdsDataType::TimeN,
+                type_info: TypeInfo::var_len_scale(TdsDataType::TimeN, 4, 3).unwrap(),
+                column_name: String::new(),
+                multi_part_name: None,
+                crypto_metadata: None,
+            };
+            let mut bytes = vec![4];
+            bytes.extend_from_slice(&1234_u32.to_le_bytes());
+            assert_eq!(
+                buffered_value(&bytes, &metadata),
+                (
+                    ColumnValues::Time(SqlTime {
+                        time_nanoseconds: 12_340_000,
+                        scale: 3,
+                    }),
+                    5,
+                )
+            );
+        }
+
+        #[test]
+        fn buffered_decode_guid_uses_tds_little_endian_layout() {
+            let metadata = varlen_metadata(TdsDataType::Guid, 16);
+            let expected = uuid::Uuid::from_u128(0x0011_2233_4455_6677_8899_aabb_ccdd_eeff);
+            let mut bytes = vec![16];
+            bytes.extend_from_slice(&expected.to_bytes_le());
+            assert_eq!(
+                buffered_value(&bytes, &metadata),
+                (ColumnValues::Uuid(expected), 17)
+            );
+        }
+
+        #[test]
+        fn buffered_decode_nvarchar_waits_for_the_complete_payload() {
+            let metadata = ColumnMetadata {
+                user_type: 0,
+                flags: 0,
+                data_type: TdsDataType::NVarChar,
+                type_info: TypeInfo::var_len_string(TdsDataType::NVarChar, 100, None).unwrap(),
+                column_name: String::new(),
+                multi_part_name: None,
+                crypto_metadata: None,
+            };
+            let payload = "row_1"
+                .encode_utf16()
+                .flat_map(u16::to_le_bytes)
+                .collect::<Vec<_>>();
+            let mut bytes = u16::try_from(payload.len()).unwrap().to_le_bytes().to_vec();
+            bytes.extend_from_slice(&payload);
+            assert_eq!(
+                GenericDecoder::default()
+                    .try_decode_buffered(&bytes[..bytes.len() - 1], &metadata)
+                    .unwrap(),
+                None
+            );
+            let (value, used) = buffered_value(&bytes, &metadata);
+            let ColumnValues::String(value) = value else {
+                panic!("expected string");
+            };
+            assert_eq!(value.to_utf8_string(), "row_1");
+            assert_eq!(used, bytes.len());
         }
 
         /// Runs both decode() and decode_into() on the same bytes and asserts
@@ -5150,6 +5917,44 @@ mod test {
         }
 
         // ── Decimal error paths ────────────────────────────────────────
+
+        #[test]
+        fn buffered_decimal_into_waits_for_the_complete_value() {
+            let metadata = precision_scale_metadata(TdsDataType::DecimalN, 9, 18, 4);
+            let mut wire = vec![9, 1];
+            wire.extend_from_slice(&123_4500_u64.to_le_bytes());
+            let decoder = GenericDecoder::default();
+
+            let mut incomplete = DefaultRowWriter::new(1);
+            assert_eq!(
+                decoder
+                    .try_decode_buffered_into(&wire[..5], &metadata, 0, &mut incomplete)
+                    .unwrap(),
+                None
+            );
+            assert!(incomplete.take_row().is_empty());
+
+            let mut complete = DefaultRowWriter::new(1);
+            assert_eq!(
+                decoder
+                    .try_decode_buffered_into(&wire, &metadata, 0, &mut complete)
+                    .unwrap(),
+                Some(wire.len())
+            );
+            match &complete.take_row()[0] {
+                ColumnValues::Decimal(parts) => assert_eq!(parts.to_string(), "123.4500"),
+                other => panic!("expected Decimal, got {other:?}"),
+            }
+
+            let mut null = DefaultRowWriter::new(1);
+            assert_eq!(
+                decoder
+                    .try_decode_buffered_into(&[0], &metadata, 0, &mut null)
+                    .unwrap(),
+                Some(1)
+            );
+            assert_eq!(null.take_row(), vec![ColumnValues::Null]);
+        }
 
         #[tokio::test]
         async fn decimal_wrong_type_info_variant() {

--- a/mssql-tds/src/datatypes/decoder.rs
+++ b/mssql-tds/src/datatypes/decoder.rs
@@ -4678,9 +4678,10 @@ mod test {
             // Run decode()
             let mut reader1 = ByteReader::new(bytes.clone());
             let expected = decoder.decode(&mut reader1, metadata).await.unwrap();
+            let consumed = reader1.pos;
 
             // Run decode_into()
-            let mut reader2 = ByteReader::new(bytes);
+            let mut reader2 = ByteReader::new(bytes.clone());
             let mut writer = DefaultRowWriter::new(1);
             decoder
                 .decode_into(&mut reader2, metadata, 0, &mut writer)
@@ -4693,6 +4694,45 @@ mod test {
                 "decode_into mismatch for {:?}",
                 metadata.data_type
             );
+            assert_eq!(reader2.pos, consumed);
+
+            if let Some((value, used)) = decoder.try_decode_buffered(&bytes, metadata).unwrap() {
+                assert_eq!(value, expected, "buffered value mismatch");
+                assert_eq!(used, consumed, "buffered value consumed wrong width");
+                assert_eq!(
+                    decoder
+                        .try_decode_buffered(&bytes[..bytes.len() - 1], metadata)
+                        .unwrap(),
+                    None,
+                    "buffered value accepted one-byte-short input"
+                );
+            }
+
+            let mut buffered_writer = DefaultRowWriter::new(1);
+            if let Some(used) = decoder
+                .try_decode_buffered_into(&bytes, metadata, 0, &mut buffered_writer)
+                .unwrap()
+            {
+                assert_eq!(
+                    buffered_writer.take_row()[0],
+                    expected,
+                    "buffered writer mismatch"
+                );
+                assert_eq!(used, consumed, "buffered writer consumed wrong width");
+                let mut short_writer = DefaultRowWriter::new(1);
+                assert_eq!(
+                    decoder
+                        .try_decode_buffered_into(
+                            &bytes[..bytes.len() - 1],
+                            metadata,
+                            0,
+                            &mut short_writer,
+                        )
+                        .unwrap(),
+                    None,
+                    "buffered writer accepted one-byte-short input"
+                );
+            }
             expected
         }
 

--- a/mssql-tds/src/datatypes/decoder.rs
+++ b/mssql-tds/src/datatypes/decoder.rs
@@ -696,6 +696,107 @@ impl PlpColumnStream {
 }
 
 impl GenericDecoder {
+    /// Decodes a complete buffered `sql_variant`, retaining its wire base type.
+    ///
+    /// Only fixed-width and character bases are handled synchronously. Other
+    /// valid shapes return `None` without consuming bytes and use the async path.
+    pub(crate) fn try_decode_buffered_variant(
+        &self,
+        bytes: &[u8],
+    ) -> TdsResult<Option<(Option<TdsDataType>, ColumnValues, usize)>> {
+        let mut outer = BufferedSlice::new(bytes);
+        let Some(length) = outer.u32() else {
+            return Ok(None);
+        };
+        if length == 0 {
+            return Ok(Some((None, ColumnValues::Null, outer.position)));
+        }
+        let Some(payload) = outer.take_slice(length as usize) else {
+            return Ok(None);
+        };
+        let mut reader = BufferedSlice::new(payload);
+        let Some(base_byte) = reader.byte() else {
+            return Ok(None);
+        };
+        let base = TdsDataType::try_from(base_byte)?;
+        let Some(property_bytes) = reader.byte() else {
+            return Ok(None);
+        };
+        let data_length = usize::try_from(length)
+            .ok()
+            .and_then(|length| length.checked_sub(2 + usize::from(property_bytes)))
+            .ok_or_else(|| {
+                crate::error::Error::ProtocolError(format!(
+                    "SQL_VARIANT data length calculation underflow: length={length}, prop_bytes={property_bytes}"
+                ))
+            })?;
+
+        let value = match property_bytes {
+            0 => {
+                let Ok(fixed_type) = FixedLengthTypes::try_from(base) else {
+                    return Ok(None);
+                };
+                let metadata = ColumnMetadata {
+                    user_type: 0,
+                    flags: 0,
+                    type_info: TypeInfo {
+                        tds_type: base,
+                        length: data_length,
+                        type_info_variant: TypeInfoVariant::FixedLen(fixed_type),
+                    },
+                    data_type: base,
+                    column_name: String::new(),
+                    multi_part_name: None,
+                    crypto_metadata: None,
+                };
+                let Some((value, used)) =
+                    self.try_decode_buffered(&payload[reader.position..], &metadata)?
+                else {
+                    return Ok(None);
+                };
+                if used != data_length {
+                    return Ok(None);
+                }
+                reader.position += used;
+                value
+            }
+            7 if matches!(
+                base,
+                TdsDataType::BigVarChar
+                    | TdsDataType::BigChar
+                    | TdsDataType::NVarChar
+                    | TdsDataType::NChar
+            ) =>
+            {
+                let Some(collation_bytes) = reader.take::<5>() else {
+                    return Ok(None);
+                };
+                let Some(_max_length) = reader.u16() else {
+                    return Ok(None);
+                };
+                let Some(value_bytes) = reader.take_slice(data_length) else {
+                    return Ok(None);
+                };
+                let encoding = if matches!(base, TdsDataType::NVarChar | TdsDataType::NChar) {
+                    EncodingType::Utf16
+                } else {
+                    let collation: SqlCollation = collation_bytes.as_slice().try_into()?;
+                    if collation.utf8() {
+                        EncodingType::Utf8
+                    } else {
+                        EncodingType::LcidBased(collation)
+                    }
+                };
+                ColumnValues::String(SqlString::new(value_bytes.to_vec(), encoding))
+            }
+            _ => return Ok(None),
+        };
+        if reader.position != payload.len() {
+            return Ok(None);
+        }
+        Ok(Some((Some(base), value, outer.position)))
+    }
+
     /// Decodes one complete non-PLP column from `bytes` without awaiting.
     ///
     /// `None` means the buffered bytes are incomplete or this type still
@@ -4918,6 +5019,10 @@ mod test {
                 0xAB,
                 "the NULL variant consumed the following column's bytes"
             );
+            assert_eq!(
+                decoder.try_decode_buffered_variant(&[0, 0, 0, 0]).unwrap(),
+                Some((None, ColumnValues::Null, 4))
+            );
         }
 
         /// A non-NULL variant reports its base type alongside the value, which
@@ -4930,7 +5035,10 @@ mod test {
             let md = fixed_metadata(TdsDataType::SsVariant, 0);
             // 6-byte payload: base type INT4 (0x38), zero property bytes, then
             // the four value bytes. 0xAB trails to prove nothing overreads.
-            let mut reader = ByteReader::new(vec![6, 0, 0, 0, 0x38, 0x00, 42, 0, 0, 0, 0xAB]);
+            let wire = vec![6, 0, 0, 0, 0x38, 0x00, 42, 0, 0, 0];
+            let mut with_sentinel = wire.clone();
+            with_sentinel.push(0xAB);
+            let mut reader = ByteReader::new(with_sentinel);
             let decoder = GenericDecoder::default();
             let mut writer = DefaultRowWriter::new(1);
             decoder
@@ -4941,6 +5049,48 @@ mod test {
             assert_eq!(writer.variant_base(0), Some(TdsDataType::Int4));
             assert_eq!(writer.take_row()[0], ColumnValues::Int(42));
             assert_eq!(reader.read_byte().await.unwrap(), 0xAB);
+            assert_eq!(
+                decoder.try_decode_buffered_variant(&wire).unwrap(),
+                Some((Some(TdsDataType::Int4), ColumnValues::Int(42), wire.len()))
+            );
+            assert_eq!(
+                decoder
+                    .try_decode_buffered_variant(&wire[..wire.len() - 1])
+                    .unwrap(),
+                None
+            );
+        }
+
+        #[test]
+        fn buffered_sql_variant_decodes_nvarchar_and_bigint() {
+            let text = "ODBCVARIANT"
+                .encode_utf16()
+                .flat_map(u16::to_le_bytes)
+                .collect::<Vec<_>>();
+            let length = 2 + 7 + text.len();
+            let mut wire = (length as u32).to_le_bytes().to_vec();
+            wire.extend_from_slice(&[TdsDataType::NVarChar as u8, 7, 0x09, 0x04, 0, 0, 0, 64, 0]);
+            wire.extend_from_slice(&text);
+            let decoder = GenericDecoder::default();
+            let (base, value, used) = decoder.try_decode_buffered_variant(&wire).unwrap().unwrap();
+            assert_eq!(base, Some(TdsDataType::NVarChar));
+            assert_eq!(used, wire.len());
+            let ColumnValues::String(value) = value else {
+                panic!("expected string variant");
+            };
+            assert_eq!(value.to_utf8_string(), "ODBCVARIANT");
+
+            let mut bigint = 10_u32.to_le_bytes().to_vec();
+            bigint.extend_from_slice(&[TdsDataType::Int8 as u8, 0]);
+            bigint.extend_from_slice(&i64::MIN.to_le_bytes());
+            assert_eq!(
+                decoder.try_decode_buffered_variant(&bigint).unwrap(),
+                Some((
+                    Some(TdsDataType::Int8),
+                    ColumnValues::BigInt(i64::MIN),
+                    bigint.len(),
+                ))
+            );
         }
 
         #[tokio::test]

--- a/mssql-tds/src/datatypes/decoder.rs
+++ b/mssql-tds/src/datatypes/decoder.rs
@@ -4666,6 +4666,157 @@ mod test {
             assert_eq!(used, bytes.len());
         }
 
+        #[test]
+        fn buffered_decoders_reject_invalid_or_incomplete_values() {
+            let decoder = GenericDecoder::default();
+            let plp = ColumnMetadata {
+                user_type: 0,
+                flags: 0,
+                data_type: TdsDataType::BigVarBinary,
+                type_info: TypeInfo::partial_len(TdsDataType::BigVarBinary, usize::MAX, None)
+                    .unwrap(),
+                column_name: String::new(),
+                multi_part_name: None,
+                crypto_metadata: None,
+            };
+            assert_eq!(decoder.try_decode_buffered(&[], &plp).unwrap(), None);
+            let mut writer = DefaultRowWriter::new(1);
+            assert_eq!(
+                decoder
+                    .try_decode_buffered_into(&[], &plp, 0, &mut writer)
+                    .unwrap(),
+                None
+            );
+
+            let invalid = [
+                (vec![3, 0, 0, 0], varlen_metadata(TdsDataType::IntN, 8)),
+                (
+                    vec![5, 0, 0, 0, 0, 0],
+                    varlen_metadata(TdsDataType::MoneyN, 8),
+                ),
+                (vec![15], varlen_metadata(TdsDataType::Guid, 16)),
+                (
+                    vec![4, 0, 0, 0, 0],
+                    scale_metadata(TdsDataType::DateTimeOffsetN, 10, 7),
+                ),
+            ];
+            for (bytes, metadata) in invalid {
+                assert!(decoder.try_decode_buffered(&bytes, &metadata).is_err());
+                let mut writer = DefaultRowWriter::new(1);
+                assert!(
+                    decoder
+                        .try_decode_buffered_into(&bytes, &metadata, 0, &mut writer)
+                        .is_err()
+                );
+            }
+
+            let incomplete = [
+                (vec![0; 7], fixed_metadata(TdsDataType::Int8, 8)),
+                (vec![0; 3], fixed_metadata(TdsDataType::Money, 8)),
+                (vec![0; 3], fixed_metadata(TdsDataType::DateTim4, 4)),
+                (vec![0; 7], fixed_metadata(TdsDataType::DateTime, 8)),
+                (vec![4, 0, 0], varlen_metadata(TdsDataType::IntN, 4)),
+                (vec![8, 0, 0, 0, 0], varlen_metadata(TdsDataType::MoneyN, 8)),
+                (vec![2, 0, b'a'], varlen_metadata(TdsDataType::NVarChar, 10)),
+                (
+                    vec![2, 0, 1],
+                    varlen_metadata(TdsDataType::BigVarBinary, 10),
+                ),
+            ];
+            for (bytes, metadata) in incomplete {
+                assert_eq!(
+                    decoder.try_decode_buffered(&bytes, &metadata).unwrap(),
+                    None
+                );
+                let mut writer = DefaultRowWriter::new(1);
+                assert_eq!(
+                    decoder
+                        .try_decode_buffered_into(&bytes, &metadata, 0, &mut writer)
+                        .unwrap(),
+                    None
+                );
+            }
+
+            let missing_scale = varlen_metadata(TdsDataType::TimeN, 5);
+            assert!(
+                decoder
+                    .try_decode_buffered(&[3, 1, 0, 0], &missing_scale)
+                    .is_err()
+            );
+            let mut writer = DefaultRowWriter::new(1);
+            assert!(
+                decoder
+                    .try_decode_buffered_into(&[3, 1, 0, 0], &missing_scale, 0, &mut writer,)
+                    .is_err()
+            );
+
+            let invalid_decimal = varlen_metadata(TdsDataType::DecimalN, 9);
+            let mut writer = DefaultRowWriter::new(1);
+            assert!(
+                decoder
+                    .try_decode_buffered_into(
+                        &[5, 1, 1, 0, 0, 0],
+                        &invalid_decimal,
+                        0,
+                        &mut writer,
+                    )
+                    .is_err()
+            );
+            let invalid_precision = precision_scale_metadata(TdsDataType::DecimalN, 9, 39, 0);
+            let mut writer = DefaultRowWriter::new(1);
+            assert!(
+                decoder
+                    .try_decode_buffered_into(
+                        &[5, 1, 1, 0, 0, 0],
+                        &invalid_precision,
+                        0,
+                        &mut writer,
+                    )
+                    .is_err()
+            );
+            let oversized_decimal = precision_scale_metadata(TdsDataType::DecimalN, 21, 38, 0);
+            let mut writer = DefaultRowWriter::new(1);
+            assert!(
+                decoder
+                    .try_decode_buffered_into(&[21, 1], &oversized_decimal, 0, &mut writer,)
+                    .is_err()
+            );
+
+            let unsupported = fixed_metadata(TdsDataType::SsVariant, 0);
+            let mut writer = DefaultRowWriter::new(1);
+            assert_eq!(
+                decoder
+                    .try_decode_buffered_into(&[0; 4], &unsupported, 0, &mut writer)
+                    .unwrap(),
+                None
+            );
+        }
+
+        #[tokio::test]
+        async fn buffered_decoders_cover_wide_nullable_values() {
+            let int = varlen_metadata(TdsDataType::IntN, 8);
+            let mut int_wire = vec![8];
+            int_wire.extend_from_slice(&i64::MIN.to_le_bytes());
+            assert_eq!(
+                assert_decode_equivalence(int_wire, &int).await,
+                ColumnValues::BigInt(i64::MIN)
+            );
+
+            let time = scale_metadata(TdsDataType::TimeN, 5, 7);
+            assert_eq!(
+                assert_decode_equivalence(vec![0], &time).await,
+                ColumnValues::Null
+            );
+
+            let numeric = precision_scale_metadata(TdsDataType::NumericN, 9, 18, 4);
+            let mut numeric_wire = vec![9, 1];
+            numeric_wire.extend_from_slice(&1_234_500_u64.to_le_bytes());
+            assert!(matches!(
+                assert_decode_equivalence(numeric_wire, &numeric).await,
+                ColumnValues::Numeric(_)
+            ));
+        }
+
         /// Runs both decode() and decode_into() on the same bytes and asserts
         /// that decode_into via DefaultRowWriter produces the same ColumnValues
         /// as decode().

--- a/mssql-tds/src/datatypes/decoder.rs
+++ b/mssql-tds/src/datatypes/decoder.rs
@@ -294,16 +294,19 @@ pub(crate) struct GenericDecoder {
     string_decoder: StringDecoder,
 }
 
+/// Non-consuming-on-failure reader for values already buffered by the transport.
 struct BufferedSlice<'a> {
     bytes: &'a [u8],
     position: usize,
 }
 
 impl<'a> BufferedSlice<'a> {
+    /// Starts reading at the beginning of `bytes`.
     fn new(bytes: &'a [u8]) -> Self {
         Self { bytes, position: 0 }
     }
 
+    /// Reads a fixed-size byte array and advances only when it is complete.
     fn take<const N: usize>(&mut self) -> Option<[u8; N]> {
         let end = self.position.checked_add(N)?;
         let value = self.bytes.get(self.position..end)?.try_into().ok()?;
@@ -311,10 +314,12 @@ impl<'a> BufferedSlice<'a> {
         Some(value)
     }
 
+    /// Copies a complete variable-size value from the buffered bytes.
     fn take_bytes(&mut self, len: usize) -> Option<Vec<u8>> {
         self.take_slice(len).map(<[u8]>::to_vec)
     }
 
+    /// Borrows a complete variable-size value from the buffered bytes.
     fn take_slice(&mut self, len: usize) -> Option<&'a [u8]> {
         let end = self.position.checked_add(len)?;
         let value = self.bytes.get(self.position..end)?;
@@ -322,44 +327,54 @@ impl<'a> BufferedSlice<'a> {
         Some(value)
     }
 
+    /// Reads one byte.
     fn byte(&mut self) -> Option<u8> {
         self.take().map(|[value]| value)
     }
 
+    /// Reads a little-endian signed 16-bit integer.
     fn i16(&mut self) -> Option<i16> {
         self.take().map(i16::from_le_bytes)
     }
 
+    /// Reads a little-endian unsigned 16-bit integer.
     fn u16(&mut self) -> Option<u16> {
         self.take().map(u16::from_le_bytes)
     }
 
+    /// Reads a little-endian unsigned 24-bit integer.
     fn u24(&mut self) -> Option<u32> {
         let [b0, b1, b2] = self.take()?;
         Some(u32::from_le_bytes([b0, b1, b2, 0]))
     }
 
+    /// Reads a little-endian signed 32-bit integer.
     fn i32(&mut self) -> Option<i32> {
         self.take().map(i32::from_le_bytes)
     }
 
+    /// Reads a little-endian unsigned 32-bit integer.
     fn u32(&mut self) -> Option<u32> {
         self.take().map(u32::from_le_bytes)
     }
 
+    /// Reads a little-endian unsigned 40-bit integer.
     fn u40(&mut self) -> Option<u64> {
         let [b0, b1, b2, b3, b4] = self.take()?;
         Some(u64::from_le_bytes([b0, b1, b2, b3, b4, 0, 0, 0]))
     }
 
+    /// Reads a little-endian signed 64-bit integer.
     fn i64(&mut self) -> Option<i64> {
         self.take().map(i64::from_le_bytes)
     }
 
+    /// Reads a little-endian 32-bit floating-point value.
     fn f32(&mut self) -> Option<f32> {
         self.take().map(f32::from_le_bytes)
     }
 
+    /// Reads a little-endian 64-bit floating-point value.
     fn f64(&mut self) -> Option<f64> {
         self.take().map(f64::from_le_bytes)
     }
@@ -1007,6 +1022,10 @@ impl GenericDecoder {
         Ok(Some((value, reader.position)))
     }
 
+    /// Decodes one complete non-PLP column directly into `writer`.
+    ///
+    /// Returns the consumed byte count, or `None` without writing when the
+    /// buffered value is incomplete or requires the async decoder.
     pub(crate) fn try_decode_buffered_into<W: RowWriter + ?Sized>(
         &self,
         bytes: &[u8],

--- a/mssql-tds/src/datatypes/decoder.rs
+++ b/mssql-tds/src/datatypes/decoder.rs
@@ -1089,6 +1089,54 @@ impl GenericDecoder {
                     ColumnValues::Uuid(uuid::Uuid::from_bytes_le(bytes))
                 }
             }
+            TdsDataType::DecimalN | TdsDataType::NumericN => {
+                let Some(length) = reader.byte() else {
+                    return Ok(None);
+                };
+                let TypeInfoVariant::VarLenPrecisionScale(_, _, precision, scale) =
+                    metadata.type_info.type_info_variant
+                else {
+                    return Err(crate::error::Error::ProtocolError(format!(
+                        "Invalid type info variant for Decimal/Numeric: expected VarLenPrecisionScale, got: {:?}",
+                        metadata.type_info.type_info_variant
+                    )));
+                };
+                if !decimal_metadata_is_valid(precision, scale) {
+                    return Err(crate::error::Error::ProtocolError(format!(
+                        "Invalid decimal precision {precision} / scale {scale}"
+                    )));
+                }
+                if length == 0 {
+                    ColumnValues::Null
+                } else {
+                    let Some(sign) = reader.byte() else {
+                        return Ok(None);
+                    };
+                    let magnitude_len = usize::from(length - 1);
+                    let number_of_int_parts = magnitude_len.div_ceil(4);
+                    if number_of_int_parts > MAX_DECIMAL_INT_PARTS {
+                        return Err(crate::error::Error::ProtocolError(format!(
+                            "Decimal int parts {number_of_int_parts} exceeds maximum allowed {MAX_DECIMAL_INT_PARTS} (length was {length})"
+                        )));
+                    }
+                    let Some(source) = reader.take_slice(magnitude_len) else {
+                        return Ok(None);
+                    };
+                    let mut magnitude = [0u8; DECIMAL_MAGNITUDE_BYTES];
+                    magnitude[..magnitude_len].copy_from_slice(source);
+                    let value = DecimalParts::new(
+                        sign == 1,
+                        precision,
+                        scale,
+                        u128::from_le_bytes(magnitude),
+                    );
+                    if metadata.data_type == TdsDataType::DecimalN {
+                        ColumnValues::Decimal(value)
+                    } else {
+                        ColumnValues::Numeric(value)
+                    }
+                }
+            }
             TdsDataType::NChar
             | TdsDataType::NVarChar
             | TdsDataType::BigChar
@@ -4915,6 +4963,13 @@ mod test {
             let numeric = precision_scale_metadata(TdsDataType::NumericN, 9, 18, 4);
             let mut numeric_wire = vec![9, 1];
             numeric_wire.extend_from_slice(&1_234_500_u64.to_le_bytes());
+            let buffered_numeric = GenericDecoder::default()
+                .try_decode_buffered(&numeric_wire, &numeric)
+                .unwrap();
+            assert!(matches!(
+                buffered_numeric,
+                Some((ColumnValues::Numeric(_), 10))
+            ));
             assert!(matches!(
                 assert_decode_equivalence(numeric_wire, &numeric).await,
                 ColumnValues::Numeric(_)
@@ -6124,6 +6179,13 @@ mod test {
             let mut part = [0u8; 4];
             LittleEndian::write_i32(&mut part, 12345);
             buf.extend_from_slice(&part);
+            let buffered_decimal = GenericDecoder::default()
+                .try_decode_buffered(&buf, &md)
+                .unwrap();
+            assert!(matches!(
+                buffered_decimal,
+                Some((ColumnValues::Decimal(_), 6))
+            ));
             let val = assert_decode_equivalence(buf, &md).await;
             assert!(matches!(val, ColumnValues::Decimal(_)));
         }

--- a/mssql-tds/src/io/token_stream.rs
+++ b/mssql-tds/src/io/token_stream.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 use crate::core::{CancelHandle, TdsResult};
+use crate::datatypes::column_values::ColumnValues;
 use crate::datatypes::decoder::{GenericDecoder, PlpColumnStream, decrypt_encrypted_column};
 use crate::datatypes::row_writer::{DiscardRowWriter, RowWriter, write_column_value};
 use crate::io::packet_reader::TdsPacketReader;
@@ -192,6 +193,27 @@ impl PlpPauseState {
 #[async_trait]
 #[cfg(not(fuzzing))]
 pub(crate) trait TdsTokenStreamReader {
+    /// Attempts to read a complete row header from bytes already buffered by the
+    /// transport. Returns `None` without consuming bytes when async I/O or an
+    /// unsupported synchronous parser is required.
+    fn try_receive_row_header(
+        &mut self,
+        _context: &ParserContext,
+    ) -> TdsResult<Option<RowPauseState>> {
+        Ok(None)
+    }
+
+    /// Attempts to decode `target` from bytes already buffered by the transport.
+    /// Returns `None` without consuming bytes when async I/O or an unsupported
+    /// synchronous decoder is required.
+    fn try_read_buffered_column(
+        &mut self,
+        _pause_state: &RowPauseState,
+        _target: usize,
+    ) -> TdsResult<Option<ColumnValues>> {
+        Ok(None)
+    }
+
     async fn receive_token(
         &mut self,
         context: &ParserContext,
@@ -253,6 +275,21 @@ pub(crate) trait TdsTokenStreamReader {
 #[async_trait]
 #[cfg(fuzzing)]
 pub trait TdsTokenStreamReader {
+    fn try_receive_row_header(
+        &mut self,
+        _context: &ParserContext,
+    ) -> TdsResult<Option<RowPauseState>> {
+        Ok(None)
+    }
+
+    fn try_read_buffered_column(
+        &mut self,
+        _pause_state: &RowPauseState,
+        _target: usize,
+    ) -> TdsResult<Option<ColumnValues>> {
+        Ok(None)
+    }
+
     async fn receive_token(
         &mut self,
         context: &ParserContext,

--- a/mssql-tds/src/io/token_stream.rs
+++ b/mssql-tds/src/io/token_stream.rs
@@ -206,6 +206,7 @@ pub(crate) trait TdsTokenStreamReader {
     /// Attempts to decode `target` from bytes already buffered by the transport.
     /// Returns `None` without consuming bytes when async I/O or an unsupported
     /// synchronous decoder is required.
+    #[cfg_attr(not(any(test, feature = "test-util", fuzzing)), allow(dead_code))]
     fn try_read_buffered_column(
         &mut self,
         _pause_state: &RowPauseState,

--- a/mssql-tds/src/io/token_stream.rs
+++ b/mssql-tds/src/io/token_stream.rs
@@ -219,7 +219,7 @@ pub(crate) trait TdsTokenStreamReader {
     fn try_read_buffered_test_row(
         &mut self,
         _pause_state: &mut RowPauseState,
-    ) -> TdsResult<Option<Vec<i32>>> {
+    ) -> TdsResult<Option<(Vec<i32>, bool)>> {
         Ok(None)
     }
 
@@ -302,7 +302,7 @@ pub trait TdsTokenStreamReader {
     fn try_read_buffered_test_row(
         &mut self,
         _pause_state: &mut RowPauseState,
-    ) -> TdsResult<Option<Vec<i32>>> {
+    ) -> TdsResult<Option<(Vec<i32>, bool)>> {
         Ok(None)
     }
 

--- a/mssql-tds/src/io/token_stream.rs
+++ b/mssql-tds/src/io/token_stream.rs
@@ -216,6 +216,7 @@ pub(crate) trait TdsTokenStreamReader {
     }
 
     #[cfg(any(test, feature = "test-util"))]
+    /// Test hook that returns a buffered integer-row prefix and whether it is complete.
     fn try_read_buffered_test_row(
         &mut self,
         _pause_state: &mut RowPauseState,
@@ -299,6 +300,7 @@ pub trait TdsTokenStreamReader {
         Ok(None)
     }
 
+    /// Attempts to decode a buffered row prefix for dynamic test transports.
     fn try_read_buffered_test_row(
         &mut self,
         _pause_state: &mut RowPauseState,

--- a/mssql-tds/src/io/token_stream.rs
+++ b/mssql-tds/src/io/token_stream.rs
@@ -214,6 +214,14 @@ pub(crate) trait TdsTokenStreamReader {
         Ok(None)
     }
 
+    #[cfg(any(test, feature = "test-util"))]
+    fn try_read_buffered_test_row(
+        &mut self,
+        _pause_state: &mut RowPauseState,
+    ) -> TdsResult<Option<Vec<i32>>> {
+        Ok(None)
+    }
+
     async fn receive_token(
         &mut self,
         context: &ParserContext,
@@ -287,6 +295,13 @@ pub trait TdsTokenStreamReader {
         _pause_state: &RowPauseState,
         _target: usize,
     ) -> TdsResult<Option<ColumnValues>> {
+        Ok(None)
+    }
+
+    fn try_read_buffered_test_row(
+        &mut self,
+        _pause_state: &mut RowPauseState,
+    ) -> TdsResult<Option<Vec<i32>>> {
         Ok(None)
     }
 

--- a/mssql-tds/src/test_client_support.rs
+++ b/mssql-tds/src/test_client_support.rs
@@ -52,6 +52,8 @@ pub struct ScriptedToken(Tokens);
 #[derive(Debug)]
 struct TokenReplayTransport {
     pending_tokens: VecDeque<Tokens>,
+    pending_rows: VecDeque<VecDeque<i32>>,
+    active_row: Option<VecDeque<i32>>,
     reset_mode: ResetConnectionMode,
     reset_dispatched: bool,
     known_dead: bool,
@@ -61,15 +63,72 @@ impl TokenReplayTransport {
     fn new(tokens: Vec<Tokens>) -> Self {
         Self {
             pending_tokens: VecDeque::from(tokens),
+            pending_rows: VecDeque::new(),
+            active_row: None,
             reset_mode: ResetConnectionMode::None,
             reset_dispatched: false,
             known_dead: false,
         }
     }
+
+    fn with_int_rows(metadata: Tokens, rows: Vec<Vec<i32>>) -> Self {
+        let done = Tokens::Done(DoneToken {
+            status: DoneStatus::FINAL,
+            cur_cmd: CurrentCommand::Select,
+            row_count: 0,
+        });
+        let mut transport = Self::new(vec![metadata, done]);
+        transport.pending_rows = rows.into_iter().map(VecDeque::from).collect();
+        transport
+    }
+
+    fn position_int_row(&mut self, context: &ParserContext) -> TdsResult<Option<RowPauseState>> {
+        let Some(row) = self.pending_rows.pop_front() else {
+            return Ok(None);
+        };
+        let ParserContext::ColumnMetadata(metadata, decryptor) = context else {
+            return Err(crate::error::Error::ProtocolError(
+                "Expected column metadata while positioning a scripted row".to_string(),
+            ));
+        };
+        self.active_row = Some(row);
+        Ok(Some(RowPauseState {
+            next_column_index: 0,
+            metadata: std::sync::Arc::clone(metadata),
+            nbc_null_bitmap: None,
+            decryptor: decryptor.clone(),
+        }))
+    }
 }
 
 #[async_trait]
 impl TdsTokenStreamReader for TokenReplayTransport {
+    fn try_receive_row_header(
+        &mut self,
+        context: &ParserContext,
+    ) -> TdsResult<Option<RowPauseState>> {
+        self.position_int_row(context)
+    }
+
+    fn try_read_buffered_column(
+        &mut self,
+        _pause_state: &RowPauseState,
+        _target: usize,
+    ) -> TdsResult<Option<crate::datatypes::column_values::ColumnValues>> {
+        Ok(self
+            .active_row
+            .as_mut()
+            .and_then(VecDeque::pop_front)
+            .map(crate::datatypes::column_values::ColumnValues::Int))
+    }
+
+    fn try_read_buffered_test_row(
+        &mut self,
+        _pause_state: &mut RowPauseState,
+    ) -> TdsResult<Option<Vec<i32>>> {
+        Ok(self.active_row.take().map(VecDeque::into))
+    }
+
     async fn receive_token(
         &mut self,
         _context: &ParserContext,
@@ -101,10 +160,13 @@ impl TdsTokenStreamReader for TokenReplayTransport {
     // `RowHeader::Token`, never `Positioned`.
     async fn receive_row_header(
         &mut self,
-        _context: &ParserContext,
+        context: &ParserContext,
         _remaining_request_timeout: Option<Duration>,
         _cancel_handle: Option<&CancelHandle>,
     ) -> TdsResult<RowHeader> {
+        if let Some(row) = self.position_int_row(context)? {
+            return Ok(RowHeader::Positioned(row));
+        }
         if let Some(tok) = self.pending_tokens.pop_front() {
             return Ok(RowHeader::Token(tok));
         }
@@ -218,6 +280,28 @@ impl TdsTransport for TokenReplayTransport {
 pub fn tds_client_from_tokens(tokens: Vec<ScriptedToken>) -> TdsClient {
     let tokens: Vec<Tokens> = tokens.into_iter().map(|t| t.0).collect();
     let transport = AnyTransport::dynamic(TokenReplayTransport::new(tokens));
+    let negotiated_settings = create_test_negotiated_settings_internal();
+    let execution_context = ExecutionContext::new();
+    let client_context = ClientContext::with_data_source("tcp:localhost,1433");
+    TdsClient::new(
+        transport,
+        negotiated_settings,
+        execution_context,
+        client_context,
+        Vec::new(),
+    )
+}
+
+/// Builds a client that first returns integer-column metadata and then replays
+/// the supplied rows through the buffered cursor APIs.
+pub fn tds_client_from_int_rows(rows: Vec<Vec<i32>>) -> TdsClient {
+    let width = rows.first().map_or(0, Vec::len);
+    let metadata = Tokens::ColMetadata(ColMetadataToken {
+        column_count: u16::try_from(width).unwrap_or(u16::MAX),
+        columns: int_columns(width),
+        cek_table: Vec::new(),
+    });
+    let transport = AnyTransport::dynamic(TokenReplayTransport::with_int_rows(metadata, rows));
     let negotiated_settings = create_test_negotiated_settings_internal();
     let execution_context = ExecutionContext::new();
     let client_context = ClientContext::with_data_source("tcp:localhost,1433");
@@ -376,6 +460,23 @@ pub fn sql_error(number: u32, severity: u8, message: &str) -> ScriptedToken {
         proc_name: String::new(),
         line_number: 1,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn buffered_rows_require_column_metadata_context() {
+        let metadata = Tokens::ColMetadata(ColMetadataToken::default());
+        let mut transport = TokenReplayTransport::with_int_rows(metadata, vec![vec![1]]);
+
+        assert!(
+            transport
+                .position_int_row(&ParserContext::None(()))
+                .is_err()
+        );
+    }
 }
 
 // ── Byte-level replay harness (test-only) ──────────────────────────────────

--- a/mssql-tds/src/test_client_support.rs
+++ b/mssql-tds/src/test_client_support.rs
@@ -54,6 +54,7 @@ struct TokenReplayTransport {
     pending_tokens: VecDeque<Tokens>,
     pending_rows: VecDeque<VecDeque<i32>>,
     active_row: Option<VecDeque<i32>>,
+    buffered_prefix_columns: Option<usize>,
     reset_mode: ResetConnectionMode,
     reset_dispatched: bool,
     known_dead: bool,
@@ -65,13 +66,18 @@ impl TokenReplayTransport {
             pending_tokens: VecDeque::from(tokens),
             pending_rows: VecDeque::new(),
             active_row: None,
+            buffered_prefix_columns: None,
             reset_mode: ResetConnectionMode::None,
             reset_dispatched: false,
             known_dead: false,
         }
     }
 
-    fn with_int_rows(metadata: Tokens, rows: Vec<Vec<i32>>) -> Self {
+    fn with_int_rows(
+        metadata: Tokens,
+        rows: Vec<Vec<i32>>,
+        buffered_prefix_columns: Option<usize>,
+    ) -> Self {
         let done = Tokens::Done(DoneToken {
             status: DoneStatus::FINAL,
             cur_cmd: CurrentCommand::Select,
@@ -79,6 +85,7 @@ impl TokenReplayTransport {
         });
         let mut transport = Self::new(vec![metadata, done]);
         transport.pending_rows = rows.into_iter().map(VecDeque::from).collect();
+        transport.buffered_prefix_columns = buffered_prefix_columns;
         transport
     }
 
@@ -125,8 +132,20 @@ impl TdsTokenStreamReader for TokenReplayTransport {
     fn try_read_buffered_test_row(
         &mut self,
         _pause_state: &mut RowPauseState,
-    ) -> TdsResult<Option<Vec<i32>>> {
-        Ok(self.active_row.take().map(VecDeque::into))
+    ) -> TdsResult<Option<(Vec<i32>, bool)>> {
+        let Some(row) = self.active_row.as_mut() else {
+            return Ok(None);
+        };
+        let take = self
+            .buffered_prefix_columns
+            .unwrap_or(row.len())
+            .min(row.len());
+        let prefix = row.drain(..take).collect();
+        let complete = row.is_empty();
+        if complete {
+            self.active_row = None;
+        }
+        Ok(Some((prefix, complete)))
     }
 
     async fn receive_token(
@@ -178,12 +197,19 @@ impl TdsTokenStreamReader for TokenReplayTransport {
     // these resume paths are therefore unreachable for it.
     async fn resume_row_into(
         &mut self,
-        _pause_state: RowPauseState,
+        mut pause_state: RowPauseState,
         _remaining_request_timeout: Option<Duration>,
         _cancel_handle: Option<&CancelHandle>,
         _plan: ColumnPolicy,
-        _writer: &mut (dyn RowWriter + Send),
+        writer: &mut (dyn RowWriter + Send),
     ) -> TdsResult<RowReadResult> {
+        if let Some(mut row) = self.active_row.take() {
+            while let Some(value) = row.pop_front() {
+                writer.write_i32(pause_state.next_column_index, value);
+                pause_state.next_column_index += 1;
+            }
+            return Ok(RowReadResult::RowWritten);
+        }
         Err(crate::error::Error::ConnectionClosed("test".to_string()))
     }
 
@@ -301,7 +327,37 @@ pub fn tds_client_from_int_rows(rows: Vec<Vec<i32>>) -> TdsClient {
         columns: int_columns(width),
         cek_table: Vec::new(),
     });
-    let transport = AnyTransport::dynamic(TokenReplayTransport::with_int_rows(metadata, rows));
+    let transport =
+        AnyTransport::dynamic(TokenReplayTransport::with_int_rows(metadata, rows, None));
+    let negotiated_settings = create_test_negotiated_settings_internal();
+    let execution_context = ExecutionContext::new();
+    let client_context = ClientContext::with_data_source("tcp:localhost,1433");
+    TdsClient::new(
+        transport,
+        negotiated_settings,
+        execution_context,
+        client_context,
+        Vec::new(),
+    )
+}
+
+/// Builds an integer-row client whose buffered whole-row attempt writes only
+/// `buffered_prefix_columns` before forcing async continuation.
+pub fn tds_client_from_partial_int_rows(
+    rows: Vec<Vec<i32>>,
+    buffered_prefix_columns: usize,
+) -> TdsClient {
+    let width = rows.first().map_or(0, Vec::len);
+    let metadata = Tokens::ColMetadata(ColMetadataToken {
+        column_count: u16::try_from(width).unwrap_or(u16::MAX),
+        columns: int_columns(width),
+        cek_table: Vec::new(),
+    });
+    let transport = AnyTransport::dynamic(TokenReplayTransport::with_int_rows(
+        metadata,
+        rows,
+        Some(buffered_prefix_columns),
+    ));
     let negotiated_settings = create_test_negotiated_settings_internal();
     let execution_context = ExecutionContext::new();
     let client_context = ClientContext::with_data_source("tcp:localhost,1433");
@@ -469,7 +525,7 @@ mod tests {
     #[test]
     fn buffered_rows_require_column_metadata_context() {
         let metadata = Tokens::ColMetadata(ColMetadataToken::default());
-        let mut transport = TokenReplayTransport::with_int_rows(metadata, vec![vec![1]]);
+        let mut transport = TokenReplayTransport::with_int_rows(metadata, vec![vec![1]], None);
 
         assert!(
             transport

--- a/mssql-tds/src/test_client_support.rs
+++ b/mssql-tds/src/test_client_support.rs
@@ -73,6 +73,7 @@ impl TokenReplayTransport {
         }
     }
 
+    /// Creates a token replay transport with optional partial-row buffering.
     fn with_int_rows(
         metadata: Tokens,
         rows: Vec<Vec<i32>>,
@@ -89,6 +90,7 @@ impl TokenReplayTransport {
         transport
     }
 
+    /// Positions the next scripted integer row under the supplied metadata.
     fn position_int_row(&mut self, context: &ParserContext) -> TdsResult<Option<RowPauseState>> {
         let Some(row) = self.pending_rows.pop_front() else {
             return Ok(None);


### PR DESCRIPTION
## Description

`SQLGetData` consumers re-describe every column for every row, causing `SQLDescribeColW` to allocate a temporary UTF-16 vector for each cell. Encode column names directly into the caller buffer while preserving UTF-16 code-unit lengths, NUL termination, truncation diagnostics, null-buffer length queries, and surrogate-pair behavior.

Exact workload, seven repetitions:

| Driver | Median | Change vs. parent |
|---|---:|---:|
| Microsoft ODBC 18.6.2.1 | 112.908377 ms | -31.60% |
| PR #418 direct parent (`e929095b`) | 165.063205 ms | baseline |
| This PR (`5abd501d`) | 145.534042 ms | -11.83% |

The optimized build remains 28.90% slower than Microsoft ODBC. The >=5% improvement reproduced in all four confirmation rounds with five repetitions per leg; the median confirmation improvement was 8.70%.

## Related Issues

Depends on #418.

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [ ] `cargo btest` passes
- [x] New/changed functionality has tests
- [x] Public API changes are documented

Validation used `cargo nextest run -p mssql-odbc --frozen --no-fail-fast` (1,113 passed, 1 skipped). There are no public API changes.
