### PR TITLE
Buffer complete rows for faster SQLGetData

### DIFF
--- a/mssql-odbc/src/api/fetch_scroll.rs
+++ b/mssql-odbc/src/api/fetch_scroll.rs
@@ -27,7 +27,7 @@ use mssql_tds::datatypes::column_values::{
     SqlSmallDateTime, SqlSmallMoney, SqlTime, SqlXml,
 };
 use mssql_tds::datatypes::decoder::DecimalParts;
-use mssql_tds::datatypes::row_writer::RowWriter;
+use mssql_tds::datatypes::row_writer::{DefaultRowWriter, RowWriter};
 use mssql_tds::datatypes::sql_json::SqlJson;
 use mssql_tds::datatypes::sql_string::{EncodingType, SqlString};
 use mssql_tds::datatypes::sql_vector::SqlVector;
@@ -55,7 +55,8 @@ use crate::conversion::fetch_convert::{
 };
 use crate::error::{free_errors, post_sql_error};
 use crate::handles::stmt::{
-    ColumnBinding, STMT_STATE_CURSOR_OPEN, STMT_STATE_FETCH_IN_PROGRESS, StmtState,
+    BufferedGetDataRow, ColumnBinding, STMT_STATE_CURSOR_OPEN, STMT_STATE_FETCH_IN_PROGRESS,
+    StmtState,
 };
 use crate::handles::{HandleType, StmtHandle, handle_from_raw};
 
@@ -709,6 +710,7 @@ fn fill_rowset(
     let mut worst = RowOutcome::Success;
     let mut fetch_error: Option<TdsError> = None;
     let mut last_column_read = 0usize;
+    let mut buffered_get_data_row = None;
 
     // Read once per fetch, not once per bind, so an application can move the
     // whole rowset between calls by updating the pointed-to value.
@@ -717,11 +719,53 @@ fn fill_rowset(
         .last()
         .is_some_and(|binding| binding.column_number as usize == column_count)
         && client.current_result_supports_row_into();
+    let can_buffer_get_data_row =
+        row_array_size == 1 && bindings.is_empty() && client.current_result_supports_row_into();
 
     dispatch_rows(row_budget, || {
         let mut outcome = RowOutcome::Success;
         let mut columns_read = 0usize;
-        if can_write_complete_rows {
+        if can_buffer_get_data_row {
+            let mut writer = DefaultRowWriter::new(column_count);
+            let result = match client.try_next_buffered_row_into(&mut writer) {
+                Ok(BufferedRowPoll::Complete) => Ok(()),
+                Ok(BufferedRowPoll::Partial) => {
+                    dbc.runtime.block_on(client.finish_row_into(&mut writer))
+                }
+                Ok(BufferedRowPoll::Exhausted) => return false,
+                Ok(BufferedRowPoll::Pending) => {
+                    let cursor_poll = client.try_next_row_cursor();
+                    match cursor_poll.and_then(|poll| {
+                        poll.resolve(|| dbc.runtime.block_on(client.next_row_cursor()))
+                    }) {
+                        Ok(true) => match client.try_finish_row_into(&mut writer) {
+                            Ok(true) => Ok(()),
+                            Ok(false) => dbc.runtime.block_on(client.finish_row_into(&mut writer)),
+                            Err(error) => Err(error),
+                        },
+                        Ok(false) => return false,
+                        Err(error) => {
+                            fetch_error = Some(error);
+                            return false;
+                        }
+                    }
+                }
+                Err(error) => Err(error),
+            };
+            if let Err(error) = result {
+                fetch_error = Some(error);
+                outcome = RowOutcome::Error(RowIssue::Restricted);
+            } else {
+                let variant_bases = (0..column_count)
+                    .map(|index| writer.variant_base(index))
+                    .collect();
+                buffered_get_data_row = Some(BufferedGetDataRow {
+                    values: writer.take_row().into_iter().map(Some).collect(),
+                    variant_bases,
+                });
+                columns_read = column_count;
+            }
+        } else if can_write_complete_rows {
             let mut writer = BoundRowWriter::new(bindings, rows_filled as usize, bind_offset);
             let result = match client.try_next_buffered_row_into(&mut writer) {
                 Ok(BufferedRowPoll::Complete) => Ok(()),
@@ -910,7 +954,12 @@ fn fill_rowset(
         // already consumed, so a following SQLGetData continues from there
         // rather than re-reading a column the fill loop took.
         stmt_state.begin_row();
-        stmt_state.current_row_last_col = last_column_read;
+        stmt_state.current_row_last_col = if buffered_get_data_row.is_some() {
+            0
+        } else {
+            last_column_read
+        };
+        stmt_state.buffered_get_data_row = buffered_get_data_row;
     } else {
         stmt_state.reset_row_stream();
     }

--- a/mssql-odbc/src/api/get_data.rs
+++ b/mssql-odbc/src/api/get_data.rs
@@ -206,6 +206,32 @@ fn sql_get_data_safe(
         return finish_get_data(stmt, statement_handle, stmt_state, col_index, rc);
     }
 
+    if stmt_state.buffered_get_data_row.is_some() {
+        let captured = {
+            let row = stmt_state.buffered_get_data_row.as_mut();
+            row.and_then(|row| {
+                let value = row.values.get_mut(col_index - 1)?.take()?;
+                let variant_base = row.variant_bases.get(col_index - 1).copied().flatten();
+                Some((value, variant_base))
+            })
+        };
+        let Some((value, variant_base)) = captured else {
+            post_diag(&mut stmt_state, ERR_INVALID_DESCRIPTOR_INDEX);
+            return SQL_ERROR;
+        };
+        stmt_state.last_captured = Some((col_index, value));
+        stmt_state.last_variant_base = variant_base.map(|base| (col_index, base));
+        let rc = write_captured_column(
+            &mut stmt_state,
+            col_index,
+            target_type,
+            target_value_ptr,
+            buffer_length,
+            strlen_or_ind_ptr,
+        );
+        return finish_get_data(stmt, statement_handle, stmt_state, col_index, rc);
+    }
+
     // Resume the decoder to the requested column then write output.
     drop(stmt_state);
     let rc = resume_row_to_column(stmt, statement_handle, col_index);
@@ -275,8 +301,9 @@ fn finish_get_data(
     let ready = stmt_state.current_row_last_col == col_index
         && col_index == stmt_state.column_metadata.len()
         && stmt_state.active_plp.is_none();
+    let row_was_buffered = stmt_state.buffered_get_data_row.is_some();
     drop(stmt_state);
-    if !ready {
+    if !ready || row_was_buffered {
         return rc;
     }
 
@@ -1492,7 +1519,9 @@ mod tests {
     use crate::api::odbc_types::{SQL_NO_DATA, SQL_NULL_HANDLE};
     use crate::error::diag::DiagRecord;
     use crate::handles::DbcHandle;
+    use crate::handles::stmt::BufferedGetDataRow;
     use crate::test_support::TestHandles;
+    use mssql_tds::datatypes::sqldatatypes::TdsDataType;
     use mssql_tds::test_client_support::{int_columns, tds_client_from_int_rows};
 
     /// Assert the most recent diagnostic matches the expected canonical
@@ -1944,6 +1973,121 @@ mod tests {
         let mut state = dbc.inner.lock().unwrap();
         state.client = Some(client);
         state.active_stmt = Some(h.stmt);
+    }
+
+    fn stmt_with_buffered_get_data_row(h: &TestHandles, values: Vec<i32>) {
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        let mut state = stmt.inner.lock().unwrap();
+        state.set_state(STMT_STATE_CURSOR_OPEN);
+        state.column_metadata = int_columns(values.len());
+        state.row_positioned = true;
+        state.buffered_get_data_row = Some(BufferedGetDataRow {
+            variant_bases: vec![None; values.len()],
+            values: values
+                .into_iter()
+                .map(|value| Some(ColumnValues::Int(value)))
+                .collect(),
+        });
+    }
+
+    #[test]
+    fn get_data_reads_complete_buffered_row_without_a_client() {
+        let h = TestHandles::with_env_dbc_stmt();
+        stmt_with_buffered_get_data_row(&h, vec![10, 20, 30]);
+        let mut value = 0_i32;
+        let mut indicator = 0;
+
+        assert_eq!(
+            unsafe {
+                sql_get_data(
+                    h.stmt,
+                    2,
+                    SQL_C_SLONG,
+                    (&mut value as *mut i32).cast(),
+                    0,
+                    &mut indicator,
+                )
+            },
+            SQL_SUCCESS
+        );
+        assert_eq!(value, 20);
+        assert_eq!(indicator, 4);
+
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        let state = stmt.inner.lock().unwrap();
+        assert_eq!(state.current_row_last_col, 2);
+        assert!(state.last_captured.is_none());
+        assert!(state.diag_records.is_empty());
+    }
+
+    #[test]
+    fn buffered_get_data_soft_failure_keeps_value_for_retry() {
+        let h = TestHandles::with_env_dbc_stmt();
+        stmt_with_buffered_get_data_row(&h, vec![42]);
+        let mut value = 0_i32;
+        let mut indicator = 0;
+
+        assert_eq!(
+            unsafe {
+                sql_get_data(
+                    h.stmt,
+                    1,
+                    SQL_C_BINARY,
+                    (&mut value as *mut i32).cast(),
+                    4,
+                    &mut indicator,
+                )
+            },
+            SQL_ERROR
+        );
+        assert_eq!(
+            unsafe {
+                sql_get_data(
+                    h.stmt,
+                    1,
+                    SQL_C_SLONG,
+                    (&mut value as *mut i32).cast(),
+                    0,
+                    &mut indicator,
+                )
+            },
+            SQL_SUCCESS
+        );
+        assert_eq!(value, 42);
+    }
+
+    #[test]
+    fn buffered_get_data_preserves_variant_base_for_probe() {
+        let h = TestHandles::with_env_dbc_stmt();
+        stmt_with_buffered_get_data_row(&h, vec![42]);
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        stmt.inner
+            .lock()
+            .unwrap()
+            .buffered_get_data_row
+            .as_mut()
+            .unwrap()
+            .variant_bases[0] = Some(TdsDataType::Int4);
+        let mut probe = 0_u8;
+        let mut indicator = 0;
+
+        assert_eq!(
+            unsafe {
+                sql_get_data(
+                    h.stmt,
+                    1,
+                    SQL_C_BINARY,
+                    (&mut probe as *mut u8).cast(),
+                    0,
+                    &mut indicator,
+                )
+            },
+            SQL_SUCCESS
+        );
+        assert_eq!(
+            stmt.inner.lock().unwrap().last_variant_base,
+            Some((1, TdsDataType::Int4))
+        );
     }
 
     #[test]

--- a/mssql-odbc/src/api/get_data.rs
+++ b/mssql-odbc/src/api/get_data.rs
@@ -20,7 +20,8 @@ use crate::api::util::{copy_with_nul, write_if_some};
 use crate::error::{free_errors, post_sql_error};
 use crate::handles::stmt::{ActivePlpStream, STMT_STATE_CURSOR_OPEN, StmtState};
 use crate::handles::{HandleType, StmtHandle, handle_from_raw};
-use mssql_tds::connection::tds_client::{CursorColumn, PlpChunk};
+use mssql_tds::connection::tds_client::{CursorColumn, CursorPoll, PlpChunk};
+use mssql_tds::core::TdsResult;
 use mssql_tds::encoding_rs::{self, Decoder};
 
 use crate::conversion::error::{ConvError, ConvOk};
@@ -527,51 +528,74 @@ fn resume_row_to_column(
         }
     };
 
-    let mut client = {
-        let Ok(mut dbc_state) = dbc.inner.lock() else {
-            error!("SQLGetData: dbc mutex poisoned while resuming row");
-            return SQL_ERROR;
-        };
+    let target = column_number - 1; // 0-based
+    let Ok(mut dbc_state) = dbc.inner.lock() else {
+        error!("SQLGetData: dbc mutex poisoned while resuming row");
+        return SQL_ERROR;
+    };
 
-        if let Some(busy_stmt) = dbc_state.active_stmt
-            && busy_stmt != statement_handle
-        {
-            drop(dbc_state);
-            if let Ok(mut stmt_state) = stmt.inner.lock() {
-                post_diag(&mut stmt_state, ERR_CONNECTION_BUSY);
-            }
-            return SQL_ERROR;
+    if let Some(busy_stmt) = dbc_state.active_stmt
+        && busy_stmt != statement_handle
+    {
+        drop(dbc_state);
+        if let Ok(mut stmt_state) = stmt.inner.lock() {
+            post_diag(&mut stmt_state, ERR_CONNECTION_BUSY);
         }
+        return SQL_ERROR;
+    }
 
-        let Some(client) = dbc_state.client.take() else {
+    let cursor_poll = {
+        let Some(client) = dbc_state.client.as_mut() else {
             drop(dbc_state);
             if let Ok(mut stmt_state) = stmt.inner.lock() {
                 post_diag(&mut stmt_state, ERR_NO_ACTIVE_TDS_CLIENT);
             }
             return SQL_ERROR;
         };
-
-        // Claim while still holding this lock — see the identical fix and
-        // its rationale in more_results.rs's client-take site (AB#47508's
-        // early release can have already left this `None`).
-        dbc_state.active_stmt = Some(statement_handle);
-
-        client
+        client.try_read_row_column(target)
     };
 
-    let target = column_number - 1; // 0-based
-    let cursor_poll = client.try_read_row_column(target);
-    let cursor_result = cursor_poll
-        .and_then(|poll| poll.resolve(|| dbc.runtime.block_on(client.read_row_column(target))));
-
-    let Ok(mut dbc_state) = dbc.inner.lock() else {
-        error!("SQLGetData: dbc mutex poisoned after row resume");
-        return SQL_ERROR;
-    };
-    dbc_state.client = Some(client);
     dbc_state.active_stmt = Some(statement_handle);
-    drop(dbc_state);
+    let cursor_result = match cursor_poll {
+        Ok(CursorPoll::Ready(column)) => {
+            drop(dbc_state);
+            Ok(column)
+        }
+        Err(error) => {
+            drop(dbc_state);
+            Err(error)
+        }
+        Ok(CursorPoll::Pending) => {
+            let Some(mut client) = dbc_state.client.take() else {
+                drop(dbc_state);
+                if let Ok(mut stmt_state) = stmt.inner.lock() {
+                    post_diag(&mut stmt_state, ERR_NO_ACTIVE_TDS_CLIENT);
+                }
+                return SQL_ERROR;
+            };
+            drop(dbc_state);
 
+            let result = dbc.runtime.block_on(client.read_row_column(target));
+
+            let Ok(mut dbc_state) = dbc.inner.lock() else {
+                error!("SQLGetData: dbc mutex poisoned after row resume");
+                return SQL_ERROR;
+            };
+            dbc_state.client = Some(client);
+            dbc_state.active_stmt = Some(statement_handle);
+            drop(dbc_state);
+            result
+        }
+    };
+
+    apply_cursor_result(stmt, column_number, cursor_result)
+}
+
+fn apply_cursor_result(
+    stmt: &StmtHandle,
+    column_number: usize,
+    cursor_result: TdsResult<CursorColumn>,
+) -> SqlReturn {
     match cursor_result {
         Ok(CursorColumn::Value {
             value,
@@ -1902,28 +1926,52 @@ mod tests {
         s.last_captured = Some((1, value));
     }
 
-    #[test]
-    fn get_data_resolves_a_buffered_cursor_column() {
-        let h = TestHandles::with_env_dbc_stmt();
+    fn stmt_with_buffered_ints(h: &TestHandles, values: Vec<i32>) {
         h.mark_dbc_connected();
         let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
         {
             let mut state = stmt.inner.lock().unwrap();
             state.set_state(STMT_STATE_CURSOR_OPEN);
-            state.column_metadata = int_columns(1);
+            state.column_metadata = int_columns(values.len());
             state.row_positioned = true;
         }
         let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
-        let mut client = tds_client_from_int_rows(vec![vec![42]]);
+        let mut client = tds_client_from_int_rows(vec![values]);
         dbc.runtime
             .block_on(client.execute("SELECT buffered row".to_string(), ()))
             .unwrap();
         assert!(dbc.runtime.block_on(client.next_row_cursor()).unwrap());
+        let mut state = dbc.inner.lock().unwrap();
+        state.client = Some(client);
+        state.active_stmt = Some(h.stmt);
+    }
+
+    #[test]
+    fn resume_row_to_column_keeps_ready_client_installed_and_captures_value() {
+        let h = TestHandles::with_env_dbc_stmt();
+        stmt_with_buffered_ints(&h, vec![42]);
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+
+        assert_eq!(resume_row_to_column(stmt, h.stmt, 1), SQL_SUCCESS);
+
         {
-            let mut state = dbc.inner.lock().unwrap();
-            state.client = Some(client);
-            state.active_stmt = Some(h.stmt);
+            let state = dbc.inner.lock().unwrap();
+            assert!(state.client.is_some());
+            assert_eq!(state.active_stmt, Some(h.stmt));
         }
+        let state = stmt.inner.lock().unwrap();
+        assert_eq!(state.last_captured, Some((1, ColumnValues::Int(42))));
+        assert_eq!(state.last_variant_base, None);
+        assert!(!state.row_exhausted);
+        assert_eq!(state.partial_text_offset, None);
+    }
+
+    #[test]
+    fn get_data_resolves_a_buffered_cursor_column() {
+        let h = TestHandles::with_env_dbc_stmt();
+        stmt_with_buffered_ints(&h, vec![42]);
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
         let mut value = 0_i32;
         let mut indicator = 0;
 
@@ -1942,6 +1990,26 @@ mod tests {
         );
         assert_eq!(value, 42);
         assert_eq!(indicator, 4);
+        assert!(dbc.inner.lock().unwrap().client.is_some());
+    }
+
+    #[test]
+    fn resume_row_to_column_restores_client_after_pending_fallback() {
+        let h = TestHandles::with_env_dbc_stmt();
+        stmt_with_buffered_ints(&h, vec![10, 17]);
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+
+        assert_eq!(resume_row_to_column(stmt, h.stmt, 2), SQL_SUCCESS);
+
+        let dbc_state = dbc.inner.lock().unwrap();
+        assert!(dbc_state.client.is_some());
+        assert_eq!(dbc_state.active_stmt, Some(h.stmt));
+        drop(dbc_state);
+        let state = stmt.inner.lock().unwrap();
+        assert_eq!(state.last_captured, Some((2, ColumnValues::Int(10))));
+        assert!(state.has_state(STMT_STATE_CURSOR_OPEN));
+        assert!(state.diag_records.is_empty());
     }
 
     /// The byte count a probe reports for each value kind. Variable-length

--- a/mssql-odbc/src/handles/stmt.rs
+++ b/mssql-odbc/src/handles/stmt.rs
@@ -56,6 +56,12 @@ pub(crate) struct ActivePlpStream {
     pub(crate) pending_units: Vec<u16>,
 }
 
+#[derive(Debug)]
+pub(crate) struct BufferedGetDataRow {
+    pub(crate) values: Vec<Option<ColumnValues>>,
+    pub(crate) variant_bases: Vec<Option<TdsDataType>>,
+}
+
 impl ActivePlpStream {
     /// Opens a stream for `column`. Every carry field starts empty, so a call
     /// site names only what identifies the stream — and a carry field added
@@ -242,6 +248,8 @@ pub(crate) struct StmtState {
     pub(crate) row_positioned: bool,
     /// The column value captured by the most recent resume_row_to_column call, with its 1-based column index.
     pub(crate) last_captured: Option<(usize, ColumnValues)>,
+    /// Complete non-PLP row captured by SQLFetch for subsequent SQLGetData calls.
+    pub(crate) buffered_get_data_row: Option<BufferedGetDataRow>,
     /// Base type of `last_captured` when that column is `sql_variant`, with its
     /// 1-based column index. Set per value, since a variant column can hold a
     /// different type in every row.
@@ -877,6 +885,7 @@ impl StmtState {
     pub(crate) fn reset_row_stream(&mut self) {
         self.row_positioned = false;
         self.last_captured = None;
+        self.buffered_get_data_row = None;
         self.last_variant_base = None;
         self.row_exhausted = false;
         self.active_plp = None;
@@ -1024,6 +1033,7 @@ impl StmtHandle {
                 pending_unprepare: None,
                 row_positioned: false,
                 last_captured: None,
+                buffered_get_data_row: None,
                 last_variant_base: None,
                 row_exhausted: false,
                 active_plp: None,
@@ -1178,6 +1188,21 @@ mod tests {
         with_state(|s| {
             assert!(s.bindings.is_empty());
             assert!(s.row_bind_offset_ptr.is_null());
+        });
+    }
+
+    #[test]
+    fn beginning_a_row_discards_the_previous_buffered_get_data_row() {
+        with_state(|s| {
+            s.buffered_get_data_row = Some(BufferedGetDataRow {
+                values: vec![Some(ColumnValues::Int(1))],
+                variant_bases: vec![Some(TdsDataType::Int4)],
+            });
+
+            s.begin_row();
+
+            assert!(s.row_positioned);
+            assert!(s.buffered_get_data_row.is_none());
         });
     }
 }


### PR DESCRIPTION
<!--
Thank you for your interest in this project!

This repository is not currently accepting external pull requests. If you've found
a bug or have a feature request, please open an issue instead.

If you are a Microsoft team member, please follow the instructions in the internal
contribution guide.
-->

## Description

Rust remained about 25% slower than Microsoft ODBC Driver 18.6.2.1 on the fixed-inline row-wise `SQLGetData` benchmark after #446. This PR combines the buffered-client fast path from the closed #447 experiment, then removes the remaining per-cell DBC/client polling by capturing eligible rows during `SQLFetch`.

The whole-row path is limited to unbound, single-row fetches whose metadata is non-PLP and unencrypted. Incremental, PLP, encrypted, incomplete, bound, and multi-row paths retain the existing behavior. Buffered values preserve forward-only access, soft-failure retries, diagnostics, `sql_variant` base types, and connection-busy release semantics.

Exact benchmark: `getdata/rowwise_20k_c15_fixed/inline_values/iterations:1/manual_time`, five repetitions per leg, same harness and SQL Server, alternating driver order.

| Pass | Rust candidate median | Microsoft 18.6.2.1 median | Candidate / Microsoft |
|---|---:|---:|---:|
| Initial | 104.165 ms | 114.997 ms | 0.905799 |
| Confirmation 1 | 104.712 ms | 117.568 ms | 0.890645 |
| Confirmation 2 | 103.408 ms | 115.010 ms | 0.899120 |
| Confirmation 3 | 107.159 ms | 125.936 ms | 0.850897 |
| Confirmation 4 | 107.345 ms | 123.703 ms | 0.867771 |

Rust won 4/4 confirmation rounds. The confirmation median ratio is **0.879208**, or about 12.1% lower wall time than Microsoft.

Validation completed with `cargo fmt --all -- --check`, targeted all-feature/all-target `cargo check` and `cargo clippy -D warnings`, and the full `mssql-odbc` nextest suite (1,118 passed, 1 skipped).

## Related Issues

Stack parent: #446

Native stack root: #418

## Checklist

- [x] `cargo bfmt` passes
- [ ] `cargo bclippy` passes
- [ ] `cargo btest` passes
- [x] New/changed functionality has tests
- [x] Public API changes are documented