### PR TITLE
[py-core] Implementing API's: description, fetch-many, fetch-all, next-set and error handling infrastructure.

### DIFF
--- a/mssql-py-core/src/async_cursor.rs
+++ b/mssql-py-core/src/async_cursor.rs
@@ -228,6 +228,7 @@ impl PyAsyncCursor {
             self.session_state.clone(),
             self.cursor_id,
             self.fetch_state.clone(),
+            self.description_state.clone(),
         ))
     }
 
@@ -416,6 +417,11 @@ impl PyAsyncCursor {
     /// Fetch all remaining rows in the current result set.
     fn fetchall<'py>(slf: Py<Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         crate::async_fetch::fetchall(slf, py)
+    }
+
+    /// Advance to the next statement result, returning `True` or `False` at batch end.
+    fn nextset<'py>(slf: Py<Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        crate::async_fetch::nextset(slf, py)
     }
 
     /// Drain pending results, release prepared handles, and close this cursor.

--- a/mssql-py-core/src/async_cursor.rs
+++ b/mssql-py-core/src/async_cursor.rs
@@ -39,6 +39,7 @@ use crate::async_fetch::FetchState;
 use crate::async_session::{
     AsyncConnectionState, ClaimError, CursorCloseClaim, CursorId, SessionOperationGuard,
 };
+use crate::async_tracing::{in_cursor_operation_span, record_result_set_status};
 
 /// Converts a failed session claim into a Python error with operation-specific busy text.
 fn map_claim_error_with_busy_message(error: ClaimError, busy_message: &'static str) -> PyErr {
@@ -109,7 +110,10 @@ impl FinalizerCleanup {
     async fn run(mut self, claim: CursorCloseClaim) {
         let cleanup = self.cleanup.take().expect("finalizer cleanup is available");
         if let Err(error) = cleanup.run(claim).await {
+            record_result_set_status("error");
             tracing::warn!("PyAsyncCursor finalizer cleanup failed: {error}");
+        } else {
+            record_result_set_status("closed");
         }
         self.completion_guard.complete();
     }
@@ -295,21 +299,34 @@ impl Drop for PyAsyncCursor {
             }
             Err(ClaimError::Busy) => {
                 tracing::warn!(
+                    cursor_id = self.cursor_id,
+                    operation = "finalize",
                     "PyAsyncCursor finalizer skipped: session busy; prepared handle deferred to connection close"
                 );
                 return;
             }
             Err(error) => {
-                tracing::warn!("PyAsyncCursor finalizer could not claim cleanup: {error:?}");
+                tracing::warn!(
+                    cursor_id = self.cursor_id,
+                    operation = "finalize",
+                    "PyAsyncCursor finalizer could not claim cleanup: {error:?}"
+                );
                 session_state.abandon_cursor(self.cursor_id);
                 return;
             }
         };
+        let operation_id = claim.operation_id;
         let finalizer = FinalizerCleanup {
             cleanup: Some(cleanup),
             completion_guard: FinalizerCompletionGuard::new(session_state, self.cursor_id),
         };
-        pyo3_async_runtimes::tokio::get_runtime().spawn(finalizer.run(claim));
+        pyo3_async_runtimes::tokio::get_runtime().spawn(in_cursor_operation_span(
+            finalizer.run(claim),
+            self.cursor_id,
+            operation_id,
+            "finalize",
+            "closing",
+        ));
     }
 }
 
@@ -462,13 +479,17 @@ impl PyAsyncCursor {
             }
         };
         let operation_id = claim.operation_id;
+        let cursor_id = cleanup.cursor_id;
         let future = async move {
             cleanup.run(claim).await.map_err(|error| {
+                record_result_set_status("error");
                 tracing::error!("PyAsyncCursor::close: failed: {error}");
                 PyRuntimeError::new_err(format!("Cursor close failed: {error}"))
             })?;
+            record_result_set_status("closed");
             Python::attach(|py| Ok(py.None()))
         };
+        let future = in_cursor_operation_span(future, cursor_id, operation_id, "close", "closing");
         let future = async move {
             match dispatch {
                 Some(dispatch) => future.with_subscriber(dispatch).await,

--- a/mssql-py-core/src/async_cursor.rs
+++ b/mssql-py-core/src/async_cursor.rs
@@ -33,6 +33,7 @@ use pyo3::types::PyTuple;
 use tokio::sync::Mutex;
 use tracing::instrument::WithSubscriber;
 
+use crate::async_description::DescriptionState;
 use crate::async_execute::{ExecuteResources, PreparedState, release_prepared_statements};
 use crate::async_fetch::FetchState;
 use crate::async_session::{
@@ -171,6 +172,7 @@ pub struct PyAsyncCursor {
     cleanup_started: Arc<AtomicBool>,
     closed: Arc<AtomicBool>,
     fetch_state: Arc<FetchState>,
+    description_state: Arc<DescriptionState>,
 }
 
 impl PyAsyncCursor {
@@ -199,6 +201,7 @@ impl PyAsyncCursor {
             cleanup_started: Arc::new(AtomicBool::new(false)),
             closed: Arc::new(AtomicBool::new(false)),
             fetch_state: Arc::new(FetchState::new()),
+            description_state: Arc::new(DescriptionState::new()),
         }
     }
 
@@ -242,6 +245,7 @@ impl PyAsyncCursor {
             self.input_sizes_generation,
             self.cleanup_required.clone(),
             self.fetch_state.clone(),
+            self.description_state.clone(),
         ))
     }
 
@@ -346,6 +350,15 @@ impl PyAsyncCursor {
     #[getter]
     fn timeout(&self) -> u32 {
         self.default_query_timeout
+    }
+
+    /// A seven-item DB-API descriptor for each column in the current result set.
+    #[getter]
+    fn description<'py>(
+        &self,
+        py: Python<'py>,
+    ) -> PyResult<Option<Bound<'py, pyo3::types::PyList>>> {
+        self.description_state.to_python(py)
     }
 
     /// Set SQL type, size, and scale hints for the next successful `execute()`.

--- a/mssql-py-core/src/async_cursor.rs
+++ b/mssql-py-core/src/async_cursor.rs
@@ -34,6 +34,7 @@ use tokio::sync::Mutex;
 use tracing::instrument::WithSubscriber;
 
 use crate::async_description::DescriptionState;
+use crate::async_errors::ProgrammingError;
 use crate::async_execute::{ExecuteResources, PreparedState, release_prepared_statements};
 use crate::async_fetch::FetchState;
 use crate::async_session::{
@@ -48,7 +49,7 @@ fn map_claim_error_with_busy_message(error: ClaimError, busy_message: &'static s
         ClaimError::Closed => PyRuntimeError::new_err("Connection is closed"),
         ClaimError::Broken => PyRuntimeError::new_err("Connection is broken"),
         ClaimError::Busy => PyRuntimeError::new_err(busy_message),
-        ClaimError::NoResultSet => PyRuntimeError::new_err("No active result set"),
+        ClaimError::NoResultSet => ProgrammingError::new_err("No active result set"),
     }
 }
 
@@ -334,8 +335,19 @@ impl Drop for PyAsyncCursor {
 mod tests {
     use std::sync::Arc;
 
-    use super::FinalizerCompletionGuard;
+    use pyo3::Python;
+
+    use super::{FinalizerCompletionGuard, map_claim_error};
+    use crate::async_errors::ProgrammingError;
     use crate::async_session::{AsyncConnectionState, ClaimError, ConnectionLifecycle};
+
+    #[test]
+    fn no_result_set_claim_maps_to_programming_error() {
+        let error = map_claim_error(ClaimError::NoResultSet);
+
+        Python::attach(|py| assert!(error.is_instance_of::<ProgrammingError>(py)));
+        assert!(error.to_string().contains("No active result set"));
+    }
 
     #[test]
     fn completed_finalizer_preserves_settled_session() {
@@ -374,7 +386,7 @@ impl PyAsyncCursor {
 
     /// A seven-item DB-API descriptor for each column in the current result set.
     #[getter]
-    fn description<'py>(&self, py: Python<'py>) -> Option<Bound<'py, pyo3::types::PyList>> {
+    fn description<'py>(&self, py: Python<'py>) -> Option<Bound<'py, pyo3::types::PyTuple>> {
         self.description_state.get(py)
     }
 

--- a/mssql-py-core/src/async_cursor.rs
+++ b/mssql-py-core/src/async_cursor.rs
@@ -166,6 +166,7 @@ pub struct PyAsyncCursor {
     /// `cursor()` time (`0` = no timeout). Applied by the future `execute`
     /// path unless overridden per-call.
     default_query_timeout: u32,
+    arraysize: isize,
     input_sizes: Option<Vec<crate::types::ParameterHint>>,
     input_sizes_generation: u64,
     cleanup_required: Arc<AtomicBool>,
@@ -195,6 +196,7 @@ impl PyAsyncCursor {
             session_state,
             cursor_id,
             default_query_timeout,
+            arraysize: 1,
             input_sizes: None,
             input_sizes_generation: 0,
             cleanup_required: Arc::new(AtomicBool::new(false)),
@@ -354,11 +356,20 @@ impl PyAsyncCursor {
 
     /// A seven-item DB-API descriptor for each column in the current result set.
     #[getter]
-    fn description<'py>(
-        &self,
-        py: Python<'py>,
-    ) -> PyResult<Option<Bound<'py, pyo3::types::PyList>>> {
-        self.description_state.to_python(py)
+    fn description<'py>(&self, py: Python<'py>) -> Option<Bound<'py, pyo3::types::PyList>> {
+        self.description_state.get(py)
+    }
+
+    /// Number of rows requested by `fetchmany()` when no size is supplied.
+    #[getter]
+    fn arraysize(&self) -> isize {
+        self.arraysize
+    }
+
+    /// Set the default number of rows requested by `fetchmany()`.
+    #[setter]
+    fn set_arraysize(&mut self, arraysize: isize) {
+        self.arraysize = arraysize;
     }
 
     /// Set SQL type, size, and scale hints for the next successful `execute()`.
@@ -389,6 +400,17 @@ impl PyAsyncCursor {
     /// Fetch the next row and return an awaitable resolving to a tuple or `None`.
     fn fetchone<'py>(slf: Py<Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         crate::async_fetch::fetchone(slf, py)
+    }
+
+    /// Fetch at most `size` rows, defaulting to `arraysize`.
+    #[pyo3(signature = (size=None))]
+    fn fetchmany<'py>(
+        slf: Py<Self>,
+        py: Python<'py>,
+        size: Option<isize>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let size = size.unwrap_or_else(|| slf.borrow(py).arraysize);
+        crate::async_fetch::fetchmany(slf, py, size)
     }
 
     /// Drain pending results, release prepared handles, and close this cursor.

--- a/mssql-py-core/src/async_cursor.rs
+++ b/mssql-py-core/src/async_cursor.rs
@@ -413,6 +413,11 @@ impl PyAsyncCursor {
         crate::async_fetch::fetchmany(slf, py, size)
     }
 
+    /// Fetch all remaining rows in the current result set.
+    fn fetchall<'py>(slf: Py<Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        crate::async_fetch::fetchall(slf, py)
+    }
+
     /// Drain pending results, release prepared handles, and close this cursor.
     ///
     /// Returns an awaitable resolving to `None`. Closing an already closed

--- a/mssql-py-core/src/async_description.rs
+++ b/mssql-py-core/src/async_description.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Mutex as StdMutex;
 
-use mssql_tds::datatypes::sqldatatypes::TdsDataType;
+use mssql_tds::datatypes::sqldatatypes::{TdsDataType, VectorBaseType};
 use mssql_tds::query::metadata::ColumnMetadata;
 use pyo3::prelude::*;
 use pyo3::types::{
@@ -14,14 +14,14 @@ use pyo3::types::{
 };
 
 /// Cursor-local Python snapshot of the current result-set metadata.
-pub(crate) struct DescriptionState(StdMutex<Option<Py<PyList>>>);
+pub(crate) struct DescriptionState(StdMutex<Option<Py<PyTuple>>>);
 
 impl DescriptionState {
     pub(crate) fn new() -> Self {
         Self(StdMutex::new(None))
     }
 
-    pub(crate) fn replace(&self, description: Option<Py<PyList>>) -> Option<Py<PyList>> {
+    pub(crate) fn replace(&self, description: Option<Py<PyTuple>>) -> Option<Py<PyTuple>> {
         std::mem::replace(
             &mut self
                 .0
@@ -31,7 +31,7 @@ impl DescriptionState {
         )
     }
 
-    pub(crate) fn get<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyList>> {
+    pub(crate) fn get<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyTuple>> {
         self.0
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -42,7 +42,7 @@ impl DescriptionState {
 
 pub(crate) async fn materialize(
     metadata: Option<Vec<ColumnMetadata>>,
-) -> PyResult<Option<Py<PyList>>> {
+) -> PyResult<Option<Py<PyTuple>>> {
     let Some(metadata) = metadata else {
         return Ok(None);
     };
@@ -86,10 +86,18 @@ fn python_type<'py>(py: Python<'py>, metadata: &ColumnMetadata) -> PyResult<Boun
         | TdsDataType::BigVarBinary
         | TdsDataType::Image
         | TdsDataType::Udt => py.get_type::<PyBytes>(),
+        TdsDataType::Vector => vector_python_type(py, metadata.get_scale()),
         TdsDataType::Guid => imported_python_type(py, "uuid", "UUID")?,
         _ => py.get_type::<PyString>(),
     };
     Ok(python_type)
+}
+
+fn vector_python_type(py: Python<'_>, base_type: Option<u8>) -> Bound<'_, PyType> {
+    match base_type.and_then(|value| VectorBaseType::try_from(value).ok()) {
+        Some(VectorBaseType::Float32) => py.get_type::<PyList>(),
+        Some(VectorBaseType::Float16) | None => py.get_type::<PyString>(),
+    }
 }
 
 fn imported_python_type<'py>(
@@ -177,7 +185,7 @@ fn decimal_digits(metadata: &ColumnMetadata) -> u8 {
 fn description_to_python<'py>(
     py: Python<'py>,
     metadata: &[ColumnMetadata],
-) -> PyResult<Bound<'py, PyList>> {
+) -> PyResult<Bound<'py, PyTuple>> {
     let mut description = Vec::with_capacity(metadata.len());
     for column in metadata {
         let size = column_size(column);
@@ -198,5 +206,29 @@ fn description_to_python<'py>(
             ],
         )?);
     }
-    PyList::new(py, description)
+    PyTuple::new(py, description)
+}
+
+#[cfg(test)]
+mod tests {
+    use mssql_tds::datatypes::sqldatatypes::VectorBaseType;
+    use pyo3::Python;
+    use pyo3::types::{PyAnyMethods, PyList, PyString};
+
+    use super::vector_python_type;
+
+    #[test]
+    fn vector_python_type_matches_row_conversion() {
+        Python::attach(|py| {
+            assert!(
+                vector_python_type(py, Some(VectorBaseType::Float32 as u8))
+                    .is(py.get_type::<PyList>())
+            );
+            assert!(
+                vector_python_type(py, Some(VectorBaseType::Float16 as u8))
+                    .is(py.get_type::<PyString>())
+            );
+            assert!(vector_python_type(py, None).is(py.get_type::<PyString>()));
+        });
+    }
 }

--- a/mssql-py-core/src/async_description.rs
+++ b/mssql-py-core/src/async_description.rs
@@ -13,37 +13,48 @@ use pyo3::types::{
     PyTuple, PyType,
 };
 
-/// Cursor-local snapshot of the current result-set metadata.
-pub(crate) struct DescriptionState(StdMutex<Option<Vec<ColumnMetadata>>>);
+/// Cursor-local Python snapshot of the current result-set metadata.
+pub(crate) struct DescriptionState(StdMutex<Option<Py<PyList>>>);
 
 impl DescriptionState {
     pub(crate) fn new() -> Self {
         Self(StdMutex::new(None))
     }
 
-    pub(crate) fn replace(
-        &self,
-        metadata: Option<Vec<ColumnMetadata>>,
-    ) -> Option<Vec<ColumnMetadata>> {
+    pub(crate) fn replace(&self, description: Option<Py<PyList>>) -> Option<Py<PyList>> {
         std::mem::replace(
             &mut self
                 .0
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner),
-            metadata,
+            description,
         )
     }
 
-    pub(crate) fn to_python<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyList>>> {
-        let metadata = self
-            .0
+    pub(crate) fn get<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyList>> {
+        self.0
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        metadata
-            .as_deref()
-            .map(|columns| description_to_python(py, columns))
-            .transpose()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_ref()
+            .map(|description| description.clone_ref(py).into_bound(py))
     }
+}
+
+pub(crate) async fn materialize(
+    metadata: Option<Vec<ColumnMetadata>>,
+) -> PyResult<Option<Py<PyList>>> {
+    let Some(metadata) = metadata else {
+        return Ok(None);
+    };
+    tokio::task::spawn_blocking(move || {
+        Python::attach(|py| Ok(Some(description_to_python(py, &metadata)?.unbind())))
+    })
+    .await
+    .map_err(|error| {
+        pyo3::exceptions::PyRuntimeError::new_err(format!(
+            "Failed to materialize cursor description: {error}"
+        ))
+    })?
 }
 
 fn python_type<'py>(py: Python<'py>, metadata: &ColumnMetadata) -> PyResult<Bound<'py, PyType>> {

--- a/mssql-py-core/src/async_description.rs
+++ b/mssql-py-core/src/async_description.rs
@@ -1,0 +1,191 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! DB-API result-set metadata for the asynchronous cursor.
+
+use std::sync::Mutex as StdMutex;
+
+use mssql_tds::datatypes::sqldatatypes::TdsDataType;
+use mssql_tds::query::metadata::ColumnMetadata;
+use pyo3::prelude::*;
+use pyo3::types::{
+    PyBool, PyBytes, PyDate, PyDateTime, PyFloat, PyInt, PyList, PyModule, PyString, PyTime,
+    PyTuple, PyType,
+};
+
+/// Cursor-local snapshot of the current result-set metadata.
+pub(crate) struct DescriptionState(StdMutex<Option<Vec<ColumnMetadata>>>);
+
+impl DescriptionState {
+    pub(crate) fn new() -> Self {
+        Self(StdMutex::new(None))
+    }
+
+    pub(crate) fn replace(
+        &self,
+        metadata: Option<Vec<ColumnMetadata>>,
+    ) -> Option<Vec<ColumnMetadata>> {
+        std::mem::replace(
+            &mut self
+                .0
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+            metadata,
+        )
+    }
+
+    pub(crate) fn to_python<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyList>>> {
+        let metadata = self
+            .0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        metadata
+            .as_deref()
+            .map(|columns| description_to_python(py, columns))
+            .transpose()
+    }
+}
+
+fn python_type<'py>(py: Python<'py>, metadata: &ColumnMetadata) -> PyResult<Bound<'py, PyType>> {
+    let python_type = match metadata.data_type {
+        TdsDataType::Int1
+        | TdsDataType::Int2
+        | TdsDataType::Int4
+        | TdsDataType::Int8
+        | TdsDataType::IntN => py.get_type::<PyInt>(),
+        TdsDataType::Bit | TdsDataType::BitN => py.get_type::<PyBool>(),
+        TdsDataType::Flt4 | TdsDataType::Flt8 | TdsDataType::FltN => py.get_type::<PyFloat>(),
+        TdsDataType::Decimal
+        | TdsDataType::DecimalN
+        | TdsDataType::Numeric
+        | TdsDataType::NumericN
+        | TdsDataType::Money
+        | TdsDataType::Money4
+        | TdsDataType::MoneyN => imported_python_type(py, "decimal", "Decimal")?,
+        TdsDataType::DateN => py.get_type::<PyDate>(),
+        TdsDataType::TimeN => py.get_type::<PyTime>(),
+        TdsDataType::DateTime
+        | TdsDataType::DateTim4
+        | TdsDataType::DateTimeN
+        | TdsDataType::DateTime2N
+        | TdsDataType::DateTimeOffsetN => py.get_type::<PyDateTime>(),
+        TdsDataType::Binary
+        | TdsDataType::VarBinary
+        | TdsDataType::BigBinary
+        | TdsDataType::BigVarBinary
+        | TdsDataType::Image
+        | TdsDataType::Udt => py.get_type::<PyBytes>(),
+        TdsDataType::Guid => imported_python_type(py, "uuid", "UUID")?,
+        _ => py.get_type::<PyString>(),
+    };
+    Ok(python_type)
+}
+
+fn imported_python_type<'py>(
+    py: Python<'py>,
+    module: &str,
+    name: &str,
+) -> PyResult<Bound<'py, PyType>> {
+    Ok(PyModule::import(py, module)?
+        .getattr(name)?
+        .cast_into::<PyType>()?)
+}
+
+fn column_size(metadata: &ColumnMetadata) -> u64 {
+    if metadata.is_plp() {
+        return 0;
+    }
+
+    match metadata.data_type {
+        TdsDataType::Int1 => 3,
+        TdsDataType::Int2 => 5,
+        TdsDataType::Int4 => 10,
+        TdsDataType::Int8 => 19,
+        TdsDataType::IntN => match metadata.type_info.length {
+            1 => 3,
+            2 => 5,
+            4 => 10,
+            8 => 19,
+            _ => 0,
+        },
+        TdsDataType::Bit | TdsDataType::BitN => 1,
+        TdsDataType::Flt4 => 7,
+        TdsDataType::Flt8 => 15,
+        TdsDataType::FltN => match metadata.type_info.length {
+            4 => 7,
+            8 => 15,
+            _ => 0,
+        },
+        TdsDataType::DateN => 10,
+        TdsDataType::TimeN => {
+            let scale = u64::from(metadata.get_scale().unwrap_or(0));
+            if scale == 0 { 8 } else { 9 + scale }
+        }
+        TdsDataType::DateTime => 23,
+        TdsDataType::DateTim4 => 16,
+        TdsDataType::DateTimeN => match metadata.type_info.length {
+            8 => 23,
+            4 => 16,
+            _ => 0,
+        },
+        TdsDataType::DateTime2N => {
+            let scale = u64::from(metadata.get_scale().unwrap_or(0));
+            if scale == 0 { 19 } else { 20 + scale }
+        }
+        TdsDataType::DateTimeOffsetN => {
+            let scale = u64::from(metadata.get_scale().unwrap_or(0));
+            if scale == 0 { 26 } else { 27 + scale }
+        }
+        TdsDataType::Decimal
+        | TdsDataType::DecimalN
+        | TdsDataType::Numeric
+        | TdsDataType::NumericN
+        | TdsDataType::Money
+        | TdsDataType::Money4
+        | TdsDataType::MoneyN => u64::from(metadata.get_precision().unwrap_or(0)),
+        TdsDataType::NChar | TdsDataType::NVarChar | TdsDataType::NText => {
+            (metadata.type_info.length / 2) as u64
+        }
+        _ => metadata.type_info.length as u64,
+    }
+}
+
+fn decimal_digits(metadata: &ColumnMetadata) -> u8 {
+    match metadata.data_type {
+        TdsDataType::Money | TdsDataType::Money4 | TdsDataType::MoneyN => 4,
+        TdsDataType::DateTime => 3,
+        TdsDataType::DateTim4 => 0,
+        TdsDataType::DateTimeN => match metadata.type_info.length {
+            8 => 3,
+            _ => 0,
+        },
+        _ => metadata.get_scale().unwrap_or(0),
+    }
+}
+
+fn description_to_python<'py>(
+    py: Python<'py>,
+    metadata: &[ColumnMetadata],
+) -> PyResult<Bound<'py, PyList>> {
+    let mut description = Vec::with_capacity(metadata.len());
+    for column in metadata {
+        let size = column_size(column);
+        description.push(PyTuple::new(
+            py,
+            [
+                column.column_name.clone().into_pyobject(py)?.into_any(),
+                python_type(py, column)?.into_any(),
+                py.None().into_bound(py),
+                size.into_pyobject(py)?.into_any(),
+                size.into_pyobject(py)?.into_any(),
+                decimal_digits(column).into_pyobject(py)?.into_any(),
+                column
+                    .is_nullable()
+                    .into_pyobject(py)?
+                    .to_owned()
+                    .into_any(),
+            ],
+        )?);
+    }
+    PyList::new(py, description)
+}

--- a/mssql-py-core/src/async_description.rs
+++ b/mssql-py-core/src/async_description.rs
@@ -178,6 +178,7 @@ fn decimal_digits(metadata: &ColumnMetadata) -> u8 {
             8 => 3,
             _ => 0,
         },
+        TdsDataType::Vector => 0,
         _ => metadata.get_scale().unwrap_or(0),
     }
 }

--- a/mssql-py-core/src/async_errors.rs
+++ b/mssql-py-core/src/async_errors.rs
@@ -35,10 +35,15 @@ pub(crate) fn add_exceptions(module: &Bound<'_, PyModule>) -> PyResult<()> {
     Ok(())
 }
 
-pub(crate) fn map_tds_error(context: &str, error: TdsError) -> PyErr {
+pub(crate) fn map_tds_error(
+    context: &str,
+    error: TdsError,
+    statement_info_messages: Vec<SqlInfoMessage>,
+) -> PyErr {
     let message = format!("{context}: {error}");
     match error {
-        TdsError::SqlServerError { diagnostics } => {
+        TdsError::SqlServerError { mut diagnostics } => {
+            diagnostics.info_messages.extend(statement_info_messages);
             database_error_with_diagnostics(message, diagnostics)
         }
         TdsError::UsageError(_) => ProgrammingError::new_err(message),
@@ -147,7 +152,7 @@ fn diagnostic_dict<'py>(
 
 #[cfg(test)]
 mod tests {
-    use mssql_tds::error::{Error as TdsError, SqlErrorInfo, SqlServerDiagnostics};
+    use mssql_tds::error::{Error as TdsError, SqlErrorInfo, SqlInfoMessage, SqlServerDiagnostics};
     use pyo3::types::PyAnyMethods;
     use pyo3::{Py, PyAny, Python};
 
@@ -163,6 +168,7 @@ mod tests {
             TdsError::TimeoutError(mssql_tds::error::TimeoutErrorType::String(
                 "deadline exceeded".to_string(),
             )),
+            Vec::new(),
         );
 
         Python::attach(|py| assert!(error.is_instance_of::<OperationalError>(py)));
@@ -172,12 +178,17 @@ mod tests {
     #[test]
     fn maps_client_error_categories() {
         Python::attach(|py| {
-            let usage = map_tds_error("operation failed", TdsError::UsageError("usage".into()));
+            let usage = map_tds_error(
+                "operation failed",
+                TdsError::UsageError("usage".into()),
+                Vec::new(),
+            );
             assert!(usage.is_instance_of::<ProgrammingError>(py));
 
             let conversion = map_tds_error(
                 "operation failed",
                 TdsError::TypeConversionError("conversion".into()),
+                Vec::new(),
             );
             assert!(conversion.is_instance_of::<DataError>(py));
 
@@ -187,18 +198,21 @@ mod tests {
                     feature: "feature".into(),
                     context: "context".into(),
                 },
+                Vec::new(),
             );
             assert!(unsupported.is_instance_of::<NotSupportedError>(py));
 
             let protocol = map_tds_error(
                 "operation failed",
                 TdsError::ProtocolError("protocol".into()),
+                Vec::new(),
             );
             assert!(protocol.is_instance_of::<InternalError>(py));
 
             let connection = map_tds_error(
                 "operation failed",
                 TdsError::ConnectionClosed("closed".into()),
+                Vec::new(),
             );
             assert!(connection.is_instance_of::<OperationalError>(py));
         });
@@ -216,11 +230,28 @@ mod tests {
                 proc_name: Some("procedure".to_string()),
                 line_number: Some(7),
             }],
-            Vec::new(),
+            vec![SqlInfoMessage {
+                message: "existing info".to_string(),
+                state: 1,
+                class: 0,
+                number: 0,
+                server_name: Some("server".to_string()),
+                proc_name: None,
+                line_number: Some(5),
+            }],
         );
         let error = map_tds_error(
             "PyAsyncCursor.nextset failed while advancing results",
             TdsError::SqlServerError { diagnostics },
+            vec![SqlInfoMessage {
+                message: "statement info".to_string(),
+                state: 1,
+                class: 10,
+                number: 50_000,
+                server_name: Some("server".to_string()),
+                proc_name: Some("procedure".to_string()),
+                line_number: Some(6),
+            }],
         );
 
         Python::attach(|py| {
@@ -240,6 +271,40 @@ mod tests {
                     .extract::<u32>()
                     .unwrap(),
                 50_001
+            );
+            let info_messages = error
+                .value(py)
+                .getattr("info_messages")
+                .unwrap()
+                .extract::<Vec<Py<PyAny>>>()
+                .unwrap();
+            assert_eq!(info_messages.len(), 2);
+            assert_eq!(
+                info_messages[0]
+                    .bind(py)
+                    .get_item("message")
+                    .unwrap()
+                    .extract::<String>()
+                    .unwrap(),
+                "existing info"
+            );
+            assert_eq!(
+                info_messages[1]
+                    .bind(py)
+                    .get_item("message")
+                    .unwrap()
+                    .extract::<String>()
+                    .unwrap(),
+                "statement info"
+            );
+            assert_eq!(
+                info_messages[1]
+                    .bind(py)
+                    .get_item("number")
+                    .unwrap()
+                    .extract::<u32>()
+                    .unwrap(),
+                50_000
             );
         });
     }

--- a/mssql-py-core/src/async_errors.rs
+++ b/mssql-py-core/src/async_errors.rs
@@ -1,0 +1,246 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! DB-API exception mapping for asynchronous TDS operations.
+
+use mssql_tds::error::{Error as TdsError, SqlErrorInfo, SqlInfoMessage, SqlServerDiagnostics};
+use pyo3::create_exception;
+use pyo3::exceptions::PyException;
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList};
+
+create_exception!(mssql_py_core, Error, PyException);
+create_exception!(mssql_py_core, Warning, PyException);
+create_exception!(mssql_py_core, InterfaceError, Error);
+create_exception!(mssql_py_core, DatabaseError, Error);
+create_exception!(mssql_py_core, DataError, DatabaseError);
+create_exception!(mssql_py_core, OperationalError, DatabaseError);
+create_exception!(mssql_py_core, IntegrityError, DatabaseError);
+create_exception!(mssql_py_core, InternalError, DatabaseError);
+create_exception!(mssql_py_core, ProgrammingError, DatabaseError);
+create_exception!(mssql_py_core, NotSupportedError, DatabaseError);
+
+pub(crate) fn add_exceptions(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    let py = module.py();
+    module.add("Error", py.get_type::<Error>())?;
+    module.add("Warning", py.get_type::<Warning>())?;
+    module.add("InterfaceError", py.get_type::<InterfaceError>())?;
+    module.add("DatabaseError", py.get_type::<DatabaseError>())?;
+    module.add("DataError", py.get_type::<DataError>())?;
+    module.add("OperationalError", py.get_type::<OperationalError>())?;
+    module.add("IntegrityError", py.get_type::<IntegrityError>())?;
+    module.add("InternalError", py.get_type::<InternalError>())?;
+    module.add("ProgrammingError", py.get_type::<ProgrammingError>())?;
+    module.add("NotSupportedError", py.get_type::<NotSupportedError>())?;
+    Ok(())
+}
+
+pub(crate) fn map_tds_error(context: &str, error: TdsError) -> PyErr {
+    let message = format!("{context}: {error}");
+    match error {
+        TdsError::SqlServerError { diagnostics } => {
+            database_error_with_diagnostics(message, diagnostics)
+        }
+        TdsError::UsageError(_) => ProgrammingError::new_err(message),
+        TdsError::TypeConversionError(_)
+        | TdsError::UnsupportedEncoding { .. }
+        | TdsError::ColumnEncryptionError(_) => DataError::new_err(message),
+        TdsError::UnimplementedFeature { .. } => NotSupportedError::new_err(message),
+        TdsError::ProtocolError(_)
+        | TdsError::ImplementationError(_)
+        | TdsError::ConnectionResetNotAcknowledged => InternalError::new_err(message),
+        TdsError::Io(_)
+        | TdsError::Redirection { .. }
+        | TdsError::ConnectionError(_)
+        | TdsError::TlsError(_)
+        | TdsError::TlsHandshakeError { .. }
+        | TdsError::TimeoutError(_)
+        | TdsError::OperationCancelledError(_)
+        | TdsError::ConnectionClosed(_)
+        | TdsError::CertificateNotFound { .. }
+        | TdsError::InvalidCertificateFormat { .. }
+        | TdsError::CertificateExpired
+        | TdsError::CertificateMismatch
+        | TdsError::CertificateFileIoError { .. }
+        | TdsError::NoServerCertificate
+        | TdsError::BulkCopyError(_)
+        | TdsError::Security(_)
+        | TdsError::SessionRecoveryFailed { .. }
+        | TdsError::SessionNotRecoverable(_)
+        | TdsError::ReconnectionValidationFailed(_) => OperationalError::new_err(message),
+    }
+}
+
+fn database_error_with_diagnostics(message: String, diagnostics: SqlServerDiagnostics) -> PyErr {
+    let error = DatabaseError::new_err(message);
+    Python::attach(|py| {
+        let value = error.value(py);
+        let errors = diagnostics
+            .errors
+            .iter()
+            .map(|item| sql_error_dict(py, item))
+            .collect::<PyResult<Vec<_>>>()?;
+        let info_messages = diagnostics
+            .info_messages
+            .iter()
+            .map(|item| sql_info_dict(py, item))
+            .collect::<PyResult<Vec<_>>>()?;
+        value.setattr("sql_errors", PyList::new(py, errors)?)?;
+        value.setattr("info_messages", PyList::new(py, info_messages)?)?;
+        Ok::<(), PyErr>(())
+    })
+    .unwrap_or_else(|attribute_error| {
+        tracing::warn!(
+            "Failed to attach SQL Server diagnostics to Python exception: {attribute_error}"
+        );
+    });
+    error
+}
+
+fn sql_error_dict<'py>(py: Python<'py>, item: &SqlErrorInfo) -> PyResult<Bound<'py, PyDict>> {
+    diagnostic_dict(
+        py,
+        &item.message,
+        item.state,
+        item.class,
+        item.number,
+        item.server_name.as_deref(),
+        item.proc_name.as_deref(),
+        item.line_number,
+    )
+}
+
+fn sql_info_dict<'py>(py: Python<'py>, item: &SqlInfoMessage) -> PyResult<Bound<'py, PyDict>> {
+    diagnostic_dict(
+        py,
+        &item.message,
+        item.state,
+        item.class,
+        item.number,
+        item.server_name.as_deref(),
+        item.proc_name.as_deref(),
+        item.line_number,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn diagnostic_dict<'py>(
+    py: Python<'py>,
+    message: &str,
+    state: u8,
+    class: i32,
+    number: u32,
+    server_name: Option<&str>,
+    proc_name: Option<&str>,
+    line_number: Option<i32>,
+) -> PyResult<Bound<'py, PyDict>> {
+    let diagnostic = PyDict::new(py);
+    diagnostic.set_item("message", message)?;
+    diagnostic.set_item("state", state)?;
+    diagnostic.set_item("class", class)?;
+    diagnostic.set_item("number", number)?;
+    diagnostic.set_item("server_name", server_name)?;
+    diagnostic.set_item("proc_name", proc_name)?;
+    diagnostic.set_item("line_number", line_number)?;
+    Ok(diagnostic)
+}
+
+#[cfg(test)]
+mod tests {
+    use mssql_tds::error::{Error as TdsError, SqlErrorInfo, SqlServerDiagnostics};
+    use pyo3::types::PyAnyMethods;
+    use pyo3::{Py, PyAny, Python};
+
+    use super::{
+        DataError, DatabaseError, InternalError, NotSupportedError, OperationalError,
+        ProgrammingError, map_tds_error,
+    };
+
+    #[test]
+    fn maps_timeout_to_operational_error() {
+        let error = map_tds_error(
+            "PyAsyncCursor.fetchone failed while reading rows",
+            TdsError::TimeoutError(mssql_tds::error::TimeoutErrorType::String(
+                "deadline exceeded".to_string(),
+            )),
+        );
+
+        Python::attach(|py| assert!(error.is_instance_of::<OperationalError>(py)));
+        assert!(error.to_string().contains("deadline exceeded"));
+    }
+
+    #[test]
+    fn maps_client_error_categories() {
+        Python::attach(|py| {
+            let usage = map_tds_error("operation failed", TdsError::UsageError("usage".into()));
+            assert!(usage.is_instance_of::<ProgrammingError>(py));
+
+            let conversion = map_tds_error(
+                "operation failed",
+                TdsError::TypeConversionError("conversion".into()),
+            );
+            assert!(conversion.is_instance_of::<DataError>(py));
+
+            let unsupported = map_tds_error(
+                "operation failed",
+                TdsError::UnimplementedFeature {
+                    feature: "feature".into(),
+                    context: "context".into(),
+                },
+            );
+            assert!(unsupported.is_instance_of::<NotSupportedError>(py));
+
+            let protocol = map_tds_error(
+                "operation failed",
+                TdsError::ProtocolError("protocol".into()),
+            );
+            assert!(protocol.is_instance_of::<InternalError>(py));
+
+            let connection = map_tds_error(
+                "operation failed",
+                TdsError::ConnectionClosed("closed".into()),
+            );
+            assert!(connection.is_instance_of::<OperationalError>(py));
+        });
+    }
+
+    #[test]
+    fn preserves_sql_server_diagnostics() {
+        let diagnostics = SqlServerDiagnostics::new(
+            vec![SqlErrorInfo {
+                message: "test failure".to_string(),
+                state: 2,
+                class: 16,
+                number: 50_001,
+                server_name: Some("server".to_string()),
+                proc_name: Some("procedure".to_string()),
+                line_number: Some(7),
+            }],
+            Vec::new(),
+        );
+        let error = map_tds_error(
+            "PyAsyncCursor.nextset failed while advancing results",
+            TdsError::SqlServerError { diagnostics },
+        );
+
+        Python::attach(|py| {
+            assert!(error.is_instance_of::<DatabaseError>(py));
+            let errors = error
+                .value(py)
+                .getattr("sql_errors")
+                .unwrap()
+                .extract::<Vec<Py<PyAny>>>()
+                .unwrap();
+            assert_eq!(errors.len(), 1);
+            assert_eq!(
+                errors[0]
+                    .bind(py)
+                    .get_item("number")
+                    .unwrap()
+                    .extract::<u32>()
+                    .unwrap(),
+                50_001
+            );
+        });
+    }
+}

--- a/mssql-py-core/src/async_execute.rs
+++ b/mssql-py-core/src/async_execute.rs
@@ -144,12 +144,17 @@ impl ExecuteResources {
 
 enum ExecuteOutcome {
     Idle,
-    Fetching(Vec<ColumnMetadata>),
+    NoRows,
+    Rows(Vec<ColumnMetadata>),
 }
 
 impl ExecuteOutcome {
     fn has_open_batch(&self) -> bool {
-        matches!(self, Self::Fetching(_))
+        !matches!(self, Self::Idle)
+    }
+
+    fn has_rows(&self) -> bool {
+        matches!(self, Self::Rows(_))
     }
 }
 
@@ -252,13 +257,10 @@ async fn execute_on_client(
             .execute_sp_executesql(operation, rpc_parameters, options)
             .await?
     };
-    if !matches!(first, StatementResult::Rows) {
-        client.advance_to_rows().await?;
-    }
-    Ok(if client.has_open_batch() {
-        ExecuteOutcome::Fetching(client.get_metadata().clone())
-    } else {
-        ExecuteOutcome::Idle
+    Ok(match first {
+        StatementResult::Rows => ExecuteOutcome::Rows(client.get_metadata().clone()),
+        StatementResult::NoRows { .. } if client.has_open_batch() => ExecuteOutcome::NoRows,
+        StatementResult::NoRows { .. } | StatementResult::End => ExecuteOutcome::Idle,
     })
 }
 
@@ -342,13 +344,14 @@ pub(crate) fn execute<'py>(
         match result {
             Ok(outcome) => {
                 let has_open_batch = outcome.has_open_batch();
+                let has_result_set = outcome.has_rows();
                 operation_guard.finish_execute(has_open_batch);
                 let metadata = match outcome {
-                    ExecuteOutcome::Idle => None,
-                    ExecuteOutcome::Fetching(metadata) => Some(metadata),
+                    ExecuteOutcome::Rows(metadata) => Some(metadata),
+                    ExecuteOutcome::Idle | ExecuteOutcome::NoRows => None,
                 };
                 let column_count = metadata.as_ref().map_or(0, Vec::len);
-                future_fetch_state.set(if has_open_batch {
+                future_fetch_state.set(if has_result_set {
                     FetchStatus::Ready
                 } else {
                     FetchStatus::NoResultSet
@@ -372,7 +375,7 @@ pub(crate) fn execute<'py>(
                 let description_materialization_ms = description_started.elapsed().as_millis();
                 future_description_state.replace(description);
                 tracing::info!(
-                    "PyAsyncCursor::execute: query executed successfully; has_result_set={has_open_batch}; column_count={column_count}; description_materialization_ms={description_materialization_ms}"
+                    "PyAsyncCursor::execute: query executed successfully; has_result_set={has_result_set}; column_count={column_count}; description_materialization_ms={description_materialization_ms}; has_open_batch={has_open_batch}"
                 );
                 Ok(cursor)
             }

--- a/mssql-py-core/src/async_execute.rs
+++ b/mssql-py-core/src/async_execute.rs
@@ -7,11 +7,12 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use mssql_tds::connection::tds_client::{
-    ExecuteOptions, PreparedStatement, StatementId, StatementResult, TdsClient,
+    ExecuteOptions, PreparedStatement, ResultSet, StatementId, StatementResult, TdsClient,
 };
 use mssql_tds::error::Error;
 use mssql_tds::message::parameters::rpc_parameters::RpcParameter;
 use mssql_tds::message::transaction_management::TransactionIsolationLevel;
+use mssql_tds::query::metadata::ColumnMetadata;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use pyo3::types::PyTuple;
@@ -19,6 +20,7 @@ use tokio::sync::Mutex;
 use tracing::instrument::WithSubscriber;
 
 use crate::async_cursor::{PyAsyncCursor, map_claim_error};
+use crate::async_description::DescriptionState;
 use crate::async_fetch::{FetchState, FetchStatus};
 use crate::async_parameters::{ParameterMetadata, bind_parameters, parse_input_sizes};
 use crate::async_session::{AsyncConnectionState, CursorId, ExecuteClaim, SessionOperationGuard};
@@ -103,6 +105,7 @@ pub(crate) struct ExecuteResources {
     input_sizes_generation: u64,
     cleanup_required: Arc<AtomicBool>,
     fetch_state: Arc<FetchState>,
+    description_state: Arc<DescriptionState>,
 }
 
 impl ExecuteResources {
@@ -119,6 +122,7 @@ impl ExecuteResources {
         input_sizes_generation: u64,
         cleanup_required: Arc<AtomicBool>,
         fetch_state: Arc<FetchState>,
+        description_state: Arc<DescriptionState>,
     ) -> Self {
         Self {
             client,
@@ -132,18 +136,19 @@ impl ExecuteResources {
             input_sizes_generation,
             cleanup_required,
             fetch_state,
+            description_state,
         }
     }
 }
 
 enum ExecuteOutcome {
     Idle,
-    Fetching,
+    Fetching(Vec<ColumnMetadata>),
 }
 
 impl ExecuteOutcome {
     fn has_open_batch(&self) -> bool {
-        matches!(self, Self::Fetching)
+        matches!(self, Self::Fetching(_))
     }
 }
 
@@ -250,7 +255,7 @@ async fn execute_on_client(
         client.advance_to_rows().await?;
     }
     Ok(if client.has_open_batch() {
-        ExecuteOutcome::Fetching
+        ExecuteOutcome::Fetching(client.get_metadata().clone())
     } else {
         ExecuteOutcome::Idle
     })
@@ -289,6 +294,7 @@ pub(crate) fn execute<'py>(
         input_sizes_generation,
         cleanup_required,
         fetch_state,
+        description_state,
     } = resources;
     // TODO(async execute preflight): Parameter normalization and Python-to-TDS
     // conversion currently run synchronously under the GIL before the awaitable is
@@ -312,6 +318,8 @@ pub(crate) fn execute<'py>(
     let future_state = session_state.clone();
     let previous_fetch_status = fetch_state.replace(FetchStatus::NoResultSet);
     let future_fetch_state = fetch_state.clone();
+    let previous_description = description_state.replace(None);
+    let future_description_state = description_state.clone();
 
     let future = async move {
         let mut operation_guard = SessionOperationGuard::new(future_state, operation_id);
@@ -332,19 +340,28 @@ pub(crate) fn execute<'py>(
 
         match result {
             Ok(outcome) => {
-                operation_guard.finish_execute(outcome.has_open_batch());
-                future_fetch_state.set(if outcome.has_open_batch() {
+                let has_open_batch = outcome.has_open_batch();
+                operation_guard.finish_execute(has_open_batch);
+                let metadata = match outcome {
+                    ExecuteOutcome::Idle => None,
+                    ExecuteOutcome::Fetching(metadata) => Some(metadata),
+                };
+                let column_count = metadata.as_ref().map_or(0, Vec::len);
+                future_fetch_state.set(if has_open_batch {
                     FetchStatus::Ready
                 } else {
                     FetchStatus::NoResultSet
                 });
+                future_description_state.replace(metadata);
                 Python::attach(|py| {
                     let mut cursor_ref = cursor.borrow_mut(py);
                     if cursor_ref.input_sizes_generation() == input_sizes_generation {
                         cursor_ref.clear_input_sizes();
                     }
                 });
-                tracing::info!("PyAsyncCursor::execute: query executed successfully");
+                tracing::info!(
+                    "PyAsyncCursor::execute: query executed successfully; has_result_set={has_open_batch}; column_count={column_count}"
+                );
                 Ok(cursor)
             }
             Err(error) => {
@@ -365,6 +382,7 @@ pub(crate) fn execute<'py>(
         Err(error) => {
             session_state.release_operation(operation_id);
             fetch_state.set(previous_fetch_status);
+            description_state.replace(previous_description);
             Err(error)
         }
     }

--- a/mssql-py-core/src/async_execute.rs
+++ b/mssql-py-core/src/async_execute.rs
@@ -10,11 +10,10 @@ use std::time::Instant;
 use mssql_tds::connection::tds_client::{
     ExecuteOptions, PreparedStatement, ResultSet, StatementId, StatementResult, TdsClient,
 };
-use mssql_tds::error::Error;
+use mssql_tds::error::{Error, SqlInfoMessage};
 use mssql_tds::message::parameters::rpc_parameters::RpcParameter;
 use mssql_tds::message::transaction_management::TransactionIsolationLevel;
 use mssql_tds::query::metadata::ColumnMetadata;
-use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use pyo3::types::PyTuple;
 use tokio::sync::Mutex;
@@ -22,6 +21,7 @@ use tracing::instrument::WithSubscriber;
 
 use crate::async_cursor::{PyAsyncCursor, map_claim_error};
 use crate::async_description::{DescriptionState, materialize};
+use crate::async_errors::{InternalError, map_tds_error};
 use crate::async_fetch::{FetchState, FetchStatus};
 use crate::async_parameters::{ParameterMetadata, bind_parameters, parse_input_sizes};
 use crate::async_session::{AsyncConnectionState, CursorId, ExecuteClaim, SessionOperationGuard};
@@ -144,18 +144,33 @@ impl ExecuteResources {
 }
 
 enum ExecuteOutcome {
-    Idle,
     NoRows,
+    TerminalNoRows,
     Rows(Vec<ColumnMetadata>),
 }
 
 impl ExecuteOutcome {
     fn has_open_batch(&self) -> bool {
-        !matches!(self, Self::Idle)
+        !matches!(self, Self::TerminalNoRows)
     }
 
     fn has_rows(&self) -> bool {
         matches!(self, Self::Rows(_))
+    }
+
+    fn fetch_status(&self) -> FetchStatus {
+        match self {
+            Self::NoRows => FetchStatus::NoResultSet,
+            Self::TerminalNoRows => FetchStatus::TerminalNoRows,
+            Self::Rows(_) => FetchStatus::Ready,
+        }
+    }
+
+    fn result_set_status(&self) -> &'static str {
+        match self {
+            Self::NoRows | Self::TerminalNoRows => "no_rows",
+            Self::Rows(_) => "rows",
+        }
     }
 }
 
@@ -261,13 +276,17 @@ async fn execute_on_client(
     Ok(match first {
         StatementResult::Rows => ExecuteOutcome::Rows(client.get_metadata().clone()),
         StatementResult::NoRows { .. } if client.has_open_batch() => ExecuteOutcome::NoRows,
-        StatementResult::NoRows { .. } | StatementResult::End => ExecuteOutcome::Idle,
+        StatementResult::NoRows { .. } | StatementResult::End => ExecuteOutcome::TerminalNoRows,
     })
 }
 
-fn map_execute_error(error: impl std::fmt::Display) -> PyErr {
+fn map_execute_error(error: Error, info_messages: Vec<SqlInfoMessage>) -> PyErr {
     tracing::debug!("PyAsyncCursor::execute: failed: {error}");
-    PyRuntimeError::new_err(format!("Query execution failed: {error}"))
+    map_tds_error(
+        "PyAsyncCursor.execute failed while executing query",
+        error,
+        info_messages,
+    )
 }
 
 pub(crate) fn set_input_sizes(
@@ -335,35 +354,37 @@ pub(crate) fn execute<'py>(
             request.reset_cursor
         );
 
-        let (result, has_open_batch) = {
+        let (result, info_messages, has_open_batch) = {
             let mut client = client.lock().await;
             let result = execute_on_client(&mut client, &prepared_state, &claim, request).await;
+            let info_messages = if matches!(
+                result,
+                Err(ExecuteFailure {
+                    error: Error::SqlServerError { .. },
+                    ..
+                })
+            ) {
+                client.take_info_messages()
+            } else {
+                Vec::new()
+            };
             let has_open_batch = client.has_open_batch();
-            (result, has_open_batch)
+            (result, info_messages, has_open_batch)
         };
 
         match result {
             Ok(outcome) => {
                 let has_open_batch = outcome.has_open_batch();
                 let has_result_set = outcome.has_rows();
-                record_result_set_status(if has_result_set {
-                    "rows"
-                } else if has_open_batch {
-                    "no_rows"
-                } else {
-                    "exhausted"
-                });
+                let fetch_status = outcome.fetch_status();
+                record_result_set_status(outcome.result_set_status());
                 operation_guard.finish_execute(has_open_batch);
                 let metadata = match outcome {
                     ExecuteOutcome::Rows(metadata) => Some(metadata),
-                    ExecuteOutcome::Idle | ExecuteOutcome::NoRows => None,
+                    ExecuteOutcome::NoRows | ExecuteOutcome::TerminalNoRows => None,
                 };
                 let column_count = metadata.as_ref().map_or(0, Vec::len);
-                future_fetch_state.set(if has_result_set {
-                    FetchStatus::Ready
-                } else {
-                    FetchStatus::NoResultSet
-                });
+                future_fetch_state.set(fetch_status);
                 Python::attach(|py| {
                     let mut cursor_ref = cursor.borrow_mut(py);
                     if cursor_ref.input_sizes_generation() == input_sizes_generation {
@@ -376,7 +397,7 @@ pub(crate) fn execute<'py>(
                         "PyAsyncCursor::execute: cursor description materialization failed; column_count={column_count}; elapsed_ms={}; error={error}",
                         description_started.elapsed().as_millis()
                     );
-                    PyRuntimeError::new_err(format!(
+                    InternalError::new_err(format!(
                         "Query executed but cursor description materialization failed: {error}"
                     ))
                 })?;
@@ -390,7 +411,7 @@ pub(crate) fn execute<'py>(
             Err(error) => {
                 record_result_set_status("error");
                 operation_guard.settle(error.break_connection || has_open_batch);
-                Err(map_execute_error(error.error))
+                Err(map_execute_error(error.error, info_messages))
             }
         }
     };

--- a/mssql-py-core/src/async_execute.rs
+++ b/mssql-py-core/src/async_execute.rs
@@ -384,7 +384,6 @@ pub(crate) fn execute<'py>(
                     ExecuteOutcome::NoRows | ExecuteOutcome::TerminalNoRows => None,
                 };
                 let column_count = metadata.as_ref().map_or(0, Vec::len);
-                future_fetch_state.set(fetch_status);
                 Python::attach(|py| {
                     let mut cursor_ref = cursor.borrow_mut(py);
                     if cursor_ref.input_sizes_generation() == input_sizes_generation {
@@ -403,6 +402,7 @@ pub(crate) fn execute<'py>(
                 })?;
                 let description_materialization_ms = description_started.elapsed().as_millis();
                 future_description_state.replace(description);
+                future_fetch_state.set(fetch_status);
                 tracing::info!(
                     "PyAsyncCursor::execute: query executed successfully; has_result_set={has_result_set}; column_count={column_count}; description_materialization_ms={description_materialization_ms}; has_open_batch={has_open_batch}"
                 );

--- a/mssql-py-core/src/async_execute.rs
+++ b/mssql-py-core/src/async_execute.rs
@@ -5,6 +5,7 @@
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
 
 use mssql_tds::connection::tds_client::{
     ExecuteOptions, PreparedStatement, ResultSet, StatementId, StatementResult, TdsClient,
@@ -20,7 +21,7 @@ use tokio::sync::Mutex;
 use tracing::instrument::WithSubscriber;
 
 use crate::async_cursor::{PyAsyncCursor, map_claim_error};
-use crate::async_description::DescriptionState;
+use crate::async_description::{DescriptionState, materialize};
 use crate::async_fetch::{FetchState, FetchStatus};
 use crate::async_parameters::{ParameterMetadata, bind_parameters, parse_input_sizes};
 use crate::async_session::{AsyncConnectionState, CursorId, ExecuteClaim, SessionOperationGuard};
@@ -352,15 +353,26 @@ pub(crate) fn execute<'py>(
                 } else {
                     FetchStatus::NoResultSet
                 });
-                future_description_state.replace(metadata);
                 Python::attach(|py| {
                     let mut cursor_ref = cursor.borrow_mut(py);
                     if cursor_ref.input_sizes_generation() == input_sizes_generation {
                         cursor_ref.clear_input_sizes();
                     }
                 });
+                let description_started = Instant::now();
+                let description = materialize(metadata).await.map_err(|error| {
+                    tracing::error!(
+                        "PyAsyncCursor::execute: cursor description materialization failed; column_count={column_count}; elapsed_ms={}; error={error}",
+                        description_started.elapsed().as_millis()
+                    );
+                    PyRuntimeError::new_err(format!(
+                        "Query executed but cursor description materialization failed: {error}"
+                    ))
+                })?;
+                let description_materialization_ms = description_started.elapsed().as_millis();
+                future_description_state.replace(description);
                 tracing::info!(
-                    "PyAsyncCursor::execute: query executed successfully; has_result_set={has_open_batch}; column_count={column_count}"
+                    "PyAsyncCursor::execute: query executed successfully; has_result_set={has_open_batch}; column_count={column_count}; description_materialization_ms={description_materialization_ms}"
                 );
                 Ok(cursor)
             }

--- a/mssql-py-core/src/async_execute.rs
+++ b/mssql-py-core/src/async_execute.rs
@@ -25,6 +25,7 @@ use crate::async_description::{DescriptionState, materialize};
 use crate::async_fetch::{FetchState, FetchStatus};
 use crate::async_parameters::{ParameterMetadata, bind_parameters, parse_input_sizes};
 use crate::async_session::{AsyncConnectionState, CursorId, ExecuteClaim, SessionOperationGuard};
+use crate::async_tracing::{in_cursor_operation_span, record_result_set_status};
 use crate::types::ParameterHint;
 
 /// Cursor-local state for prepared execution and deferred handle cleanup.
@@ -345,6 +346,13 @@ pub(crate) fn execute<'py>(
             Ok(outcome) => {
                 let has_open_batch = outcome.has_open_batch();
                 let has_result_set = outcome.has_rows();
+                record_result_set_status(if has_result_set {
+                    "rows"
+                } else if has_open_batch {
+                    "no_rows"
+                } else {
+                    "exhausted"
+                });
                 operation_guard.finish_execute(has_open_batch);
                 let metadata = match outcome {
                     ExecuteOutcome::Rows(metadata) => Some(metadata),
@@ -380,11 +388,13 @@ pub(crate) fn execute<'py>(
                 Ok(cursor)
             }
             Err(error) => {
+                record_result_set_status("error");
                 operation_guard.settle(error.break_connection || has_open_batch);
                 Err(map_execute_error(error.error))
             }
         }
     };
+    let future = in_cursor_operation_span(future, cursor_id, operation_id, "execute", "pending");
     let future = async move {
         match dispatch {
             Some(dispatch) => future.with_subscriber(dispatch).await,

--- a/mssql-py-core/src/async_fetch.rs
+++ b/mssql-py-core/src/async_fetch.rs
@@ -19,10 +19,11 @@ use crate::async_cursor::{PyAsyncCursor, map_claim_error};
 use crate::async_description::{DescriptionState, materialize};
 use crate::async_errors::map_tds_error;
 use crate::async_session::{AsyncConnectionState, ClaimError, CursorId, OperationId};
+use crate::async_tracing::{in_cursor_operation_span, record_result_set_status};
 use crate::row_writer::PyRowWriter;
 
 const FETCH_YIELD_INTERVAL: usize = 256;
-const FETCHALL_MATERIALIZE_CHUNK_SIZE: usize = 256;
+const LIST_MATERIALIZE_CHUNK_SIZE: usize = 256;
 
 #[derive(Clone, Copy, Eq, PartialEq)]
 #[repr(u8)]
@@ -196,43 +197,32 @@ impl FetchOutput {
             Self::Many | Self::All => Ok(PyList::empty(py).into_any().unbind()),
         }
     }
-
-    fn materialize(self, py: Python<'_>, rows: Vec<PyRowWriter>) -> PyResult<Py<PyAny>> {
-        match self {
-            Self::One => match rows.into_iter().next() {
-                Some(writer) => Ok(writer.to_py_tuple(py)?.into_any().unbind()),
-                None => Ok(py.None()),
-            },
-            Self::Many | Self::All => {
-                let rows = rows
-                    .into_iter()
-                    .map(|writer| writer.to_py_tuple(py).map(Bound::unbind))
-                    .collect::<PyResult<Vec<_>>>()?;
-                Ok(PyList::new(py, rows)?.into_any().unbind())
-            }
-        }
-    }
 }
 
 async fn materialize_rows(output: FetchOutput, rows: Vec<PyRowWriter>) -> PyResult<Py<PyAny>> {
-    if matches!(output, FetchOutput::All) {
-        return materialize_all_rows(rows).await;
-    }
-    tokio::task::spawn_blocking(move || Python::attach(|py| output.materialize(py, rows)))
+    match output {
+        FetchOutput::One => tokio::task::spawn_blocking(move || {
+            Python::attach(|py| match rows.into_iter().next() {
+                Some(writer) => Ok(writer.to_py_tuple(py)?.into_any().unbind()),
+                None => Ok(py.None()),
+            })
+        })
         .await
-        .map_err(map_materialization_join_error)?
+        .map_err(map_materialization_join_error)?,
+        FetchOutput::Many | FetchOutput::All => materialize_list_rows(rows).await,
+    }
 }
 
-async fn materialize_all_rows(rows: Vec<PyRowWriter>) -> PyResult<Py<PyAny>> {
+async fn materialize_list_rows(rows: Vec<PyRowWriter>) -> PyResult<Py<PyAny>> {
     let mut rows = rows.into_iter();
     let mut list: Option<Py<PyList>> = None;
 
     loop {
         let chunk = rows
             .by_ref()
-            .take(FETCHALL_MATERIALIZE_CHUNK_SIZE)
+            .take(LIST_MATERIALIZE_CHUNK_SIZE)
             .collect::<Vec<_>>();
-        let finished = chunk.len() < FETCHALL_MATERIALIZE_CHUNK_SIZE;
+        let finished = chunk.len() < LIST_MATERIALIZE_CHUNK_SIZE;
         list = Some(
             tokio::task::spawn_blocking(move || {
                 Python::attach(|py| {
@@ -377,6 +367,7 @@ fn fetch<'py>(
             Ok(batch) => {
                 let returned = batch.rows.len();
                 let exhausted = batch.exhausted;
+                record_result_set_status(if exhausted { "exhausted" } else { "ready" });
                 fetch_state.set(if batch.exhausted {
                     FetchStatus::Exhausted
                 } else {
@@ -418,6 +409,7 @@ fn fetch<'py>(
                 }
             }
             Err(error) => {
+                record_result_set_status("error");
                 fetch_guard.fail(has_open_batch);
                 fetch_state.set(FetchStatus::NoResultSet);
                 Err(map_fetch_error(
@@ -428,6 +420,7 @@ fn fetch<'py>(
             }
         }
     };
+    let future = in_cursor_operation_span(future, cursor_id, operation_id, operation, "reading");
     let future = async move {
         match dispatch {
             Some(dispatch) => future.with_subscriber(dispatch).await,
@@ -547,6 +540,11 @@ pub(crate) fn nextset<'py>(
             Ok((result, metadata)) => {
                 let has_result = !matches!(result, StatementResult::End);
                 let has_rows = matches!(result, StatementResult::Rows);
+                record_result_set_status(match result {
+                    StatementResult::Rows => "rows",
+                    StatementResult::NoRows { .. } => "no_rows",
+                    StatementResult::End => "exhausted",
+                });
                 let column_count = metadata.as_ref().map_or(0, Vec::len);
                 future_fetch_state.set(match result {
                     StatementResult::Rows => FetchStatus::Ready,
@@ -586,12 +584,14 @@ pub(crate) fn nextset<'py>(
                 }
             }
             Err(error) => {
+                record_result_set_status("error");
                 fetch_guard.fail(has_open_batch);
                 future_fetch_state.set(FetchStatus::NoResultSet);
                 Err(map_nextset_error(error, read_ms))
             }
         }
     };
+    let future = in_cursor_operation_span(future, cursor_id, operation_id, "nextset", "advancing");
     let future = async move {
         match dispatch {
             Some(dispatch) => future.with_subscriber(dispatch).await,

--- a/mssql-py-core/src/async_fetch.rs
+++ b/mssql-py-core/src/async_fetch.rs
@@ -18,6 +18,9 @@ use crate::async_cursor::{PyAsyncCursor, map_claim_error};
 use crate::async_session::{AsyncConnectionState, CursorId, OperationId};
 use crate::row_writer::PyRowWriter;
 
+const FETCH_YIELD_INTERVAL: usize = 256;
+const FETCHALL_MATERIALIZE_CHUNK_SIZE: usize = 256;
+
 #[derive(Clone, Copy, Eq, PartialEq)]
 #[repr(u8)]
 pub(crate) enum FetchStatus {
@@ -136,6 +139,38 @@ impl Drop for FetchGuard {
     }
 }
 
+struct MaterializationGuard {
+    operation: &'static str,
+    dispatch: Option<tracing::Dispatch>,
+    completed: bool,
+}
+
+impl MaterializationGuard {
+    fn new(operation: &'static str, dispatch: Option<tracing::Dispatch>) -> Self {
+        Self {
+            operation,
+            dispatch,
+            completed: false,
+        }
+    }
+
+    fn complete(&mut self) {
+        self.completed = true;
+    }
+}
+
+impl Drop for MaterializationGuard {
+    fn drop(&mut self) {
+        if !self.completed {
+            let _guard = self.dispatch.as_ref().map(tracing::dispatcher::set_default);
+            tracing::warn!(
+                "PyAsyncCursor::{}: interrupted during row materialization; connection remains usable",
+                self.operation
+            );
+        }
+    }
+}
+
 struct FetchBatch {
     rows: Vec<PyRowWriter>,
     exhausted: bool,
@@ -145,17 +180,14 @@ struct FetchBatch {
 enum FetchOutput {
     One,
     Many,
+    All,
 }
 
 impl FetchOutput {
-    fn logs_batch_summary(self) -> bool {
-        matches!(self, Self::Many)
-    }
-
     fn empty(self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         match self {
             Self::One => Ok(py.None()),
-            Self::Many => Ok(PyList::empty(py).into_any().unbind()),
+            Self::Many | Self::All => Ok(PyList::empty(py).into_any().unbind()),
         }
     }
 
@@ -165,7 +197,7 @@ impl FetchOutput {
                 Some(writer) => Ok(writer.to_py_tuple(py)?.into_any().unbind()),
                 None => Ok(py.None()),
             },
-            Self::Many => {
+            Self::Many | Self::All => {
                 let rows = rows
                     .into_iter()
                     .map(|writer| writer.to_py_tuple(py).map(Bound::unbind))
@@ -177,13 +209,60 @@ impl FetchOutput {
 }
 
 async fn materialize_rows(output: FetchOutput, rows: Vec<PyRowWriter>) -> PyResult<Py<PyAny>> {
+    if matches!(output, FetchOutput::All) {
+        return materialize_all_rows(rows).await;
+    }
     tokio::task::spawn_blocking(move || Python::attach(|py| output.materialize(py, rows)))
         .await
-        .map_err(|error| {
-            pyo3::exceptions::PyRuntimeError::new_err(format!(
-                "Failed to materialize fetched rows: {error}"
-            ))
-        })?
+        .map_err(map_materialization_join_error)?
+}
+
+async fn materialize_all_rows(rows: Vec<PyRowWriter>) -> PyResult<Py<PyAny>> {
+    let mut rows = rows.into_iter();
+    let mut list: Option<Py<PyList>> = None;
+
+    loop {
+        let chunk = rows
+            .by_ref()
+            .take(FETCHALL_MATERIALIZE_CHUNK_SIZE)
+            .collect::<Vec<_>>();
+        let finished = chunk.len() < FETCHALL_MATERIALIZE_CHUNK_SIZE;
+        list = Some(
+            tokio::task::spawn_blocking(move || {
+                Python::attach(|py| {
+                    let converted = chunk
+                        .into_iter()
+                        .map(|writer| writer.to_py_tuple(py).map(Bound::unbind))
+                        .collect::<PyResult<Vec<_>>>()?;
+                    let chunk = PyList::new(py, converted)?;
+                    let list = match list {
+                        Some(list) => {
+                            let bound = list.bind(py);
+                            let end = bound.len();
+                            bound.set_slice(end, end, chunk.as_any())?;
+                            list
+                        }
+                        None => chunk.unbind(),
+                    };
+                    Ok::<Py<PyList>, PyErr>(list)
+                })
+            })
+            .await
+            .map_err(map_materialization_join_error)??,
+        );
+        if finished {
+            return Ok(list
+                .expect("materialization always creates a list")
+                .into_any());
+        }
+        tokio::task::yield_now().await;
+    }
+}
+
+fn map_materialization_join_error(error: tokio::task::JoinError) -> PyErr {
+    pyo3::exceptions::PyRuntimeError::new_err(format!(
+        "Failed to materialize fetched rows: {error}"
+    ))
 }
 
 async fn fetch_rows_on_client(client: &mut TdsClient, limit: usize) -> Result<FetchBatch, Error> {
@@ -205,6 +284,9 @@ async fn fetch_rows_on_client(client: &mut TdsClient, limit: usize) -> Result<Fe
             });
         }
         rows.push(writer);
+        if rows.len() % FETCH_YIELD_INTERVAL == 0 {
+            tokio::task::yield_now().await;
+        }
     }
     Ok(FetchBatch {
         rows,
@@ -246,11 +328,16 @@ fn fetch<'py>(
     let operation_id = claim.operation_id;
     let future_state = session_state.clone();
     let guard_dispatch = dispatch.clone();
+    let materialization_dispatch = dispatch.clone();
 
     let future = async move {
         let started = Instant::now();
-        if output.logs_batch_summary() {
-            tracing::debug!("PyAsyncCursor::{operation}: started; requested={limit}");
+        match output {
+            FetchOutput::Many => {
+                tracing::debug!("PyAsyncCursor::{operation}: started; requested={limit}");
+            }
+            FetchOutput::All => tracing::debug!("PyAsyncCursor::{operation}: started"),
+            FetchOutput::One => {}
         }
         // Retain the Python cursor until the row operation settles so its finalizer
         // cannot race the in-flight TDS read.
@@ -264,6 +351,7 @@ fn fetch<'py>(
             let has_open_batch = client.has_open_batch();
             (result, has_open_batch)
         };
+        let read_ms = started.elapsed().as_millis();
 
         match result {
             Ok(batch) => {
@@ -275,13 +363,23 @@ fn fetch<'py>(
                     FetchStatus::Ready
                 });
                 fetch_guard.complete(batch.exhausted, has_open_batch);
+                let materialization_started = Instant::now();
+                let mut materialization_guard =
+                    MaterializationGuard::new(operation, materialization_dispatch);
                 match materialize_rows(output, batch.rows).await {
                     Ok(rows) => {
-                        if output.logs_batch_summary() {
-                            tracing::debug!(
-                                "PyAsyncCursor::{operation}: completed; requested={limit}; returned={returned}; exhausted={exhausted}; elapsed_ms={}",
-                                started.elapsed().as_millis()
-                            );
+                        materialization_guard.complete();
+                        let materialization_ms = materialization_started.elapsed().as_millis();
+                        match output {
+                            FetchOutput::Many => tracing::debug!(
+                                "PyAsyncCursor::{operation}: completed; requested={limit}; returned={returned}; exhausted={exhausted}; elapsed_ms={}; read_ms={read_ms}; materialization_ms={materialization_ms}",
+                                started.elapsed().as_millis(),
+                            ),
+                            FetchOutput::All => tracing::debug!(
+                                "PyAsyncCursor::{operation}: completed; returned={returned}; exhausted={exhausted}; elapsed_ms={}; read_ms={read_ms}; materialization_ms={materialization_ms}",
+                                started.elapsed().as_millis(),
+                            ),
+                            FetchOutput::One => {}
                         }
                         if exhausted {
                             tracing::info!("PyAsyncCursor::{operation}: result set exhausted");
@@ -289,9 +387,11 @@ fn fetch<'py>(
                         Ok(rows)
                     }
                     Err(error) => {
+                        materialization_guard.complete();
                         tracing::error!(
-                            "PyAsyncCursor::{operation}: row materialization failed; returned={returned}; elapsed_ms={}; error={error}",
-                            started.elapsed().as_millis()
+                            "PyAsyncCursor::{operation}: row materialization failed; returned={returned}; elapsed_ms={}; read_ms={read_ms}; materialization_ms={}; error={error}",
+                            started.elapsed().as_millis(),
+                            materialization_started.elapsed().as_millis(),
                         );
                         Err(error)
                     }
@@ -356,6 +456,22 @@ pub(crate) fn fetchmany<'py>(
         size as usize,
         FetchOutput::Many,
         "fetchmany",
+    )
+}
+
+/// Return an awaitable resolving to all remaining rows in the current result set.
+pub(crate) fn fetchall<'py>(
+    cursor: Py<PyAsyncCursor>,
+    py: Python<'py>,
+) -> PyResult<Bound<'py, PyAny>> {
+    let resources = cursor.borrow(py).fetch_resources()?;
+    fetch(
+        cursor,
+        py,
+        resources,
+        usize::MAX,
+        FetchOutput::All,
+        "fetchall",
     )
 }
 

--- a/mssql-py-core/src/async_fetch.rs
+++ b/mssql-py-core/src/async_fetch.rs
@@ -17,6 +17,7 @@ use tracing::instrument::WithSubscriber;
 
 use crate::async_cursor::{PyAsyncCursor, map_claim_error};
 use crate::async_description::{DescriptionState, materialize};
+use crate::async_errors::map_tds_error;
 use crate::async_session::{AsyncConnectionState, ClaimError, CursorId, OperationId};
 use crate::row_writer::PyRowWriter;
 
@@ -301,16 +302,18 @@ async fn fetch_rows_on_client(client: &mut TdsClient, limit: usize) -> Result<Fe
 
 fn map_fetch_error(operation: &str, error: Error, elapsed_ms: u128) -> PyErr {
     tracing::error!("PyAsyncCursor::{operation}: failed; elapsed_ms={elapsed_ms}; error={error}");
-    pyo3::exceptions::PyRuntimeError::new_err(format!(
-        "PyAsyncCursor.{operation} failed while reading rows: {error}"
-    ))
+    map_tds_error(
+        &format!("PyAsyncCursor.{operation} failed while reading rows"),
+        error,
+    )
 }
 
 fn map_nextset_error(error: Error, elapsed_ms: u128) -> PyErr {
     tracing::error!("PyAsyncCursor::nextset: failed; elapsed_ms={elapsed_ms}; error={error}");
-    pyo3::exceptions::PyRuntimeError::new_err(format!(
-        "PyAsyncCursor.nextset failed while advancing results: {error}"
-    ))
+    map_tds_error(
+        "PyAsyncCursor.nextset failed while advancing results",
+        error,
+    )
 }
 
 fn fetch<'py>(
@@ -647,22 +650,28 @@ mod tests {
     }
 
     #[test]
-    fn maps_fetch_error_to_python_runtime_error() {
+    fn maps_fetch_protocol_error_to_python_internal_error() {
         let error = map_fetch_error(
             "fetchone",
             Error::ProtocolError("invalid row token".to_string()),
             7,
         );
 
+        pyo3::Python::attach(|py| {
+            assert!(error.is_instance_of::<crate::async_errors::InternalError>(py));
+        });
         assert!(error.to_string().contains(
             "PyAsyncCursor.fetchone failed while reading rows: Protocol Error: invalid row token"
         ));
     }
 
     #[test]
-    fn maps_nextset_error_to_python_runtime_error() {
+    fn maps_nextset_protocol_error_to_python_internal_error() {
         let error = map_nextset_error(Error::ProtocolError("invalid result token".to_string()), 7);
 
+        pyo3::Python::attach(|py| {
+            assert!(error.is_instance_of::<crate::async_errors::InternalError>(py));
+        });
         assert!(error.to_string().contains(
             "PyAsyncCursor.nextset failed while advancing results: Protocol Error: invalid result token"
         ));

--- a/mssql-py-core/src/async_fetch.rs
+++ b/mssql-py-core/src/async_fetch.rs
@@ -650,7 +650,10 @@ mod tests {
 
     use mssql_tds::error::Error;
 
-    use super::{FetchGuard, map_fetch_error, map_nextset_error};
+    use super::{
+        FetchGuard, MaterializationGuard, map_fetch_error, map_materialization_join_error,
+        map_nextset_error,
+    };
     use crate::async_session::{AsyncConnectionState, ClaimError, ConnectionLifecycle};
 
     fn claimed_fetch() -> (Arc<AsyncConnectionState>, u64) {
@@ -714,5 +717,29 @@ mod tests {
         assert!(error.to_string().contains(
             "PyAsyncCursor.nextset failed while advancing results: Protocol Error: invalid result token"
         ));
+    }
+
+    #[test]
+    fn dropping_interrupted_materialization_guard_is_safe() {
+        drop(MaterializationGuard::new("fetchall", None));
+    }
+
+    #[tokio::test]
+    async fn maps_materialization_task_panic_to_python_runtime_error() {
+        let join_error = tokio::task::spawn_blocking(|| panic!("materialization failed"))
+            .await
+            .unwrap_err();
+
+        let error = map_materialization_join_error(join_error);
+
+        pyo3::Python::attach(|py| {
+            assert!(error.is_instance_of::<pyo3::exceptions::PyRuntimeError>(py));
+        });
+        assert!(
+            error
+                .to_string()
+                .contains("Failed to materialize fetched rows: task")
+        );
+        assert!(error.to_string().contains("materialization failed"));
     }
 }

--- a/mssql-py-core/src/async_fetch.rs
+++ b/mssql-py-core/src/async_fetch.rs
@@ -9,7 +9,7 @@ use std::time::Instant;
 
 use mssql_tds::connection::tds_client::StatementResult;
 use mssql_tds::connection::tds_client::{ResultSet, TdsClient};
-use mssql_tds::error::Error;
+use mssql_tds::error::{Error, SqlInfoMessage};
 use pyo3::prelude::*;
 use pyo3::types::PyList;
 use tokio::sync::Mutex;
@@ -17,7 +17,7 @@ use tracing::instrument::WithSubscriber;
 
 use crate::async_cursor::{PyAsyncCursor, map_claim_error};
 use crate::async_description::{DescriptionState, materialize};
-use crate::async_errors::map_tds_error;
+use crate::async_errors::{InternalError, map_tds_error};
 use crate::async_session::{AsyncConnectionState, ClaimError, CursorId, OperationId};
 use crate::async_tracing::{in_cursor_operation_span, record_result_set_status};
 use crate::row_writer::PyRowWriter;
@@ -31,6 +31,7 @@ pub(crate) enum FetchStatus {
     NoResultSet,
     Ready,
     Exhausted,
+    TerminalNoRows,
 }
 
 pub(crate) struct FetchState(AtomicU8);
@@ -44,6 +45,7 @@ impl FetchState {
         match self.0.load(Ordering::Acquire) {
             value if value == FetchStatus::Ready as u8 => FetchStatus::Ready,
             value if value == FetchStatus::Exhausted as u8 => FetchStatus::Exhausted,
+            value if value == FetchStatus::TerminalNoRows as u8 => FetchStatus::TerminalNoRows,
             _ => FetchStatus::NoResultSet,
         }
     }
@@ -53,6 +55,7 @@ impl FetchState {
         match previous {
             value if value == FetchStatus::Ready as u8 => FetchStatus::Ready,
             value if value == FetchStatus::Exhausted as u8 => FetchStatus::Exhausted,
+            value if value == FetchStatus::TerminalNoRows as u8 => FetchStatus::TerminalNoRows,
             _ => FetchStatus::NoResultSet,
         }
     }
@@ -290,19 +293,26 @@ async fn fetch_rows_on_client(client: &mut TdsClient, limit: usize) -> Result<Fe
     })
 }
 
-fn map_fetch_error(operation: &str, error: Error, elapsed_ms: u128) -> PyErr {
+fn map_fetch_error(
+    operation: &str,
+    error: Error,
+    info_messages: Vec<SqlInfoMessage>,
+    elapsed_ms: u128,
+) -> PyErr {
     tracing::error!("PyAsyncCursor::{operation}: failed; elapsed_ms={elapsed_ms}; error={error}");
     map_tds_error(
         &format!("PyAsyncCursor.{operation} failed while reading rows"),
         error,
+        info_messages,
     )
 }
 
-fn map_nextset_error(error: Error, elapsed_ms: u128) -> PyErr {
+fn map_nextset_error(error: Error, info_messages: Vec<SqlInfoMessage>, elapsed_ms: u128) -> PyErr {
     tracing::error!("PyAsyncCursor::nextset: failed; elapsed_ms={elapsed_ms}; error={error}");
     map_tds_error(
         "PyAsyncCursor.nextset failed while advancing results",
         error,
+        info_messages,
     )
 }
 
@@ -322,7 +332,10 @@ fn fetch<'py>(
         fetch_state,
         description_state: _,
     } = resources;
-    if fetch_state.status() == FetchStatus::NoResultSet {
+    if matches!(
+        fetch_state.status(),
+        FetchStatus::NoResultSet | FetchStatus::TerminalNoRows
+    ) {
         session_state.ensure_open().map_err(map_claim_error)?;
         return Err(map_claim_error(ClaimError::NoResultSet));
     }
@@ -355,11 +368,16 @@ fn fetch<'py>(
         let mut fetch_guard =
             FetchGuard::new(future_state, operation_id, operation, guard_dispatch);
 
-        let (result, has_open_batch) = {
+        let (result, info_messages, has_open_batch) = {
             let mut client = client.lock().await;
             let result = fetch_rows_on_client(&mut client, limit).await;
+            let info_messages = if matches!(result, Err(Error::SqlServerError { .. })) {
+                client.take_info_messages()
+            } else {
+                Vec::new()
+            };
             let has_open_batch = client.has_open_batch();
-            (result, has_open_batch)
+            (result, info_messages, has_open_batch)
         };
         let read_ms = started.elapsed().as_millis();
 
@@ -415,6 +433,7 @@ fn fetch<'py>(
                 Err(map_fetch_error(
                     operation,
                     error,
+                    info_messages,
                     started.elapsed().as_millis(),
                 ))
             }
@@ -458,6 +477,12 @@ pub(crate) fn fetchmany<'py>(
             .session_state
             .ensure_open()
             .map_err(map_claim_error)?;
+        if matches!(
+            resources.fetch_state.status(),
+            FetchStatus::NoResultSet | FetchStatus::TerminalNoRows
+        ) {
+            return Err(map_claim_error(ClaimError::NoResultSet));
+        }
         return pyo3_async_runtimes::tokio::future_into_py(py, async move {
             Python::attach(|py| FetchOutput::Many.empty(py))
         });
@@ -504,7 +529,12 @@ pub(crate) fn nextset<'py>(
     } = resources;
     let claim = match session_state.claim_fetch(cursor_id) {
         Ok(claim) => claim,
-        Err(ClaimError::NoResultSet) if fetch_state.status() == FetchStatus::Exhausted => {
+        Err(ClaimError::NoResultSet)
+            if matches!(
+                fetch_state.status(),
+                FetchStatus::Exhausted | FetchStatus::TerminalNoRows
+            ) =>
+        {
             return pyo3_async_runtimes::tokio::future_into_py(py, async { Ok(false) });
         }
         Err(error) => return Err(map_claim_error(error)),
@@ -516,7 +546,6 @@ pub(crate) fn nextset<'py>(
     let future_fetch_state = fetch_state.clone();
     let future_description_state = description_state.clone();
     let guard_dispatch = dispatch.clone();
-    let materialization_dispatch = dispatch.clone();
 
     let future = async move {
         let started = Instant::now();
@@ -525,14 +554,19 @@ pub(crate) fn nextset<'py>(
         let mut fetch_guard =
             FetchGuard::new(future_state, operation_id, "nextset", guard_dispatch);
 
-        let (result, has_open_batch) = {
+        let (result, info_messages, has_open_batch) = {
             let mut client = client.lock().await;
             let result = client.advance().await.map(|result| {
                 let metadata =
                     matches!(result, StatementResult::Rows).then(|| client.get_metadata().clone());
                 (result, metadata)
             });
-            (result, client.has_open_batch())
+            let info_messages = if matches!(result, Err(Error::SqlServerError { .. })) {
+                client.take_info_messages()
+            } else {
+                Vec::new()
+            };
+            (result, info_messages, client.has_open_batch())
         };
         let read_ms = started.elapsed().as_millis();
 
@@ -546,20 +580,19 @@ pub(crate) fn nextset<'py>(
                     StatementResult::End => "exhausted",
                 });
                 let column_count = metadata.as_ref().map_or(0, Vec::len);
-                future_fetch_state.set(match result {
+                let next_fetch_status = match result {
                     StatementResult::Rows => FetchStatus::Ready,
-                    StatementResult::NoRows { .. } => FetchStatus::NoResultSet,
+                    StatementResult::NoRows { .. } if has_open_batch => FetchStatus::NoResultSet,
+                    StatementResult::NoRows { .. } => FetchStatus::TerminalNoRows,
                     StatementResult::End => FetchStatus::Exhausted,
-                });
-                fetch_guard.complete(!has_rows, has_open_batch);
+                };
 
                 let materialization_started = Instant::now();
-                let mut materialization_guard =
-                    MaterializationGuard::new("nextset", materialization_dispatch);
                 match materialize(metadata).await {
                     Ok(description) => {
-                        materialization_guard.complete();
                         future_description_state.replace(description);
+                        future_fetch_state.set(next_fetch_status);
+                        fetch_guard.complete(!has_rows, has_open_batch);
                         tracing::debug!(
                             "PyAsyncCursor::nextset: completed; has_result={has_result}; has_rows={has_rows}; column_count={column_count}; elapsed_ms={}; read_ms={read_ms}; materialization_ms={}",
                             started.elapsed().as_millis(),
@@ -571,13 +604,14 @@ pub(crate) fn nextset<'py>(
                         Ok(has_result)
                     }
                     Err(error) => {
-                        materialization_guard.complete();
+                        future_fetch_state.set(FetchStatus::NoResultSet);
+                        fetch_guard.complete(true, has_open_batch);
                         tracing::error!(
                             "PyAsyncCursor::nextset: description materialization failed; column_count={column_count}; elapsed_ms={}; read_ms={read_ms}; materialization_ms={}; error={error}",
                             started.elapsed().as_millis(),
                             materialization_started.elapsed().as_millis(),
                         );
-                        Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        Err(InternalError::new_err(format!(
                             "Advanced result set but cursor description materialization failed: {error}"
                         )))
                     }
@@ -587,7 +621,7 @@ pub(crate) fn nextset<'py>(
                 record_result_set_status("error");
                 fetch_guard.fail(has_open_batch);
                 future_fetch_state.set(FetchStatus::NoResultSet);
-                Err(map_nextset_error(error, read_ms))
+                Err(map_nextset_error(error, info_messages, read_ms))
             }
         }
     };
@@ -654,6 +688,7 @@ mod tests {
         let error = map_fetch_error(
             "fetchone",
             Error::ProtocolError("invalid row token".to_string()),
+            Vec::new(),
             7,
         );
 
@@ -667,7 +702,11 @@ mod tests {
 
     #[test]
     fn maps_nextset_protocol_error_to_python_internal_error() {
-        let error = map_nextset_error(Error::ProtocolError("invalid result token".to_string()), 7);
+        let error = map_nextset_error(
+            Error::ProtocolError("invalid result token".to_string()),
+            Vec::new(),
+            7,
+        );
 
         pyo3::Python::attach(|py| {
             assert!(error.is_instance_of::<crate::async_errors::InternalError>(py));

--- a/mssql-py-core/src/async_fetch.rs
+++ b/mssql-py-core/src/async_fetch.rs
@@ -5,10 +5,12 @@
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};
+use std::time::Instant;
 
 use mssql_tds::connection::tds_client::{ResultSet, TdsClient};
 use mssql_tds::error::Error;
 use pyo3::prelude::*;
+use pyo3::types::PyList;
 use tokio::sync::Mutex;
 use tracing::instrument::WithSubscriber;
 
@@ -84,21 +86,30 @@ impl FetchResources {
 struct FetchGuard {
     session_state: Arc<AsyncConnectionState>,
     operation_id: OperationId,
+    operation: &'static str,
+    dispatch: Option<tracing::Dispatch>,
     completed: bool,
 }
 
 impl FetchGuard {
-    fn new(session_state: Arc<AsyncConnectionState>, operation_id: OperationId) -> Self {
+    fn new(
+        session_state: Arc<AsyncConnectionState>,
+        operation_id: OperationId,
+        operation: &'static str,
+        dispatch: Option<tracing::Dispatch>,
+    ) -> Self {
         Self {
             session_state,
             operation_id,
+            operation,
+            dispatch,
             completed: false,
         }
     }
 
-    fn complete(&mut self, has_row: bool, has_open_batch: bool) {
+    fn complete(&mut self, result_set_exhausted: bool, has_open_batch: bool) {
         self.session_state
-            .finish_fetch(self.operation_id, has_row, has_open_batch);
+            .finish_fetch(self.operation_id, result_set_exhausted, has_open_batch);
         self.completed = true;
     }
 
@@ -114,36 +125,108 @@ impl FetchGuard {
 impl Drop for FetchGuard {
     fn drop(&mut self) {
         if !self.completed {
+            let _guard = self.dispatch.as_ref().map(tracing::dispatcher::set_default);
+            tracing::warn!(
+                "PyAsyncCursor::{}: interrupted; connection marked broken",
+                self.operation
+            );
             self.session_state.mark_broken();
             self.session_state.release_operation(self.operation_id);
         }
     }
 }
 
-async fn fetch_one_on_client(client: &mut TdsClient) -> Result<Option<PyRowWriter>, Error> {
+struct FetchBatch {
+    rows: Vec<PyRowWriter>,
+    exhausted: bool,
+}
+
+#[derive(Clone, Copy)]
+enum FetchOutput {
+    One,
+    Many,
+}
+
+impl FetchOutput {
+    fn logs_batch_summary(self) -> bool {
+        matches!(self, Self::Many)
+    }
+
+    fn empty(self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        match self {
+            Self::One => Ok(py.None()),
+            Self::Many => Ok(PyList::empty(py).into_any().unbind()),
+        }
+    }
+
+    fn materialize(self, py: Python<'_>, rows: Vec<PyRowWriter>) -> PyResult<Py<PyAny>> {
+        match self {
+            Self::One => match rows.into_iter().next() {
+                Some(writer) => Ok(writer.to_py_tuple(py)?.into_any().unbind()),
+                None => Ok(py.None()),
+            },
+            Self::Many => {
+                let rows = rows
+                    .into_iter()
+                    .map(|writer| writer.to_py_tuple(py).map(Bound::unbind))
+                    .collect::<PyResult<Vec<_>>>()?;
+                Ok(PyList::new(py, rows)?.into_any().unbind())
+            }
+        }
+    }
+}
+
+async fn materialize_rows(output: FetchOutput, rows: Vec<PyRowWriter>) -> PyResult<Py<PyAny>> {
+    tokio::task::spawn_blocking(move || Python::attach(|py| output.materialize(py, rows)))
+        .await
+        .map_err(|error| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "Failed to materialize fetched rows: {error}"
+            ))
+        })?
+}
+
+async fn fetch_rows_on_client(client: &mut TdsClient, limit: usize) -> Result<FetchBatch, Error> {
     if !client.on_rows() {
-        return Ok(None);
+        return Ok(FetchBatch {
+            rows: Vec::new(),
+            exhausted: true,
+        });
     }
 
-    let mut writer = PyRowWriter::new(client.get_metadata().len());
-    if client.next_row_into(&mut writer).await? {
-        Ok(Some(writer))
-    } else {
-        Ok(None)
+    let column_count = client.get_metadata().len();
+    let mut rows = Vec::with_capacity(limit.min(1024));
+    while rows.len() < limit {
+        let mut writer = PyRowWriter::new(column_count);
+        if !client.next_row_into(&mut writer).await? {
+            return Ok(FetchBatch {
+                rows,
+                exhausted: true,
+            });
+        }
+        rows.push(writer);
     }
+    Ok(FetchBatch {
+        rows,
+        exhausted: false,
+    })
 }
 
-fn map_fetch_error(error: Error) -> PyErr {
-    tracing::error!("PyAsyncCursor::fetchone: failed: {error}");
-    pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to fetch row: {error}"))
+fn map_fetch_error(operation: &str, error: Error, elapsed_ms: u128) -> PyErr {
+    tracing::error!("PyAsyncCursor::{operation}: failed; elapsed_ms={elapsed_ms}; error={error}");
+    pyo3::exceptions::PyRuntimeError::new_err(format!(
+        "PyAsyncCursor.{operation} failed while reading rows: {error}"
+    ))
 }
 
-/// Return an awaitable resolving to the next row tuple or `None`.
-pub(crate) fn fetchone<'py>(
+fn fetch<'py>(
     cursor: Py<PyAsyncCursor>,
     py: Python<'py>,
+    resources: FetchResources,
+    limit: usize,
+    output: FetchOutput,
+    operation: &'static str,
 ) -> PyResult<Bound<'py, PyAny>> {
-    let resources = cursor.borrow(py).fetch_resources()?;
     let FetchResources {
         client,
         dispatch,
@@ -154,7 +237,7 @@ pub(crate) fn fetchone<'py>(
     if fetch_state.status() == FetchStatus::Exhausted {
         session_state.ensure_open().map_err(map_claim_error)?;
         return pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            Python::attach(|py| Ok(py.None()))
+            Python::attach(|py| output.empty(py))
         });
     }
     let claim = session_state
@@ -162,41 +245,66 @@ pub(crate) fn fetchone<'py>(
         .map_err(map_claim_error)?;
     let operation_id = claim.operation_id;
     let future_state = session_state.clone();
+    let guard_dispatch = dispatch.clone();
 
     let future = async move {
+        let started = Instant::now();
+        if output.logs_batch_summary() {
+            tracing::debug!("PyAsyncCursor::{operation}: started; requested={limit}");
+        }
         // Retain the Python cursor until the row operation settles so its finalizer
         // cannot race the in-flight TDS read.
         let _cursor = cursor;
-        let mut fetch_guard = FetchGuard::new(future_state, operation_id);
+        let mut fetch_guard =
+            FetchGuard::new(future_state, operation_id, operation, guard_dispatch);
 
         let (result, has_open_batch) = {
             let mut client = client.lock().await;
-            let result = fetch_one_on_client(&mut client).await;
+            let result = fetch_rows_on_client(&mut client, limit).await;
             let has_open_batch = client.has_open_batch();
             (result, has_open_batch)
         };
 
         match result {
-            Ok(writer) => {
-                let has_row = writer.is_some();
-                fetch_state.set(if has_row {
-                    FetchStatus::Ready
-                } else {
+            Ok(batch) => {
+                let returned = batch.rows.len();
+                let exhausted = batch.exhausted;
+                fetch_state.set(if batch.exhausted {
                     FetchStatus::Exhausted
+                } else {
+                    FetchStatus::Ready
                 });
-                fetch_guard.complete(has_row, has_open_batch);
-                if !has_row {
-                    tracing::info!("PyAsyncCursor::fetchone: result set exhausted");
+                fetch_guard.complete(batch.exhausted, has_open_batch);
+                match materialize_rows(output, batch.rows).await {
+                    Ok(rows) => {
+                        if output.logs_batch_summary() {
+                            tracing::debug!(
+                                "PyAsyncCursor::{operation}: completed; requested={limit}; returned={returned}; exhausted={exhausted}; elapsed_ms={}",
+                                started.elapsed().as_millis()
+                            );
+                        }
+                        if exhausted {
+                            tracing::info!("PyAsyncCursor::{operation}: result set exhausted");
+                        }
+                        Ok(rows)
+                    }
+                    Err(error) => {
+                        tracing::error!(
+                            "PyAsyncCursor::{operation}: row materialization failed; returned={returned}; elapsed_ms={}; error={error}",
+                            started.elapsed().as_millis()
+                        );
+                        Err(error)
+                    }
                 }
-                Python::attach(|py| match writer {
-                    Some(writer) => Ok(writer.to_py_tuple(py)?.into_any().unbind()),
-                    None => Ok(py.None()),
-                })
             }
             Err(error) => {
                 fetch_guard.fail(has_open_batch);
                 fetch_state.set(FetchStatus::NoResultSet);
-                Err(map_fetch_error(error))
+                Err(map_fetch_error(
+                    operation,
+                    error,
+                    started.elapsed().as_millis(),
+                ))
             }
         }
     };
@@ -214,6 +322,41 @@ pub(crate) fn fetchone<'py>(
             Err(error)
         }
     }
+}
+
+/// Return an awaitable resolving to the next row tuple or `None`.
+pub(crate) fn fetchone<'py>(
+    cursor: Py<PyAsyncCursor>,
+    py: Python<'py>,
+) -> PyResult<Bound<'py, PyAny>> {
+    let resources = cursor.borrow(py).fetch_resources()?;
+    fetch(cursor, py, resources, 1, FetchOutput::One, "fetchone")
+}
+
+/// Return an awaitable resolving to at most `size` row tuples.
+pub(crate) fn fetchmany<'py>(
+    cursor: Py<PyAsyncCursor>,
+    py: Python<'py>,
+    size: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let resources = cursor.borrow(py).fetch_resources()?;
+    if size <= 0 {
+        resources
+            .session_state
+            .ensure_open()
+            .map_err(map_claim_error)?;
+        return pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            Python::attach(|py| FetchOutput::Many.empty(py))
+        });
+    }
+    fetch(
+        cursor,
+        py,
+        resources,
+        size as usize,
+        FetchOutput::Many,
+        "fetchmany",
+    )
 }
 
 #[cfg(test)]
@@ -236,7 +379,7 @@ mod tests {
     #[test]
     fn failed_fetch_releases_reusable_session_without_open_batch() {
         let (state, operation_id) = claimed_fetch();
-        let mut guard = FetchGuard::new(Arc::clone(&state), operation_id);
+        let mut guard = FetchGuard::new(Arc::clone(&state), operation_id, "fetchone", None);
 
         guard.fail(false);
 
@@ -247,7 +390,7 @@ mod tests {
     #[test]
     fn failed_fetch_breaks_session_with_open_batch() {
         let (state, operation_id) = claimed_fetch();
-        let mut guard = FetchGuard::new(Arc::clone(&state), operation_id);
+        let mut guard = FetchGuard::new(Arc::clone(&state), operation_id, "fetchone", None);
 
         guard.fail(true);
 
@@ -257,12 +400,14 @@ mod tests {
 
     #[test]
     fn maps_fetch_error_to_python_runtime_error() {
-        let error = map_fetch_error(Error::ProtocolError("invalid row token".to_string()));
-
-        assert!(
-            error
-                .to_string()
-                .contains("Failed to fetch row: Protocol Error: invalid row token")
+        let error = map_fetch_error(
+            "fetchone",
+            Error::ProtocolError("invalid row token".to_string()),
+            7,
         );
+
+        assert!(error.to_string().contains(
+            "PyAsyncCursor.fetchone failed while reading rows: Protocol Error: invalid row token"
+        ));
     }
 }

--- a/mssql-py-core/src/async_fetch.rs
+++ b/mssql-py-core/src/async_fetch.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::time::Instant;
 
+use mssql_tds::connection::tds_client::StatementResult;
 use mssql_tds::connection::tds_client::{ResultSet, TdsClient};
 use mssql_tds::error::Error;
 use pyo3::prelude::*;
@@ -15,7 +16,8 @@ use tokio::sync::Mutex;
 use tracing::instrument::WithSubscriber;
 
 use crate::async_cursor::{PyAsyncCursor, map_claim_error};
-use crate::async_session::{AsyncConnectionState, CursorId, OperationId};
+use crate::async_description::{DescriptionState, materialize};
+use crate::async_session::{AsyncConnectionState, ClaimError, CursorId, OperationId};
 use crate::row_writer::PyRowWriter;
 
 const FETCH_YIELD_INTERVAL: usize = 256;
@@ -65,6 +67,7 @@ pub(crate) struct FetchResources {
     session_state: Arc<AsyncConnectionState>,
     cursor_id: CursorId,
     fetch_state: Arc<FetchState>,
+    description_state: Arc<DescriptionState>,
 }
 
 impl FetchResources {
@@ -74,6 +77,7 @@ impl FetchResources {
         session_state: Arc<AsyncConnectionState>,
         cursor_id: CursorId,
         fetch_state: Arc<FetchState>,
+        description_state: Arc<DescriptionState>,
     ) -> Self {
         Self {
             client,
@@ -81,6 +85,7 @@ impl FetchResources {
             session_state,
             cursor_id,
             fetch_state,
+            description_state,
         }
     }
 }
@@ -301,6 +306,13 @@ fn map_fetch_error(operation: &str, error: Error, elapsed_ms: u128) -> PyErr {
     ))
 }
 
+fn map_nextset_error(error: Error, elapsed_ms: u128) -> PyErr {
+    tracing::error!("PyAsyncCursor::nextset: failed; elapsed_ms={elapsed_ms}; error={error}");
+    pyo3::exceptions::PyRuntimeError::new_err(format!(
+        "PyAsyncCursor.nextset failed while advancing results: {error}"
+    ))
+}
+
 fn fetch<'py>(
     cursor: Py<PyAsyncCursor>,
     py: Python<'py>,
@@ -315,7 +327,12 @@ fn fetch<'py>(
         session_state,
         cursor_id,
         fetch_state,
+        description_state: _,
     } = resources;
+    if fetch_state.status() == FetchStatus::NoResultSet {
+        session_state.ensure_open().map_err(map_claim_error)?;
+        return Err(map_claim_error(ClaimError::NoResultSet));
+    }
     if fetch_state.status() == FetchStatus::Exhausted {
         session_state.ensure_open().map_err(map_claim_error)?;
         return pyo3_async_runtimes::tokio::future_into_py(py, async move {
@@ -475,13 +492,128 @@ pub(crate) fn fetchall<'py>(
     )
 }
 
+/// Return an awaitable that advances to the next statement result.
+pub(crate) fn nextset<'py>(
+    cursor: Py<PyAsyncCursor>,
+    py: Python<'py>,
+) -> PyResult<Bound<'py, PyAny>> {
+    let resources = cursor.borrow(py).fetch_resources()?;
+    let FetchResources {
+        client,
+        dispatch,
+        session_state,
+        cursor_id,
+        fetch_state,
+        description_state,
+    } = resources;
+    let claim = match session_state.claim_fetch(cursor_id) {
+        Ok(claim) => claim,
+        Err(ClaimError::NoResultSet) if fetch_state.status() == FetchStatus::Exhausted => {
+            return pyo3_async_runtimes::tokio::future_into_py(py, async { Ok(false) });
+        }
+        Err(error) => return Err(map_claim_error(error)),
+    };
+    let operation_id = claim.operation_id;
+    let future_state = session_state.clone();
+    let previous_fetch_status = fetch_state.replace(FetchStatus::NoResultSet);
+    let previous_description = description_state.replace(None);
+    let future_fetch_state = fetch_state.clone();
+    let future_description_state = description_state.clone();
+    let guard_dispatch = dispatch.clone();
+    let materialization_dispatch = dispatch.clone();
+
+    let future = async move {
+        let started = Instant::now();
+        tracing::debug!("PyAsyncCursor::nextset: started");
+        let _cursor = cursor;
+        let mut fetch_guard =
+            FetchGuard::new(future_state, operation_id, "nextset", guard_dispatch);
+
+        let (result, has_open_batch) = {
+            let mut client = client.lock().await;
+            let result = client.advance().await.map(|result| {
+                let metadata =
+                    matches!(result, StatementResult::Rows).then(|| client.get_metadata().clone());
+                (result, metadata)
+            });
+            (result, client.has_open_batch())
+        };
+        let read_ms = started.elapsed().as_millis();
+
+        match result {
+            Ok((result, metadata)) => {
+                let has_result = !matches!(result, StatementResult::End);
+                let has_rows = matches!(result, StatementResult::Rows);
+                let column_count = metadata.as_ref().map_or(0, Vec::len);
+                future_fetch_state.set(match result {
+                    StatementResult::Rows => FetchStatus::Ready,
+                    StatementResult::NoRows { .. } => FetchStatus::NoResultSet,
+                    StatementResult::End => FetchStatus::Exhausted,
+                });
+                fetch_guard.complete(!has_rows, has_open_batch);
+
+                let materialization_started = Instant::now();
+                let mut materialization_guard =
+                    MaterializationGuard::new("nextset", materialization_dispatch);
+                match materialize(metadata).await {
+                    Ok(description) => {
+                        materialization_guard.complete();
+                        future_description_state.replace(description);
+                        tracing::debug!(
+                            "PyAsyncCursor::nextset: completed; has_result={has_result}; has_rows={has_rows}; column_count={column_count}; elapsed_ms={}; read_ms={read_ms}; materialization_ms={}",
+                            started.elapsed().as_millis(),
+                            materialization_started.elapsed().as_millis(),
+                        );
+                        if !has_result {
+                            tracing::info!("PyAsyncCursor::nextset: batch exhausted");
+                        }
+                        Ok(has_result)
+                    }
+                    Err(error) => {
+                        materialization_guard.complete();
+                        tracing::error!(
+                            "PyAsyncCursor::nextset: description materialization failed; column_count={column_count}; elapsed_ms={}; read_ms={read_ms}; materialization_ms={}; error={error}",
+                            started.elapsed().as_millis(),
+                            materialization_started.elapsed().as_millis(),
+                        );
+                        Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
+                            "Advanced result set but cursor description materialization failed: {error}"
+                        )))
+                    }
+                }
+            }
+            Err(error) => {
+                fetch_guard.fail(has_open_batch);
+                future_fetch_state.set(FetchStatus::NoResultSet);
+                Err(map_nextset_error(error, read_ms))
+            }
+        }
+    };
+    let future = async move {
+        match dispatch {
+            Some(dispatch) => future.with_subscriber(dispatch).await,
+            None => future.await,
+        }
+    };
+
+    match pyo3_async_runtimes::tokio::future_into_py(py, future) {
+        Ok(awaitable) => Ok(awaitable),
+        Err(error) => {
+            session_state.restore_fetch(operation_id);
+            fetch_state.set(previous_fetch_status);
+            description_state.replace(previous_description);
+            Err(error)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
 
     use mssql_tds::error::Error;
 
-    use super::{FetchGuard, map_fetch_error};
+    use super::{FetchGuard, map_fetch_error, map_nextset_error};
     use crate::async_session::{AsyncConnectionState, ClaimError, ConnectionLifecycle};
 
     fn claimed_fetch() -> (Arc<AsyncConnectionState>, u64) {
@@ -524,6 +656,15 @@ mod tests {
 
         assert!(error.to_string().contains(
             "PyAsyncCursor.fetchone failed while reading rows: Protocol Error: invalid row token"
+        ));
+    }
+
+    #[test]
+    fn maps_nextset_error_to_python_runtime_error() {
+        let error = map_nextset_error(Error::ProtocolError("invalid result token".to_string()), 7);
+
+        assert!(error.to_string().contains(
+            "PyAsyncCursor.nextset failed while advancing results: Protocol Error: invalid result token"
         ));
     }
 }

--- a/mssql-py-core/src/async_session.rs
+++ b/mssql-py-core/src/async_session.rs
@@ -290,7 +290,7 @@ impl AsyncConnectionState {
     pub(crate) fn finish_fetch(
         &self,
         operation_id: OperationId,
-        has_row: bool,
+        result_set_exhausted: bool,
         has_open_batch: bool,
     ) {
         let mut state = self.lock();
@@ -301,7 +301,7 @@ impl AsyncConnectionState {
             return;
         }
 
-        if has_row || has_open_batch {
+        if !result_set_exhausted || has_open_batch {
             active.phase = OperationPhase::Fetching;
         } else {
             state.active_operation = None;
@@ -451,7 +451,7 @@ mod tests {
         assert_eq!(state.claim_fetch(2).unwrap_err(), ClaimError::Busy);
         assert_eq!(state.claim_execute(1).unwrap_err(), ClaimError::Busy);
 
-        state.finish_fetch(fetch.operation_id, true, true);
+        state.finish_fetch(fetch.operation_id, false, true);
         assert_eq!(
             state.lock().active_operation.as_ref().unwrap().phase,
             OperationPhase::Fetching
@@ -465,11 +465,11 @@ mod tests {
         state.finish_execute(execute.operation_id, true);
 
         let current_result_end = state.claim_fetch(1).unwrap();
-        state.finish_fetch(current_result_end.operation_id, false, true);
+        state.finish_fetch(current_result_end.operation_id, true, true);
         assert_eq!(state.claim_execute(2).unwrap_err(), ClaimError::Busy);
 
         let batch_end = state.claim_fetch(1).unwrap();
-        state.finish_fetch(batch_end.operation_id, false, false);
+        state.finish_fetch(batch_end.operation_id, true, false);
         assert!(state.claim_execute(2).is_ok());
     }
 

--- a/mssql-py-core/src/async_tracing.rs
+++ b/mssql-py-core/src/async_tracing.rs
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Structured tracing helpers for asynchronous cursor operations.
+
+use std::future::Future;
+
+use tracing::Instrument;
+
+use crate::async_session::{CursorId, OperationId};
+
+pub(crate) async fn in_cursor_operation_span<F>(
+    future: F,
+    cursor_id: CursorId,
+    operation_id: OperationId,
+    operation: &'static str,
+    initial_result_set_status: &'static str,
+) -> F::Output
+where
+    F: Future,
+{
+    let span = tracing::info_span!(
+        "async_cursor_operation",
+        cursor_id,
+        operation_id,
+        operation,
+        result_set_status = initial_result_set_status,
+    );
+    future.instrument(span).await
+}
+
+pub(crate) fn record_result_set_status(status: &'static str) {
+    tracing::Span::current().record("result_set_status", status);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt::Debug;
+    use std::sync::{Arc, Mutex};
+
+    use tracing::Subscriber;
+    use tracing::field::{Field, Visit};
+    use tracing::span::{Attributes, Id, Record};
+    use tracing_subscriber::Layer;
+    use tracing_subscriber::layer::SubscriberExt;
+
+    use super::{in_cursor_operation_span, record_result_set_status};
+
+    #[derive(Clone, Default)]
+    struct CaptureLayer {
+        fields: Arc<Mutex<Vec<(String, String)>>>,
+    }
+
+    struct FieldVisitor<'a>(&'a Mutex<Vec<(String, String)>>);
+
+    impl Visit for FieldVisitor<'_> {
+        fn record_debug(&mut self, field: &Field, value: &dyn Debug) {
+            self.0
+                .lock()
+                .unwrap()
+                .push((field.name().to_string(), format!("{value:?}")));
+        }
+    }
+
+    impl<S: Subscriber> Layer<S> for CaptureLayer {
+        fn on_new_span(
+            &self,
+            attributes: &Attributes<'_>,
+            _id: &Id,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            attributes.record(&mut FieldVisitor(&self.fields));
+        }
+
+        fn on_record(
+            &self,
+            _id: &Id,
+            values: &Record<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            values.record(&mut FieldVisitor(&self.fields));
+        }
+    }
+
+    #[tokio::test]
+    async fn cursor_operation_span_records_correlation_and_result_status() {
+        let capture = CaptureLayer::default();
+        let fields = Arc::clone(&capture.fields);
+        let dispatch =
+            tracing::Dispatch::new(tracing_subscriber::Registry::default().with(capture));
+        let _default = tracing::dispatcher::set_default(&dispatch);
+
+        in_cursor_operation_span(
+            async { record_result_set_status("exhausted") },
+            41,
+            73,
+            "fetchmany",
+            "reading",
+        )
+        .await;
+
+        let fields = fields.lock().unwrap();
+        assert!(fields.contains(&("cursor_id".to_string(), "41".to_string())));
+        assert!(fields.contains(&("operation_id".to_string(), "73".to_string())));
+        assert!(fields.contains(&("operation".to_string(), "\"fetchmany\"".to_string())));
+        assert!(fields.contains(&("result_set_status".to_string(), "\"reading\"".to_string())));
+        assert!(fields.contains(&("result_set_status".to_string(), "\"exhausted\"".to_string())));
+    }
+}

--- a/mssql-py-core/src/async_tracing.rs
+++ b/mssql-py-core/src/async_tracing.rs
@@ -9,6 +9,9 @@ use tracing::Instrument;
 
 use crate::async_session::{CursorId, OperationId};
 
+pub(crate) const CURSOR_OPERATION_SPAN_NAME: &str = "async_cursor_operation";
+pub(crate) const CURSOR_OPERATION_SPAN_TARGET: &str = "mssql_py_core::async_tracing";
+
 pub(crate) async fn in_cursor_operation_span<F>(
     future: F,
     cursor_id: CursorId,

--- a/mssql-py-core/src/lib.rs
+++ b/mssql-py-core/src/lib.rs
@@ -9,6 +9,7 @@ use mssql_tds::connection::client_context::DriverVersion;
 mod arrow_bulkcopy;
 mod async_connection;
 mod async_cursor;
+mod async_description;
 mod async_execute;
 mod async_fetch;
 mod async_parameters;

--- a/mssql-py-core/src/lib.rs
+++ b/mssql-py-core/src/lib.rs
@@ -10,6 +10,7 @@ mod arrow_bulkcopy;
 mod async_connection;
 mod async_cursor;
 mod async_description;
+mod async_errors;
 mod async_execute;
 mod async_fetch;
 mod async_parameters;
@@ -98,6 +99,7 @@ fn mssql_py_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<async_connection::PyAsyncConnection>()?;
     m.add_class::<async_cursor::PyAsyncCursor>()?;
     m.add_class::<async_parameters::PyTableValuedParameter>()?;
+    async_errors::add_exceptions(m)?;
     // SQL Server-specific TDS type tokens accepted by setinputsizes().
     m.add("SQL_MONEY", 60)?;
     m.add("SQL_SMALLMONEY", 122)?;

--- a/mssql-py-core/src/lib.rs
+++ b/mssql-py-core/src/lib.rs
@@ -16,6 +16,7 @@ mod async_fetch;
 mod async_parameters;
 mod async_runtime;
 mod async_session;
+mod async_tracing;
 mod bulkcopy;
 mod connection;
 mod cursor;

--- a/mssql-py-core/src/tracing_init.rs
+++ b/mssql-py-core/src/tracing_init.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use std::sync::Once;
 use tracing::Subscriber;
 use tracing_appender::non_blocking;
-use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields};
+use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields, FormattedFields};
 use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::{EnvFilter, Registry, layer::SubscriberExt};
 
@@ -69,6 +69,17 @@ where
             "{}, {}, {}, {}, ",
             timestamp, thread_id_str, level, target
         )?;
+
+        if let Some(scope) = ctx.event_scope() {
+            for span in scope.from_root() {
+                let extensions = span.extensions();
+                if let Some(fields) = extensions.get::<FormattedFields<N>>()
+                    && !fields.is_empty()
+                {
+                    write!(writer, "{}{{{fields}}}: ", span.name())?;
+                }
+            }
+        }
 
         // Message (fields)
         ctx.field_format().format_fields(writer.by_ref(), event)?;
@@ -327,6 +338,15 @@ mod tests {
             tracing::error!("Error message");
             tracing::warn!("Warn message");
             tracing::info!("Info message");
+            let span = tracing::info_span!(
+                "async_cursor_operation",
+                cursor_id = 41_u64,
+                operation_id = 73_u64,
+                operation = "fetchmany",
+                result_set_status = "reading",
+            );
+            let _entered = span.enter();
+            tracing::info!("Correlated message");
             tracing::debug!("Debug message - should not appear");
             tracing::trace!("Trace message - should not appear");
 
@@ -365,6 +385,12 @@ mod tests {
             assert!(log_content.contains("Error message"));
             assert!(log_content.contains("Warn message"));
             assert!(log_content.contains("Info message"));
+            assert!(log_content.contains("Correlated message"));
+            assert!(log_content.contains("async_cursor_operation{"));
+            assert!(log_content.contains("cursor_id=41"));
+            assert!(log_content.contains("operation_id=73"));
+            assert!(log_content.contains("operation=\"fetchmany\""));
+            assert!(log_content.contains("result_set_status=\"reading\""));
 
             // Should NOT contain DEBUG or TRACE (filtered out by the default 'info' level)
             assert!(!log_content.contains("Debug message"));

--- a/mssql-py-core/src/tracing_init.rs
+++ b/mssql-py-core/src/tracing_init.rs
@@ -13,6 +13,8 @@ use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields, FormattedFi
 use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::{EnvFilter, Registry, layer::SubscriberExt};
 
+use crate::async_tracing::{CURSOR_OPERATION_SPAN_NAME, CURSOR_OPERATION_SPAN_TARGET};
+
 static INIT: Once = Once::new();
 static GUARD: OnceCell<tracing_appender::non_blocking::WorkerGuard> = OnceCell::new();
 
@@ -72,6 +74,11 @@ where
 
         if let Some(scope) = ctx.event_scope() {
             for span in scope.from_root() {
+                if span.name() != CURSOR_OPERATION_SPAN_NAME
+                    || span.metadata().target() != CURSOR_OPERATION_SPAN_TARGET
+                {
+                    continue;
+                }
                 let extensions = span.extensions();
                 if let Some(fields) = extensions.get::<FormattedFields<N>>()
                     && !fields.is_empty()
@@ -339,6 +346,7 @@ mod tests {
             tracing::warn!("Warn message");
             tracing::info!("Info message");
             let span = tracing::info_span!(
+                target: CURSOR_OPERATION_SPAN_TARGET,
                 "async_cursor_operation",
                 cursor_id = 41_u64,
                 operation_id = 73_u64,
@@ -346,6 +354,12 @@ mod tests {
                 result_set_status = "reading",
             );
             let _entered = span.enter();
+            let sensitive_span = tracing::info_span!(
+                target: "mssql_tds::connection::tds_client",
+                "execute",
+                sql_command = "SELECT 'SECRET_SQL_LITERAL'",
+            );
+            let _sensitive_entered = sensitive_span.enter();
             tracing::info!("Correlated message");
             tracing::debug!("Debug message - should not appear");
             tracing::trace!("Trace message - should not appear");
@@ -391,6 +405,8 @@ mod tests {
             assert!(log_content.contains("operation_id=73"));
             assert!(log_content.contains("operation=\"fetchmany\""));
             assert!(log_content.contains("result_set_status=\"reading\""));
+            assert!(!log_content.contains("sql_command"));
+            assert!(!log_content.contains("SECRET_SQL_LITERAL"));
 
             // Should NOT contain DEBUG or TRACE (filtered out by the default 'info' level)
             assert!(!log_content.contains("Debug message"));

--- a/mssql-py-core/tests/test_async_connection.py
+++ b/mssql-py-core/tests/test_async_connection.py
@@ -9,7 +9,6 @@ import subprocess
 import sys
 import textwrap
 import warnings
-from decimal import Decimal
 
 import pytest
 import mssql_py_core
@@ -172,7 +171,14 @@ def test_connection_operations_reuse_connect_logger(client_context):
             "column_count=1; elapsed_ms=" in message
             for message in logger.messages
         )
-        assert await cursor.fetchone() == (Decimal("1.00"),)
+        with pytest.raises(
+            mssql_py_core.ProgrammingError, match="No active result set"
+        ):
+            await cursor.fetchone()
+
+        await cursor.execute("SELECT 2 AS recovered_value", use_prepare=False)
+        assert cursor.description[0][:2] == ("recovered_value", int)
+        assert await cursor.fetchone() == (2,)
         await cursor.close()
 
         logger.messages.clear()

--- a/mssql-py-core/tests/test_async_connection.py
+++ b/mssql-py-core/tests/test_async_connection.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import textwrap
 import warnings
+from decimal import Decimal
 
 import pytest
 import mssql_py_core
@@ -146,9 +147,32 @@ def test_connection_operations_reuse_connect_logger(client_context):
         await cursor.execute("SELECT 1 AS value", use_prepare=False)
         assert any(
             "PyAsyncCursor::execute: query executed successfully; "
-            "has_result_set=true; column_count=1" in message
+            "has_result_set=true; column_count=1; description_materialization_ms="
+            in message
             for message in logger.messages
         )
+        assert await cursor.fetchone() == (1,)
+
+        decimal_module = sys.modules["decimal"]
+        sys.modules["decimal"] = None
+        logger.messages.clear()
+        try:
+            with pytest.raises(
+                RuntimeError,
+                match="Query executed but cursor description materialization failed",
+            ):
+                await cursor.execute(
+                    "SELECT CAST(1 AS decimal(10, 2)) AS value", use_prepare=False
+                )
+        finally:
+            sys.modules["decimal"] = decimal_module
+        assert cursor.description is None
+        assert any(
+            "PyAsyncCursor::execute: cursor description materialization failed; "
+            "column_count=1; elapsed_ms=" in message
+            for message in logger.messages
+        )
+        assert await cursor.fetchone() == (Decimal("1.00"),)
         await cursor.close()
 
         logger.messages.clear()

--- a/mssql-py-core/tests/test_async_connection.py
+++ b/mssql-py-core/tests/test_async_connection.py
@@ -142,6 +142,16 @@ def test_connection_operations_reuse_connect_logger(client_context):
         assert await conn.commit() is None
 
         logger.messages.clear()
+        cursor = conn.cursor()
+        await cursor.execute("SELECT 1 AS value", use_prepare=False)
+        assert any(
+            "PyAsyncCursor::execute: query executed successfully; "
+            "has_result_set=true; column_count=1" in message
+            for message in logger.messages
+        )
+        await cursor.close()
+
+        logger.messages.clear()
         await conn.close()
         assert any(
             "PyAsyncConnection::close: connection closed" in message

--- a/mssql-py-core/tests/test_async_connection.py
+++ b/mssql-py-core/tests/test_async_connection.py
@@ -158,7 +158,7 @@ def test_connection_operations_reuse_connect_logger(client_context):
         logger.messages.clear()
         try:
             with pytest.raises(
-                RuntimeError,
+                mssql_py_core.InternalError,
                 match="Query executed but cursor description materialization failed",
             ):
                 await cursor.execute(

--- a/mssql-py-core/tests/test_async_description.py
+++ b/mssql-py-core/tests/test_async_description.py
@@ -1,0 +1,202 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for asynchronous DB-API cursor result-set metadata."""
+
+import asyncio
+import datetime
+import inspect
+import uuid
+import warnings
+from decimal import Decimal
+
+import mssql_py_core
+import pytest
+
+
+async def connect(client_context):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        return await mssql_py_core.PyAsyncConnection.connect(
+            client_context, autocommit=True
+        )
+
+
+def test_description_is_exposed_read_only_and_initially_none(mock_client_context):
+    async def run():
+        conn = await connect(mock_client_context)
+        try:
+            cursor = conn.cursor()
+            assert cursor.description is None
+            with pytest.raises(AttributeError):
+                cursor.description = []
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_description_matches_sync_cursor_contract(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            await cursor.execute(
+                "SELECT database_id, name FROM sys.databases", use_prepare=False
+            )
+            assert cursor.description == [
+                ("database_id", int, None, 10, 10, 0, False),
+                ("name", str, None, 128, 128, 0, False),
+            ]
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_description_type_size_precision_scale_and_nullability(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            await cursor.execute(
+                """
+                SELECT
+                    CAST(NULL AS bit) AS bit_value,
+                    CAST(NULL AS tinyint) AS tinyint_value,
+                    CAST(NULL AS smallint) AS smallint_value,
+                    CAST(NULL AS int) AS int_value,
+                    CAST(NULL AS bigint) AS bigint_value,
+                    CAST(NULL AS real) AS real_value,
+                    CAST(NULL AS float) AS float_value,
+                    CAST(NULL AS decimal(38, 7)) AS decimal_value,
+                    CAST(NULL AS money) AS money_value,
+                    CAST(NULL AS smallmoney) AS smallmoney_value,
+                    CAST(NULL AS nvarchar(100)) AS text_value,
+                    CAST(NULL AS varchar(max)) AS max_text_value,
+                    CAST(NULL AS varbinary(40)) AS binary_value,
+                    CAST(NULL AS varbinary(max)) AS max_binary_value,
+                    CAST(NULL AS date) AS date_value,
+                    CAST(NULL AS time(6)) AS time_value,
+                    CAST(NULL AS datetime) AS datetime_value,
+                    CAST(NULL AS smalldatetime) AS smalldatetime_value,
+                    CAST(NULL AS datetime2(6)) AS datetime2_value,
+                    CAST(NULL AS datetimeoffset(6)) AS offset_value,
+                    CAST(NULL AS uniqueidentifier) AS guid_value,
+                    CAST(NULL AS xml) AS xml_value
+                """,
+                use_prepare=False,
+            )
+
+            description = cursor.description
+            assert description is not None
+            assert [column[1] for column in description] == [
+                bool,
+                int,
+                int,
+                int,
+                int,
+                float,
+                float,
+                Decimal,
+                Decimal,
+                Decimal,
+                str,
+                str,
+                bytes,
+                bytes,
+                datetime.date,
+                datetime.time,
+                datetime.datetime,
+                datetime.datetime,
+                datetime.datetime,
+                datetime.datetime,
+                uuid.UUID,
+                str,
+            ]
+            assert all(inspect.isclass(column[1]) for column in description)
+            assert [column[3:] for column in description] == [
+                (1, 1, 0, True),
+                (3, 3, 0, True),
+                (5, 5, 0, True),
+                (10, 10, 0, True),
+                (19, 19, 0, True),
+                (7, 7, 0, True),
+                (15, 15, 0, True),
+                (38, 38, 7, True),
+                (19, 19, 4, True),
+                (10, 10, 4, True),
+                (100, 100, 0, True),
+                (0, 0, 0, True),
+                (40, 40, 0, True),
+                (0, 0, 0, True),
+                (10, 10, 0, True),
+                (15, 15, 6, True),
+                (23, 23, 3, True),
+                (16, 16, 0, True),
+                (26, 26, 6, True),
+                (33, 33, 6, True),
+                (16, 16, 0, True),
+                (0, 0, 0, True),
+            ]
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_description_survives_fetch_empty_result_exhaustion_and_close(client_context):
+    async def run():
+        conn = await connect(client_context)
+        cursor = conn.cursor()
+        try:
+            await cursor.execute(
+                "SELECT CAST(1 AS int) AS value", use_prepare=False
+            )
+            description = cursor.description
+            assert await cursor.fetchone() == (1,)
+            assert await cursor.fetchone() is None
+            assert cursor.description == description
+
+            await cursor.execute(
+                "SELECT CAST(1 AS int) AS value WHERE 1 = 0", use_prepare=False
+            )
+            description = cursor.description
+            assert description == [("value", int, None, 10, 10, 0, True)]
+            assert await cursor.fetchone() is None
+            assert await cursor.fetchone() is None
+            assert cursor.description == description
+            await cursor.close()
+            assert cursor.description == description
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_description_is_replaced_or_cleared_by_execute(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            await cursor.execute("SELECT 1 AS first_value", use_prepare=False)
+            assert cursor.description[0][0] == "first_value"
+
+            await cursor.execute("SELECT N'x' AS second_value", use_prepare=False)
+            assert cursor.description[0][:2] == ("second_value", str)
+
+            await cursor.execute("SET NOCOUNT ON", use_prepare=False)
+            assert cursor.description is None
+
+            await cursor.execute("SELECT 1 AS recovered", use_prepare=False)
+            with pytest.raises(RuntimeError, match="Query execution failed"):
+                await cursor.execute("SELECT * FROM __missing_async_description_table__")
+            assert cursor.description is None
+        finally:
+            await conn.close()
+
+    asyncio.run(run())

--- a/mssql-py-core/tests/test_async_description.py
+++ b/mssql-py-core/tests/test_async_description.py
@@ -78,7 +78,28 @@ def test_description_type_size_precision_scale_and_nullability(client_context):
             cursor = conn.cursor()
             await cursor.execute(
                 """
+                CREATE TABLE #fixed_metadata (
+                    fixed_tinyint_value tinyint NOT NULL,
+                    fixed_smallint_value smallint NOT NULL,
+                    fixed_bigint_value bigint NOT NULL,
+                    fixed_real_value real NOT NULL,
+                    fixed_float_value float NOT NULL,
+                    fixed_datetime_value datetime NOT NULL,
+                    fixed_smalldatetime_value smalldatetime NOT NULL
+                )
+                """,
+                use_prepare=False,
+            )
+            await cursor.execute(
+                """
                 SELECT
+                    fixed_tinyint_value,
+                    fixed_smallint_value,
+                    fixed_bigint_value,
+                    fixed_real_value,
+                    fixed_float_value,
+                    fixed_datetime_value,
+                    fixed_smalldatetime_value,
                     CAST(NULL AS bit) AS bit_value,
                     CAST(NULL AS tinyint) AS tinyint_value,
                     CAST(NULL AS smallint) AS smallint_value,
@@ -101,6 +122,7 @@ def test_description_type_size_precision_scale_and_nullability(client_context):
                     CAST(NULL AS datetimeoffset(6)) AS offset_value,
                     CAST(NULL AS uniqueidentifier) AS guid_value,
                     CAST(NULL AS xml) AS xml_value
+                FROM #fixed_metadata
                 """,
                 use_prepare=False,
             )
@@ -108,6 +130,13 @@ def test_description_type_size_precision_scale_and_nullability(client_context):
             description = cursor.description
             assert description is not None
             assert [column[1] for column in description] == [
+                int,
+                int,
+                int,
+                float,
+                float,
+                datetime.datetime,
+                datetime.datetime,
                 bool,
                 int,
                 int,
@@ -133,6 +162,13 @@ def test_description_type_size_precision_scale_and_nullability(client_context):
             ]
             assert all(inspect.isclass(column[1]) for column in description)
             assert [column[3:] for column in description] == [
+                (3, 3, 0, False),
+                (5, 5, 0, False),
+                (19, 19, 0, False),
+                (7, 7, 0, False),
+                (15, 15, 0, False),
+                (23, 23, 3, False),
+                (16, 16, 0, False),
                 (1, 1, 0, True),
                 (3, 3, 0, True),
                 (5, 5, 0, True),
@@ -166,8 +202,17 @@ def test_description_type_size_precision_scale_and_nullability(client_context):
 def test_description_vector_type_and_scale_match_fetched_value(client_context):
     async def run():
         conn = await connect(client_context)
+        database = f"pycore_vector_{uuid.uuid4().hex}"
+        cursor = conn.cursor()
+        database_created = False
         try:
-            cursor = conn.cursor()
+            await cursor.execute(f"CREATE DATABASE [{database}]", use_prepare=False)
+            database_created = True
+            await cursor.execute(f"USE [{database}]", use_prepare=False)
+            await cursor.execute(
+                "ALTER DATABASE SCOPED CONFIGURATION SET PREVIEW_FEATURES = ON",
+                use_prepare=False,
+            )
             await cursor.execute(
                 "SELECT "
                 "CAST('[1,2,3]' AS vector(3)) AS float32_vector, "
@@ -184,6 +229,11 @@ def test_description_vector_type_and_scale_match_fetched_value(client_context):
             assert row[0] == pytest.approx([1.0, 2.0, 3.0])
             assert isinstance(row[1], str)
         finally:
+            if database_created:
+                await cursor.execute("USE [master]", use_prepare=False)
+                await cursor.execute(
+                    f"DROP DATABASE [{database}]", use_prepare=False
+                )
             await conn.close()
 
     asyncio.run(run())

--- a/mssql-py-core/tests/test_async_description.py
+++ b/mssql-py-core/tests/test_async_description.py
@@ -184,11 +184,29 @@ def test_description_is_replaced_or_cleared_by_execute(client_context):
         conn = await connect(client_context)
         try:
             cursor = conn.cursor()
-            await cursor.execute("SELECT 1 AS first_value", use_prepare=False)
-            assert cursor.description[0][0] == "first_value"
+            await cursor.execute(
+                "SELECT value AS first_value, CAST(value AS decimal(10, 2)) AS amount "
+                "FROM (VALUES (1), (2)) rows(value) ORDER BY value",
+                use_prepare=False,
+            )
+            assert [column[:2] for column in cursor.description] == [
+                ("first_value", int),
+                ("amount", Decimal),
+            ]
+            assert await cursor.fetchone() == (1, Decimal("1.00"))
 
-            await cursor.execute("SELECT N'x' AS second_value", use_prepare=False)
-            assert cursor.description[0][:2] == ("second_value", str)
+            # Re-execute with unread rows and a different column order, width, and types.
+            await cursor.execute(
+                "SELECT N'x' AS text_value, CAST(3.5 AS float) AS ratio, "
+                "CAST(7 AS bigint) AS first_value",
+                use_prepare=False,
+            )
+            assert [column[:2] for column in cursor.description] == [
+                ("text_value", str),
+                ("ratio", float),
+                ("first_value", int),
+            ]
+            assert await cursor.fetchone() == ("x", 3.5, 7)
 
             await cursor.execute("SET NOCOUNT ON", use_prepare=False)
             assert cursor.description is None

--- a/mssql-py-core/tests/test_async_description.py
+++ b/mssql-py-core/tests/test_async_description.py
@@ -49,6 +49,7 @@ def test_description_matches_sync_cursor_contract(client_context):
                 ("database_id", int, None, 10, 10, 0, False),
                 ("name", str, None, 128, 128, 0, False),
             ]
+            assert cursor.description is cursor.description
         finally:
             await conn.close()
 

--- a/mssql-py-core/tests/test_async_description.py
+++ b/mssql-py-core/tests/test_async_description.py
@@ -163,20 +163,26 @@ def test_description_type_size_precision_scale_and_nullability(client_context):
 
 
 @pytest.mark.integration
-def test_description_vector_type_matches_fetched_value(client_context):
+def test_description_vector_type_and_scale_match_fetched_value(client_context):
     async def run():
         conn = await connect(client_context)
         try:
             cursor = conn.cursor()
             await cursor.execute(
-                "SELECT CAST('[1,2,3]' AS vector(3)) AS vector_value",
+                "SELECT "
+                "CAST('[1,2,3]' AS vector(3)) AS float32_vector, "
+                "CAST('[1,2,3]' AS vector(3, float16)) AS float16_vector",
                 use_prepare=False,
             )
 
-            assert cursor.description[0][0:2] == ("vector_value", list)
+            assert cursor.description[0][0:2] == ("float32_vector", list)
+            assert cursor.description[0][5] == 0
+            assert cursor.description[1][0:2] == ("float16_vector", str)
+            assert cursor.description[1][5] == 0
             row = await cursor.fetchone()
             assert isinstance(row[0], list)
             assert row[0] == pytest.approx([1.0, 2.0, 3.0])
+            assert isinstance(row[1], str)
         finally:
             await conn.close()
 

--- a/mssql-py-core/tests/test_async_description.py
+++ b/mssql-py-core/tests/test_async_description.py
@@ -45,11 +45,25 @@ def test_description_matches_sync_cursor_contract(client_context):
             await cursor.execute(
                 "SELECT database_id, name FROM sys.databases", use_prepare=False
             )
-            assert cursor.description == [
+            assert cursor.description == (
                 ("database_id", int, None, 10, 10, 0, False),
                 ("name", str, None, 128, 128, 0, False),
-            ]
+            )
+            assert isinstance(cursor.description, tuple)
+            assert all(isinstance(column, tuple) for column in cursor.description)
             assert cursor.description is cursor.description
+
+            description = cursor.description
+            with pytest.raises(AttributeError):
+                description.append(("injected", str, None, 0, 0, 0, True))
+            with pytest.raises(TypeError):
+                description[0] = ("replaced", int, None, 10, 10, 0, False)
+            with pytest.raises(TypeError):
+                del description[0]
+            assert cursor.description == (
+                ("database_id", int, None, 10, 10, 0, False),
+                ("name", str, None, 128, 128, 0, False),
+            )
         finally:
             await conn.close()
 
@@ -149,6 +163,27 @@ def test_description_type_size_precision_scale_and_nullability(client_context):
 
 
 @pytest.mark.integration
+def test_description_vector_type_matches_fetched_value(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            await cursor.execute(
+                "SELECT CAST('[1,2,3]' AS vector(3)) AS vector_value",
+                use_prepare=False,
+            )
+
+            assert cursor.description[0][0:2] == ("vector_value", list)
+            row = await cursor.fetchone()
+            assert isinstance(row[0], list)
+            assert row[0] == pytest.approx([1.0, 2.0, 3.0])
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
 def test_description_survives_fetch_empty_result_exhaustion_and_close(client_context):
     async def run():
         conn = await connect(client_context)
@@ -166,7 +201,7 @@ def test_description_survives_fetch_empty_result_exhaustion_and_close(client_con
                 "SELECT CAST(1 AS int) AS value WHERE 1 = 0", use_prepare=False
             )
             description = cursor.description
-            assert description == [("value", int, None, 10, 10, 0, True)]
+            assert description == (("value", int, None, 10, 10, 0, True),)
             assert await cursor.fetchone() is None
             assert await cursor.fetchone() is None
             assert cursor.description == description
@@ -212,8 +247,10 @@ def test_description_is_replaced_or_cleared_by_execute(client_context):
             assert cursor.description is None
 
             await cursor.execute("SELECT 1 AS recovered", use_prepare=False)
-            with pytest.raises(RuntimeError, match="Query execution failed"):
+            with pytest.raises(mssql_py_core.DatabaseError) as exc_info:
                 await cursor.execute("SELECT * FROM __missing_async_description_table__")
+            assert exc_info.value.sql_errors
+            assert exc_info.value.sql_errors[0]["number"] == 208
             assert cursor.description is None
         finally:
             await conn.close()

--- a/mssql-py-core/tests/test_async_execute.py
+++ b/mssql-py-core/tests/test_async_execute.py
@@ -272,6 +272,67 @@ def test_execute_accepts_empty_mapping_without_markers(mock_client_context):
     asyncio.run(run())
 
 
+@pytest.mark.integration
+@pytest.mark.parametrize("use_prepare", [True, False])
+def test_execute_server_error_uses_dbapi_hierarchy_and_diagnostics(
+    client_context, use_prepare
+):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            await cursor.execute("SELECT 1 AS previous_value", use_prepare=False)
+
+            with pytest.raises(mssql_py_core.Error) as exc_info:
+                await cursor.execute(
+                    "SELECT * FROM __missing_async_execute_table__",
+                    use_prepare=use_prepare,
+                )
+
+            assert isinstance(exc_info.value, mssql_py_core.DatabaseError)
+            assert "PyAsyncCursor.execute failed while executing query" in str(
+                exc_info.value
+            )
+            assert exc_info.value.sql_errors
+            assert exc_info.value.sql_errors[0]["number"] == 208
+            assert "invalid object name" in exc_info.value.sql_errors[0][
+                "message"
+            ].lower()
+            assert exc_info.value.info_messages == []
+            assert cursor.description is None
+
+            await cursor.execute("SELECT 2 AS recovered", use_prepare=False)
+            assert await cursor.fetchone() == (2,)
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_execute_syntax_error_preserves_server_diagnostics(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            with pytest.raises(mssql_py_core.DatabaseError) as exc_info:
+                await cursor.execute(
+                    "SELECT 1 +",
+                    use_prepare=False,
+                )
+
+            assert exc_info.value.sql_errors
+            assert exc_info.value.sql_errors[0]["number"] == 102
+            assert "incorrect syntax" in exc_info.value.sql_errors[0][
+                "message"
+            ].lower()
+            assert exc_info.value.info_messages == []
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
 def test_execute_rejects_missing_named_parameter(mock_client_context):
     async def run():
         conn = await connect(mock_client_context)
@@ -399,7 +460,7 @@ def test_setinputsizes_survives_asynchronous_execution_failure(client_context):
         try:
             cursor = conn.cursor()
             cursor.setinputsizes([(-9, 20, 0)])  # SQL_WVARCHAR
-            with pytest.raises(RuntimeError, match="expected failure"):
+            with pytest.raises(mssql_py_core.DatabaseError, match="expected failure"):
                 await cursor.execute("THROW 50000, 'expected failure', 1; SELECT ?", "ascii")
 
             await cursor.execute(

--- a/mssql-py-core/tests/test_async_execute.py
+++ b/mssql-py-core/tests/test_async_execute.py
@@ -81,14 +81,16 @@ def test_execute_restores_state_when_awaitable_creation_fails(mock_client_contex
         conn = await connect(mock_client_context)
         cursor = conn.cursor()
         await cursor.execute("SELECT 1", use_prepare=False)
+        description = cursor.description
         assert await cursor.fetchone() == (1,)
         assert await cursor.fetchone() is None
-        return conn, cursor
+        return conn, cursor, description
 
-    conn, cursor = asyncio.run(create_exhausted_cursor())
+    conn, cursor, description = asyncio.run(create_exhausted_cursor())
     try:
         with pytest.raises(RuntimeError, match="no running event loop"):
             cursor.execute("SELECT 2", use_prepare=False)
+        assert cursor.description == description
 
         async def verify_restored_state():
             assert await cursor.fetchone() is None

--- a/mssql-py-core/tests/test_async_fetch.py
+++ b/mssql-py-core/tests/test_async_fetch.py
@@ -5,6 +5,7 @@
 
 import asyncio
 import datetime
+import sys
 import uuid
 import warnings
 from decimal import Decimal
@@ -33,6 +34,7 @@ def test_module_exposes_fetchone():
     assert hasattr(mssql_py_core.PyAsyncCursor, "fetchone")
     assert hasattr(mssql_py_core.PyAsyncCursor, "fetchmany")
     assert hasattr(mssql_py_core.PyAsyncCursor, "fetchall")
+    assert hasattr(mssql_py_core.PyAsyncCursor, "nextset")
 
 
 def test_fetchone_without_result_set_raises(mock_client_context):
@@ -50,6 +52,10 @@ def test_fetchone_without_result_set_raises(mock_client_context):
                 cursor.fetchall(1)
             with pytest.raises(TypeError):
                 cursor.fetchall(size=1)
+            with pytest.raises(RuntimeError, match="No active result set"):
+                await cursor.nextset()
+            with pytest.raises(TypeError):
+                cursor.nextset(1)
         finally:
             await conn.close()
 
@@ -68,6 +74,8 @@ def test_fetchone_after_cursor_close_raises(mock_client_context):
                 await cursor.fetchmany(0)
             with pytest.raises(RuntimeError, match="Cursor is closed"):
                 await cursor.fetchall()
+            with pytest.raises(RuntimeError, match="Cursor is closed"):
+                await cursor.nextset()
         finally:
             await conn.close()
 
@@ -211,6 +219,7 @@ def test_fetchone_logs_exhaustion(client_context):
                 in message
                 for level, message, _module in logger.events
             )
+
         finally:
             await conn.close()
 
@@ -380,6 +389,210 @@ def test_fetchall_keeps_event_loop_responsive(client_context):
             stop_heartbeat = True
             if "heartbeat_task" in locals():
                 await heartbeat_task
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_nextset_drains_rows_and_updates_description(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            await cursor.execute(
+                "SELECT 1 AS first_value UNION ALL SELECT 2; "
+                "SELECT N'x' AS second_value; SELECT 3 AS third_value",
+                use_prepare=False,
+            )
+            assert cursor.description[0][:2] == ("first_value", int)
+            assert await cursor.fetchone() == (1,)
+
+            assert await cursor.nextset() is True
+            assert cursor.description[0][:2] == ("second_value", str)
+            assert await cursor.fetchall() == [("x",)]
+
+            assert await cursor.nextset() is True
+            assert cursor.description[0][:2] == ("third_value", int)
+            assert await cursor.fetchone() == (3,)
+
+            assert await cursor.nextset() is False
+            assert cursor.description is None
+            assert await cursor.nextset() is False
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_nextset_surfaces_statement_without_rows(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            await cursor.execute(
+                "DECLARE @rows TABLE (value int); "
+                "SELECT 1 AS first_value; "
+                "INSERT INTO @rows VALUES (1); "
+                "SELECT 2 AS second_value",
+                use_prepare=False,
+            )
+            assert await cursor.nextset() is True
+            assert cursor.description is None
+            with pytest.raises(RuntimeError, match="No active result set"):
+                await cursor.fetchone()
+
+            assert await cursor.nextset() is True
+            assert cursor.description[0][:2] == ("second_value", int)
+            assert await cursor.fetchall() == [(2,)]
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_nextset_logs_result_transitions(client_context):
+    async def run():
+        logger = RecordingLogger()
+        conn = await connect(client_context, logger)
+        try:
+            cursor = conn.cursor()
+            await cursor.execute("SELECT 1; SELECT N'x' AS value", use_prepare=False)
+            logger.events.clear()
+
+            assert await cursor.nextset() is True
+            assert (
+                10,
+                "PyAsyncCursor::nextset: started",
+                "async_fetch.rs",
+            ) in logger.events
+            assert any(
+                level == 10
+                and "PyAsyncCursor::nextset: completed; has_result=true; has_rows=true; column_count=1; elapsed_ms="
+                in message
+                for level, message, _module in logger.events
+            )
+
+            assert await cursor.nextset() is False
+            assert (
+                20,
+                "PyAsyncCursor::nextset: batch exhausted",
+                "async_fetch.rs",
+            ) in logger.events
+
+            await cursor.execute(
+                "SELECT 1; SELECT CAST(1 AS decimal(10, 2)) AS value",
+                use_prepare=False,
+            )
+            decimal_module = sys.modules["decimal"]
+            sys.modules["decimal"] = None
+            logger.events.clear()
+            try:
+                with pytest.raises(
+                    RuntimeError,
+                    match="Advanced result set but cursor description materialization failed",
+                ):
+                    await cursor.nextset()
+            finally:
+                sys.modules["decimal"] = decimal_module
+            assert cursor.description is None
+            assert await cursor.fetchone() == (Decimal("1.00"),)
+            assert any(
+                level == 40
+                and "PyAsyncCursor::nextset: description materialization failed; "
+                "column_count=1; elapsed_ms=" in message
+                and "; read_ms=" in message
+                and "; materialization_ms=" in message
+                for level, message, _module in logger.events
+            )
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_nextset_keeps_event_loop_responsive_while_draining(client_context):
+    async def run():
+        conn = await connect(client_context)
+        heartbeat_ticks = 0
+        stop_heartbeat = False
+
+        async def heartbeat():
+            nonlocal heartbeat_ticks
+            while not stop_heartbeat:
+                heartbeat_ticks += 1
+                await asyncio.sleep(0)
+
+        try:
+            cursor = conn.cursor()
+            await cursor.execute(
+                """
+                WITH numbers AS (
+                    SELECT 0 AS value
+                    UNION ALL
+                    SELECT value + 1 FROM numbers WHERE value < 32767
+                )
+                SELECT value FROM numbers OPTION (MAXRECURSION 32767);
+                SELECT 42 AS final_value
+                """,
+                use_prepare=False,
+            )
+            heartbeat_task = asyncio.create_task(heartbeat())
+            await asyncio.sleep(0)
+            ticks_before_nextset = heartbeat_ticks
+
+            assert await cursor.nextset() is True
+            ticks_during_nextset = heartbeat_ticks - ticks_before_nextset
+
+            assert ticks_during_nextset > 0
+            assert await cursor.fetchone() == (42,)
+        finally:
+            stop_heartbeat = True
+            if "heartbeat_task" in locals():
+                await heartbeat_task
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_nextset_rejects_concurrent_operation_and_cancellation_breaks_session(
+    client_context,
+):
+    async def run():
+        conn = await connect(client_context)
+        cursor = conn.cursor()
+        try:
+            await cursor.execute(
+                "SELECT REPLICATE(CAST('x' AS varchar(max)), 32000000); SELECT 2",
+                use_prepare=False,
+            )
+            task = asyncio.ensure_future(cursor.nextset())
+            with pytest.raises(RuntimeError, match="busy with another cursor operation"):
+                cursor.nextset()
+            await asyncio.sleep(0)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+            probe = conn.cursor()
+            for _ in range(100):
+                try:
+                    await probe.execute("SELECT 1", use_prepare=False)
+                except RuntimeError as error:
+                    if "busy" in str(error).lower():
+                        await asyncio.sleep(0.01)
+                        continue
+                    assert "broken" in str(error).lower()
+                    break
+                else:
+                    pytest.fail("Cancelled nextset left the connection reusable")
+            else:
+                pytest.fail("Cancelled nextset left the connection permanently busy")
+        finally:
             await conn.close()
 
     asyncio.run(run())

--- a/mssql-py-core/tests/test_async_fetch.py
+++ b/mssql-py-core/tests/test_async_fetch.py
@@ -32,6 +32,7 @@ async def connect(client_context, python_logger=None):
 def test_module_exposes_fetchone():
     assert hasattr(mssql_py_core.PyAsyncCursor, "fetchone")
     assert hasattr(mssql_py_core.PyAsyncCursor, "fetchmany")
+    assert hasattr(mssql_py_core.PyAsyncCursor, "fetchall")
 
 
 def test_fetchone_without_result_set_raises(mock_client_context):
@@ -43,6 +44,12 @@ def test_fetchone_without_result_set_raises(mock_client_context):
                 await cursor.fetchone()
             with pytest.raises(RuntimeError, match="No active result set"):
                 await cursor.fetchmany(1)
+            with pytest.raises(RuntimeError, match="No active result set"):
+                await cursor.fetchall()
+            with pytest.raises(TypeError):
+                cursor.fetchall(1)
+            with pytest.raises(TypeError):
+                cursor.fetchall(size=1)
         finally:
             await conn.close()
 
@@ -59,6 +66,8 @@ def test_fetchone_after_cursor_close_raises(mock_client_context):
                 await cursor.fetchone()
             with pytest.raises(RuntimeError, match="Cursor is closed"):
                 await cursor.fetchmany(0)
+            with pytest.raises(RuntimeError, match="Cursor is closed"):
+                await cursor.fetchall()
         finally:
             await conn.close()
 
@@ -182,6 +191,26 @@ def test_fetchone_logs_exhaustion(client_context):
                 in message
                 for level, message, _module in logger.events
             )
+
+            await cursor.execute("SELECT 1 UNION ALL SELECT 2", use_prepare=False)
+            logger.events.clear()
+            assert await cursor.fetchall() == [(1,), (2,)]
+            assert (
+                10,
+                "PyAsyncCursor::fetchall: started",
+                "async_fetch.rs",
+            ) in logger.events
+            assert (
+                20,
+                "PyAsyncCursor::fetchall: result set exhausted",
+                "async_fetch.rs",
+            ) in logger.events
+            assert any(
+                level == 10
+                and "PyAsyncCursor::fetchall: completed; returned=2; exhausted=true; elapsed_ms="
+                in message
+                for level, message, _module in logger.events
+            )
         finally:
             await conn.close()
 
@@ -257,6 +286,100 @@ def test_fetchmany_stops_at_current_result_set(client_context):
             await owner.close()
             await other.execute("SET NOCOUNT ON", use_prepare=False)
         finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_fetchall_returns_remaining_rows_and_releases_finished_batch(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            owner = conn.cursor()
+            other = conn.cursor()
+            await owner.execute(
+                "SELECT value FROM (VALUES (1), (2), (3), (4)) rows(value) ORDER BY value",
+                use_prepare=False,
+            )
+            description = owner.description
+
+            assert await owner.fetchone() == (1,)
+            assert await owner.fetchmany(1) == [(2,)]
+            assert await owner.fetchall() == [(3,), (4,)]
+            assert await owner.fetchall() == []
+            assert owner.description == description
+
+            await other.execute("SET NOCOUNT ON", use_prepare=False)
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_fetchall_empty_result_and_current_result_set_boundary(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            owner = conn.cursor()
+            other = conn.cursor()
+
+            await owner.execute("SELECT 1 WHERE 1 = 0", use_prepare=False)
+            assert await owner.fetchall() == []
+            await other.execute("SET NOCOUNT ON", use_prepare=False)
+
+            await owner.execute("SELECT 1; SELECT 2", use_prepare=False)
+            assert await owner.fetchall() == [(1,)]
+            assert await owner.fetchall() == []
+            with pytest.raises(RuntimeError, match="busy with another cursor"):
+                await other.execute("SELECT 3", use_prepare=False)
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_fetchall_keeps_event_loop_responsive(client_context):
+    async def run():
+        conn = await connect(client_context)
+        heartbeat_ticks = 0
+        stop_heartbeat = False
+
+        async def heartbeat():
+            nonlocal heartbeat_ticks
+            while not stop_heartbeat:
+                heartbeat_ticks += 1
+                await asyncio.sleep(0)
+
+        try:
+            cursor = conn.cursor()
+            await cursor.execute(
+                """
+                WITH numbers AS (
+                    SELECT 0 AS value
+                    UNION ALL
+                    SELECT value + 1 FROM numbers WHERE value < 4095
+                )
+                SELECT value FROM numbers ORDER BY value
+                OPTION (MAXRECURSION 4095)
+                """,
+                use_prepare=False,
+            )
+            heartbeat_task = asyncio.create_task(heartbeat())
+            await asyncio.sleep(0)
+            ticks_before_fetch = heartbeat_ticks
+
+            rows = await cursor.fetchall()
+            ticks_during_fetch = heartbeat_ticks - ticks_before_fetch
+
+            assert rows == [(value,) for value in range(4096)]
+            assert ticks_during_fetch > 0
+        finally:
+            stop_heartbeat = True
+            if "heartbeat_task" in locals():
+                await heartbeat_task
             await conn.close()
 
     asyncio.run(run())
@@ -760,7 +883,7 @@ def test_exhausted_fetchone_after_connection_close_raises(client_context):
 
 
 @pytest.mark.integration
-@pytest.mark.parametrize("operation", ["fetchone", "fetchmany"])
+@pytest.mark.parametrize("operation", ["fetchone", "fetchmany", "fetchall"])
 def test_fetch_rejects_concurrent_read_on_same_cursor(client_context, operation):
     async def run():
         conn = await connect(client_context)
@@ -771,12 +894,14 @@ def test_fetch_rejects_concurrent_read_on_same_cursor(client_context, operation)
                 use_prepare=False,
             )
 
-            first = cursor.fetchone() if operation == "fetchone" else cursor.fetchmany(1)
+            operations = {
+                "fetchone": lambda: cursor.fetchone(),
+                "fetchmany": lambda: cursor.fetchmany(1),
+                "fetchall": lambda: cursor.fetchall(),
+            }
+            first = operations[operation]()
             with pytest.raises(RuntimeError, match="busy with another cursor operation"):
-                if operation == "fetchone":
-                    cursor.fetchone()
-                else:
-                    cursor.fetchmany(1)
+                operations[operation]()
             result = await first
             value = result[0] if operation == "fetchone" else result[0][0]
             assert len(value) == 8000000
@@ -788,7 +913,7 @@ def test_fetch_rejects_concurrent_read_on_same_cursor(client_context, operation)
 
 
 @pytest.mark.integration
-@pytest.mark.parametrize("operation", ["fetchone", "fetchmany"])
+@pytest.mark.parametrize("operation", ["fetchone", "fetchmany", "fetchall"])
 def test_cancelling_blocked_fetch_breaks_session(client_context, operation):
     async def run():
         conn = await connect(client_context)
@@ -798,9 +923,12 @@ def test_cancelling_blocked_fetch_breaks_session(client_context, operation):
                 "SELECT REPLICATE(CAST('x' AS varchar(max)), 32000000)",
                 use_prepare=False,
             )
-            awaitable = (
-                cursor.fetchone() if operation == "fetchone" else cursor.fetchmany(1)
-            )
+            operations = {
+                "fetchone": lambda: cursor.fetchone(),
+                "fetchmany": lambda: cursor.fetchmany(1),
+                "fetchall": lambda: cursor.fetchall(),
+            }
+            awaitable = operations[operation]()
             task = asyncio.ensure_future(awaitable)
             await asyncio.sleep(0)
             task.cancel()

--- a/mssql-py-core/tests/test_async_fetch.py
+++ b/mssql-py-core/tests/test_async_fetch.py
@@ -31,6 +31,7 @@ async def connect(client_context, python_logger=None):
 
 def test_module_exposes_fetchone():
     assert hasattr(mssql_py_core.PyAsyncCursor, "fetchone")
+    assert hasattr(mssql_py_core.PyAsyncCursor, "fetchmany")
 
 
 def test_fetchone_without_result_set_raises(mock_client_context):
@@ -40,6 +41,8 @@ def test_fetchone_without_result_set_raises(mock_client_context):
             cursor = conn.cursor()
             with pytest.raises(RuntimeError, match="No active result set"):
                 await cursor.fetchone()
+            with pytest.raises(RuntimeError, match="No active result set"):
+                await cursor.fetchmany(1)
         finally:
             await conn.close()
 
@@ -54,6 +57,39 @@ def test_fetchone_after_cursor_close_raises(mock_client_context):
             await cursor.close()
             with pytest.raises(RuntimeError, match="Cursor is closed"):
                 await cursor.fetchone()
+            with pytest.raises(RuntimeError, match="Cursor is closed"):
+                await cursor.fetchmany(0)
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+def test_fetchmany_argument_and_arraysize_contract(mock_client_context):
+    async def run():
+        conn = await connect(mock_client_context)
+        try:
+            cursor = conn.cursor()
+            assert cursor.arraysize == 1
+            cursor.arraysize = 3
+            assert cursor.arraysize == 3
+
+            assert await cursor.fetchmany(0) == []
+            assert await cursor.fetchmany(-1) == []
+            assert await cursor.fetchmany(False) == []
+            cursor.arraysize = -2
+            assert await cursor.fetchmany() == []
+
+            with pytest.raises(RuntimeError, match="No active result set"):
+                await cursor.fetchmany(True)
+            with pytest.raises(TypeError):
+                cursor.fetchmany(1.5)
+            with pytest.raises(TypeError):
+                cursor.fetchmany(1, 2)
+            with pytest.raises(TypeError):
+                cursor.fetchmany(unknown=1)
+            with pytest.raises(TypeError):
+                cursor.arraysize = 1.5
         finally:
             await conn.close()
 
@@ -126,6 +162,100 @@ def test_fetchone_logs_exhaustion(client_context):
                 "PyAsyncCursor::fetchone: result set exhausted",
                 "async_fetch.rs",
             ) in logger.events
+
+            await cursor.execute("SELECT 1", use_prepare=False)
+            logger.events.clear()
+            assert await cursor.fetchmany(2) == [(1,)]
+            assert (
+                10,
+                "PyAsyncCursor::fetchmany: started; requested=2",
+                "async_fetch.rs",
+            ) in logger.events
+            assert (
+                20,
+                "PyAsyncCursor::fetchmany: result set exhausted",
+                "async_fetch.rs",
+            ) in logger.events
+            assert any(
+                level == 10
+                and "PyAsyncCursor::fetchmany: completed; requested=2; returned=1; exhausted=true; elapsed_ms="
+                in message
+                for level, message, _module in logger.events
+            )
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_fetchmany_uses_arraysize_and_interleaves_without_skipping(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            cursor.arraysize = 2
+            await cursor.execute(
+                "SELECT value FROM (VALUES (1), (2), (3), (4), (5)) rows(value) ORDER BY value",
+                use_prepare=False,
+            )
+            description = cursor.description
+
+            assert await cursor.fetchone() == (1,)
+            assert await cursor.fetchmany() == [(2,), (3,)]
+            assert await cursor.fetchmany(None) == [(4,), (5,)]
+            assert cursor.description == description
+            assert await cursor.fetchmany(size=2) == []
+            assert await cursor.fetchmany() == []
+            assert await cursor.fetchone() is None
+            assert cursor.description == description
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_fetchmany_nonpositive_size_does_not_advance_and_partial_batch_releases_session(
+    client_context,
+):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            owner = conn.cursor()
+            other = conn.cursor()
+            await owner.execute(
+                "SELECT value FROM (VALUES (1), (2), (3)) rows(value) ORDER BY value",
+                use_prepare=False,
+            )
+
+            assert await owner.fetchmany(0) == []
+            assert await owner.fetchmany(-10) == []
+            assert await owner.fetchmany(2) == [(1,), (2,)]
+            assert await owner.fetchmany(2) == [(3,)]
+            await other.execute("SET NOCOUNT ON", use_prepare=False)
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_fetchmany_stops_at_current_result_set(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            owner = conn.cursor()
+            other = conn.cursor()
+            await owner.execute("SELECT 1; SELECT 2", use_prepare=False)
+
+            assert await owner.fetchmany(10) == [(1,)]
+            assert await owner.fetchmany(10) == []
+            with pytest.raises(RuntimeError, match="busy with another cursor"):
+                await other.execute("SELECT 3", use_prepare=False)
+
+            await owner.close()
+            await other.execute("SET NOCOUNT ON", use_prepare=False)
         finally:
             await conn.close()
 
@@ -630,7 +760,8 @@ def test_exhausted_fetchone_after_connection_close_raises(client_context):
 
 
 @pytest.mark.integration
-def test_fetchone_rejects_concurrent_read_on_same_cursor(client_context):
+@pytest.mark.parametrize("operation", ["fetchone", "fetchmany"])
+def test_fetch_rejects_concurrent_read_on_same_cursor(client_context, operation):
     async def run():
         conn = await connect(client_context)
         try:
@@ -640,10 +771,15 @@ def test_fetchone_rejects_concurrent_read_on_same_cursor(client_context):
                 use_prepare=False,
             )
 
-            first = cursor.fetchone()
+            first = cursor.fetchone() if operation == "fetchone" else cursor.fetchmany(1)
             with pytest.raises(RuntimeError, match="busy with another cursor operation"):
-                cursor.fetchone()
-            assert len((await first)[0]) == 8000000
+                if operation == "fetchone":
+                    cursor.fetchone()
+                else:
+                    cursor.fetchmany(1)
+            result = await first
+            value = result[0] if operation == "fetchone" else result[0][0]
+            assert len(value) == 8000000
             assert await cursor.fetchone() is None
         finally:
             await conn.close()
@@ -652,7 +788,8 @@ def test_fetchone_rejects_concurrent_read_on_same_cursor(client_context):
 
 
 @pytest.mark.integration
-def test_cancelling_blocked_fetchone_breaks_session(client_context):
+@pytest.mark.parametrize("operation", ["fetchone", "fetchmany"])
+def test_cancelling_blocked_fetch_breaks_session(client_context, operation):
     async def run():
         conn = await connect(client_context)
         cursor = conn.cursor()
@@ -661,7 +798,10 @@ def test_cancelling_blocked_fetchone_breaks_session(client_context):
                 "SELECT REPLICATE(CAST('x' AS varchar(max)), 32000000)",
                 use_prepare=False,
             )
-            task = asyncio.ensure_future(cursor.fetchone())
+            awaitable = (
+                cursor.fetchone() if operation == "fetchone" else cursor.fetchmany(1)
+            )
+            task = asyncio.ensure_future(awaitable)
             await asyncio.sleep(0)
             task.cancel()
             with pytest.raises(asyncio.CancelledError):
@@ -678,9 +818,9 @@ def test_cancelling_blocked_fetchone_breaks_session(client_context):
                     assert "broken" in str(error).lower()
                     break
                 else:
-                    pytest.fail("Cancelled FetchOne left the connection reusable")
+                    pytest.fail(f"Cancelled {operation} left the connection reusable")
             else:
-                pytest.fail("Cancelled FetchOne left the connection permanently busy")
+                pytest.fail(f"Cancelled {operation} left the connection permanently busy")
         finally:
             await conn.close()
 

--- a/mssql-py-core/tests/test_async_fetch.py
+++ b/mssql-py-core/tests/test_async_fetch.py
@@ -266,6 +266,52 @@ def test_fetchmany_uses_arraysize_and_interleaves_without_skipping(client_contex
 
 
 @pytest.mark.integration
+def test_large_fetchmany_keeps_event_loop_responsive(client_context):
+    async def run():
+        conn = await connect(client_context)
+        heartbeat_ticks = 0
+        stop_heartbeat = False
+
+        async def heartbeat():
+            nonlocal heartbeat_ticks
+            while not stop_heartbeat:
+                heartbeat_ticks += 1
+                await asyncio.sleep(0)
+
+        try:
+            cursor = conn.cursor()
+            cursor.arraysize = 4096
+            await cursor.execute(
+                """
+                WITH numbers AS (
+                    SELECT 0 AS value
+                    UNION ALL
+                    SELECT value + 1 FROM numbers WHERE value < 4095
+                )
+                SELECT value FROM numbers ORDER BY value
+                OPTION (MAXRECURSION 4095)
+                """,
+                use_prepare=False,
+            )
+            heartbeat_task = asyncio.create_task(heartbeat())
+            await asyncio.sleep(0)
+            ticks_before_fetch = heartbeat_ticks
+
+            rows = await cursor.fetchmany()
+            ticks_during_fetch = heartbeat_ticks - ticks_before_fetch
+
+            assert rows == [(value,) for value in range(4096)]
+            assert ticks_during_fetch > 0
+        finally:
+            stop_heartbeat = True
+            if "heartbeat_task" in locals():
+                await heartbeat_task
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
 def test_fetchmany_nonpositive_size_does_not_advance_and_partial_batch_releases_session(
     client_context,
 ):

--- a/mssql-py-core/tests/test_async_fetch.py
+++ b/mssql-py-core/tests/test_async_fetch.py
@@ -5,7 +5,10 @@
 
 import asyncio
 import datetime
+import importlib.abc
+import importlib.machinery
 import sys
+import threading
 import uuid
 import warnings
 from decimal import Decimal
@@ -54,17 +57,25 @@ def test_fetchone_without_result_set_raises(mock_client_context):
         conn = await connect(mock_client_context)
         try:
             cursor = conn.cursor()
-            with pytest.raises(RuntimeError, match="No active result set"):
+            with pytest.raises(mssql_py_core.Error) as exc_info:
                 await cursor.fetchone()
-            with pytest.raises(RuntimeError, match="No active result set"):
+            assert isinstance(exc_info.value, mssql_py_core.ProgrammingError)
+            assert "No active result set" in str(exc_info.value)
+            with pytest.raises(
+                mssql_py_core.ProgrammingError, match="No active result set"
+            ):
                 await cursor.fetchmany(1)
-            with pytest.raises(RuntimeError, match="No active result set"):
+            with pytest.raises(
+                mssql_py_core.ProgrammingError, match="No active result set"
+            ):
                 await cursor.fetchall()
             with pytest.raises(TypeError):
                 cursor.fetchall(1)
             with pytest.raises(TypeError):
                 cursor.fetchall(size=1)
-            with pytest.raises(RuntimeError, match="No active result set"):
+            with pytest.raises(
+                mssql_py_core.ProgrammingError, match="No active result set"
+            ):
                 await cursor.nextset()
             with pytest.raises(TypeError):
                 cursor.nextset(1)
@@ -103,13 +114,27 @@ def test_fetchmany_argument_and_arraysize_contract(mock_client_context):
             cursor.arraysize = 3
             assert cursor.arraysize == 3
 
-            assert await cursor.fetchmany(0) == []
-            assert await cursor.fetchmany(-1) == []
-            assert await cursor.fetchmany(False) == []
+            with pytest.raises(
+                mssql_py_core.ProgrammingError, match="No active result set"
+            ):
+                await cursor.fetchmany(0)
+            with pytest.raises(
+                mssql_py_core.ProgrammingError, match="No active result set"
+            ):
+                await cursor.fetchmany(-1)
+            with pytest.raises(
+                mssql_py_core.ProgrammingError, match="No active result set"
+            ):
+                await cursor.fetchmany(False)
             cursor.arraysize = -2
-            assert await cursor.fetchmany() == []
+            with pytest.raises(
+                mssql_py_core.ProgrammingError, match="No active result set"
+            ):
+                await cursor.fetchmany()
 
-            with pytest.raises(RuntimeError, match="No active result set"):
+            with pytest.raises(
+                mssql_py_core.ProgrammingError, match="No active result set"
+            ):
                 await cursor.fetchmany(True)
             with pytest.raises(TypeError):
                 cursor.fetchmany(1.5)
@@ -513,7 +538,9 @@ def test_fetch_interleaving_across_result_transitions_and_ownership(client_conte
 
             assert await owner.nextset() is True
             assert owner.description is None
-            with pytest.raises(RuntimeError, match="No active result set"):
+            with pytest.raises(
+                mssql_py_core.ProgrammingError, match="No active result set"
+            ):
                 await owner.fetchall()
 
             assert await owner.nextset() is True
@@ -561,7 +588,9 @@ def test_execute_preserves_leading_statement_without_rows(client_context, use_pr
             )
 
             assert owner.description is None
-            with pytest.raises(RuntimeError, match="No active result set"):
+            with pytest.raises(
+                mssql_py_core.ProgrammingError, match="No active result set"
+            ):
                 await owner.fetchone()
             with pytest.raises(RuntimeError, match="busy with another cursor"):
                 await other.execute("SELECT 2", use_prepare=False)
@@ -571,6 +600,91 @@ def test_execute_preserves_leading_statement_without_rows(client_context, use_pr
             assert await owner.fetchall() == [(1,)]
             assert await owner.nextset() is False
             await other.execute("SET NOCOUNT ON", use_prepare=False)
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("use_prepare", [True, False])
+def test_nextset_reports_batch_end_after_terminal_no_rows(client_context, use_prepare):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            other = conn.cursor()
+
+            await cursor.execute(
+                "CREATE TABLE #async_terminal_no_rows (value int)",
+                use_prepare=False,
+            )
+            assert cursor.description is None
+            await other.execute("SELECT 0", use_prepare=False)
+            assert await other.fetchall() == [(0,)]
+            assert await cursor.nextset() is False
+            assert await cursor.nextset() is False
+
+            await cursor.execute(
+                "INSERT INTO #async_terminal_no_rows VALUES (?)",
+                1,
+                use_prepare=use_prepare,
+            )
+            assert cursor.description is None
+            with pytest.raises(
+                mssql_py_core.ProgrammingError, match="No active result set"
+            ):
+                await cursor.fetchone()
+            with pytest.raises(
+                mssql_py_core.ProgrammingError, match="No active result set"
+            ):
+                await cursor.fetchmany()
+            with pytest.raises(
+                mssql_py_core.ProgrammingError, match="No active result set"
+            ):
+                await cursor.fetchall()
+            assert await cursor.nextset() is False
+            assert await cursor.nextset() is False
+
+            await cursor.execute(
+                "SELECT 2 AS selected_value; "
+                "INSERT INTO #async_terminal_no_rows VALUES (2)",
+                use_prepare=False,
+            )
+            assert await cursor.fetchall() == [(2,)]
+            assert await cursor.nextset() is True
+            assert cursor.description is None
+            with pytest.raises(
+                mssql_py_core.ProgrammingError, match="No active result set"
+            ):
+                await cursor.fetchone()
+            assert await cursor.nextset() is False
+            assert await cursor.nextset() is False
+
+            await cursor.execute("PRINT 'terminal information'", use_prepare=False)
+            assert cursor.description is None
+            with pytest.raises(
+                mssql_py_core.ProgrammingError, match="No active result set"
+            ):
+                await cursor.fetchone()
+            assert await cursor.nextset() is False
+
+            await other.execute(
+                "SELECT value FROM #async_terminal_no_rows ORDER BY value",
+                use_prepare=False,
+            )
+            assert await other.fetchall() == [(1,), (2,)]
+
+            await cursor.execute("SET NOCOUNT ON", use_prepare=False)
+            assert cursor.description is None
+            with pytest.raises(
+                mssql_py_core.ProgrammingError, match="No active result set"
+            ):
+                await cursor.fetchone()
+            await other.execute("SELECT 3", use_prepare=False)
+            assert await other.fetchall() == [(3,)]
+            assert await cursor.nextset() is False
+            assert await cursor.nextset() is False
         finally:
             await conn.close()
 
@@ -629,7 +743,9 @@ def test_nextset_surfaces_statement_without_rows(client_context):
 
             assert await cursor.nextset() is True
             assert cursor.description is None
-            with pytest.raises(RuntimeError, match="No active result set"):
+            with pytest.raises(
+                mssql_py_core.ProgrammingError, match="No active result set"
+            ):
                 await cursor.fetchone()
 
             assert await cursor.nextset() is True
@@ -678,9 +794,14 @@ def test_nextset_preserves_sql_server_error_type_and_diagnostics(client_context)
         try:
             cursor = conn.cursor()
             await cursor.execute(
-                "SELECT 1; RAISERROR('nextset failure', 16, 1)",
+                "SELECT 1; "
+                "RAISERROR('nextset information', 10, 2); "
+                "RAISERROR('nextset failure', 16, 1)",
                 use_prepare=False,
             )
+
+            assert await cursor.nextset() is True
+            assert cursor.description is None
 
             with pytest.raises(mssql_py_core.DatabaseError) as exc_info:
                 await cursor.nextset()
@@ -692,7 +813,14 @@ def test_nextset_preserves_sql_server_error_type_and_diagnostics(client_context)
             assert exc_info.value.sql_errors[0]["number"] == 50000
             assert exc_info.value.sql_errors[0]["class"] == 16
             assert exc_info.value.sql_errors[0]["state"] == 1
-            assert exc_info.value.info_messages == []
+            assert len(exc_info.value.info_messages) == 1
+            assert exc_info.value.info_messages[0]["number"] == 50000
+            assert exc_info.value.info_messages[0]["class"] == 0
+            assert exc_info.value.info_messages[0]["state"] == 2
+            assert (
+                exc_info.value.info_messages[0]["message"]
+                == "nextset information"
+            )
 
             await conn.cursor().execute("SET NOCOUNT ON", use_prepare=False)
         finally:
@@ -732,7 +860,8 @@ def test_nextset_logs_result_transitions(client_context):
             ) in logger.events
 
             await cursor.execute(
-                "SELECT 1; SELECT CAST(1 AS decimal(10, 2)) AS value",
+                "SELECT 1; SELECT CAST(1 AS decimal(10, 2)) AS value; "
+                "SELECT 3 AS recovered_value",
                 use_prepare=False,
             )
             decimal_module = sys.modules["decimal"]
@@ -740,14 +869,21 @@ def test_nextset_logs_result_transitions(client_context):
             logger.events.clear()
             try:
                 with pytest.raises(
-                    RuntimeError,
+                    mssql_py_core.InternalError,
                     match="Advanced result set but cursor description materialization failed",
                 ):
                     await cursor.nextset()
             finally:
                 sys.modules["decimal"] = decimal_module
             assert cursor.description is None
-            assert await cursor.fetchone() == (Decimal("1.00"),)
+            with pytest.raises(
+                mssql_py_core.ProgrammingError, match="No active result set"
+            ):
+                await cursor.fetchone()
+            assert await cursor.nextset() is True
+            assert cursor.description[0][:2] == ("recovered_value", int)
+            assert await cursor.fetchone() == (3,)
+            assert await cursor.nextset() is False
             assert any(
                 level == 40
                 and "PyAsyncCursor::nextset: description materialization failed; "
@@ -757,6 +893,78 @@ def test_nextset_logs_result_transitions(client_context):
                 for level, message, _module in logger.events
             )
         finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_nextset_cancellation_during_description_materialization_does_not_publish_rows(
+    client_context,
+):
+    class BlockingDecimalFinder(importlib.abc.MetaPathFinder):
+        def __init__(self, entered, release):
+            self.entered = entered
+            self.release = release
+
+        def find_spec(self, fullname, path, target=None):
+            if fullname != "decimal":
+                return None
+            self.entered.set()
+            self.release.wait()
+            return importlib.machinery.PathFinder.find_spec(fullname, path, target)
+
+    async def run():
+        conn = await connect(client_context)
+        entered = threading.Event()
+        release = threading.Event()
+        finder = BlockingDecimalFinder(entered, release)
+        decimal_module = sys.modules.pop("decimal")
+        sys.meta_path.insert(0, finder)
+        try:
+            cursor = conn.cursor()
+            await cursor.execute(
+                "SELECT 1; SELECT CAST(2 AS decimal(10, 2)) AS value",
+                use_prepare=False,
+            )
+            task = asyncio.ensure_future(cursor.nextset())
+            for _ in range(200):
+                if entered.is_set():
+                    break
+                await asyncio.sleep(0.01)
+            else:
+                pytest.fail("Description materialization did not start")
+
+            task.cancel()
+            release.set()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+            assert cursor.description is None
+            probe = conn.cursor()
+            for _ in range(100):
+                try:
+                    await probe.execute("SELECT 3", use_prepare=False)
+                except RuntimeError as error:
+                    if "busy" in str(error).lower():
+                        await asyncio.sleep(0.01)
+                        continue
+                    assert "broken" in str(error).lower()
+                    break
+                else:
+                    pytest.fail(
+                        "Cancelled description materialization left the connection reusable"
+                    )
+            else:
+                pytest.fail(
+                    "Cancelled description materialization left the connection permanently busy"
+                )
+        finally:
+            release.set()
+            if finder in sys.meta_path:
+                sys.meta_path.remove(finder)
+            await asyncio.to_thread(__import__, "decimal")
+            sys.modules["decimal"] = decimal_module
             await conn.close()
 
     asyncio.run(run())

--- a/mssql-py-core/tests/test_async_fetch.py
+++ b/mssql-py-core/tests/test_async_fetch.py
@@ -25,6 +25,19 @@ class RecordingLogger:
         self.events.append((level, message, module_name))
 
 
+class BlockingDecimalFinder(importlib.abc.MetaPathFinder):
+    def __init__(self, entered, release):
+        self.entered = entered
+        self.release = release
+
+    def find_spec(self, fullname, path, target=None):
+        if fullname != "decimal":
+            return None
+        self.entered.set()
+        self.release.wait()
+        return importlib.machinery.PathFinder.find_spec(fullname, path, target)
+
+
 async def connect(client_context, python_logger=None):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", FutureWarning)
@@ -902,18 +915,6 @@ def test_nextset_logs_result_transitions(client_context):
 def test_nextset_cancellation_during_description_materialization_does_not_publish_rows(
     client_context,
 ):
-    class BlockingDecimalFinder(importlib.abc.MetaPathFinder):
-        def __init__(self, entered, release):
-            self.entered = entered
-            self.release = release
-
-        def find_spec(self, fullname, path, target=None):
-            if fullname != "decimal":
-                return None
-            self.entered.set()
-            self.release.wait()
-            return importlib.machinery.PathFinder.find_spec(fullname, path, target)
-
     async def run():
         conn = await connect(client_context)
         entered = threading.Event()
@@ -965,6 +966,67 @@ def test_nextset_cancellation_during_description_materialization_does_not_publis
                 sys.meta_path.remove(finder)
             await asyncio.to_thread(__import__, "decimal")
             sys.modules["decimal"] = decimal_module
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_fetchall_cancellation_during_row_materialization_keeps_connection_reusable(
+    client_context,
+):
+    async def run():
+        logger = RecordingLogger()
+        conn = await connect(client_context, logger)
+        entered = threading.Event()
+        release = threading.Event()
+        finder = BlockingDecimalFinder(entered, release)
+        decimal_module = None
+        try:
+            cursor = conn.cursor()
+            await cursor.execute(
+                "SELECT CAST(1 AS decimal(10, 2)) AS value", use_prepare=False
+            )
+            decimal_module = sys.modules.pop("decimal")
+            sys.meta_path.insert(0, finder)
+            logger.events.clear()
+
+            task = asyncio.ensure_future(cursor.fetchall())
+            for _ in range(200):
+                if entered.is_set():
+                    break
+                await asyncio.sleep(0.01)
+            else:
+                pytest.fail("Row materialization did not start")
+
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            for _ in range(100):
+                if any(
+                    level == 30
+                    and message
+                    == "PyAsyncCursor::fetchall: interrupted during row materialization; connection remains usable"
+                    and module == "async_fetch.rs"
+                    for level, message, module in logger.events
+                ):
+                    break
+                await asyncio.sleep(0.01)
+            else:
+                pytest.fail(f"Missing materialization warning: {logger.events}")
+
+            release.set()
+            await asyncio.to_thread(__import__, "decimal")
+            probe = conn.cursor()
+            await probe.execute("SELECT 2", use_prepare=False)
+            assert await probe.fetchone() == (2,)
+        finally:
+            release.set()
+            if finder in sys.meta_path:
+                sys.meta_path.remove(finder)
+            await asyncio.to_thread(__import__, "decimal")
+            if decimal_module is not None:
+                sys.modules["decimal"] = decimal_module
             await conn.close()
 
     asyncio.run(run())

--- a/mssql-py-core/tests/test_async_fetch.py
+++ b/mssql-py-core/tests/test_async_fetch.py
@@ -247,6 +247,63 @@ def test_fetchmany_uses_arraysize_and_interleaves_without_skipping(client_contex
             assert await cursor.fetchmany() == []
             assert await cursor.fetchone() is None
             assert cursor.description == description
+
+            # Regression parity with mssql-python issue #427: fetchmany then fetchone.
+            await cursor.execute(
+                "SELECT value FROM (VALUES (1), (2)) rows(value) ORDER BY value",
+                use_prepare=False,
+            )
+            assert await cursor.fetchmany(1) == [(1,)]
+            assert await cursor.fetchone() == (2,)
+
+            # Repeated alternation must preserve the exact row position.
+            await cursor.execute(
+                "SELECT value FROM (VALUES (1), (2), (3), (4)) rows(value) "
+                "ORDER BY value",
+                use_prepare=False,
+            )
+            assert await cursor.fetchmany(1) == [(1,)]
+            assert await cursor.fetchone() == (2,)
+            assert await cursor.fetchmany(1) == [(3,)]
+            assert await cursor.fetchone() == (4,)
+            assert await cursor.fetchone() is None
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_fetchmany_and_fetchall_preserve_mixed_large_lob_batches(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            query = """
+                SELECT id, lob_value
+                FROM (VALUES
+                    (1, CAST(N'' AS nvarchar(max))),
+                    (2, CAST(NULL AS nvarchar(max))),
+                    (3, CAST(N'Small' AS nvarchar(max))),
+                    (4, REPLICATE(CAST(N'x' AS nvarchar(max)), 1000)),
+                    (5, REPLICATE(CAST(N'y' AS nvarchar(max)), 10000))
+                ) rows(id, lob_value)
+                ORDER BY id
+            """
+            await cursor.execute(query, use_prepare=False)
+
+            assert await cursor.fetchmany(2) == [(1, ""), (2, None)]
+            assert await cursor.fetchone() == (3, "Small")
+            remaining = await cursor.fetchall()
+            assert remaining == [(4, "x" * 1000), (5, "y" * 10000)]
+            assert await cursor.fetchmany(2) == []
+            assert await cursor.fetchall() == []
+
+            await cursor.execute(query, use_prepare=False)
+            rows = await cursor.fetchall()
+            assert rows[:3] == [(1, ""), (2, None), (3, "Small")]
+            assert rows[3][1] == "x" * 1000
+            assert rows[4][1] == "y" * 10000
         finally:
             await conn.close()
 
@@ -402,15 +459,20 @@ def test_nextset_drains_rows_and_updates_description(client_context):
             cursor = conn.cursor()
             await cursor.execute(
                 "SELECT 1 AS first_value UNION ALL SELECT 2; "
-                "SELECT N'x' AS second_value; SELECT 3 AS third_value",
+                "SELECT value AS second_value, LEN(value) AS value_length "
+                "FROM (VALUES (N'x'), (N'yy'), (N'zzz')) rows(value); "
+                "SELECT 3 AS third_value",
                 use_prepare=False,
             )
             assert cursor.description[0][:2] == ("first_value", int)
             assert await cursor.fetchone() == (1,)
 
             assert await cursor.nextset() is True
-            assert cursor.description[0][:2] == ("second_value", str)
-            assert await cursor.fetchall() == [("x",)]
+            assert [column[:2] for column in cursor.description] == [
+                ("second_value", str),
+                ("value_length", int),
+            ]
+            assert await cursor.fetchall() == [("x", 1), ("yy", 2), ("zzz", 3)]
 
             assert await cursor.nextset() is True
             assert cursor.description[0][:2] == ("third_value", int)
@@ -419,6 +481,104 @@ def test_nextset_drains_rows_and_updates_description(client_context):
             assert await cursor.nextset() is False
             assert cursor.description is None
             assert await cursor.nextset() is False
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_fetch_interleaving_across_result_transitions_and_ownership(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            owner = conn.cursor()
+            other = conn.cursor()
+            await owner.execute(
+                """
+                DECLARE @sink TABLE (value int);
+                SELECT value FROM (VALUES (1), (2), (3), (4), (5), (6)) rows(value)
+                    ORDER BY value;
+                INSERT INTO @sink VALUES (1);
+                SELECT value FROM (VALUES (10), (11), (12), (13)) rows(value)
+                    ORDER BY value;
+                SELECT CAST(1 AS int) AS empty_value WHERE 1 = 0;
+                SELECT value FROM (VALUES (20), (21)) rows(value) ORDER BY value;
+                """,
+                use_prepare=False,
+            )
+
+            assert await owner.fetchone() == (1,)
+            assert await owner.fetchmany(2) == [(2,), (3,)]
+            assert await owner.fetchall() == [(4,), (5,), (6,)]
+            assert await owner.fetchall() == []
+            with pytest.raises(RuntimeError, match="busy with another cursor"):
+                await other.execute("SELECT 99", use_prepare=False)
+
+            assert await owner.nextset() is True
+            assert owner.description is None
+            with pytest.raises(RuntimeError, match="No active result set"):
+                await owner.fetchall()
+
+            assert await owner.nextset() is True
+            assert await owner.fetchone() == (10,)
+            assert await owner.fetchmany(2) == [(11,), (12,)]
+            assert await owner.fetchall() == [(13,)]
+
+            assert await owner.nextset() is True
+            assert owner.description[0][0] == "empty_value"
+            assert await owner.fetchone() is None
+            assert await owner.fetchmany(2) == []
+            assert await owner.fetchall() == []
+
+            assert await owner.nextset() is True
+            assert await owner.fetchmany(1) == [(20,)]
+            assert await owner.fetchall() == [(21,)]
+            assert await owner.nextset() is False
+            assert await owner.nextset() is False
+            await other.execute("SET NOCOUNT ON", use_prepare=False)
+
+            await owner.execute("SELECT 1; SELECT 2", use_prepare=False)
+            await owner.close()
+            with pytest.raises(RuntimeError, match="Cursor is closed"):
+                await owner.nextset()
+            await other.execute("SET NOCOUNT ON", use_prepare=False)
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_nextset_asyncio_timeout_breaks_connection_ownership(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            await cursor.execute(
+                "SELECT TOP (10000000) REPLICATE(CAST('x' AS varchar(100)), 100) "
+                "FROM sys.all_objects AS first_rows "
+                "CROSS JOIN sys.all_objects AS second_rows; SELECT 2",
+                use_prepare=False,
+            )
+
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(cursor.nextset(), timeout=0.01)
+
+            probe = conn.cursor()
+            for _ in range(100):
+                try:
+                    await probe.execute("SELECT 3", use_prepare=False)
+                except RuntimeError as error:
+                    if "busy" in str(error).lower():
+                        await asyncio.sleep(0.01)
+                        continue
+                    assert "broken" in str(error).lower()
+                    break
+                else:
+                    pytest.fail("Timed-out nextset left the connection reusable")
+            else:
+                pytest.fail("Timed-out nextset left the connection permanently busy")
         finally:
             await conn.close()
 

--- a/mssql-py-core/tests/test_async_fetch.py
+++ b/mssql-py-core/tests/test_async_fetch.py
@@ -37,6 +37,18 @@ def test_module_exposes_fetchone():
     assert hasattr(mssql_py_core.PyAsyncCursor, "nextset")
 
 
+def test_module_exposes_dbapi_exception_hierarchy():
+    assert issubclass(mssql_py_core.Warning, Exception)
+    assert issubclass(mssql_py_core.InterfaceError, mssql_py_core.Error)
+    assert issubclass(mssql_py_core.DatabaseError, mssql_py_core.Error)
+    assert issubclass(mssql_py_core.DataError, mssql_py_core.DatabaseError)
+    assert issubclass(mssql_py_core.OperationalError, mssql_py_core.DatabaseError)
+    assert issubclass(mssql_py_core.IntegrityError, mssql_py_core.DatabaseError)
+    assert issubclass(mssql_py_core.InternalError, mssql_py_core.DatabaseError)
+    assert issubclass(mssql_py_core.ProgrammingError, mssql_py_core.DatabaseError)
+    assert issubclass(mssql_py_core.NotSupportedError, mssql_py_core.DatabaseError)
+
+
 def test_fetchone_without_result_set_raises(mock_client_context):
     async def run():
         conn = await connect(mock_client_context)
@@ -247,63 +259,6 @@ def test_fetchmany_uses_arraysize_and_interleaves_without_skipping(client_contex
             assert await cursor.fetchmany() == []
             assert await cursor.fetchone() is None
             assert cursor.description == description
-
-            # Regression parity with mssql-python issue #427: fetchmany then fetchone.
-            await cursor.execute(
-                "SELECT value FROM (VALUES (1), (2)) rows(value) ORDER BY value",
-                use_prepare=False,
-            )
-            assert await cursor.fetchmany(1) == [(1,)]
-            assert await cursor.fetchone() == (2,)
-
-            # Repeated alternation must preserve the exact row position.
-            await cursor.execute(
-                "SELECT value FROM (VALUES (1), (2), (3), (4)) rows(value) "
-                "ORDER BY value",
-                use_prepare=False,
-            )
-            assert await cursor.fetchmany(1) == [(1,)]
-            assert await cursor.fetchone() == (2,)
-            assert await cursor.fetchmany(1) == [(3,)]
-            assert await cursor.fetchone() == (4,)
-            assert await cursor.fetchone() is None
-        finally:
-            await conn.close()
-
-    asyncio.run(run())
-
-
-@pytest.mark.integration
-def test_fetchmany_and_fetchall_preserve_mixed_large_lob_batches(client_context):
-    async def run():
-        conn = await connect(client_context)
-        try:
-            cursor = conn.cursor()
-            query = """
-                SELECT id, lob_value
-                FROM (VALUES
-                    (1, CAST(N'' AS nvarchar(max))),
-                    (2, CAST(NULL AS nvarchar(max))),
-                    (3, CAST(N'Small' AS nvarchar(max))),
-                    (4, REPLICATE(CAST(N'x' AS nvarchar(max)), 1000)),
-                    (5, REPLICATE(CAST(N'y' AS nvarchar(max)), 10000))
-                ) rows(id, lob_value)
-                ORDER BY id
-            """
-            await cursor.execute(query, use_prepare=False)
-
-            assert await cursor.fetchmany(2) == [(1, ""), (2, None)]
-            assert await cursor.fetchone() == (3, "Small")
-            remaining = await cursor.fetchall()
-            assert remaining == [(4, "x" * 1000), (5, "y" * 10000)]
-            assert await cursor.fetchmany(2) == []
-            assert await cursor.fetchall() == []
-
-            await cursor.execute(query, use_prepare=False)
-            rows = await cursor.fetchall()
-            assert rows[:3] == [(1, ""), (2, None), (3, "Small")]
-            assert rows[3][1] == "x" * 1000
-            assert rows[4][1] == "y" * 10000
         finally:
             await conn.close()
 
@@ -459,20 +414,15 @@ def test_nextset_drains_rows_and_updates_description(client_context):
             cursor = conn.cursor()
             await cursor.execute(
                 "SELECT 1 AS first_value UNION ALL SELECT 2; "
-                "SELECT value AS second_value, LEN(value) AS value_length "
-                "FROM (VALUES (N'x'), (N'yy'), (N'zzz')) rows(value); "
-                "SELECT 3 AS third_value",
+                "SELECT N'x' AS second_value; SELECT 3 AS third_value",
                 use_prepare=False,
             )
             assert cursor.description[0][:2] == ("first_value", int)
             assert await cursor.fetchone() == (1,)
 
             assert await cursor.nextset() is True
-            assert [column[:2] for column in cursor.description] == [
-                ("second_value", str),
-                ("value_length", int),
-            ]
-            assert await cursor.fetchall() == [("x", 1), ("yy", 2), ("zzz", 3)]
+            assert cursor.description[0][:2] == ("second_value", str)
+            assert await cursor.fetchall() == [("x",)]
 
             assert await cursor.nextset() is True
             assert cursor.description[0][:2] == ("third_value", int)
@@ -550,6 +500,38 @@ def test_fetch_interleaving_across_result_transitions_and_ownership(client_conte
 
 
 @pytest.mark.integration
+@pytest.mark.parametrize("use_prepare", [True, False])
+def test_execute_preserves_leading_statement_without_rows(client_context, use_prepare):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            owner = conn.cursor()
+            other = conn.cursor()
+            await owner.execute(
+                "DECLARE @rows TABLE (value int); "
+                "INSERT INTO @rows VALUES (1); "
+                "SELECT value AS selected_value FROM @rows",
+                use_prepare=use_prepare,
+            )
+
+            assert owner.description is None
+            with pytest.raises(RuntimeError, match="No active result set"):
+                await owner.fetchone()
+            with pytest.raises(RuntimeError, match="busy with another cursor"):
+                await other.execute("SELECT 2", use_prepare=False)
+
+            assert await owner.nextset() is True
+            assert owner.description[0][:2] == ("selected_value", int)
+            assert await owner.fetchall() == [(1,)]
+            assert await owner.nextset() is False
+            await other.execute("SET NOCOUNT ON", use_prepare=False)
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
 def test_nextset_asyncio_timeout_breaks_connection_ownership(client_context):
     async def run():
         conn = await connect(client_context)
@@ -598,6 +580,7 @@ def test_nextset_surfaces_statement_without_rows(client_context):
                 "SELECT 2 AS second_value",
                 use_prepare=False,
             )
+
             assert await cursor.nextset() is True
             assert cursor.description is None
             with pytest.raises(RuntimeError, match="No active result set"):
@@ -606,6 +589,66 @@ def test_nextset_surfaces_statement_without_rows(client_context):
             assert await cursor.nextset() is True
             assert cursor.description[0][:2] == ("second_value", int)
             assert await cursor.fetchall() == [(2,)]
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_fetch_preserves_sql_server_error_type_and_diagnostics(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            await cursor.execute(
+                "SELECT 1 / divisor AS value "
+                "FROM (VALUES (1), (0)) AS source(divisor) "
+                "ORDER BY divisor DESC",
+                use_prepare=False,
+            )
+
+            with pytest.raises(mssql_py_core.DatabaseError) as exc_info:
+                await cursor.fetchall()
+
+            assert "PyAsyncCursor.fetchall failed while reading rows" in str(
+                exc_info.value
+            )
+            assert exc_info.value.sql_errors
+            assert exc_info.value.sql_errors[0]["number"] == 8134
+            assert "divide by zero" in exc_info.value.sql_errors[0]["message"].lower()
+
+            await conn.cursor().execute("SET NOCOUNT ON", use_prepare=False)
+        finally:
+            await conn.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.integration
+def test_nextset_preserves_sql_server_error_type_and_diagnostics(client_context):
+    async def run():
+        conn = await connect(client_context)
+        try:
+            cursor = conn.cursor()
+            await cursor.execute(
+                "SELECT 1; RAISERROR('nextset failure', 16, 1)",
+                use_prepare=False,
+            )
+
+            with pytest.raises(mssql_py_core.DatabaseError) as exc_info:
+                await cursor.nextset()
+
+            assert "PyAsyncCursor.nextset failed while advancing results" in str(
+                exc_info.value
+            )
+            assert exc_info.value.sql_errors
+            assert exc_info.value.sql_errors[0]["number"] == 50000
+            assert exc_info.value.sql_errors[0]["class"] == 16
+            assert exc_info.value.sql_errors[0]["state"] == 1
+            assert exc_info.value.info_messages == []
+
+            await conn.cursor().execute("SET NOCOUNT ON", use_prepare=False)
         finally:
             await conn.close()
 


### PR DESCRIPTION
<!--
Thank you for your interest in this project!

This repository is not currently accepting external pull requests. If you've found
a bug or have a feature request, please open an issue instead.

If you are a Microsoft team member, please follow the instructions in the internal
contribution guide.
-->

## Description

This pull request introduces significant enhancements to the async DB-API cursor implementation, focusing on improved DB-API compliance and Python interoperability. The most notable changes are the addition of DB-API metadata and error mapping, support for standard cursor attributes and methods, and improved result set handling. These updates make the async cursor more feature-complete and user-friendly for Python developers.

**DB-API Metadata and Error Handling:**

* Added a new `DescriptionState` struct and logic to provide a DB-API compliant `description` attribute on the async cursor, exposing column metadata for result sets. (`mssql-py-core/src/async_description.rs`, `mssql-py-core/src/async_cursor.rs`, `mssql-py-core/src/async_execute.rs`) [[1]](diffhunk://#diff-daca175388312df03993e26c30dec9ce23066be6ead37eff06a6bea9dc6547faR1-R202) [[2]](diffhunk://#diff-85fa845be93caab797168826f6e49584a85ce9577adb715c7dc051dd4919a179R36) [[3]](diffhunk://#diff-85fa845be93caab797168826f6e49584a85ce9577adb715c7dc051dd4919a179R169-R176) [[4]](diffhunk://#diff-85fa845be93caab797168826f6e49584a85ce9577adb715c7dc051dd4919a179R199-R206) [[5]](diffhunk://#diff-85fa845be93caab797168826f6e49584a85ce9577adb715c7dc051dd4919a179R231) [[6]](diffhunk://#diff-85fa845be93caab797168826f6e49584a85ce9577adb715c7dc051dd4919a179R251) [[7]](diffhunk://#diff-328fea57da508546b0b0692e436ac066b3fd06112caf4d08d601980473401383R109) [[8]](diffhunk://#diff-328fea57da508546b0b0692e436ac066b3fd06112caf4d08d601980473401383R126) [[9]](diffhunk://#diff-328fea57da508546b0b0692e436ac066b3fd06112caf4d08d601980473401383R140-R157) [[10]](diffhunk://#diff-328fea57da508546b0b0692e436ac066b3fd06112caf4d08d601980473401383L249-R263)
* Introduced a new `async_errors.rs` module implementing DB-API exception classes and robust mapping from TDS errors to Python exceptions, including diagnostics propagation. (`mssql-py-core/src/async_errors.rs`)

**DB-API Cursor Attribute and Method Support:**

* Added `arraysize` attribute with getter and setter, and updated `fetchmany()` to use `arraysize` as the default batch size, aligning with DB-API expectations. (`mssql-py-core/src/async_cursor.rs`) [[1]](diffhunk://#diff-85fa845be93caab797168826f6e49584a85ce9577adb715c7dc051dd4919a179R169-R176) [[2]](diffhunk://#diff-85fa845be93caab797168826f6e49584a85ce9577adb715c7dc051dd4919a179R199-R206) [[3]](diffhunk://#diff-85fa845be93caab797168826f6e49584a85ce9577adb715c7dc051dd4919a179R358-R375) [[4]](diffhunk://#diff-85fa845be93caab797168826f6e49584a85ce9577adb715c7dc051dd4919a179R406-R426)
* Implemented standard cursor methods: `fetchmany()`, `fetchall()`, and `nextset()` for batch and result set navigation. (`mssql-py-core/src/async_cursor.rs`)

**Result Set and Metadata Flow:**

* Refactored execution and result set logic to capture and propagate column metadata, enabling accurate population of the `description` attribute and improved batch/result set management. (`mssql-py-core/src/async_execute.rs`, `mssql-py-core/src/async_cursor.rs`) [[1]](diffhunk://#diff-328fea57da508546b0b0692e436ac066b3fd06112caf4d08d601980473401383R8-R24) [[2]](diffhunk://#diff-328fea57da508546b0b0692e436ac066b3fd06112caf4d08d601980473401383L249-R263) [[3]](diffhunk://#diff-85fa845be93caab797168826f6e49584a85ce9577adb715c7dc051dd4919a179R231) [[4]](diffhunk://#diff-85fa845be93caab797168826f6e49584a85ce9577adb715c7dc051dd4919a179R251)

These changes collectively bring the async cursor implementation closer to full Python DB-API 2.0 compatibility and improve the developer experience.

## Related Issues

<!--
Required: link a GitHub issue OR an Azure DevOps work item. The PR check will
fail without one.
GitHub issue: Fixes #123 (or https://github.com/microsoft/mssql-rs/issues/123)
ADO work item: https://sqlclientdrivers.visualstudio.com/<...>/_workitems/edit/<ID>
  (any project/collection path is accepted, e.g. .../<project>/_workitems/edit/123
  or .../DefaultCollection/<project>/_workitems/edit/123)
-->
ADO work item: https://dev.azure.com/SqlClientDrivers/mssql-python/_workitems/edit/47780, https://dev.azure.com/SqlClientDrivers/mssql-python/_workitems/edit/47781, https://dev.azure.com/SqlClientDrivers/mssql-python/_workitems/edit/47782, https://dev.azure.com/SqlClientDrivers/mssql-python/_workitems/edit/47783, https://dev.azure.com/SqlClientDrivers/mssql-python/_workitems/edit/47788

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes
- [x] New/changed functionality has tests
- [ ] Public API changes are documented
