### PR TITLE
Unify mssql-odbc driver artifact naming and address PR #397 review nits

### DIFF
--- a/.github/prompts/verify-odbc-changes.prompt.md
+++ b/.github/prompts/verify-odbc-changes.prompt.md
@@ -33,7 +33,7 @@ applyTo: "mssql-odbc/**"
 ### 5. Testing
 - [ ] Run mssql-odbc unit tests:
   ```bash
-  cargo nextest run -p mssql-odbc
+  cargo nextest run -p mssqlodbc
   ```
 - [ ] Run mssql-odbc end-to-end tests:
   ```bash

--- a/.pipeline/scripts/containerized-build.sh
+++ b/.pipeline/scripts/containerized-build.sh
@@ -26,11 +26,13 @@ cd ..
 if [ "$BUILD_TYPE" = "Debug" ] || [ "$BUILD_TYPE" = "Both" ]; then
   echo '==> Building debug...'
   cargo build --frozen
+  bash mssql-odbc/scripts/finalize-artifact.sh debug
 fi
 
 if [ "$BUILD_TYPE" = "Release" ] || [ "$BUILD_TYPE" = "Both" ]; then
   echo '==> Building release...'
   cargo build --frozen --release
+  bash mssql-odbc/scripts/finalize-artifact.sh release
 fi
 
 # Archive nextest (used by later test stages)

--- a/.pipeline/scripts/containerized-build.sh
+++ b/.pipeline/scripts/containerized-build.sh
@@ -27,12 +27,17 @@ if [ "$BUILD_TYPE" = "Debug" ] || [ "$BUILD_TYPE" = "Both" ]; then
   echo '==> Building debug...'
   cargo build --frozen
   bash mssql-odbc/scripts/finalize-artifact.sh debug
+  # The CopyFiles exclusion in build-template-container.yml hardcodes Cargo's
+  # private library name; fail loudly if a [lib] rename desyncs it, rather than
+  # silently publishing the private artifact next to the shipped one.
+  test -f target/debug/libmssqlodbc.so || { echo 'ERROR: target/debug/libmssqlodbc.so missing; update the CopyFiles exclusion in .pipeline/templates/build-template-container.yml' >&2; exit 1; }
 fi
 
 if [ "$BUILD_TYPE" = "Release" ] || [ "$BUILD_TYPE" = "Both" ]; then
   echo '==> Building release...'
   cargo build --frozen --release
   bash mssql-odbc/scripts/finalize-artifact.sh release
+  test -f target/release/libmssqlodbc.so || { echo 'ERROR: target/release/libmssqlodbc.so missing; update the CopyFiles exclusion in .pipeline/templates/build-template-container.yml' >&2; exit 1; }
 fi
 
 # Archive nextest (used by later test stages)

--- a/.pipeline/scripts/containerized-odbc-build-glibc228.sh
+++ b/.pipeline/scripts/containerized-odbc-build-glibc228.sh
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# Build the mssql-odbc driver (libmsodbcsql18.so) and the C++ gtest e2e binaries
+# Build the mssql-odbc driver (libmssqlodbc.so) and the C++ gtest e2e binaries
 # on a glibc-2.28 base (PyPA manylinux_2_28 = AlmaLinux 8), then stage them into
 # a drop directory the surrounding pipeline job publishes as an artifact. Later
 # the RHEL 8 test stage downloads the drop and reruns the prebuilt binaries via

--- a/.pipeline/scripts/containerized-odbc-build-glibc228.sh
+++ b/.pipeline/scripts/containerized-odbc-build-glibc228.sh
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# Build the mssql-odbc driver (mssql-odbc.so) and the C++ gtest e2e binaries
+# Build the mssql-odbc driver (mssqlodbc.so) and the C++ gtest e2e binaries
 # on a glibc-2.28 base (PyPA manylinux_2_28 = AlmaLinux 8), then stage them into
 # a drop directory the surrounding pipeline job publishes as an artifact. Later
 # the RHEL 8 test stage downloads the drop and reruns the prebuilt binaries via

--- a/.pipeline/scripts/containerized-odbc-build-glibc228.sh
+++ b/.pipeline/scripts/containerized-odbc-build-glibc228.sh
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# Build the mssql-odbc driver (libmssqlodbc.so) and the C++ gtest e2e binaries
+# Build the mssql-odbc driver (mssql-odbc.so) and the C++ gtest e2e binaries
 # on a glibc-2.28 base (PyPA manylinux_2_28 = AlmaLinux 8), then stage them into
 # a drop directory the surrounding pipeline job publishes as an artifact. Later
 # the RHEL 8 test stage downloads the drop and reruns the prebuilt binaries via

--- a/.pipeline/scripts/containerized-odbc-build.sh
+++ b/.pipeline/scripts/containerized-odbc-build.sh
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# Build the mssql-odbc driver (libmssqlodbc.so) and the C++ gtest e2e binaries
+# Build the mssql-odbc driver (mssql-odbc.so) and the C++ gtest e2e binaries
 # inside a Linux build container, then stage them into a drop directory that the
 # surrounding pipeline job publishes as an artifact. Later test stages download
 # the drop and rerun the prebuilt binaries via run_e2e.sh --skip-build.

--- a/.pipeline/scripts/containerized-odbc-build.sh
+++ b/.pipeline/scripts/containerized-odbc-build.sh
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# Build the mssql-odbc driver (mssql-odbc.so) and the C++ gtest e2e binaries
+# Build the mssql-odbc driver (mssqlodbc.so) and the C++ gtest e2e binaries
 # inside a Linux build container, then stage them into a drop directory that the
 # surrounding pipeline job publishes as an artifact. Later test stages download
 # the drop and rerun the prebuilt binaries via run_e2e.sh --skip-build.

--- a/.pipeline/scripts/containerized-odbc-build.sh
+++ b/.pipeline/scripts/containerized-odbc-build.sh
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# Build the mssql-odbc driver (libmsodbcsql18.so) and the C++ gtest e2e binaries
+# Build the mssql-odbc driver (libmssqlodbc.so) and the C++ gtest e2e binaries
 # inside a Linux build container, then stage them into a drop directory that the
 # surrounding pipeline job publishes as an artifact. Later test stages download
 # the drop and rerun the prebuilt binaries via run_e2e.sh --skip-build.

--- a/.pipeline/scripts/containerized-odbc-swap-build.sh
+++ b/.pipeline/scripts/containerized-odbc-swap-build.sh
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# Build just the mssql-odbc cdylib (libmssqlodbc.so) inside the Linux build
+# Build just the mssql-odbc cdylib (mssql-odbc.so) inside the Linux build
 # container and stage it into a drop directory, for the job that swaps it in for
 # the driver mssql-python bundles (see swap-mssql-python-odbc-driver.sh).
 #
@@ -12,7 +12,6 @@
 #
 # Env:
 #   ODBC_DROP_DIR     Drop directory to stage into (default: /workspace/odbc-swap-drop).
-#   CARGO_TARGET_DIR  Cargo target directory, if the job overrides it.
 
 set -euo pipefail
 
@@ -27,9 +26,6 @@ mkdir -p "$DROP_DIR"
 
 cargo build --release -p mssql-odbc
 
-# Honour CARGO_TARGET_DIR the way the sibling build jobs in this stage set it, so
-# adding it here later cannot break the copy after a full release build.
-TARGET_DIR="${CARGO_TARGET_DIR:-/workspace/target}"
-
-cp "$TARGET_DIR/release/libmssqlodbc.so" "$DROP_DIR/"
+DRIVER_PATH="$(bash /workspace/mssql-odbc/scripts/finalize-artifact.sh release)"
+cp "$DRIVER_PATH" "$DROP_DIR/"
 ls -la "$DROP_DIR"

--- a/.pipeline/scripts/containerized-odbc-swap-build.sh
+++ b/.pipeline/scripts/containerized-odbc-swap-build.sh
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# Build just the mssql-odbc cdylib (libmsodbcsql18.so) inside the Linux build
+# Build just the mssql-odbc cdylib (libmssqlodbc.so) inside the Linux build
 # container and stage it into a drop directory, for the job that swaps it in for
 # the driver mssql-python bundles (see swap-mssql-python-odbc-driver.sh).
 #
@@ -31,5 +31,5 @@ cargo build --release -p mssql-odbc
 # adding it here later cannot break the copy after a full release build.
 TARGET_DIR="${CARGO_TARGET_DIR:-/workspace/target}"
 
-cp "$TARGET_DIR/release/libmsodbcsql18.so" "$DROP_DIR/"
+cp "$TARGET_DIR/release/libmssqlodbc.so" "$DROP_DIR/"
 ls -la "$DROP_DIR"

--- a/.pipeline/scripts/containerized-odbc-swap-build.sh
+++ b/.pipeline/scripts/containerized-odbc-swap-build.sh
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# Build just the mssql-odbc cdylib (mssql-odbc.so) inside the Linux build
+# Build just the mssql-odbc cdylib (mssqlodbc.so) inside the Linux build
 # container and stage it into a drop directory, for the job that swaps it in for
 # the driver mssql-python bundles (see swap-mssql-python-odbc-driver.sh).
 #
@@ -24,8 +24,8 @@ DROP_DIR="${ODBC_DROP_DIR:-/workspace/odbc-swap-drop}"
 rm -rf "$DROP_DIR"
 mkdir -p "$DROP_DIR"
 
-cargo build --release -p mssql-odbc
+cargo build --release -p mssqlodbc
 
-DRIVER_PATH="$(bash /workspace/mssql-odbc/scripts/finalize-artifact.sh release)"
+DRIVER_PATH="$(bash mssql-odbc/scripts/finalize-artifact.sh release)"
 cp "$DRIVER_PATH" "$DROP_DIR/"
 ls -la "$DROP_DIR"

--- a/.pipeline/scripts/containerized-test.sh
+++ b/.pipeline/scripts/containerized-test.sh
@@ -13,8 +13,8 @@ mkdir -p /workspace/target/nextest/ci
 # mssql-odbc is a workspace member but was excluded by the mssql-tds-only filter.
 # Include it so its Rust unit tests run and land in the shared JUnit report. Its
 # pure-Rust unit tests need no SQL Server; the C++ e2e suite runs separately.
-cargo llvm-cov nextest "$@" --frozen --no-report --all-targets --package mssql-tds --package mssql-odbc --no-fail-fast --profile ci --success-output immediate
+cargo llvm-cov nextest "$@" --frozen --no-report --all-targets --package mssql-tds --package mssqlodbc --no-fail-fast --profile ci --success-output immediate
 
 echo '==> Generating coverage report...'
-cargo llvm-cov report --package mssql-tds --package mssql-odbc --lcov --output-path /workspace/target/lcov.info
-cargo llvm-cov report --package mssql-tds --package mssql-odbc --cobertura --output-path /workspace/target/cobertura.xml
+cargo llvm-cov report --package mssql-tds --package mssqlodbc --lcov --output-path /workspace/target/lcov.info
+cargo llvm-cov report --package mssql-tds --package mssqlodbc --cobertura --output-path /workspace/target/cobertura.xml

--- a/.pipeline/scripts/swap-mssql-python-odbc-driver.sh
+++ b/.pipeline/scripts/swap-mssql-python-odbc-driver.sh
@@ -17,7 +17,7 @@
 # the result does not depend on which one wins on sys.path.
 #
 # Env:
-#   MSSQL_ODBC_DRIVER   Path to the shipped mssql-odbc.so (required).
+#   MSSQL_ODBC_DRIVER   Path to the shipped mssqlodbc.so (required).
 #   MSSQL_PYTHON_DIR    mssql-python checkout (default: /workspace).
 
 set -euo pipefail
@@ -26,7 +26,7 @@ MSSQL_PYTHON_DIR="${MSSQL_PYTHON_DIR:-/workspace}"
 DRIVER_SO="${MSSQL_ODBC_DRIVER:-}"
 
 if [ -z "$DRIVER_SO" ] || [ ! -f "$DRIVER_SO" ]; then
-    echo "##[error]MSSQL_ODBC_DRIVER must point at the shipped mssql-odbc.so (got: '${DRIVER_SO:-unset}')"
+    echo "##[error]MSSQL_ODBC_DRIVER must point at the shipped mssqlodbc.so (got: '${DRIVER_SO:-unset}')"
     exit 1
 fi
 

--- a/.pipeline/scripts/swap-mssql-python-odbc-driver.sh
+++ b/.pipeline/scripts/swap-mssql-python-odbc-driver.sh
@@ -17,7 +17,7 @@
 # the result does not depend on which one wins on sys.path.
 #
 # Env:
-#   MSSQL_ODBC_DRIVER   Path to the built libmsodbcsql18.so (required).
+#   MSSQL_ODBC_DRIVER   Path to the built libmssqlodbc.so (required).
 #   MSSQL_PYTHON_DIR    mssql-python checkout (default: /workspace).
 
 set -euo pipefail
@@ -26,7 +26,7 @@ MSSQL_PYTHON_DIR="${MSSQL_PYTHON_DIR:-/workspace}"
 DRIVER_SO="${MSSQL_ODBC_DRIVER:-}"
 
 if [ -z "$DRIVER_SO" ] || [ ! -f "$DRIVER_SO" ]; then
-    echo "##[error]MSSQL_ODBC_DRIVER must point at the built libmsodbcsql18.so (got: '${DRIVER_SO:-unset}')"
+    echo "##[error]MSSQL_ODBC_DRIVER must point at the built libmssqlodbc.so (got: '${DRIVER_SO:-unset}')"
     exit 1
 fi
 

--- a/.pipeline/scripts/swap-mssql-python-odbc-driver.sh
+++ b/.pipeline/scripts/swap-mssql-python-odbc-driver.sh
@@ -17,7 +17,7 @@
 # the result does not depend on which one wins on sys.path.
 #
 # Env:
-#   MSSQL_ODBC_DRIVER   Path to the built libmssqlodbc.so (required).
+#   MSSQL_ODBC_DRIVER   Path to the shipped mssql-odbc.so (required).
 #   MSSQL_PYTHON_DIR    mssql-python checkout (default: /workspace).
 
 set -euo pipefail
@@ -26,7 +26,7 @@ MSSQL_PYTHON_DIR="${MSSQL_PYTHON_DIR:-/workspace}"
 DRIVER_SO="${MSSQL_ODBC_DRIVER:-}"
 
 if [ -z "$DRIVER_SO" ] || [ ! -f "$DRIVER_SO" ]; then
-    echo "##[error]MSSQL_ODBC_DRIVER must point at the built libmssqlodbc.so (got: '${DRIVER_SO:-unset}')"
+    echo "##[error]MSSQL_ODBC_DRIVER must point at the shipped mssql-odbc.so (got: '${DRIVER_SO:-unset}')"
     exit 1
 fi
 

--- a/.pipeline/templates/build-template-container.yml
+++ b/.pipeline/templates/build-template-container.yml
@@ -437,6 +437,7 @@ steps:
     Contents: |
       *
       !.cargo-lock
+      !libmssqlodbc.so
     TargetFolder: '$(Build.ArtifactStagingDirectory)/debug'
 
 - task: CopyFiles@2
@@ -447,6 +448,7 @@ steps:
     Contents: |
       *
       !.cargo-lock
+      !libmssqlodbc.so
     TargetFolder: '$(Build.ArtifactStagingDirectory)/release'
 
 - script: |

--- a/.pipeline/templates/build-template.yml
+++ b/.pipeline/templates/build-template.yml
@@ -120,8 +120,8 @@ steps:
 
   - script: |
         export CERT_HOST_NAME="sql1"
-        cargo llvm-cov nextest ${{ parameters.testFilter }} --frozen --no-report --all-targets --package mssql-tds --package mssql-odbc --no-fail-fast --profile ci --success-output immediate
-    displayName: Run tests (mssql-tds and mssql-odbc packages)
+        cargo llvm-cov nextest ${{ parameters.testFilter }} --frozen --no-report --all-targets --package mssql-tds --package mssqlodbc --no-fail-fast --profile ci --success-output immediate
+    displayName: Run tests (mssql-tds and mssqlodbc packages)
     condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
     env:
       SQL_PASSWORD: $(SQL_PASSWORD)
@@ -139,10 +139,10 @@ steps:
   # `test_client_support.rs` is test-only scaffolding (gated behind the
   # `test-util` feature) used to drive a `TdsClient` from scripted tokens in
   # unit tests; it is not product code, so it is excluded from coverage.
-  - script: cargo llvm-cov report --package mssql-tds --package mssql-odbc --ignore-filename-regex 'test_client_support\.rs' --lcov --output-path "$(Build.SourcesDirectory)/target/lcov.info"
+  - script: cargo llvm-cov report --package mssql-tds --package mssqlodbc --ignore-filename-regex 'test_client_support\.rs' --lcov --output-path "$(Build.SourcesDirectory)/target/lcov.info"
     condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
     workingDirectory: "$(Build.SourcesDirectory)"
-    displayName: Save code coverage in lcov format (mssql-tds and mssql-odbc)
+    displayName: Save code coverage in lcov format (mssql-tds and mssqlodbc)
 
   - ${{ if eq(parameters.osType, 'Linux') }}:
     - bash: |
@@ -159,10 +159,10 @@ steps:
   # with the mssql-py-core Python report and publishes the single combined
   # report to the ADO coverage tab, because ADO does not merge coverage across
   # stages/jobs. The merged report is what the GitHub diff-cover workflow uses.
-  - script: cargo llvm-cov report --package mssql-tds --package mssql-odbc --ignore-filename-regex 'test_client_support\.rs' --cobertura --output-path "$(Build.SourcesDirectory)/target/cobertura.xml"
+  - script: cargo llvm-cov report --package mssql-tds --package mssqlodbc --ignore-filename-regex 'test_client_support\.rs' --cobertura --output-path "$(Build.SourcesDirectory)/target/cobertura.xml"
     condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
     workingDirectory: "$(Build.SourcesDirectory)"
-    displayName: Save code coverage in Cobertura format (mssql-tds and mssql-odbc)
+    displayName: Save code coverage in Cobertura format (mssql-tds and mssqlodbc)
 
   - task: PublishPipelineArtifact@1
     condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))

--- a/.pipeline/templates/test-mssql-python-odbc-template.yml
+++ b/.pipeline/templates/test-mssql-python-odbc-template.yml
@@ -210,7 +210,7 @@ steps:
     set -euo pipefail
     docker exec mssql-python-odbc-tests bash -c '
       source /opt/venv/bin/activate
-      MSSQL_ODBC_DRIVER=/mssql-odbc/libmsodbcsql18.so \
+      MSSQL_ODBC_DRIVER=/mssql-odbc/libmssqlodbc.so \
         bash /mssql-rs-scripts/swap-mssql-python-odbc-driver.sh
     '
   displayName: Replace bundled msodbcsql18 with mssql-odbc

--- a/.pipeline/templates/test-mssql-python-odbc-template.yml
+++ b/.pipeline/templates/test-mssql-python-odbc-template.yml
@@ -210,7 +210,7 @@ steps:
     set -euo pipefail
     docker exec mssql-python-odbc-tests bash -c '
       source /opt/venv/bin/activate
-      MSSQL_ODBC_DRIVER=/mssql-odbc/mssql-odbc.so \
+      MSSQL_ODBC_DRIVER=/mssql-odbc/mssqlodbc.so \
         bash /mssql-rs-scripts/swap-mssql-python-odbc-driver.sh
     '
   displayName: Replace bundled msodbcsql18 with mssql-odbc

--- a/.pipeline/templates/test-mssql-python-odbc-template.yml
+++ b/.pipeline/templates/test-mssql-python-odbc-template.yml
@@ -210,7 +210,7 @@ steps:
     set -euo pipefail
     docker exec mssql-python-odbc-tests bash -c '
       source /opt/venv/bin/activate
-      MSSQL_ODBC_DRIVER=/mssql-odbc/libmssqlodbc.so \
+      MSSQL_ODBC_DRIVER=/mssql-odbc/mssql-odbc.so \
         bash /mssql-rs-scripts/swap-mssql-python-odbc-driver.sh
     '
   displayName: Replace bundled msodbcsql18 with mssql-odbc

--- a/mssql-odbc/Cargo.toml
+++ b/mssql-odbc/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mssql-odbc"
+name = "mssqlodbc"
 version = "0.1.0"
 edition = "2024"
 publish = false

--- a/mssql-odbc/Cargo.toml
+++ b/mssql-odbc/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 publish = false
 
 [lib]
-name = "msodbcsql18"
+name = "mssqlodbc"
 crate-type = ["cdylib"]
 
 [dependencies]

--- a/mssql-odbc/README.md
+++ b/mssql-odbc/README.md
@@ -5,7 +5,7 @@ built on top of [mssql-tds](../mssql-tds).
 
 ## What it does
 
-Produces a shared library (`libmssqlodbc.so` / `libmssqlodbc.dylib` / `mssqlodbc.dll`) that implements
+Ships a shared library (`mssql-odbc.so` / `mssql-odbc.dylib` / `mssql-odbc.dll`) that implements
 the ODBC C API. The ODBC Driver Manager (`unixODBC` on Linux/macOS, `odbc32` on Windows)
 loads it via `dlopen` — applications use standard ODBC calls without knowing the driver
 is written in Rust.
@@ -13,21 +13,28 @@ is written in Rust.
 ## Build
 
 ```bash
-cargo build              # debug build
-cargo build --release    # release build
+cargo build
+bash scripts/finalize-artifact.sh debug
+
+cargo build --release
+bash scripts/finalize-artifact.sh release
 ```
+
+On Windows, run `scripts/finalize-artifact.ps1` with `-Profile debug` or
+`-Profile release` after the corresponding Cargo build. Cargo uses the internal
+target name `mssqlodbc`; the finalization scripts create the shipped artifact.
 
 Output location: `target/{debug,release}/` with a platform-specific filename:
 
 | Platform | Output file |
 |---|---|
-| Linux | `libmssqlodbc.so` |
-| macOS | `libmssqlodbc.dylib` |
-| Windows | `mssqlodbc.dll` |
+| Linux | `mssql-odbc.so` |
+| macOS | `mssql-odbc.dylib` |
+| Windows | `mssql-odbc.dll` |
 
 The `build.rs` script embeds platform-specific metadata:
-- **Linux:** `soname` → `libmssqlodbc.so`
-- **macOS:** `install_name` → `libmssqlodbc.dylib`
+- **Linux:** `soname` → `mssql-odbc.so`
+- **macOS:** `install_name` → `mssql-odbc.dylib`
 - **Windows:** no extra linker args needed
 
 ## Testing
@@ -84,7 +91,7 @@ Application
     ↓ ODBC C API (SQLAllocHandle, SQLDriverConnect, ...)
 Driver Manager (unixODBC / odbc32)
     ↓ dlopen / LoadLibrary
-libmssqlodbc.so (this crate)
+mssql-odbc.so (this crate)
     ↓
 mssql-tds (TDS protocol)
     ↓

--- a/mssql-odbc/README.md
+++ b/mssql-odbc/README.md
@@ -5,7 +5,7 @@ built on top of [mssql-tds](../mssql-tds).
 
 ## What it does
 
-Produces a shared library (`libmsodbcsql18.so` / `libmsodbcsql.18.dylib` / `msodbcsql18.dll`) that implements
+Produces a shared library (`libmssqlodbc.so` / `libmssqlodbc.dylib` / `mssqlodbc.dll`) that implements
 the ODBC C API. The ODBC Driver Manager (`unixODBC` on Linux/macOS, `odbc32` on Windows)
 loads it via `dlopen` — applications use standard ODBC calls without knowing the driver
 is written in Rust.
@@ -21,13 +21,13 @@ Output location: `target/{debug,release}/` with a platform-specific filename:
 
 | Platform | Output file |
 |---|---|
-| Linux | `libmsodbcsql18.so` |
-| macOS | `libmsodbcsql18.dylib` |
-| Windows | `msodbcsql18.dll` |
+| Linux | `libmssqlodbc.so` |
+| macOS | `libmssqlodbc.dylib` |
+| Windows | `mssqlodbc.dll` |
 
 The `build.rs` script embeds platform-specific metadata:
-- **Linux:** `soname` → `libmsodbcsql-18.4.so.1.1`
-- **macOS:** `install_name` → `libmsodbcsql.18.dylib`
+- **Linux:** `soname` → `libmssqlodbc.so`
+- **macOS:** `install_name` → `libmssqlodbc.dylib`
 - **Windows:** no extra linker args needed
 
 ## Testing
@@ -71,10 +71,10 @@ Examples:
 MSSQL_TDS_TRACE=true cargo btest -p mssql-odbc
 
 # ODBC-driver-focused debug logs only
-MSSQL_TDS_TRACE=true MSSQL_TDS_TRACE_LEVEL="warn,msodbcsql18=debug" cargo btest -p mssql-odbc
+MSSQL_TDS_TRACE=true MSSQL_TDS_TRACE_LEVEL="warn,mssqlodbc=debug" cargo btest -p mssql-odbc
 
 # Full filter syntax is supported
-MSSQL_TDS_TRACE=true MSSQL_TDS_TRACE_LEVEL="warn,msodbcsql18=debug,mssql_tds=off" cargo btest -p mssql-odbc
+MSSQL_TDS_TRACE=true MSSQL_TDS_TRACE_LEVEL="warn,mssqlodbc=debug,mssql_tds=off" cargo btest -p mssql-odbc
 ```
 
 ## Architecture
@@ -84,7 +84,7 @@ Application
     ↓ ODBC C API (SQLAllocHandle, SQLDriverConnect, ...)
 Driver Manager (unixODBC / odbc32)
     ↓ dlopen / LoadLibrary
-libmsodbcsql18.so (this crate)
+libmssqlodbc.so (this crate)
     ↓
 mssql-tds (TDS protocol)
     ↓

--- a/mssql-odbc/README.md
+++ b/mssql-odbc/README.md
@@ -5,7 +5,7 @@ built on top of [mssql-tds](../mssql-tds).
 
 ## What it does
 
-Ships a shared library (`mssql-odbc.so` / `mssql-odbc.dylib` / `mssql-odbc.dll`) that implements
+Ships a shared library (`mssqlodbc.so` / `mssqlodbc.dylib` / `mssqlodbc.dll`) that implements
 the ODBC C API. The ODBC Driver Manager (`unixODBC` on Linux/macOS, `odbc32` on Windows)
 loads it via `dlopen` — applications use standard ODBC calls without knowing the driver
 is written in Rust.
@@ -20,21 +20,21 @@ cargo build --release
 bash scripts/finalize-artifact.sh release
 ```
 
-On Windows, run `scripts/finalize-artifact.ps1` with `-Profile debug` or
-`-Profile release` after the corresponding Cargo build. Cargo uses the internal
+On Windows, run `scripts/finalize-artifact.ps1` with `-BuildProfile debug` or
+`-BuildProfile release` after the corresponding Cargo build. Cargo uses the internal
 target name `mssqlodbc`; the finalization scripts create the shipped artifact.
 
 Output location: `target/{debug,release}/` with a platform-specific filename:
 
 | Platform | Output file |
 |---|---|
-| Linux | `mssql-odbc.so` |
-| macOS | `mssql-odbc.dylib` |
-| Windows | `mssql-odbc.dll` |
+| Linux | `mssqlodbc.so` |
+| macOS | `mssqlodbc.dylib` |
+| Windows | `mssqlodbc.dll` |
 
 The `build.rs` script embeds platform-specific metadata:
-- **Linux:** `soname` → `mssql-odbc.so`
-- **macOS:** `install_name` → `mssql-odbc.dylib`
+- **Linux:** `soname` → `mssqlodbc.so`
+- **macOS:** `install_name` → `mssqlodbc.dylib`
 - **Windows:** no extra linker args needed
 
 ## Testing
@@ -42,7 +42,7 @@ The `build.rs` script embeds platform-specific metadata:
 ### Rust unit tests
 
 ```bash
-cargo btest -p mssql-odbc
+cargo btest -p mssqlodbc
 ```
 
 ### C++ e2e tests (Google Test)
@@ -75,13 +75,13 @@ Examples:
 
 ```bash
 # Enable default warn-level logging
-MSSQL_TDS_TRACE=true cargo btest -p mssql-odbc
+MSSQL_TDS_TRACE=true cargo btest -p mssqlodbc
 
 # ODBC-driver-focused debug logs only
-MSSQL_TDS_TRACE=true MSSQL_TDS_TRACE_LEVEL="warn,mssqlodbc=debug" cargo btest -p mssql-odbc
+MSSQL_TDS_TRACE=true MSSQL_TDS_TRACE_LEVEL="warn,mssqlodbc=debug" cargo btest -p mssqlodbc
 
 # Full filter syntax is supported
-MSSQL_TDS_TRACE=true MSSQL_TDS_TRACE_LEVEL="warn,mssqlodbc=debug,mssql_tds=off" cargo btest -p mssql-odbc
+MSSQL_TDS_TRACE=true MSSQL_TDS_TRACE_LEVEL="warn,mssqlodbc=debug,mssql_tds=off" cargo btest -p mssqlodbc
 ```
 
 ## Architecture
@@ -91,7 +91,7 @@ Application
     ↓ ODBC C API (SQLAllocHandle, SQLDriverConnect, ...)
 Driver Manager (unixODBC / odbc32)
     ↓ dlopen / LoadLibrary
-mssql-odbc.so (this crate)
+mssqlodbc.so (this crate)
     ↓
 mssql-tds (TDS protocol)
     ↓

--- a/mssql-odbc/build.rs
+++ b/mssql-odbc/build.rs
@@ -6,12 +6,12 @@ fn main() {
 
     match target_os.as_str() {
         "linux" => {
-            // Embed soname: libmssqlodbc.so
-            println!("cargo:rustc-cdylib-link-arg=-Wl,-soname,libmssqlodbc.so");
+            // Embed soname: mssql-odbc.so
+            println!("cargo:rustc-cdylib-link-arg=-Wl,-soname,mssql-odbc.so");
         }
         "macos" => {
-            // Embed install name: libmssqlodbc.dylib
-            println!("cargo:rustc-cdylib-link-arg=-Wl,-install_name,libmssqlodbc.dylib");
+            // Embed install name: mssql-odbc.dylib
+            println!("cargo:rustc-cdylib-link-arg=-Wl,-install_name,mssql-odbc.dylib");
         }
         _ => {}
     }

--- a/mssql-odbc/build.rs
+++ b/mssql-odbc/build.rs
@@ -4,14 +4,21 @@
 fn main() {
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
 
+    // Single source of truth for the shipped driver filename: the SONAME, the
+    // macOS install name, and `driver_name()` (via `env!`) all read this.
+    let artifact = match target_os.as_str() {
+        "windows" => "mssqlodbc.dll",
+        "macos" => "mssqlodbc.dylib",
+        _ => "mssqlodbc.so",
+    };
+    println!("cargo:rustc-env=MSSQL_ODBC_ARTIFACT={artifact}");
+
     match target_os.as_str() {
         "linux" => {
-            // Embed soname: mssql-odbc.so
-            println!("cargo:rustc-cdylib-link-arg=-Wl,-soname,mssql-odbc.so");
+            println!("cargo:rustc-cdylib-link-arg=-Wl,-soname,{artifact}");
         }
         "macos" => {
-            // Embed install name: mssql-odbc.dylib
-            println!("cargo:rustc-cdylib-link-arg=-Wl,-install_name,mssql-odbc.dylib");
+            println!("cargo:rustc-cdylib-link-arg=-Wl,-install_name,{artifact}");
         }
         _ => {}
     }

--- a/mssql-odbc/build.rs
+++ b/mssql-odbc/build.rs
@@ -6,12 +6,12 @@ fn main() {
 
     match target_os.as_str() {
         "linux" => {
-            // Embed soname: libmsodbcsql-18.4.so.1.1
-            println!("cargo:rustc-cdylib-link-arg=-Wl,-soname,libmsodbcsql-18.4.so.1.1");
+            // Embed soname: libmssqlodbc.so
+            println!("cargo:rustc-cdylib-link-arg=-Wl,-soname,libmssqlodbc.so");
         }
         "macos" => {
-            // Embed install name: libmsodbcsql.18.dylib
-            println!("cargo:rustc-cdylib-link-arg=-Wl,-install_name,libmsodbcsql.18.dylib");
+            // Embed install name: libmssqlodbc.dylib
+            println!("cargo:rustc-cdylib-link-arg=-Wl,-install_name,libmssqlodbc.dylib");
         }
         _ => {}
     }

--- a/mssql-odbc/docs/connection_string_parser.md
+++ b/mssql-odbc/docs/connection_string_parser.md
@@ -223,4 +223,4 @@ Exhaustive unit tests live in the `#[cfg(test)] mod tests` block of
 table above plus
 value validation, first-wins duplicates, whitespace fidelity, `}}` escaping,
 separator/empty-input edge cases, and the `S_OK` / `S_FALSE` / `E_FAIL` mapping.
-Run them with `cargo btest` (or `cargo nextest run -p mssql-odbc`).
+Run them with `cargo btest` (or `cargo nextest run -p mssqlodbc`).

--- a/mssql-odbc/plan.md
+++ b/mssql-odbc/plan.md
@@ -9,7 +9,7 @@ This project delivers a **production-ready ODBC Driver 18 for SQL Server written
 The driver wraps the `mssql-tds` library (TDS protocol implementation, workspace-local path dependency) with a full ODBC 3.x API layer — ~78 exported functions (including W wide-char variants) covering connectivity, query execution, data types, authentication, encryption, bulk operations, and more.
 
 **Target platforms**: Windows, Linux, macOS (x64 and ARM64) - Same as the platforms currently supported by msodbcsql
-**Binary output**: `mssql-odbc.dll` (Windows), `mssql-odbc.so` (Linux), `mssql-odbc.dylib` (macOS)
+**Binary output**: `mssqlodbc.dll` (Windows), `mssqlodbc.so` (Linux), `mssqlodbc.dylib` (macOS)
 
 ---
 

--- a/mssql-odbc/plan.md
+++ b/mssql-odbc/plan.md
@@ -9,7 +9,7 @@ This project delivers a **production-ready ODBC Driver 18 for SQL Server written
 The driver wraps the `mssql-tds` library (TDS protocol implementation, workspace-local path dependency) with a full ODBC 3.x API layer — ~78 exported functions (including W wide-char variants) covering connectivity, query execution, data types, authentication, encryption, bulk operations, and more.
 
 **Target platforms**: Windows, Linux, macOS (x64 and ARM64) - Same as the platforms currently supported by msodbcsql
-**Binary output**: `mssqlodbc.dll` (Windows), `libmssqlodbc.so` (Linux), `libmssqlodbc.dylib` (macOS)
+**Binary output**: `mssql-odbc.dll` (Windows), `mssql-odbc.so` (Linux), `mssql-odbc.dylib` (macOS)
 
 ---
 

--- a/mssql-odbc/plan.md
+++ b/mssql-odbc/plan.md
@@ -9,7 +9,7 @@ This project delivers a **production-ready ODBC Driver 18 for SQL Server written
 The driver wraps the `mssql-tds` library (TDS protocol implementation, workspace-local path dependency) with a full ODBC 3.x API layer — ~78 exported functions (including W wide-char variants) covering connectivity, query execution, data types, authentication, encryption, bulk operations, and more.
 
 **Target platforms**: Windows, Linux, macOS (x64 and ARM64) - Same as the platforms currently supported by msodbcsql
-**Binary output**: `msodbcsql18.dll` (Windows), `libmsodbcsql-18.so.1.1` (Linux), `libmsodbcsql.18.dylib` (macOS)
+**Binary output**: `mssqlodbc.dll` (Windows), `libmssqlodbc.so` (Linux), `libmssqlodbc.dylib` (macOS)
 
 ---
 

--- a/mssql-odbc/scripts/finalize-artifact.ps1
+++ b/mssql-odbc/scripts/finalize-artifact.ps1
@@ -1,0 +1,29 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+param(
+    [ValidateSet("debug", "release")]
+    [string]$Profile = "debug"
+)
+
+$ErrorActionPreference = "Stop"
+$OdbcCrateDir = Split-Path -Parent $PSScriptRoot
+
+Push-Location $OdbcCrateDir
+try {
+    $Metadata = cargo metadata --format-version 1 --no-deps 2>$null | ConvertFrom-Json
+    if (-not $Metadata.target_directory) {
+        throw "cargo metadata did not return a target directory"
+    }
+} finally {
+    Pop-Location
+}
+
+$SourcePath = Join-Path $Metadata.target_directory "$Profile\mssqlodbc.dll"
+$ProductPath = Join-Path $Metadata.target_directory "$Profile\mssql-odbc.dll"
+if (-not (Test-Path $SourcePath -PathType Leaf)) {
+    throw "Cargo artifact not found at $SourcePath"
+}
+
+Copy-Item -Force $SourcePath $ProductPath
+(Resolve-Path $ProductPath).Path

--- a/mssql-odbc/scripts/finalize-artifact.ps1
+++ b/mssql-odbc/scripts/finalize-artifact.ps1
@@ -3,7 +3,7 @@
 
 param(
     [ValidateSet("debug", "release")]
-    [string]$Profile = "debug"
+    [string]$BuildProfile = "debug"
 )
 
 $ErrorActionPreference = "Stop"
@@ -19,11 +19,11 @@ try {
     Pop-Location
 }
 
-$SourcePath = Join-Path $Metadata.target_directory "$Profile\mssqlodbc.dll"
-$ProductPath = Join-Path $Metadata.target_directory "$Profile\mssql-odbc.dll"
-if (-not (Test-Path $SourcePath -PathType Leaf)) {
-    throw "Cargo artifact not found at $SourcePath"
+# On Windows the Cargo cdylib output has no `lib` prefix, so it already carries
+# the shipped basename `mssqlodbc.dll`. No copy is needed; just resolve it.
+$ArtifactPath = Join-Path $Metadata.target_directory "$BuildProfile\mssqlodbc.dll"
+if (-not (Test-Path $ArtifactPath -PathType Leaf)) {
+    throw "Cargo artifact not found at $ArtifactPath"
 }
 
-Copy-Item -Force $SourcePath $ProductPath
-(Resolve-Path $ProductPath).Path
+(Resolve-Path $ArtifactPath).Path

--- a/mssql-odbc/scripts/finalize-artifact.sh
+++ b/mssql-odbc/scripts/finalize-artifact.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+set -euo pipefail
+
+PROFILE="${1:-debug}"
+case "$PROFILE" in
+    debug|release) ;;
+    *) echo "Usage: $0 [debug|release]" >&2; exit 2 ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ODBC_CRATE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TARGET_DIR="$(cd "$ODBC_CRATE_DIR" \
+    && cargo metadata --format-version 1 --no-deps 2>/dev/null \
+    | grep -o '"target_directory":"[^"]*"' | head -n1 \
+    | sed 's/^"target_directory":"//; s/"$//')"
+
+case "$(uname -s)" in
+    Darwin)
+        CARGO_ARTIFACT="libmssqlodbc.dylib"
+        PRODUCT_ARTIFACT="mssql-odbc.dylib"
+        ;;
+    Linux)
+        CARGO_ARTIFACT="libmssqlodbc.so"
+        PRODUCT_ARTIFACT="mssql-odbc.so"
+        ;;
+    *)
+        echo "Error: use finalize-artifact.ps1 on Windows" >&2
+        exit 1
+        ;;
+esac
+
+SOURCE_PATH="$TARGET_DIR/$PROFILE/$CARGO_ARTIFACT"
+PRODUCT_PATH="$TARGET_DIR/$PROFILE/$PRODUCT_ARTIFACT"
+if [ ! -f "$SOURCE_PATH" ]; then
+    echo "Error: Cargo artifact not found at $SOURCE_PATH" >&2
+    exit 1
+fi
+
+cp -f "$SOURCE_PATH" "$PRODUCT_PATH"
+printf '%s\n' "$PRODUCT_PATH"

--- a/mssql-odbc/scripts/finalize-artifact.sh
+++ b/mssql-odbc/scripts/finalize-artifact.sh
@@ -12,19 +12,25 @@ esac
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ODBC_CRATE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-TARGET_DIR="$(cd "$ODBC_CRATE_DIR" \
-    && cargo metadata --format-version 1 --no-deps 2>/dev/null \
+if ! METADATA="$(cd "$ODBC_CRATE_DIR" && cargo metadata --format-version 1 --no-deps)"; then
+    echo "Error: could not resolve Cargo target directory (is cargo on PATH?)" >&2
+    exit 1
+fi
+if ! TARGET_DIR="$(printf '%s\n' "$METADATA" \
     | grep -o '"target_directory":"[^"]*"' | head -n1 \
-    | sed 's/^"target_directory":"//; s/"$//')"
+    | sed 's/^"target_directory":"//; s/"$//')" || [ -z "$TARGET_DIR" ]; then
+    echo "Error: cargo metadata did not return a target directory" >&2
+    exit 1
+fi
 
 case "$(uname -s)" in
     Darwin)
         CARGO_ARTIFACT="libmssqlodbc.dylib"
-        PRODUCT_ARTIFACT="mssql-odbc.dylib"
+        PRODUCT_ARTIFACT="mssqlodbc.dylib"
         ;;
     Linux)
         CARGO_ARTIFACT="libmssqlodbc.so"
-        PRODUCT_ARTIFACT="mssql-odbc.so"
+        PRODUCT_ARTIFACT="mssqlodbc.so"
         ;;
     *)
         echo "Error: use finalize-artifact.ps1 on Windows" >&2

--- a/mssql-odbc/src/api/exports.rs
+++ b/mssql-odbc/src/api/exports.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Exported ODBC entry points for the msodbcsql18 shared library.
+//! Exported ODBC entry points for the mssqlodbc shared library.
 //!
 //! Every `#[unsafe(no_mangle)] pub extern "C"` function that appears in the
 //! driver's symbol table is listed here. Implementations live in sibling

--- a/mssql-odbc/src/api/exports.rs
+++ b/mssql-odbc/src/api/exports.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Exported ODBC entry points for the mssqlodbc shared library.
+//! Exported ODBC entry points for the mssql-odbc shared library.
 //!
 //! Every `#[unsafe(no_mangle)] pub extern "C"` function that appears in the
 //! driver's symbol table is listed here. Implementations live in sibling

--- a/mssql-odbc/src/api/exports.rs
+++ b/mssql-odbc/src/api/exports.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Exported ODBC entry points for the mssql-odbc shared library.
+//! Exported ODBC entry points for the mssqlodbc shared library.
 //!
 //! Every `#[unsafe(no_mangle)] pub extern "C"` function that appears in the
 //! driver's symbol table is listed here. Implementations live in sibling

--- a/mssql-odbc/src/api/get_info.rs
+++ b/mssql-odbc/src/api/get_info.rs
@@ -268,19 +268,9 @@ fn write_wide_str(
     }
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
 fn driver_name() -> &'static str {
-    "mssql-odbc.dll"
-}
-
-#[cfg(target_os = "linux")]
-fn driver_name() -> &'static str {
-    "mssql-odbc.so"
-}
-
-#[cfg(target_os = "macos")]
-fn driver_name() -> &'static str {
-    "mssql-odbc.dylib"
+    env!("MSSQL_ODBC_ARTIFACT")
 }
 
 #[cfg(test)]
@@ -383,11 +373,11 @@ mod tests {
     #[test]
     fn driver_name_writes_wide_string() {
         #[cfg(target_os = "windows")]
-        let expected = "mssql-odbc.dll";
+        let expected = "mssqlodbc.dll";
         #[cfg(target_os = "linux")]
-        let expected = "mssql-odbc.so";
+        let expected = "mssqlodbc.so";
         #[cfg(target_os = "macos")]
-        let expected = "mssql-odbc.dylib";
+        let expected = "mssqlodbc.dylib";
 
         assert_eq!(driver_name(), expected);
 

--- a/mssql-odbc/src/api/get_info.rs
+++ b/mssql-odbc/src/api/get_info.rs
@@ -268,7 +268,6 @@ fn write_wide_str(
     }
 }
 
-#[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
 fn driver_name() -> &'static str {
     env!("MSSQL_ODBC_ARTIFACT")
 }

--- a/mssql-odbc/src/api/get_info.rs
+++ b/mssql-odbc/src/api/get_info.rs
@@ -270,17 +270,17 @@ fn write_wide_str(
 
 #[cfg(target_os = "windows")]
 fn driver_name() -> &'static str {
-    "mssqlodbc.dll"
+    "mssql-odbc.dll"
 }
 
 #[cfg(target_os = "linux")]
 fn driver_name() -> &'static str {
-    "libmssqlodbc.so"
+    "mssql-odbc.so"
 }
 
 #[cfg(target_os = "macos")]
 fn driver_name() -> &'static str {
-    "libmssqlodbc.dylib"
+    "mssql-odbc.dylib"
 }
 
 #[cfg(test)]

--- a/mssql-odbc/src/api/get_info.rs
+++ b/mssql-odbc/src/api/get_info.rs
@@ -382,6 +382,15 @@ mod tests {
 
     #[test]
     fn driver_name_writes_wide_string() {
+        #[cfg(target_os = "windows")]
+        let expected = "mssql-odbc.dll";
+        #[cfg(target_os = "linux")]
+        let expected = "mssql-odbc.so";
+        #[cfg(target_os = "macos")]
+        let expected = "mssql-odbc.dylib";
+
+        assert_eq!(driver_name(), expected);
+
         let h = TestHandles::with_env_dbc();
         let mut buf = [0u16; 64];
         let mut len: SqlSmallInt = -1;
@@ -395,7 +404,6 @@ mod tests {
             )
         };
         assert_eq!(rc, SQL_SUCCESS);
-        let expected = driver_name();
         assert_eq!(len, (expected.encode_utf16().count() * 2) as SqlSmallInt);
         let n = (len as usize) / 2;
         assert_eq!(String::from_utf16_lossy(&buf[..n]), expected);

--- a/mssql-odbc/src/api/get_info.rs
+++ b/mssql-odbc/src/api/get_info.rs
@@ -270,17 +270,17 @@ fn write_wide_str(
 
 #[cfg(target_os = "windows")]
 fn driver_name() -> &'static str {
-    "msodbcsql18.dll"
+    "mssqlodbc.dll"
 }
 
 #[cfg(target_os = "linux")]
 fn driver_name() -> &'static str {
-    "libmsodbcsql18.so"
+    "libmssqlodbc.so"
 }
 
 #[cfg(target_os = "macos")]
 fn driver_name() -> &'static str {
-    "libmsodbcsql18.dylib"
+    "libmssqlodbc.dylib"
 }
 
 #[cfg(test)]

--- a/mssql-odbc/tests/e2e/README.md
+++ b/mssql-odbc/tests/e2e/README.md
@@ -274,8 +274,8 @@ running the tests.
   substituting your chosen driver name for `<driver name>`:
   ```
   HKLM\Software\ODBC\ODBCINST.INI\<driver name>
-      Driver = <path to mssql-odbc.dll>
-      Setup  = <path to mssql-odbc.dll>
+      Driver = <path to mssqlodbc.dll>
+      Setup  = <path to mssqlodbc.dll>
 
   HKLM\Software\ODBC\ODBCINST.INI\ODBC Drivers
       <driver name> = Installed
@@ -383,11 +383,11 @@ splits the flow into a build half and a run half so a single set of binaries can
 be exercised on many Linux versions:
 
 - **`build_e2e.sh [--release] [--out=DIR]`** — builds the Rust driver and the
-  C++ gtest binaries, then stages `build/` (with `mssql-odbc.so` copied
+  C++ gtest binaries, then stages `build/` (with `mssqlodbc.so` copied
   inside) into `DIR`. That directory is published as a pipeline artifact.
 - **`run_e2e.sh --skip-build [--driver=PATH]`** — skips all compilation. It
   restores the prebuilt `build/` tree, auto-resolves the driver from
-  `build/mssql-odbc.so` (or `--driver`), registers it, and reruns the
+  `build/mssqlodbc.so` (or `--driver`), registers it, and reruns the
   prebuilt binaries via CTest.
 
 `CTestTestfile.cmake` bakes **absolute** paths to the test executables, so the

--- a/mssql-odbc/tests/e2e/README.md
+++ b/mssql-odbc/tests/e2e/README.md
@@ -274,8 +274,8 @@ running the tests.
   substituting your chosen driver name for `<driver name>`:
   ```
   HKLM\Software\ODBC\ODBCINST.INI\<driver name>
-      Driver = <path to mssqlodbc.dll>
-      Setup  = <path to mssqlodbc.dll>
+      Driver = <path to mssql-odbc.dll>
+      Setup  = <path to mssql-odbc.dll>
 
   HKLM\Software\ODBC\ODBCINST.INI\ODBC Drivers
       <driver name> = Installed
@@ -383,11 +383,11 @@ splits the flow into a build half and a run half so a single set of binaries can
 be exercised on many Linux versions:
 
 - **`build_e2e.sh [--release] [--out=DIR]`** — builds the Rust driver and the
-  C++ gtest binaries, then stages `build/` (with `libmssqlodbc.so` copied
+  C++ gtest binaries, then stages `build/` (with `mssql-odbc.so` copied
   inside) into `DIR`. That directory is published as a pipeline artifact.
 - **`run_e2e.sh --skip-build [--driver=PATH]`** — skips all compilation. It
   restores the prebuilt `build/` tree, auto-resolves the driver from
-  `build/libmssqlodbc.so` (or `--driver`), registers it, and reruns the
+  `build/mssql-odbc.so` (or `--driver`), registers it, and reruns the
   prebuilt binaries via CTest.
 
 `CTestTestfile.cmake` bakes **absolute** paths to the test executables, so the

--- a/mssql-odbc/tests/e2e/README.md
+++ b/mssql-odbc/tests/e2e/README.md
@@ -53,14 +53,14 @@ tests/e2e/
 In `--verbose` mode, `run_e2e.sh` defaults to:
 
 - `MSSQL_TDS_TRACE=true`
-- `MSSQL_TDS_TRACE_LEVEL=warn,msodbcsql18=debug`
+- `MSSQL_TDS_TRACE_LEVEL=warn,mssqlodbc=debug`
 
 unless those variables are already set in your environment.
 
 To override the verbose default filter:
 
 ```bash
-MSSQL_TDS_TRACE_LEVEL="warn,msodbcsql18=trace" ./run_e2e.sh --verbose
+MSSQL_TDS_TRACE_LEVEL="warn,mssqlodbc=trace" ./run_e2e.sh --verbose
 ```
 
 ### Comparing against msodbcsql 18
@@ -274,8 +274,8 @@ running the tests.
   substituting your chosen driver name for `<driver name>`:
   ```
   HKLM\Software\ODBC\ODBCINST.INI\<driver name>
-      Driver = <path to msodbcsql18.dll>
-      Setup  = <path to msodbcsql18.dll>
+      Driver = <path to mssqlodbc.dll>
+      Setup  = <path to mssqlodbc.dll>
 
   HKLM\Software\ODBC\ODBCINST.INI\ODBC Drivers
       <driver name> = Installed
@@ -383,11 +383,11 @@ splits the flow into a build half and a run half so a single set of binaries can
 be exercised on many Linux versions:
 
 - **`build_e2e.sh [--release] [--out=DIR]`** — builds the Rust driver and the
-  C++ gtest binaries, then stages `build/` (with `libmsodbcsql18.so` copied
+  C++ gtest binaries, then stages `build/` (with `libmssqlodbc.so` copied
   inside) into `DIR`. That directory is published as a pipeline artifact.
 - **`run_e2e.sh --skip-build [--driver=PATH]`** — skips all compilation. It
   restores the prebuilt `build/` tree, auto-resolves the driver from
-  `build/libmsodbcsql18.so` (or `--driver`), registers it, and reruns the
+  `build/libmssqlodbc.so` (or `--driver`), registers it, and reruns the
   prebuilt binaries via CTest.
 
 `CTestTestfile.cmake` bakes **absolute** paths to the test executables, so the

--- a/mssql-odbc/tests/e2e/build_e2e.sh
+++ b/mssql-odbc/tests/e2e/build_e2e.sh
@@ -43,9 +43,9 @@ done
 # Resolve the driver shared-library filename for this platform.
 # ----------------------------------------------------------------------------
 if [[ "$(uname -s)" == "Darwin" ]]; then
-    DRIVER_FILE="libmsodbcsql18.dylib"
+    DRIVER_FILE="libmssqlodbc.dylib"
 else
-    DRIVER_FILE="libmsodbcsql18.so"
+    DRIVER_FILE="libmssqlodbc.so"
 fi
 
 # ----------------------------------------------------------------------------

--- a/mssql-odbc/tests/e2e/build_e2e.sh
+++ b/mssql-odbc/tests/e2e/build_e2e.sh
@@ -43,9 +43,9 @@ done
 # Resolve the driver shared-library filename for this platform.
 # ----------------------------------------------------------------------------
 if [[ "$(uname -s)" == "Darwin" ]]; then
-    DRIVER_FILE="mssql-odbc.dylib"
+    DRIVER_FILE="mssqlodbc.dylib"
 else
-    DRIVER_FILE="mssql-odbc.so"
+    DRIVER_FILE="mssqlodbc.so"
 fi
 
 # ----------------------------------------------------------------------------

--- a/mssql-odbc/tests/e2e/build_e2e.sh
+++ b/mssql-odbc/tests/e2e/build_e2e.sh
@@ -43,9 +43,9 @@ done
 # Resolve the driver shared-library filename for this platform.
 # ----------------------------------------------------------------------------
 if [[ "$(uname -s)" == "Darwin" ]]; then
-    DRIVER_FILE="libmssqlodbc.dylib"
+    DRIVER_FILE="mssql-odbc.dylib"
 else
-    DRIVER_FILE="libmssqlodbc.so"
+    DRIVER_FILE="mssql-odbc.so"
 fi
 
 # ----------------------------------------------------------------------------
@@ -61,24 +61,7 @@ echo "=== Building mssql-odbc driver ($BUILD_TYPE) ==="
     fi
 )
 
-# Resolve the Cargo target dir (workspace-level for a workspace member) without
-# depending on python3/jq, which the musl (Alpine) build image doesn't ship.
-TARGET_DIR="$(cd "$ODBC_CRATE_DIR" \
-    && cargo metadata --format-version 1 --no-deps 2>/dev/null \
-    | grep -o '"target_directory":"[^"]*"' | head -n1 \
-    | sed 's/^"target_directory":"//; s/"$//' || true)"
-if [ -z "$TARGET_DIR" ]; then
-    # Fallback: workspace-root target first, then a standalone crate build.
-    for cand in "$ODBC_CRATE_DIR/../target" "$ODBC_CRATE_DIR/target"; do
-        if [ -f "$cand/$BUILD_TYPE/$DRIVER_FILE" ]; then TARGET_DIR="$cand"; break; fi
-    done
-fi
-DRIVER_PATH="$TARGET_DIR/$BUILD_TYPE/$DRIVER_FILE"
-
-if [ ! -f "$DRIVER_PATH" ]; then
-    echo "Error: Rust driver not found at $DRIVER_PATH" >&2
-    exit 1
-fi
+DRIVER_PATH="$(bash "$ODBC_CRATE_DIR/scripts/finalize-artifact.sh" "$BUILD_TYPE")"
 echo "Driver: $DRIVER_PATH"
 
 # ----------------------------------------------------------------------------

--- a/mssql-odbc/tests/e2e/run_e2e.ps1
+++ b/mssql-odbc/tests/e2e/run_e2e.ps1
@@ -432,7 +432,7 @@ function Write-ParityReport([string]$RustXml, [string]$MsXml) {
 # distinct gtest processes and ctest retries never clobber each other's .profraw).
 # PowerShell has no `eval`, so parse each KEY=VALUE line (stripping surrounding
 # quotes) into the process env. The subsequent `cargo build` then produces an
-# instrumented mssqlodbc.dll, and every ctest child process inherits
+# instrumented mssql-odbc.dll, and every ctest child process inherits
 # LLVM_PROFILE_FILE from this environment. The llvm-cov target dir is also
 # exported so the later `cargo metadata` resolves the INSTRUMENTED DLL.
 function Enable-CoverageInstrumentation {
@@ -604,23 +604,7 @@ try {
         Pop-Location
     }
 
-    # Cargo builds into the workspace root's target/ by default, but honors
-    # CARGO_TARGET_DIR (set by CI). Resolve via `cargo metadata` so the driver is
-    # found regardless of where it landed.
-    $TargetDir = $null
-    Push-Location $OdbcCrateDir
-    try {
-        $meta = cargo metadata --format-version 1 --no-deps 2>$null | ConvertFrom-Json
-        if ($meta -and $meta.target_directory) { $TargetDir = $meta.target_directory }
-    } catch { }
-    Pop-Location
-    if (-not $TargetDir) { $TargetDir = Join-Path $WorkspaceDir "target" }
-
-    $DriverPath = Join-Path $TargetDir "$BuildType\mssqlodbc.dll"
-    if (-not (Test-Path $DriverPath)) {
-        Write-Error "Driver not found at $DriverPath"
-    }
-    $DriverPath = (Resolve-Path $DriverPath).Path
+    $DriverPath = & (Join-Path $OdbcCrateDir "scripts\finalize-artifact.ps1") -Profile $BuildType
     Write-Host "Rust driver: $DriverPath"
 
     if ($Coverage) {

--- a/mssql-odbc/tests/e2e/run_e2e.ps1
+++ b/mssql-odbc/tests/e2e/run_e2e.ps1
@@ -432,7 +432,7 @@ function Write-ParityReport([string]$RustXml, [string]$MsXml) {
 # distinct gtest processes and ctest retries never clobber each other's .profraw).
 # PowerShell has no `eval`, so parse each KEY=VALUE line (stripping surrounding
 # quotes) into the process env. The subsequent `cargo build` then produces an
-# instrumented msodbcsql18.dll, and every ctest child process inherits
+# instrumented mssqlodbc.dll, and every ctest child process inherits
 # LLVM_PROFILE_FILE from this environment. The llvm-cov target dir is also
 # exported so the later `cargo metadata` resolves the INSTRUMENTED DLL.
 function Enable-CoverageInstrumentation {
@@ -616,7 +616,7 @@ try {
     Pop-Location
     if (-not $TargetDir) { $TargetDir = Join-Path $WorkspaceDir "target" }
 
-    $DriverPath = Join-Path $TargetDir "$BuildType\msodbcsql18.dll"
+    $DriverPath = Join-Path $TargetDir "$BuildType\mssqlodbc.dll"
     if (-not (Test-Path $DriverPath)) {
         Write-Error "Driver not found at $DriverPath"
     }

--- a/mssql-odbc/tests/e2e/run_e2e.ps1
+++ b/mssql-odbc/tests/e2e/run_e2e.ps1
@@ -432,7 +432,7 @@ function Write-ParityReport([string]$RustXml, [string]$MsXml) {
 # distinct gtest processes and ctest retries never clobber each other's .profraw).
 # PowerShell has no `eval`, so parse each KEY=VALUE line (stripping surrounding
 # quotes) into the process env. The subsequent `cargo build` then produces an
-# instrumented mssql-odbc.dll, and every ctest child process inherits
+# instrumented mssqlodbc.dll, and every ctest child process inherits
 # LLVM_PROFILE_FILE from this environment. The llvm-cov target dir is also
 # exported so the later `cargo metadata` resolves the INSTRUMENTED DLL.
 function Enable-CoverageInstrumentation {
@@ -488,7 +488,7 @@ function New-CoverageReport([string]$OutputPath) {
     }
     Push-Location $WorkspaceDir
     try {
-        cargo llvm-cov report --package mssql-tds --package mssql-odbc `
+        cargo llvm-cov report --package mssql-tds --package mssqlodbc `
             --cobertura --output-path $OutputPath
         if ($LASTEXITCODE -eq 0) {
             Write-Host "Coverage report written to $OutputPath"
@@ -604,7 +604,7 @@ try {
         Pop-Location
     }
 
-    $DriverPath = & (Join-Path $OdbcCrateDir "scripts\finalize-artifact.ps1") -Profile $BuildType
+    $DriverPath = & (Join-Path $OdbcCrateDir "scripts\finalize-artifact.ps1") -BuildProfile $BuildType
     Write-Host "Rust driver: $DriverPath"
 
     if ($Coverage) {

--- a/mssql-odbc/tests/e2e/run_e2e.sh
+++ b/mssql-odbc/tests/e2e/run_e2e.sh
@@ -17,7 +17,7 @@
 #
 # --skip-build reuses a driver and CMake `build/` produced earlier by
 # build_e2e.sh (no cargo/cmake needed — only the unixODBC runtime). Combine
-# with --driver=PATH to point at the prebuilt mssql-odbc.so. This is how
+# with --driver=PATH to point at the prebuilt mssqlodbc.so. This is how
 # CI runs prebuilt binaries across distro containers.
 #
 # --retries=N reruns each failing test up to N extra times (ctest
@@ -182,7 +182,7 @@ trap cleanup EXIT
 # `cargo llvm-cov show-env` exports RUSTFLAGS (-C instrument-coverage), the
 # llvm-cov target dir and an LLVM_PROFILE_FILE pattern (with %p/%m so distinct
 # gtest processes and ctest retries never clobber each other's .profraw). The
-# subsequent `cargo build` then produces an instrumented mssql-odbc.so, and
+# subsequent `cargo build` then produces an instrumented mssqlodbc.so, and
 # every ctest child process inherits LLVM_PROFILE_FILE from this environment.
 setup_coverage_env() {
     echo "=== Enabling coverage instrumentation for the Rust driver ==="
@@ -213,9 +213,9 @@ build_rust_driver() {
     # Resolve the shipped shared-library filename for this platform.
     local libname
     if [[ "$(uname -s)" == "Darwin" ]]; then
-        libname="mssql-odbc.dylib"
+        libname="mssqlodbc.dylib"
     else
-        libname="mssql-odbc.so"
+        libname="mssqlodbc.so"
     fi
 
     # Prebuilt mode: an explicit --driver=PATH wins; otherwise --skip-build
@@ -244,17 +244,20 @@ build_rust_driver() {
     else
         echo "=== Skipping driver build (--skip-build) ==="
         # build_e2e.sh stages the driver inside the build tree, so prefer that
-        # copy when it exists before falling back to the cargo target dir.
+        # copy when it exists before re-running the finalizer.
         if [ -f "$BUILD_DIR/$libname" ]; then
             RUST_DRIVER_PATH="$BUILD_DIR/$libname"
             echo "Using staged driver: $RUST_DRIVER_PATH"
             return
         fi
-        local target_dir
-        target_dir="$(cd "$ODBC_CRATE_DIR" && cargo metadata --format-version 1 --no-deps 2>/dev/null \
-            | python3 -c 'import sys,json; print(json.load(sys.stdin)["target_directory"])' 2>/dev/null \
-            || echo "$ODBC_CRATE_DIR/target")"
-        RUST_DRIVER_PATH="$target_dir/$BUILD_TYPE/$libname"
+        # No staged copy: re-run the finalizer so the shipped artifact reflects
+        # Cargo's current output. Resolving the finalized copy directly could run
+        # a stale driver, since `cargo build` never refreshes that copy.
+        if ! RUST_DRIVER_PATH="$(bash "$ODBC_CRATE_DIR/scripts/finalize-artifact.sh" "$BUILD_TYPE")"; then
+            echo "Error: could not finalize the driver for --skip-build" >&2
+            echo "Hint: run 'cargo build' (add --release for release), or pass --driver=PATH" >&2
+            exit 1
+        fi
     fi
 
     if [ ! -f "$RUST_DRIVER_PATH" ]; then
@@ -457,7 +460,7 @@ generate_coverage_report() {
         echo "WARNING: failed to create ODBC e2e coverage output directory" >&2
         return 0
     fi
-    if cargo llvm-cov report --package mssql-tds --package mssql-odbc \
+    if cargo llvm-cov report --package mssql-tds --package mssqlodbc \
         --cobertura --output-path "$COVERAGE_OUTPUT"; then
         echo "Coverage report written to $COVERAGE_OUTPUT"
     else

--- a/mssql-odbc/tests/e2e/run_e2e.sh
+++ b/mssql-odbc/tests/e2e/run_e2e.sh
@@ -17,7 +17,7 @@
 #
 # --skip-build reuses a driver and CMake `build/` produced earlier by
 # build_e2e.sh (no cargo/cmake needed — only the unixODBC runtime). Combine
-# with --driver=PATH to point at the prebuilt libmssqlodbc.so. This is how
+# with --driver=PATH to point at the prebuilt mssql-odbc.so. This is how
 # CI runs prebuilt binaries across distro containers.
 #
 # --retries=N reruns each failing test up to N extra times (ctest
@@ -182,7 +182,7 @@ trap cleanup EXIT
 # `cargo llvm-cov show-env` exports RUSTFLAGS (-C instrument-coverage), the
 # llvm-cov target dir and an LLVM_PROFILE_FILE pattern (with %p/%m so distinct
 # gtest processes and ctest retries never clobber each other's .profraw). The
-# subsequent `cargo build` then produces an instrumented libmssqlodbc.so, and
+# subsequent `cargo build` then produces an instrumented mssql-odbc.so, and
 # every ctest child process inherits LLVM_PROFILE_FILE from this environment.
 setup_coverage_env() {
     echo "=== Enabling coverage instrumentation for the Rust driver ==="
@@ -210,12 +210,12 @@ setup_tracing() {
 # Step 2: Build the Rust driver and resolve its shared library path
 # ----------------------------------------------------------------------------
 build_rust_driver() {
-    # Resolve the driver's shared-library filename for this platform.
+    # Resolve the shipped shared-library filename for this platform.
     local libname
     if [[ "$(uname -s)" == "Darwin" ]]; then
-        libname="libmssqlodbc.dylib"
+        libname="mssql-odbc.dylib"
     else
-        libname="libmssqlodbc.so"
+        libname="mssql-odbc.so"
     fi
 
     # Prebuilt mode: an explicit --driver=PATH wins; otherwise --skip-build
@@ -240,6 +240,7 @@ build_rust_driver() {
                 cargo build
             fi
         )
+        RUST_DRIVER_PATH="$(bash "$ODBC_CRATE_DIR/scripts/finalize-artifact.sh" "$BUILD_TYPE")"
     else
         echo "=== Skipping driver build (--skip-build) ==="
         # build_e2e.sh stages the driver inside the build tree, so prefer that
@@ -249,19 +250,12 @@ build_rust_driver() {
             echo "Using staged driver: $RUST_DRIVER_PATH"
             return
         fi
+        local target_dir
+        target_dir="$(cd "$ODBC_CRATE_DIR" && cargo metadata --format-version 1 --no-deps 2>/dev/null \
+            | python3 -c 'import sys,json; print(json.load(sys.stdin)["target_directory"])' 2>/dev/null \
+            || echo "$ODBC_CRATE_DIR/target")"
+        RUST_DRIVER_PATH="$target_dir/$BUILD_TYPE/$libname"
     fi
-
-    # Cargo builds into the workspace root's target/ directory, which may
-    # differ from the crate-local directory. Use `cargo metadata` to resolve it.
-    # Under coverage, `cargo llvm-cov show-env` may redirect the build via
-    # CARGO_TARGET_DIR; `cargo metadata` honors that env var, so target_directory
-    # always points at wherever the instrumented .so actually lands.
-    local target_dir
-    target_dir="$(cd "$ODBC_CRATE_DIR" && cargo metadata --format-version 1 --no-deps 2>/dev/null \
-        | python3 -c 'import sys,json; print(json.load(sys.stdin)["target_directory"])' 2>/dev/null \
-        || echo "$ODBC_CRATE_DIR/target")"
-
-    RUST_DRIVER_PATH="$target_dir/$BUILD_TYPE/$libname"
 
     if [ ! -f "$RUST_DRIVER_PATH" ]; then
         echo "Error: Rust driver not found at $RUST_DRIVER_PATH" >&2

--- a/mssql-odbc/tests/e2e/run_e2e.sh
+++ b/mssql-odbc/tests/e2e/run_e2e.sh
@@ -17,7 +17,7 @@
 #
 # --skip-build reuses a driver and CMake `build/` produced earlier by
 # build_e2e.sh (no cargo/cmake needed — only the unixODBC runtime). Combine
-# with --driver=PATH to point at the prebuilt libmsodbcsql18.so. This is how
+# with --driver=PATH to point at the prebuilt libmssqlodbc.so. This is how
 # CI runs prebuilt binaries across distro containers.
 #
 # --retries=N reruns each failing test up to N extra times (ctest
@@ -49,7 +49,7 @@
 # Rust driver logs are controlled by MSSQL_TDS_TRACE and
 # MSSQL_TDS_TRACE_LEVEL.
 # In --verbose mode, this script defaults to:
-#   MSSQL_TDS_TRACE=true MSSQL_TDS_TRACE_LEVEL=warn,msodbcsql18=debug
+#   MSSQL_TDS_TRACE=true MSSQL_TDS_TRACE_LEVEL=warn,mssqlodbc=debug
 # unless they are already set in the environment.
 #
 # Examples:
@@ -182,7 +182,7 @@ trap cleanup EXIT
 # `cargo llvm-cov show-env` exports RUSTFLAGS (-C instrument-coverage), the
 # llvm-cov target dir and an LLVM_PROFILE_FILE pattern (with %p/%m so distinct
 # gtest processes and ctest retries never clobber each other's .profraw). The
-# subsequent `cargo build` then produces an instrumented libmsodbcsql18.so, and
+# subsequent `cargo build` then produces an instrumented libmssqlodbc.so, and
 # every ctest child process inherits LLVM_PROFILE_FILE from this environment.
 setup_coverage_env() {
     echo "=== Enabling coverage instrumentation for the Rust driver ==="
@@ -201,7 +201,7 @@ setup_coverage_env() {
 setup_tracing() {
     if [ "$VERBOSE" -eq 1 ]; then
         export MSSQL_TDS_TRACE="${MSSQL_TDS_TRACE:-true}"
-        export MSSQL_TDS_TRACE_LEVEL="${MSSQL_TDS_TRACE_LEVEL:-warn,msodbcsql18=debug}"
+        export MSSQL_TDS_TRACE_LEVEL="${MSSQL_TDS_TRACE_LEVEL:-warn,mssqlodbc=debug}"
         echo "Verbose: MSSQL_TDS_TRACE=$MSSQL_TDS_TRACE MSSQL_TDS_TRACE_LEVEL=$MSSQL_TDS_TRACE_LEVEL"
     fi
 }
@@ -213,9 +213,9 @@ build_rust_driver() {
     # Resolve the driver's shared-library filename for this platform.
     local libname
     if [[ "$(uname -s)" == "Darwin" ]]; then
-        libname="libmsodbcsql18.dylib"
+        libname="libmssqlodbc.dylib"
     else
-        libname="libmsodbcsql18.so"
+        libname="libmssqlodbc.so"
     fi
 
     # Prebuilt mode: an explicit --driver=PATH wins; otherwise --skip-build

--- a/mssql-tds/src/test_client_support.rs
+++ b/mssql-tds/src/test_client_support.rs
@@ -3,7 +3,7 @@
 
 //! Test-only helpers for driving a [`TdsClient`] against a scripted sequence of
 //! TDS tokens, without a live server. Gated behind the `test-util` feature so
-//! downstream crates (e.g. `mssql-odbc`) can unit-test the code paths that
+//! downstream crates (e.g. `mssqlodbc`) can unit-test the code paths that
 //! require a positioned client — statement-wise navigation, no-row results,
 //! end-of-batch — which otherwise are only reachable through end-to-end tests.
 //!

--- a/scripts/dockerentry/alpine-odbc-build.sh
+++ b/scripts/dockerentry/alpine-odbc-build.sh
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# Build the mssql-odbc driver (libmssqlodbc.so) and the C++ gtest e2e binaries
+# Build the mssql-odbc driver (mssql-odbc.so) and the C++ gtest e2e binaries
 # inside the Alpine (musl) build container, then stage them into a drop
 # directory that the surrounding pipeline job publishes as an artifact. Later
 # musl test stages download the drop and rerun the prebuilt binaries via

--- a/scripts/dockerentry/alpine-odbc-build.sh
+++ b/scripts/dockerentry/alpine-odbc-build.sh
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# Build the mssql-odbc driver (mssql-odbc.so) and the C++ gtest e2e binaries
+# Build the mssql-odbc driver (mssqlodbc.so) and the C++ gtest e2e binaries
 # inside the Alpine (musl) build container, then stage them into a drop
 # directory that the surrounding pipeline job publishes as an artifact. Later
 # musl test stages download the drop and rerun the prebuilt binaries via

--- a/scripts/dockerentry/alpine-odbc-build.sh
+++ b/scripts/dockerentry/alpine-odbc-build.sh
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# Build the mssql-odbc driver (libmsodbcsql18.so) and the C++ gtest e2e binaries
+# Build the mssql-odbc driver (libmssqlodbc.so) and the C++ gtest e2e binaries
 # inside the Alpine (musl) build container, then stage them into a drop
 # directory that the surrounding pipeline job publishes as an artifact. Later
 # musl test stages download the drop and rerun the prebuilt binaries via

--- a/scripts/dockerentry/odbc-e2e-alpine.sh
+++ b/scripts/dockerentry/odbc-e2e-alpine.sh
@@ -7,7 +7,7 @@
 # prebuilt musl driver + ctest binaries (no compiler, no cargo): bash (run_e2e.sh
 # is a bash script), ctest (from cmake), the unixODBC driver manager runtime,
 # libssl, libstdc++/libgcc, and the Kerberos runtime the driver may link. The
-# prebuilt build/ tree (with libmssqlodbc.so staged inside) is restored to
+# prebuilt build/ tree (with mssql-odbc.so staged inside) is restored to
 # mssql-odbc/tests/e2e/build by the calling template.
 #
 # Connection details arrive via ODBC_TEST_* env vars; ODBC_E2E_RETRIES controls

--- a/scripts/dockerentry/odbc-e2e-alpine.sh
+++ b/scripts/dockerentry/odbc-e2e-alpine.sh
@@ -7,7 +7,7 @@
 # prebuilt musl driver + ctest binaries (no compiler, no cargo): bash (run_e2e.sh
 # is a bash script), ctest (from cmake), the unixODBC driver manager runtime,
 # libssl, libstdc++/libgcc, and the Kerberos runtime the driver may link. The
-# prebuilt build/ tree (with mssql-odbc.so staged inside) is restored to
+# prebuilt build/ tree (with mssqlodbc.so staged inside) is restored to
 # mssql-odbc/tests/e2e/build by the calling template.
 #
 # Connection details arrive via ODBC_TEST_* env vars; ODBC_E2E_RETRIES controls

--- a/scripts/dockerentry/odbc-e2e-alpine.sh
+++ b/scripts/dockerentry/odbc-e2e-alpine.sh
@@ -7,7 +7,7 @@
 # prebuilt musl driver + ctest binaries (no compiler, no cargo): bash (run_e2e.sh
 # is a bash script), ctest (from cmake), the unixODBC driver manager runtime,
 # libssl, libstdc++/libgcc, and the Kerberos runtime the driver may link. The
-# prebuilt build/ tree (with libmsodbcsql18.so staged inside) is restored to
+# prebuilt build/ tree (with libmssqlodbc.so staged inside) is restored to
 # mssql-odbc/tests/e2e/build by the calling template.
 #
 # Connection details arrive via ODBC_TEST_* env vars; ODBC_E2E_RETRIES controls

--- a/scripts/dockerentry/odbc-e2e-azlinux3.sh
+++ b/scripts/dockerentry/odbc-e2e-azlinux3.sh
@@ -6,7 +6,7 @@
 # (tdnf). Installs only the RUNTIME deps to rerun the prebuilt driver + ctest
 # binaries: ctest (from cmake), the unixODBC driver manager runtime, OpenSSL
 # libs, and the Kerberos runtime. The prebuilt build/ tree (with
-# libmsodbcsql18.so staged inside) is restored to mssql-odbc/tests/e2e/build by
+# libmssqlodbc.so staged inside) is restored to mssql-odbc/tests/e2e/build by
 # the calling template.
 #
 # Connection details arrive via ODBC_TEST_* env vars; ODBC_E2E_RETRIES controls

--- a/scripts/dockerentry/odbc-e2e-azlinux3.sh
+++ b/scripts/dockerentry/odbc-e2e-azlinux3.sh
@@ -6,7 +6,7 @@
 # (tdnf). Installs only the RUNTIME deps to rerun the prebuilt driver + ctest
 # binaries: ctest (from cmake), the unixODBC driver manager runtime, OpenSSL
 # libs, and the Kerberos runtime. The prebuilt build/ tree (with
-# mssql-odbc.so staged inside) is restored to mssql-odbc/tests/e2e/build by
+# mssqlodbc.so staged inside) is restored to mssql-odbc/tests/e2e/build by
 # the calling template.
 #
 # Connection details arrive via ODBC_TEST_* env vars; ODBC_E2E_RETRIES controls

--- a/scripts/dockerentry/odbc-e2e-azlinux3.sh
+++ b/scripts/dockerentry/odbc-e2e-azlinux3.sh
@@ -6,7 +6,7 @@
 # (tdnf). Installs only the RUNTIME deps to rerun the prebuilt driver + ctest
 # binaries: ctest (from cmake), the unixODBC driver manager runtime, OpenSSL
 # libs, and the Kerberos runtime. The prebuilt build/ tree (with
-# libmssqlodbc.so staged inside) is restored to mssql-odbc/tests/e2e/build by
+# mssql-odbc.so staged inside) is restored to mssql-odbc/tests/e2e/build by
 # the calling template.
 #
 # Connection details arrive via ODBC_TEST_* env vars; ODBC_E2E_RETRIES controls

--- a/scripts/dockerentry/odbc-e2e-deb.sh
+++ b/scripts/dockerentry/odbc-e2e-deb.sh
@@ -6,7 +6,7 @@
 # (apt) containers. Installs only the RUNTIME dependencies needed to rerun the
 # prebuilt driver + ctest binaries (no compiler, no cargo): ctest (from cmake),
 # the unixODBC driver manager runtime, libssl, and the Kerberos runtime the
-# driver may link. The prebuilt build/ tree (with mssql-odbc.so staged
+# driver may link. The prebuilt build/ tree (with mssqlodbc.so staged
 # inside) is restored to mssql-odbc/tests/e2e/build by the calling template.
 #
 # Connection details arrive via ODBC_TEST_* env vars; ODBC_E2E_RETRIES controls

--- a/scripts/dockerentry/odbc-e2e-deb.sh
+++ b/scripts/dockerentry/odbc-e2e-deb.sh
@@ -6,7 +6,7 @@
 # (apt) containers. Installs only the RUNTIME dependencies needed to rerun the
 # prebuilt driver + ctest binaries (no compiler, no cargo): ctest (from cmake),
 # the unixODBC driver manager runtime, libssl, and the Kerberos runtime the
-# driver may link. The prebuilt build/ tree (with libmsodbcsql18.so staged
+# driver may link. The prebuilt build/ tree (with libmssqlodbc.so staged
 # inside) is restored to mssql-odbc/tests/e2e/build by the calling template.
 #
 # Connection details arrive via ODBC_TEST_* env vars; ODBC_E2E_RETRIES controls

--- a/scripts/dockerentry/odbc-e2e-deb.sh
+++ b/scripts/dockerentry/odbc-e2e-deb.sh
@@ -6,7 +6,7 @@
 # (apt) containers. Installs only the RUNTIME dependencies needed to rerun the
 # prebuilt driver + ctest binaries (no compiler, no cargo): ctest (from cmake),
 # the unixODBC driver manager runtime, libssl, and the Kerberos runtime the
-# driver may link. The prebuilt build/ tree (with libmssqlodbc.so staged
+# driver may link. The prebuilt build/ tree (with mssql-odbc.so staged
 # inside) is restored to mssql-odbc/tests/e2e/build by the calling template.
 #
 # Connection details arrive via ODBC_TEST_* env vars; ODBC_E2E_RETRIES controls

--- a/scripts/dockerentry/odbc-e2e-rhel.sh
+++ b/scripts/dockerentry/odbc-e2e-rhel.sh
@@ -7,7 +7,7 @@
 # only the RUNTIME deps to rerun the prebuilt driver + ctest binaries: ctest
 # (from cmake), the unixODBC driver manager runtime, OpenSSL libs, and the
 # Kerberos runtime. The prebuilt
-# build/ tree (with libmsodbcsql18.so staged inside) is restored to
+# build/ tree (with libmssqlodbc.so staged inside) is restored to
 # mssql-odbc/tests/e2e/build by the calling template.
 #
 # Connection details arrive via ODBC_TEST_* env vars; ODBC_E2E_RETRIES controls

--- a/scripts/dockerentry/odbc-e2e-rhel.sh
+++ b/scripts/dockerentry/odbc-e2e-rhel.sh
@@ -7,7 +7,7 @@
 # only the RUNTIME deps to rerun the prebuilt driver + ctest binaries: ctest
 # (from cmake), the unixODBC driver manager runtime, OpenSSL libs, and the
 # Kerberos runtime. The prebuilt
-# build/ tree (with libmssqlodbc.so staged inside) is restored to
+# build/ tree (with mssql-odbc.so staged inside) is restored to
 # mssql-odbc/tests/e2e/build by the calling template.
 #
 # Connection details arrive via ODBC_TEST_* env vars; ODBC_E2E_RETRIES controls

--- a/scripts/dockerentry/odbc-e2e-rhel.sh
+++ b/scripts/dockerentry/odbc-e2e-rhel.sh
@@ -7,7 +7,7 @@
 # only the RUNTIME deps to rerun the prebuilt driver + ctest binaries: ctest
 # (from cmake), the unixODBC driver manager runtime, OpenSSL libs, and the
 # Kerberos runtime. The prebuilt
-# build/ tree (with mssql-odbc.so staged inside) is restored to
+# build/ tree (with mssqlodbc.so staged inside) is restored to
 # mssql-odbc/tests/e2e/build by the calling template.
 #
 # Connection details arrive via ODBC_TEST_* env vars; ODBC_E2E_RETRIES controls


### PR DESCRIPTION
## Description

Follow-up to #397 (already merged). Two small commits landed on the same branch after that PR merged:

- **Unify Rust ODBC driver naming on mssqlodbc**: uild.rs now sets MSSQL_ODBC_ARTIFACT as the single source of truth for the shipped driver filename per platform (mssqlodbc.so/.dylib/.dll), consumed by both the linker SONAME/install_name args and driver_name() via nv!, instead of duplicating the filename in multiple places.
- **Address review nits**: dropped a vestigial 	arget_os cfg on driver_name() (no longer needed since uild.rs emits MSSQL_ODBC_ARTIFACT unconditionally) and fixed a stale doc comment in xports.rs still naming the old mssql-odbc shared library (now mssqlodbc).

## Related Issues

https://sqlclientdrivers.visualstudio.com/DefaultCollection/mssql-rs/_workitems/edit/47676

## Validation

- cargo bfmt
- cargo bclippy
- cargo btest

## Checklist

- [ ] cargo bfmt passes
- [ ] cargo bclippy passes
- [ ] cargo btest passes
- [x] New/changed functionality has tests
- [x] Public API changes are documented