### PR TITLE
Stop PR comments and /coverage runs cancelling in-flight coverage reports

### DIFF
--- a/.github/workflows/pr-code-coverage.yml
+++ b/.github/workflows/pr-code-coverage.yml
@@ -45,8 +45,33 @@ on:
 # Each job opts into only the scopes it needs.
 permissions: {}
 
+# Concurrency is resolved at run creation, before the job `if:` is evaluated, so
+# a run that will skip (an ordinary PR comment) would otherwise cancel the real
+# in-flight run and leave a red, misleading check behind. Two things keep runs
+# apart:
+#
+#   1. Runs that the `coverage-report` job will skip get a unique
+#      `-noop-<run_id>` suffix, so they share a group with nothing and cancel
+#      nothing. The predicate mirrors the job `if:` below — keep them in sync.
+#   2. The event name is part of the group, so the automatic `pull_request` path
+#      and the manual `/coverage` path never cancel each other. Both are "real"
+#      runs, but only the `pull_request` run's check is attached to the PR head
+#      SHA; letting a `/coverage` run cancel it would re-create the same red
+#      check this guard exists to prevent — precisely when someone is manually
+#      recovering a report.
+#
+# Within each path `cancel-in-progress` still applies, so a new push supersedes
+# a stale wait and a second `/coverage` supersedes the first.
 concurrency:
-  group: pr-coverage-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: >-
+    pr-coverage-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}${{
+    !((github.event_name == 'pull_request' &&
+    github.event.pull_request.head.repo.full_name == github.repository) ||
+    (github.event_name == 'issue_comment' &&
+    github.event.issue.pull_request != null &&
+    startsWith(github.event.comment.body, '/coverage') &&
+    contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)))
+    && format('-noop-{0}', github.run_id) || '' }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
## Description

Commenting on a PR cancels that PR's in-flight code coverage run and leaves a red `coverage-report` check that reads as a coverage regression.

`concurrency` is resolved at **run creation**, before the job-level `if:` is evaluated. So an ordinary review comment starts an `issue_comment` run, that run joins the shared `pr-coverage-<n>` group, `cancel-in-progress` kills the real `pull_request` run mid-wait, and only then does the job evaluate its `if:` and skip. The canceller contributes nothing and destroys the run that was doing the work. Because the artifact wait is up to 1h15m and review rounds consist of posting comments, essentially any PR under active review loses its coverage report.

This splits the group two ways:

1. **Runs the job will skip get a unique `-noop-<run_id>` suffix**, so they share a group with nothing and cancel nothing. The predicate mirrors the full job `if:`, so forked-PR events and non-maintainer comments are covered too, not just the `/coverage` prefix.
2. **The event name joins the group key**, so the automatic `pull_request` path and the manual `/coverage` path cannot pre-empt each other.

Point 2 is worth spelling out, because it is the part that is easy to miss. `/coverage` comments and ordinary comments are *both* `issue_comment` events, and a `/coverage` run is a "real" run — so a no-op shunt alone still leaves it sharing a group with an in-flight `pull_request` run. Only the `pull_request` run's check is attached to the PR head SHA, so letting `/coverage` cancel it re-creates the same red check this guard exists to prevent, at exactly the moment someone is manually recovering the report.

Within each path `cancel-in-progress` still applies: a new push supersedes a stale wait, and a second `/coverage` supersedes the first.

## Relationship to #300

**#300 and this PR are alternatives — only one should land.** #300 (draft, opened 2026-08-15) implements point 1, and its no-op predicate is the basis for the one here. This PR adds point 2, which #300 leaves open:

| Scenario | #300 | This PR |
| --- | --- | --- |
| Ordinary comment cancels in-flight `pull_request` run | fixed | fixed |
| Forked-PR / non-maintainer no-op cancels a real run | fixed | fixed |
| **`/coverage` cancels in-flight `pull_request` run** | **still occurs** | fixed |
| New push supersedes a stale `pull_request` run | preserved | preserved |
| Second `/coverage` supersedes the first | preserved | preserved |

Happy for the maintainers to instead take #300 and add the event key there, if keeping that PR's history is preferable.

## Related Issues

Fixes #279

Consolidated #266 and #465 into #279 as duplicates; all three reported this same bug.

## Testing

No Rust code is touched, so the `cargo` checks are not applicable. Verified three ways:

**1. YAML parses and the folded scalar collapses to a single line** (a stray newline in a group key would be a silent behaviour change):

```
PARSE OK
cancel-in-progress: True
has newline: False
```

**2. `Analyze (actions)` passes** on this PR, which is CodeQL's workflow analysis over the changed file.

**3. Simulated GitHub's expression semantics** (`a && b` -> `a` if falsy else `b`; `a || b` -> `a` if truthy else `b`) over every trigger path:

| Scenario | Job runs? | Resulting group |
| --- | --- | --- |
| push to same-repo PR | yes | `pr-coverage-464-pull_request` |
| push to same-repo PR (again) | yes | `pr-coverage-464-pull_request` |
| push to forked PR | no | `pr-coverage-464-pull_request-noop-3` |
| ordinary review comment | no | `pr-coverage-464-issue_comment-noop-4` |
| another ordinary comment | no | `pr-coverage-464-issue_comment-noop-5` |
| `/coverage` by maintainer | yes | `pr-coverage-464-issue_comment` |
| `/coverage` by maintainer (2nd) | yes | `pr-coverage-464-issue_comment` |
| `/coverage` by non-maintainer | no | `pr-coverage-464-issue_comment-noop-8` |
| comment on a plain issue | no | `pr-coverage-464-issue_comment-noop-9` |

All eight derived assertions pass, including the two that must *not* regress (a new push still supersedes a stale push run; a second `/coverage` still supersedes the first).

### Why this PR cannot demonstrate the fix on itself

Two reasons, both worth stating plainly rather than implying a green check here means anything:

- `paths-ignore` excludes `.github/**`, so this PR triggers no coverage run at all.
- More fundamentally, `issue_comment`-triggered workflows always execute the **default branch** copy of the workflow file. So until this merges, comments anywhere — including here — are still governed by `main`'s current group expression. The fix cannot take effect from a PR branch.

Post-merge verification is one comment on any PR with a coverage run in flight: the run should survive, and the comment's own run should appear as `skipped` in a `-noop-` group.

## Breaking Changes / Migration Notes

None. Skipped runs still appear as `skipped` exactly as before; only group membership changes.

## Checklist

- [x] `cargo bfmt` passes (N/A — no Rust changes)
- [x] `cargo bclippy` passes (N/A — no Rust changes)
- [x] `cargo btest` passes (N/A — no Rust changes)
- [x] New/changed functionality has tests (N/A — workflow config; verified by simulation above)
- [x] Public API changes are documented (no public API changes)