### PR TITLE
Publish mssql-odbc native driver artifacts to Azure Artifacts (NuGet)

### DIFF
--- a/.pipeline/OneBranch/OdbcNativePublish.yml
+++ b/.pipeline/OneBranch/OdbcNativePublish.yml
@@ -1,0 +1,74 @@
+#################################################################################
+#                        OneBranch Pipelines - NonOfficial                      #
+# Builds the mssql-odbc native driver across Linux (glibc/musl/glibc-2.28,      #
+# x64+ARM64) and Windows (x64+ARM64), packages the binaries into a NuGet        #
+# archive, and publishes to Azure Artifacts.                                    #
+# Documentation:  https://aka.ms/obpipelines                                    #
+# Yaml Schema:    https://aka.ms/obpipelines/yaml/schema                        #
+# Retail Tasks:   https://aka.ms/obpipelines/tasks                              #
+# Support:        https://aka.ms/onebranchsup                                   #
+#################################################################################
+
+# Source repo is GitHub microsoft/mssql-rs. CI runs on merge to main.
+# No PR trigger: unlike the Python wheels pipeline, every build-odbc-*
+# template here is hard-gated to CI (non-PR) runs already (see
+# build-odbc-template.yml et al.), so a PR run would spin up every agent and
+# skip every step - pure wasted capacity with zero validation value.
+trigger:
+- main
+
+pr: none
+
+# Nightly builds
+schedules:
+- cron: '0 3 * * *'
+  displayName: Nightly build
+  branches:
+    include:
+    - main
+  always: true
+
+parameters:
+- name: publishToFeed
+  displayName: 'Publish NuGet package to Azure Artifacts feed'
+  type: boolean
+  default: true
+
+variables:
+  CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)]  # For onebranch.pipeline.version task
+  LinuxContainerImage: 'mcr.microsoft.com/onebranch/azurelinux/build:3.0'
+  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest'
+  DEBIAN_FRONTEND: noninteractive
+  # IMPORTANT: This feed must be an Azure Artifacts NuGet feed in your ADO org with
+  # azure-feed://mscodehub/Rust/Rust@Release as an upstream source.
+  # The pipeline build service account needs Collaborator permissions on this feed.
+  # See https://aka.ms/rustinado for setup details.
+  toolchainFeed: 'https://sqlclientdrivers.pkgs.visualstudio.com/mssql-rs/_packaging/mssql-rs/nuget/v3/index.json'
+
+resources:
+  repositories:
+    - repository: templates
+      type: git
+      name: OneBranch.Pipelines/GovernedTemplates
+      ref: refs/heads/main
+
+extends:
+  template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates
+  parameters:
+    featureFlags:
+      EnableCDPxPAT: false
+      WindowsHostVersion: 1ESWindows2022
+    globalSdl:
+      binskim:
+        # Rust build scripts will not be built with spectre-mitigations enabled
+        scanOutputDirectoryOnly: true
+      clippy:
+        enabled: true
+    nugetPublishing:
+      feeds:
+      - name: public/mssql-rs_Public
+        continueOnConflict: true
+    stages:
+    - template: /.pipeline/OneBranch/odbc-native-stages.yml@self
+      parameters:
+        publishToFeed: ${{ parameters.publishToFeed }}

--- a/.pipeline/OneBranch/odbc-native-stages.yml
+++ b/.pipeline/OneBranch/odbc-native-stages.yml
@@ -1,0 +1,305 @@
+#################################################################################
+#                     ODBC Native Artifact - Build Stages                       #
+# Builds the mssql-odbc native driver across Linux (glibc, musl, glibc-2.28;    #
+# x64 + ARM64) and Windows (x64 + ARM64), packages the driver binaries into a   #
+# NuGet archive, and publishes to Azure Artifacts via OneBranch's native        #
+# nugetPublishing mechanism.                                                    #
+#                                                                               #
+# macOS is intentionally out of scope for v1 - mssql-odbc has no build lane     #
+# there yet (see docs/rust-odbc-provider-integration-w-mssqlpython.md).         #
+#                                                                               #
+# Build jobs use custom 1ES pools (Rust, Docker, Python pre-installed), same    #
+# pools/images as validation-stages.yml's Build_Linux*/Build_Windows* jobs.     #
+# Publish job uses managed OneBranch pool with ob_nugetPublishing_enabled.      #
+#################################################################################
+
+parameters:
+- name: publishToFeed
+  type: boolean
+  default: false
+  displayName: 'Publish NuGet package to Azure Artifacts feed'
+
+stages:
+#############################################################################
+# Build Stage - Linux (glibc/musl/glibc-2.28) + Windows, x64 and ARM64
+#############################################################################
+- stage: Build
+  jobs:
+  #########################################################################
+  # Linux x64
+  #########################################################################
+  - job: Linux_x64
+    displayName: 'Linux x64'
+    pool:
+      type: linux
+      isCustom: true
+      name: RUST-1ES-POOL-WUS3
+      demands:
+        - imageOverride -equals RUST-1ES-UBUSLIM
+    variables:
+      ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
+    steps:
+    - template: /.pipeline/templates/cargo-authenticate-template.yml
+      parameters:
+        osType: Linux
+    - script: .pipeline/scripts/install-rustup.sh
+      displayName: 'Install Rustup'
+    - task: DockerInstaller@0
+      inputs:
+        dockerVersion: '29.0.0'
+      displayName: 'Install Docker'
+    - template: /.pipeline/templates/install-ubuntu-dependency.yaml
+      parameters:
+        installDocker: true
+    - template: /.pipeline/templates/build-odbc-template.yml
+      parameters:
+        architecture: x64
+        artifactName: 'Odbc_Linux_x64'
+    - template: /.pipeline/templates/build-odbc-alpine-template.yml
+      parameters:
+        architecture: x64
+        artifactName: 'Odbc_Musl_x64'
+    - template: /.pipeline/templates/build-odbc-glibc228-template.yml
+      parameters:
+        architecture: x64
+        artifactName: 'Odbc_glibc228_x64'
+
+  #########################################################################
+  # Linux ARM64
+  #########################################################################
+  - job: Linux_ARM64
+    displayName: 'Linux ARM64'
+    pool:
+      type: linux
+      isCustom: true
+      name: RUST-1ES-POOL-ARM-WUS3
+      demands:
+        - imageOverride -equals RUST-UBUNTU-ARM64
+    variables:
+      ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
+    steps:
+    - template: /.pipeline/templates/cargo-authenticate-template.yml
+      parameters:
+        osType: Linux
+    - script: .pipeline/scripts/install-rustup.sh
+      displayName: 'Install Rustup'
+    - task: DockerInstaller@0
+      inputs:
+        dockerVersion: '29.0.0'
+      displayName: 'Install Docker'
+    - template: /.pipeline/templates/install-ubuntu-dependency.yaml
+      parameters:
+        installDocker: true
+    - template: /.pipeline/templates/build-odbc-template.yml
+      parameters:
+        architecture: ARM64
+        artifactName: 'Odbc_Linux_arm64'
+    - template: /.pipeline/templates/build-odbc-alpine-template.yml
+      parameters:
+        architecture: ARM64
+        artifactName: 'Odbc_Musl_arm64'
+    - template: /.pipeline/templates/build-odbc-glibc228-template.yml
+      parameters:
+        architecture: ARM64
+        buildImage: 'ghcr.io/microsoft/mssql-rs/python-build/manylinux_2_28_aarch64_rust:latest'
+        artifactName: 'Odbc_glibc228_arm64'
+
+  #########################################################################
+  # Windows x64
+  #########################################################################
+  - job: Windows_x64
+    displayName: 'Windows x64'
+    pool:
+      type: windows
+      isCustom: true
+      name: RUST-1ES-POOL-WUS3
+      demands:
+        - imageOverride -equals RUST-Win22-Sql25-1P
+    variables:
+      ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
+      CARGO_TARGET_DIR: C:\cargo_target_dir
+    steps:
+    - template: /.pipeline/templates/cargo-authenticate-template.yml
+      parameters:
+        osType: Windows
+    - template: /.pipeline/templates/install-dependencies.yml
+      parameters:
+        osType: Windows
+        skipPythonSetup: true
+        skipRustupInstall: false
+        enableJsDeps: false
+    - template: /.pipeline/templates/build-odbc-windows-template.yml
+      parameters:
+        architecture: x64
+        artifactName: 'Odbc_Windows_x64'
+
+  #########################################################################
+  # Windows ARM64
+  #########################################################################
+  - job: Windows_ARM64
+    displayName: 'Windows ARM64'
+    pool:
+      type: windows
+      isCustom: true
+      name: RUST-1ES-POOL-ARM-WUS3
+      demands:
+        - imageOverride -equals RUST-WINSRV-ARM
+    variables:
+      ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
+      CARGO_TARGET_DIR: C:\cargo_target_dir
+    steps:
+    # Node.js workaround for ARM64 ADO tasks
+    - pwsh: ./scripts/setup-nodejs-path.ps1
+      displayName: 'Add Node.js to PATH for ADO tasks'
+    - pwsh: ./scripts/install-nodejs-to-agent.ps1
+      displayName: 'Install Node.js to agent externals folder'
+    - template: /.pipeline/templates/cargo-authenticate-template.yml
+      parameters:
+        osType: Windows
+    - template: /.pipeline/templates/install-dependencies.yml
+      parameters:
+        osType: Windows
+        skipPythonSetup: true
+        skipRustupInstall: false
+        enableJsDeps: false
+    - template: /.pipeline/templates/build-odbc-windows-template.yml
+      parameters:
+        architecture: ARM64
+        artifactName: 'Odbc_Windows_arm64'
+
+#############################################################################
+# Publish Stage - Collect driver binaries, create NuGet package, publish
+#############################################################################
+- ${{ if eq(parameters.publishToFeed, true) }}:
+  - stage: Publish
+    dependsOn: Build
+    # Skip publish on PR builds - only publish on CI, scheduled, or manual runs
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+    jobs:
+    - job: PackageAndPublish
+      displayName: 'Package native drivers into NuGet and publish'
+      pool:
+        type: windows
+      variables:
+        ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
+        ob_nugetPublishing_enabled: true
+      steps:
+      - download: current
+        displayName: 'Download all build artifacts'
+
+      - pwsh: |
+          $ErrorActionPreference = 'Stop'
+
+          # artifact name -> (platform tag, driver filename). Each build job's
+          # drop nests the driver under build/ (see build-odbc-*-template.yml
+          # and build-odbc-windows-template.yml), so every source path below
+          # shares that same relative layout.
+          $platforms = [ordered]@{
+            'Odbc_Linux_x64'      = @{ tag = 'linux_x64';      file = 'libmssqlodbc.so' }
+            'Odbc_Linux_arm64'    = @{ tag = 'linux_arm64';    file = 'libmssqlodbc.so' }
+            'Odbc_Musl_x64'       = @{ tag = 'musl_x64';       file = 'libmssqlodbc.so' }
+            'Odbc_Musl_arm64'     = @{ tag = 'musl_arm64';     file = 'libmssqlodbc.so' }
+            'Odbc_glibc228_x64'   = @{ tag = 'glibc228_x64';   file = 'libmssqlodbc.so' }
+            'Odbc_glibc228_arm64' = @{ tag = 'glibc228_arm64'; file = 'libmssqlodbc.so' }
+            'Odbc_Windows_x64'    = @{ tag = 'windows_x64';    file = 'mssqlodbc.dll' }
+            'Odbc_Windows_arm64'  = @{ tag = 'windows_arm64';  file = 'mssqlodbc.dll' }
+          }
+
+          $nativeRoot = "$(Build.StagingDirectory)/native"
+          New-Item -ItemType Directory -Force -Path $nativeRoot | Out-Null
+
+          $missing = @()
+          foreach ($artifactName in $platforms.Keys) {
+            $info = $platforms[$artifactName]
+            $srcFile = "$(Pipeline.Workspace)/$artifactName/build/$($info.file)"
+            if (-not (Test-Path $srcFile)) {
+              $missing += $artifactName
+              continue
+            }
+            $destDir = Join-Path $nativeRoot $info.tag
+            New-Item -ItemType Directory -Force -Path $destDir | Out-Null
+            Copy-Item $srcFile $destDir
+            Write-Host "Staged $($info.file) -> native/$($info.tag)"
+          }
+
+          if ($missing.Count -gt 0) {
+            Write-Error "Missing driver drop(s) for: $($missing -join ', ')"
+            exit 1
+          }
+
+          Write-Host "=== Staged native/ tree ==="
+          Get-ChildItem $nativeRoot -Recurse -File | ForEach-Object {
+            Write-Host "  $($_.FullName.Substring($nativeRoot.Length + 1))  ($([math]::Round($_.Length/1KB, 1)) KB)"
+          }
+        displayName: 'Collect native driver binaries'
+
+      - pwsh: |
+          $ErrorActionPreference = 'Stop'
+
+          # Extract version from mssql-odbc/Cargo.toml
+          $cargoToml = Get-Content "$(Build.SourcesDirectory)/mssql-odbc/Cargo.toml" -Raw
+          if ($cargoToml -match 'version\s*=\s*"([^"]+)"') {
+            $version = $Matches[1]
+          } else {
+            Write-Error "Could not extract version from Cargo.toml"
+            exit 1
+          }
+
+          # Determine prerelease suffix based on Build.Reason. No official/clean
+          # release path yet - see mssql-py-core's Publish stage for that shape
+          # if/when this package needs one.
+          $buildReason = "$(Build.Reason)"
+          $dateStamp = Get-Date -Format "yyyyMMdd"
+          $buildId = "$(Build.BuildId)"
+          $commitSha = "$(Build.SourceVersion)"
+          $shortSha = $commitSha.Substring(0, 8)
+
+          if ($buildReason -eq 'Schedule') {
+            # Nightly build: 0.1.0-nightly.20260217
+            $packageVersion = "$version-nightly.$dateStamp"
+            Write-Host "Nightly build detected"
+          } else {
+            # CI push / manual trigger: 0.1.0-dev.20260217.12345
+            $packageVersion = "$version-dev.$dateStamp.$buildId"
+            Write-Host "Dev build detected (reason: $buildReason)"
+          }
+
+          Write-Host "Package version: $packageVersion"
+          Write-Host "##vso[task.setvariable variable=nugetVersion]$packageVersion"
+
+          # Create .nuspec
+          $nuspecContent = @"
+          <?xml version="1.0"?>
+          <package>
+            <metadata>
+              <id>mssql-odbc-wheels</id>
+              <version>$packageVersion</version>
+              <description>Native mssql-odbc driver binaries across all platforms. Commit: $shortSha. Build: $(Build.BuildNumber)</description>
+              <authors>SqlClientDrivers</authors>
+            </metadata>
+            <files>
+              <file src="native\**\*.*" target="native" />
+            </files>
+          </package>
+          "@
+
+          $nuspecPath = "$(Build.StagingDirectory)/mssql-odbc-wheels.nuspec"
+          $nuspecContent | Out-File -FilePath $nuspecPath -Encoding utf8
+          Write-Host "Created nuspec at $nuspecPath"
+        displayName: 'Generate NuGet package metadata'
+
+      - task: NuGetCommand@2
+        displayName: 'Create NuGet package'
+        inputs:
+          command: pack
+          packagesToPack: '$(Build.StagingDirectory)/mssql-odbc-wheels.nuspec'
+          packDestination: '$(ob_outputDirectory)/packages'
+          basePath: '$(Build.StagingDirectory)'
+
+      - pwsh: |
+          Write-Host "=== NuGet package created ==="
+          Get-ChildItem "$(ob_outputDirectory)/packages" -Filter *.nupkg | ForEach-Object {
+            Write-Host "  $($_.Name)  ($([math]::Round($_.Length/1MB, 2)) MB)"
+          }
+          Write-Host "OneBranch will auto-publish from $(ob_outputDirectory)/packages"
+        displayName: 'Verify NuGet package'

--- a/.pipeline/OneBranch/odbc-native-stages.yml
+++ b/.pipeline/OneBranch/odbc-native-stages.yml
@@ -297,12 +297,12 @@ stages:
           # and build-odbc-windows-template.yml), so every source path below
           # shares that same relative layout.
           $platforms = [ordered]@{
-            'drop_Build_Linux_x64'      = @{ tag = 'linux_x64';      file = 'libmssqlodbc.so' }
-            'drop_Build_Linux_ARM64'    = @{ tag = 'linux_arm64';    file = 'libmssqlodbc.so' }
-            'drop_Build_Musl_x64'       = @{ tag = 'musl_x64';       file = 'libmssqlodbc.so' }
-            'drop_Build_Musl_ARM64'     = @{ tag = 'musl_arm64';     file = 'libmssqlodbc.so' }
-            'drop_Build_Glibc228_x64'   = @{ tag = 'glibc228_x64';   file = 'libmssqlodbc.so' }
-            'drop_Build_Glibc228_ARM64' = @{ tag = 'glibc228_arm64'; file = 'libmssqlodbc.so' }
+            'drop_Build_Linux_x64'      = @{ tag = 'linux_x64';      file = 'mssqlodbc.so' }
+            'drop_Build_Linux_ARM64'    = @{ tag = 'linux_arm64';    file = 'mssqlodbc.so' }
+            'drop_Build_Musl_x64'       = @{ tag = 'musl_x64';       file = 'mssqlodbc.so' }
+            'drop_Build_Musl_ARM64'     = @{ tag = 'musl_arm64';     file = 'mssqlodbc.so' }
+            'drop_Build_Glibc228_x64'   = @{ tag = 'glibc228_x64';   file = 'mssqlodbc.so' }
+            'drop_Build_Glibc228_ARM64' = @{ tag = 'glibc228_arm64'; file = 'mssqlodbc.so' }
             'drop_Build_Windows_x64'    = @{ tag = 'windows_x64';    file = 'mssqlodbc.dll' }
             'drop_Build_Windows_ARM64'  = @{ tag = 'windows_arm64';  file = 'mssqlodbc.dll' }
           }

--- a/.pipeline/OneBranch/odbc-native-stages.yml
+++ b/.pipeline/OneBranch/odbc-native-stages.yml
@@ -39,9 +39,9 @@ stages:
     pool:
       type: linux
       isCustom: true
-      name: RUST-1ES-POOL-WUS3
+      name: RUST-X64-WUS3
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-UBUSLIM
     variables:
       ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
     steps:
@@ -67,9 +67,9 @@ stages:
     pool:
       type: linux
       isCustom: true
-      name: RUST-1ES-POOL-WUS3
+      name: RUST-X64-WUS3
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-UBUSLIM
     variables:
       ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
     steps:
@@ -95,9 +95,9 @@ stages:
     pool:
       type: linux
       isCustom: true
-      name: RUST-1ES-POOL-WUS3
+      name: RUST-X64-WUS3
       demands:
-        - imageOverride -equals RUST-1ES-UBUSLIM
+        - imageOverride -equals RUST-UBUSLIM
     variables:
       ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
     steps:
@@ -126,7 +126,7 @@ stages:
     pool:
       type: linux
       isCustom: true
-      name: RUST-1ES-POOL-ARM-WUS3
+      name: RUST-ARM64-WUS3
       demands:
         - imageOverride -equals RUST-UBUNTU-ARM64
     variables:
@@ -154,7 +154,7 @@ stages:
     pool:
       type: linux
       isCustom: true
-      name: RUST-1ES-POOL-ARM-WUS3
+      name: RUST-ARM64-WUS3
       demands:
         - imageOverride -equals RUST-UBUNTU-ARM64
     variables:
@@ -182,7 +182,7 @@ stages:
     pool:
       type: linux
       isCustom: true
-      name: RUST-1ES-POOL-ARM-WUS3
+      name: RUST-ARM64-WUS3
       demands:
         - imageOverride -equals RUST-UBUNTU-ARM64
     variables:
@@ -214,9 +214,9 @@ stages:
     pool:
       type: windows
       isCustom: true
-      name: RUST-1ES-POOL-WUS3
+      name: RUST-X64-WUS3
       demands:
-        - imageOverride -equals RUST-Win22-Sql25-1P
+        - imageOverride -equals RUST-W22-SQL25
     variables:
       ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
       CARGO_TARGET_DIR: C:\cargo_target_dir
@@ -243,7 +243,7 @@ stages:
     pool:
       type: windows
       isCustom: true
-      name: RUST-1ES-POOL-ARM-WUS3
+      name: RUST-ARM64-WUS3
       demands:
         - imageOverride -equals RUST-WINSRV-ARM
     variables:

--- a/.pipeline/OneBranch/odbc-native-stages.yml
+++ b/.pipeline/OneBranch/odbc-native-stages.yml
@@ -26,10 +26,16 @@ stages:
 - stage: Build
   jobs:
   #########################################################################
-  # Linux x64
+  # Linux x64 (glibc), Musl x64, glibc-2.28 x64
+  #
+  # One job per artifact: OneBranch's governed template requires every
+  # PublishPipelineArtifact within a job to be named drop_<Stage>_<Job>, so a
+  # single job can't publish 3 differently-named artifacts (see build-odbc-*
+  # calls below - each publishes its own artifact via the shared, reused
+  # templates, which are not modified here).
   #########################################################################
   - job: Linux_x64
-    displayName: 'Linux x64'
+    displayName: 'Linux x64 (glibc)'
     pool:
       type: linux
       isCustom: true
@@ -54,21 +60,69 @@ stages:
     - template: /.pipeline/templates/build-odbc-template.yml
       parameters:
         architecture: x64
-        artifactName: 'Odbc_Linux_x64'
+        artifactName: 'drop_Build_Linux_x64'
+
+  - job: Musl_x64
+    displayName: 'Musl x64'
+    pool:
+      type: linux
+      isCustom: true
+      name: RUST-1ES-POOL-WUS3
+      demands:
+        - imageOverride -equals RUST-1ES-UBUSLIM
+    variables:
+      ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
+    steps:
+    - template: /.pipeline/templates/cargo-authenticate-template.yml
+      parameters:
+        osType: Linux
+    - script: .pipeline/scripts/install-rustup.sh
+      displayName: 'Install Rustup'
+    - task: DockerInstaller@0
+      inputs:
+        dockerVersion: '29.0.0'
+      displayName: 'Install Docker'
+    - template: /.pipeline/templates/install-ubuntu-dependency.yaml
+      parameters:
+        installDocker: true
     - template: /.pipeline/templates/build-odbc-alpine-template.yml
       parameters:
         architecture: x64
-        artifactName: 'Odbc_Musl_x64'
+        artifactName: 'drop_Build_Musl_x64'
+
+  - job: Glibc228_x64
+    displayName: 'glibc 2.28 x64'
+    pool:
+      type: linux
+      isCustom: true
+      name: RUST-1ES-POOL-WUS3
+      demands:
+        - imageOverride -equals RUST-1ES-UBUSLIM
+    variables:
+      ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
+    steps:
+    - template: /.pipeline/templates/cargo-authenticate-template.yml
+      parameters:
+        osType: Linux
+    - script: .pipeline/scripts/install-rustup.sh
+      displayName: 'Install Rustup'
+    - task: DockerInstaller@0
+      inputs:
+        dockerVersion: '29.0.0'
+      displayName: 'Install Docker'
+    - template: /.pipeline/templates/install-ubuntu-dependency.yaml
+      parameters:
+        installDocker: true
     - template: /.pipeline/templates/build-odbc-glibc228-template.yml
       parameters:
         architecture: x64
-        artifactName: 'Odbc_glibc228_x64'
+        artifactName: 'drop_Build_Glibc228_x64'
 
   #########################################################################
-  # Linux ARM64
+  # Linux ARM64 (glibc), Musl ARM64, glibc-2.28 ARM64
   #########################################################################
   - job: Linux_ARM64
-    displayName: 'Linux ARM64'
+    displayName: 'Linux ARM64 (glibc)'
     pool:
       type: linux
       isCustom: true
@@ -93,16 +147,64 @@ stages:
     - template: /.pipeline/templates/build-odbc-template.yml
       parameters:
         architecture: ARM64
-        artifactName: 'Odbc_Linux_arm64'
+        artifactName: 'drop_Build_Linux_ARM64'
+
+  - job: Musl_ARM64
+    displayName: 'Musl ARM64'
+    pool:
+      type: linux
+      isCustom: true
+      name: RUST-1ES-POOL-ARM-WUS3
+      demands:
+        - imageOverride -equals RUST-UBUNTU-ARM64
+    variables:
+      ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
+    steps:
+    - template: /.pipeline/templates/cargo-authenticate-template.yml
+      parameters:
+        osType: Linux
+    - script: .pipeline/scripts/install-rustup.sh
+      displayName: 'Install Rustup'
+    - task: DockerInstaller@0
+      inputs:
+        dockerVersion: '29.0.0'
+      displayName: 'Install Docker'
+    - template: /.pipeline/templates/install-ubuntu-dependency.yaml
+      parameters:
+        installDocker: true
     - template: /.pipeline/templates/build-odbc-alpine-template.yml
       parameters:
         architecture: ARM64
-        artifactName: 'Odbc_Musl_arm64'
+        artifactName: 'drop_Build_Musl_ARM64'
+
+  - job: Glibc228_ARM64
+    displayName: 'glibc 2.28 ARM64'
+    pool:
+      type: linux
+      isCustom: true
+      name: RUST-1ES-POOL-ARM-WUS3
+      demands:
+        - imageOverride -equals RUST-UBUNTU-ARM64
+    variables:
+      ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
+    steps:
+    - template: /.pipeline/templates/cargo-authenticate-template.yml
+      parameters:
+        osType: Linux
+    - script: .pipeline/scripts/install-rustup.sh
+      displayName: 'Install Rustup'
+    - task: DockerInstaller@0
+      inputs:
+        dockerVersion: '29.0.0'
+      displayName: 'Install Docker'
+    - template: /.pipeline/templates/install-ubuntu-dependency.yaml
+      parameters:
+        installDocker: true
     - template: /.pipeline/templates/build-odbc-glibc228-template.yml
       parameters:
         architecture: ARM64
         buildImage: 'ghcr.io/microsoft/mssql-rs/python-build/manylinux_2_28_aarch64_rust:latest'
-        artifactName: 'Odbc_glibc228_arm64'
+        artifactName: 'drop_Build_Glibc228_ARM64'
 
   #########################################################################
   # Windows x64
@@ -131,7 +233,7 @@ stages:
     - template: /.pipeline/templates/build-odbc-windows-template.yml
       parameters:
         architecture: x64
-        artifactName: 'Odbc_Windows_x64'
+        artifactName: 'drop_Build_Windows_x64'
 
   #########################################################################
   # Windows ARM64
@@ -165,7 +267,7 @@ stages:
     - template: /.pipeline/templates/build-odbc-windows-template.yml
       parameters:
         architecture: ARM64
-        artifactName: 'Odbc_Windows_arm64'
+        artifactName: 'drop_Build_Windows_ARM64'
 
 #############################################################################
 # Publish Stage - Collect driver binaries, create NuGet package, publish
@@ -195,14 +297,14 @@ stages:
           # and build-odbc-windows-template.yml), so every source path below
           # shares that same relative layout.
           $platforms = [ordered]@{
-            'Odbc_Linux_x64'      = @{ tag = 'linux_x64';      file = 'libmssqlodbc.so' }
-            'Odbc_Linux_arm64'    = @{ tag = 'linux_arm64';    file = 'libmssqlodbc.so' }
-            'Odbc_Musl_x64'       = @{ tag = 'musl_x64';       file = 'libmssqlodbc.so' }
-            'Odbc_Musl_arm64'     = @{ tag = 'musl_arm64';     file = 'libmssqlodbc.so' }
-            'Odbc_glibc228_x64'   = @{ tag = 'glibc228_x64';   file = 'libmssqlodbc.so' }
-            'Odbc_glibc228_arm64' = @{ tag = 'glibc228_arm64'; file = 'libmssqlodbc.so' }
-            'Odbc_Windows_x64'    = @{ tag = 'windows_x64';    file = 'mssqlodbc.dll' }
-            'Odbc_Windows_arm64'  = @{ tag = 'windows_arm64';  file = 'mssqlodbc.dll' }
+            'drop_Build_Linux_x64'      = @{ tag = 'linux_x64';      file = 'libmssqlodbc.so' }
+            'drop_Build_Linux_ARM64'    = @{ tag = 'linux_arm64';    file = 'libmssqlodbc.so' }
+            'drop_Build_Musl_x64'       = @{ tag = 'musl_x64';       file = 'libmssqlodbc.so' }
+            'drop_Build_Musl_ARM64'     = @{ tag = 'musl_arm64';     file = 'libmssqlodbc.so' }
+            'drop_Build_Glibc228_x64'   = @{ tag = 'glibc228_x64';   file = 'libmssqlodbc.so' }
+            'drop_Build_Glibc228_ARM64' = @{ tag = 'glibc228_arm64'; file = 'libmssqlodbc.so' }
+            'drop_Build_Windows_x64'    = @{ tag = 'windows_x64';    file = 'mssqlodbc.dll' }
+            'drop_Build_Windows_ARM64'  = @{ tag = 'windows_arm64';  file = 'mssqlodbc.dll' }
           }
 
           $nativeRoot = "$(Build.StagingDirectory)/native"

--- a/.pipeline/templates/build-odbc-windows-template.yml
+++ b/.pipeline/templates/build-odbc-windows-template.yml
@@ -1,0 +1,42 @@
+# filepath: .pipeline/templates/build-odbc-windows-template.yml
+#
+# Build the mssql-odbc driver (mssqlodbc.dll) natively on Windows and publish
+# it as a pipeline artifact for the native NuGet package Publish stage.
+#
+# Driver only - no C++ gtest e2e binaries. Windows e2e coverage stays in the
+# PR-only leg in build-template.yml; this is the CI-only leg that stages a
+# releasable driver drop, mirroring build-odbc-template.yml on Linux.
+#
+# CI (non-PR) only.
+
+parameters:
+  # 'x64' or 'ARM64' - selects the build pool the surrounding job runs on.
+  - name: architecture
+    type: string
+  # Pipeline artifact name, e.g. 'Odbc_Windows_x64' / 'Odbc_Windows_arm64'.
+  - name: artifactName
+    type: string
+
+steps:
+  - pwsh: |
+      $ErrorActionPreference = 'Stop'
+      cargo build --release --package mssql-odbc
+    displayName: 'Build mssql-odbc driver (${{ parameters.architecture }})'
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+
+  - pwsh: |
+      $ErrorActionPreference = 'Stop'
+      # Nest under build/ so the Publish stage's extraction step can use the
+      # same relative layout (build/<driver file>) across every platform.
+      $dropDir = "$(Build.SourcesDirectory)\odbc-drop\build"
+      New-Item -ItemType Directory -Force -Path $dropDir | Out-Null
+      Copy-Item "$(CARGO_TARGET_DIR)\release\mssqlodbc.dll" $dropDir
+    displayName: 'Stage driver into drop (${{ parameters.architecture }})'
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+
+  - task: PublishPipelineArtifact@1
+    displayName: 'Publish ${{ parameters.artifactName }}'
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+    inputs:
+      targetPath: '$(Build.SourcesDirectory)/odbc-drop'
+      artifact: ${{ parameters.artifactName }}


### PR DESCRIPTION
## Description

Adds a new OneBranch pipeline that builds the mssqlodbc native driver across Linux (glibc, musl, glibc-2.28; x64+ARM64) and Windows (x64+ARM64), packages the binaries into a single NuGet package, and publishes it to the existing public/mssql-rs_Public Azure Artifacts feed (the same feed already used for mssql-py-core-wheels). Goal: let mssql-python pull the native driver directly from the feed instead of building it from source.

**New files:**
- .pipeline/OneBranch/OdbcNativePublish.yml — top-level OneBranch pipeline definition, modeled on NonOfficialPythonWheelsPublish.yml. Triggers on merge to main and nightly (