### PR TITLE
Wire mssql-odbc C++ e2e suite into the macOS CI job

### DIFF
--- a/.pipeline/OneBranch/NonOfficialPythonWheelsPublish.yml
+++ b/.pipeline/OneBranch/NonOfficialPythonWheelsPublish.yml
@@ -32,7 +32,7 @@ parameters:
   default: true
 
 - name: buildOdbcNative
-  displayName: 'Build mssql-odbc native driver binaries alongside the wheels'
+  displayName: 'Also build mssql-odbc native driver'
   type: boolean
   default: false
 

--- a/.pipeline/OneBranch/NonOfficialPythonWheelsPublish.yml
+++ b/.pipeline/OneBranch/NonOfficialPythonWheelsPublish.yml
@@ -31,6 +31,11 @@ parameters:
   type: boolean
   default: true
 
+- name: buildOdbcNative
+  displayName: 'Build mssql-odbc native driver binaries alongside the wheels'
+  type: boolean
+  default: false
+
 variables:
   CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)]  # For onebranch.pipeline.version task
   LinuxContainerImage: 'mcr.microsoft.com/onebranch/azurelinux/build:3.0'
@@ -70,5 +75,6 @@ extends:
       parameters:
         buildAllTargets: true
         buildPythonWheels: true
+        buildOdbcNative: ${{ parameters.buildOdbcNative }}
         isOfficial: false
         publishToFeed: ${{ parameters.publishToFeed }}

--- a/.pipeline/OneBranch/stages.yml
+++ b/.pipeline/OneBranch/stages.yml
@@ -6,6 +6,10 @@
 # Then packages all wheels into a NuGet archive and publishes to Azure         #
 # Artifacts via OneBranch native nugetPublishing mechanism.                    #
 #                                                                               #
+# When buildOdbcNative is true, the Windows/Linux x64+ARM64 jobs also build   #
+# the mssql-odbc native driver (glibc/musl/glibc-2.28 on Linux) and publish   #
+# it as a separate mssql-odbc-native NuGet package. No macOS lane yet.         #
+#                                                                               #
 # Build jobs use custom 1ES pools (Rust, Docker, Python pre-installed).        #
 # Publish job uses managed OneBranch pool with ob_nugetPublishing_enabled.     #
 # Artifact publishing on custom pools requires explicit                        #
@@ -23,6 +27,11 @@ parameters:
   type: boolean
   default: true
   displayName: 'Build Python wheels'
+
+- name: buildOdbcNative
+  type: boolean
+  default: false
+  displayName: 'Build mssql-odbc native driver binaries alongside the wheels'
 
 - name: isOfficial
   type: boolean
@@ -77,6 +86,18 @@ stages:
           architecture: x64
           publishArtifacts: false
           signWindowsWheels: ${{ parameters.isOfficial }}
+    - ${{ if eq(parameters.buildOdbcNative, true) }}:
+      - template: /.pipeline/templates/build-odbc-windows-template.yml
+        parameters:
+          architecture: x64
+          artifactName: 'Odbc_Windows_x64'
+          publishArtifacts: false
+      - task: CopyFiles@2
+        displayName: 'Collect ODBC native driver (Windows x64)'
+        inputs:
+          sourceFolder: '$(Build.SourcesDirectory)\odbc-drop'
+          targetFolder: '$(ob_outputDirectory)\odbc_windows_x64'
+          contents: '**'
     - task: PublishPipelineArtifact@1
       displayName: 'Publish Windows x64 Artifacts'
       inputs:
@@ -133,6 +154,18 @@ stages:
             - '3.12'
             - '3.13'
             - '3.14'
+      - ${{ if eq(parameters.buildOdbcNative, true) }}:
+        - template: /.pipeline/templates/build-odbc-windows-template.yml
+          parameters:
+            architecture: ARM64
+            artifactName: 'Odbc_Windows_ARM64'
+            publishArtifacts: false
+        - task: CopyFiles@2
+          displayName: 'Collect ODBC native driver (Windows ARM64)'
+          inputs:
+            sourceFolder: '$(Build.SourcesDirectory)\odbc-drop'
+            targetFolder: '$(ob_outputDirectory)\odbc_windows_arm64'
+            contents: '**'
       - task: PublishPipelineArtifact@1
         displayName: 'Publish Windows ARM64 Artifacts'
         inputs:
@@ -179,6 +212,44 @@ stages:
           osType: Alpine
           architecture: x64
           publishArtifacts: false
+    - ${{ if eq(parameters.buildOdbcNative, true) }}:
+      - template: /.pipeline/templates/build-odbc-template.yml
+        parameters:
+          architecture: x64
+          artifactName: 'Odbc_Linux_x64_glibc'
+          publishArtifacts: false
+      - task: CopyFiles@2
+        displayName: 'Collect ODBC glibc driver (Linux x64)'
+        inputs:
+          sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
+          targetFolder: '$(ob_outputDirectory)/odbc_glibc_x64'
+          contents: '**'
+      - script: rm -rf $(Build.SourcesDirectory)/odbc-drop
+        displayName: 'Clear odbc-drop before next ODBC variant'
+      - template: /.pipeline/templates/build-odbc-alpine-template.yml
+        parameters:
+          architecture: x64
+          artifactName: 'Odbc_Linux_x64_musl'
+          publishArtifacts: false
+      - task: CopyFiles@2
+        displayName: 'Collect ODBC musl driver (Linux x64)'
+        inputs:
+          sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
+          targetFolder: '$(ob_outputDirectory)/odbc_musl_x64'
+          contents: '**'
+      - script: rm -rf $(Build.SourcesDirectory)/odbc-drop
+        displayName: 'Clear odbc-drop before next ODBC variant'
+      - template: /.pipeline/templates/build-odbc-glibc228-template.yml
+        parameters:
+          architecture: x64
+          artifactName: 'Odbc_Linux_x64_glibc228'
+          publishArtifacts: false
+      - task: CopyFiles@2
+        displayName: 'Collect ODBC glibc-2.28 driver (Linux x64)'
+        inputs:
+          sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
+          targetFolder: '$(ob_outputDirectory)/odbc_glibc228_x64'
+          contents: '**'
     - task: PublishPipelineArtifact@1
       displayName: 'Publish Linux x64 Artifacts'
       inputs:
@@ -226,6 +297,45 @@ stages:
             osType: Alpine
             architecture: arm64
             publishArtifacts: false
+      - ${{ if eq(parameters.buildOdbcNative, true) }}:
+        - template: /.pipeline/templates/build-odbc-template.yml
+          parameters:
+            architecture: ARM64
+            artifactName: 'Odbc_Linux_ARM64_glibc'
+            publishArtifacts: false
+        - task: CopyFiles@2
+          displayName: 'Collect ODBC glibc driver (Linux ARM64)'
+          inputs:
+            sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
+            targetFolder: '$(ob_outputDirectory)/odbc_glibc_arm64'
+            contents: '**'
+        - script: rm -rf $(Build.SourcesDirectory)/odbc-drop
+          displayName: 'Clear odbc-drop before next ODBC variant'
+        - template: /.pipeline/templates/build-odbc-alpine-template.yml
+          parameters:
+            architecture: ARM64
+            artifactName: 'Odbc_Linux_ARM64_musl'
+            publishArtifacts: false
+        - task: CopyFiles@2
+          displayName: 'Collect ODBC musl driver (Linux ARM64)'
+          inputs:
+            sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
+            targetFolder: '$(ob_outputDirectory)/odbc_musl_arm64'
+            contents: '**'
+        - script: rm -rf $(Build.SourcesDirectory)/odbc-drop
+          displayName: 'Clear odbc-drop before next ODBC variant'
+        - template: /.pipeline/templates/build-odbc-glibc228-template.yml
+          parameters:
+            architecture: ARM64
+            buildImage: 'ghcr.io/microsoft/mssql-rs/python-build/manylinux_2_28_aarch64_rust:latest'
+            artifactName: 'Odbc_Linux_ARM64_glibc228'
+            publishArtifacts: false
+        - task: CopyFiles@2
+          displayName: 'Collect ODBC glibc-2.28 driver (Linux ARM64)'
+          inputs:
+            sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
+            targetFolder: '$(ob_outputDirectory)/odbc_glibc228_arm64'
+            contents: '**'
       - task: PublishPipelineArtifact@1
         displayName: 'Publish Linux ARM64 Artifacts'
         inputs:
@@ -398,3 +508,81 @@ stages:
           }
           Write-Host "OneBranch will auto-publish from $(ob_outputDirectory)/packages"
         displayName: 'Verify NuGet package'
+
+      # mssql-odbc native driver binaries - packaged as a separate NuGet
+      # (unrelated product/consumers from the Python wheels above), built
+      # from the same artifacts this job already downloaded.
+      - ${{ if eq(parameters.buildOdbcNative, true) }}:
+        - pwsh: |
+            $ErrorActionPreference = 'Stop'
+
+            # source artifact/subfolder -> (platform tag, driver filename).
+            # Subfolder names match the CopyFiles targetFolder used in each
+            # Build job (see Windows_x64/Windows_ARM64/Linux_x64/Linux_ARM64
+            # above); every source path shares the build/<file> layout that
+            # build-odbc-*-template.yml and build-odbc-windows-template.yml
+            # stage the driver into.
+            $platforms = [ordered]@{
+              'drop_Build_Linux_x64_linux_x64/odbc_glibc_x64'             = @{ tag = 'linux_x64';      file = 'mssqlodbc.so' }
+              'drop_Build_Linux_x64_linux_x64/odbc_musl_x64'              = @{ tag = 'musl_x64';       file = 'mssqlodbc.so' }
+              'drop_Build_Linux_x64_linux_x64/odbc_glibc228_x64'          = @{ tag = 'glibc228_x64';   file = 'mssqlodbc.so' }
+              'drop_Build_Linux_ARM64_linux_arm64/odbc_glibc_arm64'       = @{ tag = 'linux_arm64';    file = 'mssqlodbc.so' }
+              'drop_Build_Linux_ARM64_linux_arm64/odbc_musl_arm64'        = @{ tag = 'musl_arm64';     file = 'mssqlodbc.so' }
+              'drop_Build_Linux_ARM64_linux_arm64/odbc_glibc228_arm64'    = @{ tag = 'glibc228_arm64'; file = 'mssqlodbc.so' }
+              'drop_Build_Windows_x64_windows_x64/odbc_windows_x64'       = @{ tag = 'windows_x64';    file = 'mssqlodbc.dll' }
+              'drop_Build_Windows_ARM64_windows_arm64/odbc_windows_arm64' = @{ tag = 'windows_arm64';  file = 'mssqlodbc.dll' }
+            }
+
+            foreach ($key in $platforms.Keys) {
+              $info = $platforms[$key]
+              $sourcePath = "$(Pipeline.Workspace)/$key/build/$($info.file)"
+              if (-not (Test-Path $sourcePath)) {
+                Write-Error "Missing ODBC driver binary: $sourcePath"
+                exit 1
+              }
+              $destDir = "$(Build.StagingDirectory)/odbc-native/$($info.tag)"
+              New-Item -ItemType Directory -Force -Path $destDir | Out-Null
+              Copy-Item $sourcePath "$destDir/$($info.file)"
+              Write-Host "Staged $($info.tag): $sourcePath -> $destDir/$($info.file)"
+            }
+          displayName: 'Collect ODBC native driver binaries'
+
+        - pwsh: |
+            $ErrorActionPreference = 'Stop'
+
+            # Reuses $(nugetVersion)/$(shortSha) computed above for the wheels
+            # package - both packages are built from the same commit/run.
+            $nuspecContent = @"
+            <?xml version="1.0"?>
+            <package>
+              <metadata>
+                <id>mssql-odbc-native</id>
+                <version>$(nugetVersion)</version>
+                <description>mssql-odbc native driver binaries across platforms. Commit: $(Build.SourceVersion). Build: $(Build.BuildNumber)</description>
+                <authors>SqlClientDrivers</authors>
+              </metadata>
+              <files>
+                <file src="odbc-native\**\*" target="native" />
+              </files>
+            </package>
+            "@
+
+            $nuspecPath = "$(Build.StagingDirectory)/mssql-odbc-native.nuspec"
+            $nuspecContent | Out-File -FilePath $nuspecPath -Encoding utf8
+            Write-Host "Created nuspec at $nuspecPath"
+          displayName: 'Generate ODBC native NuGet package metadata'
+
+        - task: NuGetCommand@2
+          displayName: 'Create ODBC native NuGet package'
+          inputs:
+            command: pack
+            packagesToPack: '$(Build.StagingDirectory)/mssql-odbc-native.nuspec'
+            packDestination: '$(ob_outputDirectory)/packages'
+            basePath: '$(Build.StagingDirectory)'
+
+        - pwsh: |
+            Write-Host "=== ODBC native NuGet package created ==="
+            Get-ChildItem "$(ob_outputDirectory)/packages" -Filter mssql-odbc-native*.nupkg | ForEach-Object {
+              Write-Host "  $($_.Name)  ($([math]::Round($_.Length/1MB, 2)) MB)"
+            }
+          displayName: 'Verify ODBC native NuGet package'

--- a/.pipeline/OneBranch/stages.yml
+++ b/.pipeline/OneBranch/stages.yml
@@ -31,7 +31,7 @@ parameters:
 - name: buildOdbcNative
   type: boolean
   default: false
-  displayName: 'Build mssql-odbc native driver binaries alongside the wheels'
+  displayName: 'Also build mssql-odbc native driver'
 
 - name: isOfficial
   type: boolean

--- a/.pipeline/OneBranch/stages.yml
+++ b/.pipeline/OneBranch/stages.yml
@@ -526,7 +526,7 @@ stages:
             }
 
             # Windows_ARM64/Linux_ARM64 jobs only run when buildAllTargets is
-            # true (see the job-level ${{ if }} guards above); skip these
+            # true (see the job-level conditional guards above); skip these
             # entries otherwise, or the Test-Path check below always fails.
             if ($buildAllTargets) {
               $platforms['drop_Build_Linux_ARM64_linux_arm64/odbc_glibc_arm64']       = @{ tag = 'linux_arm64';    file = 'mssqlodbc.so' }

--- a/.pipeline/OneBranch/stages.yml
+++ b/.pipeline/OneBranch/stages.yml
@@ -224,8 +224,6 @@ stages:
           sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
           targetFolder: '$(ob_outputDirectory)/odbc_glibc_x64'
           contents: '**'
-      - script: rm -rf $(Build.SourcesDirectory)/odbc-drop
-        displayName: 'Clear odbc-drop before next ODBC variant'
       - template: /.pipeline/templates/build-odbc-alpine-template.yml
         parameters:
           architecture: x64
@@ -237,8 +235,6 @@ stages:
           sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
           targetFolder: '$(ob_outputDirectory)/odbc_musl_x64'
           contents: '**'
-      - script: rm -rf $(Build.SourcesDirectory)/odbc-drop
-        displayName: 'Clear odbc-drop before next ODBC variant'
       - template: /.pipeline/templates/build-odbc-glibc228-template.yml
         parameters:
           architecture: x64
@@ -309,8 +305,6 @@ stages:
             sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
             targetFolder: '$(ob_outputDirectory)/odbc_glibc_arm64'
             contents: '**'
-        - script: rm -rf $(Build.SourcesDirectory)/odbc-drop
-          displayName: 'Clear odbc-drop before next ODBC variant'
         - template: /.pipeline/templates/build-odbc-alpine-template.yml
           parameters:
             architecture: ARM64
@@ -322,8 +316,6 @@ stages:
             sourceFolder: '$(Build.SourcesDirectory)/odbc-drop'
             targetFolder: '$(ob_outputDirectory)/odbc_musl_arm64'
             contents: '**'
-        - script: rm -rf $(Build.SourcesDirectory)/odbc-drop
-          displayName: 'Clear odbc-drop before next ODBC variant'
         - template: /.pipeline/templates/build-odbc-glibc228-template.yml
           parameters:
             architecture: ARM64
@@ -516,6 +508,10 @@ stages:
         - pwsh: |
             $ErrorActionPreference = 'Stop'
 
+            # Template expansion produces bare True/False which aren't valid
+            # PowerShell; string comparison converts to a proper boolean.
+            $buildAllTargets = "${{ parameters.buildAllTargets }}" -eq "True"
+
             # source artifact/subfolder -> (platform tag, driver filename).
             # Subfolder names match the CopyFiles targetFolder used in each
             # Build job (see Windows_x64/Windows_ARM64/Linux_x64/Linux_ARM64
@@ -526,11 +522,17 @@ stages:
               'drop_Build_Linux_x64_linux_x64/odbc_glibc_x64'             = @{ tag = 'linux_x64';      file = 'mssqlodbc.so' }
               'drop_Build_Linux_x64_linux_x64/odbc_musl_x64'              = @{ tag = 'musl_x64';       file = 'mssqlodbc.so' }
               'drop_Build_Linux_x64_linux_x64/odbc_glibc228_x64'          = @{ tag = 'glibc228_x64';   file = 'mssqlodbc.so' }
-              'drop_Build_Linux_ARM64_linux_arm64/odbc_glibc_arm64'       = @{ tag = 'linux_arm64';    file = 'mssqlodbc.so' }
-              'drop_Build_Linux_ARM64_linux_arm64/odbc_musl_arm64'        = @{ tag = 'musl_arm64';     file = 'mssqlodbc.so' }
-              'drop_Build_Linux_ARM64_linux_arm64/odbc_glibc228_arm64'    = @{ tag = 'glibc228_arm64'; file = 'mssqlodbc.so' }
               'drop_Build_Windows_x64_windows_x64/odbc_windows_x64'       = @{ tag = 'windows_x64';    file = 'mssqlodbc.dll' }
-              'drop_Build_Windows_ARM64_windows_arm64/odbc_windows_arm64' = @{ tag = 'windows_arm64';  file = 'mssqlodbc.dll' }
+            }
+
+            # Windows_ARM64/Linux_ARM64 jobs only run when buildAllTargets is
+            # true (see the job-level ${{ if }} guards above); skip these
+            # entries otherwise, or the Test-Path check below always fails.
+            if ($buildAllTargets) {
+              $platforms['drop_Build_Linux_ARM64_linux_arm64/odbc_glibc_arm64']       = @{ tag = 'linux_arm64';    file = 'mssqlodbc.so' }
+              $platforms['drop_Build_Linux_ARM64_linux_arm64/odbc_musl_arm64']        = @{ tag = 'musl_arm64';     file = 'mssqlodbc.so' }
+              $platforms['drop_Build_Linux_ARM64_linux_arm64/odbc_glibc228_arm64']    = @{ tag = 'glibc228_arm64'; file = 'mssqlodbc.so' }
+              $platforms['drop_Build_Windows_ARM64_windows_arm64/odbc_windows_arm64'] = @{ tag = 'windows_arm64';  file = 'mssqlodbc.dll' }
             }
 
             foreach ($key in $platforms.Keys) {
@@ -550,14 +552,46 @@ stages:
         - pwsh: |
             $ErrorActionPreference = 'Stop'
 
-            # Reuses $(nugetVersion)/$(shortSha) computed above for the wheels
-            # package - both packages are built from the same commit/run.
+            # mssql-odbc is versioned independently from mssql-py-core, so
+            # compute its own package version rather than reusing $(nugetVersion).
+            $cargoToml = Get-Content "$(Build.SourcesDirectory)/mssql-odbc/Cargo.toml" -Raw
+            if ($cargoToml -match 'version\s*=\s*"([^"]+)"') {
+              $version = $Matches[1]
+            } else {
+              Write-Error "Could not extract version from mssql-odbc/Cargo.toml"
+              exit 1
+            }
+
+            $buildReason = "$(Build.Reason)"
+            $isOfficial = "${{ parameters.isOfficial }}" -eq "True"
+            $dateStamp = Get-Date -Format "yyyyMMdd"
+            $buildId = "$(Build.BuildId)"
+
+            switch ($buildReason) {
+              'Schedule' { $odbcPackageVersion = "$version-nightly.$dateStamp" }
+              'Manual' {
+                if ($isOfficial) {
+                  $odbcPackageVersion = $version
+                } else {
+                  $odbcPackageVersion = "$version-dev.$dateStamp.$buildId"
+                }
+              }
+              default { $odbcPackageVersion = "$version-dev.$dateStamp.$buildId" }
+            }
+
+            Write-Host "ODBC native package version: $odbcPackageVersion"
+            Write-Host "##vso[task.setvariable variable=odbcNugetVersion]$odbcPackageVersion"
+          displayName: 'Compute ODBC native package version'
+
+        - pwsh: |
+            $ErrorActionPreference = 'Stop'
+
             $nuspecContent = @"
             <?xml version="1.0"?>
             <package>
               <metadata>
                 <id>mssql-odbc-native</id>
-                <version>$(nugetVersion)</version>
+                <version>$(odbcNugetVersion)</version>
                 <description>mssql-odbc native driver binaries across platforms. Commit: $(Build.SourceVersion). Build: $(Build.BuildNumber)</description>
                 <authors>SqlClientDrivers</authors>
               </metadata>

--- a/.pipeline/templates/build-odbc-alpine-template.yml
+++ b/.pipeline/templates/build-odbc-alpine-template.yml
@@ -18,6 +18,11 @@ parameters:
   - name: buildImage
     type: string
     default: 'ghcr.io/microsoft/mssql-rs/build/alpine:3.18'
+  # Publish this template's own artifact (disable when the caller does one
+  # combined publish for the whole job, e.g. OneBranch's stages.yml).
+  - name: publishArtifacts
+    type: boolean
+    default: true
 
 steps:
   - script: |
@@ -34,9 +39,10 @@ steps:
       CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN)
       CARGO_REGISTRIES_MSSQL_RS_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_TOKEN)
 
-  - task: PublishPipelineArtifact@1
-    displayName: 'Publish ${{ parameters.artifactName }}'
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-    inputs:
-      targetPath: '$(Build.SourcesDirectory)/odbc-drop'
-      artifact: ${{ parameters.artifactName }}
+  - ${{ if eq(parameters.publishArtifacts, true) }}:
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish ${{ parameters.artifactName }}'
+      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+      inputs:
+        targetPath: '$(Build.SourcesDirectory)/odbc-drop'
+        artifact: ${{ parameters.artifactName }}

--- a/.pipeline/templates/build-odbc-glibc228-template.yml
+++ b/.pipeline/templates/build-odbc-glibc228-template.yml
@@ -19,6 +19,11 @@ parameters:
   - name: architecture
     type: string
     default: 'x64'
+  # Publish this template's own artifact (disable when the caller does one
+  # combined publish for the whole job, e.g. OneBranch's stages.yml).
+  - name: publishArtifacts
+    type: boolean
+    default: true
 
 steps:
   - script: |
@@ -35,9 +40,10 @@ steps:
       CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN)
       CARGO_REGISTRIES_MSSQL_RS_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_TOKEN)
 
-  - task: PublishPipelineArtifact@1
-    displayName: 'Publish ${{ parameters.artifactName }}'
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-    inputs:
-      targetPath: '$(Build.SourcesDirectory)/odbc-drop'
-      artifact: ${{ parameters.artifactName }}
+  - ${{ if eq(parameters.publishArtifacts, true) }}:
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish ${{ parameters.artifactName }}'
+      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+      inputs:
+        targetPath: '$(Build.SourcesDirectory)/odbc-drop'
+        artifact: ${{ parameters.artifactName }}

--- a/.pipeline/templates/build-odbc-template.yml
+++ b/.pipeline/templates/build-odbc-template.yml
@@ -18,6 +18,11 @@ parameters:
   - name: buildImage
     type: string
     default: 'ghcr.io/microsoft/mssql-rs/build/ubuntu:22.04'
+  # Publish this template's own artifact (disable when the caller does one
+  # combined publish for the whole job, e.g. OneBranch's stages.yml).
+  - name: publishArtifacts
+    type: boolean
+    default: true
 
 steps:
   - script: |
@@ -36,9 +41,10 @@ steps:
       CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN)
       CARGO_REGISTRIES_MSSQL_RS_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_TOKEN)
 
-  - task: PublishPipelineArtifact@1
-    displayName: 'Publish ${{ parameters.artifactName }}'
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-    inputs:
-      targetPath: '$(Build.SourcesDirectory)/odbc-drop'
-      artifact: ${{ parameters.artifactName }}
+  - ${{ if eq(parameters.publishArtifacts, true) }}:
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish ${{ parameters.artifactName }}'
+      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+      inputs:
+        targetPath: '$(Build.SourcesDirectory)/odbc-drop'
+        artifact: ${{ parameters.artifactName }}

--- a/.pipeline/templates/build-odbc-windows-template.yml
+++ b/.pipeline/templates/build-odbc-windows-template.yml
@@ -25,7 +25,7 @@ parameters:
 steps:
   - pwsh: |
       $ErrorActionPreference = 'Stop'
-      cargo build --release --package mssql-odbc
+      cargo build --release --package mssqlodbc
     displayName: 'Build mssql-odbc driver (${{ parameters.architecture }})'
     condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
 

--- a/.pipeline/templates/build-odbc-windows-template.yml
+++ b/.pipeline/templates/build-odbc-windows-template.yml
@@ -1,0 +1,48 @@
+# filepath: .pipeline/templates/build-odbc-windows-template.yml
+#
+# Build the mssql-odbc driver (mssqlodbc.dll) natively on Windows and publish
+# it as a pipeline artifact for the native NuGet package Publish stage.
+#
+# Driver only - no C++ gtest e2e binaries. Windows e2e coverage stays in the
+# PR-only leg in build-template.yml; this is the CI-only leg that stages a
+# releasable driver drop, mirroring build-odbc-template.yml on Linux.
+#
+# CI (non-PR) only.
+
+parameters:
+  # 'x64' or 'ARM64' - selects the build pool the surrounding job runs on.
+  - name: architecture
+    type: string
+  # Pipeline artifact name, e.g. 'Odbc_Windows_x64' / 'Odbc_Windows_arm64'.
+  - name: artifactName
+    type: string
+  # Publish this template's own artifact (disable when the caller does one
+  # combined publish for the whole job, e.g. OneBranch's stages.yml).
+  - name: publishArtifacts
+    type: boolean
+    default: true
+
+steps:
+  - pwsh: |
+      $ErrorActionPreference = 'Stop'
+      cargo build --release --package mssql-odbc
+    displayName: 'Build mssql-odbc driver (${{ parameters.architecture }})'
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+
+  - pwsh: |
+      $ErrorActionPreference = 'Stop'
+      # Nest under build/ so the Publish stage's extraction step can use the
+      # same relative layout (build/<driver file>) across every platform.
+      $dropDir = "$(Build.SourcesDirectory)\odbc-drop\build"
+      New-Item -ItemType Directory -Force -Path $dropDir | Out-Null
+      Copy-Item "$(CARGO_TARGET_DIR)\release\mssqlodbc.dll" $dropDir
+    displayName: 'Stage driver into drop (${{ parameters.architecture }})'
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+
+  - ${{ if eq(parameters.publishArtifacts, true) }}:
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish ${{ parameters.artifactName }}'
+      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+      inputs:
+        targetPath: '$(Build.SourcesDirectory)/odbc-drop'
+        artifact: ${{ parameters.artifactName }}

--- a/.pipeline/templates/build-template.yml
+++ b/.pipeline/templates/build-template.yml
@@ -42,7 +42,7 @@ parameters:
   default: true
 
 - name: enableOdbcE2E
-  displayName: Enable ODBC C++ e2e suite (Windows, PR only) with coverage
+  displayName: Enable ODBC C++ e2e suite (Windows/macOS, PR only) with coverage
   type: boolean
   default: false
 
@@ -171,13 +171,14 @@ steps:
       targetPath: "$(Build.SourcesDirectory)/target/cobertura.xml"
       artifactName: "CoberturaCoverageRust_${{ parameters.osType }}"
 
-# ODBC C++ e2e suite (Windows only). The gtest suite loads the Rust ODBC driver
-# DLL through the Windows Driver Manager as separate processes, so its execution
-# was contributing zero coverage. run_e2e.ps1 -Coverage instruments the driver
-# via cargo llvm-cov, lets the gtest processes emit .profraw, and produces a
-# repo-root-relative Cobertura report for mssql-odbc (and statically-linked
-# mssql-tds). The report is unioned into the Merge Coverage stage so lines
-# reachable only via the ODBC surface count toward PR diff coverage.
+# ODBC C++ e2e suite (Windows and macOS). The gtest suite loads the Rust ODBC
+# driver through the platform's Driver Manager as separate processes, so its
+# execution was contributing zero coverage. run_e2e.ps1/run_e2e.sh -Coverage
+# instruments the driver via cargo llvm-cov, lets the gtest processes emit
+# .profraw, and produces a repo-root-relative Cobertura report for mssql-odbc
+# (and statically-linked mssql-tds). The report is unioned into the Merge
+# Coverage stage so lines reachable only via the ODBC surface count toward PR
+# diff coverage.
 - ${{ if and(eq(parameters.osType, 'Windows'), eq(parameters.enableOdbcE2E, true)) }}:
   # Reference driver for the parity comparison below, installed by
   # install-msodbcsql.ps1. Pinned to the msodbcsqlVersion pipeline variable so a
@@ -238,6 +239,43 @@ steps:
     inputs:
       targetPath: "$(Build.SourcesDirectory)/target/cobertura-odbc-e2e.xml"
       artifactName: "CoberturaCoverageOdbcE2E_Windows"
+
+# ODBC C++ e2e suite (macOS). Same mechanism as the Windows leg above, but via
+# run_e2e.sh (unixODBC) instead of run_e2e.ps1, and with no msodbcsql parity
+# comparison: unlike Windows (winget) and Linux (packages.microsoft.com in a
+# container), there is no scripted macOS installer for the reference driver
+# here yet, so this leg only proves the Rust driver's own e2e suite passes.
+- ${{ if and(eq(parameters.osType, 'MacOS'), eq(parameters.enableOdbcE2E, true)) }}:
+  - script: |
+      export ODBC_TEST_SERVER='localhost'
+      export ODBC_TEST_UID='sa'
+      export ODBC_TEST_PWD="$SQL_PASSWORD"
+      export ODBC_TEST_TRUST_CERT='Yes'
+      ./mssql-odbc/tests/e2e/run_e2e.sh --retries=3 \
+        --coverage="$(Build.SourcesDirectory)/target/cobertura-odbc-e2e.xml"
+    displayName: Run ODBC C++ e2e tests (macOS) with coverage
+    condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+    env:
+      SQL_PASSWORD: $(SQL_PASSWORD)
+      RUST_BACKTRACE: full
+
+  - task: PublishTestResults@2
+    condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
+    displayName: "Publish ODBC e2e test results (macOS)"
+    inputs:
+      testResultsFormat: "JUnit"
+      testResultsFiles: $(Build.SourcesDirectory)/mssql-odbc/tests/e2e/build/junit-mssql-odbc.xml
+      testRunTitle: $(System.PhaseName)-OdbcE2E
+
+  # Best-effort (continueOnError) so a coverage hiccup never fails the build; the
+  # Merge Coverage stage skips it if absent.
+  - task: PublishPipelineArtifact@1
+    condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
+    displayName: "Publish ODBC e2e macOS Cobertura coverage artifact"
+    continueOnError: true
+    inputs:
+      targetPath: "$(Build.SourcesDirectory)/target/cobertura-odbc-e2e.xml"
+      artifactName: "CoberturaCoverageOdbcE2E_MacOS"
 
 - ${{ if eq(parameters.enableJsBuild, true) }}:
   - bash: |

--- a/.pipeline/templates/install-dependencies.yml
+++ b/.pipeline/templates/install-dependencies.yml
@@ -82,6 +82,9 @@ steps:
       echo "##vso[task.setvariable variable=CPPFLAGS]-I$(brew --prefix krb5)/include"
       echo "##vso[task.setvariable variable=PKG_CONFIG_PATH]$(brew --prefix krb5)/lib/pkgconfig"
 
+      # unixODBC + cmake for the mssql-odbc C++ e2e suite (tests/e2e/run_e2e.sh)
+      brew install unixodbc cmake
+
       # Install Rustup
       .pipeline/scripts/install-rustup.sh
     displayName: "Install MacOS dependencies"

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -416,6 +416,7 @@ stages:
           buildType: ${{ parameters.buildType }}
           testFilter: -E 'not (test(connectivity))'
           enableClippy: false
+          enableOdbcE2E: true
       - script: |
           set +e
           echo "=== Colima status ==="
@@ -998,11 +999,11 @@ stages:
 
 # Merge the mssql-tds Rust coverage from every OS that runs the tests
 # (Build_Windows, Build_Linux, Test_MacOS), the ODBC C++ e2e coverage
-# (Build_Linux x64 and Build_Windows), and the mssql-py-core coverage from the
-# Python tests (Build_Linux) into one Cobertura report. ADO does not merge
-# coverage across stages/jobs, so it is combined here and published as
-# CoberturaCoverage (the artifact the GitHub diff-cover workflow consumes) and
-# to the ADO coverage tab.
+# (Build_Linux x64, Build_Windows, and Test_MacOS), and the mssql-py-core
+# coverage from the Python tests (Build_Linux) into one Cobertura report. ADO
+# does not merge coverage across stages/jobs, so it is combined here and
+# published as CoberturaCoverage (the artifact the GitHub diff-cover workflow
+# consumes) and to the ADO coverage tab.
 - stage: Coverage
   displayName: Merge Coverage
   dependsOn:
@@ -1046,6 +1047,13 @@ stages:
           artifactName: 'CoberturaCoverageOdbcE2E_Windows'
           targetPath: '$(Pipeline.Workspace)/cov-odbc-e2e-windows'
       - task: DownloadPipelineArtifact@2
+        displayName: Download ODBC e2e macOS coverage
+        continueOnError: true
+        inputs:
+          buildType: 'current'
+          artifactName: 'CoberturaCoverageOdbcE2E_MacOS'
+          targetPath: '$(Pipeline.Workspace)/cov-odbc-e2e-macos'
+      - task: DownloadPipelineArtifact@2
         displayName: Download Rust (mssql-tds) macOS coverage
         continueOnError: true
         inputs:
@@ -1080,7 +1088,8 @@ stages:
             "$(Pipeline.Workspace)/cov-rust-linux/cobertura.xml" \
             "$(Pipeline.Workspace)/cov-rust-macos/cobertura.xml" \
             "$(Pipeline.Workspace)/cov-odbc-e2e-linux/cobertura-odbc-e2e.xml" \
-            "$(Pipeline.Workspace)/cov-odbc-e2e-windows/cobertura-odbc-e2e.xml"; do
+            "$(Pipeline.Workspace)/cov-odbc-e2e-windows/cobertura-odbc-e2e.xml" \
+            "$(Pipeline.Workspace)/cov-odbc-e2e-macos/cobertura-odbc-e2e.xml"; do
             [ -f "$report" ] && inputs+=("$report")
           done
           # mssql-py-core coverage is measured from within its own crate


### PR DESCRIPTION
[AB#47798](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47798)

### Summary
Wires the existing `mssql-odbc/tests/e2e` C++ gtest suite (which already had Darwin-aware build/run scripts) into the `Test_MacOS` CI job, so the ODBC driver gets real end-to-end conformance coverage on macOS, not just a Rust-level unit-test build.

- `install-dependencies.yml`: installs `unixodbc` + `cmake` on macOS agents (prerequisites for the e2e suite; previously only installed for the Linux/Windows legs).
- `build-template.yml`: extends `enableOdbcE2E` to macOS. Runs `run_e2e.sh --retries=3 --coverage=...` (no `--compare-with-msodbcsql` leg, since there is no macOS reference-driver installer yet, unlike Windows' `winget`/Linux's container-based `packages.microsoft.com` install). Publishes JUnit results and a `CoberturaCoverageOdbcE2E_MacOS` artifact, mirroring the Windows leg.
- `validation-stages.yml`: `Test_MacOS` now passes `enableOdbcE2E: true`; the `Merge_Coverage` job downloads and unions the new macOS ODBC e2e coverage report alongside the existing Windows/Linux ones.

### Scope / what's NOT in this PR
- No msodbcsql parity comparison on macOS (no reference-driver installer exists for that platform yet).
- No macOS lane for the `mssql-odbc-native` NuGet artifact or the `mssql-python-rust-odbc` wheel — those are separate, larger follow-ups (native artifact build + universal2 lipo merge) tracked separately.

### Checklist
- [x] Local validation: YAML template changes only, no Rust code touched (`cargo bfmt`/`cargo bclippy`/`cargo btest` not applicable)
- [ ] PR pipeline validation green
- [ ] Copilot review requested and addressed
