### PR TITLE
Surface pre-row server errors during ODBC execution

### DIFF
--- a/mssql-odbc/src/api/exec_common.rs
+++ b/mssql-odbc/src/api/exec_common.rs
@@ -637,7 +637,9 @@ pub(super) fn finish_execute(
         return fail_with_tds(dbc, stmt, statement_handle, client, &e);
     }
 
-    // Result-bearing query: leave the cursor open for SQLFetch.
+    // Result-bearing query: leave the cursor open for SQLFetch. This must stay
+    // below the peek: the peek drains any INFO token in the post-metadata
+    // window, and taking the messages first would leave them for a later fetch.
     let info_messages = client.take_info_messages();
     let Ok(mut stmt_state) = stmt.inner.lock() else {
         error!("{op}: stmt mutex poisoned");
@@ -839,6 +841,51 @@ mod tests {
                 .diag_records
                 .iter()
                 .any(|record| record.native_error == 1222)
+        );
+    }
+
+    /// The peek does not stop at rows and errors: `handle_row_read_token`'s
+    /// `Tokens::Info` arm captures and continues, so an INFO token sitting
+    /// between `COLMETADATA` and the first `ROW`/`DONE` is now drained during
+    /// execution rather than by the first `SQLFetch`. The success tail posts it,
+    /// which turns `SQL_SUCCESS` into `SQL_SUCCESS_WITH_INFO` for that window.
+    ///
+    /// This matches msodbcsql, whose parse loop covers the same window before
+    /// parking at the first row. It is pinned here because the behaviour is
+    /// otherwise invisible: moving the peek below `take_info_messages()` would
+    /// silently restore execute-time `SQL_SUCCESS` and defer the diagnostic
+    /// back to `SQLFetch`, and no other test would fail.
+    #[test]
+    fn finish_execute_reports_an_info_message_arriving_before_the_first_row() {
+        use mssql_tds::test_client_support::info;
+
+        let h = TestHandles::with_env_dbc_stmt();
+        h.mark_dbc_connected();
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        let mut client = tds_client_from_tokens(vec![
+            col_metadata(int_columns(1)),
+            info(
+                8153,
+                10,
+                "Null value is eliminated by an aggregate or other SET operation.",
+            ),
+            done_no_more(),
+        ]);
+        dbc.runtime
+            .block_on(client.execute("SELECT SUM(col) FROM t".to_string(), ()))
+            .unwrap();
+
+        let rc = finish_execute(dbc, stmt, h.stmt, client, "SQLExecDirectW");
+
+        assert_eq!(rc, SQL_SUCCESS_WITH_INFO);
+        let stmt_state = stmt.inner.lock().unwrap();
+        assert!(
+            stmt_state
+                .diag_records
+                .iter()
+                .any(|record| record.native_error == 8153),
+            "the warning must be posted under the execute that drained it"
         );
     }
 

--- a/mssql-odbc/src/api/exec_common.rs
+++ b/mssql-odbc/src/api/exec_common.rs
@@ -577,6 +577,15 @@ pub(super) fn finish_execute(
         };
     }
 
+    // SQL Server can send COLMETADATA before the statement has produced its
+    // first row. Wait for that row, end-of-set, or an ERROR token so execution
+    // errors surface from SQLExecDirect/SQLExecute instead of a later SQLFetch.
+    // A row is only positioned and parked; SQLFetch still receives it normally.
+    if let Err(e) = dbc.runtime.block_on(client.peek_past_current_row()) {
+        error!(%e, "{op}: failed before the first result row");
+        return fail_with_tds(dbc, stmt, statement_handle, client, &e);
+    }
+
     // Result-bearing query: leave the cursor open for SQLFetch.
     let info_messages = client.take_info_messages();
     let Ok(mut stmt_state) = stmt.inner.lock() else {
@@ -611,7 +620,8 @@ mod tests {
     use crate::params::BoundParam;
     use crate::test_support::TestHandles;
     use mssql_tds::test_client_support::{
-        ScriptedToken, col_metadata_empty, done_more, done_no_more, tds_client_from_tokens,
+        ScriptedToken, col_metadata, col_metadata_empty, done_more, done_no_more, int_columns,
+        sql_error, tds_client_from_tokens,
     };
     use std::ffi::c_void;
 
@@ -650,6 +660,33 @@ mod tests {
         assert!(try_claim_idle_client(dbc, h.dbc).is_none());
         // The existing claim must be left untouched.
         assert_eq!(dbc.inner.lock().unwrap().active_stmt, Some(other));
+    }
+
+    #[test]
+    fn finish_execute_surfaces_an_error_before_the_first_row() {
+        let h = TestHandles::with_env_dbc_stmt();
+        h.mark_dbc_connected();
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        let mut client = tds_client_from_tokens(vec![
+            col_metadata(int_columns(1)),
+            sql_error(1222, 16, "Lock request time out period exceeded."),
+            done_no_more(),
+        ]);
+        dbc.runtime
+            .block_on(client.execute("SELECT blocked".to_string(), ()))
+            .unwrap();
+
+        let rc = finish_execute(dbc, stmt, h.stmt, client, "SQLExecDirectW");
+
+        assert_eq!(rc, SQL_ERROR);
+        let stmt_state = stmt.inner.lock().unwrap();
+        assert!(
+            stmt_state
+                .diag_records
+                .iter()
+                .any(|record| record.native_error == 1222)
+        );
     }
 
     /// Builds a scripted client positioned on a row-returning result (empty

--- a/mssql-odbc/tests/e2e/tests/transaction_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/transaction_test.cpp
@@ -558,6 +558,29 @@ TEST_F(TransactionLiveTest, IsolationIsAppliedOnTheServer) {
 // path can prove neither branch regresses.
 class BlockedSelectTest : public TransactionLiveTest {
   protected:
+    // Frees the second connection's handles even when an ASSERT_* returns early
+    // from the helper below. The fixture's TearDown covers dbc_ only, so a
+    // reader left connected would trip HY010 when the environment handle is
+    // freed — turning one assertion failure into a confusing second one.
+    class ScopedConnection {
+      public:
+        ScopedConnection() = default;
+        ~ScopedConnection() {
+            if (stmt != SQL_NULL_HSTMT) {
+                SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+            }
+            if (dbc != SQL_NULL_HDBC) {
+                SQLDisconnect(dbc);
+                SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+            }
+        }
+        ScopedConnection(const ScopedConnection&) = delete;
+        ScopedConnection& operator=(const ScopedConnection&) = delete;
+
+        SQLHDBC dbc = SQL_NULL_HDBC;
+        SQLHSTMT stmt = SQL_NULL_HSTMT;
+    };
+
     // Holds an exclusive row lock on |table| from dbc_, then runs a blocked
     // SELECT on a second connection via |execute_blocked| and asserts it
     // reports native error 1222 rather than hanging or succeeding.
@@ -571,20 +594,21 @@ class BlockedSelectTest : public TransactionLiveTest {
         ASSERT_SQL_OK(SetAutocommit(dbc_, SQL_AUTOCOMMIT_OFF), SQL_HANDLE_DBC, dbc_);
         Exec("UPDATE " + table + " SET value = 1 WHERE id = 1");
 
-        SQLHDBC reader = SQL_NULL_HDBC;
-        ASSERT_SQL_OK(SQLAllocHandle(SQL_HANDLE_DBC, env_, &reader), SQL_HANDLE_ENV, env_);
+        ScopedConnection reader;
+        ASSERT_SQL_OK(SQLAllocHandle(SQL_HANDLE_DBC, env_, &reader.dbc), SQL_HANDLE_ENV, env_);
         SqlTString connstr = ODBCTestUtils::BuildConnectionString();
         SQLTCHAR out_str[1024] = {};
         SQLSMALLINT out_len = 0;
-        ASSERT_SQL_OK(SQLDriverConnect(reader, nullptr, const_cast<SQLTCHAR*>(connstr.c_str()),
+        ASSERT_SQL_OK(SQLDriverConnect(reader.dbc, nullptr,
+                                       const_cast<SQLTCHAR*>(connstr.c_str()),
                                        static_cast<SQLSMALLINT>(connstr.size()), out_str,
                                        static_cast<SQLSMALLINT>(std::size(out_str)), &out_len,
                                        SQL_DRIVER_NOPROMPT),
-                      SQL_HANDLE_DBC, reader);
+                      SQL_HANDLE_DBC, reader.dbc);
 
-        SQLHSTMT reader_stmt = SQL_NULL_HSTMT;
-        ASSERT_SQL_OK(SQLAllocHandle(SQL_HANDLE_STMT, reader, &reader_stmt), SQL_HANDLE_DBC,
-                      reader);
+        ASSERT_SQL_OK(SQLAllocHandle(SQL_HANDLE_STMT, reader.dbc, &reader.stmt), SQL_HANDLE_DBC,
+                      reader.dbc);
+        SQLHSTMT reader_stmt = reader.stmt;
         // Bounds the wait if execution regresses to waiting for a token the
         // server will never send. This is a real deadline only once the
         // query-timeout enforcement of AB#46385 (#442) is in; this PR merges
@@ -600,20 +624,22 @@ class BlockedSelectTest : public TransactionLiveTest {
 
         EXPECT_EQ(SQL_ERROR, rc) << "the lock timeout must surface from execution, not a later "
                                     "SQLFetch";
-        SQLTCHAR state[6] = {};
         SQLINTEGER native = 0;
         SQLTCHAR message[1024] = {};
         SQLSMALLINT length = 0;
+        SQLTCHAR state[6] = {};
         ASSERT_SQL_OK(SQLGetDiagRec(SQL_HANDLE_STMT, reader_stmt, 1, state, &native, message,
                                     static_cast<SQLSMALLINT>(std::size(message)), &length),
                       SQL_HANDLE_STMT, reader_stmt);
         EXPECT_EQ(1222, native);
+        // 1222 is in neither driver's per-error table, so both fall through to
+        // their severity rule: class 16 maps to 42000. Asserted so a SQLSTATE
+        // divergence on this exact error cannot pass, and the msodbcsql parity
+        // leg validates it for free.
+        EXPECT_SQLSTATE(SQL_HANDLE_STMT, reader_stmt, "42000");
         EXPECT_LT(elapsed, std::chrono::seconds(5));
 
         ASSERT_SQL_OK(SQLEndTran(SQL_HANDLE_DBC, dbc_, SQL_ROLLBACK), SQL_HANDLE_DBC, dbc_);
-        SQLFreeHandle(SQL_HANDLE_STMT, reader_stmt);
-        SQLDisconnect(reader);
-        SQLFreeHandle(SQL_HANDLE_DBC, reader);
     }
 };
 

--- a/mssql-odbc/tests/e2e/tests/transaction_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/transaction_test.cpp
@@ -12,6 +12,7 @@
 #include "odbc_test_fixture.h"
 
 #include <chrono>
+#include <functional>
 #include <string>
 
 // SQL_TXN_SS_SNAPSHOT lives in msodbcsql.h, which these tests do not include.
@@ -548,53 +549,92 @@ TEST_F(TransactionLiveTest, IsolationIsAppliedOnTheServer) {
 }
 
 // A server-side lock timeout is a statement error, not a client query timeout.
-// SQLExecDirect must consume the ERROR/DONE response and return it instead of
+// Execution must consume the ERROR/DONE response and return it instead of
 // waiting indefinitely for another token (AB#47771).
-TEST_F(TransactionLiveTest, BlockedSelectReturnsServerLockTimeout) {
-    const std::string table = GlobalTempTable("lock_timeout");
-    Exec("CREATE TABLE " + table + "(id int PRIMARY KEY, value int)");
-    Exec("INSERT INTO " + table + " VALUES (1, 0)");
+//
+// Both execution paths are covered: mssql-python's cursor.execute() defaults to
+// use_prepare=True and so drives SQLPrepare + SQLExecute, not SQLExecDirect
+// (AB#47510). The fix lives in the shared finish_execute, but only a test per
+// path can prove neither branch regresses.
+class BlockedSelectTest : public TransactionLiveTest {
+  protected:
+    // Holds an exclusive row lock on |table| from dbc_, then runs a blocked
+    // SELECT on a second connection via |execute_blocked| and asserts it
+    // reports native error 1222 rather than hanging or succeeding.
+    void RunBlockedSelect(const std::string& suffix,
+                          const std::function<SQLRETURN(SQLHSTMT, const std::string&)>&
+                              execute_blocked) {
+        const std::string table = GlobalTempTable(suffix);
+        Exec("CREATE TABLE " + table + "(id int PRIMARY KEY, value int)");
+        Exec("INSERT INTO " + table + " VALUES (1, 0)");
 
-    ASSERT_SQL_OK(SetAutocommit(dbc_, SQL_AUTOCOMMIT_OFF), SQL_HANDLE_DBC, dbc_);
-    Exec("UPDATE " + table + " SET value = 1 WHERE id = 1");
+        ASSERT_SQL_OK(SetAutocommit(dbc_, SQL_AUTOCOMMIT_OFF), SQL_HANDLE_DBC, dbc_);
+        Exec("UPDATE " + table + " SET value = 1 WHERE id = 1");
 
-    SQLHDBC reader = SQL_NULL_HDBC;
-    ASSERT_SQL_OK(SQLAllocHandle(SQL_HANDLE_DBC, env_, &reader), SQL_HANDLE_ENV, env_);
-    SqlTString connstr = ODBCTestUtils::BuildConnectionString();
-    SQLTCHAR out_str[1024] = {};
-    SQLSMALLINT out_len = 0;
-    ASSERT_SQL_OK(SQLDriverConnect(reader, nullptr, const_cast<SQLTCHAR*>(connstr.c_str()),
-                                   static_cast<SQLSMALLINT>(connstr.size()), out_str,
-                                   static_cast<SQLSMALLINT>(std::size(out_str)), &out_len,
-                                   SQL_DRIVER_NOPROMPT),
-                  SQL_HANDLE_DBC, reader);
+        SQLHDBC reader = SQL_NULL_HDBC;
+        ASSERT_SQL_OK(SQLAllocHandle(SQL_HANDLE_DBC, env_, &reader), SQL_HANDLE_ENV, env_);
+        SqlTString connstr = ODBCTestUtils::BuildConnectionString();
+        SQLTCHAR out_str[1024] = {};
+        SQLSMALLINT out_len = 0;
+        ASSERT_SQL_OK(SQLDriverConnect(reader, nullptr, const_cast<SQLTCHAR*>(connstr.c_str()),
+                                       static_cast<SQLSMALLINT>(connstr.size()), out_str,
+                                       static_cast<SQLSMALLINT>(std::size(out_str)), &out_len,
+                                       SQL_DRIVER_NOPROMPT),
+                      SQL_HANDLE_DBC, reader);
 
-    SQLHSTMT reader_stmt = SQL_NULL_HSTMT;
-    ASSERT_SQL_OK(SQLAllocHandle(SQL_HANDLE_STMT, reader, &reader_stmt), SQL_HANDLE_DBC, reader);
-    ASSERT_SQL_OK(SQLSetStmtAttr(reader_stmt, SQL_ATTR_QUERY_TIMEOUT,
-                                 reinterpret_cast<SQLPOINTER>(static_cast<SQLULEN>(10)), 0),
-                  SQL_HANDLE_STMT, reader_stmt);
-    ASSERT_SQL_OK(Run(reader_stmt, "SET LOCK_TIMEOUT 1000"), SQL_HANDLE_STMT, reader_stmt);
+        SQLHSTMT reader_stmt = SQL_NULL_HSTMT;
+        ASSERT_SQL_OK(SQLAllocHandle(SQL_HANDLE_STMT, reader, &reader_stmt), SQL_HANDLE_DBC,
+                      reader);
+        // Bounds the wait if execution regresses to waiting for a token the
+        // server will never send. This is a real deadline only once the
+        // query-timeout enforcement of AB#46385 (#442) is in; this PR merges
+        // after it.
+        ASSERT_SQL_OK(SQLSetStmtAttr(reader_stmt, SQL_ATTR_QUERY_TIMEOUT,
+                                     reinterpret_cast<SQLPOINTER>(static_cast<SQLULEN>(10)), 0),
+                      SQL_HANDLE_STMT, reader_stmt);
+        ASSERT_SQL_OK(Run(reader_stmt, "SET LOCK_TIMEOUT 1000"), SQL_HANDLE_STMT, reader_stmt);
 
-    const auto start = std::chrono::steady_clock::now();
-    const SQLRETURN rc = Run(reader_stmt, "SELECT value FROM " + table + " WHERE id = 1");
-    const auto elapsed = std::chrono::steady_clock::now() - start;
+        const auto start = std::chrono::steady_clock::now();
+        const SQLRETURN rc = execute_blocked(reader_stmt, table);
+        const auto elapsed = std::chrono::steady_clock::now() - start;
 
-    EXPECT_EQ(SQL_ERROR, rc);
-    SQLTCHAR state[6] = {};
-    SQLINTEGER native = 0;
-    SQLTCHAR message[1024] = {};
-    SQLSMALLINT length = 0;
-    ASSERT_SQL_OK(SQLGetDiagRec(SQL_HANDLE_STMT, reader_stmt, 1, state, &native, message,
-                                static_cast<SQLSMALLINT>(std::size(message)), &length),
-                  SQL_HANDLE_STMT, reader_stmt);
-    EXPECT_EQ(1222, native);
-    EXPECT_LT(elapsed, std::chrono::seconds(5));
+        EXPECT_EQ(SQL_ERROR, rc) << "the lock timeout must surface from execution, not a later "
+                                    "SQLFetch";
+        SQLTCHAR state[6] = {};
+        SQLINTEGER native = 0;
+        SQLTCHAR message[1024] = {};
+        SQLSMALLINT length = 0;
+        ASSERT_SQL_OK(SQLGetDiagRec(SQL_HANDLE_STMT, reader_stmt, 1, state, &native, message,
+                                    static_cast<SQLSMALLINT>(std::size(message)), &length),
+                      SQL_HANDLE_STMT, reader_stmt);
+        EXPECT_EQ(1222, native);
+        EXPECT_LT(elapsed, std::chrono::seconds(5));
 
-    ASSERT_SQL_OK(SQLEndTran(SQL_HANDLE_DBC, dbc_, SQL_ROLLBACK), SQL_HANDLE_DBC, dbc_);
-    SQLFreeHandle(SQL_HANDLE_STMT, reader_stmt);
-    SQLDisconnect(reader);
-    SQLFreeHandle(SQL_HANDLE_DBC, reader);
+        ASSERT_SQL_OK(SQLEndTran(SQL_HANDLE_DBC, dbc_, SQL_ROLLBACK), SQL_HANDLE_DBC, dbc_);
+        SQLFreeHandle(SQL_HANDLE_STMT, reader_stmt);
+        SQLDisconnect(reader);
+        SQLFreeHandle(SQL_HANDLE_DBC, reader);
+    }
+};
+
+TEST_F(BlockedSelectTest, ExecDirectReturnsServerLockTimeout) {
+    RunBlockedSelect("lock_timeout", [](SQLHSTMT hstmt, const std::string& table) {
+        return Run(hstmt, "SELECT value FROM " + table + " WHERE id = 1");
+    });
+}
+
+// The path mssql-python actually uses. SQLPrepare materializes the statement
+// (its COLMETADATA arrives before the row), so the ERROR token trails metadata
+// on SQLExecute exactly as it does on SQLExecDirect.
+TEST_F(BlockedSelectTest, PreparedExecuteReturnsServerLockTimeout) {
+    RunBlockedSelect("lock_timeout_prep", [](SQLHSTMT hstmt, const std::string& table) {
+        SqlTString sql =
+            ODBCTestUtils::ToSqlTStr("SELECT value FROM " + table + " WHERE id = 1");
+        SQLRETURN prepare_rc =
+            SQLPrepare(hstmt, const_cast<SQLTCHAR*>(sql.c_str()), SQL_NTS);
+        EXPECT_SQL_OK(prepare_rc, SQL_HANDLE_STMT, hstmt);
+        return SQLExecute(hstmt);
+    });
 }
 
 // The isolation level survives commit and rollback — it is a session setting.

--- a/mssql-odbc/tests/e2e/tests/transaction_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/transaction_test.cpp
@@ -11,6 +11,7 @@
 
 #include "odbc_test_fixture.h"
 
+#include <chrono>
 #include <string>
 
 // SQL_TXN_SS_SNAPSHOT lives in msodbcsql.h, which these tests do not include.
@@ -544,6 +545,56 @@ TEST_F(TransactionLiveTest, IsolationIsAppliedOnTheServer) {
         EXPECT_EQ(server_level, ServerIsolation()) << "level 0x" << std::hex << odbc_level;
     }
     ASSERT_SQL_OK(SetIsolation(dbc_, SQL_TXN_READ_COMMITTED), SQL_HANDLE_DBC, dbc_);
+}
+
+// A server-side lock timeout is a statement error, not a client query timeout.
+// SQLExecDirect must consume the ERROR/DONE response and return it instead of
+// waiting indefinitely for another token (AB#47771).
+TEST_F(TransactionLiveTest, BlockedSelectReturnsServerLockTimeout) {
+    const std::string table = GlobalTempTable("lock_timeout");
+    Exec("CREATE TABLE " + table + "(id int PRIMARY KEY, value int)");
+    Exec("INSERT INTO " + table + " VALUES (1, 0)");
+
+    ASSERT_SQL_OK(SetAutocommit(dbc_, SQL_AUTOCOMMIT_OFF), SQL_HANDLE_DBC, dbc_);
+    Exec("UPDATE " + table + " SET value = 1 WHERE id = 1");
+
+    SQLHDBC reader = SQL_NULL_HDBC;
+    ASSERT_SQL_OK(SQLAllocHandle(SQL_HANDLE_DBC, env_, &reader), SQL_HANDLE_ENV, env_);
+    SqlTString connstr = ODBCTestUtils::BuildConnectionString();
+    SQLTCHAR out_str[1024] = {};
+    SQLSMALLINT out_len = 0;
+    ASSERT_SQL_OK(SQLDriverConnect(reader, nullptr, const_cast<SQLTCHAR*>(connstr.c_str()),
+                                   static_cast<SQLSMALLINT>(connstr.size()), out_str,
+                                   static_cast<SQLSMALLINT>(std::size(out_str)), &out_len,
+                                   SQL_DRIVER_NOPROMPT),
+                  SQL_HANDLE_DBC, reader);
+
+    SQLHSTMT reader_stmt = SQL_NULL_HSTMT;
+    ASSERT_SQL_OK(SQLAllocHandle(SQL_HANDLE_STMT, reader, &reader_stmt), SQL_HANDLE_DBC, reader);
+    ASSERT_SQL_OK(SQLSetStmtAttr(reader_stmt, SQL_ATTR_QUERY_TIMEOUT,
+                                 reinterpret_cast<SQLPOINTER>(static_cast<SQLULEN>(10)), 0),
+                  SQL_HANDLE_STMT, reader_stmt);
+    ASSERT_SQL_OK(Run(reader_stmt, "SET LOCK_TIMEOUT 1000"), SQL_HANDLE_STMT, reader_stmt);
+
+    const auto start = std::chrono::steady_clock::now();
+    const SQLRETURN rc = Run(reader_stmt, "SELECT value FROM " + table + " WHERE id = 1");
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+
+    EXPECT_EQ(SQL_ERROR, rc);
+    SQLTCHAR state[6] = {};
+    SQLINTEGER native = 0;
+    SQLTCHAR message[1024] = {};
+    SQLSMALLINT length = 0;
+    ASSERT_SQL_OK(SQLGetDiagRec(SQL_HANDLE_STMT, reader_stmt, 1, state, &native, message,
+                                static_cast<SQLSMALLINT>(std::size(message)), &length),
+                  SQL_HANDLE_STMT, reader_stmt);
+    EXPECT_EQ(1222, native);
+    EXPECT_LT(elapsed, std::chrono::seconds(5));
+
+    ASSERT_SQL_OK(SQLEndTran(SQL_HANDLE_DBC, dbc_, SQL_ROLLBACK), SQL_HANDLE_DBC, dbc_);
+    SQLFreeHandle(SQL_HANDLE_STMT, reader_stmt);
+    SQLDisconnect(reader);
+    SQLFreeHandle(SQL_HANDLE_DBC, reader);
 }
 
 // The isolation level survives commit and rollback — it is a session setting.

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -5678,13 +5678,12 @@ impl TdsClient {
         }
     }
 
-    /// Peeks past the row just fully consumed to discover whether another
-    /// row follows, without losing it if one does. Callers (the ODBC busy
-    /// gate) use this once every column of the current row has been
-    /// delivered to learn — one call earlier than they otherwise would —
-    /// whether the wire is now idle for this statement, matching msodbcsql's
-    /// wire-state busy gate rather than holding the connection busy for the
-    /// statement's entire cursor lifetime.
+    /// Peeks ahead to the next row and preserves it for the next cursor advance.
+    ///
+    /// ODBC execution uses this before its first fetch so an ERROR token sent
+    /// after COLMETADATA is reported by SQLExecDirect/SQLExecute. The ODBC busy
+    /// gate also uses it after delivering a row to discover whether another
+    /// row follows or the wire is now idle.
     ///
     /// Returns `Ok(true)` if another row is now positioned: it is parked
     /// exactly as [`next_row_cursor`](Self::next_row_cursor) parks any
@@ -5694,11 +5693,9 @@ impl TdsClient {
     /// `next_row_cursor` call would eventually report, just discovered now
     /// because the wire happened to already have the answer.
     ///
-    /// # Caller obligation
-    /// Only call this once every column of the row positioned before this
-    /// call has been read (all bound columns, or `SQLGetData` through the
-    /// last column) — like `next_row_cursor`, this discards anything left
-    /// unread on that row.
+    /// Call this before the first row is positioned, or after every column of
+    /// the current row has been read. Like `next_row_cursor`, it discards any
+    /// unread columns from an already-positioned row.
     pub async fn peek_past_current_row(&mut self) -> TdsResult<bool> {
         let has_row = self.next_row_cursor().await?;
         self.row_already_positioned = has_row;


### PR DESCRIPTION
## Description

SQL Server can send result metadata before a blocked query produces its first row or server error. The ODBC execution path previously returned success as soon as it received that metadata, leaving a later lock-timeout error for `SQLFetch`. In mssql-python, that caused the expected execution exception to be missed and cleanup to block behind the still-open transaction.

This change waits for and parks the first result row before reporting execution success. The row remains available to `SQLFetch`, while server errors arriving after metadata now surface from `SQLExecDirect` or `SQLExecute`.

Changed files:

- `mssql-odbc/src/api/exec_common.rs` — peek and park the first row in `finish_execute`; unit regressions.
- `mssql-tds/src/connection/tds_client.rs` — doc-comment only, rewriting the `peek_past_current_row` contract now that execution calls it before the first row is positioned.
- `mssql-odbc/tests/e2e/tests/transaction_test.cpp` — the two live regressions below.

### Observable behaviour change beyond errors

The peek stops at rows and errors, but *captures and continues* past INFO tokens (`handle_row_read_token`'s `Tokens::Info` arm). So a server informational message arriving between `COLMETADATA` and the first `ROW`/`DONE` is now drained during execution instead of by the first `SQLFetch`, and the success tail posts it — meaning `SQLExecDirect`/`SQLExecute` can now return `SQL_SUCCESS_WITH_INFO` where it previously returned `SQL_SUCCESS`.

Because ODBC clears a handle's diagnostics at the start of the next call on it, an application that only inspects `SQLGetDiagRec` *after* fetching will no longer see such a warning at all. This is a parity improvement rather than a divergence — msodbcsql's parse loop covers the same window before it parks at the first row, so it reports these from execute too — but it is a real change for queries that were already succeeding, so it is called out here rather than left implicit.

## Tests

Unit regressions in `exec_common.rs` cover both halves of the window, each verified by mutation:

- `finish_execute_surfaces_an_error_before_the_first_row` — error 1222 after metadata; fails if the peek is removed.
- `finish_execute_reports_an_info_message_arriving_before_the_first_row` — msg 8153 after metadata returns `SQL_SUCCESS_WITH_INFO` with the record posted; fails (`SQL_SUCCESS`, no record) if the peek is moved below `take_info_messages()`, which is the one edit that would silently restore the old behaviour.

Two live two-connection regressions hold an update lock, set `LOCK_TIMEOUT 1000`, and verify execution returns native error 1222 and SQLSTATE `42000`:

- `BlockedSelectTest.ExecDirectReturnsServerLockTimeout` — the `SQLExecDirect` path.
- `BlockedSelectTest.PreparedExecuteReturnsServerLockTimeout` — the `SQLPrepare` + `SQLExecute` path, which is what `mssql-python`'s `cursor.execute()` uses because it defaults to `use_prepare=True`.

Both share one body and both were verified to fail without the `finish_execute` change and pass with it (driver `.so` hash-checked between runs, since the build copies the cdylib to a second filename and a stale copy silently passes). Both also pass unchanged against msodbcsql 18.6, so the parity contract this file carries is satisfied.

## Related Issues

[AB#47771](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47771): https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47771

[AB#47510](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47510) reaches the same defect from the `mssql-python` `test_003_connection` hang.

## Dependency

#442 (`SQL_ATTR_QUERY_TIMEOUT` enforcement) has merged and is merged into this branch. That makes the query-timeout attribute these tests set a real deadline: `next_row_cursor` passes `remaining_request_timeout` into `receive_row_header`, and `peek_past_current_row` delegates to `next_row_cursor`.

## Testing

- `cargo bfmt`
- `cargo bclippy`
- `cargo nextest run -p mssqlodbc` (1,180 passed, 1 skipped)
- ODBC live e2e suite against SQL Server 2025: 36/36 test binaries, including both new cases
- Both new e2e cases also run green against msodbcsql 18.6 on the same server

### Not yet verified

End-to-end `mssql-python` validation. An earlier revision of this description claimed `tests/test_003_connection.py::test_set_attr_txn_isolation_effect` passed against this branch; that could not be reproduced by a second reviewer, so the claim is withdrawn.

Worth stating precisely, because the obvious counter-evidence does not hold: the green `mssql-python suite on mssql-odbc driver (cross-repo)` check does **not** establish that this test passes. That leg runs every `tests/test_*.py` (`run-mssql-python-odbc-tests.sh:105`), but it deliberately downgrades test failures, crashes, timeouts and skips to a warning — `failTaskOnFailedTests: false` plus an explicit "partially succeeded" result, documented as "expected while the driver is in development". So it stays green even when files fail, and cannot be read as validating any individual test.

## Deferred / to file

Raised in review, out of scope here, recorded so none of it is implicit:

- **`SQLMoreResults` pre-row-error gap** — `more_results.rs:158` returns `SQL_SUCCESS` as soon as `advance()` reports metadata, with no peek, so for `SELECT 1; SELECT <blocked>` the same defect reappears one call later. msodbcsql closes it via the same parse loop (`sqlcresl.cpp:355`), so this is a reference-driver divergence. Hang off [AB#47771](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47771).
- **Missed early busy release on a zero-row result set** — the peek now makes `!has_open_batch()` knowable at execute time, but the success tail clears the exhaustion flags and keeps the claim. Not a regression (behaviour matches pre-PR, and the zero-row path is covered green by `ExecDirectLiveTest.EmptyResultSet`, `FetchScrollLiveTest.ReturnsNoDataAtEndOfResultSet` and two `connection_busy_test` cases), but a newly-available signal being discarded. Belongs under [AB#47508](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47508) with its own e2e case, since it changes busy-gate timing.
- **Stale-handle defect on [AB#47510](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47510)** — after a server error mid-result-set the statement handle can return stale empty rows; a fresh handle on the same connection is fine. Concrete mechanism from review: msodbcsql calls `CleanUphStmt(lpstmt, FREE_MEMORY)` when `retcode == SQL_ERROR` (`sqlccmd.cpp:6896-6905`), whereas `fail_with_tds` resets no statement state.

## Breaking Changes / Migration Notes

No API change. One observable behaviour change, described under "Observable behaviour change beyond errors" above: a post-metadata server warning is now reported from execute (`SQL_SUCCESS_WITH_INFO`) rather than from the first `SQLFetch`, which matches msodbcsql.

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes
- [x] New/changed functionality has tests
- [x] Public API changes are documented (no public API changes)