### PR TITLE
Require an invocation before a review claims a capability is unavailable

### DIFF
--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -95,21 +95,22 @@ you happen to be reviewing. Skill maintenance is not that author's problem.
      `$BASE` and compare failure sets; only the difference belongs in the review.
    - **Is this coverage gap real?** Introduce the bug the missing test would catch and
      show the suite still passes.
-   - **Does the platform-gated half still compile?** `cargo check` / `cargo clippy
-     --target <triple>` type-checks `#[cfg(windows)]` and `#[cfg(target_os = ...)]`
-     code without needing a matching host, because neither links (`rustup target add
-     aarch64-pc-windows-msvc`; ~30 s warm for `-p mssqlodbc --lib`). It cannot run a
-     Windows test binary, so runtime behaviour there still rests on the CI matrix —
-     but "my host is Linux, so the matrix owns this" is the wrong default when
-     reviewing platform-gated code, and a mutation applied to an arm your host does
-     not select proves nothing on its own. A failure here can still come from a
-     dependency's build script rather than the reviewed code: targeting a Linux
-     triple pulls `openssl-sys` in through `native-tls`, and its build script fails
-     before rustc ever sees the crate if it can't find a target OpenSSL sysroot —
-     confirmed on `mssql-odbc`, where the Windows-target direction above needs no
-     OpenSSL at all (`native-tls` routes through Schannel on Windows, Security.framework
-     on macOS — only Linux targets hit the sysroot lookup). That is an environment gap,
-     not a type error; read what actually failed before attributing it to the diff.
+   - **Does the platform-gated half still compile?** `cargo check --target <triple>` /
+     `cargo clippy --target <triple>` type-checks `#[cfg(windows)]` and
+     `#[cfg(target_os = ...)]` code without needing a matching host, because neither
+     links (`rustup target add aarch64-pc-windows-msvc`; ~30 s warm for
+     `-p mssqlodbc --lib`). It cannot run a Windows test binary, so runtime behaviour
+     there still rests on the CI matrix — but "my host is Linux, so the matrix owns
+     this" is the wrong default when reviewing platform-gated code, and a mutation
+     applied to an arm your host does not select proves nothing on its own. A failure
+     here can still come from a dependency's build script rather than the reviewed
+     code: targeting a Linux triple pulls `openssl-sys` in through `native-tls`, and
+     its build script fails before rustc ever sees the crate if it can't find a target
+     OpenSSL sysroot — confirmed on `mssql-odbc`, where the Windows-target direction
+     above needs no OpenSSL at all (`native-tls` routes through Schannel on Windows,
+     Security.framework on macOS — only Linux targets hit the sysroot lookup). That is
+     an environment gap, not a type error; read what actually failed before
+     attributing it to the diff.
 
    ```bash
    cargo nextest run -p <affected-crate> --lib --no-fail-fast   # or `cargo btest`

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -22,8 +22,8 @@ you happen to be reviewing. Skill maintenance is not that author's problem.
    is worth it when you can: it catches a PR that drifts from what its work item
    asked, or one still open against a closed item. Attempt the lookup before treating
    it as out of reach — on an already-authenticated host, the Azure DevOps MCP server
-   answers `wit_work_item` without an interactive prompt. See step 6 for what to do
-   when a call actually fails, and for unattended runs.
+   answers `wit_work_item` without an interactive prompt (verified 2026-09-02). See
+   step 6 for what to do when a call actually fails, and for unattended runs.
 2. **Check the PR out locally.** A diff alone is not enough to review this codebase —
    most defects here turn on unchanged code (the other implementer of a trait, the
    caller three layers up, the `#[cfg]` variant of a constant). Use a dedicated
@@ -385,11 +385,11 @@ than `gh pr review`, diff-hunk anchoring, `--paginate` when verifying — are in
   "I could not check X" only after invoking the thing and recording what happened —
   quote the response when one comes back, or state that none did (a timeout after a
   bounded wait, a hard error) when it doesn't; a silent hang is itself an outcome, not
-  an excuse to skip the record. Three of the four caveats closing one recent review —
-  no ADO access, no Windows host, Linux-only mutation scope — did not survive being
-  tested. Keep two categories apart: *the environment cannot do this* needs a failed
-  invocation, while *the defect is inherently untestable* (process teardown, a TOCTOU
-  window) needs only an argument and stays valid.
+  an excuse to skip the record. Three of the four caveats closing one review
+  (2026-09-02, AB#47807) — no ADO access, no Windows host, Linux-only mutation scope —
+  did not survive being tested. Keep two categories apart: *the environment cannot do
+  this* needs a failed invocation, while *the defect is inherently untestable* (process
+  teardown, a TOCTOU window) needs only an argument and stays valid.
 - If a change is correct, don't invent problems. An empty severity group means "none
   found" — say so briefly.
 - Reviewing is not merging. The PR author owns the merge — never merge someone

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -21,9 +21,9 @@ you happen to be reviewing. Skill maintenance is not that author's problem.
    Azure DevOps work item — flag a PR that has neither. Resolving an `AB#` reference
    is worth it when you can: it catches a PR that drifts from what its work item
    asked, or one still open against a closed item. Attempt the lookup before treating
-   it as out of reach — the Azure DevOps MCP server answers `wit_work_item` without
-   an interactive prompt. See step 6 for what to do when a call actually fails, and
-   for unattended runs.
+   it as out of reach — on an already-authenticated host, the Azure DevOps MCP server
+   answers `wit_work_item` without an interactive prompt. See step 6 for what to do
+   when a call actually fails, and for unattended runs.
 2. **Check the PR out locally.** A diff alone is not enough to review this codebase —
    most defects here turn on unchanged code (the other implementer of a trait, the
    caller three layers up, the `#[cfg]` variant of a constant). Use a dedicated
@@ -96,12 +96,19 @@ you happen to be reviewing. Skill maintenance is not that author's problem.
      show the suite still passes.
    - **Does the platform-gated half still compile?** `cargo check` / `cargo clippy
      --target <triple>` type-checks `#[cfg(windows)]` and `#[cfg(target_os = ...)]`
-     code from any host, because neither links (`rustup target add
+     code without needing a matching host, because neither links (`rustup target add
      aarch64-pc-windows-msvc`; ~30 s warm for `-p mssqlodbc --lib`). It cannot run a
      Windows test binary, so runtime behaviour there still rests on the CI matrix —
      but "my host is Linux, so the matrix owns this" is the wrong default when
      reviewing platform-gated code, and a mutation applied to an arm your host does
-     not select proves nothing on its own.
+     not select proves nothing on its own. A failure here can still come from a
+     dependency's build script rather than the reviewed code: targeting a non-Windows
+     triple pulls `openssl-sys` in through `native-tls`, and its build script fails
+     before rustc ever sees the crate if it can't find a target OpenSSL sysroot —
+     confirmed on `mssql-odbc`, where the Windows-target direction above needs no
+     OpenSSL at all (`native-tls` routes through Schannel there). That is an
+     environment gap, not a type error; read what actually failed before attributing
+     it to the diff.
 
    ```bash
    cargo nextest run -p <affected-crate> --lib --no-fail-fast   # or `cargo btest`
@@ -375,12 +382,14 @@ than `gh pr review`, diff-hunk anchoring, `--paginate` when verifying — are in
 - Distinguish facts (verified in code) from concerns (worth checking). Don't state
   guesses as defects. Say what you ran and what you read.
 - **An unavailability is a claim, and it carries the same burden as a defect.** Write
-  "I could not check X" only after invoking the thing and quoting what came back.
-  Three of the four caveats closing one recent review — no ADO access, no Windows
-  host, Linux-only mutation scope — did not survive being tested. Keep two categories
-  apart: *the environment cannot do this* needs a failed invocation, while *the defect
-  is inherently untestable* (process teardown, a TOCTOU window) needs only an argument
-  and stays valid.
+  "I could not check X" only after invoking the thing and recording what happened —
+  quote the response when one comes back, or state that none did (a timeout after a
+  bounded wait, a hard error) when it doesn't; a silent hang is itself an outcome, not
+  an excuse to skip the record. Three of the four caveats closing one recent review —
+  no ADO access, no Windows host, Linux-only mutation scope — did not survive being
+  tested. Keep two categories apart: *the environment cannot do this* needs a failed
+  invocation, while *the defect is inherently untestable* (process teardown, a TOCTOU
+  window) needs only an argument and stays valid.
 - If a change is correct, don't invent problems. An empty severity group means "none
   found" — say so briefly.
 - Reviewing is not merging. The PR author owns the merge — never merge someone

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -20,8 +20,10 @@ you happen to be reviewing. Skill maintenance is not that author's problem.
    missing or doesn't match the diff. This repo requires a linked GitHub issue or
    Azure DevOps work item — flag a PR that has neither. Resolving an `AB#` reference
    is worth it when you can: it catches a PR that drifts from what its work item
-   asked, or one still open against a closed item. See step 6 for handling ADO in an
-   unattended run.
+   asked, or one still open against a closed item. Attempt the lookup before treating
+   it as out of reach — the Azure DevOps MCP server answers `wit_work_item` without
+   an interactive prompt. See step 6 for what to do when a call actually fails, and
+   for unattended runs.
 2. **Check the PR out locally.** A diff alone is not enough to review this codebase —
    most defects here turn on unchanged code (the other implementer of a trait, the
    caller three layers up, the `#[cfg]` variant of a constant). Use a dedicated
@@ -92,6 +94,14 @@ you happen to be reviewing. Skill maintenance is not that author's problem.
      `$BASE` and compare failure sets; only the difference belongs in the review.
    - **Is this coverage gap real?** Introduce the bug the missing test would catch and
      show the suite still passes.
+   - **Does the platform-gated half still compile?** `cargo check` / `cargo clippy
+     --target <triple>` type-checks `#[cfg(windows)]` and `#[cfg(target_os = ...)]`
+     code from any host, because neither links (`rustup target add
+     aarch64-pc-windows-msvc`; ~30 s warm for `-p mssqlodbc --lib`). It cannot run a
+     Windows test binary, so runtime behaviour there still rests on the CI matrix —
+     but "my host is Linux, so the matrix owns this" is the wrong default when
+     reviewing platform-gated code, and a mutation applied to an arm your host does
+     not select proves nothing on its own.
 
    ```bash
    cargo nextest run -p <affected-crate> --lib --no-fail-fast   # or `cargo btest`
@@ -120,18 +130,28 @@ you happen to be reviewing. Skill maintenance is not that author's problem.
    - notes in the body that it came from an unattended run, so the author knows the
      findings were not checked by a human first.
    - never merges, and never resolves a thread it did not open.
-   - treats every interactive authentication path as unavailable, and prefers a tool
-     that fails loudly over one that waits politely. The Azure DevOps MCP server is the
-     known trap: its OAuth flow blocks on a browser nobody will open, and the run keeps
-     reporting itself as healthy while it hangs. Use whatever non-interactive ADO access
-     you have instead, bound it with a timeout, and mark ADO unavailable for the rest of
-     the run on the first failure rather than retrying per PR.
+   - treats every *interactive* authentication path as unavailable, and prefers a tool
+     that fails loudly over one that waits politely. The hazard belongs to the context
+     rather than to any one server: a flow that would open a browser has nobody to
+     answer it, and the run can keep reporting itself as healthy while it hangs. Bound
+     each such call with a timeout, and on a real failure mark that dependency
+     unavailable for the rest of the run instead of retrying per PR.
 
-   **Fail open.** ADO is context, not a gate: it confirms a PR does what its work item
-   asked. When it is unreachable, take an `AB#<number>` at face value as satisfying the
-   linked-work-item requirement in step 1 and review normally. Report the skipped
-   cross-check in the run log, not in the PR — a reviewer's infrastructure trouble is
-   not the author's problem.
+     This does **not** describe the Azure DevOps MCP server in ordinary use. It answers
+     `wit_work_item` and `wit_query` non-interactively on an already-authenticated
+     host — verified 2026-09-02, an `action: get` on a work item returned immediately
+     with no prompt and no hang. Earlier revisions of this file named it as a known
+     trap; that has since been read as a standing fact about the tool and has cost
+     real cross-checks. Call it, then decide.
+
+   **Fail open — after a failed call, not instead of one.** ADO is context, not a
+   gate: it confirms a PR does what its work item asked. When a lookup *actually*
+   fails, take an `AB#<number>` at face value as satisfying the linked-work-item
+   requirement in step 1, review normally, and report the skipped cross-check in the
+   run log rather than in the PR — a reviewer's infrastructure trouble is not the
+   author's problem. Reaching for this paragraph without having attempted the lookup
+   is the failure mode it exists to bound, and it silently drops the one check that
+   catches a PR drifting from what its work item asked.
 7. Ground yourself in reference code and public/private documentation/specifications.
    If you don't know the codebase, or which references to use, ask for context before
    reviewing.
@@ -354,6 +374,13 @@ than `gh pr review`, diff-hunk anchoring, `--paginate` when verifying — are in
   that contradiction *is* the finding.
 - Distinguish facts (verified in code) from concerns (worth checking). Don't state
   guesses as defects. Say what you ran and what you read.
+- **An unavailability is a claim, and it carries the same burden as a defect.** Write
+  "I could not check X" only after invoking the thing and quoting what came back.
+  Three of the four caveats closing one recent review — no ADO access, no Windows
+  host, Linux-only mutation scope — did not survive being tested. Keep two categories
+  apart: *the environment cannot do this* needs a failed invocation, while *the defect
+  is inherently untestable* (process teardown, a TOCTOU window) needs only an argument
+  and stays valid.
 - If a change is correct, don't invent problems. An empty severity group means "none
   found" — say so briefly.
 - Reviewing is not merging. The PR author owns the merge — never merge someone

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -111,18 +111,19 @@ you happen to be reviewing. Skill maintenance is not that author's problem.
      Either way, confirm the specific CI job for that platform actually ran and passed
      on the PR's head commit rather than assuming "the matrix owns this" without
      looking; a local check only adds a faster answer to the same question CI already
-     gates. Neither approach can run a Windows test binary, and a mutation applied to
-     an arm your invocation doesn't select — the wrong target, or `--lib` over
-     `--all-targets` — proves nothing on its own; that still rests on CI. A local
-     check can also fail in a dependency's build script rather than the reviewed
-     code: targeting a non-Windows, non-macOS triple pulls in `openssl-sys` — through
-     `native-tls`'s backend choice and, in `mssql-tds`, through a direct `openssl`
-     dependency for the Always Encrypted primitives — and its build script fails
-     before rustc ever sees the crate if it can't find a target OpenSSL sysroot.
-     Confirmed on `mssql-tds`: the Windows-target direction above needs none at all
-     (`native-tls` routes through Schannel on Windows, Security.framework on macOS).
-     That is an environment gap, not a type error; read what actually failed before
-     attributing it to the diff.
+     gates, since neither `cargo check` nor `cargo clippy` executes a compiled test
+     binary — only CI's Windows job actually runs the `#[cfg(windows)]` tests. A
+     mutation applied to an arm your invocation doesn't select — the wrong target, or
+     `--lib` over `--all-targets` — proves nothing on its own. A local check can also
+     fail in a dependency's build script rather than the reviewed code: targeting a
+     non-Windows, non-macOS triple pulls in `openssl-sys` — through `native-tls`'s
+     backend choice and, in `mssql-tds`, through a direct `openssl` dependency for the
+     Always Encrypted primitives — and its build script fails before rustc ever sees
+     the crate if it can't find a target OpenSSL sysroot. Confirmed on `mssql-tds`:
+     the Windows-target direction above needs none at all (`native-tls` routes
+     through Schannel on Windows, Security.framework on macOS). That is an
+     environment gap, not a type error; read what actually failed before attributing
+     it to the diff.
 
    ```bash
    cargo nextest run -p <affected-crate> --lib --no-fail-fast   # or `cargo btest`

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -99,21 +99,29 @@ you happen to be reviewing. Skill maintenance is not that author's problem.
      available, `cargo check --target <triple>` / `cargo clippy --target <triple>`
      type-checks `#[cfg(windows)]` and `#[cfg(target_os = ...)]` code without a
      matching host, because neither links (`rustup target add
-     aarch64-pc-windows-msvc`; ~30 s warm for `-p mssqlodbc --lib`). This is a
-     convenience, not a requirement — installing a target and building locally isn't
-     something every reviewer wants or needs to do. Either way, confirm the specific
-     CI job for that platform actually ran and passed on the PR's head commit rather
-     than assuming "the matrix owns this" without looking; a local check only adds a
-     faster answer to the same question CI already gates. Neither approach can run a
-     Windows test binary, and a mutation applied to an arm your host does not select
-     proves nothing on its own — that still rests on CI. A local check can also fail
-     in a dependency's build script rather than the reviewed code: targeting a Linux
-     triple pulls `openssl-sys` in through `native-tls`, and its build script fails
-     before rustc ever sees the crate if it can't find a target OpenSSL sysroot —
-     confirmed on `mssql-odbc`, where the Windows-target direction above needs no
-     OpenSSL at all (`native-tls` routes through Schannel on Windows,
-     Security.framework on macOS — only Linux targets hit the sysroot lookup). That is
-     an environment gap, not a type error; read what actually failed before
+     aarch64-pc-windows-msvc`; ~26 s warm for `-p mssql-tds --all-targets`). Use
+     `--all-targets`, not `--lib`: most of this repo's platform-gated code lives
+     inside inline `#[cfg(test)] mod tests` blocks, which `--lib` compiles without the
+     `test` cfg and so skips silently, `--target` notwithstanding — confirmed by
+     mutating a `#[cfg(windows)]` test in `datasource_parser.rs`, which `--lib` missed
+     and `--all-targets` caught. `mssql-tds` is also the crate to reach for here, not
+     `mssql-odbc`: it carries roughly 120 `cfg(windows)`/`cfg(target_os)` sites against
+     `mssql-odbc`'s ~18. This is a convenience, not a requirement — installing a
+     target and building locally isn't something every reviewer wants or needs to do.
+     Either way, confirm the specific CI job for that platform actually ran and passed
+     on the PR's head commit rather than assuming "the matrix owns this" without
+     looking; a local check only adds a faster answer to the same question CI already
+     gates. Neither approach can run a Windows test binary, and a mutation applied to
+     an arm your invocation doesn't select — the wrong target, or `--lib` over
+     `--all-targets` — proves nothing on its own; that still rests on CI. A local
+     check can also fail in a dependency's build script rather than the reviewed
+     code: targeting a non-Windows, non-macOS triple pulls in `openssl-sys` — through
+     `native-tls`'s backend choice and, in `mssql-tds`, through a direct `openssl`
+     dependency for the Always Encrypted primitives — and its build script fails
+     before rustc ever sees the crate if it can't find a target OpenSSL sysroot.
+     Confirmed on `mssql-tds`: the Windows-target direction above needs none at all
+     (`native-tls` routes through Schannel on Windows, Security.framework on macOS).
+     That is an environment gap, not a type error; read what actually failed before
      attributing it to the diff.
 
    ```bash
@@ -393,10 +401,10 @@ than `gh pr review`, diff-hunk anchoring, `--paginate` when verifying — are in
   response when one comes back, state that none did (a timeout after a bounded wait, a
   hard error) when it doesn't, or say the tool isn't exposed in this session's
   inventory at all when there was nothing to call — a silent hang or a missing tool is
-  an outcome, not an excuse to skip the record. Three of the four caveats closing one
-  review (2026-09-02, AB#47807) — no ADO access, type-checking Windows-gated code
-  without a Windows host, Linux-only mutation scope — did not survive being tested;
-  running a Windows test binary did. Keep two categories apart: *the environment
+  an outcome, not an excuse to skip the record. Three of the four caveats closing a
+  2026-09-02 review of #459 (AB#47509) — no ADO access, type-checking Windows-gated
+  code without a Windows host, Linux-only mutation scope — did not survive being
+  tested; running a Windows test binary did. Keep two categories apart: *the environment
   cannot do this* needs a failed invocation or a confirmed absence, while *the defect
   is inherently untestable* (process teardown, a TOCTOU window) needs only an argument
   and stays valid.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -95,19 +95,23 @@ you happen to be reviewing. Skill maintenance is not that author's problem.
      `$BASE` and compare failure sets; only the difference belongs in the review.
    - **Is this coverage gap real?** Introduce the bug the missing test would catch and
      show the suite still passes.
-   - **Does the platform-gated half still compile?** `cargo check --target <triple>` /
-     `cargo clippy --target <triple>` type-checks `#[cfg(windows)]` and
-     `#[cfg(target_os = ...)]` code without needing a matching host, because neither
-     links (`rustup target add aarch64-pc-windows-msvc`; ~30 s warm for
-     `-p mssqlodbc --lib`). It cannot run a Windows test binary, so runtime behaviour
-     there still rests on the CI matrix — but "my host is Linux, so the matrix owns
-     this" is the wrong default when reviewing platform-gated code, and a mutation
-     applied to an arm your host does not select proves nothing on its own. A failure
-     here can still come from a dependency's build script rather than the reviewed
-     code: targeting a Linux triple pulls `openssl-sys` in through `native-tls`, and
-     its build script fails before rustc ever sees the crate if it can't find a target
-     OpenSSL sysroot — confirmed on `mssql-odbc`, where the Windows-target direction
-     above needs no OpenSSL at all (`native-tls` routes through Schannel on Windows,
+   - **Does the platform-gated half still compile?** Where the toolchain is already
+     available, `cargo check --target <triple>` / `cargo clippy --target <triple>`
+     type-checks `#[cfg(windows)]` and `#[cfg(target_os = ...)]` code without a
+     matching host, because neither links (`rustup target add
+     aarch64-pc-windows-msvc`; ~30 s warm for `-p mssqlodbc --lib`). This is a
+     convenience, not a requirement — installing a target and building locally isn't
+     something every reviewer wants or needs to do. Either way, confirm the specific
+     CI job for that platform actually ran and passed on the PR's head commit rather
+     than assuming "the matrix owns this" without looking; a local check only adds a
+     faster answer to the same question CI already gates. Neither approach can run a
+     Windows test binary, and a mutation applied to an arm your host does not select
+     proves nothing on its own — that still rests on CI. A local check can also fail
+     in a dependency's build script rather than the reviewed code: targeting a Linux
+     triple pulls `openssl-sys` in through `native-tls`, and its build script fails
+     before rustc ever sees the crate if it can't find a target OpenSSL sysroot —
+     confirmed on `mssql-odbc`, where the Windows-target direction above needs no
+     OpenSSL at all (`native-tls` routes through Schannel on Windows,
      Security.framework on macOS — only Linux targets hit the sysroot lookup). That is
      an environment gap, not a type error; read what actually failed before
      attributing it to the diff.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -23,7 +23,8 @@ you happen to be reviewing. Skill maintenance is not that author's problem.
    asked, or one still open against a closed item. Attempt the lookup before treating
    it as out of reach — on an already-authenticated host, the Azure DevOps MCP server
    answers `wit_work_item` without an interactive prompt (verified 2026-09-02). See
-   step 6 for what to do when a call actually fails, and for unattended runs.
+   step 6 for what to do when a call actually fails or isn't exposed in this session
+   at all, and for unattended runs.
 2. **Check the PR out locally.** A diff alone is not enough to review this codebase —
    most defects here turn on unchanged code (the other implementer of a trait, the
    caller three layers up, the `#[cfg]` variant of a constant). Use a dedicated
@@ -102,13 +103,13 @@ you happen to be reviewing. Skill maintenance is not that author's problem.
      but "my host is Linux, so the matrix owns this" is the wrong default when
      reviewing platform-gated code, and a mutation applied to an arm your host does
      not select proves nothing on its own. A failure here can still come from a
-     dependency's build script rather than the reviewed code: targeting a non-Windows
+     dependency's build script rather than the reviewed code: targeting a Linux
      triple pulls `openssl-sys` in through `native-tls`, and its build script fails
      before rustc ever sees the crate if it can't find a target OpenSSL sysroot —
      confirmed on `mssql-odbc`, where the Windows-target direction above needs no
-     OpenSSL at all (`native-tls` routes through Schannel there). That is an
-     environment gap, not a type error; read what actually failed before attributing
-     it to the diff.
+     OpenSSL at all (`native-tls` routes through Schannel on Windows, Security.framework
+     on macOS — only Linux targets hit the sysroot lookup). That is an environment gap,
+     not a type error; read what actually failed before attributing it to the diff.
 
    ```bash
    cargo nextest run -p <affected-crate> --lib --no-fail-fast   # or `cargo btest`
@@ -145,20 +146,21 @@ you happen to be reviewing. Skill maintenance is not that author's problem.
      unavailable for the rest of the run instead of retrying per PR.
 
      This does **not** describe the Azure DevOps MCP server in ordinary use. It answers
-     `wit_work_item` and `wit_query` non-interactively on an already-authenticated
-     host — verified 2026-09-02, an `action: get` on a work item returned immediately
-     with no prompt and no hang. Earlier revisions of this file named it as a known
-     trap; that has since been read as a standing fact about the tool and has cost
-     real cross-checks. Call it, then decide.
+     `wit_work_item` non-interactively on an already-authenticated host — verified
+     2026-09-02, an `action: get` on a work item returned immediately with no prompt
+     and no hang (`wit_query` hasn't been invoked, so it isn't claimed here). Earlier
+     revisions of this file named it as a known trap; that has since been read as a
+     standing fact about the tool and has cost real cross-checks. Call it, then decide.
 
    **Fail open — after a failed call, not instead of one.** ADO is context, not a
    gate: it confirms a PR does what its work item asked. When a lookup *actually*
-   fails, take an `AB#<number>` at face value as satisfying the linked-work-item
-   requirement in step 1, review normally, and report the skipped cross-check in the
-   run log rather than in the PR — a reviewer's infrastructure trouble is not the
-   author's problem. Reaching for this paragraph without having attempted the lookup
-   is the failure mode it exists to bound, and it silently drops the one check that
-   catches a PR drifting from what its work item asked.
+   fails, or the tool isn't exposed in this session's inventory at all so there is
+   nothing to call, take an `AB#<number>` at face value as satisfying the
+   linked-work-item requirement in step 1, review normally, and report the skipped
+   cross-check in the run log rather than in the PR — a reviewer's infrastructure
+   trouble is not the author's problem. Reaching for this paragraph while the tool is
+   available but unattempted is the failure mode it exists to bound, and it silently
+   drops the one check that catches a PR drifting from what its work item asked.
 7. Ground yourself in reference code and public/private documentation/specifications.
    If you don't know the codebase, or which references to use, ask for context before
    reviewing.
@@ -382,14 +384,17 @@ than `gh pr review`, diff-hunk anchoring, `--paginate` when verifying — are in
 - Distinguish facts (verified in code) from concerns (worth checking). Don't state
   guesses as defects. Say what you ran and what you read.
 - **An unavailability is a claim, and it carries the same burden as a defect.** Write
-  "I could not check X" only after invoking the thing and recording what happened —
-  quote the response when one comes back, or state that none did (a timeout after a
-  bounded wait, a hard error) when it doesn't; a silent hang is itself an outcome, not
-  an excuse to skip the record. Three of the four caveats closing one review
-  (2026-09-02, AB#47807) — no ADO access, no Windows host, Linux-only mutation scope —
-  did not survive being tested. Keep two categories apart: *the environment cannot do
-  this* needs a failed invocation, while *the defect is inherently untestable* (process
-  teardown, a TOCTOU window) needs only an argument and stays valid.
+  "I could not check X" only after recording what happened when you tried: quote the
+  response when one comes back, state that none did (a timeout after a bounded wait, a
+  hard error) when it doesn't, or say the tool isn't exposed in this session's
+  inventory at all when there was nothing to call — a silent hang or a missing tool is
+  an outcome, not an excuse to skip the record. Three of the four caveats closing one
+  review (2026-09-02, AB#47807) — no ADO access, type-checking Windows-gated code
+  without a Windows host, Linux-only mutation scope — did not survive being tested;
+  running a Windows test binary did. Keep two categories apart: *the environment
+  cannot do this* needs a failed invocation or a confirmed absence, while *the defect
+  is inherently untestable* (process teardown, a TOCTOU window) needs only an argument
+  and stays valid.
 - If a change is correct, don't invent problems. An empty severity group means "none
   found" — say so briefly.
 - Reviewing is not merging. The PR author owns the merge — never merge someone

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -94,17 +94,18 @@ you happen to be reviewing. Skill maintenance is not that author's problem.
      `$BASE` and compare failure sets; only the difference belongs in the review.
    - **Is this coverage gap real?** Introduce the bug the missing test would catch and
      show the suite still passes.
-   - **Does the platform-gated half still compile?** `cargo check --target <triple>`
-     / `cargo clippy --target <triple> --all-targets` type-checks `#[cfg(windows)]`
-     and `#[cfg(target_os = ...)]` code from any host, since neither links. Use
-     `--all-targets`, not `--lib`: a substantial share of this repo's platform-gated
-     code — including platform-gated tests — lives inside inline `#[cfg(test)] mod
-     tests` blocks, which `--lib` skips silently (a different `--lib` than the
-     `nextest run --lib` below, which does run those tests). This is optional and
-     doesn't *run* anything either — still confirm the platform's CI job actually
-     passed on the head commit rather than assuming the matrix covers it. A
-     non-Windows/non-macOS triple also pulls in `openssl-sys`, whose build script can
-     fail without a target sysroot; that's an environment gap, not a finding.
+   - **Does the platform-gated half still compile?** `cargo check --target <triple>
+     --all-targets` / `cargo clippy --target <triple> --all-targets` type-checks
+     `#[cfg(windows)]` and `#[cfg(target_os = ...)]` code from any host, since
+     neither links. Use `--all-targets`, not `--lib`: a substantial share of this
+     repo's platform-gated code — including platform-gated tests — lives inside
+     inline `#[cfg(test)] mod tests` blocks, which `--lib` skips silently (a
+     different `--lib` than the `nextest run --lib` below, which does run those
+     tests). This is optional and doesn't *run* anything either — still confirm the
+     platform's CI job actually passed on the head commit rather than assuming the
+     matrix covers it. A non-Windows/non-macOS triple also pulls in `openssl-sys`,
+     whose build script can fail without a target sysroot; that's an environment
+     gap, not a finding.
 
    ```bash
    cargo nextest run -p <affected-crate> --lib --no-fail-fast   # or `cargo btest`

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -104,10 +104,13 @@ you happen to be reviewing. Skill maintenance is not that author's problem.
      inside inline `#[cfg(test)] mod tests` blocks, which `--lib` compiles without the
      `test` cfg and so skips silently, `--target` notwithstanding — confirmed by
      mutating a `#[cfg(windows)]` test in `datasource_parser.rs`, which `--lib` missed
-     and `--all-targets` caught. `mssql-tds` is also the crate to reach for here, not
-     `mssql-odbc`: it carries roughly 120 `cfg(windows)`/`cfg(target_os)` sites against
-     `mssql-odbc`'s ~18. This is a convenience, not a requirement — installing a
-     target and building locally isn't something every reviewer wants or needs to do.
+     and `--all-targets` caught. (This example measures `mssql-tds`, not `mssql-odbc`,
+     because it carries far more platform-gated surface to demonstrate against —
+     roughly 120 `cfg(windows)`/`cfg(target_os)` sites against `mssql-odbc`'s ~18 —
+     not because it's a crate to default to: check whichever crate the diff actually
+     touches, per the crate-selection rule below.) This is a convenience, not a
+     requirement — installing a target and building locally isn't something every
+     reviewer wants or needs to do.
      Either way, confirm the specific CI job for that platform actually ran and passed
      on the PR's head commit rather than assuming "the matrix owns this" without
      looking; a local check only adds a faster answer to the same question CI already

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -21,10 +21,9 @@ you happen to be reviewing. Skill maintenance is not that author's problem.
    Azure DevOps work item — flag a PR that has neither. Resolving an `AB#` reference
    is worth it when you can: it catches a PR that drifts from what its work item
    asked, or one still open against a closed item. Attempt the lookup before treating
-   it as out of reach — on an already-authenticated host, the Azure DevOps MCP server
-   answers `wit_work_item` without an interactive prompt (verified 2026-09-02). See
-   step 6 for what to do when a call actually fails or isn't exposed in this session
-   at all, and for unattended runs.
+   it as out of reach — see step 6 for what the Azure DevOps MCP server actually
+   does, what to do when a call fails or isn't exposed in this session at all, and
+   how unattended runs handle this differently.
 2. **Check the PR out locally.** A diff alone is not enough to review this codebase —
    most defects here turn on unchanged code (the other implementer of a trait, the
    caller three layers up, the `#[cfg]` variant of a constant). Use a dedicated
@@ -95,38 +94,17 @@ you happen to be reviewing. Skill maintenance is not that author's problem.
      `$BASE` and compare failure sets; only the difference belongs in the review.
    - **Is this coverage gap real?** Introduce the bug the missing test would catch and
      show the suite still passes.
-   - **Does the platform-gated half still compile?** Where the toolchain is already
-     available, `cargo check --target <triple>` / `cargo clippy --target <triple>`
-     type-checks `#[cfg(windows)]` and `#[cfg(target_os = ...)]` code without a
-     matching host, because neither links (`rustup target add
-     aarch64-pc-windows-msvc`; ~26 s warm for `-p mssql-tds --all-targets`). Use
-     `--all-targets`, not `--lib`: most of this repo's platform-gated code lives
-     inside inline `#[cfg(test)] mod tests` blocks, which `--lib` compiles without the
-     `test` cfg and so skips silently, `--target` notwithstanding — confirmed by
-     mutating a `#[cfg(windows)]` test in `datasource_parser.rs`, which `--lib` missed
-     and `--all-targets` caught. (This example measures `mssql-tds`, not `mssql-odbc`,
-     because it carries far more platform-gated surface to demonstrate against —
-     roughly 120 `cfg(windows)`/`cfg(target_os)` sites against `mssql-odbc`'s ~18 —
-     not because it's a crate to default to: check whichever crate the diff actually
-     touches, per the crate-selection rule below.) This is a convenience, not a
-     requirement — installing a target and building locally isn't something every
-     reviewer wants or needs to do.
-     Either way, confirm the specific CI job for that platform actually ran and passed
-     on the PR's head commit rather than assuming "the matrix owns this" without
-     looking; a local check only adds a faster answer to the same question CI already
-     gates, since neither `cargo check` nor `cargo clippy` executes a compiled test
-     binary — only CI's Windows job actually runs the `#[cfg(windows)]` tests. A
-     mutation applied to an arm your invocation doesn't select — the wrong target, or
-     `--lib` over `--all-targets` — proves nothing on its own. A local check can also
-     fail in a dependency's build script rather than the reviewed code: targeting a
-     non-Windows, non-macOS triple pulls in `openssl-sys` — through `native-tls`'s
-     backend choice and, in `mssql-tds`, through a direct `openssl` dependency for the
-     Always Encrypted primitives — and its build script fails before rustc ever sees
-     the crate if it can't find a target OpenSSL sysroot. Confirmed on `mssql-tds`:
-     the Windows-target direction above needs none at all (`native-tls` routes
-     through Schannel on Windows, Security.framework on macOS). That is an
-     environment gap, not a type error; read what actually failed before attributing
-     it to the diff.
+   - **Does the platform-gated half still compile?** `cargo check --target <triple>`
+     / `cargo clippy --target <triple> --all-targets` type-checks `#[cfg(windows)]`
+     and `#[cfg(target_os = ...)]` code from any host, since neither links. Use
+     `--all-targets`, not `--lib`: a substantial share of this repo's platform-gated
+     code — including platform-gated tests — lives inside inline `#[cfg(test)] mod
+     tests` blocks, which `--lib` skips silently (a different `--lib` than the
+     `nextest run --lib` below, which does run those tests). This is optional and
+     doesn't *run* anything either — still confirm the platform's CI job actually
+     passed on the head commit rather than assuming the matrix covers it. A
+     non-Windows/non-macOS triple also pulls in `openssl-sys`, whose build script can
+     fail without a target sysroot; that's an environment gap, not a finding.
 
    ```bash
    cargo nextest run -p <affected-crate> --lib --no-fail-fast   # or `cargo btest`
@@ -160,14 +138,10 @@ you happen to be reviewing. Skill maintenance is not that author's problem.
      rather than to any one server: a flow that would open a browser has nobody to
      answer it, and the run can keep reporting itself as healthy while it hangs. Bound
      each such call with a timeout, and on a real failure mark that dependency
-     unavailable for the rest of the run instead of retrying per PR.
-
-     This does **not** describe the Azure DevOps MCP server in ordinary use. It answers
-     `wit_work_item` non-interactively on an already-authenticated host — verified
-     2026-09-02, an `action: get` on a work item returned immediately with no prompt
-     and no hang (`wit_query` hasn't been invoked, so it isn't claimed here). Earlier
-     revisions of this file named it as a known trap; that has since been read as a
-     standing fact about the tool and has cost real cross-checks. Call it, then decide.
+     unavailable for the rest of the run instead of retrying per PR. This is not a
+     reason to skip the Azure DevOps MCP server: it answers `wit_work_item`
+     non-interactively on an already-authenticated host (verified 2026-09-02). Call
+     it, then decide.
 
    **Fail open — after a failed call, not instead of one.** ADO is context, not a
    gate: it confirms a PR does what its work item asked. When a lookup *actually*
@@ -175,9 +149,7 @@ you happen to be reviewing. Skill maintenance is not that author's problem.
    nothing to call, take an `AB#<number>` at face value as satisfying the
    linked-work-item requirement in step 1, review normally, and report the skipped
    cross-check in the run log rather than in the PR — a reviewer's infrastructure
-   trouble is not the author's problem. Reaching for this paragraph while the tool is
-   available but unattempted is the failure mode it exists to bound, and it silently
-   drops the one check that catches a PR drifting from what its work item asked.
+   trouble is not the author's problem.
 7. Ground yourself in reference code and public/private documentation/specifications.
    If you don't know the codebase, or which references to use, ask for context before
    reviewing.
@@ -401,18 +373,11 @@ than `gh pr review`, diff-hunk anchoring, `--paginate` when verifying — are in
 - Distinguish facts (verified in code) from concerns (worth checking). Don't state
   guesses as defects. Say what you ran and what you read.
 - **An unavailability is a claim, and it carries the same burden as a defect.** Write
-  "I could not check X" only after recording what happened when you tried: quote the
-  response when one comes back, state that none did (a timeout after a bounded wait, a
-  hard error) when it doesn't, or say the tool isn't exposed in this session's
-  inventory at all when there was nothing to call — a silent hang or a missing tool is
-  an outcome, not an excuse to skip the record. Two of the four caveats closing a
-  2026-09-02 review of #459 (AB#47509) — no ADO access, type-checking Windows-gated
-  code without a Windows host — did not survive being tested; Linux-only mutation
-  scope and running a Windows test binary both did, since neither invoking
-  `wit_work_item` nor cross-target `clippy` executes a test. Keep two categories
-  apart: *the environment cannot do this* needs a failed invocation or a confirmed
-  absence, while *the defect is inherently untestable* (process teardown, a TOCTOU
-  window) needs only an argument and stays valid.
+  "I could not check X" only after recording the attempt: the response, the timeout
+  after a bounded wait, or that the tool isn't in this session's inventory at all.
+  Keep two categories apart: *the environment cannot do this* needs a failed
+  invocation or a confirmed absence, while *the defect is inherently untestable*
+  (process teardown, a TOCTOU window) needs only an argument and stays valid.
 - If a change is correct, don't invent problems. An empty severity group means "none
   found" — say so briefly.
 - Reviewing is not merging. The PR author owns the merge — never merge someone

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -402,13 +402,14 @@ than `gh pr review`, diff-hunk anchoring, `--paginate` when verifying — are in
   response when one comes back, state that none did (a timeout after a bounded wait, a
   hard error) when it doesn't, or say the tool isn't exposed in this session's
   inventory at all when there was nothing to call — a silent hang or a missing tool is
-  an outcome, not an excuse to skip the record. Three of the four caveats closing a
+  an outcome, not an excuse to skip the record. Two of the four caveats closing a
   2026-09-02 review of #459 (AB#47509) — no ADO access, type-checking Windows-gated
-  code without a Windows host, Linux-only mutation scope — did not survive being
-  tested; running a Windows test binary did. Keep two categories apart: *the environment
-  cannot do this* needs a failed invocation or a confirmed absence, while *the defect
-  is inherently untestable* (process teardown, a TOCTOU window) needs only an argument
-  and stays valid.
+  code without a Windows host — did not survive being tested; Linux-only mutation
+  scope and running a Windows test binary both did, since neither invoking
+  `wit_work_item` nor cross-target `clippy` executes a test. Keep two categories
+  apart: *the environment cannot do this* needs a failed invocation or a confirmed
+  absence, while *the defect is inherently untestable* (process teardown, a TOCTOU
+  window) needs only an argument and stays valid.
 - If a change is correct, don't invent problems. An empty severity group means "none
   found" — say so briefly.
 - Reviewing is not merging. The PR author owns the merge — never merge someone


### PR DESCRIPTION
## Description

The code-review skill told attended reviews that Azure DevOps was unreachable, so they skipped the work-item cross-check without ever calling the tool. A recent review closed with *"ADO is not reachable non-interactively from this session; I took the work-item reference at face value per the skill's fail-open rule."* The reviewer followed the skill correctly — the instruction was defective.

This is a **scope leak, not a stale fact**, which matters because the fix differs. A stale fact gets corrected; a scope leak has to be re-scoped, or it returns the next time someone re-verifies the tool and edits the wrong sentence. Three defects compounded:

1. **The hazard was attributed to the tool, not the context.** The step 6 bullet sits under *"An unattended run still:"*, where treating interactive auth as unavailable is correct. But it read `The Azure DevOps MCP server is the known trap`, a standing claim about the server — so it travelled into attended sessions, where a human can answer any prompt.
2. **"Fail open" was never scoped.** It sits outside the unattended-run bullet list and reads as a general rule, with nothing bounding "unreachable" to a call that was attempted and failed.
3. **Step 1 imported both into every review.** Step 1 is universal and ended with `See step 6 for handling ADO in an unattended run`.

A fourth, independent issue: step 5 described cross-platform coverage as CI-only and never mentioned that `cargo check` / `cargo clippy --target` type-check `cfg`-gated code from any host without linking — making "my host is Linux, so the CI matrix owns Windows" the default.

### Verified 2026-09-02, by invocation

- Azure DevOps MCP `wit_work_item` (`action: get`) returned a work item **immediately** — no interactive prompt, no hang.
- `cargo clippy --target aarch64-pc-windows-msvc -p mssql-tds --all-targets` exits 0 in ~26 s and **does** compile the `cfg(windows)` paths — `--all-targets`, not `--lib`: confirmed by mutating a `#[cfg(windows)]` test in `datasource_parser.rs`, which `--lib` missed entirely and `--all-targets` caught.
- Running a Windows-target test binary genuinely *is* unavailable here (no MSVC linker), and cross-target `clippy` can't stand in for it — it type-checks, it never executes a test, so it says nothing about whether mutations can be run outside Linux either. Those are the two caveats of four that survived testing; only ADO access and type-checking Windows-gated code without a Windows host were actually disproven by invocation.

### What changed

| # | Location | Change |
|---|---|---|
| 1 | Step 1 | Attempt the lookup before treating it as out of reach |
| 2 | Step 6 bullet | Re-scoped to the *context*, not one server; records the non-interactive behaviour with date and evidence |
| 3 | Fail open | Retitled *"after a failed call, not instead of one"* |
| 4 | Step 5 | Cross-target type-checking for platform-gated code |
| 5 | Principles | *"An unavailability is a claim, and it carries the same burden as a defect"* |

Edit 5 is the one that generalises — the others fix ADO and Windows; that one covers the next capability nobody has probed.

The interactive-auth warning is **kept**, not deleted: it remains correct for pipeline runs, and removing it would trade one over-application for a real hang later. The "known trap" history is left visible so a reviewer who remembers the old wording can see the change was deliberate.

**Out of scope:** using the Windows SDK ODBC headers as the authority for symbol/type questions. Useful, but Windows-host-specific — it belongs in a personal agent, not a shared skill that macOS and Linux teammates read.

### Review corrections

Review found several issues in the initial version, all fixed on this head (see resolved threads and commit history for detail):

- A timeout/no-response failure couldn't satisfy the Principles bullet's "quote what came back" — recording the outcome is now the requirement, quoting only when a response exists (Copilot).
- Step 1's ADO claim and the Principles citation were undated, against the file's own preamble (David-Engel).
- `wit_query` was claimed verified alongside `wit_work_item`, but only the latter was actually invoked (Copilot).
- No outcome existed for "the tool isn't exposed in this session at all" — added, and mirrored into steps 1 and 6 (Copilot).
- `cargo check` was shown without `--target`, silently defeating the check it documents (Copilot).
- The local cross-target check read as a requirement; reframed as optional, with a CI-job-verification fallback (saurabh500).
- The exemplar used `-p mssqlodbc --lib`, which skips `#[cfg(test)]` entirely — most of this repo's platform-gated code lives in inline test modules, so the example never validated what it claimed to. Switched to `-p mssql-tds --all-targets`, the crate where the platform-gated surface actually is (shiwanigupta0809, Theekshna).
- The Principles bullet's "(2026-09-02, [AB#47807](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47807))" cited this PR's own work item instead of the review it described — the caveats are from a 2026-09-02 review of #459, tracked under [AB#47509](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47509) (Theekshna).
- The `openssl-sys` build-script caveat attributed the dependency solely to `native-tls` and scoped it to Linux; `mssql-tds` also pulls `openssl` directly for Always Encrypted, and the gate is non-Windows/non-macOS generally (David-Engel).
- "Neither approach can run a Windows test binary" sat next to a sentence about CI and read as if CI couldn't run Windows tests either — false, CI's Windows job runs them via `nextest`. Reworded to name `cargo check`/`cargo clippy` specifically (Copilot).
- The Principles bullet claimed cross-target `clippy` disproved "Linux-only mutation scope", but `clippy` only type-checks — it never executes a test, so it can't speak to mutation-test execution. That caveat survives alongside the Windows-test-binary one; only two of the four caveats were actually disproven by invocation (Copilot).

## Related Issues

https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47807

[AB#47807](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47807)

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [ ] `cargo btest` passes — see note
- [ ] New/changed functionality has tests — n/a, documentation only
- [ ] Public API changes are documented — n/a, no API change

**Note on `cargo btest`:** it fails on this workstation, and it fails **identically on `origin/main`**. I ran the same invocation on a clean `origin/main` worktree: `mssql-tds --test transaction` reports `16 tests run: 0 passed, 16 failed` on both. The failures are the transaction, connectivity and bench suites, all of which need a live SQL Server that is not configured here. This branch changes exactly one file — `.github/skills/code-review/SKILL.md` — and no Rust, build script or manifest, so it cannot affect them. CI is the authority on that box.

Coverage: `pr-code-coverage.yml`'s `paths-ignore` covers `.github/**`, so no Code Coverage Report comment is expected on this PR.