### PR TITLE
Release busy connections after parameterized results

### DIFF
--- a/mssql-odbc/src/api/exec_common.rs
+++ b/mssql-odbc/src/api/exec_common.rs
@@ -227,8 +227,10 @@ pub(super) fn return_client_busy(dbc: &DbcHandle, client: TdsClient) {
 /// delivered, so posting now would never reach the caller. The next call
 /// that would otherwise short-circuit past the wire believing there is
 /// nothing left (`SQLFetch`'s `result_set_exhausted` fast path,
-/// If the row-set DONE carries MORE, the TDS layer consumes trailing RPC
-/// completion tokens and parks any genuine next result boundary for
+/// `SQLMoreResults`) drains and reports it instead.
+///
+/// If an RPC row set ends on `DONEINPROC` with MORE, the TDS layer consumes
+/// only trailing RPC control tokens and parks the first non-tail token for
 /// `SQLMoreResults`. A failure while consuming that completion tail abandons
 /// the batch: timeout/cancellation has already drained through ATTENTION, and
 /// other failures retire the connection. The error is deferred to the next
@@ -281,10 +283,11 @@ pub(super) fn release_busy_if_row_exhausted(
         Err(_) => !client.has_open_batch(),
     };
 
-    // A row-returning RPC can end its visible row set with DONE_MORE because
+    // A row-returning RPC can end its visible row set with DONEINPROC MORE because
     // RETURNVALUE, RETURNSTATUS, and a terminal DONE still follow. Consume
-    // those protocol-only tokens now. A genuine next result is parked inside
-    // TdsClient, so SQLMoreResults still observes it in order.
+    // those protocol-only tokens now. The first non-tail token is parked inside
+    // TdsClient, so SQLMoreResults still observes it in order. Plain batch DONE
+    // tokens return immediately without probing the next result.
     let completion_result = if result_set_exhausted && peek_result.is_ok() {
         Some(dbc.runtime.block_on(client.complete_current_result()))
     } else {
@@ -294,6 +297,7 @@ pub(super) fn release_busy_if_row_exhausted(
         Some(Ok(done)) => *done,
         _ => !client.has_open_batch(),
     };
+    let completion_failed = matches!(&completion_result, Some(Err(_)));
     let release = result_set_exhausted && batch_done;
 
     let mut read_error = peek_result.err();
@@ -324,7 +328,7 @@ pub(super) fn release_busy_if_row_exhausted(
         }
         if let Some(e) = read_error {
             error!(%e, "release_busy_if_row_exhausted: finishing current result failed");
-            if batch_done {
+            if batch_done || completion_failed {
                 stmt_state.pending_fetch_error = Some(e);
             }
         }
@@ -820,8 +824,8 @@ mod tests {
     use crate::params::BoundParam;
     use crate::test_support::TestHandles;
     use mssql_tds::test_client_support::{
-        ScriptedToken, col_metadata, col_metadata_empty, done_more, done_no_more, int_columns,
-        sql_error, tds_client_from_tokens,
+        ScriptedToken, col_metadata, col_metadata_empty, done_in_proc_more, done_more,
+        done_no_more, done_proc_no_more, int_columns, sql_error, tds_client_from_tokens,
     };
     use std::ffi::c_void;
 
@@ -1086,7 +1090,14 @@ mod tests {
         // when no application-visible result follows. The RPC's terminal DONE
         // must be consumed before another statement can safely use the wire.
         let h = TestHandles::with_env_dbc_stmt();
-        position_and_inject(&h, vec![col_metadata_empty(), done_more(), done_no_more()]);
+        position_and_inject(
+            &h,
+            vec![
+                col_metadata_empty(),
+                done_in_proc_more(),
+                done_proc_no_more(),
+            ],
+        );
 
         let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
         let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
@@ -1103,7 +1114,7 @@ mod tests {
     #[test]
     fn release_busy_if_row_exhausted_defers_a_truncated_rpc_tail() {
         let h = TestHandles::with_env_dbc_stmt();
-        position_and_inject(&h, vec![col_metadata_empty(), done_more()]);
+        position_and_inject(&h, vec![col_metadata_empty(), done_in_proc_more()]);
 
         let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
         let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };

--- a/mssql-odbc/src/api/exec_common.rs
+++ b/mssql-odbc/src/api/exec_common.rs
@@ -227,15 +227,21 @@ pub(super) fn return_client_busy(dbc: &DbcHandle, client: TdsClient) {
 /// delivered, so posting now would never reach the caller. The next call
 /// that would otherwise short-circuit past the wire believing there is
 /// nothing left (`SQLFetch`'s `result_set_exhausted` fast path,
-/// `SQLMoreResults`) drains and reports it instead.
+/// `SQLMoreResults`) drains and reports it instead. A failure that does
+/// *not* end the batch (a raw transport error) is left unposted entirely:
+/// `release` is false in that case, so nothing about this statement's state
+/// changes, and the caller's very next real operation on this connection
+/// takes the normal, non-fast-path route and organically rediscovers and
+/// reports the same failure through its own existing error handling —
+/// posting it here too would attach a diagnostic to this call's own
+/// still-successful return.
 ///
 /// If an RPC row set ends on `DONEINPROC` with MORE, the TDS layer consumes
 /// only trailing RPC control tokens and parks the first non-tail token for
-/// `SQLMoreResults`. A failure while consuming that completion tail abandons
-/// the batch: timeout/cancellation has already drained through ATTENTION, and
-/// other failures retire the connection. The error is deferred to the next
-/// statement operation because this call has already committed to returning
-/// the row successfully.
+/// `SQLMoreResults`. A failure while consuming that completion tail always
+/// ends the batch — [`TdsClient::complete_current_result`] abandons whatever
+/// is left rather than stranding it — so it takes the deferred-error route
+/// above, never the unposted one.
 ///
 /// `row_delivered` tells this call whether it actually delivered data —
 /// `true` for `SQLGetData` (a column was just captured) and for a
@@ -297,7 +303,6 @@ pub(super) fn release_busy_if_row_exhausted(
         Some(Ok(done)) => *done,
         _ => !client.has_open_batch(),
     };
-    let completion_failed = matches!(&completion_result, Some(Err(_)));
     let release = result_set_exhausted && batch_done;
 
     let mut read_error = peek_result.err();
@@ -328,7 +333,7 @@ pub(super) fn release_busy_if_row_exhausted(
         }
         if let Some(e) = read_error {
             error!(%e, "release_busy_if_row_exhausted: finishing current result failed");
-            if batch_done || completion_failed {
+            if batch_done {
                 stmt_state.pending_fetch_error = Some(e);
             }
         }

--- a/mssql-odbc/src/api/exec_common.rs
+++ b/mssql-odbc/src/api/exec_common.rs
@@ -227,14 +227,13 @@ pub(super) fn return_client_busy(dbc: &DbcHandle, client: TdsClient) {
 /// delivered, so posting now would never reach the caller. The next call
 /// that would otherwise short-circuit past the wire believing there is
 /// nothing left (`SQLFetch`'s `result_set_exhausted` fast path,
-/// `SQLMoreResults`) drains and reports it instead. A failure that does
-/// *not* end the batch (a raw transport error) is left unposted entirely:
-/// `release` is false in that case, so nothing about this statement's state
-/// changes, and the caller's very next real operation on this connection
-/// takes the normal, non-fast-path route and organically rediscovers and
-/// reports the same failure through its own existing error handling —
-/// posting it here too would attach a diagnostic to this call's own
-/// still-successful return.
+/// If the row-set DONE carries MORE, the TDS layer consumes trailing RPC
+/// completion tokens and parks any genuine next result boundary for
+/// `SQLMoreResults`. A failure while consuming that completion tail abandons
+/// the batch: timeout/cancellation has already drained through ATTENTION, and
+/// other failures retire the connection. The error is deferred to the next
+/// statement operation because this call has already committed to returning
+/// the row successfully.
 ///
 /// `row_delivered` tells this call whether it actually delivered data —
 /// `true` for `SQLGetData` (a column was just captured) and for a
@@ -269,7 +268,6 @@ pub(super) fn release_busy_if_row_exhausted(
         Ok(CursorPoll::Pending) => dbc.runtime.block_on(client.peek_past_current_row()),
         Err(error) => Err(error),
     };
-    let batch_done = !client.has_open_batch();
 
     // `Ok(true)`: another row, already parked for the next fetch — never
     // exhausted. `Ok(false)`: the current result set's own DONE token was
@@ -280,9 +278,28 @@ pub(super) fn release_busy_if_row_exhausted(
     // the wire itself has given up on the whole batch (see doc comment).
     let result_set_exhausted = match &peek_result {
         Ok(has_more) => !has_more,
-        Err(_) => batch_done,
+        Err(_) => !client.has_open_batch(),
+    };
+
+    // A row-returning RPC can end its visible row set with DONE_MORE because
+    // RETURNVALUE, RETURNSTATUS, and a terminal DONE still follow. Consume
+    // those protocol-only tokens now. A genuine next result is parked inside
+    // TdsClient, so SQLMoreResults still observes it in order.
+    let completion_result = if result_set_exhausted && peek_result.is_ok() {
+        Some(dbc.runtime.block_on(client.complete_current_result()))
+    } else {
+        None
+    };
+    let batch_done = match &completion_result {
+        Some(Ok(done)) => *done,
+        _ => !client.has_open_batch(),
     };
     let release = result_set_exhausted && batch_done;
+
+    let mut read_error = peek_result.err();
+    if let Some(Err(error)) = completion_result {
+        read_error = Some(error);
+    }
 
     let drained_info = if release {
         client.take_info_messages()
@@ -305,8 +322,8 @@ pub(super) fn release_busy_if_row_exhausted(
         } else {
             stmt_state.pending_fetch_info = drained_info;
         }
-        if let Err(e) = peek_result {
-            error!(%e, "release_busy_if_row_exhausted: peek past current row failed");
+        if let Some(e) = read_error {
+            error!(%e, "release_busy_if_row_exhausted: finishing current result failed");
             if batch_done {
                 stmt_state.pending_fetch_error = Some(e);
             }
@@ -1061,6 +1078,47 @@ mod tests {
              SQLMoreResults must also be able to fast-path without touching \
              the connection"
         );
+    }
+
+    #[test]
+    fn release_busy_if_row_exhausted_drains_a_protocol_only_rpc_tail() {
+        // A SELECT inside sp_executesql/sp_prepexec ends with DONE_MORE even
+        // when no application-visible result follows. The RPC's terminal DONE
+        // must be consumed before another statement can safely use the wire.
+        let h = TestHandles::with_env_dbc_stmt();
+        position_and_inject(&h, vec![col_metadata_empty(), done_more(), done_no_more()]);
+
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        let client = dbc.inner.lock().unwrap().client.take().unwrap();
+
+        release_busy_if_row_exhausted(dbc, stmt, h.stmt, client, true);
+
+        assert!(dbc.inner.lock().unwrap().active_stmt.is_none());
+        let ss = stmt.inner.lock().unwrap();
+        assert!(ss.result_set_exhausted);
+        assert!(ss.batch_exhausted);
+    }
+
+    #[test]
+    fn release_busy_if_row_exhausted_defers_a_truncated_rpc_tail() {
+        let h = TestHandles::with_env_dbc_stmt();
+        position_and_inject(&h, vec![col_metadata_empty(), done_more()]);
+
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        let client = dbc.inner.lock().unwrap().client.take().unwrap();
+
+        release_busy_if_row_exhausted(dbc, stmt, h.stmt, client, true);
+
+        assert!(dbc.inner.lock().unwrap().active_stmt.is_none());
+        let ss = stmt.inner.lock().unwrap();
+        assert!(ss.result_set_exhausted);
+        assert!(ss.batch_exhausted);
+        assert!(matches!(
+            ss.pending_fetch_error,
+            Some(TdsError::ConnectionClosed(_))
+        ));
     }
 
     /// The reviewer-flagged AB#47508 regression: `SELECT 1; SELECT 2;` as one

--- a/mssql-odbc/tests/e2e/run_e2e.ps1
+++ b/mssql-odbc/tests/e2e/run_e2e.ps1
@@ -581,6 +581,26 @@ function Initialize-CMake {
     }
 }
 
+# CMake build trees are not portable across Windows and WSL: each environment
+# records a different absolute source path in CMakeCache.txt. Remove a tree
+# configured from another path before asking Windows CMake to reuse it.
+function Remove-IncompatibleCMakeBuildTree([string]$BuildDir) {
+    $cachePath = Join-Path $BuildDir "CMakeCache.txt"
+    if (-not (Test-Path $cachePath)) { return }
+
+    $sourceEntry = Get-Content -Path $cachePath |
+        Where-Object { $_ -match '^CMAKE_HOME_DIRECTORY:INTERNAL=' } |
+        Select-Object -First 1
+    if (-not $sourceEntry) { return }
+
+    $cachedSource = ($sourceEntry -replace '^CMAKE_HOME_DIRECTORY:INTERNAL=', '').Replace('\', '/').TrimEnd('/')
+    $windowsSource = $ScriptDir.Replace('\', '/').TrimEnd('/')
+    if (-not [string]::Equals($cachedSource, $windowsSource, [System.StringComparison]::OrdinalIgnoreCase)) {
+        Write-Host "Removing incompatible CMake build tree (cached source: $cachedSource)"
+        Remove-Item -Path $BuildDir -Recurse -Force
+    }
+}
+
 try {
     if ($Retries -gt 0) {
         Write-Host "Retries enabled: each failing test reruns up to $Retries time(s)."
@@ -649,6 +669,7 @@ try {
     Write-Host ""
     Write-Host "=== Configuring e2e tests (CMake) ==="
     Initialize-CMake
+    Remove-IncompatibleCMakeBuildTree (Join-Path $ScriptDir "build")
     Push-Location $ScriptDir
     try {
         try {

--- a/mssql-odbc/tests/e2e/tests/connection_busy_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/connection_busy_test.cpp
@@ -123,7 +123,7 @@ TEST_F(ConnectionBusyLiveTest, PreparedParameterFetchToNoDataReleasesConnection)
 TEST_F(ConnectionBusyLiveTest, PreparedParameterMultiRowReleasesAfterLastRow) {
     SQLHSTMT b = AllocStmt();
 
-    ASSERT_SQL_OK(Prepare(stmt_, "SELECT ? FROM (VALUES (1), (2)) AS v(n) ORDER BY n"),
+    ASSERT_SQL_OK(Prepare(stmt_, "SELECT ?, v.n FROM (VALUES (1), (2)) AS v(n) ORDER BY v.n"),
                   SQL_HANDLE_STMT, stmt_);
     SQLINTEGER parameter = 42;
     SQLLEN parameter_ind = 0;
@@ -131,15 +131,19 @@ TEST_F(ConnectionBusyLiveTest, PreparedParameterMultiRowReleasesAfterLastRow) {
     ASSERT_SQL_OK(SQLExecute(stmt_), SQL_HANDLE_STMT, stmt_);
 
     SQLINTEGER value = 0;
+    SQLINTEGER row_number = 0;
     ASSERT_SQL_OK(SQLBindCol(stmt_, 1, SQL_C_SLONG, &value, sizeof(value), nullptr),
+                  SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLBindCol(stmt_, 2, SQL_C_SLONG, &row_number, sizeof(row_number), nullptr),
                   SQL_HANDLE_STMT, stmt_);
     ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
     EXPECT_EQ(42, value);
+    EXPECT_EQ(1, row_number);
     EXPECT_EQ(SQL_ERROR, Run(b, "SELECT 2"));
     EXPECT_SQLSTATE(SQL_HANDLE_STMT, b, "HY000");
 
     ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
-    EXPECT_EQ(42, value);
+    EXPECT_EQ(2, row_number);
     EXPECT_SQL_OK(Run(b, "SELECT 2"), SQL_HANDLE_STMT, b);
 }
 

--- a/mssql-odbc/tests/e2e/tests/connection_busy_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/connection_busy_test.cpp
@@ -120,6 +120,41 @@ TEST_F(ConnectionBusyLiveTest, PreparedParameterFetchToNoDataReleasesConnection)
     EXPECT_SQL_OK(Run(b, "SELECT 2"), SQL_HANDLE_STMT, b);
 }
 
+TEST_F(ConnectionBusyLiveTest, PreparedParameterMultiRowReleasesAfterLastRow) {
+    SQLHSTMT b = AllocStmt();
+
+    ASSERT_SQL_OK(Prepare(stmt_, "SELECT ? FROM (VALUES (1), (2)) AS v(n) ORDER BY n"),
+                  SQL_HANDLE_STMT, stmt_);
+    SQLINTEGER parameter = 42;
+    SQLLEN parameter_ind = 0;
+    ASSERT_SQL_OK(BindInt(stmt_, 1, &parameter, &parameter_ind), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLExecute(stmt_), SQL_HANDLE_STMT, stmt_);
+
+    SQLINTEGER value = 0;
+    ASSERT_SQL_OK(SQLBindCol(stmt_, 1, SQL_C_SLONG, &value, sizeof(value), nullptr),
+                  SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(42, value);
+    EXPECT_SQLSTATE(SQL_ERROR, Run(b, "SELECT 2"), "HY000", SQL_HANDLE_STMT, b);
+
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(42, value);
+    EXPECT_SQL_OK(Run(b, "SELECT 2"), SQL_HANDLE_STMT, b);
+}
+
+TEST_F(ConnectionBusyLiveTest, PreparedParameterZeroRowReleasesConnection) {
+    SQLHSTMT b = AllocStmt();
+
+    ASSERT_SQL_OK(Prepare(stmt_, "SELECT ? WHERE 1 = 0"), SQL_HANDLE_STMT, stmt_);
+    SQLINTEGER parameter = 42;
+    SQLLEN parameter_ind = 0;
+    ASSERT_SQL_OK(BindInt(stmt_, 1, &parameter, &parameter_ind), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLExecute(stmt_), SQL_HANDLE_STMT, stmt_);
+    ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt_));
+
+    EXPECT_SQL_OK(Run(b, "SELECT 2"), SQL_HANDLE_STMT, b);
+}
+
 // SQLExecDirect with bound parameters uses sp_executesql rather than the
 // prepared sp_prepexec path. Its RPC completion tokens must obey the same
 // release rule after the single row is consumed.

--- a/mssql-odbc/tests/e2e/tests/connection_busy_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/connection_busy_test.cpp
@@ -38,7 +38,209 @@ protected:
         SqlTString text = ODBCTestUtils::ToSqlTStr(sql);
         return SQLExecDirect(hstmt, const_cast<SQLTCHAR*>(text.c_str()), SQL_NTS);
     }
+
+    static SQLRETURN Prepare(SQLHSTMT hstmt, const std::string& sql) {
+        SqlTString text = ODBCTestUtils::ToSqlTStr(sql);
+        return SQLPrepare(hstmt, const_cast<SQLTCHAR*>(text.c_str()), SQL_NTS);
+    }
+
+    static SQLRETURN BindInt(SQLHSTMT hstmt, SQLUSMALLINT ordinal,
+                             SQLINTEGER* value, SQLLEN* indicator) {
+        return SQLBindParameter(hstmt, ordinal, SQL_PARAM_INPUT, SQL_C_SLONG,
+                                SQL_INTEGER, 0, 0, value, 0, indicator);
+    }
 };
+
+// A first execution of a prepared statement uses sp_prepexec. Its output
+// handle trails the row result on the wire, but it is part of the same RPC
+// response and must not keep the connection claimed after the only row and
+// all its columns have been consumed.
+TEST_F(ConnectionBusyLiveTest, PreparedNullParameterBoundFetchReleasesConnection) {
+    SQLHSTMT b = AllocStmt();
+
+    ASSERT_SQL_OK(Prepare(stmt_, "SELECT ?"), SQL_HANDLE_STMT, stmt_);
+    SQLINTEGER parameter = 0;
+    SQLLEN parameter_ind = SQL_NULL_DATA;
+    ASSERT_SQL_OK(BindInt(stmt_, 1, &parameter, &parameter_ind), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLExecute(stmt_), SQL_HANDLE_STMT, stmt_);
+
+    SQLINTEGER value = 0;
+    SQLLEN value_ind = 0;
+    ASSERT_SQL_OK(SQLBindCol(stmt_, 1, SQL_C_SLONG, &value, sizeof(value), &value_ind),
+                  SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(SQL_NULL_DATA, value_ind);
+
+    EXPECT_SQL_OK(Run(b, "SELECT 2"), SQL_HANDLE_STMT, b);
+}
+
+TEST_F(ConnectionBusyLiveTest, PreparedParametersGetDataThroughLastColumnReleaseConnection) {
+    SQLHSTMT b = AllocStmt();
+
+    ASSERT_SQL_OK(Prepare(stmt_, "SELECT ?, ?"), SQL_HANDLE_STMT, stmt_);
+    SQLINTEGER first_parameter = 1;
+    SQLINTEGER second_parameter = 2;
+    SQLLEN first_ind = 0;
+    SQLLEN second_ind = 0;
+    ASSERT_SQL_OK(BindInt(stmt_, 1, &first_parameter, &first_ind), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(BindInt(stmt_, 2, &second_parameter, &second_ind), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLExecute(stmt_), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+
+    SQLINTEGER first = 0;
+    SQLINTEGER second = 0;
+    ASSERT_SQL_OK(SQLGetData(stmt_, 1, SQL_C_SLONG, &first, sizeof(first), nullptr),
+                  SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLGetData(stmt_, 2, SQL_C_SLONG, &second, sizeof(second), nullptr),
+                  SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(1, first);
+    EXPECT_EQ(2, second);
+
+    EXPECT_SQL_OK(Run(b, "SELECT 3"), SQL_HANDLE_STMT, b);
+}
+
+// fetchall-style consumers issue one final SQLFetch to receive SQL_NO_DATA.
+// That completion must drain the trailing RPC tokens and release the claim.
+TEST_F(ConnectionBusyLiveTest, PreparedParameterFetchToNoDataReleasesConnection) {
+    SQLHSTMT b = AllocStmt();
+
+    ASSERT_SQL_OK(Prepare(stmt_, "SELECT ?"), SQL_HANDLE_STMT, stmt_);
+    SQLINTEGER parameter = -42;
+    SQLLEN parameter_ind = 0;
+    ASSERT_SQL_OK(BindInt(stmt_, 1, &parameter, &parameter_ind), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLExecute(stmt_), SQL_HANDLE_STMT, stmt_);
+
+    SQLINTEGER value = 0;
+    ASSERT_SQL_OK(SQLBindCol(stmt_, 1, SQL_C_SLONG, &value, sizeof(value), nullptr),
+                  SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(-42, value);
+    ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt_));
+
+    EXPECT_SQL_OK(Run(b, "SELECT 2"), SQL_HANDLE_STMT, b);
+}
+
+// SQLExecDirect with bound parameters uses sp_executesql rather than the
+// prepared sp_prepexec path. Its RPC completion tokens must obey the same
+// release rule after the single row is consumed.
+TEST_F(ConnectionBusyLiveTest, ExecDirectParameterBoundFetchReleasesConnection) {
+    SQLHSTMT b = AllocStmt();
+
+    SQLINTEGER parameter = 42;
+    SQLLEN parameter_ind = 0;
+    ASSERT_SQL_OK(BindInt(stmt_, 1, &parameter, &parameter_ind), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(Run(stmt_, "SELECT ?"), SQL_HANDLE_STMT, stmt_);
+
+    SQLINTEGER value = 0;
+    ASSERT_SQL_OK(SQLBindCol(stmt_, 1, SQL_C_SLONG, &value, sizeof(value), nullptr),
+                  SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(42, value);
+
+    EXPECT_SQL_OK(Run(b, "SELECT 2"), SQL_HANDLE_STMT, b);
+}
+
+TEST_F(ConnectionBusyLiveTest, PreparedParameterCloseWithoutFetchReleasesConnection) {
+    SQLHSTMT b = AllocStmt();
+
+    ASSERT_SQL_OK(Prepare(stmt_, "SELECT ?"), SQL_HANDLE_STMT, stmt_);
+    SQLINTEGER parameter = 42;
+    SQLLEN parameter_ind = 0;
+    ASSERT_SQL_OK(BindInt(stmt_, 1, &parameter, &parameter_ind), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLExecute(stmt_), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
+
+    EXPECT_SQL_OK(Run(b, "SELECT 2"), SQL_HANDLE_STMT, b);
+}
+
+TEST_F(ConnectionBusyLiveTest, ExecDirectParameterCloseWithoutFetchReleasesConnection) {
+    SQLHSTMT b = AllocStmt();
+
+    SQLINTEGER parameter = 42;
+    SQLLEN parameter_ind = 0;
+    ASSERT_SQL_OK(BindInt(stmt_, 1, &parameter, &parameter_ind), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(Run(stmt_, "SELECT ?"), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
+
+    EXPECT_SQL_OK(Run(b, "SELECT 2"), SQL_HANDLE_STMT, b);
+}
+
+// Mirrors msodbcsql MARSODBC TCTestAPIs variation 2: a parameterized direct
+// query with two rowsets must retain the second rowset for SQLMoreResults.
+TEST_F(ConnectionBusyLiveTest, ExecDirectParametersPreserveSecondResultSet) {
+    SQLHSTMT b = AllocStmt();
+
+    SQLINTEGER first_parameter = 41;
+    SQLINTEGER second_parameter = 42;
+    SQLLEN first_ind = 0;
+    SQLLEN second_ind = 0;
+    ASSERT_SQL_OK(BindInt(stmt_, 1, &first_parameter, &first_ind), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(BindInt(stmt_, 2, &second_parameter, &second_ind), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(Run(stmt_, "SELECT ?; SELECT ?"), SQL_HANDLE_STMT, stmt_);
+
+    SQLINTEGER value = 0;
+    ASSERT_SQL_OK(SQLBindCol(stmt_, 1, SQL_C_SLONG, &value, sizeof(value), nullptr),
+                  SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(41, value);
+
+    EXPECT_EQ(SQL_ERROR, Run(b, "SELECT 20"));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, b, "HY000");
+
+    ASSERT_SQL_OK(SQLMoreResults(stmt_), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(42, value);
+    EXPECT_EQ(SQL_NO_DATA, SQLMoreResults(stmt_));
+
+    EXPECT_SQL_OK(Run(b, "SELECT 20"), SQL_HANDLE_STMT, b);
+}
+
+// Mirrors msodbcsql PrepareEx variation 49, with parameters added to keep the
+// sp_prepexec completion tail in the scenario. Re-execution also proves that
+// the handle captured after the first RPC remains usable by sp_execute.
+TEST_F(ConnectionBusyLiveTest, PreparedParametersPreserveMultipleResultsAcrossReuse) {
+    SQLHSTMT b = AllocStmt();
+
+    ASSERT_SQL_OK(Prepare(stmt_, "SELECT ?; SELECT ?"), SQL_HANDLE_STMT, stmt_);
+    SQLINTEGER first_parameter = 41;
+    SQLINTEGER second_parameter = 42;
+    SQLLEN first_ind = 0;
+    SQLLEN second_ind = 0;
+    ASSERT_SQL_OK(BindInt(stmt_, 1, &first_parameter, &first_ind), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(BindInt(stmt_, 2, &second_parameter, &second_ind), SQL_HANDLE_STMT, stmt_);
+
+    SQLINTEGER value = 0;
+    ASSERT_SQL_OK(SQLBindCol(stmt_, 1, SQL_C_SLONG, &value, sizeof(value), nullptr),
+                  SQL_HANDLE_STMT, stmt_);
+    for (int execution = 0; execution < 2; ++execution) {
+        ASSERT_SQL_OK(SQLExecute(stmt_), SQL_HANDLE_STMT, stmt_);
+        ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+        EXPECT_EQ(41, value);
+        ASSERT_SQL_OK(SQLMoreResults(stmt_), SQL_HANDLE_STMT, stmt_);
+        ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+        EXPECT_EQ(42, value);
+        EXPECT_EQ(SQL_NO_DATA, SQLMoreResults(stmt_));
+    }
+
+    EXPECT_SQL_OK(Run(b, "SELECT 20"), SQL_HANDLE_STMT, b);
+}
+
+// Cursor wrappers may free an executed statement directly rather than fetching
+// or calling SQLCloseCursor first. Freeing it must drain the rowset and the
+// sp_prepexec tail before a second statement uses the connection.
+TEST_F(ConnectionBusyLiveTest, FreeUnfetchedPreparedParameterStatementReleasesConnection) {
+    SQLHSTMT a = AllocStmt();
+    SQLHSTMT b = AllocStmt();
+
+    ASSERT_SQL_OK(Prepare(a, "SELECT ?"), SQL_HANDLE_STMT, a);
+    SQLINTEGER parameter = 1;
+    SQLLEN parameter_ind = 0;
+    ASSERT_SQL_OK(BindInt(a, 1, &parameter, &parameter_ind), SQL_HANDLE_STMT, a);
+    ASSERT_SQL_OK(SQLExecute(a), SQL_HANDLE_STMT, a);
+    FreeStmt(a);
+
+    EXPECT_SQL_OK(Run(b, "SELECT 2"), SQL_HANDLE_STMT, b);
+}
 
 // Row 1: a fully-bound single-column fetch of A's only row must release the
 // connection immediately — the peek past that row finds the terminating

--- a/mssql-odbc/tests/e2e/tests/connection_busy_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/connection_busy_test.cpp
@@ -135,7 +135,8 @@ TEST_F(ConnectionBusyLiveTest, PreparedParameterMultiRowReleasesAfterLastRow) {
                   SQL_HANDLE_STMT, stmt_);
     ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
     EXPECT_EQ(42, value);
-    EXPECT_SQLSTATE(SQL_ERROR, Run(b, "SELECT 2"), "HY000", SQL_HANDLE_STMT, b);
+    EXPECT_EQ(SQL_ERROR, Run(b, "SELECT 2"));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, b, "HY000");
 
     ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
     EXPECT_EQ(42, value);

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -4454,6 +4454,9 @@ impl TdsClient {
     /// The response-tail control tokens that precede `DONEPROC` are absorbed
     /// exactly as the main loop absorbs them.
     ///
+    /// Every error exit ends the batch, so no caller can propagate a tail
+    /// failure over a batch nothing will finish reading.
+    ///
     /// Unlike msodbcsql's short, non-failing single-byte peek, this consumes the
     /// trailer under the request's remaining timeout. An expiry therefore fails
     /// the request after the attention acknowledgement restores synchronization;
@@ -4515,10 +4518,33 @@ impl TdsClient {
                 }
                 other => {
                     self.parked_token = Some(Box::new(other));
-                    return processing_error.map_or(Ok(()), Err);
+                    return match processing_error {
+                        None => Ok(()),
+                        Some(error) => Err(self.abandon_after_tail_failure(error).await),
+                    };
                 }
             }
         }
+    }
+
+    /// Ends the batch after a tail token failed to process, keeping the rule
+    /// "a tail failure always ends the batch" with the loop that breaks it.
+    ///
+    /// The look-ahead parked whatever it could not process, so the rest of the
+    /// response is unread and nothing will come back for it. Leaving the batch
+    /// open masks the returned error behind `ALREADY_EXECUTING_ERROR` on every
+    /// later command for the whole connection.
+    async fn abandon_after_tail_failure(
+        &mut self,
+        error: crate::error::Error,
+    ) -> crate::error::Error {
+        if self.execution_context.has_open_batch() {
+            if let Err(drain_error) = self.drain_stream_or_retire().await {
+                warn!(error = ?drain_error, "Drain after an RPC tail failure failed");
+            }
+            self.execution_context.set_has_open_batch(false);
+        }
+        error
     }
 
     fn fail_rpc_terminator_look_ahead(&mut self, error: &crate::error::Error) {
@@ -4641,17 +4667,6 @@ impl TdsClient {
         if let Err(error) = self.settle_rpc_terminator(&parser_context).await {
             self.current_metadata = None;
             self.abort_pending_prepare_capture();
-            // A tail token that failed to process before the terminal DONEPROC
-            // leaves the rest of the response unread. The caller has an error to
-            // report and no way back to this batch, so consume it here rather
-            // than leaving the connection claimed by a statement that will never
-            // read it.
-            if self.execution_context.has_open_batch() {
-                if let Err(drain_error) = self.drain_stream_or_retire().await {
-                    warn!(error = ?drain_error, "Drain after an RPC tail failure failed");
-                }
-                self.execution_context.set_has_open_batch(false);
-            }
             return Err(error);
         }
         Ok(!self.execution_context.has_open_batch())
@@ -10069,6 +10084,35 @@ mod tests {
             Err(crate::error::Error::ColumnEncryptionError(_))
         ));
         assert!(!client.has_open_batch());
+        assert!(client.parked_token.is_none());
+    }
+
+    #[tokio::test]
+    async fn advance_abandons_the_batch_when_a_tail_token_fails() {
+        // The other `settle_rpc_terminator` call site. Propagating the failure
+        // with the batch still open would mask it behind ALREADY_EXECUTING_ERROR
+        // on every later command for the whole connection.
+        let transport = TestTransport::with_tokens(vec![
+            info_token(0, 0, "print"),
+            done_in_proc_more(),
+            Tokens::ReturnValue(ae_return_value_token(
+                "@out",
+                ColumnValues::Bytes(vec![1, 2, 3]),
+                Some(ae_crypto_metadata()),
+            )),
+            empty_col_metadata(),
+            done_no_more(),
+        ]);
+        let mut client = create_test_client_with_transport(transport);
+        client.current_command_ce_setting = ExecutionColumnEncryptionSetting::Enabled;
+        client.current_result_set_has_been_read_till_end = true;
+        client.execution_context.set_has_open_batch(true);
+
+        assert!(matches!(
+            client.advance().await,
+            Err(crate::error::Error::ColumnEncryptionError(_))
+        ));
+        assert!(!client.command_is_busy());
         assert!(client.parked_token.is_none());
     }
 

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -4184,6 +4184,7 @@ impl TdsClient {
                     // Use saturating_add to prevent integer overflow from malicious/corrupted TDS responses
                     *count = count.saturating_add(done.row_count);
                     self.current_result_set_has_been_read_till_end = true;
+                    self.current_result_ended_with_done_in_proc = is_done_in_proc;
 
                     let is_last = !done.has_more();
 
@@ -4242,6 +4243,7 @@ impl TdsClient {
                             // trailing DONEPROC; find out before the caller
                             // treats it as another result.
                             self.settle_rpc_terminator(&parser_context).await?;
+                            self.current_result_ended_with_done_in_proc = false;
                         }
                         return Ok(ResultBoundaryKind::NoRows {
                             rows_affected: if has_update_count {
@@ -4399,11 +4401,14 @@ impl TdsClient {
         }
     }
 
-    /// Returns `true` while the current batch still has unconsumed results on
-    /// the wire or in [`parked_token`](Self::parked_token) (a positioned result
-    /// set, an RPC-tail look-ahead token, or further statements to navigate to).
+    /// Returns `true` while the current batch still has unconsumed results (a
+    /// positioned result set, or further statements to navigate to).
     /// Used by the ODBC layer to decide whether the connection stays busy after
     /// positioning on a no-row statement result.
+    ///
+    /// A token parked by the RPC-terminator look-ahead is covered without being
+    /// inspected here: parking means the terminal DONEPROC was not reached, so
+    /// the flag this reads is still set.
     pub fn has_open_batch(&self) -> bool {
         self.execution_context.has_open_batch()
     }
@@ -4532,7 +4537,8 @@ impl TdsClient {
 
     /// Returns `true` when an open result batch or streamed write blocks a new command.
     pub(in crate::connection) fn command_is_busy(&self) -> bool {
-        self.has_open_batch() || !matches!(self.streamed_write_state, StreamedWriteState::Idle)
+        self.execution_context.has_open_batch()
+            || !matches!(self.streamed_write_state, StreamedWriteState::Idle)
     }
 
     /// Returns `true` when the client is currently positioned on a row-returning
@@ -4608,6 +4614,11 @@ impl TdsClient {
     /// `DONEINPROC`, [`settle_rpc_terminator`](Self::settle_rpc_terminator)
     /// consumes only that control-token tail and parks the first non-tail token
     /// for [`advance`](Self::advance). Plain batch DONE tokens are never probed.
+    ///
+    /// The `DONEINPROC` gate is msodbcsql's: `OnDone` probes the tail only for
+    /// `RS_SELECTION && DONEINPROC && DONE_MORE` (`sqlctokn.cpp:2208-2240`).
+    /// Widening it to every DONE would make an ordinary multi-statement batch
+    /// block here on the next statement's result.
     ///
     /// Returns `true` only when the batch is fully exhausted.
     pub async fn complete_current_result(&mut self) -> TdsResult<bool> {
@@ -6801,6 +6812,7 @@ impl TdsClient {
         self.cancel_handle = None;
         self.active_row_read_state = ActiveRowReadState::Idle;
         self.row_already_positioned = false;
+        self.parked_token = None;
         self.current_command_ce_setting = ExecutionColumnEncryptionSetting::UseConnectionSetting;
         self.execution_context.set_has_open_batch(false);
 
@@ -9989,6 +10001,32 @@ mod tests {
         assert!(!client.has_open_batch());
         assert!(client.is_connection_dead());
         assert!(client.current_result_set_has_been_read_till_end);
+    }
+
+    #[tokio::test]
+    async fn advancing_to_a_no_row_result_clears_the_rpc_tail_gate() {
+        let transport = TestTransport::with_tokens(vec![
+            done_in_proc_more(),
+            done_count(CurrentCommand::Update, 3, true),
+        ]);
+        let mut client = create_test_client_with_transport(transport);
+        client.current_metadata = Some(stale_metadata());
+        client.execution_context.set_has_open_batch(true);
+
+        assert!(!client.peek_past_current_row().await.unwrap());
+        assert!(!client.complete_current_result().await.unwrap());
+        assert!(client.current_result_ended_with_done_in_proc);
+
+        assert!(matches!(
+            client.advance().await,
+            Ok(StatementResult::NoRows {
+                rows_affected: Some(3)
+            })
+        ));
+        assert!(
+            !client.current_result_ended_with_done_in_proc,
+            "a plain batch DONE must not leave the previous RPC's tail gate armed"
+        );
     }
 
     #[tokio::test]

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -36,7 +36,9 @@ use crate::{
         ColumnPolicy, ParserContext, PlpPauseState, RowHeader, RowPauseState, RowReadResult,
     },
     message::{batch::SqlBatch, messages::Request},
-    token::tokens::{ColMetadataToken, CurrentCommand, DoneStatus, EnvChangeTokenSubType, Tokens},
+    token::tokens::{
+        ColMetadataToken, CurrentCommand, DoneStatus, DoneToken, EnvChangeTokenSubType, Tokens,
+    },
 };
 use std::collections::HashMap;
 use std::future::Future;
@@ -425,12 +427,10 @@ pub struct TdsClient {
     /// cursor RPC response and interpreted as a [`CursorStatus`](crate::cursor::CursorStatus).
     pub(in crate::connection) last_return_status: ReturnStatus,
     pub(in crate::connection) current_result_set_has_been_read_till_end: bool,
-
-    /// Result boundary read ahead after the current row set was exhausted.
-    /// RPC completion tokens may trail that row set before either the terminal
-    /// DONE or a genuine next result. The former can be consumed immediately;
-    /// the latter must remain observable by the next [`advance`](Self::advance).
-    pending_result_boundary: Option<ResultBoundaryKind>,
+    /// Whether the DONE that exhausted the current row set was `DONEINPROC`.
+    /// Only that token makes MORE ambiguous between another application result
+    /// and the RPC's protocol-only completion tail.
+    current_result_ended_with_done_in_proc: bool,
 
     /// Column Encryption setting for the command currently executing. Set by
     /// each execute entry point; consulted by the parameter-encryption and
@@ -557,7 +557,7 @@ impl TdsClient {
             output_param_ceks: HashMap::new(),
             last_return_status: ReturnStatus::NotReceived,
             current_result_set_has_been_read_till_end: false,
-            pending_result_boundary: None,
+            current_result_ended_with_done_in_proc: false,
             current_command_ce_setting:
                 crate::connection::client_context::ExecutionColumnEncryptionSetting::default(),
             pending_capture: None,
@@ -768,7 +768,7 @@ impl TdsClient {
         // metadata.
         self.clear_session_bound_caches();
         self.current_result_set_has_been_read_till_end = false;
-        self.pending_result_boundary = None;
+        self.current_result_ended_with_done_in_proc = false;
         self.active_row_read_state = ActiveRowReadState::Idle;
         self.row_already_positioned = false;
         self.parked_token = None;
@@ -4157,6 +4157,7 @@ impl TdsClient {
                 Tokens::ColMetadata(md) => {
                     info!(?md);
                     self.current_result_set_has_been_read_till_end = false;
+                    self.current_result_ended_with_done_in_proc = false;
                     // Positioning on a row-returning result: its count is
                     // unavailable on a forward-only cursor. Clear any count
                     // captured from a preceding DONE-only (DML) result in the
@@ -4380,6 +4381,7 @@ impl TdsClient {
                 self.current_metadata = Some(md);
                 self.execution_context.set_has_open_batch(true);
                 self.current_result_set_has_been_read_till_end = false;
+                self.current_result_ended_with_done_in_proc = false;
                 StatementResult::Rows
             }
             ResultBoundaryKind::NoRows { rows_affected } => {
@@ -4398,11 +4400,12 @@ impl TdsClient {
     }
 
     /// Returns `true` while the current batch still has unconsumed results on
-    /// the wire (a positioned result set, or further statements to navigate to).
+    /// the wire or in [`parked_token`](Self::parked_token) (a positioned result
+    /// set, an RPC-tail look-ahead token, or further statements to navigate to).
     /// Used by the ODBC layer to decide whether the connection stays busy after
     /// positioning on a no-row statement result.
     pub fn has_open_batch(&self) -> bool {
-        self.execution_context.has_open_batch() || self.pending_result_boundary.is_some()
+        self.execution_context.has_open_batch()
     }
 
     /// Reads the next response token, replaying one parked by the RPC-terminator
@@ -4514,10 +4517,15 @@ impl TdsClient {
         self.execution_context.set_has_open_batch(false);
         self.remaining_request_timeout = None;
         self.cancel_handle = None;
-        if !matches!(
+        let attention_error = matches!(
             error,
             crate::error::Error::TimeoutError(_) | crate::error::Error::OperationCancelledError(_)
-        ) {
+        );
+        if attention_error && self.transport.connection_known_dead() {
+            // ATTENTION did not restore a message boundary. Reconnecting would
+            // hide failed cancellation cleanup, so do not recover this session.
+            self.recovery_context.session_recovery_negotiated = false;
+        } else if !attention_error {
             self.retire_after_failed_drain(error);
         }
     }
@@ -4552,9 +4560,6 @@ impl TdsClient {
     /// skip straight to the next row-returning result set.
     #[instrument(skip(self), level = "info")]
     pub async fn advance(&mut self) -> TdsResult<StatementResult> {
-        if let Some(boundary) = self.pending_result_boundary.take() {
-            return Ok(self.apply_result_boundary(boundary));
-        }
         if !self.has_open_batch() {
             return Ok(StatementResult::End);
         }
@@ -4596,72 +4601,35 @@ impl TdsClient {
         }
     }
 
-    /// Finishes an exhausted row set far enough to determine whether the wire
-    /// contains only protocol-level completion tokens or another result that a
-    /// consumer must observe.
+    /// Settles the protocol-only tail after an exhausted RPC row set.
     ///
     /// SQL Server RPC responses can end a row set with `DONE_MORE`, then emit
-    /// RETURNVALUE/RETURNSTATUS tokens and a terminal DONE. Those control tokens
-    /// do not constitute another ODBC result and must not keep the connection
-    /// busy. If a real next row set, update count, or message result is found,
-    /// its boundary is parked and returned by the next [`advance`](Self::advance)
-    /// call without reading past it.
+    /// RETURNVALUE/RETURNSTATUS tokens and a terminal DONEPROC. For a
+    /// `DONEINPROC`, [`settle_rpc_terminator`](Self::settle_rpc_terminator)
+    /// consumes only that control-token tail and parks the first non-tail token
+    /// for [`advance`](Self::advance). Plain batch DONE tokens are never probed.
     ///
     /// Returns `true` only when the batch is fully exhausted.
     pub async fn complete_current_result(&mut self) -> TdsResult<bool> {
         if !self.current_result_set_has_been_read_till_end {
             return Ok(false);
         }
-        if self.pending_result_boundary.is_some() {
-            return Ok(false);
-        }
         if !self.execution_context.has_open_batch() {
             return Ok(true);
         }
-
-        let boundary = match self.advance_to_result_boundary().await {
-            Ok(boundary) => boundary,
-            Err(error) => {
-                // Timeout and cancellation already send ATTENTION and drain
-                // through its acknowledgement. Other failures leave this
-                // response unsafe to resume unless token handling already
-                // completed the batch, as server ERROR handling does.
-                let attention_error = matches!(
-                    &error,
-                    crate::error::Error::TimeoutError(_)
-                        | crate::error::Error::OperationCancelledError(_)
-                );
-                if attention_error && self.transport.connection_known_dead() {
-                    // ATTENTION did not restore a message boundary. Reconnecting
-                    // would hide a failed cancellation cleanup, so this session
-                    // is not eligible for transparent recovery.
-                    self.recovery_context.session_recovery_negotiated = false;
-                } else if self.execution_context.has_open_batch() && !attention_error {
-                    self.retire_after_failed_drain(&error);
-                }
-                self.execution_context.set_has_open_batch(false);
-                self.pending_result_boundary = None;
-                self.current_metadata = None;
-                self.current_result_set_has_been_read_till_end = true;
-                self.abort_pending_prepare_capture();
-                return Err(error);
-            }
-        };
-
-        match boundary {
-            ResultBoundaryKind::End => {
-                self.apply_result_boundary(ResultBoundaryKind::End);
-                Ok(true)
-            }
-            boundary => {
-                // Token parsing updates this state while reading ahead. Keep
-                // the current row set exhausted until `advance` applies the
-                // parked boundary.
-                self.current_result_set_has_been_read_till_end = true;
-                self.pending_result_boundary = Some(boundary);
-                Ok(false)
-            }
+        if !self.current_result_ended_with_done_in_proc {
+            return Ok(false);
         }
+
+        let parser_context = ParserContext::ColumnEncryption(
+            self.negotiated_settings.is_column_encryption_supported(),
+        );
+        if let Err(error) = self.settle_rpc_terminator(&parser_context).await {
+            self.current_metadata = None;
+            self.abort_pending_prepare_capture();
+            return Err(error);
+        }
+        Ok(!self.execution_context.has_open_batch())
     }
 
     /// This functions returns to the next row in the result set.
@@ -6600,26 +6568,8 @@ impl TdsClient {
 
     async fn handle_row_read_token(&mut self, token: Tokens) -> TdsResult<Option<bool>> {
         match token {
-            Tokens::DoneInProc(done) | Tokens::DoneProc(done) | Tokens::Done(done) => {
-                info!("done while get_next_row: {:?}", done);
-
-                if done.has_error() {
-                    return Err(crate::error::Error::ProtocolError(
-                        "Server reported error in DONE token without preceding ERROR token"
-                            .to_string(),
-                    ));
-                }
-
-                let count = self.count_map.entry(done.cur_cmd).or_insert(0);
-                *count = count.saturating_add(done.row_count);
-
-                self.current_result_set_has_been_read_till_end = true;
-                if !done.has_more() {
-                    info!("No more rows for current command: {:?}", done.cur_cmd);
-                    self.execution_context.set_has_open_batch(false);
-                }
-                Ok(Some(false))
-            }
+            Tokens::DoneInProc(done) => self.handle_row_done(done, true),
+            Tokens::DoneProc(done) | Tokens::Done(done) => self.handle_row_done(done, false),
             Tokens::Order(order_token) => {
                 info!(?order_token);
                 Ok(None)
@@ -6682,6 +6632,30 @@ impl TdsClient {
                 "Unexpected token while finding the next row: {token:?}"
             ))),
         }
+    }
+
+    fn handle_row_done(
+        &mut self,
+        done: DoneToken,
+        ended_with_done_in_proc: bool,
+    ) -> TdsResult<Option<bool>> {
+        info!("done while get_next_row: {:?}", done);
+
+        if done.has_error() {
+            return Err(crate::error::Error::ProtocolError(
+                "Server reported error in DONE token without preceding ERROR token".to_string(),
+            ));
+        }
+
+        let count = self.count_map.entry(done.cur_cmd).or_insert(0);
+        *count = count.saturating_add(done.row_count);
+        self.current_result_set_has_been_read_till_end = true;
+        self.current_result_ended_with_done_in_proc = ended_with_done_in_proc;
+        if !done.has_more() {
+            info!("No more rows for current command: {:?}", done.cur_cmd);
+            self.execution_context.set_has_open_batch(false);
+        }
+        Ok(Some(false))
     }
 
     /// Returns a clone of all [`ReturnValue`]s collected during the current
@@ -6820,7 +6794,7 @@ impl TdsClient {
         // The sp_prepexec @handle, if any, was captured during the drain above
         // (see push_return_value) and survives this clear.
         self.current_metadata = None;
-        self.pending_result_boundary = None;
+        self.current_result_ended_with_done_in_proc = false;
         self.return_values.clear();
         self.abort_pending_prepare_capture();
         self.remaining_request_timeout = None;
@@ -8246,6 +8220,22 @@ mod tests {
         Tokens::Done(DoneToken {
             status: DoneStatus::MORE,
             cur_cmd: CurrentCommand::Insert,
+            row_count: 0,
+        })
+    }
+
+    fn done_in_proc_more() -> Tokens {
+        Tokens::DoneInProc(DoneToken {
+            status: DoneStatus::MORE,
+            cur_cmd: CurrentCommand::Select,
+            row_count: 0,
+        })
+    }
+
+    fn done_proc_no_more() -> Tokens {
+        Tokens::DoneProc(DoneToken {
+            status: DoneStatus::FINAL,
+            cur_cmd: CurrentCommand::Select,
             row_count: 0,
         })
     }
@@ -9960,10 +9950,10 @@ mod tests {
     #[tokio::test]
     async fn complete_current_result_drains_rpc_tail_and_captures_prepared_handle() {
         let transport = TestTransport::with_tokens(vec![
-            done_more(),
+            done_in_proc_more(),
             Tokens::ReturnValue(ae_return_value_token("@handle", ColumnValues::Int(9), None)),
             Tokens::ReturnStatus(ReturnStatusToken { value: 0 }),
-            done_no_more(),
+            done_proc_no_more(),
         ]);
         let mut client = create_test_client_with_transport(transport);
         client.current_metadata = Some(stale_metadata());
@@ -9985,7 +9975,7 @@ mod tests {
 
     #[tokio::test]
     async fn complete_current_result_retires_a_truncated_rpc_tail() {
-        let transport = TestTransport::with_tokens(vec![done_more()]);
+        let transport = TestTransport::with_tokens(vec![done_in_proc_more()]);
         let mut client = create_test_client_with_transport(transport);
         client.current_metadata = Some(stale_metadata());
         client.current_result_set_has_been_read_till_end = false;
@@ -10003,7 +9993,11 @@ mod tests {
 
     #[tokio::test]
     async fn complete_current_result_parks_a_following_rowset() {
-        let transport = TestTransport::with_tokens(vec![done_more(), empty_col_metadata()]);
+        let transport = TestTransport::with_tokens(vec![
+            done_in_proc_more(),
+            empty_col_metadata(),
+            done_no_more(),
+        ]);
         let mut client = create_test_client_with_transport(transport);
         client.current_metadata = Some(stale_metadata());
         client.current_result_set_has_been_read_till_end = false;
@@ -10016,34 +10010,10 @@ mod tests {
 
         assert!(matches!(client.advance().await, Ok(StatementResult::Rows)));
         assert!(!client.current_result_set_has_been_read_till_end);
-    }
 
-    #[tokio::test]
-    async fn complete_current_result_parks_a_terminal_update_count() {
-        let transport = TestTransport::with_tokens(vec![
-            done_more(),
-            done_count(CurrentCommand::Update, 7, false),
-        ]);
-        let mut client = create_test_client_with_transport(transport);
-        client.current_metadata = Some(stale_metadata());
-        client.current_result_set_has_been_read_till_end = false;
-        client.execution_context.set_has_open_batch(true);
-
-        assert!(!client.peek_past_current_row().await.unwrap());
-        assert!(!client.complete_current_result().await.unwrap());
-        assert!(
-            client.has_open_batch(),
-            "the parked count is still a result"
-        );
-
-        assert!(matches!(
-            client.advance().await,
-            Ok(StatementResult::NoRows {
-                rows_affected: Some(7)
-            })
-        ));
+        client.close_query().await.unwrap();
+        assert!(client.parked_token.is_none());
         assert!(!client.has_open_batch());
-        assert!(matches!(client.advance().await, Ok(StatementResult::End)));
     }
 
     #[tokio::test]
@@ -10145,6 +10115,72 @@ mod tests {
         // Only one leading '@' is stripped.
         assert_eq!(TdsClient::normalize_param_name("@@version"), "@VERSION");
         assert_eq!(TdsClient::normalize_param_name(""), "");
+    }
+
+    #[tokio::test]
+    async fn complete_current_result_does_not_probe_a_plain_batch() {
+        let transport = TestTransport::with_tokens(vec![done_more(), empty_col_metadata()]);
+        let mut client = create_test_client_with_transport(transport);
+        client.current_metadata = Some(stale_metadata());
+        client.execution_context.set_has_open_batch(true);
+
+        assert!(!client.peek_past_current_row().await.unwrap());
+        assert!(!client.complete_current_result().await.unwrap());
+        assert!(client.parked_token.is_none());
+        assert!(matches!(client.advance().await, Ok(StatementResult::Rows)));
+    }
+
+    #[tokio::test]
+    async fn complete_current_result_requires_an_exhausted_rowset() {
+        let mut client = create_test_client_with_tokens(vec![done_in_proc_more()]);
+        client.execution_context.set_has_open_batch(true);
+
+        assert!(!client.complete_current_result().await.unwrap());
+        assert!(client.execution_context.has_open_batch());
+    }
+
+    #[tokio::test]
+    async fn complete_current_result_disarms_recovery_when_attention_cleanup_fails() {
+        let transport = TestTransport::with_tokens(vec![done_in_proc_more()]);
+        let mut client = create_test_client_with_transport(transport);
+        client.current_metadata = Some(stale_metadata());
+        client.execution_context.set_has_open_batch(true);
+        client.recovery_context.session_recovery_negotiated = true;
+
+        assert!(!client.peek_past_current_row().await.unwrap());
+        let cancellation = CancelHandle::new();
+        client.cancel_handle = Some(cancellation.child_handle());
+        cancellation.cancel();
+        client.transport.mark_known_dead();
+
+        assert!(matches!(
+            client.complete_current_result().await,
+            Err(crate::error::Error::OperationCancelledError(_))
+        ));
+        assert!(!client.recovery_context.session_recovery_negotiated);
+        assert!(!client.has_open_batch());
+    }
+
+    #[tokio::test]
+    async fn complete_current_result_preserves_recovery_when_cancel_leaves_transport_alive() {
+        let transport = TestTransport::with_tokens(vec![done_in_proc_more()]);
+        let mut client = create_test_client_with_transport(transport);
+        client.current_metadata = Some(stale_metadata());
+        client.execution_context.set_has_open_batch(true);
+        client.recovery_context.session_recovery_negotiated = true;
+
+        assert!(!client.peek_past_current_row().await.unwrap());
+        let cancellation = CancelHandle::new();
+        client.cancel_handle = Some(cancellation.child_handle());
+        cancellation.cancel();
+
+        assert!(matches!(
+            client.complete_current_result().await,
+            Err(crate::error::Error::OperationCancelledError(_))
+        ));
+        assert!(client.recovery_context.session_recovery_negotiated);
+        assert!(!client.is_connection_dead());
+        assert!(!client.has_open_batch());
     }
 
     #[tokio::test]

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -426,6 +426,12 @@ pub struct TdsClient {
     pub(in crate::connection) last_return_status: ReturnStatus,
     pub(in crate::connection) current_result_set_has_been_read_till_end: bool,
 
+    /// Result boundary read ahead after the current row set was exhausted.
+    /// RPC completion tokens may trail that row set before either the terminal
+    /// DONE or a genuine next result. The former can be consumed immediately;
+    /// the latter must remain observable by the next [`advance`](Self::advance).
+    pending_result_boundary: Option<ResultBoundaryKind>,
+
     /// Column Encryption setting for the command currently executing. Set by
     /// each execute entry point; consulted by the parameter-encryption and
     /// result-decryption paths to honor per-command overrides.
@@ -551,6 +557,7 @@ impl TdsClient {
             output_param_ceks: HashMap::new(),
             last_return_status: ReturnStatus::NotReceived,
             current_result_set_has_been_read_till_end: false,
+            pending_result_boundary: None,
             current_command_ce_setting:
                 crate::connection::client_context::ExecutionColumnEncryptionSetting::default(),
             pending_capture: None,
@@ -761,6 +768,7 @@ impl TdsClient {
         // metadata.
         self.clear_session_bound_caches();
         self.current_result_set_has_been_read_till_end = false;
+        self.pending_result_boundary = None;
         self.active_row_read_state = ActiveRowReadState::Idle;
         self.row_already_positioned = false;
         self.parked_token = None;
@@ -1206,16 +1214,29 @@ impl TdsClient {
             return Ok(elapsed);
         }
 
-        // Only attempt recovery when session recovery was negotiated and
-        // the server supports retry (connect_retry_count > 0).
-        if !self.recovery_context.session_recovery_negotiated {
-            return Ok(Duration::ZERO);
-        }
         let connect_retry_count = self
             .recovery_context
             .client_context
             .as_ref()
             .map_or(0, |ctx| ctx.connect_retry_count);
+
+        // A cached dead verdict is authoritative. Without this gate, callers
+        // with recovery disabled (including intentionally closed clients and
+        // clients retired after protocol desynchronization) would fall through
+        // and write another request to the unusable transport.
+        if self.transport.connection_known_dead()
+            && (!self.recovery_context.session_recovery_negotiated || connect_retry_count == 0)
+        {
+            return Err(crate::error::Error::ConnectionClosed(
+                "Connection is dead and session recovery is unavailable".to_string(),
+            ));
+        }
+
+        // Only attempt recovery when session recovery was negotiated and
+        // the server supports retry (connect_retry_count > 0).
+        if !self.recovery_context.session_recovery_negotiated {
+            return Ok(Duration::ZERO);
+        }
         if connect_retry_count == 0 {
             return Ok(Duration::ZERO);
         }
@@ -4381,7 +4402,7 @@ impl TdsClient {
     /// Used by the ODBC layer to decide whether the connection stays busy after
     /// positioning on a no-row statement result.
     pub fn has_open_batch(&self) -> bool {
-        self.execution_context.has_open_batch()
+        self.execution_context.has_open_batch() || self.pending_result_boundary.is_some()
     }
 
     /// Reads the next response token, replaying one parked by the RPC-terminator
@@ -4503,8 +4524,7 @@ impl TdsClient {
 
     /// Returns `true` when an open result batch or streamed write blocks a new command.
     pub(in crate::connection) fn command_is_busy(&self) -> bool {
-        self.execution_context.has_open_batch()
-            || !matches!(self.streamed_write_state, StreamedWriteState::Idle)
+        self.has_open_batch() || !matches!(self.streamed_write_state, StreamedWriteState::Idle)
     }
 
     /// Returns `true` when the client is currently positioned on a row-returning
@@ -4532,7 +4552,10 @@ impl TdsClient {
     /// skip straight to the next row-returning result set.
     #[instrument(skip(self), level = "info")]
     pub async fn advance(&mut self) -> TdsResult<StatementResult> {
-        if !self.execution_context.has_open_batch() {
+        if let Some(boundary) = self.pending_result_boundary.take() {
+            return Ok(self.apply_result_boundary(boundary));
+        }
+        if !self.has_open_batch() {
             return Ok(StatementResult::End);
         }
         if self.maybe_has_unread_rows()
@@ -4545,7 +4568,7 @@ impl TdsClient {
         // DONE token (has_more=false), which closes the batch. If so there is
         // nothing left on the wire to advance to; reading again would block
         // forever waiting for a token that never arrives.
-        if !self.execution_context.has_open_batch() {
+        if !self.has_open_batch() {
             return Ok(StatementResult::End);
         }
         match self.position_on_first_result().await {
@@ -4569,6 +4592,74 @@ impl TdsClient {
                 StatementResult::Rows => return Ok(true),
                 StatementResult::NoRows { .. } => continue,
                 StatementResult::End => return Ok(false),
+            }
+        }
+    }
+
+    /// Finishes an exhausted row set far enough to determine whether the wire
+    /// contains only protocol-level completion tokens or another result that a
+    /// consumer must observe.
+    ///
+    /// SQL Server RPC responses can end a row set with `DONE_MORE`, then emit
+    /// RETURNVALUE/RETURNSTATUS tokens and a terminal DONE. Those control tokens
+    /// do not constitute another ODBC result and must not keep the connection
+    /// busy. If a real next row set, update count, or message result is found,
+    /// its boundary is parked and returned by the next [`advance`](Self::advance)
+    /// call without reading past it.
+    ///
+    /// Returns `true` only when the batch is fully exhausted.
+    pub async fn complete_current_result(&mut self) -> TdsResult<bool> {
+        if !self.current_result_set_has_been_read_till_end {
+            return Ok(false);
+        }
+        if self.pending_result_boundary.is_some() {
+            return Ok(false);
+        }
+        if !self.execution_context.has_open_batch() {
+            return Ok(true);
+        }
+
+        let boundary = match self.advance_to_result_boundary().await {
+            Ok(boundary) => boundary,
+            Err(error) => {
+                // Timeout and cancellation already send ATTENTION and drain
+                // through its acknowledgement. Other failures leave this
+                // response unsafe to resume unless token handling already
+                // completed the batch, as server ERROR handling does.
+                let attention_error = matches!(
+                    &error,
+                    crate::error::Error::TimeoutError(_)
+                        | crate::error::Error::OperationCancelledError(_)
+                );
+                if attention_error && self.transport.connection_known_dead() {
+                    // ATTENTION did not restore a message boundary. Reconnecting
+                    // would hide a failed cancellation cleanup, so this session
+                    // is not eligible for transparent recovery.
+                    self.recovery_context.session_recovery_negotiated = false;
+                } else if self.execution_context.has_open_batch() && !attention_error {
+                    self.retire_after_failed_drain(&error);
+                }
+                self.execution_context.set_has_open_batch(false);
+                self.pending_result_boundary = None;
+                self.current_metadata = None;
+                self.current_result_set_has_been_read_till_end = true;
+                self.abort_pending_prepare_capture();
+                return Err(error);
+            }
+        };
+
+        match boundary {
+            ResultBoundaryKind::End => {
+                self.apply_result_boundary(ResultBoundaryKind::End);
+                Ok(true)
+            }
+            boundary => {
+                // Token parsing updates this state while reading ahead. Keep
+                // the current row set exhausted until `advance` applies the
+                // parked boundary.
+                self.current_result_set_has_been_read_till_end = true;
+                self.pending_result_boundary = Some(boundary);
+                Ok(false)
             }
         }
     }
@@ -6706,7 +6797,7 @@ impl TdsClient {
     /// cover.
     #[instrument(skip(self), level = "info")]
     pub async fn close_query(&mut self) -> TdsResult<()> {
-        if !self.execution_context.has_open_batch() {
+        if !self.has_open_batch() {
             return Ok(());
         }
         // call next row to consume any remaining tokens
@@ -6729,6 +6820,7 @@ impl TdsClient {
         // The sp_prepexec @handle, if any, was captured during the drain above
         // (see push_return_value) and survives this clear.
         self.current_metadata = None;
+        self.pending_result_boundary = None;
         self.return_values.clear();
         self.abort_pending_prepare_capture();
         self.remaining_request_timeout = None;
@@ -6768,6 +6860,7 @@ impl TdsClient {
         // An intentional close is not a recoverable disconnect: disable recovery
         // so a later call on a lingering handle cannot silently resurrect it.
         self.recovery_context.session_recovery_negotiated = false;
+        self.transport.mark_known_dead();
         self.transport.close_transport().await?;
         Ok(())
     }
@@ -7374,7 +7467,8 @@ mod tests {
         create_network_transport_with_live_peer,
     };
     use crate::token::tokens::{
-        ColMetadataToken, CurrentCommand, DoneStatus, DoneToken, InfoToken, TokenType, Tokens,
+        ColMetadataToken, CurrentCommand, DoneStatus, DoneToken, InfoToken, ReturnStatusToken,
+        TokenType, Tokens,
     };
     use async_trait::async_trait;
     use std::collections::VecDeque;
@@ -9864,6 +9958,95 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn complete_current_result_drains_rpc_tail_and_captures_prepared_handle() {
+        let transport = TestTransport::with_tokens(vec![
+            done_more(),
+            Tokens::ReturnValue(ae_return_value_token("@handle", ColumnValues::Int(9), None)),
+            Tokens::ReturnStatus(ReturnStatusToken { value: 0 }),
+            done_no_more(),
+        ]);
+        let mut client = create_test_client_with_transport(transport);
+        client.current_metadata = Some(stale_metadata());
+        client.current_result_set_has_been_read_till_end = false;
+        client.execution_context.set_has_open_batch(true);
+        client.pending_capture = Some(sid(1));
+
+        assert!(!client.peek_past_current_row().await.unwrap());
+        assert!(client.has_open_batch(), "DONE_MORE keeps the RPC open");
+        assert!(client.complete_current_result().await.unwrap());
+
+        assert!(!client.has_open_batch());
+        assert_eq!(client.prepared_handles.get(&sid(1)).copied(), Some(9));
+        assert!(matches!(
+            client.last_return_status,
+            ReturnStatus::Received(0)
+        ));
+    }
+
+    #[tokio::test]
+    async fn complete_current_result_retires_a_truncated_rpc_tail() {
+        let transport = TestTransport::with_tokens(vec![done_more()]);
+        let mut client = create_test_client_with_transport(transport);
+        client.current_metadata = Some(stale_metadata());
+        client.current_result_set_has_been_read_till_end = false;
+        client.execution_context.set_has_open_batch(true);
+
+        assert!(!client.peek_past_current_row().await.unwrap());
+        assert!(matches!(
+            client.complete_current_result().await,
+            Err(crate::error::Error::ConnectionClosed(_))
+        ));
+        assert!(!client.has_open_batch());
+        assert!(client.is_connection_dead());
+        assert!(client.current_result_set_has_been_read_till_end);
+    }
+
+    #[tokio::test]
+    async fn complete_current_result_parks_a_following_rowset() {
+        let transport = TestTransport::with_tokens(vec![done_more(), empty_col_metadata()]);
+        let mut client = create_test_client_with_transport(transport);
+        client.current_metadata = Some(stale_metadata());
+        client.current_result_set_has_been_read_till_end = false;
+        client.execution_context.set_has_open_batch(true);
+
+        assert!(!client.peek_past_current_row().await.unwrap());
+        assert!(!client.complete_current_result().await.unwrap());
+        assert!(client.current_result_set_has_been_read_till_end);
+        assert!(client.has_open_batch());
+
+        assert!(matches!(client.advance().await, Ok(StatementResult::Rows)));
+        assert!(!client.current_result_set_has_been_read_till_end);
+    }
+
+    #[tokio::test]
+    async fn complete_current_result_parks_a_terminal_update_count() {
+        let transport = TestTransport::with_tokens(vec![
+            done_more(),
+            done_count(CurrentCommand::Update, 7, false),
+        ]);
+        let mut client = create_test_client_with_transport(transport);
+        client.current_metadata = Some(stale_metadata());
+        client.current_result_set_has_been_read_till_end = false;
+        client.execution_context.set_has_open_batch(true);
+
+        assert!(!client.peek_past_current_row().await.unwrap());
+        assert!(!client.complete_current_result().await.unwrap());
+        assert!(
+            client.has_open_batch(),
+            "the parked count is still a result"
+        );
+
+        assert!(matches!(
+            client.advance().await,
+            Ok(StatementResult::NoRows {
+                rows_affected: Some(7)
+            })
+        ));
+        assert!(!client.has_open_batch());
+        assert!(matches!(client.advance().await, Ok(StatementResult::End)));
+    }
+
+    #[tokio::test]
     async fn peek_past_current_row_already_exhausted_touches_nothing() {
         // Calling the peek when `next_row_cursor` would already short-circuit
         // (end of set previously observed) must stay free: the ODBC layer
@@ -10469,16 +10652,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn check_and_reconnect_is_noop_after_close_connection() {
+    async fn check_and_reconnect_rejects_after_close_connection() {
         let mut client = create_test_client();
         client.recovery_context.session_recovery_negotiated = true;
 
         client.close_connection().await.unwrap();
         assert!(!client.recovery_context.session_recovery_negotiated);
 
-        // A dead transport must not be resurrected once the caller closed it.
-        let elapsed = client.check_and_reconnect(Some(5), None).await.unwrap();
-        assert_eq!(elapsed, Duration::ZERO);
+        // A dead transport must neither be resurrected nor reused once the
+        // caller closed it.
+        assert!(matches!(
+            client.check_and_reconnect(Some(5), None).await,
+            Err(crate::error::Error::ConnectionClosed(_))
+        ));
     }
 
     #[tokio::test]

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -4638,6 +4638,17 @@ impl TdsClient {
         if let Err(error) = self.settle_rpc_terminator(&parser_context).await {
             self.current_metadata = None;
             self.abort_pending_prepare_capture();
+            // A tail token that failed to process before the terminal DONEPROC
+            // leaves the rest of the response unread. The caller has an error to
+            // report and no way back to this batch, so consume it here rather
+            // than leaving the connection claimed by a statement that will never
+            // read it.
+            if self.execution_context.has_open_batch() {
+                if let Err(drain_error) = self.drain_stream_or_retire().await {
+                    warn!(error = ?drain_error, "Drain after an RPC tail failure failed");
+                }
+                self.execution_context.set_has_open_batch(false);
+            }
             return Err(error);
         }
         Ok(!self.execution_context.has_open_batch())
@@ -10027,6 +10038,35 @@ mod tests {
             !client.current_result_ended_with_done_in_proc,
             "a plain batch DONE must not leave the previous RPC's tail gate armed"
         );
+    }
+
+    #[tokio::test]
+    async fn complete_current_result_abandons_the_batch_when_a_tail_token_fails() {
+        // The tail parses far enough to park the next result, then reports the
+        // failed RETURNVALUE. Leaving that batch open would strand the ODBC
+        // busy claim on a statement whose cursor is already finished.
+        let transport = TestTransport::with_tokens(vec![
+            done_in_proc_more(),
+            Tokens::ReturnValue(ae_return_value_token(
+                "@out",
+                ColumnValues::Bytes(vec![1, 2, 3]),
+                Some(ae_crypto_metadata()),
+            )),
+            empty_col_metadata(),
+            done_no_more(),
+        ]);
+        let mut client = create_test_client_with_transport(transport);
+        client.current_metadata = Some(stale_metadata());
+        client.current_command_ce_setting = ExecutionColumnEncryptionSetting::Enabled;
+        client.execution_context.set_has_open_batch(true);
+
+        assert!(!client.peek_past_current_row().await.unwrap());
+        assert!(matches!(
+            client.complete_current_result().await,
+            Err(crate::error::Error::ColumnEncryptionError(_))
+        ));
+        assert!(!client.has_open_batch());
+        assert!(client.parked_token.is_none());
     }
 
     #[tokio::test]

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -1224,7 +1224,8 @@ impl TdsClient {
         // with recovery disabled (including intentionally closed clients and
         // clients retired after protocol desynchronization) would fall through
         // and write another request to the unusable transport.
-        if self.transport.connection_known_dead()
+        let known_dead = self.transport.connection_known_dead();
+        if known_dead
             && (!self.recovery_context.session_recovery_negotiated || connect_retry_count == 0)
         {
             return Err(crate::error::Error::ConnectionClosed(
@@ -1241,8 +1242,10 @@ impl TdsClient {
             return Ok(Duration::ZERO);
         }
 
-        // Non-blocking poll — returns immediately.
-        if !self.transport.is_connection_dead() {
+        // Non-blocking poll — returns immediately. Skipped once the verdict is
+        // already in: a session retired by a fatal ERROR token or a failed drain
+        // stays unusable however healthy its socket still looks.
+        if !known_dead && !self.transport.is_connection_dead() {
             return Ok(Duration::ZERO);
         }
 
@@ -10826,6 +10829,26 @@ mod tests {
         assert!(
             err.to_string().contains("Session recovery failed"),
             "Expected reconnect attempt resulting in SessionRecoveryFailed, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn check_and_reconnect_recovers_a_retired_session_on_a_live_socket() {
+        // A fatal ERROR token or a failed drain retires the session while the
+        // socket still polls healthy. Trusting that poll would send the next
+        // command over a connection the client already reports as dead.
+        let mut client = create_test_client();
+        client.recovery_context.session_recovery_negotiated = true;
+        client.transport.mark_known_dead();
+        assert!(
+            !client.transport.is_connection_dead(),
+            "socket is still open"
+        );
+
+        let err = client.check_and_reconnect(Some(1), None).await.unwrap_err();
+        assert!(
+            err.to_string().contains("Session recovery failed"),
+            "Expected a reconnect attempt, got: {err}"
         );
     }
 

--- a/mssql-tds/src/test_client_support.rs
+++ b/mssql-tds/src/test_client_support.rs
@@ -483,6 +483,24 @@ pub fn done_more() -> ScriptedToken {
     }))
 }
 
+/// A `DONEINPROC` token with MORE set, ending a row set inside an RPC.
+pub fn done_in_proc_more() -> ScriptedToken {
+    ScriptedToken(Tokens::DoneInProc(DoneToken {
+        status: DoneStatus::MORE,
+        cur_cmd: CurrentCommand::Select,
+        row_count: 0,
+    }))
+}
+
+/// A terminal `DONEPROC` token ending an RPC response.
+pub fn done_proc_no_more() -> ScriptedToken {
+    ScriptedToken(Tokens::DoneProc(DoneToken {
+        status: DoneStatus::FINAL,
+        cur_cmd: CurrentCommand::Select,
+        row_count: 0,
+    }))
+}
+
 /// A terminal DONE token (no more results — end of batch).
 pub fn done_no_more() -> ScriptedToken {
     ScriptedToken(Tokens::Done(DoneToken {

--- a/mssql-tds/tests/test_rpc_results.rs
+++ b/mssql-tds/tests/test_rpc_results.rs
@@ -6,7 +6,9 @@ mod common;
 
 mod rpc_results {
     use crate::common::{begin_connection, build_tcp_datasource, get_scalar_value, init_tracing};
-    use mssql_tds::connection::tds_client::{ResultSet, StatementId, TdsClient};
+    use mssql_tds::connection::tds_client::{
+        PreparedStatement, ResultSet, StatementId, StatementResult, TdsClient,
+    };
     use mssql_tds::datatypes::column_values::{ColumnValues, SqlDateTime2, SqlTime};
     use mssql_tds::datatypes::decoder::DecimalParts;
     use mssql_tds::datatypes::sql_string::SqlString;
@@ -204,6 +206,121 @@ mod rpc_results {
         } else {
             unreachable!("Expected a string value");
         }
+    }
+
+    #[tokio::test]
+    async fn test_sp_executesql_completion_tail_releases_batch() {
+        let mut connection = begin_connection(&build_tcp_datasource()).await;
+        let parameter = RpcParameter::new(
+            Some("@P1".to_string()),
+            StatusFlags::NONE,
+            SqlType::Int(Some(42)),
+        );
+
+        let result = connection
+            .execute_sp_executesql("SELECT @P1".to_string(), vec![parameter], ())
+            .await
+            .unwrap();
+        assert!(matches!(result, StatementResult::Rows));
+        assert!(matches!(
+            connection.next_row().await.unwrap().as_deref(),
+            Some([ColumnValues::Int(42)])
+        ));
+
+        assert!(!connection.peek_past_current_row().await.unwrap());
+        assert!(
+            connection.has_open_batch(),
+            "the RPC completion tail remains"
+        );
+        assert!(connection.complete_current_result().await.unwrap());
+        assert!(!connection.has_open_batch());
+
+        let result = connection
+            .execute("SELECT 7".to_string(), ())
+            .await
+            .unwrap();
+        assert!(matches!(result, StatementResult::Rows));
+        assert!(matches!(
+            get_scalar_value(&mut connection).await.unwrap(),
+            Some(ColumnValues::Int(7))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_execute_prepared_completion_captures_handle_for_reuse() {
+        let mut connection = begin_connection(&build_tcp_datasource()).await;
+        let mut statement = PreparedStatement::new("SELECT @P1");
+        let mut orphaned = None;
+        let make_parameter = || {
+            RpcParameter::new(
+                Some("@P1".to_string()),
+                StatusFlags::NONE,
+                SqlType::Int(Some(42)),
+            )
+        };
+
+        for _ in 0..2 {
+            let result = connection
+                .execute_prepared(&mut statement, vec![make_parameter()], &mut orphaned, ())
+                .await
+                .unwrap();
+            assert!(matches!(result, StatementResult::Rows));
+            assert!(matches!(
+                connection.next_row().await.unwrap().as_deref(),
+                Some([ColumnValues::Int(42)])
+            ));
+            assert!(!connection.peek_past_current_row().await.unwrap());
+            assert!(connection.complete_current_result().await.unwrap());
+            assert!(!connection.has_open_batch());
+            assert!(statement.id().is_some());
+        }
+
+        connection
+            .unprepare(statement.id().unwrap(), ())
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_prepared_completion_preserves_next_result_set() {
+        let mut connection = begin_connection(&build_tcp_datasource()).await;
+        let mut statement = PreparedStatement::new("SELECT @P1; SELECT @P1 + 1");
+        let mut orphaned = None;
+        let parameter = RpcParameter::new(
+            Some("@P1".to_string()),
+            StatusFlags::NONE,
+            SqlType::Int(Some(42)),
+        );
+
+        let result = connection
+            .execute_prepared(&mut statement, vec![parameter], &mut orphaned, ())
+            .await
+            .unwrap();
+        assert!(matches!(result, StatementResult::Rows));
+        assert!(matches!(
+            connection.next_row().await.unwrap().as_deref(),
+            Some([ColumnValues::Int(42)])
+        ));
+
+        assert!(!connection.peek_past_current_row().await.unwrap());
+        assert!(!connection.complete_current_result().await.unwrap());
+        assert!(connection.has_open_batch());
+        assert!(matches!(
+            connection.advance().await.unwrap(),
+            StatementResult::Rows
+        ));
+        assert!(matches!(
+            connection.next_row().await.unwrap().as_deref(),
+            Some([ColumnValues::Int(43)])
+        ));
+        assert!(!connection.peek_past_current_row().await.unwrap());
+        assert!(connection.complete_current_result().await.unwrap());
+        assert!(!connection.has_open_batch());
+
+        connection
+            .unprepare(statement.id().unwrap(), ())
+            .await
+            .unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

Fix `HY000 Connection is busy with results for another command` after a parameterized query returns rows.

A row set inside an RPC ends with `DONEINPROC` carrying `DONE_MORE` because `RETURNVALUE`, `RETURNSTATUS`, and the terminal `DONEPROC` still follow. The ODBC layer read that flag as "another result is pending" and kept the statement's claim on the connection, so a second statement was refused even though the first was fully consumed.

`TdsClient::complete_current_result` now settles that protocol-only tail through the existing `settle_rpc_terminator`, which absorbs the control tokens and parks the first non-tail token for `SQLMoreResults`. The gate is `DONEINPROC`-only, matching msodbcsql's `OnDone` (`sqlctokn.cpp:2208-2240`); ordinary batch `DONE` tokens are never probed, so a multi-statement batch does not block on the next statement's result inside a fetch.

Failures while consuming the tail abandon the batch and defer the error to the next statement call, since the fetch has already committed to returning its row. Cancellation and timeout are distinguished: an acknowledged ATTENTION leaves the connection reusable, while failed cleanup disarms session recovery.

Also in this change:

- `check_and_reconnect` rejects a transport already marked known-dead when session recovery is unavailable, and `close_connection` records that terminal state. This prevents JS, Python, CLI, ODBC, and pool callers from issuing another request over a retired transport.
- The Windows E2E runner discards a CMake build tree configured from an incompatible WSL source path.

## Related Issues

https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47770

## Tests

New coverage for prepared and direct execution, null, zero-row and multi-row parameters, `SQLGetData`, statement close and free, prepared reuse, multiple result sets, plain-batch non-probing, the tail-gate lifecycle across results, truncated tails, and cancellation with live and known-dead transports.

## Validation

- `cargo bfmt` and `cargo bclippy` pass
- `mssql-tds --lib`: 2050 passed; the only failures are pre-existing missing certificate fixtures unrelated to this change
- `mssqlodbc --lib`: 1168 passed
- Live mssql-tds RPC integration suite passes
- ODBC C++ E2E suite passes
- Retail msodbcsql 18.06.0002 parity run passes

Known CI agent issues unrelated to this change: `llvm-cov` and `cargo-clippy` missing on the macOS agent, Colima Docker setup failing, and a Linux ARM remote provider timeout.

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes
- [x] New/changed functionality has tests
- [x] Public API changes are documented