### PR TITLE
mssql-odbc: shut down the ENV runtime without joining its worker thread

### DIFF
--- a/mssql-odbc/src/api/alloc_handle.rs
+++ b/mssql-odbc/src/api/alloc_handle.rs
@@ -121,7 +121,11 @@ unsafe fn alloc_dbc(input_handle: SqlHandle, output_handle: *mut SqlHandle) -> S
         "SQLAllocHandle(DBC): SQL_ATTR_ODBC_VERSION not set on env"
     );
 
-    let dbc = Box::new(DbcHandle::new(input_handle, env.runtime.clone()));
+    let runtime = env
+        .runtime
+        .clone()
+        .expect("SQLAllocHandle(DBC): ENV runtime already shut down");
+    let dbc = Box::new(DbcHandle::new(input_handle, runtime));
     let raw = handle_to_raw(dbc);
     env_state.connections.push(raw);
 

--- a/mssql-odbc/src/api/alloc_handle.rs
+++ b/mssql-odbc/src/api/alloc_handle.rs
@@ -3,6 +3,8 @@
 
 //! Implementation of SQLAllocHandle — the ODBC handle allocation entry point.
 
+use std::sync::Arc;
+
 use tracing::{debug, error};
 
 use crate::api::odbc_types::{
@@ -121,12 +123,7 @@ unsafe fn alloc_dbc(input_handle: SqlHandle, output_handle: *mut SqlHandle) -> S
         "SQLAllocHandle(DBC): SQL_ATTR_ODBC_VERSION not set on env"
     );
 
-    // `None` only once the ENV is dropping, so a DBC can no longer be parented to it.
-    let Some(runtime) = env.runtime.clone() else {
-        error!("SQLAllocHandle(DBC): ENV runtime already shut down");
-        return SQL_ERROR;
-    };
-    let dbc = Box::new(DbcHandle::new(input_handle, runtime));
+    let dbc = Box::new(DbcHandle::new(input_handle, Arc::clone(&env.runtime)));
     let raw = handle_to_raw(dbc);
     env_state.connections.push(raw);
 

--- a/mssql-odbc/src/api/alloc_handle.rs
+++ b/mssql-odbc/src/api/alloc_handle.rs
@@ -121,10 +121,11 @@ unsafe fn alloc_dbc(input_handle: SqlHandle, output_handle: *mut SqlHandle) -> S
         "SQLAllocHandle(DBC): SQL_ATTR_ODBC_VERSION not set on env"
     );
 
-    let runtime = env
-        .runtime
-        .clone()
-        .expect("SQLAllocHandle(DBC): ENV runtime already shut down");
+    // `None` only once the ENV is dropping, so a DBC can no longer be parented to it.
+    let Some(runtime) = env.runtime.clone() else {
+        error!("SQLAllocHandle(DBC): ENV runtime already shut down");
+        return SQL_ERROR;
+    };
     let dbc = Box::new(DbcHandle::new(input_handle, runtime));
     let raw = handle_to_raw(dbc);
     env_state.connections.push(raw);

--- a/mssql-odbc/src/api/fetch_scroll.rs
+++ b/mssql-odbc/src/api/fetch_scroll.rs
@@ -1104,7 +1104,7 @@ fn trim_partial_utf8(bytes: &mut Vec<u8>) {
 /// Same contract as `deliver_bound`.
 unsafe fn deliver_bound_plp(
     client: &mut mssql_tds::connection::tds_client::TdsClient,
-    runtime: &std::sync::Arc<tokio::runtime::Runtime>,
+    runtime: &tokio::runtime::Runtime,
     binding: &ColumnBinding,
     row_index: usize,
     bind_offset: usize,
@@ -1269,7 +1269,7 @@ unsafe fn deliver_bound_plp(
 /// Consumes whatever is left of the active PLP stream and discards it.
 fn drain_plp_to_end(
     client: &mut mssql_tds::connection::tds_client::TdsClient,
-    runtime: &std::sync::Arc<tokio::runtime::Runtime>,
+    runtime: &tokio::runtime::Runtime,
     scratch: &mut [u8],
 ) -> Result<(), TdsError> {
     loop {

--- a/mssql-odbc/src/handles/dbc.rs
+++ b/mssql-odbc/src/handles/dbc.rs
@@ -5,8 +5,8 @@ use std::ffi::c_void;
 use std::sync::{Arc, Mutex};
 
 use mssql_tds::connection::tds_client::TdsClient;
-use tokio::runtime::Runtime;
 
+use super::env::SharedRuntime;
 use super::{EnvHandle, HandleType, HasObjectType};
 use crate::api::odbc_types::{DEFAULT_PACKET_SIZE, SQL_MODE_READ_WRITE, SQL_TXN_READ_COMMITTED};
 use crate::error::{DiagRecord, HasDiagnostics};
@@ -36,7 +36,7 @@ pub(crate) struct DbcHandle {
     /// the ENV owns the DBC's lifetime, not the other way around.
     pub(crate) parent_env: *mut c_void,
     /// Shared Tokio runtime from the parent ENV.
-    pub(crate) runtime: Arc<Runtime>,
+    pub(crate) runtime: Arc<SharedRuntime>,
     pub(crate) inner: Mutex<DbcState>,
 }
 
@@ -213,7 +213,7 @@ impl HasDiagnostics for DbcState {
 }
 
 impl DbcHandle {
-    pub(crate) fn new(parent_env: *mut c_void, runtime: Arc<Runtime>) -> Self {
+    pub(crate) fn new(parent_env: *mut c_void, runtime: Arc<SharedRuntime>) -> Self {
         Self {
             object_type: HandleType::Dbc,
             parent_env,

--- a/mssql-odbc/src/handles/env.rs
+++ b/mssql-odbc/src/handles/env.rs
@@ -49,8 +49,10 @@ pub(crate) struct EnvHandle {
     pub(crate) object_type: HandleType,
     pub(crate) inner: Mutex<EnvState>,
     /// Shared Tokio runtime for all connections on this ENV.
-    /// Wrapped in `Arc` so DBCs can hold a reference without lifetime issues.
-    pub(crate) runtime: Arc<Runtime>,
+    /// Wrapped in `Arc` so DBCs can hold a reference without lifetime issues,
+    /// and in `Option` so `Drop` can take ownership to shut it down (see the
+    /// `Drop` impl below). Only `None` after this handle starts dropping.
+    pub(crate) runtime: Option<Arc<Runtime>>,
 }
 
 /// Mutable state within an environment handle, protected by `inner`.
@@ -90,7 +92,7 @@ impl EnvHandle {
                 output_nts: true, // SQL_ATTR_OUTPUT_NTS defaults to SQL_TRUE
                 connections: Vec::new(),
             }),
-            runtime: Arc::new(runtime),
+            runtime: Some(Arc::new(runtime)),
         })
     }
 }
@@ -98,5 +100,42 @@ impl EnvHandle {
 impl HasObjectType for EnvHandle {
     fn object_type_mut(&mut self) -> &mut HandleType {
         &mut self.object_type
+    }
+}
+
+impl Drop for EnvHandle {
+    /// Shuts down the per-ENV Tokio runtime without joining its worker thread.
+    ///
+    /// `SQLFreeHandle(SQL_HANDLE_ENV)` can run long after the OS has already
+    /// force-terminated background threads — e.g. a caller that loads this
+    /// driver directly instead of through the ODBC Driver Manager may defer
+    /// the free to a C++ static destructor that only runs at
+    /// `DLL_PROCESS_DETACH`, by which point Windows has already killed every
+    /// thread but the one tearing the process down (AB#47509). The default
+    /// `Runtime` drop unconditionally joins its worker thread, which panics
+    /// ("threads should not terminate unexpectedly") if that thread no
+    /// longer exists. `shutdown_background` detaches instead of joining, so
+    /// it's safe no matter when this runs.
+    fn drop(&mut self) {
+        if let Some(runtime) = self.runtime.take().and_then(|rt| Arc::try_unwrap(rt).ok()) {
+            runtime.shutdown_background();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Guards against reintroducing a blocking join in `Drop`: this must
+    /// return promptly rather than waiting out the runtime's worker thread,
+    /// which is what `shutdown_background` (vs. the default `Runtime` drop)
+    /// buys us. Can't reproduce the OS-forcibly-killed-the-thread case that
+    /// actually panicked (AB#47509) from a unit test — that needs a real
+    /// process/DLL teardown — so this exercises the ordinary path instead.
+    #[test]
+    fn dropping_env_handle_does_not_hang_or_panic() {
+        let env = EnvHandle::new().expect("failed to create EnvHandle for test");
+        drop(env);
     }
 }

--- a/mssql-odbc/src/handles/env.rs
+++ b/mssql-odbc/src/handles/env.rs
@@ -125,17 +125,43 @@ impl Drop for EnvHandle {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::{Duration, Instant};
+
     use super::*;
 
-    /// Guards against reintroducing a blocking join in `Drop`: this must
-    /// return promptly rather than waiting out the runtime's worker thread,
-    /// which is what `shutdown_background` (vs. the default `Runtime` drop)
-    /// buys us. Can't reproduce the OS-forcibly-killed-the-thread case that
-    /// actually panicked (AB#47509) from a unit test — that needs a real
-    /// process/DLL teardown — so this exercises the ordinary path instead.
+    /// Guards against reintroducing a blocking join in `Drop`. The default
+    /// `Runtime` drop waits out in-flight blocking work; `shutdown_background`
+    /// detaches from it. An idle runtime joins its idle worker promptly under
+    /// either one, so this parks a blocking task to tell them apart. The
+    /// OS-already-killed-the-thread case that actually panicked (AB#47509)
+    /// needs real process/DLL teardown and isn't reproducible from a unit test.
     #[test]
-    fn dropping_env_handle_does_not_hang_or_panic() {
+    fn dropping_env_handle_does_not_wait_for_blocking_work() {
+        const PARK: Duration = Duration::from_secs(5);
+
         let env = EnvHandle::new().expect("failed to create EnvHandle for test");
+        let (started_tx, started_rx) = mpsc::channel();
+        env.runtime
+            .as_ref()
+            .expect("a live ENV owns its runtime")
+            .spawn_blocking(move || {
+                let _ = started_tx.send(());
+                thread::sleep(PARK);
+            });
+        started_rx
+            .recv_timeout(PARK)
+            .expect("blocking task should have started");
+
+        let start = Instant::now();
         drop(env);
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < PARK / 2,
+            "dropping EnvHandle blocked for {elapsed:?} waiting on the runtime's \
+             blocking work; Drop must detach via shutdown_background, not join"
+        );
     }
 }

--- a/mssql-odbc/src/handles/env.rs
+++ b/mssql-odbc/src/handles/env.rs
@@ -3,6 +3,7 @@
 
 use std::ffi::c_void;
 use std::io;
+use std::mem::ManuallyDrop;
 use std::sync::{Arc, Mutex};
 
 use tokio::runtime::Runtime;
@@ -35,6 +36,51 @@ impl TryFrom<u32> for OdbcVersion {
     }
 }
 
+/// A Tokio runtime that never joins its worker threads when it goes away.
+///
+/// `SQLFreeHandle(SQL_HANDLE_ENV)` can run long after the OS has already
+/// force-terminated background threads — e.g. a caller that loads this driver
+/// directly instead of through the ODBC Driver Manager may defer the free to a
+/// C++ static destructor that only runs at `DLL_PROCESS_DETACH`, by which point
+/// Windows has already killed every thread but the one tearing the process
+/// down (AB#47509). The default `Runtime` drop unconditionally joins its worker
+/// thread, which panics ("threads should not terminate unexpectedly") if that
+/// thread no longer exists. `shutdown_background` detaches instead of joining.
+///
+/// This lives on the shared value rather than on `EnvHandle` so the guarantee
+/// holds for whichever owner happens to release the last reference. A DBC that
+/// outlives its ENV — which a non-conformant caller can produce, since
+/// `SQLFreeHandle(ENV)` only `debug_assert!`s that the connection list is empty
+/// — would otherwise drop the runtime through the default joining path, which
+/// is exactly the teardown this exists to avoid.
+#[derive(Debug)]
+pub(crate) struct SharedRuntime(ManuallyDrop<Runtime>);
+
+impl SharedRuntime {
+    fn new(runtime: Runtime) -> Self {
+        Self(ManuallyDrop::new(runtime))
+    }
+}
+
+impl std::ops::Deref for SharedRuntime {
+    type Target = Runtime;
+
+    fn deref(&self) -> &Runtime {
+        &self.0
+    }
+}
+
+impl Drop for SharedRuntime {
+    fn drop(&mut self) {
+        // SAFETY: `drop` runs at most once and nothing reads `self.0` after
+        // this, so taking ownership out of the `ManuallyDrop` is sound. Taking
+        // it by value is what lets us call `shutdown_background`, which
+        // consumes the `Runtime`; the default drop glue would join instead.
+        let runtime = unsafe { ManuallyDrop::take(&mut self.0) };
+        runtime.shutdown_background();
+    }
+}
+
 /// Environment handle
 ///
 /// One ENV is typically allocated per application. It owns connection handles
@@ -48,11 +94,11 @@ impl TryFrom<u32> for OdbcVersion {
 pub(crate) struct EnvHandle {
     pub(crate) object_type: HandleType,
     pub(crate) inner: Mutex<EnvState>,
-    /// Shared Tokio runtime for all connections on this ENV.
-    /// Wrapped in `Arc` so DBCs can hold a reference without lifetime issues,
-    /// and in `Option` so `Drop` can take ownership to shut it down (see the
-    /// `Drop` impl below). Only `None` after this handle starts dropping.
-    pub(crate) runtime: Option<Arc<Runtime>>,
+    /// Shared Tokio runtime for all connections on this ENV, in an `Arc` so
+    /// DBCs can hold a reference without lifetime issues. Shutdown is handled
+    /// by `SharedRuntime`'s own `Drop`, so this handle needs no `Drop` of its
+    /// own and the field is never vacated while the ENV is live.
+    pub(crate) runtime: Arc<SharedRuntime>,
 }
 
 /// Mutable state within an environment handle, protected by `inner`.
@@ -92,7 +138,7 @@ impl EnvHandle {
                 output_nts: true, // SQL_ATTR_OUTPUT_NTS defaults to SQL_TRUE
                 connections: Vec::new(),
             }),
-            runtime: Some(Arc::new(runtime)),
+            runtime: Arc::new(SharedRuntime::new(runtime)),
         })
     }
 }
@@ -100,26 +146,6 @@ impl EnvHandle {
 impl HasObjectType for EnvHandle {
     fn object_type_mut(&mut self) -> &mut HandleType {
         &mut self.object_type
-    }
-}
-
-impl Drop for EnvHandle {
-    /// Shuts down the per-ENV Tokio runtime without joining its worker thread.
-    ///
-    /// `SQLFreeHandle(SQL_HANDLE_ENV)` can run long after the OS has already
-    /// force-terminated background threads — e.g. a caller that loads this
-    /// driver directly instead of through the ODBC Driver Manager may defer
-    /// the free to a C++ static destructor that only runs at
-    /// `DLL_PROCESS_DETACH`, by which point Windows has already killed every
-    /// thread but the one tearing the process down (AB#47509). The default
-    /// `Runtime` drop unconditionally joins its worker thread, which panics
-    /// ("threads should not terminate unexpectedly") if that thread no
-    /// longer exists. `shutdown_background` detaches instead of joining, so
-    /// it's safe no matter when this runs.
-    fn drop(&mut self) {
-        if let Some(runtime) = self.runtime.take().and_then(|rt| Arc::try_unwrap(rt).ok()) {
-            runtime.shutdown_background();
-        }
     }
 }
 
@@ -131,37 +157,60 @@ mod tests {
 
     use super::*;
 
-    /// Guards against reintroducing a blocking join in `Drop`. The default
-    /// `Runtime` drop waits out in-flight blocking work; `shutdown_background`
-    /// detaches from it. An idle runtime joins its idle worker promptly under
-    /// either one, so this parks a blocking task to tell them apart. The
+    const PARK: Duration = Duration::from_secs(5);
+
+    /// Parks a blocking task on `runtime` and returns once it is confirmed
+    /// running, so a later drop has in-flight blocking work to contend with.
+    fn park_blocking_task(runtime: &SharedRuntime) {
+        let (started_tx, started_rx) = mpsc::channel();
+        runtime.spawn_blocking(move || {
+            let _ = started_tx.send(());
+            thread::sleep(PARK);
+        });
+        started_rx
+            .recv_timeout(PARK)
+            .expect("blocking task should have started");
+    }
+
+    fn assert_released_promptly(what: &str, release: impl FnOnce()) {
+        let start = Instant::now();
+        release();
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < PARK / 2,
+            "{what} blocked for {elapsed:?} waiting on the runtime's blocking work; \
+             shutdown must detach via shutdown_background, not join"
+        );
+    }
+
+    /// Guards against reintroducing a blocking join. The default `Runtime` drop
+    /// waits out in-flight blocking work; `shutdown_background` detaches from
+    /// it. An idle runtime joins its idle worker promptly under either one, so
+    /// these park a blocking task to tell the two apart. The
     /// OS-already-killed-the-thread case that actually panicked (AB#47509)
     /// needs real process/DLL teardown and isn't reproducible from a unit test.
     #[test]
     fn dropping_env_handle_does_not_wait_for_blocking_work() {
-        const PARK: Duration = Duration::from_secs(5);
-
         let env = EnvHandle::new().expect("failed to create EnvHandle for test");
-        let (started_tx, started_rx) = mpsc::channel();
-        env.runtime
-            .as_ref()
-            .expect("a live ENV owns its runtime")
-            .spawn_blocking(move || {
-                let _ = started_tx.send(());
-                thread::sleep(PARK);
-            });
-        started_rx
-            .recv_timeout(PARK)
-            .expect("blocking task should have started");
+        park_blocking_task(&env.runtime);
 
-        let start = Instant::now();
+        assert_released_promptly("dropping EnvHandle", || drop(env));
+    }
+
+    /// The ENV is not always the last owner: `SQLFreeHandle(ENV)` only
+    /// `debug_assert!`s that the connection list is empty, so a non-conformant
+    /// caller can free the ENV while a DBC still holds a runtime reference.
+    /// Shutdown must still detach when that straggler releases the last one.
+    #[test]
+    fn dropping_a_dbc_that_outlived_its_env_does_not_wait_for_blocking_work() {
+        let env = EnvHandle::new().expect("failed to create EnvHandle for test");
+        let dbc_runtime = Arc::clone(&env.runtime);
+        park_blocking_task(&env.runtime);
+
         drop(env);
-        let elapsed = start.elapsed();
 
-        assert!(
-            elapsed < PARK / 2,
-            "dropping EnvHandle blocked for {elapsed:?} waiting on the runtime's \
-             blocking work; Drop must detach via shutdown_background, not join"
-        );
+        assert_released_promptly("dropping the last DBC runtime reference", || {
+            drop(dbc_runtime)
+        });
     }
 }


### PR DESCRIPTION
## Description

`EnvHandle` owns a shared Tokio multi-thread runtime (one background worker thread) used by every DBC allocated under that ENV. `SQLFreeHandle(SQL_HANDLE_ENV)` can run long after the OS has already force-terminated background threads — e.g. a caller that loads this driver directly instead of through the ODBC Driver Manager may defer the free to a C++ static destructor that only runs at `DLL_PROCESS_DETACH`, by which point Windows has already killed every thread but the one tearing the process down. The default `Runtime` drop unconditionally joins its worker thread, which panics ("threads should not terminate unexpectedly") if that thread no longer exists. This is exactly what mssql-python observes: a panic printed at process teardown when the driver is loaded directly, never when driven through the Driver Manager.

**Fix:** introduce a `SharedRuntime(ManuallyDrop<Runtime>)` newtype in `handles::env` that owns the teardown policy, and change `EnvHandle.runtime` to `Arc<SharedRuntime>`. `SharedRuntime::drop` takes the runtime by value and calls `shutdown_background()`, which detaches the worker thread instead of joining it, so it is safe no matter when the last handle is released relative to OS thread teardown. `SharedRuntime` derefs to `Runtime`, so call sites are unchanged apart from types.

Putting the teardown on the shared value rather than on `EnvHandle::drop` is the important part. An earlier iteration of this fix ran `shutdown_background()` from `impl Drop for EnvHandle` via `Arc::try_unwrap`, which only works when the ENV holds the sole reference. `free_env` only `debug_assert!`s that `connections.is_empty()`, so in a release build a non-conformant caller that frees the ENV while a DBC is still alive makes `try_unwrap` fail, silently skips `shutdown_background()`, and later drops the runtime through the DBC's `Arc` on the default joining path — the exact teardown [AB#47509](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47509) panics on. That path is reachable, not theoretical: a local repro showed the straggler `Arc` release blocking for 5.0006575s on the joining path. With the newtype, whichever owner happens to be last always detaches.

Deliberately did not switch the runtime to `new_current_thread()` — the ENV runtime is shared across DBCs that may run on different app threads concurrently, and that would risk a real concurrency regression for a cosmetic-panic fix.

Removing the `Option` also removed the `.expect("ENV runtime already shut down")` that `alloc_dbc` needed in order to unwrap it, which was a panic on a production FFI path and against this crate's panic-free rule.

### Why this also closes #445

`Runtime`'s default drop joins **blocking** tasks specifically — spawned async tasks are dropped at shutdown either way — so the entire behavioural delta of `shutdown_background()` is "stop waiting on in-flight `spawn_blocking` work." That work is:

- `tokio::net::lookup_host`'s `getaddrinfo`, in `mssql-tds` (`ssrp.rs`, `network_transport.rs`, `parallel_connect.rs`)
- the named-pipe connect in `mssql-tds`'s `named_pipes.rs`
- Entra interactive sign-in in this crate, `auth/interactive.rs:144` — the longest of the three, since `msqa::acquire_token` pumps a Win32 message loop for the full duration of a human sign-in

#445 is the DNS instance of exactly the wait this removes; [AB#47509](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47509) is the panic instance. One change, both symptoms — and `park_blocking_task` in the new tests is #445's scenario with the wedged resolver replaced by a `sleep`.

Worth noting for anyone returning to #445: its "Suggested direction" was `Arc::try_unwrap` to get an owned `Runtime`, then `shutdown_timeout`, on the reasoning that `free_env`'s `debug_assert!` means the refcount is 1 by then. That is the approach this PR tried and rejected — a `debug_assert!` is not a guarantee in a release build, so `try_unwrap` can fail exactly when it matters, and `dropping_a_dbc_that_outlived_its_env_does_not_wait_for_blocking_work` is the regression test for that hole.

### Trade-off

Detaching means a blocking-pool thread can now outlive ENV teardown instead of blocking it. That is a deliberate choice, not a free win. Concretely the two cases are a wedged `getaddrinfo` and — the longer one — an Entra interactive sign-in still pumping its message loop. The sign-in case is less bad than it first sounds: `CancelUiOnDrop` (`auth/interactive.rs`) already closes the prompt when the awaiting future is dropped, which shutdown does, so what survives is a blocking-pool thread unwinding after `SQLFreeHandle(ENV)` has returned rather than a prompt orphaned on the user's desktop. For either case to arise at all, a caller must be freeing the ENV while a connect or sign-in is still live on another thread.

It is the right trade for a driver — an unbounded block inside `SQLFreeHandle` is worse than a detached thread in a process that is usually on its way out anyway, and in the [AB#47509](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47509) scenario the thread is already gone. `shutdown_timeout(small)` was the bounded-wait alternative, and it is rejected here because any non-zero wait still attempts the join, which is precisely what panics when the OS has already destroyed the thread.

## Related Issues

- Fixes #445
- https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47509

## Testing

- `cargo bfmt` passes
- `cargo bclippy` passes
- `cargo nextest run -p mssqlodbc --lib`: 1168 passed, 1 skipped. Workspace-wide, the only failures are 7 pre-existing `mssql-tds` TLS tests that need certificate fixtures generated by a CI setup step and absent locally; they are unrelated to this change and green in CI.
- ADO PR validation: 18/18 checks pass, 100% diff coverage.

Two regression tests were added in `handles::env::tests`, both built on a shared `park_blocking_task` helper that parks a `spawn_blocking` task for 5s behind an mpsc handshake confirming the task actually started, then asserts the drop returns in well under that:

- `dropping_env_handle_does_not_wait_for_blocking_work` — guards the ordinary path.
- `dropping_a_dbc_that_outlived_its_env_does_not_wait_for_blocking_work` — guards the `Arc::try_unwrap` hole described above by dropping the ENV first and asserting the surviving DBC's release still detaches.

Both were confirmed to discriminate: each fails after ~5.0s against the default joining drop and passes with `shutdown_background()`. The bounded assertion is deliberate, so a regression fails fast instead of hanging until nextest's slow-timeout. The literal [AB#47509](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47509) failure mode (the OS force-killing the worker thread before drop runs) needs real process/DLL teardown and cannot be reproduced in a unit test; these tests cover the observable proxy, which is that drop never joins.

## Breaking changes / migration notes

None. `EnvHandle.runtime` and `SharedRuntime` are private, crate-internal; no public/FFI API changes.