### PR TITLE
mssql-odbc: convert bound max text columns

### DIFF
--- a/.github/instructions/mssql-odbc.instructions.md
+++ b/.github/instructions/mssql-odbc.instructions.md
@@ -155,17 +155,34 @@ authoritative parity reference for this crate. Its source lives in the
     outstanding 18.6.2.1 measurements land - keep the running record there
     rather than growing this file per build.
   - **A bound `max`/LOB text column converted to a typed C target is refused
-    above 1 MiB.** A typed conversion needs the whole literal, and a
-    `varchar(max)` carries up to 2 GB, so `PLP_TYPED_MATERIALIZE_LIMIT`
-    (`api/fetch_scroll.rs`) caps that one allocation; past the cap the value is
-    drained to keep the row synchronized and answered `HYC00` rather than
-    converted. The cap is this driver's own resource bound with no msodbcsql
-    counterpart, so the compare leg cannot agree by construction and
+    above 1 MiB; msodbcsql converts a truncated prefix and warns.** Both drivers
+    cap what a typed conversion may materialize - a `varchar(max)` carries up to
+    2 GB and the converter needs one contiguous literal. This driver's cap is
+    `PLP_TYPED_MATERIALIZE_LIMIT` (`api/fetch_scroll.rs`) at 1 MiB; past it the
+    value is drained to keep the row synchronized and answered `HYC00`.
+    msodbcsql clamps to `2*CONVBUF_SIZE` (~1244 bytes, sized for the longest
+    legal `double` literal) in `EstimateBytesToRead` (`odbc/sqlcdata.cpp`), then
+    converts that prefix and reports `01004` rather than failing.
+    **Measured on 18.06.0001**, `varchar(max)` bound to a typed target:
+    `'0'`×2000 + `'1'` returns `SQL_SUCCESS_WITH_INFO` with `01004` and a value
+    of **`0`** - the truncated prefix, not the `1` in the column - for both
+    `SQL_C_SBIGINT` and `SQL_C_SLONG`, and the same past 1 MiB; `'x'`×5000
+    returns `22018` (the parse fails before truncation is considered, so both
+    drivers agree there); a short `'42'` returns `42` on both. The skipped
+    case's own payload, `'1'`×1048577 into `SQL_C_SLONG`, overflows even the
+    clamped prefix and returns `22003` there against this driver's `HYC00` - so
+    both drivers error on it, with different states, and
     `AOversizedBoundVarcharMaxTypedConversionIsRefusedAndDrained` carries
-    `SKIP_IF_COMPARING_MSODBCSQL()`. Every literal this path converts - numeric,
-    GUID, datetime - is orders of magnitude below the cap, so no realistic
-    conversion input reaches it; raise or stream it if one ever does. Tracked in
-    AB#47767.
+    `SKIP_IF_COMPARING_MSODBCSQL()` on a measured divergence rather than an
+    assumed one. Refusing is deliberate: `01004` is "string data, right
+    truncated", which application code routinely ignores on a numeric fetch
+    because scalars are not expected to be truncatable, so on the prefix-parses
+    shape msodbcsql's answer is a silently wrong number. Note the cap keys on
+    the column's byte count, not on whether the text parses, so any large
+    `varchar(max)` bound to a typed target reaches it - schema drift, not a
+    contrived input. CI compares against 18.6.2.1; this measurement is
+    18.06.0001, so re-measure there before relying on the exact prefix length.
+    Tracked in AB#47767.
   - **Widening a bound narrow `max` column to `SQL_C_WCHAR` truncates on a whole
     character.** A buffer with no room for the final surrogate pair ends before
     it; msodbcsql leaves the lone high surrogate in the last payload slot on this

--- a/.github/instructions/mssql-odbc.instructions.md
+++ b/.github/instructions/mssql-odbc.instructions.md
@@ -451,6 +451,16 @@ Driver Manager (DM) provides serialization guarantees that the driver relies on
   - A success-path test.
   - A null-output-handle test.
   - An invalid-handle-type or invalid-input test.
+- **A `max`/LOB column only reaches the bound *streaming* path when it is too
+  large for the transport to buffer whole.** `try_read_buffered_column` decodes
+  any fully buffered column - PLP included - into a `ColumnValues`, so a small
+  `varchar(max)`/`varbinary(max)` is delivered by `deliver_bound`, exactly like a
+  non-max value, and never enters `deliver_bound_plp`. A few kilobytes still
+  buffers; the streaming path is reachable around a megabyte (the existing 1 MiB
+  cases in `fetch_scroll_test.cpp` prove it). Size an e2e that targets
+  `deliver_bound_plp` accordingly, or it will silently assert the non-PLP path -
+  a bound binary `max` column against a typed C target answers `22018` from the
+  typed converter when buffered, and `HYC00` when streamed.
 - Use `cargo nextest` (via `cargo btest`), not `cargo test`.
 
 ## Code style

--- a/.github/instructions/mssql-odbc.instructions.md
+++ b/.github/instructions/mssql-odbc.instructions.md
@@ -154,6 +154,28 @@ authoritative parity reference for this crate. Its source lives in the
     `SKIP_IF_COMPARING_MSODBCSQL()`. Tracked in AB#47369, which is where the
     outstanding 18.6.2.1 measurements land - keep the running record there
     rather than growing this file per build.
+  - **A bound `max`/LOB text column converted to a typed C target is refused
+    above 1 MiB.** A typed conversion needs the whole literal, and a
+    `varchar(max)` carries up to 2 GB, so `PLP_TYPED_MATERIALIZE_LIMIT`
+    (`api/fetch_scroll.rs`) caps that one allocation; past the cap the value is
+    drained to keep the row synchronized and answered `HYC00` rather than
+    converted. The cap is this driver's own resource bound with no msodbcsql
+    counterpart, so the compare leg cannot agree by construction and
+    `AOversizedBoundVarcharMaxTypedConversionIsRefusedAndDrained` carries
+    `SKIP_IF_COMPARING_MSODBCSQL()`. Every literal this path converts - numeric,
+    GUID, datetime - is orders of magnitude below the cap, so no realistic
+    conversion input reaches it; raise or stream it if one ever does. Tracked in
+    AB#47767.
+  - **Widening a bound narrow `max` column to `SQL_C_WCHAR` truncates on a whole
+    character.** A buffer with no room for the final surrogate pair ends before
+    it; msodbcsql leaves the lone high surrogate in the last payload slot on this
+    narrow-source widening path, though its wide-source path is surrogate-safe
+    (`GetColDataSurrogateSafe`, and `TrimPartialCodePt` for partial sequences).
+    This driver's existing bound `nvarchar(max)` delivery already trims to a
+    character boundary, and handing back text that does not decode from one `max`
+    type but not the other would be worse than the divergence.
+    `ABoundUtf8VarcharMaxDoesNotSplitASurrogatePairWhenWidening` carries
+    `SKIP_IF_COMPARING_MSODBCSQL()`. Tracked in AB#47767.
 
 ## No panics
 

--- a/mssql-odbc/src/api/fetch_scroll.rs
+++ b/mssql-odbc/src/api/fetch_scroll.rs
@@ -29,7 +29,7 @@ use mssql_tds::datatypes::column_values::{
 use mssql_tds::datatypes::decoder::DecimalParts;
 use mssql_tds::datatypes::row_writer::RowWriter;
 use mssql_tds::datatypes::sql_json::SqlJson;
-use mssql_tds::datatypes::sql_string::{EncodingType, SqlString};
+use mssql_tds::datatypes::sql_string::{EncodingType, SqlString, get_encoding_type};
 use mssql_tds::datatypes::sql_vector::SqlVector;
 use mssql_tds::datatypes::sqldatatypes::TdsDataType;
 use mssql_tds::error::Error as TdsError;
@@ -40,6 +40,7 @@ use super::sqlstate::*;
 use crate::api::exec_common::release_busy_if_row_exhausted;
 use crate::api::get_data::{
     TextError, column_value_to_text, convert_typed_c, is_typed_c_target, utf16le_chunk_to_utf8,
+    widen_into_pending,
 };
 use crate::api::odbc_types::{
     SQL_BIND_BY_COLUMN, SQL_C_BIT, SQL_C_CHAR, SQL_C_DOUBLE, SQL_C_FLOAT, SQL_C_GUID,
@@ -62,6 +63,12 @@ use crate::handles::stmt::{
     ColumnBinding, STMT_STATE_CURSOR_OPEN, STMT_STATE_FETCH_IN_PROGRESS, StmtState,
 };
 use crate::handles::{HandleType, StmtHandle, handle_from_raw};
+
+#[derive(Clone, Copy)]
+struct PlpColumnInfo {
+    wire_encoding: PlpEncoding,
+    text_encoding: Option<EncodingType>,
+}
 
 /// Implements SQLFetchScroll for the current forward-only result set.
 ///
@@ -718,7 +725,7 @@ fn fill_rowset(
     // inside the fill loop would make a poisoned mutex indistinguishable from a
     // column that simply is not PLP, which would silently downgrade a supported
     // column to "unsupported" and drain it.
-    let plp_encodings: Vec<Option<PlpEncoding>> = {
+    let plp_columns: Vec<Option<PlpColumnInfo>> = {
         let Ok(ss) = stmt.inner.lock() else {
             error!("SQLFetchScroll: stmt mutex poisoned reading column metadata");
             if let Ok(mut ds) = dbc.inner.lock() {
@@ -728,7 +735,19 @@ fn fill_rowset(
         };
         ss.column_metadata
             .iter()
-            .map(|m| m.plp_encoding())
+            .map(|metadata| {
+                let wire_encoding = metadata.plp_encoding()?;
+                let text_encoding = match wire_encoding {
+                    PlpEncoding::Utf16Text => Some(EncodingType::Utf16),
+                    PlpEncoding::Utf8Text => Some(EncodingType::Utf8),
+                    PlpEncoding::SingleByteText => Some(get_encoding_type(metadata)),
+                    PlpEncoding::Binary => None,
+                };
+                Some(PlpColumnInfo {
+                    wire_encoding,
+                    text_encoding,
+                })
+            })
             .collect()
     };
     // One scratch buffer for the whole fill: a bound LOB in a wide rowset would
@@ -820,7 +839,7 @@ fn fill_rowset(
                                 binding,
                                 rows_filled as usize,
                                 bind_offset,
-                                plp_encodings.get(column - 1).copied().flatten(),
+                                plp_columns.get(column - 1).copied().flatten(),
                                 &mut plp_scratch,
                             )
                         };
@@ -1054,6 +1073,18 @@ unsafe fn read_bind_offset(ptr: *mut SqlULen) -> usize {
 /// value itself is never materialized, only one chunk at a time.
 const PLP_BOUND_CHUNK: usize = 8 * 1024;
 
+/// Typed conversion needs the complete text literal. Numeric, GUID, and
+/// datetime literals are tiny in practice, so cap that exceptional allocation
+/// rather than letting an arbitrary MAX value exhaust the application process.
+const PLP_TYPED_MATERIALIZE_LIMIT: usize = 1024 * 1024;
+
+fn typed_plp_chunk_fits(current: usize, chunk: usize, known_total: Option<u64>) -> bool {
+    known_total.is_none_or(|total| total <= PLP_TYPED_MATERIALIZE_LIMIT as u64)
+        && current
+            .checked_add(chunk)
+            .is_some_and(|total| total <= PLP_TYPED_MATERIALIZE_LIMIT)
+}
+
 /// The length a bound PLP delivery reports in the indicator.
 ///
 /// Extracted so the rule can be tested without a live server: it was derived by
@@ -1108,9 +1139,47 @@ unsafe fn deliver_bound_plp(
     binding: &ColumnBinding,
     row_index: usize,
     bind_offset: usize,
-    encoding: Option<PlpEncoding>,
+    column_info: Option<PlpColumnInfo>,
     scratch: &mut [u8],
 ) -> Result<RowOutcome, TdsError> {
+    let Some(column_info) = column_info else {
+        drain_plp_to_end(client, runtime, scratch)?;
+        return Ok(RowOutcome::Error(RowIssue::Unsupported));
+    };
+
+    if is_typed_c_target(binding.target_type) {
+        let Some(text_encoding) = column_info.text_encoding else {
+            drain_plp_to_end(client, runtime, scratch)?;
+            return Ok(RowOutcome::Error(RowIssue::Unsupported));
+        };
+        let mut bytes = Vec::new();
+        let mut materializing = true;
+        loop {
+            let chunk = runtime.block_on(client.read_active_plp_chunk(scratch))?;
+            if materializing {
+                materializing = typed_plp_chunk_fits(bytes.len(), chunk.read, chunk.known_total)
+                    && bytes.try_reserve(chunk.read).is_ok();
+                if materializing {
+                    bytes.extend_from_slice(&scratch[..chunk.read]);
+                }
+            }
+            if chunk.reached_end {
+                break;
+            }
+        }
+        if !materializing {
+            return Ok(RowOutcome::Error(RowIssue::Unsupported));
+        }
+        return Ok(unsafe {
+            deliver_bound(
+                binding,
+                row_index,
+                bind_offset,
+                &ColumnValues::String(SqlString::new(bytes, text_encoding)),
+            )
+        });
+    }
+
     let stride = element_stride(binding.target_type, binding.buffer_length);
     let indicator = if binding.strlen_or_ind_ptr.is_null() {
         std::ptr::null_mut()
@@ -1125,20 +1194,30 @@ unsafe fn deliver_bound_plp(
     let slot =
         unsafe { (binding.target_value_ptr as *mut u8).add(bind_offset + row_index * stride) };
 
-    // Same pairings SQLGetData supports. Three refusals are deliberate and
-    // tracked, not oversights: bound binary delivery (AB#47239), widening
-    // varchar(max)/json to SQL_C_WCHAR, and a max column bound to a typed C
-    // target -- the last two are AB#47767, and both are cases msodbcsql
-    // delivers. The typed one means varchar(50) and varchar(max) differ for the
-    // same bind, since only the non-max path reaches convert_typed_c.
+    // Same text pairings SQLGetData supports. Bound binary delivery remains
+    // tracked separately under AB#47239.
     let target = binding.target_type;
+    let encoding = column_info.wire_encoding;
+    let widen_narrow_to_utf16 = target == SQL_C_WCHAR
+        && matches!(
+            encoding,
+            PlpEncoding::SingleByteText | PlpEncoding::Utf8Text
+        );
+    let mut narrow_decoder = if widen_narrow_to_utf16 {
+        column_info
+            .text_encoding
+            .and_then(|encoding| encoding.encoding())
+            .map(|encoding| encoding.new_decoder_without_bom_handling())
+    } else {
+        None
+    };
     let compatible = matches!(
         (target, encoding),
-        (SQL_C_WCHAR, Some(PlpEncoding::Utf16Text))
-            | (SQL_C_CHAR, Some(PlpEncoding::SingleByteText))
-            | (SQL_C_CHAR, Some(PlpEncoding::Utf8Text))
-            | (SQL_C_CHAR, Some(PlpEncoding::Utf16Text))
-    );
+        (SQL_C_WCHAR, PlpEncoding::Utf16Text)
+            | (SQL_C_CHAR, PlpEncoding::SingleByteText)
+            | (SQL_C_CHAR, PlpEncoding::Utf8Text)
+            | (SQL_C_CHAR, PlpEncoding::Utf16Text)
+    ) || narrow_decoder.is_some();
     if !compatible {
         // The stream still has to be consumed, or the next column decodes from
         // the middle of this value. A failure here is the caller's problem, not
@@ -1147,13 +1226,16 @@ unsafe fn deliver_bound_plp(
         return Ok(RowOutcome::Error(RowIssue::Unsupported));
     }
 
-    let transcode = target == SQL_C_CHAR && matches!(encoding, Some(PlpEncoding::Utf16Text));
+    let transcode_utf16_to_utf8 =
+        target == SQL_C_CHAR && matches!(encoding, PlpEncoding::Utf16Text);
+    let transcode = transcode_utf16_to_utf8 || widen_narrow_to_utf16;
     let buf_elements = char_buf_elements(target, stride);
     // Room for the payload, less the terminator the copy always writes.
     let capacity_elements = buf_elements.saturating_sub(1);
 
     let mut out_bytes: Vec<u8> = Vec::new();
     let mut out_units: Vec<u16> = Vec::new();
+    let mut decoded_units: Vec<u16> = Vec::new();
     let mut pending_byte: Option<u8> = None;
     let mut pending_high_surrogate: Option<u16> = None;
     let mut truncated = false;
@@ -1172,7 +1254,29 @@ unsafe fn deliver_bound_plp(
             continue;
         }
 
-        if target == SQL_C_WCHAR {
+        if let Some(decoder) = narrow_decoder.as_mut() {
+            decoded_units.clear();
+            widen_into_pending(
+                decoder,
+                &mut decoded_units,
+                &scratch[..chunk.read],
+                chunk.reached_end,
+                usize::MAX,
+            );
+            let remaining = capacity_elements.saturating_sub(out_units.len());
+            let mut emit = remaining.min(decoded_units.len());
+            if emit > 0
+                && emit < decoded_units.len()
+                && (0xD800..=0xDBFF).contains(&decoded_units[emit - 1])
+                && (0xDC00..=0xDFFF).contains(&decoded_units[emit])
+            {
+                emit -= 1;
+            }
+            out_units.extend_from_slice(&decoded_units[..emit]);
+            if emit < decoded_units.len() {
+                truncated = true;
+            }
+        } else if target == SQL_C_WCHAR {
             // Whole code units only; an odd tail is carried to the next chunk.
             let mut bytes = Vec::with_capacity(chunk.read + 1);
             if let Some(b) = pending_byte.take() {
@@ -1196,7 +1300,7 @@ unsafe fn deliver_bound_plp(
                     break;
                 }
             }
-        } else if transcode {
+        } else if transcode_utf16_to_utf8 {
             let utf8 = utf16le_chunk_to_utf8(
                 &scratch[..chunk.read],
                 chunk.reached_end,
@@ -1215,7 +1319,7 @@ unsafe fn deliver_bound_plp(
                     break;
                 }
             }
-        } else if matches!(encoding, Some(PlpEncoding::Utf8Text)) {
+        } else if matches!(encoding, PlpEncoding::Utf8Text) {
             for b in &scratch[..chunk.read] {
                 if out_bytes.len() < capacity_elements {
                     out_bytes.push(*b);
@@ -2761,6 +2865,22 @@ mod tests {
         assert_eq!(element_stride(SQL_C_WCHAR, 64), 64);
         // A negative length cannot become a huge stride.
         assert_eq!(element_stride(SQL_C_CHAR, -8), 0);
+    }
+
+    #[test]
+    fn typed_plp_materialization_is_bounded_for_known_and_streamed_lengths() {
+        assert!(typed_plp_chunk_fits(
+            0,
+            PLP_TYPED_MATERIALIZE_LIMIT,
+            Some(PLP_TYPED_MATERIALIZE_LIMIT as u64)
+        ));
+        assert!(!typed_plp_chunk_fits(
+            0,
+            1,
+            Some(PLP_TYPED_MATERIALIZE_LIMIT as u64 + 1)
+        ));
+        assert!(!typed_plp_chunk_fits(PLP_TYPED_MATERIALIZE_LIMIT, 1, None));
+        assert!(!typed_plp_chunk_fits(usize::MAX, 1, None));
     }
 
     /// NULL with nowhere to report it is 22002: leaving the slot untouched

--- a/mssql-odbc/src/api/fetch_scroll.rs
+++ b/mssql-odbc/src/api/fetch_scroll.rs
@@ -1142,6 +1142,17 @@ unsafe fn deliver_bound_plp(
     column_info: Option<PlpColumnInfo>,
     scratch: &mut [u8],
 ) -> Result<RowOutcome, TdsError> {
+    // Unreachable today, kept as a guard rather than an `unreachable!()`.
+    // Getting here means the cursor classified this column as
+    // `CursorColumn::PlpStreaming` while `plp_encoding()` answered `None` for
+    // the same column. Both decide on `ColumnMetadata::is_plp()` over the same
+    // COLMETADATA (`plp_columns` snapshots the statement's copy, whose length
+    // also fixes `column_count`, so the lookup is always in range), and
+    // `plp_encoding` maps every PLP type to `Some` -- new ones included, via its
+    // catch-all to `Binary`. So the two cannot disagree unless a future type
+    // makes PLP-ness visible only in the wire framing and not in TYPE_INFO.
+    // Draining keeps the row synchronized if that day comes; a panic would take
+    // the application down for a column it could simply refuse.
     let Some(column_info) = column_info else {
         drain_plp_to_end(client, runtime, scratch)?;
         return Ok(RowOutcome::Error(RowIssue::Unsupported));

--- a/mssql-odbc/src/api/get_data.rs
+++ b/mssql-odbc/src/api/get_data.rs
@@ -1125,7 +1125,7 @@ fn stream_active_plp_chunk(
 /// carries code units the caller's buffer had no room for. Both are needed:
 /// the wire and the caller advance at rates that are unrelated when the
 /// encoding is variable-width.
-fn widen_into_pending(
+pub(crate) fn widen_into_pending(
     decoder: &mut Decoder,
     pending: &mut Vec<u16>,
     payload: &[u8],

--- a/mssql-odbc/tests/e2e/tests/fetch_scroll_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/fetch_scroll_test.cpp
@@ -704,7 +704,7 @@ TEST_F(FetchScrollLiveTest, ABoundJsonWidensToWchar) {
     if (!ServerSupportsNativeJson()) {
         GTEST_SKIP() << "server has no native json type";
     }
-    ExecDirect("SELECT CAST(N'[\"\u00e9\"]' AS JSON) AS c1");
+    ExecDirect("SELECT CAST(N'[\"' + NCHAR(233) + N'\"]' AS JSON) AS c1");
 
     SQLWCHAR buf[16] = {};
     SQLLEN ind = 0;

--- a/mssql-odbc/tests/e2e/tests/fetch_scroll_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/fetch_scroll_test.cpp
@@ -723,7 +723,9 @@ TEST_F(FetchScrollLiveTest, ABoundJsonWidensToWchar) {
 TEST_F(FetchScrollLiveTest, ABoundUtf8VarcharMaxDoesNotSplitASurrogatePairWhenWidening) {
     // msodbcsql leaves the high surrogate in the ninth payload slot here. The
     // Rust driver deliberately applies the whole-character truncation rule used
-    // by its existing nvarchar(max) bound delivery instead.
+    // by its existing nvarchar(max) bound delivery instead. Recorded as a
+    // deliberate deviation in .github/instructions/mssql-odbc.instructions.md
+    // and tracked in AB#47767.
     SKIP_IF_COMPARING_MSODBCSQL();
     ExecDirect(
         "SELECT CAST(REPLICATE((NCHAR(0xD83D) + NCHAR(0xDE00)) "
@@ -805,6 +807,10 @@ TEST_F(FetchScrollLiveTest, ABoundVarcharMaxTypedConversionErrorStillDrainsTheRo
 }
 
 TEST_F(FetchScrollLiveTest, AOversizedBoundVarcharMaxTypedConversionIsRefusedAndDrained) {
+    // The 1 MiB materialization cap is this driver's own resource bound and has
+    // no msodbcsql counterpart, so parity cannot hold here by construction.
+    // Recorded as a deliberate deviation in
+    // .github/instructions/mssql-odbc.instructions.md and tracked in AB#47767.
     SKIP_IF_COMPARING_MSODBCSQL();
     ExecDirect(
         "SELECT v, n FROM ("
@@ -972,6 +978,41 @@ TEST_F(FetchScrollLiveTest, ABoundVarbinaryMaxIsStillUnsupported) {
     // And the next row too: a drain that stopped short would misread it.
     EXPECT_EQ(SQL_ERROR, SQLFetch(stmt_));
     EXPECT_EQ(2, n);
+    EXPECT_EQ(22, tail);
+
+    EXPECT_EQ(SQL_NO_DATA, SQLFetch(stmt_));
+    SQLFreeStmt(stmt_, SQL_UNBIND);
+    SQLCloseCursor(stmt_);
+}
+
+// The typed-conversion path reaches the same refusal by a different route: a
+// binary PLP column has no source encoding to convert from, so it is drained and
+// refused before any conversion is attempted. Same AB#47239 gap as above, so it
+// likewise asserts our own answer rather than parity.
+TEST_F(FetchScrollLiveTest, ABoundVarbinaryMaxToTypedCTargetIsStillUnsupported) {
+    SKIP_IF_COMPARING_MSODBCSQL();
+    ExecDirect(
+        "SELECT n, REPLICATE(CAST(0x41 AS VARBINARY(MAX)), 5000) AS lob, n * 11 AS tail "
+        "FROM (VALUES (1),(2)) AS t(n) ORDER BY n");
+
+    SQLINTEGER n = -1;
+    SQLINTEGER converted = -1;
+    SQLINTEGER tail = -1;
+    SQLLEN nInd = 0, convertedInd = 0, tailInd = 0;
+    ASSERT_SQL_OK(SQLBindCol(stmt_, 1, SQL_C_SLONG, &n, sizeof(n), &nInd), SQL_HANDLE_STMT,
+                  stmt_);
+    ASSERT_SQL_OK(
+        SQLBindCol(stmt_, 2, SQL_C_SLONG, &converted, sizeof(converted), &convertedInd),
+        SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLBindCol(stmt_, 3, SQL_C_SLONG, &tail, sizeof(tail), &tailInd),
+                  SQL_HANDLE_STMT, stmt_);
+
+    EXPECT_EQ(SQL_ERROR, SQLFetch(stmt_));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "HYC00");
+    EXPECT_EQ(11, tail) << "the column after a refused LOB must still decode";
+
+    EXPECT_EQ(SQL_ERROR, SQLFetch(stmt_));
+    EXPECT_EQ(2, n) << "the drain must leave the next row synchronized";
     EXPECT_EQ(22, tail);
 
     EXPECT_EQ(SQL_NO_DATA, SQLFetch(stmt_));

--- a/mssql-odbc/tests/e2e/tests/fetch_scroll_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/fetch_scroll_test.cpp
@@ -651,6 +651,186 @@ TEST_F(FetchScrollLiveTest, ABoundVarcharMaxTruncatedReportsFullLength) {
     SQLCloseCursor(stmt_);
 }
 
+TEST_F(FetchScrollLiveTest, ABoundVarcharMaxWidensToWchar) {
+    ExecDirect("SELECT CAST('abcdefghij' AS VARCHAR(MAX)) AS c1");
+
+    SQLWCHAR buf[32] = {};
+    SQLLEN ind = 0;
+    ASSERT_SQL_OK(SQLBindCol(stmt_, 1, SQL_C_WCHAR, buf, sizeof(buf), &ind), SQL_HANDLE_STMT,
+                  stmt_);
+    EXPECT_EQ(SQL_SUCCESS, SQLFetch(stmt_));
+    EXPECT_EQ(20, ind) << "ten UTF-16 code units";
+    EXPECT_EQ(u'a', buf[0]);
+    EXPECT_EQ(u'j', buf[9]);
+    EXPECT_EQ(0, buf[10]);
+    SQLFreeStmt(stmt_, SQL_UNBIND);
+    SQLCloseCursor(stmt_);
+}
+
+TEST_F(FetchScrollLiveTest, ABoundVarcharMaxUsesItsCollationWhenWidening) {
+    ExecDirect(
+        "SELECT CAST(NCHAR(233) COLLATE Latin1_General_100_CI_AS AS VARCHAR(MAX)) AS c1");
+
+    SQLWCHAR buf[4] = {};
+    SQLLEN ind = 0;
+    ASSERT_SQL_OK(SQLBindCol(stmt_, 1, SQL_C_WCHAR, buf, sizeof(buf), &ind), SQL_HANDLE_STMT,
+                  stmt_);
+    EXPECT_EQ(SQL_SUCCESS, SQLFetch(stmt_));
+    EXPECT_EQ(2, ind);
+    EXPECT_EQ(u'\u00e9', buf[0]);
+    EXPECT_EQ(0, buf[1]);
+    SQLFreeStmt(stmt_, SQL_UNBIND);
+    SQLCloseCursor(stmt_);
+}
+
+TEST_F(FetchScrollLiveTest, ABoundVarcharMaxTruncatedToWcharReportsNoTotal) {
+    ExecDirect("SELECT REPLICATE(CAST('y' AS VARCHAR(MAX)), 5000) AS c1");
+
+    SQLWCHAR buf[16] = {};
+    SQLLEN ind = 0;
+    ASSERT_SQL_OK(SQLBindCol(stmt_, 1, SQL_C_WCHAR, buf, sizeof(buf), &ind), SQL_HANDLE_STMT,
+                  stmt_);
+    EXPECT_EQ(SQL_SUCCESS_WITH_INFO, SQLFetch(stmt_));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "01004");
+    EXPECT_EQ(SQL_NO_TOTAL, ind) << "the converted UTF-16 length is not known while streaming";
+    EXPECT_EQ(u'y', buf[0]);
+    EXPECT_EQ(u'y', buf[14]);
+    EXPECT_EQ(0, buf[15]);
+    SQLFreeStmt(stmt_, SQL_UNBIND);
+    SQLCloseCursor(stmt_);
+}
+
+TEST_F(FetchScrollLiveTest, ABoundJsonWidensToWchar) {
+    if (!ServerSupportsNativeJson()) {
+        GTEST_SKIP() << "server has no native json type";
+    }
+    ExecDirect("SELECT CAST(N'[\"\u00e9\"]' AS JSON) AS c1");
+
+    SQLWCHAR buf[16] = {};
+    SQLLEN ind = 0;
+    ASSERT_SQL_OK(SQLBindCol(stmt_, 1, SQL_C_WCHAR, buf, sizeof(buf), &ind), SQL_HANDLE_STMT,
+                  stmt_);
+    EXPECT_EQ(SQL_SUCCESS, SQLFetch(stmt_));
+    EXPECT_EQ(10, ind) << "five UTF-16 code units";
+    EXPECT_EQ(u'[', buf[0]);
+    EXPECT_EQ(u'\u00e9', buf[2]);
+    EXPECT_EQ(u']', buf[4]);
+    EXPECT_EQ(0, buf[5]);
+    SQLFreeStmt(stmt_, SQL_UNBIND);
+    SQLCloseCursor(stmt_);
+}
+
+TEST_F(FetchScrollLiveTest, ABoundUtf8VarcharMaxDoesNotSplitASurrogatePairWhenWidening) {
+    // msodbcsql leaves the high surrogate in the ninth payload slot here. The
+    // Rust driver deliberately applies the whole-character truncation rule used
+    // by its existing nvarchar(max) bound delivery instead.
+    SKIP_IF_COMPARING_MSODBCSQL();
+    ExecDirect(
+        "SELECT CAST(REPLICATE((NCHAR(0xD83D) + NCHAR(0xDE00)) "
+        "COLLATE Latin1_General_100_CI_AS_SC_UTF8, 500) AS VARCHAR(MAX)) AS c1");
+
+    // 9 usable units: four whole pairs, and no room for the fifth pair.
+    SQLWCHAR buf[10] = {};
+    SQLLEN ind = 0;
+    ASSERT_SQL_OK(SQLBindCol(stmt_, 1, SQL_C_WCHAR, buf, sizeof(buf), &ind), SQL_HANDLE_STMT,
+                  stmt_);
+    EXPECT_EQ(SQL_SUCCESS_WITH_INFO, SQLFetch(stmt_));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "01004");
+    EXPECT_EQ(SQL_NO_TOTAL, ind);
+    for (int i = 0; i < 8; i += 2) {
+        EXPECT_GE(buf[i], 0xD800) << "high surrogate at " << i;
+        EXPECT_LT(buf[i], 0xDC00) << "high surrogate at " << i;
+        EXPECT_GE(buf[i + 1], 0xDC00) << "low surrogate at " << (i + 1);
+        EXPECT_LT(buf[i + 1], 0xE000) << "low surrogate at " << (i + 1);
+    }
+    EXPECT_EQ(0, buf[8]);
+    SQLFreeStmt(stmt_, SQL_UNBIND);
+    SQLCloseCursor(stmt_);
+}
+
+TEST_F(FetchScrollLiveTest, ABoundVarcharMaxConvertsToTypedCTargetLikeNonMax) {
+    ExecDirect(
+        "SELECT CAST('42' AS VARCHAR(50)), CAST('42' AS VARCHAR(MAX)), "
+        "CAST(N'42' AS NVARCHAR(MAX))");
+
+    SQLINTEGER regular = 0;
+    SQLINTEGER varcharMax = 0;
+    SQLINTEGER nvarcharMax = 0;
+    SQLLEN regularInd = 0;
+    SQLLEN varcharMaxInd = 0;
+    SQLLEN nvarcharMaxInd = 0;
+    ASSERT_SQL_OK(
+        SQLBindCol(stmt_, 1, SQL_C_SLONG, &regular, sizeof(regular), &regularInd),
+        SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(
+        SQLBindCol(stmt_, 2, SQL_C_SLONG, &varcharMax, sizeof(varcharMax), &varcharMaxInd),
+        SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(
+        SQLBindCol(stmt_, 3, SQL_C_SLONG, &nvarcharMax, sizeof(nvarcharMax), &nvarcharMaxInd),
+        SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(SQL_SUCCESS, SQLFetch(stmt_));
+    EXPECT_EQ(regular, varcharMax);
+    EXPECT_EQ(regular, nvarcharMax);
+    EXPECT_EQ(42, varcharMax);
+    EXPECT_EQ(regularInd, varcharMaxInd);
+    EXPECT_EQ(regularInd, nvarcharMaxInd);
+    EXPECT_EQ(static_cast<SQLLEN>(sizeof(SQLINTEGER)), varcharMaxInd);
+    SQLFreeStmt(stmt_, SQL_UNBIND);
+    SQLCloseCursor(stmt_);
+}
+
+TEST_F(FetchScrollLiveTest, ABoundVarcharMaxTypedConversionErrorStillDrainsTheRow) {
+    ExecDirect(
+        "SELECT CAST(v AS VARCHAR(MAX)), n FROM "
+        "(VALUES (1, 'not-a-number'), (2, '8')) AS t(n, v) ORDER BY n");
+
+    SQLINTEGER converted = 0;
+    SQLINTEGER tail = 0;
+    SQLLEN convertedInd = 0;
+    SQLLEN tailInd = 0;
+    ASSERT_SQL_OK(
+        SQLBindCol(stmt_, 1, SQL_C_SLONG, &converted, sizeof(converted), &convertedInd),
+        SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLBindCol(stmt_, 2, SQL_C_SLONG, &tail, sizeof(tail), &tailInd),
+                  SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(SQL_ERROR, SQLFetch(stmt_));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "22018");
+
+    EXPECT_EQ(SQL_SUCCESS, SQLFetch(stmt_));
+    EXPECT_EQ(8, converted) << "the failed PLP conversion must leave the next row synchronized";
+    EXPECT_EQ(2, tail);
+    EXPECT_EQ(SQL_NO_DATA, SQLFetch(stmt_));
+    SQLFreeStmt(stmt_, SQL_UNBIND);
+    SQLCloseCursor(stmt_);
+}
+
+TEST_F(FetchScrollLiveTest, AOversizedBoundVarcharMaxTypedConversionIsRefusedAndDrained) {
+    SKIP_IF_COMPARING_MSODBCSQL();
+    ExecDirect(
+        "SELECT v, n FROM ("
+        "SELECT REPLICATE(CAST('1' AS VARCHAR(MAX)), 1048577) AS v, 1 AS n "
+        "UNION ALL SELECT CAST('8' AS VARCHAR(MAX)), 2) AS t ORDER BY n");
+
+    SQLINTEGER converted = 0;
+    SQLINTEGER n = 0;
+    SQLLEN convertedInd = 0;
+    SQLLEN nInd = 0;
+    ASSERT_SQL_OK(
+        SQLBindCol(stmt_, 1, SQL_C_SLONG, &converted, sizeof(converted), &convertedInd),
+        SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLBindCol(stmt_, 2, SQL_C_SLONG, &n, sizeof(n), &nInd), SQL_HANDLE_STMT,
+                  stmt_);
+
+    EXPECT_EQ(SQL_ERROR, SQLFetch(stmt_));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "HYC00");
+    EXPECT_EQ(SQL_SUCCESS, SQLFetch(stmt_));
+    EXPECT_EQ(8, converted) << "the oversized PLP must be drained before the next row";
+    EXPECT_EQ(2, n);
+    EXPECT_EQ(SQL_NO_DATA, SQLFetch(stmt_));
+    SQLFreeStmt(stmt_, SQL_UNBIND);
+    SQLCloseCursor(stmt_);
+}
+
 // Non-ASCII, to prove the transcode is not a byte copy: each e-acute is two
 // UTF-16 bytes on the wire and two UTF-8 bytes delivered.
 //

--- a/mssql-odbc/tests/e2e/tests/fetch_scroll_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/fetch_scroll_test.cpp
@@ -989,11 +989,16 @@ TEST_F(FetchScrollLiveTest, ABoundVarbinaryMaxIsStillUnsupported) {
 // binary PLP column has no source encoding to convert from, so it is drained and
 // refused before any conversion is attempted. Same AB#47239 gap as above, so it
 // likewise asserts our own answer rather than parity.
-TEST_F(FetchScrollLiveTest, ABoundVarbinaryMaxToTypedCTargetIsStillUnsupported) {
+//
+// The value has to exceed what the transport can buffer for a whole column,
+// otherwise `try_read_buffered_column` materializes it and the row takes the
+// ordinary non-PLP delivery path instead of the streaming one under test -- a
+// small varbinary(max) here answers 22018 from the typed converter, not HYC00.
+TEST_F(FetchScrollLiveTest, ABoundStreamedVarbinaryMaxToTypedCTargetIsStillUnsupported) {
     SKIP_IF_COMPARING_MSODBCSQL();
     ExecDirect(
-        "SELECT n, REPLICATE(CAST(0x41 AS VARBINARY(MAX)), 5000) AS lob, n * 11 AS tail "
-        "FROM (VALUES (1),(2)) AS t(n) ORDER BY n");
+        "SELECT n, CONVERT(varbinary(max), REPLICATE(CONVERT(varchar(max), 'a'), 1100000)) "
+        "AS lob, n * 11 AS tail FROM (VALUES (1),(2)) AS t(n) ORDER BY n");
 
     SQLINTEGER n = -1;
     SQLINTEGER converted = -1;


### PR DESCRIPTION
## Summary

Implements [AB#47767](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47767).

Bound `varchar(max)` and native `json` columns can now be delivered to `SQL_C_WCHAR`. The bound PLP path derives the source encoding from column metadata and widens streamed text into UTF-16 while preserving character boundaries and existing truncation and indicator behavior.

Bound text PLP columns can also be delivered to typed C targets through the same conversion path used by non-max values. Typed conversion materializes at most 1 MiB; larger values are drained and deliberately reported as unsupported rather than risking an unbounded allocation.

Binary PLP delivery remains unsupported and is tracked separately by [AB#47239](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47239).

## Testing

- `cargo test -p mssqlodbc` (`1151` passed, `1` ignored)
- `cargo clippy -p mssqlodbc --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- Full C++ e2e suite against mssql-odbc and msodbcsql: `36/36` test binaries passed for each driver with `0` parity divergences
- Added coverage for collation-aware widening, truncation indicators, UTF-16 surrogate boundaries, typed conversion success and errors, oversized-value refusal, and PLP stream recovery

## Breaking changes / migration notes

None.