### PR TITLE
Bundle mssql-odbc in mssql-python-rs Wheels

### DIFF
--- a/.pipeline/OneBranch/NonOfficialPythonWheelsPublish.yml
+++ b/.pipeline/OneBranch/NonOfficialPythonWheelsPublish.yml
@@ -32,7 +32,7 @@ parameters:
   default: true
 
 - name: buildOdbcNative
-  displayName: 'Build mssql-odbc native driver binaries alongside the wheels'
+  displayName: 'Also build mssql-odbc native driver'
   type: boolean
   default: false
 

--- a/.pipeline/OneBranch/NonOfficialPythonWheelsPublish.yml
+++ b/.pipeline/OneBranch/NonOfficialPythonWheelsPublish.yml
@@ -31,6 +31,11 @@ parameters:
   type: boolean
   default: true
 
+- name: buildOdbcNative
+  displayName: 'Build mssql-odbc native driver binaries alongside the wheels'
+  type: boolean
+  default: false
+
 variables:
   CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)]  # For onebranch.pipeline.version task
   LinuxContainerImage: 'mcr.microsoft.com/onebranch/azurelinux/build:3.0'
@@ -70,5 +75,6 @@ extends:
       parameters:
         buildAllTargets: true
         buildPythonWheels: true
+        buildOdbcNative: ${{ parameters.buildOdbcNative }}
         isOfficial: false
         publishToFeed: ${{ parameters.publishToFeed }}

--- a/.pipeline/OneBranch/OfficialPythonWheelsBuild.yml
+++ b/.pipeline/OneBranch/OfficialPythonWheelsBuild.yml
@@ -50,4 +50,5 @@ extends:
       parameters:
         buildAllTargets: true
         buildPythonWheels: true
+        buildOdbcNative: true
         isOfficial: true

--- a/.pipeline/OneBranch/stages.yml
+++ b/.pipeline/OneBranch/stages.yml
@@ -6,6 +6,10 @@
 # Then packages all wheels into a NuGet archive and publishes to Azure         #
 # Artifacts via OneBranch native nugetPublishing mechanism.                    #
 #                                                                               #
+# When buildOdbcNative is true, the Windows/Linux x64+ARM64 jobs also build   #
+# the mssql-odbc native driver (glibc/musl/glibc-2.28 on Linux) and publish   #
+# it as a separate mssql-odbc-native NuGet package. No macOS lane yet.         #
+#                                                                               #
 # Build jobs use custom 1ES pools (Rust, Docker, Python pre-installed).        #
 # Publish job uses managed OneBranch pool with ob_nugetPublishing_enabled.     #
 # Artifact publishing on custom pools requires explicit                        #
@@ -23,6 +27,11 @@ parameters:
   type: boolean
   default: true
   displayName: 'Build Python wheels'
+
+- name: buildOdbcNative
+  type: boolean
+  default: false
+  displayName: 'Build mssql-odbc native driver binaries alongside the wheels'
 
 - name: isOfficial
   type: boolean
@@ -77,6 +86,18 @@ stages:
           architecture: x64
           publishArtifacts: false
           signWindowsWheels: ${{ parameters.isOfficial }}
+    - ${{ if eq(parameters.buildOdbcNative, true) }}:
+      - template: /.pipeline/templates/build-odbc-windows-template.yml
+        parameters:
+          architecture: x64
+          artifactName: 'Odbc_Windows_x64'
+          publishArtifacts: false
+      - task: CopyFiles@2
+        displayName: 'Collect ODBC native driver (Windows x64)'
+        inputs:
+          sourceFolder: '$(Build.SourcesDirectory)\odbc-drop'
+          targetFolder: '$(ob_outputDirectory)\odbc_windows_x64'
+          contents: '**'
     - task: PublishPipelineArtifact@1
       displayName: 'Publish Windows x64 Artifacts'
       inputs:
@@ -133,6 +154,18 @@ stages:
             - '3.12'
             - '3.13'
             - '3.14'
+      - ${{ if eq(parameters.buildOdbcNative, true) }}:
+        - template: /.pipeline/templates/build-odbc-windows-template.yml
+          parameters:
+            architecture: ARM64
+            artifactName: 'Odbc_Windows_ARM64'
+            publishArtifacts: false
+        - task: CopyFiles@2
+          displayName: 'Collect ODBC native driver (Windows ARM64)'
+          inputs:
+            sourceFolder: '$(Build.SourcesDirectory)\odbc-drop'
+            targetFolder: '$(ob_outputDirectory)\odbc_windows_arm64'
+            contents: '**'
       - task: PublishPipelineArtifact@1
         displayName: 'Publish Windows ARM64 Artifacts'
         inputs:
@@ -179,6 +212,44 @@ stages:
           osType: Alpine
           architecture: x64
           publishArtifacts: false
+    - ${{ if eq(parameters.buildOdbcNative, true) }}:
+      - template: /.pipeline/templates/build-odbc-template.yml
+        parameters:
+          architecture: x64
+          artifactName: 'Odbc_Linux_x64_glibc'
+          publishArtifacts: false
+      - task: CopyFiles@2
+        displayName: 'Collect ODBC glibc driver (Linux x64)'
+        inputs:
+          sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
+          targetFolder: '$(ob_outputDirectory)/odbc_glibc_x64'
+          contents: '**'
+      - script: rm -rf $(Build.SourcesDirectory)/odbc-drop
+        displayName: 'Clear odbc-drop before next ODBC variant'
+      - template: /.pipeline/templates/build-odbc-alpine-template.yml
+        parameters:
+          architecture: x64
+          artifactName: 'Odbc_Linux_x64_musl'
+          publishArtifacts: false
+      - task: CopyFiles@2
+        displayName: 'Collect ODBC musl driver (Linux x64)'
+        inputs:
+          sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
+          targetFolder: '$(ob_outputDirectory)/odbc_musl_x64'
+          contents: '**'
+      - script: rm -rf $(Build.SourcesDirectory)/odbc-drop
+        displayName: 'Clear odbc-drop before next ODBC variant'
+      - template: /.pipeline/templates/build-odbc-glibc228-template.yml
+        parameters:
+          architecture: x64
+          artifactName: 'Odbc_Linux_x64_glibc228'
+          publishArtifacts: false
+      - task: CopyFiles@2
+        displayName: 'Collect ODBC glibc-2.28 driver (Linux x64)'
+        inputs:
+          sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
+          targetFolder: '$(ob_outputDirectory)/odbc_glibc228_x64'
+          contents: '**'
     - task: PublishPipelineArtifact@1
       displayName: 'Publish Linux x64 Artifacts'
       inputs:
@@ -226,6 +297,45 @@ stages:
             osType: Alpine
             architecture: arm64
             publishArtifacts: false
+      - ${{ if eq(parameters.buildOdbcNative, true) }}:
+        - template: /.pipeline/templates/build-odbc-template.yml
+          parameters:
+            architecture: ARM64
+            artifactName: 'Odbc_Linux_ARM64_glibc'
+            publishArtifacts: false
+        - task: CopyFiles@2
+          displayName: 'Collect ODBC glibc driver (Linux ARM64)'
+          inputs:
+            sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
+            targetFolder: '$(ob_outputDirectory)/odbc_glibc_arm64'
+            contents: '**'
+        - script: rm -rf $(Build.SourcesDirectory)/odbc-drop
+          displayName: 'Clear odbc-drop before next ODBC variant'
+        - template: /.pipeline/templates/build-odbc-alpine-template.yml
+          parameters:
+            architecture: ARM64
+            artifactName: 'Odbc_Linux_ARM64_musl'
+            publishArtifacts: false
+        - task: CopyFiles@2
+          displayName: 'Collect ODBC musl driver (Linux ARM64)'
+          inputs:
+            sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
+            targetFolder: '$(ob_outputDirectory)/odbc_musl_arm64'
+            contents: '**'
+        - script: rm -rf $(Build.SourcesDirectory)/odbc-drop
+          displayName: 'Clear odbc-drop before next ODBC variant'
+        - template: /.pipeline/templates/build-odbc-glibc228-template.yml
+          parameters:
+            architecture: ARM64
+            buildImage: 'ghcr.io/microsoft/mssql-rs/python-build/manylinux_2_28_aarch64_rust:latest'
+            artifactName: 'Odbc_Linux_ARM64_glibc228'
+            publishArtifacts: false
+        - task: CopyFiles@2
+          displayName: 'Collect ODBC glibc-2.28 driver (Linux ARM64)'
+          inputs:
+            sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
+            targetFolder: '$(ob_outputDirectory)/odbc_glibc228_arm64'
+            contents: '**'
       - task: PublishPipelineArtifact@1
         displayName: 'Publish Linux ARM64 Artifacts'
         inputs:
@@ -398,3 +508,81 @@ stages:
           }
           Write-Host "OneBranch will auto-publish from $(ob_outputDirectory)/packages"
         displayName: 'Verify NuGet package'
+
+      # mssql-odbc native driver binaries - packaged as a separate NuGet
+      # (unrelated product/consumers from the Python wheels above), built
+      # from the same artifacts this job already downloaded.
+      - ${{ if eq(parameters.buildOdbcNative, true) }}:
+        - pwsh: |
+            $ErrorActionPreference = 'Stop'
+
+            # source artifact/subfolder -> (platform tag, driver filename).
+            # Subfolder names match the CopyFiles targetFolder used in each
+            # Build job (see Windows_x64/Windows_ARM64/Linux_x64/Linux_ARM64
+            # above); every source path shares the build/<file> layout that
+            # build-odbc-*-template.yml and build-odbc-windows-template.yml
+            # stage the driver into.
+            $platforms = [ordered]@{
+              'drop_Build_Linux_x64_linux_x64/odbc_glibc_x64'             = @{ tag = 'linux_x64';      file = 'mssqlodbc.so' }
+              'drop_Build_Linux_x64_linux_x64/odbc_musl_x64'              = @{ tag = 'musl_x64';       file = 'mssqlodbc.so' }
+              'drop_Build_Linux_x64_linux_x64/odbc_glibc228_x64'          = @{ tag = 'glibc228_x64';   file = 'mssqlodbc.so' }
+              'drop_Build_Linux_ARM64_linux_arm64/odbc_glibc_arm64'       = @{ tag = 'linux_arm64';    file = 'mssqlodbc.so' }
+              'drop_Build_Linux_ARM64_linux_arm64/odbc_musl_arm64'        = @{ tag = 'musl_arm64';     file = 'mssqlodbc.so' }
+              'drop_Build_Linux_ARM64_linux_arm64/odbc_glibc228_arm64'    = @{ tag = 'glibc228_arm64'; file = 'mssqlodbc.so' }
+              'drop_Build_Windows_x64_windows_x64/odbc_windows_x64'       = @{ tag = 'windows_x64';    file = 'mssqlodbc.dll' }
+              'drop_Build_Windows_ARM64_windows_arm64/odbc_windows_arm64' = @{ tag = 'windows_arm64';  file = 'mssqlodbc.dll' }
+            }
+
+            foreach ($key in $platforms.Keys) {
+              $info = $platforms[$key]
+              $sourcePath = "$(Pipeline.Workspace)/$key/build/$($info.file)"
+              if (-not (Test-Path $sourcePath)) {
+                Write-Error "Missing ODBC driver binary: $sourcePath"
+                exit 1
+              }
+              $destDir = "$(Build.StagingDirectory)/odbc-native/$($info.tag)"
+              New-Item -ItemType Directory -Force -Path $destDir | Out-Null
+              Copy-Item $sourcePath "$destDir/$($info.file)"
+              Write-Host "Staged $($info.tag): $sourcePath -> $destDir/$($info.file)"
+            }
+          displayName: 'Collect ODBC native driver binaries'
+
+        - pwsh: |
+            $ErrorActionPreference = 'Stop'
+
+            # Reuses $(nugetVersion)/$(shortSha) computed above for the wheels
+            # package - both packages are built from the same commit/run.
+            $nuspecContent = @"
+            <?xml version="1.0"?>
+            <package>
+              <metadata>
+                <id>mssql-odbc-native</id>
+                <version>$(nugetVersion)</version>
+                <description>mssql-odbc native driver binaries across platforms. Commit: $(Build.SourceVersion). Build: $(Build.BuildNumber)</description>
+                <authors>SqlClientDrivers</authors>
+              </metadata>
+              <files>
+                <file src="odbc-native\**\*" target="native" />
+              </files>
+            </package>
+            "@
+
+            $nuspecPath = "$(Build.StagingDirectory)/mssql-odbc-native.nuspec"
+            $nuspecContent | Out-File -FilePath $nuspecPath -Encoding utf8
+            Write-Host "Created nuspec at $nuspecPath"
+          displayName: 'Generate ODBC native NuGet package metadata'
+
+        - task: NuGetCommand@2
+          displayName: 'Create ODBC native NuGet package'
+          inputs:
+            command: pack
+            packagesToPack: '$(Build.StagingDirectory)/mssql-odbc-native.nuspec'
+            packDestination: '$(ob_outputDirectory)/packages'
+            basePath: '$(Build.StagingDirectory)'
+
+        - pwsh: |
+            Write-Host "=== ODBC native NuGet package created ==="
+            Get-ChildItem "$(ob_outputDirectory)/packages" -Filter mssql-odbc-native*.nupkg | ForEach-Object {
+              Write-Host "  $($_.Name)  ($([math]::Round($_.Length/1MB, 2)) MB)"
+            }
+          displayName: 'Verify ODBC native NuGet package'

--- a/.pipeline/OneBranch/stages.yml
+++ b/.pipeline/OneBranch/stages.yml
@@ -8,11 +8,11 @@
 #                                                                               #
 # When buildOdbcNative is true, the Windows/Linux x64+ARM64 and macOS jobs      #
 # also build the mssql-odbc native driver (glibc + musl on Linux; 2_34 only,    #
-# no glibc-2.28 on this NuGet path). The Publish job injects each platform's    #
-# driver into the mssql-py-core wheels under mssql_py_core/libs/... so a single #
-# wheel carries both the PyO3 TDS core and the Rust ODBC driver. The macOS job  #
-# builds both arch slices as SEPARATE binaries (no lipo fusion), matching       #
-# mssql-python's libs/macos/{arm64,x86_64} layout for this driver.              #
+# no glibc-2.28 on this NuGet path) and inject it into their own wheels under   #
+# mssql_py_core/libs/... (where Python is already available for the build), so  #
+# a single wheel carries both the PyO3 TDS core and the Rust ODBC driver. The   #
+# macOS job builds both arch slices as SEPARATE binaries (no lipo fusion),      #
+# matching mssql-python's libs/macos/{arm64,x86_64} layout for this driver.     #
 #                                                                               #
 # Build jobs use custom 1ES pools (Rust, Docker, Python pre-installed).        #
 # Publish job uses managed OneBranch pool with ob_nugetPublishing_enabled.     #
@@ -97,13 +97,14 @@ stages:
           artifactName: 'Odbc_Windows_x64'
           publishArtifacts: false
           signDriver: ${{ parameters.isOfficial }}
-      - task: CopyFiles@2
-        displayName: 'Collect ODBC native driver (Windows x64)'
+      - pwsh: |
+          $ErrorActionPreference = 'Stop'
+          $drivers = "$(Build.SourcesDirectory)\drivers\windows\x64"
+          New-Item -ItemType Directory -Force -Path $drivers | Out-Null
+          Copy-Item "$(Build.SourcesDirectory)\odbc-drop\build\mssqlodbc.dll" "$drivers\mssqlodbc.dll"
+          python "$(Build.SourcesDirectory)\scripts\inject-odbc-into-wheels.py" --wheels-dir "$(ob_outputDirectory)\wheels" --drivers-dir "$(Build.SourcesDirectory)\drivers"
+        displayName: 'Inject ODBC driver into wheels (Windows x64)'
         condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-        inputs:
-          sourceFolder: '$(Build.SourcesDirectory)\odbc-drop'
-          targetFolder: '$(ob_outputDirectory)\odbc_windows_x64'
-          contents: 'build/mssqlodbc.dll'
     - task: PublishPipelineArtifact@1
       displayName: 'Publish Windows x64 Artifacts'
       inputs:
@@ -167,13 +168,14 @@ stages:
             artifactName: 'Odbc_Windows_ARM64'
             publishArtifacts: false
             signDriver: ${{ parameters.isOfficial }}
-        - task: CopyFiles@2
-          displayName: 'Collect ODBC native driver (Windows ARM64)'
+        - pwsh: |
+            $ErrorActionPreference = 'Stop'
+            $drivers = "$(Build.SourcesDirectory)\drivers\windows\arm64"
+            New-Item -ItemType Directory -Force -Path $drivers | Out-Null
+            Copy-Item "$(Build.SourcesDirectory)\odbc-drop\build\mssqlodbc.dll" "$drivers\mssqlodbc.dll"
+            python "$(Build.SourcesDirectory)\scripts\inject-odbc-into-wheels.py" --wheels-dir "$(ob_outputDirectory)\wheels" --drivers-dir "$(Build.SourcesDirectory)\drivers"
+          displayName: 'Inject ODBC driver into wheels (Windows ARM64)'
           condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-          inputs:
-            sourceFolder: '$(Build.SourcesDirectory)\odbc-drop'
-            targetFolder: '$(ob_outputDirectory)\odbc_windows_arm64'
-            contents: 'build/mssqlodbc.dll'
       - task: PublishPipelineArtifact@1
         displayName: 'Publish Windows ARM64 Artifacts'
         inputs:
@@ -226,25 +228,32 @@ stages:
           architecture: x64
           artifactName: 'Odbc_Linux_x64_glibc'
           publishArtifacts: false
-      - task: CopyFiles@2
-        displayName: 'Collect ODBC glibc driver (Linux x64)'
+      - script: |
+          set -e
+          mkdir -p "$(Build.SourcesDirectory)/drivers/linux/glibc/x86_64/lib"
+          cp "$(Build.SourcesDirectory)/odbc-drop/build/mssqlodbc.so" "$(Build.SourcesDirectory)/drivers/linux/glibc/x86_64/lib/mssqlodbc.so"
+        displayName: 'Stage glibc driver (Linux x64)'
         condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-        inputs:
-          sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
-          targetFolder: '$(ob_outputDirectory)/odbc_glibc_x64'
-          contents: 'build/mssqlodbc.so'
       - template: /.pipeline/templates/build-odbc-alpine-template.yml
         parameters:
           architecture: x64
           artifactName: 'Odbc_Linux_x64_musl'
           publishArtifacts: false
-      - task: CopyFiles@2
-        displayName: 'Collect ODBC musl driver (Linux x64)'
+      - script: |
+          set -e
+          mkdir -p "$(Build.SourcesDirectory)/drivers/linux/musl/x86_64/lib"
+          cp "$(Build.SourcesDirectory)/odbc-drop/build/mssqlodbc.so" "$(Build.SourcesDirectory)/drivers/linux/musl/x86_64/lib/mssqlodbc.so"
+        displayName: 'Stage musl driver (Linux x64)'
         condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-        inputs:
-          sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
-          targetFolder: '$(ob_outputDirectory)/odbc_musl_x64'
-          contents: 'build/mssqlodbc.so'
+      - script: |
+          set -e
+          command -v python3 >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y python3; }
+          sudo chown -R $(whoami):$(whoami) "$(ob_outputDirectory)/wheels"
+          python3 "$(Build.SourcesDirectory)/scripts/inject-odbc-into-wheels.py" \
+            --wheels-dir "$(ob_outputDirectory)/wheels" \
+            --drivers-dir "$(Build.SourcesDirectory)/drivers"
+        displayName: 'Inject ODBC driver into wheels (Linux x64)'
+        condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
     - task: PublishPipelineArtifact@1
       displayName: 'Publish Linux x64 Artifacts'
       inputs:
@@ -298,25 +307,26 @@ stages:
             architecture: ARM64
             artifactName: 'Odbc_Linux_ARM64_glibc'
             publishArtifacts: false
-        - task: CopyFiles@2
-          displayName: 'Collect ODBC glibc driver (Linux ARM64)'
+        - script: |
+            set -e
+            mkdir -p "$(Build.SourcesDirectory)/drivers/linux/glibc/arm64/lib"
+            cp "$(Build.SourcesDirectory)/odbc-drop/build/mssqlodbc.so" "$(Build.SourcesDirectory)/drivers/linux/glibc/arm64/lib/mssqlodbc.so"
+          displayName: 'Stage glibc driver (Linux ARM64)'
           condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-          inputs:
-            sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
-            targetFolder: '$(ob_outputDirectory)/odbc_glibc_arm64'
-            contents: 'build/mssqlodbc.so'
         - template: /.pipeline/templates/build-odbc-alpine-template.yml
           parameters:
             architecture: ARM64
             artifactName: 'Odbc_Linux_ARM64_musl'
             publishArtifacts: false
-        - task: CopyFiles@2
-          displayName: 'Collect ODBC musl driver (Linux ARM64)'
+        - script: |
+            set -e
+            command -v python3 >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y python3; }
+            sudo chown -R $(whoami):$(whoami) "$(ob_outputDirectory)/wheels"
+            python3 "$(Build.SourcesDirectory)/scripts/inject-odbc-into-wheels.py" \
+              --wheels-dir "$(ob_outputDirectory)/wheels" \
+              --drivers-dir "$(Build.SourcesDirectory)/drivers"
+          displayName: 'Inject ODBC driver into wheels (Linux ARM64)'
           condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-          inputs:
-            sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
-            targetFolder: '$(ob_outputDirectory)/odbc_musl_arm64'
-            contents: 'build/mssqlodbc.so'
       - task: PublishPipelineArtifact@1
         displayName: 'Publish Linux ARM64 Artifacts'
         inputs:
@@ -361,25 +371,30 @@ stages:
             architecture: x64
             artifactName: 'Odbc_MacOS_x64'
             publishArtifacts: false
-        - task: CopyFiles@2
-          displayName: 'Collect ODBC native driver (macOS x64)'
+        - script: |
+            set -e
+            mkdir -p "$(Build.SourcesDirectory)/drivers/macos/x86_64/lib"
+            cp "$(Build.SourcesDirectory)/odbc-drop/build/mssqlodbc.dylib" "$(Build.SourcesDirectory)/drivers/macos/x86_64/lib/mssqlodbc.dylib"
+          displayName: 'Stage macOS x64 driver'
           condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-          inputs:
-            sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
-            targetFolder: '$(ob_outputDirectory)/odbc_macos_x64'
-            contents: 'build/mssqlodbc.dylib'
         - template: /.pipeline/templates/build-odbc-macos-template.yml
           parameters:
             architecture: ARM64
             artifactName: 'Odbc_MacOS_ARM64'
             publishArtifacts: false
-        - task: CopyFiles@2
-          displayName: 'Collect ODBC native driver (macOS ARM64)'
+        - script: |
+            set -e
+            mkdir -p "$(Build.SourcesDirectory)/drivers/macos/arm64/lib"
+            cp "$(Build.SourcesDirectory)/odbc-drop/build/mssqlodbc.dylib" "$(Build.SourcesDirectory)/drivers/macos/arm64/lib/mssqlodbc.dylib"
+          displayName: 'Stage macOS ARM64 driver'
           condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-          inputs:
-            sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
-            targetFolder: '$(ob_outputDirectory)/odbc_macos_arm64'
-            contents: 'build/mssqlodbc.dylib'
+        - script: |
+            set -e
+            python3 "$(Build.SourcesDirectory)/scripts/inject-odbc-into-wheels.py" \
+              --wheels-dir "$(ob_outputDirectory)/wheels" \
+              --drivers-dir "$(Build.SourcesDirectory)/drivers"
+          displayName: 'Inject ODBC driver into macOS wheels'
+          condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
       - task: PublishPipelineArtifact@1
         displayName: 'Publish macOS Artifacts'
         inputs:
@@ -427,66 +442,6 @@ stages:
             Write-Host "WARNING: No wheels found!"
           }
         displayName: 'List collected wheels'
-
-      # Inject the mssql-odbc native driver into each mssql-py-core wheel so a
-      # single wheel carries both the PyO3 TDS core and the Rust ODBC driver.
-      # Driver files land under mssql_py_core/libs/... in the exact layout
-      # mssql-python's native resolver reads for the mssql-odbc provider.
-      - ${{ if eq(parameters.buildOdbcNative, true) }}:
-        - task: UsePythonVersion@0
-          displayName: 'Use Python for wheel injection'
-          inputs:
-            versionSpec: '3.12'
-            addToPath: true
-
-        - pwsh: |
-            $ErrorActionPreference = 'Stop'
-
-            # Template expansion produces bare True/False which aren't valid
-            # PowerShell; string comparison converts to a proper boolean.
-            $buildAllTargets = "${{ parameters.buildAllTargets }}" -eq "True"
-
-            # Stage each collected mssqlodbc binary into a tree mirroring the
-            # libs/ subtree inject-odbc-into-wheels.py expects. Sources use the
-            # Build jobs' CopyFiles targetFolder names (odbc_<track>_<arch>/
-            # build/<file>); destinations are the runtime libs/-relative layout
-            # the mssql-python resolver reads (arch token x86_64/arm64 on Linux
-            # and macOS, x64/arm64 on Windows).
-            $driversRoot = "$(Build.StagingDirectory)/drivers"
-
-            $map = [ordered]@{
-              'drop_Build_Windows_x64_windows_x64/odbc_windows_x64/build/mssqlodbc.dll' = 'windows/x64/mssqlodbc.dll'
-              'drop_Build_Linux_x64_linux_x64/odbc_glibc_x64/build/mssqlodbc.so'        = 'linux/glibc/x86_64/lib/mssqlodbc.so'
-              'drop_Build_Linux_x64_linux_x64/odbc_musl_x64/build/mssqlodbc.so'         = 'linux/musl/x86_64/lib/mssqlodbc.so'
-            }
-
-            if ($buildAllTargets) {
-              $map['drop_Build_Windows_ARM64_windows_arm64/odbc_windows_arm64/build/mssqlodbc.dll'] = 'windows/arm64/mssqlodbc.dll'
-              $map['drop_Build_Linux_ARM64_linux_arm64/odbc_glibc_arm64/build/mssqlodbc.so']        = 'linux/glibc/arm64/lib/mssqlodbc.so'
-              $map['drop_Build_Linux_ARM64_linux_arm64/odbc_musl_arm64/build/mssqlodbc.so']         = 'linux/musl/arm64/lib/mssqlodbc.so'
-              $map['drop_Build_MacOS_universal2_macos_universal2/odbc_macos_x64/build/mssqlodbc.dylib']   = 'macos/x86_64/lib/mssqlodbc.dylib'
-              $map['drop_Build_MacOS_universal2_macos_universal2/odbc_macos_arm64/build/mssqlodbc.dylib'] = 'macos/arm64/lib/mssqlodbc.dylib'
-            }
-
-            foreach ($src in $map.Keys) {
-              $sourcePath = "$(Pipeline.Workspace)/$src"
-              if (-not (Test-Path $sourcePath)) {
-                Write-Error "Missing ODBC driver binary: $sourcePath"
-                exit 1
-              }
-              $destPath = Join-Path $driversRoot $map[$src]
-              New-Item -ItemType Directory -Force -Path (Split-Path $destPath) | Out-Null
-              Copy-Item $sourcePath $destPath
-              Write-Host "Staged $src -> $($map[$src])"
-            }
-          displayName: 'Stage ODBC driver binaries'
-
-        - pwsh: |
-            $ErrorActionPreference = 'Stop'
-            python "$(Build.SourcesDirectory)/scripts/inject-odbc-into-wheels.py" `
-              --wheels-dir "$(Build.StagingDirectory)/wheels" `
-              --drivers-dir "$(Build.StagingDirectory)/drivers"
-          displayName: 'Inject ODBC driver into wheels'
 
       - pwsh: |
           $ErrorActionPreference = 'Stop'

--- a/.pipeline/OneBranch/stages.yml
+++ b/.pipeline/OneBranch/stages.yml
@@ -31,7 +31,7 @@ parameters:
 - name: buildOdbcNative
   type: boolean
   default: false
-  displayName: 'Build mssql-odbc native driver binaries alongside the wheels'
+  displayName: 'Also build mssql-odbc native driver'
 
 - name: isOfficial
   type: boolean

--- a/.pipeline/OneBranch/stages.yml
+++ b/.pipeline/OneBranch/stages.yml
@@ -526,7 +526,7 @@ stages:
             }
 
             # Windows_ARM64/Linux_ARM64 jobs only run when buildAllTargets is
-            # true (see the job-level ${{ if }} guards above); skip these
+            # true (see the job-level conditional guards above); skip these
             # entries otherwise, or the Test-Path check below always fails.
             if ($buildAllTargets) {
               $platforms['drop_Build_Linux_ARM64_linux_arm64/odbc_glibc_arm64']       = @{ tag = 'linux_arm64';    file = 'mssqlodbc.so' }

--- a/.pipeline/OneBranch/stages.yml
+++ b/.pipeline/OneBranch/stages.yml
@@ -224,8 +224,6 @@ stages:
           sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
           targetFolder: '$(ob_outputDirectory)/odbc_glibc_x64'
           contents: '**'
-      - script: rm -rf $(Build.SourcesDirectory)/odbc-drop
-        displayName: 'Clear odbc-drop before next ODBC variant'
       - template: /.pipeline/templates/build-odbc-alpine-template.yml
         parameters:
           architecture: x64
@@ -237,8 +235,6 @@ stages:
           sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
           targetFolder: '$(ob_outputDirectory)/odbc_musl_x64'
           contents: '**'
-      - script: rm -rf $(Build.SourcesDirectory)/odbc-drop
-        displayName: 'Clear odbc-drop before next ODBC variant'
       - template: /.pipeline/templates/build-odbc-glibc228-template.yml
         parameters:
           architecture: x64
@@ -309,8 +305,6 @@ stages:
             sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
             targetFolder: '$(ob_outputDirectory)/odbc_glibc_arm64'
             contents: '**'
-        - script: rm -rf $(Build.SourcesDirectory)/odbc-drop
-          displayName: 'Clear odbc-drop before next ODBC variant'
         - template: /.pipeline/templates/build-odbc-alpine-template.yml
           parameters:
             architecture: ARM64
@@ -322,8 +316,6 @@ stages:
             sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
             targetFolder: '$(ob_outputDirectory)/odbc_musl_arm64'
             contents: '**'
-        - script: rm -rf $(Build.SourcesDirectory)/odbc-drop
-          displayName: 'Clear odbc-drop before next ODBC variant'
         - template: /.pipeline/templates/build-odbc-glibc228-template.yml
           parameters:
             architecture: ARM64
@@ -516,6 +508,10 @@ stages:
         - pwsh: |
             $ErrorActionPreference = 'Stop'
 
+            # Template expansion produces bare True/False which aren't valid
+            # PowerShell; string comparison converts to a proper boolean.
+            $buildAllTargets = "${{ parameters.buildAllTargets }}" -eq "True"
+
             # source artifact/subfolder -> (platform tag, driver filename).
             # Subfolder names match the CopyFiles targetFolder used in each
             # Build job (see Windows_x64/Windows_ARM64/Linux_x64/Linux_ARM64
@@ -526,11 +522,17 @@ stages:
               'drop_Build_Linux_x64_linux_x64/odbc_glibc_x64'             = @{ tag = 'linux_x64';      file = 'mssqlodbc.so' }
               'drop_Build_Linux_x64_linux_x64/odbc_musl_x64'              = @{ tag = 'musl_x64';       file = 'mssqlodbc.so' }
               'drop_Build_Linux_x64_linux_x64/odbc_glibc228_x64'          = @{ tag = 'glibc228_x64';   file = 'mssqlodbc.so' }
-              'drop_Build_Linux_ARM64_linux_arm64/odbc_glibc_arm64'       = @{ tag = 'linux_arm64';    file = 'mssqlodbc.so' }
-              'drop_Build_Linux_ARM64_linux_arm64/odbc_musl_arm64'        = @{ tag = 'musl_arm64';     file = 'mssqlodbc.so' }
-              'drop_Build_Linux_ARM64_linux_arm64/odbc_glibc228_arm64'    = @{ tag = 'glibc228_arm64'; file = 'mssqlodbc.so' }
               'drop_Build_Windows_x64_windows_x64/odbc_windows_x64'       = @{ tag = 'windows_x64';    file = 'mssqlodbc.dll' }
-              'drop_Build_Windows_ARM64_windows_arm64/odbc_windows_arm64' = @{ tag = 'windows_arm64';  file = 'mssqlodbc.dll' }
+            }
+
+            # Windows_ARM64/Linux_ARM64 jobs only run when buildAllTargets is
+            # true (see the job-level ${{ if }} guards above); skip these
+            # entries otherwise, or the Test-Path check below always fails.
+            if ($buildAllTargets) {
+              $platforms['drop_Build_Linux_ARM64_linux_arm64/odbc_glibc_arm64']       = @{ tag = 'linux_arm64';    file = 'mssqlodbc.so' }
+              $platforms['drop_Build_Linux_ARM64_linux_arm64/odbc_musl_arm64']        = @{ tag = 'musl_arm64';     file = 'mssqlodbc.so' }
+              $platforms['drop_Build_Linux_ARM64_linux_arm64/odbc_glibc228_arm64']    = @{ tag = 'glibc228_arm64'; file = 'mssqlodbc.so' }
+              $platforms['drop_Build_Windows_ARM64_windows_arm64/odbc_windows_arm64'] = @{ tag = 'windows_arm64';  file = 'mssqlodbc.dll' }
             }
 
             foreach ($key in $platforms.Keys) {
@@ -550,14 +552,46 @@ stages:
         - pwsh: |
             $ErrorActionPreference = 'Stop'
 
-            # Reuses $(nugetVersion)/$(shortSha) computed above for the wheels
-            # package - both packages are built from the same commit/run.
+            # mssql-odbc is versioned independently from mssql-py-core, so
+            # compute its own package version rather than reusing $(nugetVersion).
+            $cargoToml = Get-Content "$(Build.SourcesDirectory)/mssql-odbc/Cargo.toml" -Raw
+            if ($cargoToml -match 'version\s*=\s*"([^"]+)"') {
+              $version = $Matches[1]
+            } else {
+              Write-Error "Could not extract version from mssql-odbc/Cargo.toml"
+              exit 1
+            }
+
+            $buildReason = "$(Build.Reason)"
+            $isOfficial = "${{ parameters.isOfficial }}" -eq "True"
+            $dateStamp = Get-Date -Format "yyyyMMdd"
+            $buildId = "$(Build.BuildId)"
+
+            switch ($buildReason) {
+              'Schedule' { $odbcPackageVersion = "$version-nightly.$dateStamp" }
+              'Manual' {
+                if ($isOfficial) {
+                  $odbcPackageVersion = $version
+                } else {
+                  $odbcPackageVersion = "$version-dev.$dateStamp.$buildId"
+                }
+              }
+              default { $odbcPackageVersion = "$version-dev.$dateStamp.$buildId" }
+            }
+
+            Write-Host "ODBC native package version: $odbcPackageVersion"
+            Write-Host "##vso[task.setvariable variable=odbcNugetVersion]$odbcPackageVersion"
+          displayName: 'Compute ODBC native package version'
+
+        - pwsh: |
+            $ErrorActionPreference = 'Stop'
+
             $nuspecContent = @"
             <?xml version="1.0"?>
             <package>
               <metadata>
                 <id>mssql-odbc-native</id>
-                <version>$(nugetVersion)</version>
+                <version>$(odbcNugetVersion)</version>
                 <description>mssql-odbc native driver binaries across platforms. Commit: $(Build.SourceVersion). Build: $(Build.BuildNumber)</description>
                 <authors>SqlClientDrivers</authors>
               </metadata>

--- a/.pipeline/OneBranch/stages.yml
+++ b/.pipeline/OneBranch/stages.yml
@@ -6,11 +6,13 @@
 # Then packages all wheels into a NuGet archive and publishes to Azure         #
 # Artifacts via OneBranch native nugetPublishing mechanism.                    #
 #                                                                               #
-# When buildOdbcNative is true, the Windows/Linux x64+ARM64 jobs also build   #
-# the mssql-odbc native driver (glibc/musl/glibc-2.28 on Linux) and publish   #
-# it as a separate mssql-odbc-native NuGet package. The macOS job builds both  #
-# arch slices as SEPARATE binaries (no lipo fusion), matching mssql-python's  #
-# expected libs/macos/{arm64,x86_64} layout for this driver.                   #
+# When buildOdbcNative is true, the Windows/Linux x64+ARM64 and macOS jobs      #
+# also build the mssql-odbc native driver (glibc + musl on Linux; 2_34 only,    #
+# no glibc-2.28 on this NuGet path). The Publish job injects each platform's    #
+# driver into the mssql-py-core wheels under mssql_py_core/libs/... so a single #
+# wheel carries both the PyO3 TDS core and the Rust ODBC driver. The macOS job  #
+# builds both arch slices as SEPARATE binaries (no lipo fusion), matching       #
+# mssql-python's libs/macos/{arm64,x86_64} layout for this driver.              #
 #                                                                               #
 # Build jobs use custom 1ES pools (Rust, Docker, Python pre-installed).        #
 # Publish job uses managed OneBranch pool with ob_nugetPublishing_enabled.     #
@@ -94,6 +96,7 @@ stages:
           architecture: x64
           artifactName: 'Odbc_Windows_x64'
           publishArtifacts: false
+          signDriver: ${{ parameters.isOfficial }}
       - task: CopyFiles@2
         displayName: 'Collect ODBC native driver (Windows x64)'
         inputs:
@@ -162,6 +165,7 @@ stages:
             architecture: ARM64
             artifactName: 'Odbc_Windows_ARM64'
             publishArtifacts: false
+            signDriver: ${{ parameters.isOfficial }}
         - task: CopyFiles@2
           displayName: 'Collect ODBC native driver (Windows ARM64)'
           inputs:
@@ -225,7 +229,7 @@ stages:
         inputs:
           sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
           targetFolder: '$(ob_outputDirectory)/odbc_glibc_x64'
-          contents: '**'
+          contents: 'build/mssqlodbc.so'
       - template: /.pipeline/templates/build-odbc-alpine-template.yml
         parameters:
           architecture: x64
@@ -236,18 +240,7 @@ stages:
         inputs:
           sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
           targetFolder: '$(ob_outputDirectory)/odbc_musl_x64'
-          contents: '**'
-      - template: /.pipeline/templates/build-odbc-glibc228-template.yml
-        parameters:
-          architecture: x64
-          artifactName: 'Odbc_Linux_x64_glibc228'
-          publishArtifacts: false
-      - task: CopyFiles@2
-        displayName: 'Collect ODBC glibc-2.28 driver (Linux x64)'
-        inputs:
-          sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
-          targetFolder: '$(ob_outputDirectory)/odbc_glibc228_x64'
-          contents: '**'
+          contents: 'build/mssqlodbc.so'
     - task: PublishPipelineArtifact@1
       displayName: 'Publish Linux x64 Artifacts'
       inputs:
@@ -306,7 +299,7 @@ stages:
           inputs:
             sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
             targetFolder: '$(ob_outputDirectory)/odbc_glibc_arm64'
-            contents: '**'
+            contents: 'build/mssqlodbc.so'
         - template: /.pipeline/templates/build-odbc-alpine-template.yml
           parameters:
             architecture: ARM64
@@ -317,19 +310,7 @@ stages:
           inputs:
             sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
             targetFolder: '$(ob_outputDirectory)/odbc_musl_arm64'
-            contents: '**'
-        - template: /.pipeline/templates/build-odbc-glibc228-template.yml
-          parameters:
-            architecture: ARM64
-            buildImage: 'ghcr.io/microsoft/mssql-rs/python-build/manylinux_2_28_aarch64_rust:latest'
-            artifactName: 'Odbc_Linux_ARM64_glibc228'
-            publishArtifacts: false
-        - task: CopyFiles@2
-          displayName: 'Collect ODBC glibc-2.28 driver (Linux ARM64)'
-          inputs:
-            sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
-            targetFolder: '$(ob_outputDirectory)/odbc_glibc228_arm64'
-            contents: '**'
+            contents: 'build/mssqlodbc.so'
       - task: PublishPipelineArtifact@1
         displayName: 'Publish Linux ARM64 Artifacts'
         inputs:
@@ -439,6 +420,66 @@ stages:
           }
         displayName: 'List collected wheels'
 
+      # Inject the mssql-odbc native driver into each mssql-py-core wheel so a
+      # single wheel carries both the PyO3 TDS core and the Rust ODBC driver.
+      # Driver files land under mssql_py_core/libs/... in the exact layout
+      # mssql-python's native resolver reads for the mssql-odbc provider.
+      - ${{ if eq(parameters.buildOdbcNative, true) }}:
+        - task: UsePythonVersion@0
+          displayName: 'Use Python for wheel injection'
+          inputs:
+            versionSpec: '3.12'
+            addToPath: true
+
+        - pwsh: |
+            $ErrorActionPreference = 'Stop'
+
+            # Template expansion produces bare True/False which aren't valid
+            # PowerShell; string comparison converts to a proper boolean.
+            $buildAllTargets = "${{ parameters.buildAllTargets }}" -eq "True"
+
+            # Stage each collected mssqlodbc binary into a tree mirroring the
+            # libs/ subtree inject-odbc-into-wheels.py expects. Sources use the
+            # Build jobs' CopyFiles targetFolder names (odbc_<track>_<arch>/
+            # build/<file>); destinations are the runtime libs/-relative layout
+            # the mssql-python resolver reads (arch token x86_64/arm64 on Linux
+            # and macOS, x64/arm64 on Windows).
+            $driversRoot = "$(Build.StagingDirectory)/drivers"
+
+            $map = [ordered]@{
+              'drop_Build_Windows_x64_windows_x64/odbc_windows_x64/build/mssqlodbc.dll' = 'windows/x64/mssqlodbc.dll'
+              'drop_Build_Linux_x64_linux_x64/odbc_glibc_x64/build/mssqlodbc.so'        = 'linux/glibc/x86_64/lib/mssqlodbc.so'
+              'drop_Build_Linux_x64_linux_x64/odbc_musl_x64/build/mssqlodbc.so'         = 'linux/musl/x86_64/lib/mssqlodbc.so'
+            }
+
+            if ($buildAllTargets) {
+              $map['drop_Build_Windows_ARM64_windows_arm64/odbc_windows_arm64/build/mssqlodbc.dll'] = 'windows/arm64/mssqlodbc.dll'
+              $map['drop_Build_Linux_ARM64_linux_arm64/odbc_glibc_arm64/build/mssqlodbc.so']        = 'linux/glibc/arm64/lib/mssqlodbc.so'
+              $map['drop_Build_Linux_ARM64_linux_arm64/odbc_musl_arm64/build/mssqlodbc.so']         = 'linux/musl/arm64/lib/mssqlodbc.so'
+              $map['drop_Build_MacOS_universal2_macos_universal2/odbc_macos_x64/build/mssqlodbc.dylib']   = 'macos/x86_64/lib/mssqlodbc.dylib'
+              $map['drop_Build_MacOS_universal2_macos_universal2/odbc_macos_arm64/build/mssqlodbc.dylib'] = 'macos/arm64/lib/mssqlodbc.dylib'
+            }
+
+            foreach ($src in $map.Keys) {
+              $sourcePath = "$(Pipeline.Workspace)/$src"
+              if (-not (Test-Path $sourcePath)) {
+                Write-Error "Missing ODBC driver binary: $sourcePath"
+                exit 1
+              }
+              $destPath = Join-Path $driversRoot $map[$src]
+              New-Item -ItemType Directory -Force -Path (Split-Path $destPath) | Out-Null
+              Copy-Item $sourcePath $destPath
+              Write-Host "Staged $src -> $($map[$src])"
+            }
+          displayName: 'Stage ODBC driver binaries'
+
+        - pwsh: |
+            $ErrorActionPreference = 'Stop'
+            python "$(Build.SourcesDirectory)/scripts/inject-odbc-into-wheels.py" `
+              --wheels-dir "$(Build.StagingDirectory)/wheels" `
+              --drivers-dir "$(Build.StagingDirectory)/drivers"
+          displayName: 'Inject ODBC driver into wheels'
+
       - pwsh: |
           $ErrorActionPreference = 'Stop'
 
@@ -525,127 +566,3 @@ stages:
           }
           Write-Host "OneBranch will auto-publish from $(ob_outputDirectory)/packages"
         displayName: 'Verify NuGet package'
-
-      # mssql-odbc native driver binaries - packaged as a separate NuGet
-      # (unrelated product/consumers from the Python wheels above), built
-      # from the same artifacts this job already downloaded.
-      - ${{ if eq(parameters.buildOdbcNative, true) }}:
-        - pwsh: |
-            $ErrorActionPreference = 'Stop'
-
-            # Template expansion produces bare True/False which aren't valid
-            # PowerShell; string comparison converts to a proper boolean.
-            $buildAllTargets = "${{ parameters.buildAllTargets }}" -eq "True"
-
-            # source artifact/subfolder -> (platform tag, driver filename).
-            # Subfolder names match the CopyFiles targetFolder used in each
-            # Build job (see Windows_x64/Windows_ARM64/Linux_x64/Linux_ARM64/
-            # MacOS_universal2 above); every source path shares the build/<file>
-            # layout that build-odbc-*-template.yml stages the driver into.
-            $platforms = [ordered]@{
-              'drop_Build_Linux_x64_linux_x64/odbc_glibc_x64'             = @{ tag = 'linux_x64';      file = 'mssqlodbc.so' }
-              'drop_Build_Linux_x64_linux_x64/odbc_musl_x64'              = @{ tag = 'musl_x64';       file = 'mssqlodbc.so' }
-              'drop_Build_Linux_x64_linux_x64/odbc_glibc228_x64'          = @{ tag = 'glibc228_x64';   file = 'mssqlodbc.so' }
-              'drop_Build_Windows_x64_windows_x64/odbc_windows_x64'       = @{ tag = 'windows_x64';    file = 'mssqlodbc.dll' }
-            }
-
-            # Windows_ARM64/Linux_ARM64/MacOS_universal2 jobs only run when
-            # buildAllTargets is true (see the job-level conditional guards
-            # above); skip these entries otherwise, or the Test-Path check
-            # below always fails.
-            if ($buildAllTargets) {
-              $platforms['drop_Build_Linux_ARM64_linux_arm64/odbc_glibc_arm64']       = @{ tag = 'linux_arm64';    file = 'mssqlodbc.so' }
-              $platforms['drop_Build_Linux_ARM64_linux_arm64/odbc_musl_arm64']        = @{ tag = 'musl_arm64';     file = 'mssqlodbc.so' }
-              $platforms['drop_Build_Linux_ARM64_linux_arm64/odbc_glibc228_arm64']    = @{ tag = 'glibc228_arm64'; file = 'mssqlodbc.so' }
-              $platforms['drop_Build_Windows_ARM64_windows_arm64/odbc_windows_arm64'] = @{ tag = 'windows_arm64';  file = 'mssqlodbc.dll' }
-              # Separate per-arch dylibs (no lipo fusion) - mssql-python expects
-              # two distinct binaries, mirroring msodbcsql's libs/macos/{arm64,x86_64}.
-              $platforms['drop_Build_MacOS_universal2_macos_universal2/odbc_macos_x64']   = @{ tag = 'macos_x64';   file = 'mssqlodbc.dylib' }
-              $platforms['drop_Build_MacOS_universal2_macos_universal2/odbc_macos_arm64'] = @{ tag = 'macos_arm64'; file = 'mssqlodbc.dylib' }
-            }
-
-            foreach ($key in $platforms.Keys) {
-              $info = $platforms[$key]
-              $sourcePath = "$(Pipeline.Workspace)/$key/build/$($info.file)"
-              if (-not (Test-Path $sourcePath)) {
-                Write-Error "Missing ODBC driver binary: $sourcePath"
-                exit 1
-              }
-              $destDir = "$(Build.StagingDirectory)/odbc-native/$($info.tag)"
-              New-Item -ItemType Directory -Force -Path $destDir | Out-Null
-              Copy-Item $sourcePath "$destDir/$($info.file)"
-              Write-Host "Staged $($info.tag): $sourcePath -> $destDir/$($info.file)"
-            }
-          displayName: 'Collect ODBC native driver binaries'
-
-        - pwsh: |
-            $ErrorActionPreference = 'Stop'
-
-            # mssql-odbc is versioned independently from mssql-py-core, so
-            # compute its own package version rather than reusing $(nugetVersion).
-            $cargoToml = Get-Content "$(Build.SourcesDirectory)/mssql-odbc/Cargo.toml" -Raw
-            if ($cargoToml -match 'version\s*=\s*"([^"]+)"') {
-              $version = $Matches[1]
-            } else {
-              Write-Error "Could not extract version from mssql-odbc/Cargo.toml"
-              exit 1
-            }
-
-            $buildReason = "$(Build.Reason)"
-            $isOfficial = "${{ parameters.isOfficial }}" -eq "True"
-            $dateStamp = Get-Date -Format "yyyyMMdd"
-            $buildId = "$(Build.BuildId)"
-
-            switch ($buildReason) {
-              'Schedule' { $odbcPackageVersion = "$version-nightly.$dateStamp" }
-              'Manual' {
-                if ($isOfficial) {
-                  $odbcPackageVersion = $version
-                } else {
-                  $odbcPackageVersion = "$version-dev.$dateStamp.$buildId"
-                }
-              }
-              default { $odbcPackageVersion = "$version-dev.$dateStamp.$buildId" }
-            }
-
-            Write-Host "ODBC native package version: $odbcPackageVersion"
-            Write-Host "##vso[task.setvariable variable=odbcNugetVersion]$odbcPackageVersion"
-          displayName: 'Compute ODBC native package version'
-
-        - pwsh: |
-            $ErrorActionPreference = 'Stop'
-
-            $nuspecContent = @"
-            <?xml version="1.0"?>
-            <package>
-              <metadata>
-                <id>mssql-odbc-native</id>
-                <version>$(odbcNugetVersion)</version>
-                <description>mssql-odbc native driver binaries across platforms. Commit: $(Build.SourceVersion). Build: $(Build.BuildNumber)</description>
-                <authors>SqlClientDrivers</authors>
-              </metadata>
-              <files>
-                <file src="odbc-native\**\*" target="native" />
-              </files>
-            </package>
-            "@
-
-            $nuspecPath = "$(Build.StagingDirectory)/mssql-odbc-native.nuspec"
-            $nuspecContent | Out-File -FilePath $nuspecPath -Encoding utf8
-            Write-Host "Created nuspec at $nuspecPath"
-          displayName: 'Generate ODBC native NuGet package metadata'
-
-        - task: NuGetCommand@2
-          displayName: 'Create ODBC native NuGet package'
-          inputs:
-            command: pack
-            packagesToPack: '$(Build.StagingDirectory)/mssql-odbc-native.nuspec'
-            packDestination: '$(ob_outputDirectory)/packages'
-            basePath: '$(Build.StagingDirectory)'
-
-        - pwsh: |
-            Write-Host "=== ODBC native NuGet package created ==="
-            Get-ChildItem "$(ob_outputDirectory)/packages" -Filter mssql-odbc-native*.nupkg | ForEach-Object {
-              Write-Host "  $($_.Name)  ($([math]::Round($_.Length/1MB, 2)) MB)"
-            }
-          displayName: 'Verify ODBC native NuGet package'

--- a/.pipeline/OneBranch/stages.yml
+++ b/.pipeline/OneBranch/stages.yml
@@ -8,7 +8,9 @@
 #                                                                               #
 # When buildOdbcNative is true, the Windows/Linux x64+ARM64 jobs also build   #
 # the mssql-odbc native driver (glibc/musl/glibc-2.28 on Linux) and publish   #
-# it as a separate mssql-odbc-native NuGet package. No macOS lane yet.         #
+# it as a separate mssql-odbc-native NuGet package. The macOS job builds both  #
+# arch slices as SEPARATE binaries (no lipo fusion), matching mssql-python's  #
+# expected libs/macos/{arm64,x86_64} layout for this driver.                   #
 #                                                                               #
 # Build jobs use custom 1ES pools (Rust, Docker, Python pre-installed).        #
 # Publish job uses managed OneBranch pool with ob_nugetPublishing_enabled.     #
@@ -366,6 +368,29 @@ stages:
             osType: MacOS
             architecture: universal2
             publishArtifacts: false
+      - ${{ if eq(parameters.buildOdbcNative, true) }}:
+        - template: /.pipeline/templates/build-odbc-macos-template.yml
+          parameters:
+            architecture: x64
+            artifactName: 'Odbc_MacOS_x64'
+            publishArtifacts: false
+        - task: CopyFiles@2
+          displayName: 'Collect ODBC native driver (macOS x64)'
+          inputs:
+            sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
+            targetFolder: '$(ob_outputDirectory)/odbc_macos_x64'
+            contents: '**'
+        - template: /.pipeline/templates/build-odbc-macos-template.yml
+          parameters:
+            architecture: ARM64
+            artifactName: 'Odbc_MacOS_ARM64'
+            publishArtifacts: false
+        - task: CopyFiles@2
+          displayName: 'Collect ODBC native driver (macOS ARM64)'
+          inputs:
+            sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
+            targetFolder: '$(ob_outputDirectory)/odbc_macos_arm64'
+            contents: '**'
       - task: PublishPipelineArtifact@1
         displayName: 'Publish macOS Artifacts'
         inputs:
@@ -514,10 +539,9 @@ stages:
 
             # source artifact/subfolder -> (platform tag, driver filename).
             # Subfolder names match the CopyFiles targetFolder used in each
-            # Build job (see Windows_x64/Windows_ARM64/Linux_x64/Linux_ARM64
-            # above); every source path shares the build/<file> layout that
-            # build-odbc-*-template.yml and build-odbc-windows-template.yml
-            # stage the driver into.
+            # Build job (see Windows_x64/Windows_ARM64/Linux_x64/Linux_ARM64/
+            # MacOS_universal2 above); every source path shares the build/<file>
+            # layout that build-odbc-*-template.yml stages the driver into.
             $platforms = [ordered]@{
               'drop_Build_Linux_x64_linux_x64/odbc_glibc_x64'             = @{ tag = 'linux_x64';      file = 'mssqlodbc.so' }
               'drop_Build_Linux_x64_linux_x64/odbc_musl_x64'              = @{ tag = 'musl_x64';       file = 'mssqlodbc.so' }
@@ -525,14 +549,19 @@ stages:
               'drop_Build_Windows_x64_windows_x64/odbc_windows_x64'       = @{ tag = 'windows_x64';    file = 'mssqlodbc.dll' }
             }
 
-            # Windows_ARM64/Linux_ARM64 jobs only run when buildAllTargets is
-            # true (see the job-level conditional guards above); skip these
-            # entries otherwise, or the Test-Path check below always fails.
+            # Windows_ARM64/Linux_ARM64/MacOS_universal2 jobs only run when
+            # buildAllTargets is true (see the job-level conditional guards
+            # above); skip these entries otherwise, or the Test-Path check
+            # below always fails.
             if ($buildAllTargets) {
               $platforms['drop_Build_Linux_ARM64_linux_arm64/odbc_glibc_arm64']       = @{ tag = 'linux_arm64';    file = 'mssqlodbc.so' }
               $platforms['drop_Build_Linux_ARM64_linux_arm64/odbc_musl_arm64']        = @{ tag = 'musl_arm64';     file = 'mssqlodbc.so' }
               $platforms['drop_Build_Linux_ARM64_linux_arm64/odbc_glibc228_arm64']    = @{ tag = 'glibc228_arm64'; file = 'mssqlodbc.so' }
               $platforms['drop_Build_Windows_ARM64_windows_arm64/odbc_windows_arm64'] = @{ tag = 'windows_arm64';  file = 'mssqlodbc.dll' }
+              # Separate per-arch dylibs (no lipo fusion) - mssql-python expects
+              # two distinct binaries, mirroring msodbcsql's libs/macos/{arm64,x86_64}.
+              $platforms['drop_Build_MacOS_universal2_macos_universal2/odbc_macos_x64']   = @{ tag = 'macos_x64';   file = 'mssqlodbc.dylib' }
+              $platforms['drop_Build_MacOS_universal2_macos_universal2/odbc_macos_arm64'] = @{ tag = 'macos_arm64'; file = 'mssqlodbc.dylib' }
             }
 
             foreach ($key in $platforms.Keys) {

--- a/.pipeline/OneBranch/stages.yml
+++ b/.pipeline/OneBranch/stages.yml
@@ -90,7 +90,7 @@ stages:
           architecture: x64
           publishArtifacts: false
           signWindowsWheels: ${{ parameters.isOfficial }}
-    - ${{ if eq(parameters.buildOdbcNative, true) }}:
+    - ${{ if and(eq(parameters.buildOdbcNative, true), eq(parameters.buildPythonWheels, true)) }}:
       - template: /.pipeline/templates/build-odbc-windows-template.yml
         parameters:
           architecture: x64
@@ -161,7 +161,7 @@ stages:
             - '3.12'
             - '3.13'
             - '3.14'
-      - ${{ if eq(parameters.buildOdbcNative, true) }}:
+      - ${{ if and(eq(parameters.buildOdbcNative, true), eq(parameters.buildPythonWheels, true)) }}:
         - template: /.pipeline/templates/build-odbc-windows-template.yml
           parameters:
             architecture: ARM64
@@ -222,23 +222,23 @@ stages:
           osType: Alpine
           architecture: x64
           publishArtifacts: false
-    - ${{ if eq(parameters.buildOdbcNative, true) }}:
-      - template: /.pipeline/templates/build-odbc-template.yml
+    - ${{ if and(eq(parameters.buildOdbcNative, true), eq(parameters.buildPythonWheels, true)) }}:
+      - template: /.pipeline/templates/build-odbc-driver-in-wheel-image-template.yml
         parameters:
-          architecture: x64
-          artifactName: 'Odbc_Linux_x64_glibc'
-          publishArtifacts: false
+          image: 'ghcr.io/microsoft/mssql-rs/python-build/manylinux_2_34_x86_64_rust:latest'
+          libc: glibc
+          displaySuffix: 'glibc Linux x64'
       - script: |
           set -e
           mkdir -p "$(Build.SourcesDirectory)/drivers/linux/glibc/x86_64/lib"
           cp "$(Build.SourcesDirectory)/odbc-drop/build/mssqlodbc.so" "$(Build.SourcesDirectory)/drivers/linux/glibc/x86_64/lib/mssqlodbc.so"
         displayName: 'Stage glibc driver (Linux x64)'
         condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-      - template: /.pipeline/templates/build-odbc-alpine-template.yml
+      - template: /.pipeline/templates/build-odbc-driver-in-wheel-image-template.yml
         parameters:
-          architecture: x64
-          artifactName: 'Odbc_Linux_x64_musl'
-          publishArtifacts: false
+          image: 'ghcr.io/microsoft/mssql-rs/python-build/musllinux_1_2_x86_64_rust:latest'
+          libc: musl
+          displaySuffix: 'musl Linux x64'
       - script: |
           set -e
           mkdir -p "$(Build.SourcesDirectory)/drivers/linux/musl/x86_64/lib"
@@ -301,23 +301,23 @@ stages:
             osType: Alpine
             architecture: arm64
             publishArtifacts: false
-      - ${{ if eq(parameters.buildOdbcNative, true) }}:
-        - template: /.pipeline/templates/build-odbc-template.yml
+      - ${{ if and(eq(parameters.buildOdbcNative, true), eq(parameters.buildPythonWheels, true)) }}:
+        - template: /.pipeline/templates/build-odbc-driver-in-wheel-image-template.yml
           parameters:
-            architecture: ARM64
-            artifactName: 'Odbc_Linux_ARM64_glibc'
-            publishArtifacts: false
+            image: 'ghcr.io/microsoft/mssql-rs/python-build/manylinux_2_34_aarch64_rust:latest'
+            libc: glibc
+            displaySuffix: 'glibc Linux ARM64'
         - script: |
             set -e
             mkdir -p "$(Build.SourcesDirectory)/drivers/linux/glibc/arm64/lib"
             cp "$(Build.SourcesDirectory)/odbc-drop/build/mssqlodbc.so" "$(Build.SourcesDirectory)/drivers/linux/glibc/arm64/lib/mssqlodbc.so"
           displayName: 'Stage glibc driver (Linux ARM64)'
           condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-        - template: /.pipeline/templates/build-odbc-alpine-template.yml
+        - template: /.pipeline/templates/build-odbc-driver-in-wheel-image-template.yml
           parameters:
-            architecture: ARM64
-            artifactName: 'Odbc_Linux_ARM64_musl'
-            publishArtifacts: false
+            image: 'ghcr.io/microsoft/mssql-rs/python-build/musllinux_1_2_aarch64_rust:latest'
+            libc: musl
+            displaySuffix: 'musl Linux ARM64'
         - script: |
             set -e
             mkdir -p "$(Build.SourcesDirectory)/drivers/linux/musl/arm64/lib"
@@ -371,7 +371,7 @@ stages:
             osType: MacOS
             architecture: universal2
             publishArtifacts: false
-      - ${{ if eq(parameters.buildOdbcNative, true) }}:
+      - ${{ if and(eq(parameters.buildOdbcNative, true), eq(parameters.buildPythonWheels, true)) }}:
         - template: /.pipeline/templates/build-odbc-macos-template.yml
           parameters:
             architecture: x64

--- a/.pipeline/OneBranch/stages.yml
+++ b/.pipeline/OneBranch/stages.yml
@@ -320,6 +320,12 @@ stages:
             publishArtifacts: false
         - script: |
             set -e
+            mkdir -p "$(Build.SourcesDirectory)/drivers/linux/musl/arm64/lib"
+            cp "$(Build.SourcesDirectory)/odbc-drop/build/mssqlodbc.so" "$(Build.SourcesDirectory)/drivers/linux/musl/arm64/lib/mssqlodbc.so"
+          displayName: 'Stage musl driver (Linux ARM64)'
+          condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+        - script: |
+            set -e
             command -v python3 >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y python3; }
             sudo chown -R $(whoami):$(whoami) "$(ob_outputDirectory)/wheels"
             python3 "$(Build.SourcesDirectory)/scripts/inject-odbc-into-wheels.py" \

--- a/.pipeline/OneBranch/stages.yml
+++ b/.pipeline/OneBranch/stages.yml
@@ -99,10 +99,11 @@ stages:
           signDriver: ${{ parameters.isOfficial }}
       - task: CopyFiles@2
         displayName: 'Collect ODBC native driver (Windows x64)'
+        condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
         inputs:
           sourceFolder: '$(Build.SourcesDirectory)\odbc-drop'
           targetFolder: '$(ob_outputDirectory)\odbc_windows_x64'
-          contents: '**'
+          contents: 'build/mssqlodbc.dll'
     - task: PublishPipelineArtifact@1
       displayName: 'Publish Windows x64 Artifacts'
       inputs:
@@ -168,10 +169,11 @@ stages:
             signDriver: ${{ parameters.isOfficial }}
         - task: CopyFiles@2
           displayName: 'Collect ODBC native driver (Windows ARM64)'
+          condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
           inputs:
             sourceFolder: '$(Build.SourcesDirectory)\odbc-drop'
             targetFolder: '$(ob_outputDirectory)\odbc_windows_arm64'
-            contents: '**'
+            contents: 'build/mssqlodbc.dll'
       - task: PublishPipelineArtifact@1
         displayName: 'Publish Windows ARM64 Artifacts'
         inputs:
@@ -226,6 +228,7 @@ stages:
           publishArtifacts: false
       - task: CopyFiles@2
         displayName: 'Collect ODBC glibc driver (Linux x64)'
+        condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
         inputs:
           sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
           targetFolder: '$(ob_outputDirectory)/odbc_glibc_x64'
@@ -237,6 +240,7 @@ stages:
           publishArtifacts: false
       - task: CopyFiles@2
         displayName: 'Collect ODBC musl driver (Linux x64)'
+        condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
         inputs:
           sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
           targetFolder: '$(ob_outputDirectory)/odbc_musl_x64'
@@ -296,6 +300,7 @@ stages:
             publishArtifacts: false
         - task: CopyFiles@2
           displayName: 'Collect ODBC glibc driver (Linux ARM64)'
+          condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
           inputs:
             sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
             targetFolder: '$(ob_outputDirectory)/odbc_glibc_arm64'
@@ -307,6 +312,7 @@ stages:
             publishArtifacts: false
         - task: CopyFiles@2
           displayName: 'Collect ODBC musl driver (Linux ARM64)'
+          condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
           inputs:
             sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
             targetFolder: '$(ob_outputDirectory)/odbc_musl_arm64'
@@ -357,10 +363,11 @@ stages:
             publishArtifacts: false
         - task: CopyFiles@2
           displayName: 'Collect ODBC native driver (macOS x64)'
+          condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
           inputs:
             sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
             targetFolder: '$(ob_outputDirectory)/odbc_macos_x64'
-            contents: '**'
+            contents: 'build/mssqlodbc.dylib'
         - template: /.pipeline/templates/build-odbc-macos-template.yml
           parameters:
             architecture: ARM64
@@ -368,10 +375,11 @@ stages:
             publishArtifacts: false
         - task: CopyFiles@2
           displayName: 'Collect ODBC native driver (macOS ARM64)'
+          condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
           inputs:
             sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
             targetFolder: '$(ob_outputDirectory)/odbc_macos_arm64'
-            contents: '**'
+            contents: 'build/mssqlodbc.dylib'
       - task: PublishPipelineArtifact@1
         displayName: 'Publish macOS Artifacts'
         inputs:
@@ -485,7 +493,7 @@ stages:
 
           # Extract version from mssql-py-core/Cargo.toml
           $cargoToml = Get-Content "$(Build.SourcesDirectory)/mssql-py-core/Cargo.toml" -Raw
-          if ($cargoToml -match 'version\s*=\s*"([^"]+)"') {
+          if ($cargoToml -match '(?ms)^\[package\].*?^version\s*=\s*"([^"]+)"') {
             $version = $Matches[1]
           } else {
             Write-Error "Could not extract version from Cargo.toml"

--- a/.pipeline/templates/build-odbc-alpine-template.yml
+++ b/.pipeline/templates/build-odbc-alpine-template.yml
@@ -18,6 +18,11 @@ parameters:
   - name: buildImage
     type: string
     default: 'ghcr.io/microsoft/mssql-rs/build/alpine:3.18'
+  # Publish this template's own artifact (disable when the caller does one
+  # combined publish for the whole job, e.g. OneBranch's stages.yml).
+  - name: publishArtifacts
+    type: boolean
+    default: true
 
 steps:
   - script: |
@@ -34,9 +39,10 @@ steps:
       CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN)
       CARGO_REGISTRIES_MSSQL_RS_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_TOKEN)
 
-  - task: PublishPipelineArtifact@1
-    displayName: 'Publish ${{ parameters.artifactName }}'
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-    inputs:
-      targetPath: '$(Build.SourcesDirectory)/odbc-drop'
-      artifact: ${{ parameters.artifactName }}
+  - ${{ if eq(parameters.publishArtifacts, true) }}:
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish ${{ parameters.artifactName }}'
+      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+      inputs:
+        targetPath: '$(Build.SourcesDirectory)/odbc-drop'
+        artifact: ${{ parameters.artifactName }}

--- a/.pipeline/templates/build-odbc-driver-in-wheel-image-template.yml
+++ b/.pipeline/templates/build-odbc-driver-in-wheel-image-template.yml
@@ -1,0 +1,33 @@
+# Build ONLY the mssql-odbc driver inside a given wheel-build container image so
+# the driver's libc floor matches the wheel it is injected into. Unlike
+# build-odbc-template.yml this skips the C++ gtest e2e build (not needed for the
+# injected driver) and runs in the manylinux_2_34 / musllinux_1_2 image rather
+# than ubuntu / alpine. CI (non-PR) only.
+
+parameters:
+  # Wheel-build container image to build the driver in (matches the wheel).
+  - name: image
+    type: string
+  # 'glibc' or 'musl' - musl needs a C toolchain added at runtime.
+  - name: libc
+    type: string
+  # Human-readable suffix for the step display name, e.g. 'glibc Linux x64'.
+  - name: displaySuffix
+    type: string
+
+steps:
+  - script: |
+      set -e
+      bash .pipeline/scripts/docker-cargo-run.sh --rm \
+        -v "$PWD:/workspace" \
+        -v "$HOME/.cargo/registry:/root/.cargo/registry" \
+        -v "$HOME/.cargo/git:/root/.cargo/git" \
+        -e ODBC_DROP_DIR=/workspace/odbc-drop \
+        -w /workspace \
+        ${{ parameters.image }} \
+        sh /workspace/scripts/build-odbc-driver-only.sh ${{ parameters.libc }}
+    displayName: 'Build ODBC driver in wheel image (${{ parameters.displaySuffix }})'
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+    env:
+      CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN)
+      CARGO_REGISTRIES_MSSQL_RS_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_TOKEN)

--- a/.pipeline/templates/build-odbc-glibc228-template.yml
+++ b/.pipeline/templates/build-odbc-glibc228-template.yml
@@ -19,6 +19,11 @@ parameters:
   - name: architecture
     type: string
     default: 'x64'
+  # Publish this template's own artifact (disable when the caller does one
+  # combined publish for the whole job, e.g. OneBranch's stages.yml).
+  - name: publishArtifacts
+    type: boolean
+    default: true
 
 steps:
   - script: |
@@ -35,9 +40,10 @@ steps:
       CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN)
       CARGO_REGISTRIES_MSSQL_RS_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_TOKEN)
 
-  - task: PublishPipelineArtifact@1
-    displayName: 'Publish ${{ parameters.artifactName }}'
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-    inputs:
-      targetPath: '$(Build.SourcesDirectory)/odbc-drop'
-      artifact: ${{ parameters.artifactName }}
+  - ${{ if eq(parameters.publishArtifacts, true) }}:
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish ${{ parameters.artifactName }}'
+      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+      inputs:
+        targetPath: '$(Build.SourcesDirectory)/odbc-drop'
+        artifact: ${{ parameters.artifactName }}

--- a/.pipeline/templates/build-odbc-macos-template.yml
+++ b/.pipeline/templates/build-odbc-macos-template.yml
@@ -1,15 +1,12 @@
 # filepath: .pipeline/templates/build-odbc-macos-template.yml
 #
-# Cross-compile ONE mssql-odbc driver architecture slice (mssqlodbc.dylib) on
-# the shared macOS-14 (Apple Silicon) agent and publish it as a pipeline
-# artifact for the native NuGet package Publish stage.
+# Cross-compile ONE mssql-odbc driver architecture slice (mssqlodbc.dylib) via
+# `cargo build --target` and publish it as a pipeline artifact for the Publish
+# stage to inject into the macOS wheels.
 #
-# Unlike Windows/Linux, macOS has no separate per-architecture pool, so both
-# slices are built here via `cargo build --target`, one job invocation per
-# architecture. mssql-python expects two SEPARATE per-arch binaries (see its
-# sync-mssql-odbc-native-libs.py / setup_rust_odbc.py, mirroring how the
-# msodbcsql C++ driver ships libs/macos/arm64 + libs/macos/x86_64), not a
-# lipo-fused universal binary, so this deliberately does not lipo.
+# Both arch slices are built here (one job invocation per architecture) as two
+# SEPARATE per-arch binaries, not a lipo-fused universal binary, matching the
+# libs/macos/{arm64,x86_64} layout mssql-python's resolver reads for this driver.
 #
 # Driver only - no C++ gtest e2e binaries, matching build-odbc-windows-template.yml.
 #
@@ -49,6 +46,8 @@ steps:
 
   - script: |
       set -e
+      # Clean the shared drop so the ARM64 pass can't inherit x64 leftovers.
+      rm -rf "$(Build.SourcesDirectory)/odbc-drop"
       DROP_DIR="$(Build.SourcesDirectory)/odbc-drop/build"
       mkdir -p "$DROP_DIR"
       DRIVER_PATH="$(bash mssql-odbc/scripts/finalize-artifact.sh release "$(odbcTargetTriple)")"

--- a/.pipeline/templates/build-odbc-macos-template.yml
+++ b/.pipeline/templates/build-odbc-macos-template.yml
@@ -1,0 +1,65 @@
+# filepath: .pipeline/templates/build-odbc-macos-template.yml
+#
+# Cross-compile ONE mssql-odbc driver architecture slice (mssqlodbc.dylib) on
+# the shared macOS-14 (Apple Silicon) agent and publish it as a pipeline
+# artifact for the native NuGet package Publish stage.
+#
+# Unlike Windows/Linux, macOS has no separate per-architecture pool, so both
+# slices are built here via `cargo build --target`, one job invocation per
+# architecture. mssql-python expects two SEPARATE per-arch binaries (see its
+# sync-mssql-odbc-native-libs.py / setup_rust_odbc.py, mirroring how the
+# msodbcsql C++ driver ships libs/macos/arm64 + libs/macos/x86_64), not a
+# lipo-fused universal binary, so this deliberately does not lipo.
+#
+# Driver only - no C++ gtest e2e binaries, matching build-odbc-windows-template.yml.
+#
+# CI (non-PR) only.
+
+parameters:
+  # 'x64' or 'ARM64' - selects the cargo target triple below.
+  - name: architecture
+    type: string
+  # Pipeline artifact name, e.g. 'Odbc_MacOS_x64' / 'Odbc_MacOS_ARM64'.
+  - name: artifactName
+    type: string
+  # Publish this template's own artifact (disable when the caller does one
+  # combined publish for the whole job, e.g. OneBranch's stages.yml).
+  - name: publishArtifacts
+    type: boolean
+    default: true
+
+steps:
+  - script: |
+      set -e
+      case "${{ parameters.architecture }}" in
+        x64) TARGET_TRIPLE="x86_64-apple-darwin" ;;
+        ARM64) TARGET_TRIPLE="aarch64-apple-darwin" ;;
+        *) echo "Unknown architecture: ${{ parameters.architecture }}" >&2; exit 2 ;;
+      esac
+      echo "##vso[task.setvariable variable=odbcTargetTriple]$TARGET_TRIPLE"
+      rustup target add "$TARGET_TRIPLE"
+    displayName: 'Add cargo target (${{ parameters.architecture }})'
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+
+  - script: |
+      set -e
+      cargo build --release --target "$(odbcTargetTriple)" --package mssqlodbc
+    displayName: 'Build mssql-odbc driver (${{ parameters.architecture }})'
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+
+  - script: |
+      set -e
+      DROP_DIR="$(Build.SourcesDirectory)/odbc-drop/build"
+      mkdir -p "$DROP_DIR"
+      DRIVER_PATH="$(bash mssql-odbc/scripts/finalize-artifact.sh release "$(odbcTargetTriple)")"
+      cp "$DRIVER_PATH" "$DROP_DIR/mssqlodbc.dylib"
+    displayName: 'Stage driver into drop (${{ parameters.architecture }})'
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+
+  - ${{ if eq(parameters.publishArtifacts, true) }}:
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish ${{ parameters.artifactName }}'
+      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+      inputs:
+        targetPath: '$(Build.SourcesDirectory)/odbc-drop'
+        artifact: ${{ parameters.artifactName }}

--- a/.pipeline/templates/build-odbc-template.yml
+++ b/.pipeline/templates/build-odbc-template.yml
@@ -18,6 +18,11 @@ parameters:
   - name: buildImage
     type: string
     default: 'ghcr.io/microsoft/mssql-rs/build/ubuntu:22.04'
+  # Publish this template's own artifact (disable when the caller does one
+  # combined publish for the whole job, e.g. OneBranch's stages.yml).
+  - name: publishArtifacts
+    type: boolean
+    default: true
 
 steps:
   - script: |
@@ -36,9 +41,10 @@ steps:
       CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN)
       CARGO_REGISTRIES_MSSQL_RS_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_TOKEN)
 
-  - task: PublishPipelineArtifact@1
-    displayName: 'Publish ${{ parameters.artifactName }}'
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-    inputs:
-      targetPath: '$(Build.SourcesDirectory)/odbc-drop'
-      artifact: ${{ parameters.artifactName }}
+  - ${{ if eq(parameters.publishArtifacts, true) }}:
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish ${{ parameters.artifactName }}'
+      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+      inputs:
+        targetPath: '$(Build.SourcesDirectory)/odbc-drop'
+        artifact: ${{ parameters.artifactName }}

--- a/.pipeline/templates/build-odbc-windows-template.yml
+++ b/.pipeline/templates/build-odbc-windows-template.yml
@@ -21,6 +21,14 @@ parameters:
   - name: publishArtifacts
     type: boolean
     default: true
+  # Authenticode-sign the driver with ESRP (CP-230012) before it is collected.
+  # Enable for official builds; the caller must load the ESRP variable group.
+  - name: signDriver
+    type: boolean
+    default: false
+  - name: esrpConnectedServiceName
+    type: string
+    default: 'ESRP Managed Identity federated auth - AME tenant-mssql-rs'
 
 steps:
   - pwsh: |
@@ -38,6 +46,76 @@ steps:
       Copy-Item "$(CARGO_TARGET_DIR)\release\mssqlodbc.dll" $dropDir
     displayName: 'Stage driver into drop (${{ parameters.architecture }})'
     condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+
+  # Sign the raw driver at its source so it flows already-signed into whichever
+  # pipeline injects it into the wheels (NonOfficial Publish / Official Release).
+  - ${{ if eq(parameters.signDriver, true) }}:
+    - task: EsrpMalwareScanning@6
+      displayName: 'ESRP Malware Scanning driver (${{ parameters.architecture }})'
+      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+      inputs:
+        ConnectedServiceName: '${{ parameters.esrpConnectedServiceName }}'
+        AppRegistrationClientId: '$(appRegistrationClientId)'
+        AppRegistrationTenantId: '$(appRegistrationTenantId)'
+        EsrpClientId: '$(EsrpClientId)'
+        FolderPath: '$(Build.SourcesDirectory)\odbc-drop\build'
+        Pattern: 'mssqlodbc.dll'
+        UseMinimatch: true
+        UseMSIAuthentication: true
+        CleanupTempStorage: true
+        VerboseLogin: true
+
+    - task: EsrpCodeSigning@6
+      displayName: 'ESRP CodeSigning driver (${{ parameters.architecture }})'
+      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+      inputs:
+        ConnectedServiceName: '${{ parameters.esrpConnectedServiceName }}'
+        UseMSIAuthentication: true
+        AppRegistrationClientId: '$(appRegistrationClientId)'
+        AppRegistrationTenantId: '$(appRegistrationTenantId)'
+        EsrpClientId: '$(EsrpClientId)'
+        AuthAKVName: '$(AuthAKVName)'
+        AuthSignCertName: '$(AuthSignCertName)'
+        FolderPath: '$(Build.SourcesDirectory)\odbc-drop\build'
+        Pattern: 'mssqlodbc.dll'
+        UseMinimatch: true
+        signConfigType: inlineSignParams
+        inlineOperation: |
+          [
+            {
+              "KeyCode": "CP-230012",
+              "OperationCode": "SigntoolSign",
+              "ToolName": "sign",
+              "ToolVersion": "1.0",
+              "Parameters": {
+                "OpusName": "Microsoft",
+                "OpusInfo": "https://www.microsoft.com",
+                "FileDigest": "/fd SHA256",
+                "PageHash": "/NPH",
+                "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+              }
+            },
+            {
+              "KeyCode": "CP-230012",
+              "OperationCode": "SigntoolVerify",
+              "ToolName": "sign",
+              "ToolVersion": "1.0",
+              "Parameters": {}
+            }
+          ]
+        VerboseLogin: true
+
+    - pwsh: |
+        $ErrorActionPreference = 'Stop'
+        $driver = "$(Build.SourcesDirectory)\odbc-drop\build\mssqlodbc.dll"
+        $sig = Get-AuthenticodeSignature $driver
+        Write-Host "mssqlodbc.dll: $($sig.Status)"
+        if ($sig.Status -ne 'Valid') {
+          Write-Error "Driver signature invalid or missing: $($sig.Status)"
+          exit 1
+        }
+      displayName: 'Verify signed driver (${{ parameters.architecture }})'
+      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
 
   - ${{ if eq(parameters.publishArtifacts, true) }}:
     - task: PublishPipelineArtifact@1

--- a/.pipeline/templates/build-odbc-windows-template.yml
+++ b/.pipeline/templates/build-odbc-windows-template.yml
@@ -25,7 +25,7 @@ parameters:
 steps:
   - pwsh: |
       $ErrorActionPreference = 'Stop'
-      cargo build --release --package mssql-odbc
+      cargo build --release --package mssqlodbc
     displayName: 'Build mssql-odbc driver (${{ parameters.architecture }})'
     condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
 

--- a/.pipeline/templates/build-odbc-windows-template.yml
+++ b/.pipeline/templates/build-odbc-windows-template.yml
@@ -1,0 +1,48 @@
+# filepath: .pipeline/templates/build-odbc-windows-template.yml
+#
+# Build the mssql-odbc driver (mssqlodbc.dll) natively on Windows and publish
+# it as a pipeline artifact for the native NuGet package Publish stage.
+#
+# Driver only - no C++ gtest e2e binaries. Windows e2e coverage stays in the
+# PR-only leg in build-template.yml; this is the CI-only leg that stages a
+# releasable driver drop, mirroring build-odbc-template.yml on Linux.
+#
+# CI (non-PR) only.
+
+parameters:
+  # 'x64' or 'ARM64' - selects the build pool the surrounding job runs on.
+  - name: architecture
+    type: string
+  # Pipeline artifact name, e.g. 'Odbc_Windows_x64' / 'Odbc_Windows_arm64'.
+  - name: artifactName
+    type: string
+  # Publish this template's own artifact (disable when the caller does one
+  # combined publish for the whole job, e.g. OneBranch's stages.yml).
+  - name: publishArtifacts
+    type: boolean
+    default: true
+
+steps:
+  - pwsh: |
+      $ErrorActionPreference = 'Stop'
+      cargo build --release --package mssql-odbc
+    displayName: 'Build mssql-odbc driver (${{ parameters.architecture }})'
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+
+  - pwsh: |
+      $ErrorActionPreference = 'Stop'
+      # Nest under build/ so the Publish stage's extraction step can use the
+      # same relative layout (build/<driver file>) across every platform.
+      $dropDir = "$(Build.SourcesDirectory)\odbc-drop\build"
+      New-Item -ItemType Directory -Force -Path $dropDir | Out-Null
+      Copy-Item "$(CARGO_TARGET_DIR)\release\mssqlodbc.dll" $dropDir
+    displayName: 'Stage driver into drop (${{ parameters.architecture }})'
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+
+  - ${{ if eq(parameters.publishArtifacts, true) }}:
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish ${{ parameters.artifactName }}'
+      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+      inputs:
+        targetPath: '$(Build.SourcesDirectory)/odbc-drop'
+        artifact: ${{ parameters.artifactName }}

--- a/.pipeline/templates/build-odbc-windows-template.yml
+++ b/.pipeline/templates/build-odbc-windows-template.yml
@@ -43,7 +43,10 @@ steps:
       # same relative layout (build/<driver file>) across every platform.
       $dropDir = "$(Build.SourcesDirectory)\odbc-drop\build"
       New-Item -ItemType Directory -Force -Path $dropDir | Out-Null
-      Copy-Item "$(CARGO_TARGET_DIR)\release\mssqlodbc.dll" $dropDir
+      # Resolve the cargo cdylib via the finalize script (validates existence
+      # with a clear error) rather than assuming a fixed CARGO_TARGET_DIR layout.
+      $driver = & "$(Build.SourcesDirectory)/mssql-odbc/scripts/finalize-artifact.ps1" -BuildProfile release
+      Copy-Item $driver $dropDir
     displayName: 'Stage driver into drop (${{ parameters.architecture }})'
     condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
 

--- a/.pipeline/templates/build-python-wheels-template.yml
+++ b/.pipeline/templates/build-python-wheels-template.yml
@@ -290,6 +290,7 @@ steps:
         $ErrorActionPreference = 'Stop'
 
         $wheelsDir = "$(ob_outputDirectory)\wheels"
+        $unsignedDir = "$(ob_outputDirectory)\unsigned-wheels"
         $unpackedRoot = "$(ob_outputDirectory)\wheel-unpacked"
         $signedDir = "$(ob_outputDirectory)\signed-wheels"
         $verifyRoot = "$(ob_outputDirectory)\wheel-verify"
@@ -344,7 +345,9 @@ steps:
           exit 1
         }
 
-        Remove-Item -Recurse -Force $unpackedRoot, $signedDir, $verifyRoot
+        # Also drop the pre-signing originals so no un-injected, unsigned copy
+        # rides along in the Build artifact and wins the Publish collect.
+        Remove-Item -Recurse -Force $unsignedDir, $unpackedRoot, $signedDir, $verifyRoot
       displayName: 'Repack and verify signed Windows wheels'
   
   - pwsh: |

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -124,6 +124,13 @@ stages:
       - template: install-dependencies.yml
         parameters:
           osType: Windows
+      # Unit-test the ODBC wheel-injection script on PR runs; the injection
+      # pipeline steps themselves are non-PR gated, so this is the only part of
+      # that change PR validation can exercise.
+      - pwsh: |
+          python -m pip install --quiet pytest
+          python -m pytest scripts/test_inject_odbc.py -q
+        displayName: 'Unit test ODBC wheel injection script'
       - template: build-template.yml
         parameters:
           osType: Windows

--- a/mssql-odbc/scripts/finalize-artifact.sh
+++ b/mssql-odbc/scripts/finalize-artifact.sh
@@ -7,8 +7,12 @@ set -euo pipefail
 PROFILE="${1:-debug}"
 case "$PROFILE" in
     debug|release) ;;
-    *) echo "Usage: $0 [debug|release]" >&2; exit 2 ;;
+    *) echo "Usage: $0 [debug|release] [target-triple]" >&2; exit 2 ;;
 esac
+# Optional cross-compile target triple (e.g. x86_64-apple-darwin), for building
+# a single macOS architecture slice on an Apple Silicon host. Empty = native
+# build, artifact lives directly under $TARGET_DIR/$PROFILE (existing behavior).
+TARGET_TRIPLE="${2:-}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ODBC_CRATE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -38,8 +42,8 @@ case "$(uname -s)" in
         ;;
 esac
 
-SOURCE_PATH="$TARGET_DIR/$PROFILE/$CARGO_ARTIFACT"
-PRODUCT_PATH="$TARGET_DIR/$PROFILE/$PRODUCT_ARTIFACT"
+SOURCE_PATH="$TARGET_DIR/${TARGET_TRIPLE:+$TARGET_TRIPLE/}$PROFILE/$CARGO_ARTIFACT"
+PRODUCT_PATH="$TARGET_DIR/${TARGET_TRIPLE:+$TARGET_TRIPLE/}$PROFILE/$PRODUCT_ARTIFACT"
 if [ ! -f "$SOURCE_PATH" ]; then
     echo "Error: Cargo artifact not found at $SOURCE_PATH" >&2
     echo "Hint: if the [lib] name changed, update the CopyFiles exclusion in .pipeline/templates/build-template-container.yml" >&2

--- a/mssql-odbc/scripts/finalize-artifact.sh
+++ b/mssql-odbc/scripts/finalize-artifact.sh
@@ -10,7 +10,7 @@ case "$PROFILE" in
     *) echo "Usage: $0 [debug|release] [target-triple]" >&2; exit 2 ;;
 esac
 # Optional cross-compile target triple (e.g. x86_64-apple-darwin), for building
-# a single macOS architecture slice on an Apple Silicon host. Empty = native
+# a single macOS architecture slice via `cargo build --target`. Empty = native
 # build, artifact lives directly under $TARGET_DIR/$PROFILE (existing behavior).
 TARGET_TRIPLE="${2:-}"
 

--- a/scripts/build-odbc-driver-only.sh
+++ b/scripts/build-odbc-driver-only.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# Build ONLY the mssql-odbc driver (no C++ gtest e2e) inside the same wheel-build
+# container as its target wheel, so the driver's libc floor matches the wheel's
+# by construction: glibc 2.34 for manylinux_2_34, musl 1.2 for musllinux_1_2.
+# This replaces the ubuntu:22.04 / alpine:3.18 driver build on the injection
+# path, where the newer host glibc could otherwise leak a symbol floor above the
+# wheel's advertised one.
+#
+# Usage (inside the container):  build-odbc-driver-only.sh <glibc|musl>
+# Produces: $ODBC_DROP_DIR/build/mssqlodbc.so
+
+set -eu
+
+LIBC="${1:-glibc}"
+DROP_DIR="${ODBC_DROP_DIR:-/workspace/odbc-drop}"
+
+# Clean the shared drop as root inside the container; a prior pass may have left
+# it root-owned, where a host-side rm can hit permission denied.
+rm -rf "$DROP_DIR"
+
+if [ "$LIBC" = "musl" ]; then
+  # The musllinux wheel image ships Rust + openssl-dev but no C toolchain/bash.
+  apk add --no-cache build-base bash >/dev/null
+  # Dynamically link the musl CRT so the cdylib is a normal shared object.
+  export RUSTFLAGS="-C target-feature=-crt-static"
+fi
+
+cd /workspace/mssql-odbc
+cargo build --release
+DRIVER="$(bash scripts/finalize-artifact.sh release)"
+
+mkdir -p "$DROP_DIR/build"
+cp -f "$DRIVER" "$DROP_DIR/build/mssqlodbc.so"
+echo "Staged driver: $DROP_DIR/build/mssqlodbc.so"

--- a/scripts/build-odbc-driver-only.sh
+++ b/scripts/build-odbc-driver-only.sh
@@ -37,8 +37,12 @@ cp -f "$DRIVER" "$DROP_DIR/build/mssqlodbc.so"
 
 if [ "$LIBC" = "glibc" ]; then
   # Fail loudly if a base-image bump ever raises the driver's GLIBC floor above
-  # the manylinux_2_34 wheel it ships in.
-  max="$(readelf -V "$DROP_DIR/build/mssqlodbc.so" | grep -oE 'GLIBC_[0-9.]+' | sort -V | tail -1)"
+  # the manylinux_2_34 wheel it ships in. Capture readelf separately (sh has no
+  # pipefail) so a failed or empty read is fatal instead of passing silently.
+  syms="$(readelf -V "$DROP_DIR/build/mssqlodbc.so")" \
+    || { echo "ERROR: readelf failed on the driver" >&2; exit 1; }
+  max="$(printf '%s\n' "$syms" | grep -oE 'GLIBC_[0-9.]+' | sort -V | tail -1)"
+  [ -n "$max" ] || { echo "ERROR: no GLIBC version needs found in the driver" >&2; exit 1; }
   echo "max required GLIBC: $max"
   if [ "$(printf '%s\nGLIBC_2.34\n' "$max" | sort -V | tail -1)" != "GLIBC_2.34" ]; then
     echo "ERROR: $max exceeds the manylinux_2_34 (GLIBC_2.34) floor" >&2

--- a/scripts/build-odbc-driver-only.sh
+++ b/scripts/build-odbc-driver-only.sh
@@ -34,4 +34,16 @@ DRIVER="$(bash scripts/finalize-artifact.sh release)"
 
 mkdir -p "$DROP_DIR/build"
 cp -f "$DRIVER" "$DROP_DIR/build/mssqlodbc.so"
+
+if [ "$LIBC" = "glibc" ]; then
+  # Fail loudly if a base-image bump ever raises the driver's GLIBC floor above
+  # the manylinux_2_34 wheel it ships in.
+  max="$(readelf -V "$DROP_DIR/build/mssqlodbc.so" | grep -oE 'GLIBC_[0-9.]+' | sort -V | tail -1)"
+  echo "max required GLIBC: $max"
+  if [ "$(printf '%s\nGLIBC_2.34\n' "$max" | sort -V | tail -1)" != "GLIBC_2.34" ]; then
+    echo "ERROR: $max exceeds the manylinux_2_34 (GLIBC_2.34) floor" >&2
+    exit 1
+  fi
+fi
+
 echo "Staged driver: $DROP_DIR/build/mssqlodbc.so"

--- a/scripts/inject-odbc-into-wheels.py
+++ b/scripts/inject-odbc-into-wheels.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Embed the mssql-odbc native driver (mssqlodbc.{so,dylib,dll}) into the
+mssql-py-core wheels so a single wheel carries both the PyO3 TDS core and the
+Rust ODBC driver.
+
+The driver is placed under ``mssql_py_core/libs/...`` using the exact layout
+mssql-python's native resolver (``GetDriverPathForProviderCpp`` in
+ddbc_bindings.cpp) reads for the ``mssql-odbc`` provider, rooted at the
+mssql_py_core package directory:
+
+    Linux glibc : libs/linux/glibc/<arch>/lib/mssqlodbc.so
+    Linux musl  : libs/linux/musl/<arch>/lib/mssqlodbc.so
+    macOS       : libs/macos/<arch>/lib/mssqlodbc.dylib
+    Windows     : libs/windows/<winArch>/mssqlodbc.dll
+
+where <arch> is ``x86_64`` or ``arm64`` (Linux/macOS) and <winArch> is ``x64``
+or ``arm64`` (Windows). The driver is per platform+arch, so the same binary is
+duplicated across the per-Python-version wheels for a given platform.
+
+The staged --drivers-dir mirrors the ``libs/`` subtree exactly, e.g.
+
+    <drivers-dir>/windows/x64/mssqlodbc.dll
+    <drivers-dir>/linux/glibc/x86_64/lib/mssqlodbc.so
+    <drivers-dir>/macos/arm64/lib/mssqlodbc.dylib
+
+Wheels are rewritten in place with the stdlib ``zipfile`` (no third-party
+dependency), regenerating the ``RECORD`` so the added files are listed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import sys
+import zipfile
+from pathlib import Path
+
+# The package directory that becomes the provider base dir at runtime
+# (parent of mssql_py_core/__init__.py). Driver files land under
+# <this>/libs/... to match GetOdbcLibsBaseDir()'s parent_path(__file__).
+PACKAGE_DIR = "mssql_py_core"
+
+# libs/-relative driver paths per platform+arch, mirrored under --drivers-dir.
+_WIN_X64 = "windows/x64/mssqlodbc.dll"
+_WIN_ARM64 = "windows/arm64/mssqlodbc.dll"
+_GLIBC_X64 = "linux/glibc/x86_64/lib/mssqlodbc.so"
+_GLIBC_ARM64 = "linux/glibc/arm64/lib/mssqlodbc.so"
+_MUSL_X64 = "linux/musl/x86_64/lib/mssqlodbc.so"
+_MUSL_ARM64 = "linux/musl/arm64/lib/mssqlodbc.so"
+_MACOS_X64 = "macos/x86_64/lib/mssqlodbc.dylib"
+_MACOS_ARM64 = "macos/arm64/lib/mssqlodbc.dylib"
+
+
+def drivers_for_platform_tag(platform_tag: str) -> list[str]:
+    """Return the libs/-relative driver path(s) to inject for a wheel whose
+    platform tag is ``platform_tag``. Empty means the wheel is not one we
+    embed a driver into (caller treats that as an error for our matrix)."""
+    tag = platform_tag.lower()
+
+    if "win_amd64" in tag:
+        return [_WIN_X64]
+    if "win_arm64" in tag:
+        return [_WIN_ARM64]
+
+    if "manylinux" in tag:
+        if "x86_64" in tag:
+            return [_GLIBC_X64]
+        if "aarch64" in tag:
+            return [_GLIBC_ARM64]
+    if "musllinux" in tag:
+        if "x86_64" in tag:
+            return [_MUSL_X64]
+        if "aarch64" in tag:
+            return [_MUSL_ARM64]
+
+    # Re-tagged macOS wheels are universal2 -> ship both arch slices.
+    if "macosx" in tag and "universal2" in tag:
+        return [_MACOS_X64, _MACOS_ARM64]
+
+    return []
+
+
+def platform_tag_of(wheel_name: str) -> str:
+    """Extract the platform tag from a wheel filename. The wheel filename is
+    ``<dist>-<ver>(-<build>)?-<python>-<abi>-<platform>.whl``; the platform tag
+    is the final ``-``-separated field before ``.whl`` (compressed tag sets use
+    ``.`` as an inner separator, which we keep)."""
+    stem = wheel_name[:-len(".whl")] if wheel_name.endswith(".whl") else wheel_name
+    return stem.rsplit("-", 1)[-1]
+
+
+def _record_line(arcname: str, data: bytes) -> str:
+    digest = hashlib.sha256(data).digest()
+    encoded = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return f"{arcname},sha256={encoded},{len(data)}"
+
+
+def inject_wheel(wheel: Path, drivers_dir: Path) -> None:
+    platform_tag = platform_tag_of(wheel.name)
+    rel_paths = drivers_for_platform_tag(platform_tag)
+    if not rel_paths:
+        raise SystemExit(
+            f"ERROR: unrecognized platform tag '{platform_tag}' for wheel "
+            f"'{wheel.name}'; no driver mapping."
+        )
+
+    additions: dict[str, bytes] = {}
+    for rel in rel_paths:
+        src = drivers_dir / rel
+        if not src.is_file():
+            raise SystemExit(
+                f"ERROR: missing staged driver '{src}' required for wheel "
+                f"'{wheel.name}'."
+            )
+        # Wheel archives always use forward slashes.
+        additions[f"{PACKAGE_DIR}/libs/{rel}"] = src.read_bytes()
+
+    with zipfile.ZipFile(wheel, "r") as zf:
+        names = zf.namelist()
+        entries = {name: zf.read(name) for name in names}
+
+    record_name = next((n for n in names if n.endswith(".dist-info/RECORD")), None)
+    if record_name is None:
+        raise SystemExit(f"ERROR: wheel '{wheel.name}' has no dist-info/RECORD.")
+    if not any(n.startswith(PACKAGE_DIR + "/") for n in names):
+        raise SystemExit(
+            f"ERROR: wheel '{wheel.name}' has no '{PACKAGE_DIR}/' package "
+            f"directory to inject into."
+        )
+
+    entries.update(additions)
+
+    # Regenerate RECORD: a hashed line for every file (skipping directory
+    # entries and RECORD itself), then RECORD's own hash-less line last.
+    record_lines = [
+        _record_line(name, data)
+        for name, data in entries.items()
+        if name != record_name and not name.endswith("/")
+    ]
+    record_lines.append(f"{record_name},,")
+    entries[record_name] = ("\n".join(record_lines) + "\n").encode("utf-8")
+
+    tmp = wheel.with_name(wheel.name + ".tmp")
+    with zipfile.ZipFile(tmp, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, data in entries.items():
+            zf.writestr(name, data)
+    tmp.replace(wheel)
+
+    for arcname in additions:
+        print(f"  + {arcname}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--wheels-dir", required=True, type=Path,
+                        help="Directory of mssql_py_core wheels to inject into (edited in place).")
+    parser.add_argument("--drivers-dir", required=True, type=Path,
+                        help="Directory mirroring the libs/ subtree of staged mssqlodbc drivers.")
+    args = parser.parse_args()
+
+    if not args.wheels_dir.is_dir():
+        raise SystemExit(f"ERROR: --wheels-dir '{args.wheels_dir}' is not a directory.")
+    if not args.drivers_dir.is_dir():
+        raise SystemExit(f"ERROR: --drivers-dir '{args.drivers_dir}' is not a directory.")
+
+    wheels = sorted(args.wheels_dir.glob("*.whl"))
+    if not wheels:
+        raise SystemExit(f"ERROR: no wheels found in '{args.wheels_dir}'.")
+
+    for wheel in wheels:
+        print(f"Injecting mssqlodbc into {wheel.name}")
+        inject_wheel(wheel, args.drivers_dir)
+    print(f"Done: injected driver into {len(wheels)} wheel(s).")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/inject-odbc-into-wheels.py
+++ b/scripts/inject-odbc-into-wheels.py
@@ -63,18 +63,21 @@ def drivers_for_platform_tag(platform_tag: str) -> list[str]:
     if "win_arm64" in tag:
         return [_WIN_ARM64]
 
-    if "manylinux" in tag:
-        if "x86_64" in tag:
-            return [_GLIBC_X64]
-        if "aarch64" in tag:
-            return [_GLIBC_ARM64]
+    # musllinux must be checked before the generic linux branch (it contains
+    # "linux"). glibc wheels carry the bare linux_<arch> tag (auditwheel=skip
+    # means maturin does not retag them manylinux); manylinux_* maps here too.
     if "musllinux" in tag:
         if "x86_64" in tag:
             return [_MUSL_X64]
         if "aarch64" in tag:
             return [_MUSL_ARM64]
+    elif "linux" in tag:
+        if "x86_64" in tag:
+            return [_GLIBC_X64]
+        if "aarch64" in tag:
+            return [_GLIBC_ARM64]
 
-    # Re-tagged macOS wheels are universal2 -> ship both arch slices.
+    # macOS wheels are universal2 -> ship both arch slices.
     if "macosx" in tag and "universal2" in tag:
         return [_MACOS_X64, _MACOS_ARM64]
 

--- a/scripts/inject-odbc-into-wheels.py
+++ b/scripts/inject-odbc-into-wheels.py
@@ -99,6 +99,20 @@ def _record_line(arcname: str, data: bytes) -> str:
     return f"{arcname},sha256={encoded},{len(data)}"
 
 
+def _zip_info_for(arcname: str, infos: dict[str, zipfile.ZipInfo]) -> zipfile.ZipInfo:
+    """Reuse the source entry's ZipInfo so rewriting preserves its stored mode
+    and timestamp. Passing a bare str to writestr() would instead synthesize a
+    fresh ZipInfo (mode 0o600, mtime now) for every file, silently mutating the
+    whole wheel. Injected files get a deterministic timestamp and a
+    world-readable, non-executable mode."""
+    info = infos.get(arcname)
+    if info is None:
+        info = zipfile.ZipInfo(arcname, date_time=(1980, 1, 1, 0, 0, 0))
+        info.external_attr = 0o644 << 16
+    info.compress_type = zipfile.ZIP_DEFLATED
+    return info
+
+
 def inject_wheel(wheel: Path, drivers_dir: Path) -> None:
     platform_tag = platform_tag_of(wheel.name)
     rel_paths = drivers_for_platform_tag(platform_tag)
@@ -121,6 +135,7 @@ def inject_wheel(wheel: Path, drivers_dir: Path) -> None:
 
     with zipfile.ZipFile(wheel, "r") as zf:
         names = zf.namelist()
+        infos = {info.filename: info for info in zf.infolist()}
         entries = {name: zf.read(name) for name in names}
 
     record_name = next((n for n in names if n.endswith(".dist-info/RECORD")), None)
@@ -147,7 +162,7 @@ def inject_wheel(wheel: Path, drivers_dir: Path) -> None:
     tmp = wheel.with_name(wheel.name + ".tmp")
     with zipfile.ZipFile(tmp, "w", zipfile.ZIP_DEFLATED) as zf:
         for name, data in entries.items():
-            zf.writestr(name, data)
+            zf.writestr(_zip_info_for(name, infos), data)
     tmp.replace(wheel)
 
     for arcname in additions:

--- a/scripts/test_inject_odbc.py
+++ b/scripts/test_inject_odbc.py
@@ -107,6 +107,31 @@ def test_inject_roundtrip(tmp_path):
     assert "mssql_py_core-0.1.0.dist-info/RECORD,," in record
 
 
+def test_inject_preserves_entry_modes(tmp_path):
+    drivers = tmp_path / "drivers"
+    (drivers / "windows" / "x64").mkdir(parents=True)
+    (drivers / "windows" / "x64" / "mssqlodbc.dll").write_bytes(b"MZ")
+
+    wheel = tmp_path / "mssql_py_core-0.1.0-cp312-cp312-win_amd64.whl"
+    with zipfile.ZipFile(wheel, "w") as zf:
+        exe = zipfile.ZipInfo("mssql_py_core/_core.pyd")
+        exe.external_attr = 0o755 << 16
+        zf.writestr(exe, b"\x4d\x5a")
+        zf.writestr(
+            "mssql_py_core-0.1.0.dist-info/RECORD",
+            "mssql_py_core/_core.pyd,,\nmssql_py_core-0.1.0.dist-info/RECORD,,\n",
+        )
+
+    inject.inject_wheel(wheel, drivers)
+
+    with zipfile.ZipFile(wheel, "r") as zf:
+        modes = {i.filename: (i.external_attr >> 16) & 0o777 for i in zf.infolist()}
+    # Pre-existing entry keeps its stored mode (not clobbered to 0o600).
+    assert modes["mssql_py_core/_core.pyd"] == 0o755
+    # Injected driver gets an explicit world-readable, non-executable mode.
+    assert modes["mssql_py_core/libs/windows/x64/mssqlodbc.dll"] == 0o644
+
+
 def test_inject_missing_driver_fails(tmp_path):
     wheel = tmp_path / "mssql_py_core-0.1.0-cp312-cp312-win_amd64.whl"
     _make_wheel(wheel)

--- a/scripts/test_inject_odbc.py
+++ b/scripts/test_inject_odbc.py
@@ -125,11 +125,16 @@ def test_inject_preserves_entry_modes(tmp_path):
     inject.inject_wheel(wheel, drivers)
 
     with zipfile.ZipFile(wheel, "r") as zf:
-        modes = {i.filename: (i.external_attr >> 16) & 0o777 for i in zf.infolist()}
+        infos = {i.filename: i for i in zf.infolist()}
+    modes = {n: (i.external_attr >> 16) & 0o777 for n, i in infos.items()}
+    driver_arc = "mssql_py_core/libs/windows/x64/mssqlodbc.dll"
     # Pre-existing entry keeps its stored mode (not clobbered to 0o600).
     assert modes["mssql_py_core/_core.pyd"] == 0o755
     # Injected driver gets an explicit world-readable, non-executable mode.
-    assert modes["mssql_py_core/libs/windows/x64/mssqlodbc.dll"] == 0o644
+    assert modes[driver_arc] == 0o644
+    # ...and a fixed timestamp so the same driver is byte-identical across the
+    # per-Python-version wheels that receive it.
+    assert infos[driver_arc].date_time == (1980, 1, 1, 0, 0, 0)
 
 
 def test_inject_missing_driver_fails(tmp_path):

--- a/scripts/test_inject_odbc.py
+++ b/scripts/test_inject_odbc.py
@@ -1,0 +1,121 @@
+"""Unit tests for inject-odbc-into-wheels.py.
+
+Pure-stdlib coverage of the tag->driver-path table, wheel platform-tag
+parsing, RECORD line generation, and a full inject round-trip on a synthetic
+wheel. No network, no live SQL Server, no built extension required.
+
+Run: pytest scripts/test_inject_odbc.py
+"""
+
+import importlib.util
+import zipfile
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).with_name("inject-odbc-into-wheels.py")
+_spec = importlib.util.spec_from_file_location("inject_odbc", _SCRIPT)
+inject = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(inject)
+
+
+@pytest.mark.parametrize(
+    "tag, expected",
+    [
+        ("win_amd64", ["windows/x64/mssqlodbc.dll"]),
+        ("win_arm64", ["windows/arm64/mssqlodbc.dll"]),
+        # glibc wheels carry the bare linux_<arch> tag (auditwheel=skip).
+        ("linux_x86_64", ["linux/glibc/x86_64/lib/mssqlodbc.so"]),
+        ("linux_aarch64", ["linux/glibc/arm64/lib/mssqlodbc.so"]),
+        # manylinux_* is still glibc.
+        ("manylinux_2_34_x86_64", ["linux/glibc/x86_64/lib/mssqlodbc.so"]),
+        ("manylinux_2_28_aarch64", ["linux/glibc/arm64/lib/mssqlodbc.so"]),
+        ("musllinux_1_2_x86_64", ["linux/musl/x86_64/lib/mssqlodbc.so"]),
+        ("musllinux_1_2_aarch64", ["linux/musl/arm64/lib/mssqlodbc.so"]),
+        (
+            "macosx_15_0_universal2",
+            ["macos/x86_64/lib/mssqlodbc.dylib", "macos/arm64/lib/mssqlodbc.dylib"],
+        ),
+    ],
+)
+def test_drivers_for_platform_tag(tag, expected):
+    assert inject.drivers_for_platform_tag(tag) == expected
+
+
+def test_musl_and_glibc_do_not_collide():
+    # The whole design rests on these two resolving to different drivers.
+    assert inject.drivers_for_platform_tag("musllinux_1_2_x86_64") != inject.drivers_for_platform_tag(
+        "linux_x86_64"
+    )
+
+
+@pytest.mark.parametrize("tag", ["win_ia64", "linux_riscv64", "any", ""])
+def test_unrecognized_tag_returns_empty(tag):
+    assert inject.drivers_for_platform_tag(tag) == []
+
+
+@pytest.mark.parametrize(
+    "wheel_name, expected_tag",
+    [
+        ("mssql_py_core-0.1.0-cp312-cp312-win_amd64.whl", "win_amd64"),
+        ("mssql_py_core-0.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", "musllinux_1_2_aarch64"),
+        ("mssql_py_core-0.1.0-cp311-cp311-macosx_15_0_universal2.whl", "macosx_15_0_universal2"),
+    ],
+)
+def test_platform_tag_of(wheel_name, expected_tag):
+    assert inject.platform_tag_of(wheel_name) == expected_tag
+
+
+def test_record_line_format():
+    line = inject._record_line("pkg/libs/x.so", b"hello")
+    arc, digest, size = line.split(",")
+    assert arc == "pkg/libs/x.so"
+    assert digest.startswith("sha256=")
+    assert "=" not in digest[len("sha256=") :]  # base64url padding stripped
+    assert size == "5"
+
+
+def _make_wheel(path: Path) -> None:
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("mssql_py_core/__init__.py", b"# core\n")
+        zf.writestr(
+            "mssql_py_core-0.1.0.dist-info/RECORD",
+            "mssql_py_core/__init__.py,,\nmssql_py_core-0.1.0.dist-info/RECORD,,\n",
+        )
+
+
+def test_inject_roundtrip(tmp_path):
+    drivers = tmp_path / "drivers"
+    (drivers / "windows" / "x64").mkdir(parents=True)
+    driver_bytes = b"\x4d\x5aFAKE-DLL"
+    (drivers / "windows" / "x64" / "mssqlodbc.dll").write_bytes(driver_bytes)
+
+    wheel = tmp_path / "mssql_py_core-0.1.0-cp312-cp312-win_amd64.whl"
+    _make_wheel(wheel)
+
+    inject.inject_wheel(wheel, drivers)
+
+    arc = "mssql_py_core/libs/windows/x64/mssqlodbc.dll"
+    with zipfile.ZipFile(wheel, "r") as zf:
+        names = zf.namelist()
+        assert arc in names
+        assert zf.read(arc) == driver_bytes
+        record = zf.read("mssql_py_core-0.1.0.dist-info/RECORD").decode("utf-8")
+
+    assert inject._record_line(arc, driver_bytes) in record.splitlines()
+    # RECORD's own line stays hash-less.
+    assert "mssql_py_core-0.1.0.dist-info/RECORD,," in record
+
+
+def test_inject_missing_driver_fails(tmp_path):
+    wheel = tmp_path / "mssql_py_core-0.1.0-cp312-cp312-win_amd64.whl"
+    _make_wheel(wheel)
+    with pytest.raises(SystemExit):
+        inject.inject_wheel(wheel, tmp_path / "empty-drivers")
+
+
+def test_inject_unknown_tag_fails(tmp_path):
+    wheel = tmp_path / "mssql_py_core-0.1.0-cp312-cp312-win_ia64.whl"
+    _make_wheel(wheel)
+    with pytest.raises(SystemExit):
+        inject.inject_wheel(wheel, tmp_path / "drivers")


### PR DESCRIPTION
## Description

This pull request adds support for optionally building and injecting the native `mssql-odbc` driver into Python wheels as part of the CI pipeline, across Windows, Linux (glibc + musl), and macOS (x64 and ARM64) platforms. The implementation introduces new pipeline parameters, conditional build steps, and a new build template for macOS, as well as updates to existing templates to control artifact publishing.

**Key changes:**

### Pipeline parameterization and documentation

- Added a new `buildOdbcNative` boolean parameter to the main pipeline YAMLs (`.pipeline/OneBranch/NonOfficialPythonWheelsPublish.yml`, `.pipeline/OneBranch/stages.yml`) to enable or disable building and injecting the native ODBC driver. Also updated documentation in `.pipeline/OneBranch/stages.yml` to describe the new workflow. [[1]](diffhunk://#diff-c2969227d3ff035fa63ad0fddb2934fd73e18ae6861cf959f0a9fed433936e0cR34-R38) [[2]](diffhunk://#diff-a39d2f7607b7f2a138fc01be791fcb78293d61ea85b15c98c7a29014c0a5f50eR9-R16) [[3]](diffhunk://#diff-a39d2f7607b7f2a138fc01be791fcb78293d61ea85b15c98c7a29014c0a5f50eR35-R39) [[4]](diffhunk://#diff-c2969227d3ff035fa63ad0fddb2934fd73e18ae6861cf959f0a9fed433936e0cR78)

### Conditional ODBC native driver build and injection

- Introduced conditional build and injection steps for the native ODBC driver for Windows (x64, ARM64), Linux (x64, ARM64, glibc + musl), and macOS (x64, ARM64) in `.pipeline/OneBranch/stages.yml`, ensuring the driver is only built and injected when `buildOdbcNative` is true. [[1]](diffhunk://#diff-a39d2f7607b7f2a138fc01be791fcb78293d61ea85b15c98c7a29014c0a5f50eR93-R107) [[2]](diffhunk://#diff-a39d2f7607b7f2a138fc01be791fcb78293d61ea85b15c98c7a29014c0a5f50eR164-R178) [[3]](diffhunk://#diff-a39d2f7607b7f2a138fc01be791fcb78293d61ea85b15c98c7a29014c0a5f50eR225-R256) [[4]](diffhunk://#diff-a39d2f7607b7f2a138fc01be791fcb78293d61ea85b15c98c7a29014c0a5f50eR304-R329) [[5]](diffhunk://#diff-a39d2f7607b7f2a138fc01be791fcb78293d61ea85b15c98c7a29014c0a5f50eR368-R397)

### New and updated build templates

- Added a new template `.pipeline/templates/build-odbc-macos-template.yml` for cross-compiling the `mssql-odbc` driver for macOS x64 and ARM64, producing separate binaries for each architecture.
- Updated existing ODBC build templates (`build-odbc-template.yml`, `build-odbc-alpine-template.yml`, `build-odbc-glibc228-template.yml`) to support a new `publishArtifacts` parameter, allowing the caller to control whether the template publishes its own build artifacts or defers to the main pipeline. [[1]](diffhunk://#diff-effd22f30679899859b5b2f230d05322b543805e9eb2530509eb14bcde711608R21-R25) [[2]](diffhunk://#diff-effd22f30679899859b5b2f230d05322b543805e9eb2530509eb14bcde711608R44) [[3]](diffhunk://#diff-64b1db0b77aaccc4bc96366e3158c96194f0fdeff72cc370be163b63589bd0fcR21-R25) [[4]](diffhunk://#diff-64b1db0b77aaccc4bc96366e3158c96194f0fdeff72cc370be163b63589bd0fcR42) [[5]](diffhunk://#diff-4e7c14e03f13c4f5954e59e4c89e0fa457c2a846940f66cf3cdee8b98ce69ddaR22-R26) [[6]](diffhunk://#diff-4e7c14e03f13c4f5954e59e4c89e0fa457c2a846940f66cf3cdee8b98ce69ddaR43)

### Miscellaneous

- Improved version extraction from `Cargo.toml` in PowerShell to be more robust by matching only the `[package]` section.
## Related Issues

ADO work item: https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47791

## Checklist

- [ ] `cargo bfmt` passes
- [ ] `cargo bclippy` passes
- [ ] `cargo btest` passes
- [ ] New/changed functionality has tests
- [ ] Public API changes are documented
