### PR TITLE
Opt mssql-odbc into the workspace lint configuration

### DIFF
--- a/mssql-odbc/Cargo.toml
+++ b/mssql-odbc/Cargo.toml
@@ -8,6 +8,9 @@ publish = false
 name = "mssqlodbc"
 crate-type = ["cdylib"]
 
+[lints]
+workspace = true
+
 [dependencies]
 mssql-tds = { path = "../mssql-tds" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync"] }


### PR DESCRIPTION
## Description

`mssql-odbc` was the only workspace member without a `[lints]` section, so it inherited none of the workspace lint configuration. This adds the two lines that opt it in:

```toml
[lints]
workspace = true
```

**Why it was missing.** The crate predates the lint setup. `523cf5f7` (2026-04-30) added `[workspace.lints]` and opted in the four members that existed at the time; `mssql-odbc` arrived later, on 2026-07-08 via `5d375afc`, as an import from a separate codebase. `git log -S'[lints]' -- mssql-odbc/Cargo.toml` returns nothing — the section was never there.

`[workspace.lints]` is a *definition* table, not an *application* table. Members inherit only via an explicit `[lints] workspace = true`, the same opt-in pattern as `[workspace.dependencies]`.

**What it was exempt from.** `unexpected_cfgs`, plus the three currently-active clippy lints — `await_holding_lock`, `await_holding_refcell_ref` and `large_futures`. Those are the async-correctness rules (deadlock and oversized-future detection), and `mssql-odbc` is a heavily async crate that boxes future state deliberately, so it is an unfortunate one to have exempt.

**Why it went unnoticed.** `cargo clippy -p mssqlodbc` still emits plenty of warnings, but they all originate in `mssql-tds` as a path dependency. A raw warning count looks healthy and hides the gap completely — attributing warnings by file path via `--message-format=json` is what surfaces it.

## Verification

Confirmed the lints now actually reach the crate, by inspecting the rustc invocation (`cargo clippy -p mssqlodbc -v`):

```
--warn=clippy::await_holding_lock
--warn=clippy::await_holding_refcell_ref
--warn=clippy::large_futures
--warn=unexpected_cfgs
```

None of these were passed before this change. **Zero new warnings result**, so this is purely closing the gap rather than a behaviour change — no source files are touched.

## Follow-up, deliberately not in this PR

The other 35 lints in `[workspace.lints.clippy]` remain commented out workspace-wide. For sizing, `mssql-odbc` alone would emit **682** warnings in production code (`--lib`) and **3,351** including tests if all 38 were switched on. `undocumented_unsafe_blocks` (1,786) and `unwrap_used` (999) are 83% of that, and every `unwrap_used` hit is in test code. Those numbers are recorded in #475 so the staged lints can be adopted per-lint rather than all at once.

## Related Issues

Fixes #475

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes — 3,116/3,120 unit tests pass, all `mssqlodbc` tests green. The 4 failures are the pre-existing `certificate_validator` fixture tests (they need `mssql-tds/tests/test_certificates/generate_certs.sh`); integration suites need a `.env` with a live server. Both are environmental and fail identically on `main`.
- [x] New/changed functionality has tests — n/a, build configuration only
- [x] Public API changes are documented — n/a, no API change
