### PR TITLE
Enforce safety docs for private unsafe functions

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+check-private-items = true

--- a/mssql-odbc/src/api/bind_col.rs
+++ b/mssql-odbc/src/api/bind_col.rs
@@ -55,6 +55,10 @@ pub(crate) unsafe fn sql_bind_col(
     })
 }
 
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`. When
+/// non-null, `target_value_ptr` and `strlen_or_ind_ptr` must remain valid for
+/// the bound rowset until the column is unbound or the statement is freed.
 unsafe fn sql_bind_col_impl(
     statement_handle: SqlHandle,
     column_number: SqlUSmallInt,

--- a/mssql-odbc/src/api/bind_col.rs
+++ b/mssql-odbc/src/api/bind_col.rs
@@ -35,7 +35,10 @@ use crate::handles::{DescHandle, HandleType, StmtHandle, handle_from_raw};
 /// elements of `buffer_length` bytes for a character or binary target, or of
 /// the full C type size for a fixed-width target, even when `buffer_length` is
 /// zero or smaller. `strlen_or_ind_ptr`, when non-null, must be writable for
-/// `SQL_ATTR_ROW_ARRAY_SIZE` `SqlLen` values.
+/// `SQL_ATTR_ROW_ARRAY_SIZE` `SqlLen` values. When
+/// `SQL_ATTR_ROW_BIND_OFFSET_PTR` is non-null, these bound-buffer extents begin
+/// at the base plus the pointed-to byte offset, so each allocation must also
+/// cover that leading displacement.
 pub(crate) unsafe fn sql_bind_col(
     statement_handle: SqlHandle,
     column_number: SqlUSmallInt,
@@ -68,7 +71,9 @@ pub(crate) unsafe fn sql_bind_col(
 /// or binary target, or of the full C type size for a fixed-width target, even
 /// when `buffer_length` is zero or smaller. `strlen_or_ind_ptr`, when non-null,
 /// must remain valid and be writable for `SQL_ATTR_ROW_ARRAY_SIZE` `SqlLen`
-/// values.
+/// values. When `SQL_ATTR_ROW_BIND_OFFSET_PTR` is non-null, these bound-buffer
+/// extents begin at the base plus the pointed-to byte offset, so each allocation
+/// must also cover that leading displacement.
 unsafe fn sql_bind_col_impl(
     statement_handle: SqlHandle,
     column_number: SqlUSmallInt,

--- a/mssql-odbc/src/api/bind_col.rs
+++ b/mssql-odbc/src/api/bind_col.rs
@@ -30,7 +30,12 @@ use crate::handles::{DescHandle, HandleType, StmtHandle, handle_from_raw};
 ///
 /// # Safety
 /// `statement_handle` must be a valid `StmtHandle` or null. The buffers must
-/// stay valid until the column is unbound or the statement is freed.
+/// stay valid until the column is unbound or the statement is freed. At each
+/// fetch, `target_value_ptr` must be writable for `SQL_ATTR_ROW_ARRAY_SIZE`
+/// elements of `buffer_length` bytes for a character or binary target, or of
+/// the full C type size for a fixed-width target, even when `buffer_length` is
+/// zero or smaller. `strlen_or_ind_ptr`, when non-null, must be writable for
+/// `SQL_ATTR_ROW_ARRAY_SIZE` `SqlLen` values.
 pub(crate) unsafe fn sql_bind_col(
     statement_handle: SqlHandle,
     column_number: SqlUSmallInt,
@@ -57,8 +62,13 @@ pub(crate) unsafe fn sql_bind_col(
 
 /// # Safety
 /// `statement_handle` must be null or point to a live `StmtHandle`. When
-/// non-null, `target_value_ptr` and `strlen_or_ind_ptr` must remain valid for
-/// the bound rowset until the column is unbound or the statement is freed.
+/// non-null, `target_value_ptr` must remain valid until the column is unbound or
+/// the statement is freed. At each fetch, it must be writable for
+/// `SQL_ATTR_ROW_ARRAY_SIZE` elements of `buffer_length` bytes for a character
+/// or binary target, or of the full C type size for a fixed-width target, even
+/// when `buffer_length` is zero or smaller. `strlen_or_ind_ptr`, when non-null,
+/// must remain valid and be writable for `SQL_ATTR_ROW_ARRAY_SIZE` `SqlLen`
+/// values.
 unsafe fn sql_bind_col_impl(
     statement_handle: SqlHandle,
     column_number: SqlUSmallInt,

--- a/mssql-odbc/src/api/bind_param.rs
+++ b/mssql-odbc/src/api/bind_param.rs
@@ -69,6 +69,10 @@ pub(crate) unsafe fn sql_bind_parameter(
     })
 }
 
+/// # Safety
+/// `statement_handle` must point to a live `StmtHandle`.
+/// `parameter_value_ptr` and `strlen_or_ind_ptr`, when non-null, must remain
+/// valid until the parameter is unbound or the statement is freed.
 #[allow(clippy::too_many_arguments)]
 unsafe fn sql_bind_parameter_impl(
     statement_handle: SqlHandle,
@@ -376,6 +380,8 @@ pub(crate) unsafe fn sql_free_stmt_reset_params(statement_handle: SqlHandle) -> 
     })
 }
 
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`.
 unsafe fn sql_free_stmt_reset_params_impl(statement_handle: SqlHandle) -> SqlReturn {
     if statement_handle.is_null() {
         error!("SQLFreeStmt(SQL_RESET_PARAMS): statement_handle is null");

--- a/mssql-odbc/src/api/bind_param.rs
+++ b/mssql-odbc/src/api/bind_param.rs
@@ -26,6 +26,9 @@ use crate::params::conversion_matrix::is_supported_conversion;
 /// - `statement_handle` must be a valid `StmtHandle` allocated by `SQLAllocHandle`.
 /// - `parameter_value_ptr` / `strlen_or_ind_ptr`, if non-null, must remain valid
 ///   until the statement is executed (ODBC binds by reference).
+/// - When `SQL_ATTR_PARAM_BIND_OFFSET_PTR` is non-null, the readable extents
+///   begin at each bound base plus the pointed-to signed byte offset, which may
+///   be negative, so every allocation must cover that displaced range.
 #[allow(clippy::too_many_arguments)]
 pub(crate) unsafe fn sql_bind_parameter(
     statement_handle: SqlHandle,
@@ -72,7 +75,10 @@ pub(crate) unsafe fn sql_bind_parameter(
 /// # Safety
 /// `statement_handle` must point to a live `StmtHandle`.
 /// `parameter_value_ptr` and `strlen_or_ind_ptr`, when non-null, must remain
-/// valid until the parameter is unbound or the statement is freed.
+/// valid until the parameter is unbound or the statement is freed. When
+/// `SQL_ATTR_PARAM_BIND_OFFSET_PTR` is non-null, the readable extents begin at
+/// each bound base plus the pointed-to signed byte offset, which may be
+/// negative, so every allocation must cover that displaced range.
 #[allow(clippy::too_many_arguments)]
 unsafe fn sql_bind_parameter_impl(
     statement_handle: SqlHandle,

--- a/mssql-odbc/src/api/cancel.rs
+++ b/mssql-odbc/src/api/cancel.rs
@@ -34,6 +34,8 @@ pub(crate) unsafe fn sql_cancel(statement_handle: SqlHandle) -> SqlReturn {
     crate::ffi_entry!("SQLCancel", unsafe { sql_cancel_impl(statement_handle) })
 }
 
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`.
 unsafe fn sql_cancel_impl(statement_handle: SqlHandle) -> SqlReturn {
     if statement_handle.is_null() {
         error!("SQLCancel: statement_handle is null");

--- a/mssql-odbc/src/api/catalog.rs
+++ b/mssql-odbc/src/api/catalog.rs
@@ -691,6 +691,10 @@ pub(crate) unsafe fn sql_tables_w(
     })
 }
 
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`. Each
+/// non-null name pointer must be readable for its paired length in UTF-16 code
+/// units, or through a NUL terminator when that length is `SQL_NTS`.
 #[allow(clippy::too_many_arguments)]
 unsafe fn sql_tables_w_impl(
     statement_handle: SqlHandle,
@@ -834,6 +838,10 @@ pub(crate) unsafe fn sql_columns_w(
     })
 }
 
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`. Each
+/// non-null name pointer must be readable for its paired length in UTF-16 code
+/// units, or through a NUL terminator when that length is `SQL_NTS`.
 #[allow(clippy::too_many_arguments)]
 unsafe fn sql_columns_w_impl(
     statement_handle: SqlHandle,
@@ -978,6 +986,10 @@ pub(crate) unsafe fn sql_primary_keys_w(
     })
 }
 
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`. Each
+/// non-null name pointer must be readable for its paired length in UTF-16 code
+/// units, or through a NUL terminator when that length is `SQL_NTS`.
 unsafe fn sql_primary_keys_w_impl(
     statement_handle: SqlHandle,
     catalog_name: *const SqlWChar,
@@ -1113,6 +1125,10 @@ pub(crate) unsafe fn sql_foreign_keys_w(
     })
 }
 
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`. Each
+/// non-null name pointer must be readable for its paired length in UTF-16 code
+/// units, or through a NUL terminator when that length is `SQL_NTS`.
 #[allow(clippy::too_many_arguments)]
 unsafe fn sql_foreign_keys_w_impl(
     statement_handle: SqlHandle,
@@ -1307,6 +1323,10 @@ pub(crate) unsafe fn sql_statistics_w(
     })
 }
 
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`. Each
+/// non-null name pointer must be readable for its paired length in UTF-16 code
+/// units, or through a NUL terminator when that length is `SQL_NTS`.
 #[allow(clippy::too_many_arguments)]
 unsafe fn sql_statistics_w_impl(
     statement_handle: SqlHandle,
@@ -1471,6 +1491,10 @@ pub(crate) unsafe fn sql_special_columns_w(
     })
 }
 
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`. Each
+/// non-null name pointer must be readable for its paired length in UTF-16 code
+/// units, or through a NUL terminator when that length is `SQL_NTS`.
 #[allow(clippy::too_many_arguments)]
 unsafe fn sql_special_columns_w_impl(
     statement_handle: SqlHandle,
@@ -1655,6 +1679,10 @@ pub(crate) unsafe fn sql_procedures_w(
     })
 }
 
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`. Each
+/// non-null name pointer must be readable for its paired length in UTF-16 code
+/// units, or through a NUL terminator when that length is `SQL_NTS`.
 unsafe fn sql_procedures_w_impl(
     statement_handle: SqlHandle,
     catalog_name: *const SqlWChar,

--- a/mssql-odbc/src/api/catalog.rs
+++ b/mssql-odbc/src/api/catalog.rs
@@ -651,7 +651,9 @@ fn apply_catalog_metadata(
 /// Implements `SQLTablesW`.
 ///
 /// # Safety
-/// Each name pointer must be null or reference `*_len` readable UTF-16 units.
+/// Each name pointer must be null, reference its paired length in readable
+/// UTF-16 units, or be readable through a NUL terminator when that length is
+/// `SQL_NTS`.
 #[allow(clippy::too_many_arguments)]
 pub(crate) unsafe fn sql_tables_w(
     statement_handle: SqlHandle,
@@ -798,7 +800,9 @@ fn sql_tables_w_safe(
 /// Implements `SQLColumnsW`.
 ///
 /// # Safety
-/// Each name pointer must be null or reference `*_len` readable UTF-16 units.
+/// Each name pointer must be null, reference its paired length in readable
+/// UTF-16 units, or be readable through a NUL terminator when that length is
+/// `SQL_NTS`.
 #[allow(clippy::too_many_arguments)]
 pub(crate) unsafe fn sql_columns_w(
     statement_handle: SqlHandle,
@@ -953,7 +957,9 @@ fn sql_columns_w_safe(
 /// Implements `SQLPrimaryKeysW`.
 ///
 /// # Safety
-/// Each name pointer must be null or reference `*_len` readable UTF-16 units.
+/// Each name pointer must be null, reference its paired length in readable
+/// UTF-16 units, or be readable through a NUL terminator when that length is
+/// `SQL_NTS`.
 pub(crate) unsafe fn sql_primary_keys_w(
     statement_handle: SqlHandle,
     catalog_name: *const SqlWChar,
@@ -1073,7 +1079,9 @@ fn sql_primary_keys_w_safe(
 /// Implements `SQLForeignKeysW`.
 ///
 /// # Safety
-/// Each name pointer must be null or reference `*_len` readable UTF-16 units.
+/// Each name pointer must be null, reference its paired length in readable
+/// UTF-16 units, or be readable through a NUL terminator when that length is
+/// `SQL_NTS`.
 #[allow(clippy::too_many_arguments)]
 pub(crate) unsafe fn sql_foreign_keys_w(
     statement_handle: SqlHandle,
@@ -1283,7 +1291,9 @@ fn sql_foreign_keys_w_safe(
 /// Implements `SQLStatisticsW`.
 ///
 /// # Safety
-/// Each name pointer must be null or reference `*_len` readable UTF-16 units.
+/// Each name pointer must be null, reference its paired length in readable
+/// UTF-16 units, or be readable through a NUL terminator when that length is
+/// `SQL_NTS`.
 #[allow(clippy::too_many_arguments)]
 pub(crate) unsafe fn sql_statistics_w(
     statement_handle: SqlHandle,
@@ -1448,7 +1458,9 @@ fn sql_statistics_w_safe(
 /// Implements `SQLSpecialColumnsW`.
 ///
 /// # Safety
-/// Each name pointer must be null or reference `*_len` readable UTF-16 units.
+/// Each name pointer must be null, reference its paired length in readable
+/// UTF-16 units, or be readable through a NUL terminator when that length is
+/// `SQL_NTS`.
 #[allow(clippy::too_many_arguments)]
 pub(crate) unsafe fn sql_special_columns_w(
     statement_handle: SqlHandle,
@@ -1646,7 +1658,9 @@ fn sql_special_columns_w_safe(
 /// Implements `SQLProceduresW`.
 ///
 /// # Safety
-/// Each name pointer must be null or reference `*_len` readable UTF-16 units.
+/// Each name pointer must be null, reference its paired length in readable
+/// UTF-16 units, or be readable through a NUL terminator when that length is
+/// `SQL_NTS`.
 pub(crate) unsafe fn sql_procedures_w(
     statement_handle: SqlHandle,
     catalog_name: *const SqlWChar,

--- a/mssql-odbc/src/api/close_cursor.rs
+++ b/mssql-odbc/src/api/close_cursor.rs
@@ -47,6 +47,8 @@ pub(crate) unsafe fn sql_free_stmt_close(statement_handle: SqlHandle) -> SqlRetu
     })
 }
 
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`.
 unsafe fn sql_close_cursor_impl(statement_handle: SqlHandle) -> SqlReturn {
     if statement_handle.is_null() {
         error!("SQLCloseCursor: statement_handle is null");
@@ -114,6 +116,8 @@ fn sql_close_cursor_safe(statement_handle: SqlHandle, stmt: &StmtHandle) -> SqlR
     }
 }
 
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`.
 unsafe fn sql_free_stmt_close_impl(statement_handle: SqlHandle) -> SqlReturn {
     if statement_handle.is_null() {
         error!("SQLFreeStmt(SQL_CLOSE): statement_handle is null");

--- a/mssql-odbc/src/api/col_attribute.rs
+++ b/mssql-odbc/src/api/col_attribute.rs
@@ -35,6 +35,13 @@ use crate::error::free_errors;
 use crate::handles::stmt::STMT_STATE_EXEC_CONTEXT;
 use crate::handles::{HandleType, StmtHandle, handle_from_raw};
 
+/// Gets a descriptor field for a result-set column.
+///
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`.
+/// `character_attribute_ptr`, when non-null, must be writable for
+/// `buffer_length` bytes. `string_length_ptr` and `numeric_attribute_ptr`, when
+/// non-null, must each be writable for one value of their pointed-to type.
 #[allow(clippy::too_many_arguments)]
 pub(crate) unsafe fn sql_col_attribute_w(
     statement_handle: SqlHandle,
@@ -69,6 +76,11 @@ pub(crate) unsafe fn sql_col_attribute_w(
     })
 }
 
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`.
+/// `character_attribute_ptr`, when non-null, must be writable for
+/// `buffer_length` bytes. `string_length_ptr` and `numeric_attribute_ptr`, when
+/// non-null, must each be writable for one value of their pointed-to type.
 #[allow(clippy::too_many_arguments)]
 unsafe fn sql_col_attribute_w_impl(
     statement_handle: SqlHandle,

--- a/mssql-odbc/src/api/connect.rs
+++ b/mssql-odbc/src/api/connect.rs
@@ -61,6 +61,10 @@ pub(crate) unsafe fn sql_connect_w(
     })
 }
 
+/// # Safety
+/// `connection_handle` must be null or point to a live `DbcHandle`. Each
+/// non-null string pointer must be readable for its paired length in UTF-16
+/// code units, or through a NUL terminator when that length is `SQL_NTS`.
 unsafe fn sql_connect_w_impl(
     connection_handle: SqlHandle,
     server_name: *const SqlWChar,

--- a/mssql-odbc/src/api/describe_col.rs
+++ b/mssql-odbc/src/api/describe_col.rs
@@ -22,6 +22,13 @@ use crate::error::free_errors;
 use crate::handles::stmt::STMT_STATE_EXEC_CONTEXT;
 use crate::handles::{HandleType, StmtHandle, handle_from_raw};
 
+/// Gets metadata for a result-set column.
+///
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`. `column_name`,
+/// when non-null, must be writable for `buffer_length` UTF-16 code units. Every
+/// other output pointer, when non-null, must be writable for one value of its
+/// pointed-to type.
 #[allow(clippy::too_many_arguments)]
 pub(crate) unsafe fn sql_describe_col_w(
     statement_handle: SqlHandle,
@@ -62,6 +69,11 @@ pub(crate) unsafe fn sql_describe_col_w(
     })
 }
 
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`. `column_name`,
+/// when non-null, must be writable for `buffer_length` UTF-16 code units. Every
+/// other output pointer, when non-null, must be writable for one value of its
+/// pointed-to type.
 #[allow(clippy::too_many_arguments)]
 unsafe fn sql_describe_col_w_impl(
     statement_handle: SqlHandle,
@@ -316,6 +328,9 @@ mod tests {
 
     /// Calls `sql_describe_col_w` with default-ish out pointers. Intended for
     /// error-path tests where the values of the out params are irrelevant.
+    ///
+    /// # Safety
+    /// `stmt` must be null or point to a live `StmtHandle`.
     unsafe fn describe(stmt: SqlHandle, column_number: SqlUSmallInt) -> SqlReturn {
         let mut data_type: SqlSmallInt = 0;
         let mut col_size: u64 = 0;

--- a/mssql-odbc/src/api/describe_param.rs
+++ b/mssql-odbc/src/api/describe_param.rs
@@ -34,6 +34,12 @@ const SUGGESTED_SCALE: usize = 6;
 const SUGGESTED_TDS_TYPE_ID: usize = 22;
 const SUGGESTED_TDS_LENGTH: usize = 23;
 
+/// Describes a prepared statement parameter.
+///
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`. Every output
+/// pointer, when non-null, must be writable for one value of its pointed-to
+/// type.
 #[allow(clippy::too_many_arguments)]
 pub(crate) unsafe fn sql_describe_param(
     statement_handle: SqlHandle,
@@ -65,6 +71,10 @@ pub(crate) unsafe fn sql_describe_param(
     })
 }
 
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`. Every output
+/// pointer, when non-null, must be writable for one value of its pointed-to
+/// type.
 #[allow(clippy::too_many_arguments)]
 unsafe fn sql_describe_param_impl(
     statement_handle: SqlHandle,

--- a/mssql-odbc/src/api/disconnect.rs
+++ b/mssql-odbc/src/api/disconnect.rs
@@ -29,6 +29,8 @@ pub(crate) unsafe fn sql_disconnect(connection_handle: SqlHandle) -> SqlReturn {
     })
 }
 
+/// # Safety
+/// `connection_handle` must be null or point to a live `DbcHandle`.
 unsafe fn sql_disconnect_impl(connection_handle: SqlHandle) -> SqlReturn {
     if connection_handle.is_null() {
         error!("SQLDisconnect: connection_handle is null");

--- a/mssql-odbc/src/api/driver_connect.rs
+++ b/mssql-odbc/src/api/driver_connect.rs
@@ -78,6 +78,13 @@ pub(crate) unsafe fn sql_driver_connect_w(
     })
 }
 
+/// # Safety
+/// `connection_handle` must be null or point to a live `DbcHandle`.
+/// `in_connection_string`, when non-null, must be readable for
+/// `string_length_1` UTF-16 code units, or through a NUL terminator when the
+/// length is `SQL_NTS`. `out_connection_string`, when non-null, must be writable
+/// for `buffer_length` UTF-16 code units, and `string_length_2_ptr`, when
+/// non-null, must be writable for one `SqlSmallInt`.
 unsafe fn sql_driver_connect_w_impl(
     connection_handle: SqlHandle,
     in_connection_string: *const SqlWChar,
@@ -636,6 +643,9 @@ mod tests {
     /// driver's own `SQLGetDiagRecW` entry point. Tests use this to verify
     /// the diagnostic surface that real ODBC apps see, not just the internal
     /// `diag_records` vec.
+    ///
+    /// # Safety
+    /// `dbc` must point to a live `DbcHandle`.
     unsafe fn diag_sqlstate(dbc: SqlHandle, rec_number: SqlSmallInt) -> String {
         let mut state_buf = [0u16; 6];
         let mut msg_buf = [0u16; 256];

--- a/mssql-odbc/src/api/end_tran.rs
+++ b/mssql-odbc/src/api/end_tran.rs
@@ -34,6 +34,9 @@ pub(crate) unsafe fn sql_end_tran(
     })
 }
 
+/// # Safety
+/// `handle` must be null or point to a live `DbcHandle` or `EnvHandle` matching
+/// `handle_type`.
 unsafe fn sql_end_tran_impl(
     handle_type: SqlSmallInt,
     handle: SqlHandle,

--- a/mssql-odbc/src/api/exec_common.rs
+++ b/mssql-odbc/src/api/exec_common.rs
@@ -533,7 +533,10 @@ pub(super) fn snapshot_bound_params(
 ///
 /// # Safety
 /// Each bound parameter's value/indicator pointers must still satisfy the
-/// `SQLBindParameter` contract; the buffers are read here.
+/// `SQLBindParameter` contract; the buffers are read here. When
+/// `SQL_ATTR_PARAM_BIND_OFFSET_PTR` is non-null, their readable extents begin at
+/// each bound base plus the pointed-to signed byte offset, which may be
+/// negative, so every allocation must cover that displaced range.
 pub(super) unsafe fn build_named_params(
     stmt_state: &mut StmtState,
     marker_count: usize,

--- a/mssql-odbc/src/api/exec_direct.rs
+++ b/mssql-odbc/src/api/exec_direct.rs
@@ -36,6 +36,10 @@ use crate::handles::{HandleType, StmtHandle, handle_from_raw};
 /// - `statement_handle` must be a valid `StmtHandle` allocated by `SQLAllocHandle`.
 /// - `statement_text` must point to a valid UTF-16 buffer readable for `text_length` characters.
 ///   If `text_length` is `SQL_NTS`, the string must be NUL-terminated.
+/// - For each non-data-at-execution parameter, the currently bound value,
+///   indicator, and octet-length buffers must remain readable according to the
+///   bound C type and lengths. `SQL_ATTR_PARAM_BIND_OFFSET_PTR`, when set, must
+///   remain readable for one `SqlLen`.
 pub(crate) unsafe fn sql_exec_direct_w(
     statement_handle: SqlHandle,
     statement_text: *const SqlWChar,
@@ -53,6 +57,14 @@ pub(crate) unsafe fn sql_exec_direct_w(
     })
 }
 
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`.
+/// `statement_text` must be readable for `text_length` UTF-16 code units, or
+/// through a NUL terminator when `text_length` is `SQL_NTS`.
+/// For each non-data-at-execution parameter, the currently bound value,
+/// indicator, and octet-length buffers must remain readable according to the
+/// bound C type and lengths. `SQL_ATTR_PARAM_BIND_OFFSET_PTR`, when set, must
+/// remain readable for one `SqlLen`.
 unsafe fn sql_exec_direct_w_impl(
     statement_handle: SqlHandle,
     statement_text: *const SqlWChar,

--- a/mssql-odbc/src/api/exec_direct.rs
+++ b/mssql-odbc/src/api/exec_direct.rs
@@ -38,8 +38,11 @@ use crate::handles::{HandleType, StmtHandle, handle_from_raw};
 ///   If `text_length` is `SQL_NTS`, the string must be NUL-terminated.
 /// - For each non-data-at-execution parameter, the currently bound value,
 ///   indicator, and octet-length buffers must remain readable according to the
-///   bound C type and lengths. `SQL_ATTR_PARAM_BIND_OFFSET_PTR`, when set, must
-///   remain readable for one `SqlLen`.
+///   bound C type and lengths. When `SQL_ATTR_PARAM_BIND_OFFSET_PTR` is
+///   non-null, these readable extents begin at each bound base plus the
+///   pointed-to signed byte offset, which may be negative, so every allocation
+///   must cover that displaced range. The offset pointer itself must remain
+///   readable for one `SqlLen`.
 pub(crate) unsafe fn sql_exec_direct_w(
     statement_handle: SqlHandle,
     statement_text: *const SqlWChar,
@@ -63,8 +66,11 @@ pub(crate) unsafe fn sql_exec_direct_w(
 /// through a NUL terminator when `text_length` is `SQL_NTS`.
 /// For each non-data-at-execution parameter, the currently bound value,
 /// indicator, and octet-length buffers must remain readable according to the
-/// bound C type and lengths. `SQL_ATTR_PARAM_BIND_OFFSET_PTR`, when set, must
-/// remain readable for one `SqlLen`.
+/// bound C type and lengths. When `SQL_ATTR_PARAM_BIND_OFFSET_PTR` is non-null,
+/// these readable extents begin at each bound base plus the pointed-to signed
+/// byte offset, which may be negative, so every allocation must cover that
+/// displaced range. The offset pointer itself must remain readable for one
+/// `SqlLen`.
 unsafe fn sql_exec_direct_w_impl(
     statement_handle: SqlHandle,
     statement_text: *const SqlWChar,

--- a/mssql-odbc/src/api/execute.rs
+++ b/mssql-odbc/src/api/execute.rs
@@ -32,11 +32,21 @@ use crate::handles::{HandleType, StmtHandle, handle_from_raw};
 ///
 /// # Safety
 /// `statement_handle` must be a valid `StmtHandle` allocated by `SQLAllocHandle`.
+/// For each non-data-at-execution parameter, the currently bound value,
+/// indicator, and octet-length buffers must remain readable according to the
+/// bound C type and lengths. `SQL_ATTR_PARAM_BIND_OFFSET_PTR`, when set, must
+/// remain readable for one `SqlLen`.
 pub(crate) unsafe fn sql_execute(statement_handle: SqlHandle) -> SqlReturn {
     debug!(?statement_handle, "SQLExecute called");
     crate::ffi_entry!("SQLExecute", unsafe { sql_execute_impl(statement_handle) })
 }
 
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`.
+/// For each non-data-at-execution parameter, the currently bound value,
+/// indicator, and octet-length buffers must remain readable according to the
+/// bound C type and lengths. `SQL_ATTR_PARAM_BIND_OFFSET_PTR`, when set, must
+/// remain readable for one `SqlLen`.
 unsafe fn sql_execute_impl(statement_handle: SqlHandle) -> SqlReturn {
     if statement_handle.is_null() {
         error!("SQLExecute: statement_handle is null");

--- a/mssql-odbc/src/api/execute.rs
+++ b/mssql-odbc/src/api/execute.rs
@@ -34,8 +34,11 @@ use crate::handles::{HandleType, StmtHandle, handle_from_raw};
 /// `statement_handle` must be a valid `StmtHandle` allocated by `SQLAllocHandle`.
 /// For each non-data-at-execution parameter, the currently bound value,
 /// indicator, and octet-length buffers must remain readable according to the
-/// bound C type and lengths. `SQL_ATTR_PARAM_BIND_OFFSET_PTR`, when set, must
-/// remain readable for one `SqlLen`.
+/// bound C type and lengths. When `SQL_ATTR_PARAM_BIND_OFFSET_PTR` is non-null,
+/// these readable extents begin at each bound base plus the pointed-to signed
+/// byte offset, which may be negative, so every allocation must cover that
+/// displaced range. The offset pointer itself must remain readable for one
+/// `SqlLen`.
 pub(crate) unsafe fn sql_execute(statement_handle: SqlHandle) -> SqlReturn {
     debug!(?statement_handle, "SQLExecute called");
     crate::ffi_entry!("SQLExecute", unsafe { sql_execute_impl(statement_handle) })
@@ -45,8 +48,11 @@ pub(crate) unsafe fn sql_execute(statement_handle: SqlHandle) -> SqlReturn {
 /// `statement_handle` must be null or point to a live `StmtHandle`.
 /// For each non-data-at-execution parameter, the currently bound value,
 /// indicator, and octet-length buffers must remain readable according to the
-/// bound C type and lengths. `SQL_ATTR_PARAM_BIND_OFFSET_PTR`, when set, must
-/// remain readable for one `SqlLen`.
+/// bound C type and lengths. When `SQL_ATTR_PARAM_BIND_OFFSET_PTR` is non-null,
+/// these readable extents begin at each bound base plus the pointed-to signed
+/// byte offset, which may be negative, so every allocation must cover that
+/// displaced range. The offset pointer itself must remain readable for one
+/// `SqlLen`.
 unsafe fn sql_execute_impl(statement_handle: SqlHandle) -> SqlReturn {
     if statement_handle.is_null() {
         error!("SQLExecute: statement_handle is null");

--- a/mssql-odbc/src/api/exports.rs
+++ b/mssql-odbc/src/api/exports.rs
@@ -609,6 +609,11 @@ pub unsafe extern "C" fn SQLParamData(
 /// - `statement_handle` must be a valid STMT handle returned by `SQLAllocHandle`.
 /// - `data_ptr`, when `strlen_or_ind` is a positive byte count, must be
 ///   readable for that many bytes.
+/// - `data_ptr`, when `strlen_or_ind` is `SQL_NTS`, must be non-null and
+///   NUL-terminated within an allocation it owns. The terminator search reads
+///   potentially unaligned `u16` units for `SQL_C_WCHAR` and `u8` units
+///   otherwise, and runs off the end of the allocation if no terminator is
+///   present.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn SQLPutData(
     statement_handle: SqlHandle,
@@ -864,7 +869,9 @@ pub unsafe extern "C" fn SQLRowCount(
 ///
 /// # Safety
 /// - `statement_handle` must be a valid STMT handle returned by `SQLAllocHandle`.
-/// - Each name pointer must be null or reference `*_len` readable UTF-16 units.
+/// - Each name pointer must be null, reference its paired length in readable
+///   UTF-16 units, or be readable through a NUL terminator when that length is
+///   `SQL_NTS`.
 #[unsafe(no_mangle)]
 #[allow(clippy::too_many_arguments)]
 pub unsafe extern "C" fn SQLTablesW(
@@ -898,7 +905,9 @@ pub unsafe extern "C" fn SQLTablesW(
 ///
 /// # Safety
 /// - `statement_handle` must be a valid STMT handle returned by `SQLAllocHandle`.
-/// - Each name pointer must be null or reference `*_len` readable UTF-16 units.
+/// - Each name pointer must be null, reference its paired length in readable
+///   UTF-16 units, or be readable through a NUL terminator when that length is
+///   `SQL_NTS`.
 #[unsafe(no_mangle)]
 #[allow(clippy::too_many_arguments)]
 pub unsafe extern "C" fn SQLColumnsW(
@@ -932,7 +941,9 @@ pub unsafe extern "C" fn SQLColumnsW(
 ///
 /// # Safety
 /// - `statement_handle` must be a valid STMT handle returned by `SQLAllocHandle`.
-/// - Each name pointer must be null or reference `*_len` readable UTF-16 units.
+/// - Each name pointer must be null, reference its paired length in readable
+///   UTF-16 units, or be readable through a NUL terminator when that length is
+///   `SQL_NTS`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn SQLPrimaryKeysW(
     statement_handle: SqlHandle,
@@ -961,7 +972,9 @@ pub unsafe extern "C" fn SQLPrimaryKeysW(
 ///
 /// # Safety
 /// - `statement_handle` must be a valid STMT handle returned by `SQLAllocHandle`.
-/// - Each name pointer must be null or reference `*_len` readable UTF-16 units.
+/// - Each name pointer must be null, reference its paired length in readable
+///   UTF-16 units, or be readable through a NUL terminator when that length is
+///   `SQL_NTS`.
 #[unsafe(no_mangle)]
 #[allow(clippy::too_many_arguments)]
 pub unsafe extern "C" fn SQLForeignKeysW(
@@ -1003,7 +1016,9 @@ pub unsafe extern "C" fn SQLForeignKeysW(
 ///
 /// # Safety
 /// - `statement_handle` must be a valid STMT handle returned by `SQLAllocHandle`.
-/// - Each name pointer must be null or reference `*_len` readable UTF-16 units.
+/// - Each name pointer must be null, reference its paired length in readable
+///   UTF-16 units, or be readable through a NUL terminator when that length is
+///   `SQL_NTS`.
 #[unsafe(no_mangle)]
 #[allow(clippy::too_many_arguments)]
 pub unsafe extern "C" fn SQLStatisticsW(
@@ -1038,7 +1053,9 @@ pub unsafe extern "C" fn SQLStatisticsW(
 ///
 /// # Safety
 /// - `statement_handle` must be a valid STMT handle returned by `SQLAllocHandle`.
-/// - Each name pointer must be null or reference `*_len` readable UTF-16 units.
+/// - Each name pointer must be null, reference its paired length in readable
+///   UTF-16 units, or be readable through a NUL terminator when that length is
+///   `SQL_NTS`.
 #[unsafe(no_mangle)]
 #[allow(clippy::too_many_arguments)]
 pub unsafe extern "C" fn SQLSpecialColumnsW(
@@ -1074,7 +1091,9 @@ pub unsafe extern "C" fn SQLSpecialColumnsW(
 ///
 /// # Safety
 /// - `statement_handle` must be a valid STMT handle returned by `SQLAllocHandle`.
-/// - Each name pointer must be null or reference `*_len` readable UTF-16 units.
+/// - Each name pointer must be null, reference its paired length in readable
+///   UTF-16 units, or be readable through a NUL terminator when that length is
+///   `SQL_NTS`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn SQLProceduresW(
     statement_handle: SqlHandle,

--- a/mssql-odbc/src/api/exports.rs
+++ b/mssql-odbc/src/api/exports.rs
@@ -626,6 +626,9 @@ pub unsafe extern "C" fn SQLPutData(
 ///   even when `BufferLength` is zero or smaller. Its indicator and
 ///   octet-length arrays must each be writable for `SQL_ATTR_ROW_ARRAY_SIZE`
 ///   `SqlLen` values.
+/// - When `SQL_ATTR_ROW_BIND_OFFSET_PTR` is non-null, these bound-buffer
+///   extents begin at the base plus the pointed-to byte offset, so each
+///   allocation must also cover that leading displacement.
 /// - Non-null rowset pointer attributes must satisfy their declared extents:
 ///   one `SqlULen` for `SQL_ATTR_ROWS_FETCHED_PTR` and
 ///   `SQL_ATTR_ROW_BIND_OFFSET_PTR`, and `SQL_ATTR_ROW_ARRAY_SIZE`
@@ -649,7 +652,10 @@ pub unsafe extern "C" fn SQLFetch(statement_handle: SqlHandle) -> SqlReturn {
 /// `SQL_ATTR_ROW_ARRAY_SIZE` elements of `buffer_length` bytes for a character
 /// or binary target, or of the full C type size for a fixed-width target, even
 /// when `buffer_length` is zero or smaller. `strlen_or_ind_ptr`, when non-null,
-/// must be writable for `SQL_ATTR_ROW_ARRAY_SIZE` `SqlLen` values.
+/// must be writable for `SQL_ATTR_ROW_ARRAY_SIZE` `SqlLen` values. When
+/// `SQL_ATTR_ROW_BIND_OFFSET_PTR` is non-null, these bound-buffer extents begin
+/// at the base plus the pointed-to byte offset, so each allocation must also
+/// cover that leading displacement.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn SQLBindCol(
     statement_handle: SqlHandle,
@@ -684,6 +690,9 @@ pub unsafe extern "C" fn SQLBindCol(
 /// or binary target, or of the full C type size for a fixed-width target, even
 /// when `BufferLength` is zero or smaller. Its indicator and octet-length
 /// arrays must each be writable for `SQL_ATTR_ROW_ARRAY_SIZE` `SqlLen` values.
+/// When `SQL_ATTR_ROW_BIND_OFFSET_PTR` is non-null, these bound-buffer extents
+/// begin at the base plus the pointed-to byte offset, so each allocation must
+/// also cover that leading displacement.
 /// Non-null rowset pointer attributes must satisfy their declared extents: one
 /// `SqlULen` for `SQL_ATTR_ROWS_FETCHED_PTR` and
 /// `SQL_ATTR_ROW_BIND_OFFSET_PTR`, and `SQL_ATTR_ROW_ARRAY_SIZE`

--- a/mssql-odbc/src/api/exports.rs
+++ b/mssql-odbc/src/api/exports.rs
@@ -620,8 +620,10 @@ pub unsafe extern "C" fn SQLPutData(
 ///
 /// # Safety
 /// - `statement_handle` must be a valid STMT handle returned by `SQLAllocHandle`.
-/// - Every active bound-column data buffer must be writable for the configured
-///   rowset according to its C type and `BufferLength`; its indicator and
+/// - Every active bound-column data buffer must be writable for
+///   `SQL_ATTR_ROW_ARRAY_SIZE` elements of `BufferLength` bytes for a character
+///   or binary target, or of the full C type size for a fixed-width target,
+///   even when `BufferLength` is zero or smaller. Its indicator and
 ///   octet-length arrays must each be writable for `SQL_ATTR_ROW_ARRAY_SIZE`
 ///   `SqlLen` values.
 /// - Non-null rowset pointer attributes must satisfy their declared extents:
@@ -641,8 +643,13 @@ pub unsafe extern "C" fn SQLFetch(statement_handle: SqlHandle) -> SqlReturn {
 /// only.
 ///
 /// # Safety
-/// `statement_handle` must be a valid statement handle or null. The buffers must
-/// stay valid until the column is unbound or the statement is freed.
+/// `statement_handle` must be a valid statement handle or null. The buffers
+/// must stay valid until the column is unbound or the statement is freed. At
+/// each fetch, `target_value_ptr` must be writable for
+/// `SQL_ATTR_ROW_ARRAY_SIZE` elements of `buffer_length` bytes for a character
+/// or binary target, or of the full C type size for a fixed-width target, even
+/// when `buffer_length` is zero or smaller. `strlen_or_ind_ptr`, when non-null,
+/// must be writable for `SQL_ATTR_ROW_ARRAY_SIZE` `SqlLen` values.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn SQLBindCol(
     statement_handle: SqlHandle,
@@ -672,11 +679,13 @@ pub unsafe extern "C" fn SQLBindCol(
 ///
 /// # Safety
 /// `statement_handle` must be a valid statement handle or null.
-/// Every active bound-column data buffer must be writable for the configured
-/// rowset according to its C type and `BufferLength`; its indicator and
-/// octet-length arrays must each be writable for `SQL_ATTR_ROW_ARRAY_SIZE`
-/// `SqlLen` values. Non-null rowset pointer attributes must satisfy their
-/// declared extents: one `SqlULen` for `SQL_ATTR_ROWS_FETCHED_PTR` and
+/// Every active bound-column data buffer must be writable for
+/// `SQL_ATTR_ROW_ARRAY_SIZE` elements of `BufferLength` bytes for a character
+/// or binary target, or of the full C type size for a fixed-width target, even
+/// when `BufferLength` is zero or smaller. Its indicator and octet-length
+/// arrays must each be writable for `SQL_ATTR_ROW_ARRAY_SIZE` `SqlLen` values.
+/// Non-null rowset pointer attributes must satisfy their declared extents: one
+/// `SqlULen` for `SQL_ATTR_ROWS_FETCHED_PTR` and
 /// `SQL_ATTR_ROW_BIND_OFFSET_PTR`, and `SQL_ATTR_ROW_ARRAY_SIZE`
 /// `SqlUSmallInt` values for `SQL_ATTR_ROW_STATUS_PTR`.
 #[unsafe(no_mangle)]

--- a/mssql-odbc/src/api/exports.rs
+++ b/mssql-odbc/src/api/exports.rs
@@ -445,6 +445,9 @@ pub unsafe extern "C" fn SQLFreeStmt(
 /// - `statement_handle` must be a valid STMT handle returned by `SQLAllocHandle`.
 /// - `parameter_value_ptr` / `strlen_or_ind_ptr`, if non-null, must remain valid
 ///   and readable until the statement is executed.
+/// - When `SQL_ATTR_PARAM_BIND_OFFSET_PTR` is non-null, the readable extents
+///   begin at each bound base plus the pointed-to signed byte offset, which may
+///   be negative, so every allocation must cover that displaced range.
 #[unsafe(no_mangle)]
 #[allow(clippy::too_many_arguments)]
 pub unsafe extern "C" fn SQLBindParameter(
@@ -532,8 +535,10 @@ pub unsafe extern "C" fn SQLDescribeParam(
 ///   If `text_length` is `SQL_NTS`, the string must be NUL-terminated.
 /// - Each non-data-at-execution parameter's currently bound value and length
 ///   buffers must remain readable according to its C type and declared lengths.
-/// - `SQL_ATTR_PARAM_BIND_OFFSET_PTR`, when set, must remain readable for one
-///   `SqlLen`.
+/// - When `SQL_ATTR_PARAM_BIND_OFFSET_PTR` is non-null, those readable extents
+///   begin at each bound base plus the pointed-to signed byte offset, which may
+///   be negative, so every allocation must cover that displaced range. The
+///   offset pointer itself must remain readable for one `SqlLen`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn SQLExecDirectW(
     statement_handle: SqlHandle,
@@ -564,8 +569,10 @@ pub unsafe extern "C" fn SQLGetTypeInfoW(
 /// - `statement_handle` must be a valid STMT handle returned by `SQLAllocHandle`.
 /// - Each non-data-at-execution parameter's currently bound value and length
 ///   buffers must remain readable according to its C type and declared lengths.
-/// - `SQL_ATTR_PARAM_BIND_OFFSET_PTR`, when set, must remain readable for one
-///   `SqlLen`.
+/// - When `SQL_ATTR_PARAM_BIND_OFFSET_PTR` is non-null, those readable extents
+///   begin at each bound base plus the pointed-to signed byte offset, which may
+///   be negative, so every allocation must cover that displaced range. The
+///   offset pointer itself must remain readable for one `SqlLen`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn SQLExecute(statement_handle: SqlHandle) -> SqlReturn {
     crate::init_tracing();

--- a/mssql-odbc/src/api/exports.rs
+++ b/mssql-odbc/src/api/exports.rs
@@ -530,6 +530,10 @@ pub unsafe extern "C" fn SQLDescribeParam(
 /// - `statement_handle` must be a valid STMT handle returned by `SQLAllocHandle`.
 /// - `statement_text`, if non-null, must be readable for `text_length` `SQLWCHAR`s.
 ///   If `text_length` is `SQL_NTS`, the string must be NUL-terminated.
+/// - Each non-data-at-execution parameter's currently bound value and length
+///   buffers must remain readable according to its C type and declared lengths.
+/// - `SQL_ATTR_PARAM_BIND_OFFSET_PTR`, when set, must remain readable for one
+///   `SqlLen`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn SQLExecDirectW(
     statement_handle: SqlHandle,
@@ -558,6 +562,10 @@ pub unsafe extern "C" fn SQLGetTypeInfoW(
 ///
 /// # Safety
 /// - `statement_handle` must be a valid STMT handle returned by `SQLAllocHandle`.
+/// - Each non-data-at-execution parameter's currently bound value and length
+///   buffers must remain readable according to its C type and declared lengths.
+/// - `SQL_ATTR_PARAM_BIND_OFFSET_PTR`, when set, must remain readable for one
+///   `SqlLen`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn SQLExecute(statement_handle: SqlHandle) -> SqlReturn {
     crate::init_tracing();
@@ -612,6 +620,14 @@ pub unsafe extern "C" fn SQLPutData(
 ///
 /// # Safety
 /// - `statement_handle` must be a valid STMT handle returned by `SQLAllocHandle`.
+/// - Every active bound-column data buffer must be writable for the configured
+///   rowset according to its C type and `BufferLength`; its indicator and
+///   octet-length arrays must each be writable for `SQL_ATTR_ROW_ARRAY_SIZE`
+///   `SqlLen` values.
+/// - Non-null rowset pointer attributes must satisfy their declared extents:
+///   one `SqlULen` for `SQL_ATTR_ROWS_FETCHED_PTR` and
+///   `SQL_ATTR_ROW_BIND_OFFSET_PTR`, and `SQL_ATTR_ROW_ARRAY_SIZE`
+///   `SqlUSmallInt` values for `SQL_ATTR_ROW_STATUS_PTR`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn SQLFetch(statement_handle: SqlHandle) -> SqlReturn {
     crate::init_tracing();
@@ -656,6 +672,13 @@ pub unsafe extern "C" fn SQLBindCol(
 ///
 /// # Safety
 /// `statement_handle` must be a valid statement handle or null.
+/// Every active bound-column data buffer must be writable for the configured
+/// rowset according to its C type and `BufferLength`; its indicator and
+/// octet-length arrays must each be writable for `SQL_ATTR_ROW_ARRAY_SIZE`
+/// `SqlLen` values. Non-null rowset pointer attributes must satisfy their
+/// declared extents: one `SqlULen` for `SQL_ATTR_ROWS_FETCHED_PTR` and
+/// `SQL_ATTR_ROW_BIND_OFFSET_PTR`, and `SQL_ATTR_ROW_ARRAY_SIZE`
+/// `SqlUSmallInt` values for `SQL_ATTR_ROW_STATUS_PTR`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn SQLFetchScroll(
     statement_handle: SqlHandle,

--- a/mssql-odbc/src/api/exports.rs
+++ b/mssql-odbc/src/api/exports.rs
@@ -98,7 +98,11 @@ pub unsafe extern "C" fn SQLGetEnvAttr(
 /// # Safety
 /// - `connection_handle` must be a valid DBC handle.
 /// - `attribute` must be a valid connection attribute identifier.
-/// - `value_ptr` validity depends on the attribute type.
+/// - For `SQL_COPT_SS_ACCESS_TOKEN`, `value_ptr` must point to a four-byte
+///   native-endian length followed by that many readable UTF-16LE token bytes.
+/// - For `SQL_ATTR_CURRENT_CATALOG`, `value_ptr` must be readable for
+///   `string_length` bytes of UTF-16, or through a NUL terminator when
+///   `string_length` is `SQL_NTS`.
 /// - `string_length` is used only for string-type attributes.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn SQLSetConnectAttrW(
@@ -129,7 +133,11 @@ pub unsafe extern "C" fn SQLSetConnectAttrW(
 /// # Safety
 /// - `connection_handle` must be a valid DBC handle.
 /// - `attribute` must be a valid connection attribute identifier.
-/// - `value_ptr` validity depends on the attribute type.
+/// - For `SQL_COPT_SS_ACCESS_TOKEN`, `value_ptr` must point to a four-byte
+///   native-endian length followed by that many readable UTF-16LE token bytes.
+/// - For `SQL_ATTR_CURRENT_CATALOG`, `value_ptr` must be readable for
+///   `string_length` bytes, or through a NUL terminator when `string_length` is
+///   `SQL_NTS`.
 /// - `string_length` is used only for string-type attributes.
 #[cfg(not(windows))]
 #[unsafe(no_mangle)]

--- a/mssql-odbc/src/api/exports.rs
+++ b/mssql-odbc/src/api/exports.rs
@@ -776,7 +776,10 @@ pub unsafe extern "C" fn SQLColAttributeW(
 ///
 /// # Safety
 /// - `statement_handle` must be a valid STMT handle returned by `SQLAllocHandle`.
-/// - `target_value_ptr`, when non-null, must be writable for `buffer_length` bytes.
+/// - `target_value_ptr`, when non-null, must be writable for `buffer_length`
+///   bytes for variable-width targets. For a fixed-width target it must be
+///   writable for the full size of `target_type`, even when `buffer_length` is
+///   zero or smaller.
 /// - `strlen_or_ind_ptr`, when non-null, must be writable for one `SqlLen`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn SQLGetData(

--- a/mssql-odbc/src/api/fetch.rs
+++ b/mssql-odbc/src/api/fetch.rs
@@ -22,13 +22,15 @@ use crate::api::odbc_types::{SQL_FETCH_NEXT, SqlHandle, SqlReturn};
 ///
 /// # Safety
 /// `statement_handle` must be a valid `StmtHandle` or null.
-/// Every active bound-column data buffer must be writable for the configured
-/// rowset according to its C type and `BufferLength`; its indicator and
-/// octet-length arrays must each be writable for `SQL_ATTR_ROW_ARRAY_SIZE`
-/// `SqlLen` values. `SQL_ATTR_ROWS_FETCHED_PTR` must be writable for one
-/// `SqlULen`, `SQL_ATTR_ROW_STATUS_PTR` for `SQL_ATTR_ROW_ARRAY_SIZE`
-/// `SqlUSmallInt` values, and `SQL_ATTR_ROW_BIND_OFFSET_PTR` must be readable
-/// for one `SqlULen`, whenever those attributes are non-null.
+/// Every active bound-column data buffer must be writable for
+/// `SQL_ATTR_ROW_ARRAY_SIZE` elements of `BufferLength` bytes for a character
+/// or binary target, or of the full C type size for a fixed-width target, even
+/// when `BufferLength` is zero or smaller. Its indicator and octet-length
+/// arrays must each be writable for `SQL_ATTR_ROW_ARRAY_SIZE` `SqlLen` values.
+/// `SQL_ATTR_ROWS_FETCHED_PTR` must be writable for one `SqlULen`,
+/// `SQL_ATTR_ROW_STATUS_PTR` for `SQL_ATTR_ROW_ARRAY_SIZE` `SqlUSmallInt`
+/// values, and `SQL_ATTR_ROW_BIND_OFFSET_PTR` must be readable for one
+/// `SqlULen`, whenever those attributes are non-null.
 pub(crate) unsafe fn sql_fetch(statement_handle: SqlHandle) -> SqlReturn {
     debug!(?statement_handle, "SQLFetch called");
     crate::ffi_entry!("SQLFetch", unsafe {

--- a/mssql-odbc/src/api/fetch.rs
+++ b/mssql-odbc/src/api/fetch.rs
@@ -27,6 +27,9 @@ use crate::api::odbc_types::{SQL_FETCH_NEXT, SqlHandle, SqlReturn};
 /// or binary target, or of the full C type size for a fixed-width target, even
 /// when `BufferLength` is zero or smaller. Its indicator and octet-length
 /// arrays must each be writable for `SQL_ATTR_ROW_ARRAY_SIZE` `SqlLen` values.
+/// When `SQL_ATTR_ROW_BIND_OFFSET_PTR` is non-null, these bound-buffer extents
+/// begin at the base plus the pointed-to byte offset, so each allocation must
+/// also cover that leading displacement.
 /// `SQL_ATTR_ROWS_FETCHED_PTR` must be writable for one `SqlULen`,
 /// `SQL_ATTR_ROW_STATUS_PTR` for `SQL_ATTR_ROW_ARRAY_SIZE` `SqlUSmallInt`
 /// values, and `SQL_ATTR_ROW_BIND_OFFSET_PTR` must be readable for one

--- a/mssql-odbc/src/api/fetch.rs
+++ b/mssql-odbc/src/api/fetch.rs
@@ -22,6 +22,13 @@ use crate::api::odbc_types::{SQL_FETCH_NEXT, SqlHandle, SqlReturn};
 ///
 /// # Safety
 /// `statement_handle` must be a valid `StmtHandle` or null.
+/// Every active bound-column data buffer must be writable for the configured
+/// rowset according to its C type and `BufferLength`; its indicator and
+/// octet-length arrays must each be writable for `SQL_ATTR_ROW_ARRAY_SIZE`
+/// `SqlLen` values. `SQL_ATTR_ROWS_FETCHED_PTR` must be writable for one
+/// `SqlULen`, `SQL_ATTR_ROW_STATUS_PTR` for `SQL_ATTR_ROW_ARRAY_SIZE`
+/// `SqlUSmallInt` values, and `SQL_ATTR_ROW_BIND_OFFSET_PTR` must be readable
+/// for one `SqlULen`, whenever those attributes are non-null.
 pub(crate) unsafe fn sql_fetch(statement_handle: SqlHandle) -> SqlReturn {
     debug!(?statement_handle, "SQLFetch called");
     crate::ffi_entry!("SQLFetch", unsafe {

--- a/mssql-odbc/src/api/fetch_scroll.rs
+++ b/mssql-odbc/src/api/fetch_scroll.rs
@@ -77,6 +77,13 @@ struct PlpColumnInfo {
 ///
 /// # Safety
 /// `statement_handle` must be a valid `StmtHandle` or null.
+/// Every active bound-column data buffer must be writable for the configured
+/// rowset according to its C type and `BufferLength`; its indicator and
+/// octet-length arrays must each be writable for `SQL_ATTR_ROW_ARRAY_SIZE`
+/// `SqlLen` values. `SQL_ATTR_ROWS_FETCHED_PTR` must be writable for one
+/// `SqlULen`, `SQL_ATTR_ROW_STATUS_PTR` for `SQL_ATTR_ROW_ARRAY_SIZE`
+/// `SqlUSmallInt` values, and `SQL_ATTR_ROW_BIND_OFFSET_PTR` must be readable
+/// for one `SqlULen`, whenever those attributes are non-null.
 pub(crate) unsafe fn sql_fetch_scroll(
     statement_handle: SqlHandle,
     fetch_orientation: SqlSmallInt,
@@ -91,6 +98,15 @@ pub(crate) unsafe fn sql_fetch_scroll(
     })
 }
 
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`.
+/// Every active bound-column data buffer must be writable for the configured
+/// rowset according to its C type and `BufferLength`; its indicator and
+/// octet-length arrays must each be writable for `SQL_ATTR_ROW_ARRAY_SIZE`
+/// `SqlLen` values. `SQL_ATTR_ROWS_FETCHED_PTR` must be writable for one
+/// `SqlULen`, `SQL_ATTR_ROW_STATUS_PTR` for `SQL_ATTR_ROW_ARRAY_SIZE`
+/// `SqlUSmallInt` values, and `SQL_ATTR_ROW_BIND_OFFSET_PTR` must be readable
+/// for one `SqlULen`, whenever those attributes are non-null.
 pub(crate) unsafe fn sql_fetch_scroll_impl(
     statement_handle: SqlHandle,
     fetch_orientation: SqlSmallInt,
@@ -1309,6 +1325,10 @@ fn trim_partial_utf8(bytes: &mut Vec<u8>) {
 /// the two pointers alias (the common `SQLBindCol` case, and when there is no
 /// indicator at all): the length write below lands on the same location
 /// there, so nothing stale can survive either way.
+///
+/// # Safety
+/// `indicator` must be null, equal to `octet_length`, or writable for one
+/// `SqlLen`.
 unsafe fn clear_stale_null_indicator(indicator: *mut SqlLen, octet_length: *mut SqlLen) {
     if !indicator.is_null() && indicator != octet_length {
         unsafe { write_if_some(indicator, 0) };

--- a/mssql-odbc/src/api/fetch_scroll.rs
+++ b/mssql-odbc/src/api/fetch_scroll.rs
@@ -82,6 +82,9 @@ struct PlpColumnInfo {
 /// or binary target, or of the full C type size for a fixed-width target, even
 /// when `BufferLength` is zero or smaller. Its indicator and octet-length
 /// arrays must each be writable for `SQL_ATTR_ROW_ARRAY_SIZE` `SqlLen` values.
+/// When `SQL_ATTR_ROW_BIND_OFFSET_PTR` is non-null, these bound-buffer extents
+/// begin at the base plus the pointed-to byte offset, so each allocation must
+/// also cover that leading displacement.
 /// `SQL_ATTR_ROWS_FETCHED_PTR` must be writable for one `SqlULen`,
 /// `SQL_ATTR_ROW_STATUS_PTR` for `SQL_ATTR_ROW_ARRAY_SIZE` `SqlUSmallInt`
 /// values, and `SQL_ATTR_ROW_BIND_OFFSET_PTR` must be readable for one
@@ -107,6 +110,9 @@ pub(crate) unsafe fn sql_fetch_scroll(
 /// or binary target, or of the full C type size for a fixed-width target, even
 /// when `BufferLength` is zero or smaller. Its indicator and octet-length
 /// arrays must each be writable for `SQL_ATTR_ROW_ARRAY_SIZE` `SqlLen` values.
+/// When `SQL_ATTR_ROW_BIND_OFFSET_PTR` is non-null, these bound-buffer extents
+/// begin at the base plus the pointed-to byte offset, so each allocation must
+/// also cover that leading displacement.
 /// `SQL_ATTR_ROWS_FETCHED_PTR` must be writable for one `SqlULen`,
 /// `SQL_ATTR_ROW_STATUS_PTR` for `SQL_ATTR_ROW_ARRAY_SIZE` `SqlUSmallInt`
 /// values, and `SQL_ATTR_ROW_BIND_OFFSET_PTR` must be readable for one

--- a/mssql-odbc/src/api/fetch_scroll.rs
+++ b/mssql-odbc/src/api/fetch_scroll.rs
@@ -77,13 +77,15 @@ struct PlpColumnInfo {
 ///
 /// # Safety
 /// `statement_handle` must be a valid `StmtHandle` or null.
-/// Every active bound-column data buffer must be writable for the configured
-/// rowset according to its C type and `BufferLength`; its indicator and
-/// octet-length arrays must each be writable for `SQL_ATTR_ROW_ARRAY_SIZE`
-/// `SqlLen` values. `SQL_ATTR_ROWS_FETCHED_PTR` must be writable for one
-/// `SqlULen`, `SQL_ATTR_ROW_STATUS_PTR` for `SQL_ATTR_ROW_ARRAY_SIZE`
-/// `SqlUSmallInt` values, and `SQL_ATTR_ROW_BIND_OFFSET_PTR` must be readable
-/// for one `SqlULen`, whenever those attributes are non-null.
+/// Every active bound-column data buffer must be writable for
+/// `SQL_ATTR_ROW_ARRAY_SIZE` elements of `BufferLength` bytes for a character
+/// or binary target, or of the full C type size for a fixed-width target, even
+/// when `BufferLength` is zero or smaller. Its indicator and octet-length
+/// arrays must each be writable for `SQL_ATTR_ROW_ARRAY_SIZE` `SqlLen` values.
+/// `SQL_ATTR_ROWS_FETCHED_PTR` must be writable for one `SqlULen`,
+/// `SQL_ATTR_ROW_STATUS_PTR` for `SQL_ATTR_ROW_ARRAY_SIZE` `SqlUSmallInt`
+/// values, and `SQL_ATTR_ROW_BIND_OFFSET_PTR` must be readable for one
+/// `SqlULen`, whenever those attributes are non-null.
 pub(crate) unsafe fn sql_fetch_scroll(
     statement_handle: SqlHandle,
     fetch_orientation: SqlSmallInt,
@@ -100,13 +102,15 @@ pub(crate) unsafe fn sql_fetch_scroll(
 
 /// # Safety
 /// `statement_handle` must be null or point to a live `StmtHandle`.
-/// Every active bound-column data buffer must be writable for the configured
-/// rowset according to its C type and `BufferLength`; its indicator and
-/// octet-length arrays must each be writable for `SQL_ATTR_ROW_ARRAY_SIZE`
-/// `SqlLen` values. `SQL_ATTR_ROWS_FETCHED_PTR` must be writable for one
-/// `SqlULen`, `SQL_ATTR_ROW_STATUS_PTR` for `SQL_ATTR_ROW_ARRAY_SIZE`
-/// `SqlUSmallInt` values, and `SQL_ATTR_ROW_BIND_OFFSET_PTR` must be readable
-/// for one `SqlULen`, whenever those attributes are non-null.
+/// Every active bound-column data buffer must be writable for
+/// `SQL_ATTR_ROW_ARRAY_SIZE` elements of `BufferLength` bytes for a character
+/// or binary target, or of the full C type size for a fixed-width target, even
+/// when `BufferLength` is zero or smaller. Its indicator and octet-length
+/// arrays must each be writable for `SQL_ATTR_ROW_ARRAY_SIZE` `SqlLen` values.
+/// `SQL_ATTR_ROWS_FETCHED_PTR` must be writable for one `SqlULen`,
+/// `SQL_ATTR_ROW_STATUS_PTR` for `SQL_ATTR_ROW_ARRAY_SIZE` `SqlUSmallInt`
+/// values, and `SQL_ATTR_ROW_BIND_OFFSET_PTR` must be readable for one
+/// `SqlULen`, whenever those attributes are non-null.
 pub(crate) unsafe fn sql_fetch_scroll_impl(
     statement_handle: SqlHandle,
     fetch_orientation: SqlSmallInt,

--- a/mssql-odbc/src/api/get_connect_attr.rs
+++ b/mssql-odbc/src/api/get_connect_attr.rs
@@ -37,8 +37,10 @@ const DEFAULT_LOGIN_TIMEOUT_SECS: u32 = DEFAULT_CONNECT_TIMEOUT_SECS;
 ///
 /// # Safety
 /// - `connection_handle` must be a valid `DbcHandle` from `SQLAllocHandle`.
-/// - For `SQL_ATTR_LOGIN_TIMEOUT`, `value_ptr` must point to a writable
-///   `SQLUINTEGER`.
+/// - `value_ptr`, when non-null, must be writable for `buffer_length` bytes for
+///   `SQL_ATTR_CURRENT_CATALOG`, or for one value of the requested fixed-width
+///   attribute type otherwise.
+/// - `string_length_ptr`, when non-null, must be writable for one `SqlInteger`.
 pub(crate) unsafe fn sql_get_connect_attr_w(
     connection_handle: SqlHandle,
     attribute: SqlInteger,
@@ -66,6 +68,12 @@ pub(crate) unsafe fn sql_get_connect_attr_w(
     })
 }
 
+/// # Safety
+/// `connection_handle` must be null or point to a live `DbcHandle`.
+/// `value_ptr`, when non-null, must be writable for `buffer_length` bytes for
+/// `SQL_ATTR_CURRENT_CATALOG`, or for one value of the requested fixed-width
+/// attribute type otherwise. `string_length_ptr`, when non-null, must be
+/// writable for one `SqlInteger`.
 unsafe fn sql_get_connect_attr_w_impl(
     connection_handle: SqlHandle,
     attribute: SqlInteger,

--- a/mssql-odbc/src/api/get_data.rs
+++ b/mssql-odbc/src/api/get_data.rs
@@ -40,6 +40,12 @@ use mssql_tds::query::metadata::PlpEncoding;
 /// - Supports `SQL_C_CHAR` and `SQL_C_WCHAR` for text retrieval.
 /// - Supports incremental row resume and chunked PLP retrieval via
 ///   `read_active_plp_chunk`.
+///
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`.
+/// `target_value_ptr`, when non-null, must be writable for `buffer_length`
+/// bytes, including when `target_type` is `SQL_C_WCHAR`. `strlen_or_ind_ptr`,
+/// when non-null, must be writable for one `SqlLen`.
 pub(crate) unsafe fn sql_get_data(
     statement_handle: SqlHandle,
     column_number: SqlUSmallInt,
@@ -70,6 +76,11 @@ pub(crate) unsafe fn sql_get_data(
     })
 }
 
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`.
+/// `target_value_ptr`, when non-null, must be writable for `buffer_length`
+/// bytes, including when `target_type` is `SQL_C_WCHAR`. `strlen_or_ind_ptr`,
+/// when non-null, must be writable for one `SqlLen`.
 unsafe fn sql_get_data_impl(
     statement_handle: SqlHandle,
     column_number: SqlUSmallInt,

--- a/mssql-odbc/src/api/get_data.rs
+++ b/mssql-odbc/src/api/get_data.rs
@@ -44,8 +44,10 @@ use mssql_tds::query::metadata::PlpEncoding;
 /// # Safety
 /// `statement_handle` must be null or point to a live `StmtHandle`.
 /// `target_value_ptr`, when non-null, must be writable for `buffer_length`
-/// bytes, including when `target_type` is `SQL_C_WCHAR`. `strlen_or_ind_ptr`,
-/// when non-null, must be writable for one `SqlLen`.
+/// bytes for variable-width targets, including `SQL_C_WCHAR`, where the length
+/// is still measured in bytes. For a fixed-width target it must be writable for
+/// the full size of `target_type`, even when `buffer_length` is zero or smaller.
+/// `strlen_or_ind_ptr`, when non-null, must be writable for one `SqlLen`.
 pub(crate) unsafe fn sql_get_data(
     statement_handle: SqlHandle,
     column_number: SqlUSmallInt,
@@ -79,8 +81,10 @@ pub(crate) unsafe fn sql_get_data(
 /// # Safety
 /// `statement_handle` must be null or point to a live `StmtHandle`.
 /// `target_value_ptr`, when non-null, must be writable for `buffer_length`
-/// bytes, including when `target_type` is `SQL_C_WCHAR`. `strlen_or_ind_ptr`,
-/// when non-null, must be writable for one `SqlLen`.
+/// bytes for variable-width targets, including `SQL_C_WCHAR`, where the length
+/// is still measured in bytes. For a fixed-width target it must be writable for
+/// the full size of `target_type`, even when `buffer_length` is zero or smaller.
+/// `strlen_or_ind_ptr`, when non-null, must be writable for one `SqlLen`.
 unsafe fn sql_get_data_impl(
     statement_handle: SqlHandle,
     column_number: SqlUSmallInt,

--- a/mssql-odbc/src/api/get_desc_field.rs
+++ b/mssql-odbc/src/api/get_desc_field.rs
@@ -35,7 +35,11 @@ use crate::handles::{DescHandle, HandleType, handle_from_raw};
 /// Implementation of [`SQLGetDescFieldW`](super::exports::SQLGetDescFieldW).
 ///
 /// # Safety
-/// See the exported function's doc for caller requirements.
+/// `descriptor_handle` must be null or point to a live `DescHandle`. For a
+/// character field, `value_ptr`, when non-null, must be writable for
+/// `buffer_length` bytes; for any other field it must be writable for one value
+/// of that field's declared type. `string_length_ptr`, when non-null, must be
+/// writable for one `SqlInteger`.
 #[allow(clippy::too_many_arguments)]
 pub(crate) unsafe fn sql_get_desc_field_w(
     descriptor_handle: SqlHandle,
@@ -66,6 +70,12 @@ pub(crate) unsafe fn sql_get_desc_field_w(
     })
 }
 
+/// # Safety
+/// `descriptor_handle` must be null or point to a live `DescHandle`. For a
+/// character field, `value_ptr`, when non-null, must be writable for
+/// `buffer_length` bytes; for any other field it must be writable for one value
+/// of that field's declared type. `string_length_ptr`, when non-null, must be
+/// writable for one `SqlInteger`.
 #[allow(clippy::too_many_arguments)]
 unsafe fn sql_get_desc_field_w_impl(
     descriptor_handle: SqlHandle,

--- a/mssql-odbc/src/api/get_desc_rec.rs
+++ b/mssql-odbc/src/api/get_desc_rec.rs
@@ -26,7 +26,10 @@ use crate::handles::{DescHandle, HandleType, handle_from_raw};
 /// Implementation of [`SQLGetDescRecW`](super::exports::SQLGetDescRecW).
 ///
 /// # Safety
-/// See the exported function's doc for caller requirements.
+/// `descriptor_handle` must be null or point to a live `DescHandle`. `name`,
+/// when non-null, must be writable for `buffer_length` UTF-16 code units. Every
+/// other output pointer, when non-null, must be writable for one value of its
+/// pointed-to type.
 #[allow(clippy::too_many_arguments)]
 pub(crate) unsafe fn sql_get_desc_rec_w(
     descriptor_handle: SqlHandle,
@@ -72,6 +75,11 @@ pub(crate) unsafe fn sql_get_desc_rec_w(
     })
 }
 
+/// # Safety
+/// `descriptor_handle` must be null or point to a live `DescHandle`. `name`,
+/// when non-null, must be writable for `buffer_length` UTF-16 code units. Every
+/// other output pointer, when non-null, must be writable for one value of its
+/// pointed-to type.
 #[allow(clippy::too_many_arguments)]
 unsafe fn sql_get_desc_rec_w_impl(
     descriptor_handle: SqlHandle,

--- a/mssql-odbc/src/api/get_diag.rs
+++ b/mssql-odbc/src/api/get_diag.rs
@@ -362,6 +362,10 @@ unsafe fn diag_record_count(
 /// TODO: Add an OOM-resilient fallback diagnostic path for out-of-memory:
 /// store a non-allocating OOM flag on the handle and return
 /// static HY001 text for record 1 without heap allocation.
+///
+/// # Safety
+/// `handle` must be a valid, non-null handle pointer of the type identified by
+/// `handle_type`.
 unsafe fn snapshot_record(
     handle_type: SqlSmallInt,
     handle: SqlHandle,

--- a/mssql-odbc/src/api/get_env_attr.rs
+++ b/mssql-odbc/src/api/get_env_attr.rs
@@ -40,6 +40,10 @@ pub(crate) unsafe fn sql_get_env_attr(
     })
 }
 
+/// # Safety
+/// `environment_handle` must be null or point to a live `EnvHandle`.
+/// `value_ptr`, when non-null, must be writable for one `u32`, and
+/// `string_length_ptr`, when non-null, must be writable for one `SqlInteger`.
 unsafe fn sql_get_env_attr_impl(
     environment_handle: SqlHandle,
     attribute: SqlInteger,

--- a/mssql-odbc/src/api/get_functions.rs
+++ b/mssql-odbc/src/api/get_functions.rs
@@ -50,6 +50,12 @@ pub(crate) unsafe fn sql_get_functions(
     })
 }
 
+/// # Safety
+/// `connection_handle` must be null or point to a live `DbcHandle`.
+/// `supported_ptr`, when non-null, must be writable for one `SqlUSmallInt`, for
+/// `SQL_API_ALL_FUNCTIONS_SIZE` elements when requesting
+/// `SQL_API_ALL_FUNCTIONS`, or for the ODBC 3 function bitmap when requesting
+/// `SQL_API_ODBC3_ALL_FUNCTIONS`.
 unsafe fn sql_get_functions_impl(
     connection_handle: SqlHandle,
     function_id: SqlUSmallInt,

--- a/mssql-odbc/src/api/get_functions.rs
+++ b/mssql-odbc/src/api/get_functions.rs
@@ -54,8 +54,8 @@ pub(crate) unsafe fn sql_get_functions(
 /// `connection_handle` must be null or point to a live `DbcHandle`.
 /// `supported_ptr`, when non-null, must be writable for one `SqlUSmallInt`, for
 /// `SQL_API_ALL_FUNCTIONS_SIZE` elements when requesting
-/// `SQL_API_ALL_FUNCTIONS`, or for the ODBC 3 function bitmap when requesting
-/// `SQL_API_ODBC3_ALL_FUNCTIONS`.
+/// `SQL_API_ALL_FUNCTIONS`, or for `SQL_API_ODBC3_ALL_FUNCTIONS_SIZE` elements
+/// when requesting `SQL_API_ODBC3_ALL_FUNCTIONS`.
 unsafe fn sql_get_functions_impl(
     connection_handle: SqlHandle,
     function_id: SqlUSmallInt,

--- a/mssql-odbc/src/api/get_info.rs
+++ b/mssql-odbc/src/api/get_info.rs
@@ -55,6 +55,12 @@ pub(crate) unsafe fn sql_get_info_w(
     })
 }
 
+/// # Safety
+/// `connection_handle` must be null or point to a live `DbcHandle`.
+/// `info_value_ptr`, when non-null, must be writable for `buffer_length` bytes
+/// for string information or for one value of the requested numeric information
+/// type. `string_length_ptr`, when non-null, must be writable for one
+/// `SqlSmallInt`.
 unsafe fn sql_get_info_w_impl(
     connection_handle: SqlHandle,
     info_type: SqlUSmallInt,

--- a/mssql-odbc/src/api/get_type_info.rs
+++ b/mssql-odbc/src/api/get_type_info.rs
@@ -70,6 +70,8 @@ pub(crate) unsafe fn sql_get_type_info_w(
     })
 }
 
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`.
 unsafe fn sql_get_type_info_w_impl(
     statement_handle: SqlHandle,
     data_type: SqlSmallInt,

--- a/mssql-odbc/src/api/more_results.rs
+++ b/mssql-odbc/src/api/more_results.rs
@@ -38,6 +38,8 @@ pub(crate) unsafe fn sql_more_results(statement_handle: SqlHandle) -> SqlReturn 
     })
 }
 
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`.
 unsafe fn sql_more_results_impl(statement_handle: SqlHandle) -> SqlReturn {
     if statement_handle.is_null() {
         error!("SQLMoreResults: statement_handle is null");

--- a/mssql-odbc/src/api/num_result_cols.rs
+++ b/mssql-odbc/src/api/num_result_cols.rs
@@ -34,6 +34,9 @@ pub(crate) unsafe fn sql_num_result_cols(
     })
 }
 
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`.
+/// `column_count_ptr`, when non-null, must be writable for one `SqlSmallInt`.
 unsafe fn sql_num_result_cols_impl(
     statement_handle: SqlHandle,
     column_count_ptr: *mut SqlSmallInt,

--- a/mssql-odbc/src/api/param_data.rs
+++ b/mssql-odbc/src/api/param_data.rs
@@ -59,6 +59,9 @@ pub(crate) unsafe fn sql_param_data(
     })
 }
 
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`.
+/// `value_ptr_ptr`, when non-null, must be writable for one `SqlPointer`.
 unsafe fn sql_param_data_impl(
     statement_handle: SqlHandle,
     value_ptr_ptr: *mut SqlPointer,

--- a/mssql-odbc/src/api/prepare.rs
+++ b/mssql-odbc/src/api/prepare.rs
@@ -48,6 +48,10 @@ pub(crate) unsafe fn sql_prepare_w(
     })
 }
 
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`.
+/// `statement_text` must be readable for `text_length` UTF-16 code units, or
+/// through a NUL terminator when `text_length` is `SQL_NTS`.
 unsafe fn sql_prepare_w_impl(
     statement_handle: SqlHandle,
     statement_text: *const SqlWChar,

--- a/mssql-odbc/src/api/put_data.rs
+++ b/mssql-odbc/src/api/put_data.rs
@@ -451,8 +451,8 @@ mod tests {
 
     #[test]
     fn nts_byte_count_reads_a_misaligned_wide_buffer() {
-        let mut storage = [0u8; 8];
-        let ptr = unsafe { storage.as_mut_ptr().add(1) };
+        let mut storage = [0u16; 4];
+        let ptr = unsafe { storage.as_mut_ptr().cast::<u8>().add(1) };
         assert_ne!(
             ptr as usize % std::mem::align_of::<u16>(),
             0,

--- a/mssql-odbc/src/api/put_data.rs
+++ b/mssql-odbc/src/api/put_data.rs
@@ -29,11 +29,11 @@ use crate::handles::{HandleType, StmtHandle, handle_from_raw};
 /// - `data_ptr`, when `strlen_or_ind` is a positive byte count, must be
 ///   readable for that many bytes and must remain valid for the duration of
 ///   this call.
-/// - `data_ptr`, when `strlen_or_ind` is `SQL_NTS`, must be non-null, aligned
-///   for the bound parameter's C type, and NUL-terminated within an allocation
-///   it owns: the terminator search reads `u16` units for `SQL_C_WCHAR` and
-///   `u8` units otherwise, and runs off the end of the allocation if no
-///   terminator is present.
+/// - `data_ptr`, when `strlen_or_ind` is `SQL_NTS`, must be non-null and
+///   NUL-terminated within an allocation it owns: the terminator search
+///   reads potentially unaligned `u16` units for `SQL_C_WCHAR` and `u8` units
+///   otherwise, and runs off the end of the allocation if no terminator is
+///   present.
 pub(crate) unsafe fn sql_put_data(
     statement_handle: SqlHandle,
     data_ptr: SqlPointer,
@@ -50,6 +50,11 @@ pub(crate) unsafe fn sql_put_data(
     })
 }
 
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`. For a
+/// positive `strlen_or_ind`, `data_ptr` must be readable for that many bytes.
+/// For `SQL_NTS`, it must be non-null and readable through a NUL terminator as
+/// the bound C type.
 unsafe fn sql_put_data_impl(
     statement_handle: SqlHandle,
     data_ptr: SqlPointer,
@@ -70,11 +75,15 @@ unsafe fn sql_put_data_impl(
     unsafe { sql_put_data_safe(statement_handle, stmt, data_ptr, strlen_or_ind) }
 }
 
+/// # Safety
+/// `data_ptr` must be non-null and point to an allocation readable through a
+/// NUL terminator. The allocation is read as potentially unaligned `u16` units
+/// when `c_type` is `SQL_C_WCHAR`, and as `u8` units otherwise.
 unsafe fn nts_byte_count(data_ptr: SqlPointer, c_type: i16) -> usize {
     if c_type == SQL_C_WCHAR {
         let ptr = data_ptr as *const u16;
         let mut units = 0usize;
-        while unsafe { *ptr.add(units) } != 0 {
+        while unsafe { ptr.add(units).read_unaligned() } != 0 {
             units += 1;
         }
         units * std::mem::size_of::<u16>()
@@ -88,6 +97,11 @@ unsafe fn nts_byte_count(data_ptr: SqlPointer, c_type: i16) -> usize {
     }
 }
 
+/// # Safety
+/// `statement_handle` must identify the live `stmt`. For a positive
+/// `strlen_or_ind`, `data_ptr` must be readable for that many bytes. For
+/// `SQL_NTS`, it must be non-null and readable through a NUL terminator as the
+/// currently bound C type.
 unsafe fn sql_put_data_safe(
     statement_handle: SqlHandle,
     stmt: &StmtHandle,

--- a/mssql-odbc/src/api/put_data.rs
+++ b/mssql-odbc/src/api/put_data.rs
@@ -449,6 +449,23 @@ mod tests {
         assert_eq!(unsafe { nts_byte_count(ptr, 0) }, 1);
     }
 
+    #[test]
+    fn nts_byte_count_reads_a_misaligned_wide_buffer() {
+        let mut storage = [0u8; 8];
+        let ptr = unsafe { storage.as_mut_ptr().add(1) };
+        assert_ne!(
+            ptr as usize % std::mem::align_of::<u16>(),
+            0,
+            "test pointer must be misaligned"
+        );
+        unsafe {
+            ptr.cast::<u16>().write_unaligned(0x0041);
+            ptr.add(2).cast::<u16>().write_unaligned(0x0000);
+        }
+
+        assert_eq!(unsafe { nts_byte_count(ptr.cast(), SQL_C_WCHAR) }, 2);
+    }
+
     /// A binding can disappear under an open sequence via
     /// `SQLFreeStmt(SQL_RESET_PARAMS)`, leaving no C type to size `SQL_NTS`
     /// with. The call is rejected instead of guessing.

--- a/mssql-odbc/src/api/row_count.rs
+++ b/mssql-odbc/src/api/row_count.rs
@@ -32,6 +32,9 @@ pub(crate) unsafe fn sql_row_count(
     })
 }
 
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`.
+/// `row_count_ptr`, when non-null, must be writable for one `SqlLen`.
 unsafe fn sql_row_count_impl(statement_handle: SqlHandle, row_count_ptr: *mut SqlLen) -> SqlReturn {
     // msodbcsql relies on the Driver Manager to reject a null handle before the
     // driver is called and does not null-check it. We validate anyway to keep

--- a/mssql-odbc/src/api/set_connect_attr.rs
+++ b/mssql-odbc/src/api/set_connect_attr.rs
@@ -48,7 +48,7 @@ const MAX_LOGIN_TIMEOUT_SECS: u64 = 0xfffe;
 /// # Safety
 /// - `connection_handle` must be a valid `DbcHandle` from `SQLAllocHandle`.
 /// - For `SQL_COPT_SS_ACCESS_TOKEN`, `value_ptr` must point to an ACCESSTOKEN
-///   struct: a 4-byte little-endian length prefix followed by that many bytes
+///   struct: a 4-byte native-endian length prefix followed by that many bytes
 ///   of the UTF-16-LE-encoded access token.
 /// - For `SQL_ATTR_CURRENT_CATALOG`, `value_ptr` must point to `string_length`
 ///   readable bytes of UTF-16, or to a NUL-terminated wide string when
@@ -160,7 +160,7 @@ unsafe fn sql_set_connect_attr_impl(
 /// # Safety
 /// `connection_handle` must be null or point to a live `DbcHandle`. For
 /// `SQL_COPT_SS_ACCESS_TOKEN`, `value_ptr` must point to a four-byte
-/// little-endian length followed by that many readable token bytes. For
+/// native-endian length followed by that many readable token bytes. For
 /// `SQL_ATTR_CURRENT_CATALOG`, it must be readable for `string_length` bytes of
 /// UTF-16, or through a NUL terminator when `string_length` is `SQL_NTS`.
 unsafe fn sql_set_connect_attr_w_impl(
@@ -508,10 +508,10 @@ mod tests {
     use crate::test_support::TestHandles;
 
     /// Build a `SQL_COPT_SS_ACCESS_TOKEN` struct the way msodbcsql apps do:
-    /// a 4-byte little-endian length followed by UTF-16-LE token bytes.
+    /// a 4-byte native-endian length followed by UTF-16-LE token bytes.
     fn make_token_struct(jwt: &str) -> Vec<u8> {
         let token_bytes: Vec<u8> = jwt.encode_utf16().flat_map(|u| u.to_le_bytes()).collect();
-        let mut buf = (token_bytes.len() as u32).to_le_bytes().to_vec();
+        let mut buf = (token_bytes.len() as u32).to_ne_bytes().to_vec();
         buf.extend_from_slice(&token_bytes);
         buf
     }

--- a/mssql-odbc/src/api/set_connect_attr.rs
+++ b/mssql-odbc/src/api/set_connect_attr.rs
@@ -77,6 +77,13 @@ pub(crate) unsafe fn sql_set_connect_attr_w(
 /// the target driver as ANSI bytes. Once the driver is loaded, it prefers the
 /// unsuffixed setter for replay. The native Linux msodbcsql driver exports this
 /// symbol alongside `SQLSetConnectAttrW` for the same path.
+///
+/// # Safety
+/// `connection_handle` must be null or point to a live `DbcHandle`. For
+/// `SQL_ATTR_CURRENT_CATALOG`, `value_ptr` must be readable for `string_length`
+/// bytes, or through a NUL terminator when `string_length` is `SQL_NTS`. Other
+/// attributes must satisfy the corresponding `SQLSetConnectAttrW` pointer
+/// contract.
 #[cfg(not(windows))]
 pub(crate) unsafe fn sql_set_connect_attr(
     connection_handle: SqlHandle,
@@ -102,6 +109,12 @@ fn requires_ansi_transcoding(attribute: SqlInteger) -> bool {
     matches!(attribute, SQL_ATTR_CURRENT_CATALOG)
 }
 
+/// # Safety
+/// `connection_handle` must be null or point to a live `DbcHandle`. For
+/// `SQL_ATTR_CURRENT_CATALOG`, `value_ptr` must be readable for `string_length`
+/// bytes, or through a NUL terminator when `string_length` is `SQL_NTS`. Other
+/// attributes must satisfy the corresponding `SQLSetConnectAttrW` pointer
+/// contract.
 #[cfg(not(windows))]
 unsafe fn sql_set_connect_attr_impl(
     connection_handle: SqlHandle,
@@ -144,6 +157,12 @@ unsafe fn sql_set_connect_attr_impl(
     }
 }
 
+/// # Safety
+/// `connection_handle` must be null or point to a live `DbcHandle`. For
+/// `SQL_COPT_SS_ACCESS_TOKEN`, `value_ptr` must point to a four-byte
+/// little-endian length followed by that many readable token bytes. For
+/// `SQL_ATTR_CURRENT_CATALOG`, it must be readable for `string_length` bytes of
+/// UTF-16, or through a NUL terminator when `string_length` is `SQL_NTS`.
 unsafe fn sql_set_connect_attr_w_impl(
     connection_handle: SqlHandle,
     attribute: SqlInteger,

--- a/mssql-odbc/src/api/set_desc_field.rs
+++ b/mssql-odbc/src/api/set_desc_field.rs
@@ -54,7 +54,10 @@ use crate::handles::{DescHandle, HandleType, handle_from_raw};
 /// Implementation of [`SQLSetDescFieldW`](super::exports::SQLSetDescFieldW).
 ///
 /// # Safety
-/// See the exported function's doc for caller requirements.
+/// `descriptor_handle` must be null or point to a live `DescHandle`. For a
+/// character field, `value_ptr` must be readable for `buffer_length` bytes or
+/// through a NUL terminator when `buffer_length` is `SQL_NTS`. For a pointer
+/// field, its value is stored and must remain valid while it is bound.
 pub(crate) unsafe fn sql_set_desc_field_w(
     descriptor_handle: SqlHandle,
     record_number: SqlSmallInt,
@@ -81,6 +84,11 @@ pub(crate) unsafe fn sql_set_desc_field_w(
     })
 }
 
+/// # Safety
+/// `descriptor_handle` must be null or point to a live `DescHandle`. For a
+/// character field, `value_ptr` must be readable for `buffer_length` bytes or
+/// through a NUL terminator when `buffer_length` is `SQL_NTS`. For a pointer
+/// field, its value is stored and must remain valid while it is bound.
 unsafe fn sql_set_desc_field_w_impl(
     descriptor_handle: SqlHandle,
     record_number: SqlSmallInt,

--- a/mssql-odbc/src/api/set_desc_rec.rs
+++ b/mssql-odbc/src/api/set_desc_rec.rs
@@ -39,7 +39,9 @@ use crate::handles::{DescHandle, HandleType, handle_from_raw};
 /// Implementation of [`SQLSetDescRec`](super::exports::SQLSetDescRec).
 ///
 /// # Safety
-/// See the exported function's doc for caller requirements.
+/// `descriptor_handle` must be null or point to a live, non-IRD `DescHandle`.
+/// `data_ptr`, `string_length_ptr`, and `indicator_ptr`, when non-null, are
+/// stored and must remain valid while the descriptor record is bound.
 #[allow(clippy::too_many_arguments)]
 pub(crate) unsafe fn sql_set_desc_rec(
     descriptor_handle: SqlHandle,
@@ -82,6 +84,10 @@ pub(crate) unsafe fn sql_set_desc_rec(
     })
 }
 
+/// # Safety
+/// `descriptor_handle` must be null or point to a live, non-IRD `DescHandle`.
+/// `data_ptr`, `string_length_ptr`, and `indicator_ptr`, when non-null, are
+/// stored and must remain valid while the descriptor record is bound.
 #[allow(clippy::too_many_arguments)]
 unsafe fn sql_set_desc_rec_impl(
     descriptor_handle: SqlHandle,

--- a/mssql-odbc/src/api/set_env_attr.rs
+++ b/mssql-odbc/src/api/set_env_attr.rs
@@ -39,6 +39,9 @@ pub(crate) unsafe fn sql_set_env_attr(
     })
 }
 
+/// # Safety
+/// `environment_handle` must be null or point to a live `EnvHandle`.
+/// `value_ptr` must contain the ODBC tagged integer value for `attribute`.
 unsafe fn sql_set_env_attr_impl(
     environment_handle: SqlHandle,
     attribute: SqlInteger,

--- a/mssql-odbc/src/api/set_stmt_attr.rs
+++ b/mssql-odbc/src/api/set_stmt_attr.rs
@@ -115,6 +115,12 @@ pub(crate) unsafe fn sql_set_stmt_attr_w(
     })
 }
 
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`. For the two
+/// query-notification string attributes, `value_ptr` must be readable for
+/// `string_length` bytes of UTF-16 or through a NUL terminator when the length is
+/// `SQL_NTS`. Pointer-valued attributes must remain valid while associated with
+/// the statement.
 unsafe fn sql_set_stmt_attr_w_impl(
     statement_handle: SqlHandle,
     attribute: SqlInteger,
@@ -567,6 +573,11 @@ pub(crate) unsafe fn sql_get_stmt_attr_w(
     })
 }
 
+/// # Safety
+/// `statement_handle` must be null or point to a live `StmtHandle`. `value_ptr`,
+/// when non-null, must be writable for `buffer_length` bytes for string-valued
+/// attributes or for one pointer-sized value otherwise. `string_length_ptr`,
+/// when non-null, must be writable for one `SqlInteger`.
 unsafe fn sql_get_stmt_attr_w_impl(
     statement_handle: SqlHandle,
     attribute: SqlInteger,

--- a/mssql-tds/src/security/crypto/cng.rs
+++ b/mssql-tds/src/security/crypto/cng.rs
@@ -104,6 +104,11 @@ impl Drop for KeyGuard {
 }
 
 /// Opens a CNG algorithm provider for `alg_id` (e.g. `BCRYPT_AES_ALGORITHM`).
+///
+/// # Safety
+///
+/// `alg_id` must identify a valid, NUL-terminated CNG algorithm name and remain
+/// valid for the duration of the call.
 unsafe fn open_alg(alg_id: windows_sys::core::PCWSTR, flags: u32) -> TdsResult<BCRYPT_ALG_HANDLE> {
     let mut handle: BCRYPT_ALG_HANDLE = ptr::null_mut();
     nt_check("BCryptOpenAlgorithmProvider", unsafe {
@@ -113,6 +118,11 @@ unsafe fn open_alg(alg_id: windows_sys::core::PCWSTR, flags: u32) -> TdsResult<B
 }
 
 /// Reads a u32-valued property (such as `ObjectLength`) from a CNG object.
+///
+/// # Safety
+///
+/// `handle` must be a valid CNG handle and remain open for the duration of the
+/// call.
 unsafe fn get_u32_property(handle: BCRYPT_ALG_HANDLE, name: &str) -> TdsResult<u32> {
     let wide: Vec<u16> = name.encode_utf16().chain(std::iter::once(0)).collect();
     let mut value = 0u32;
@@ -143,7 +153,7 @@ pub(crate) fn fill_random(buf: &mut [u8]) -> TdsResult<()> {
 }
 
 /// Computes a SHA-256 digest (used internally before RSA sign/verify).
-unsafe fn sha256(data: &[u8]) -> TdsResult<[u8; 32]> {
+fn sha256(data: &[u8]) -> TdsResult<[u8; 32]> {
     let alg = unsafe { open_alg(BCRYPT_SHA256_ALGORITHM, 0) }?;
     let _alg = AlgGuard(alg);
     let mut hash: BCRYPT_HASH_HANDLE = ptr::null_mut();
@@ -194,7 +204,7 @@ pub(crate) fn aes_256_cbc_encrypt(
     iv: &[u8; 16],
     plaintext: &[u8],
 ) -> TdsResult<Vec<u8>> {
-    unsafe { aes_256_cbc(key, iv, plaintext, true) }
+    aes_256_cbc(key, iv, plaintext, true)
 }
 
 /// Decrypts AES-256-CBC ciphertext and strips PKCS#7 padding.
@@ -203,16 +213,11 @@ pub(crate) fn aes_256_cbc_decrypt(
     iv: &[u8; 16],
     ciphertext: &[u8],
 ) -> TdsResult<Vec<u8>> {
-    unsafe { aes_256_cbc(key, iv, ciphertext, false) }
+    aes_256_cbc(key, iv, ciphertext, false)
 }
 
 /// Shared AES-256-CBC (PKCS#7) transform. `encrypt` selects direction.
-unsafe fn aes_256_cbc(
-    key: &[u8; 32],
-    iv: &[u8; 16],
-    input: &[u8],
-    encrypt: bool,
-) -> TdsResult<Vec<u8>> {
+fn aes_256_cbc(key: &[u8; 32], iv: &[u8; 16], input: &[u8], encrypt: bool) -> TdsResult<Vec<u8>> {
     let alg = unsafe { open_alg(BCRYPT_AES_ALGORITHM, 0) }?;
     let _alg = AlgGuard(alg);
 
@@ -380,7 +385,7 @@ impl RsaKey {
     }
 
     /// Imports a legacy CAPI RSA private key blob into a CNG key handle.
-    unsafe fn import_capi(capi_blob: &[u8]) -> TdsResult<Self> {
+    fn import_capi(capi_blob: &[u8]) -> TdsResult<Self> {
         let alg = unsafe { open_alg(BCRYPT_RSA_ALGORITHM, 0) }?;
         let mut key: BCRYPT_KEY_HANDLE = ptr::null_mut();
         let status = unsafe {
@@ -439,7 +444,7 @@ impl RsaKey {
 
     /// Exports the key as a legacy CAPI RSA private blob.
     #[cfg(test)]
-    unsafe fn export_capi(&self) -> TdsResult<Vec<u8>> {
+    fn export_capi(&self) -> TdsResult<Vec<u8>> {
         let mut needed = 0u32;
         nt_check("BCryptExportKey", unsafe {
             BCryptExportKey(
@@ -632,7 +637,7 @@ impl RsaKey {
 }
 
 /// Decodes a PEM document (any label) into its DER bytes.
-unsafe fn pem_to_der(pem: &[u8]) -> TdsResult<Vec<u8>> {
+fn pem_to_der(pem: &[u8]) -> TdsResult<Vec<u8>> {
     let mut needed = 0u32;
     if unsafe {
         CryptStringToBinaryA(
@@ -669,7 +674,7 @@ unsafe fn pem_to_der(pem: &[u8]) -> TdsResult<Vec<u8>> {
 
 /// Base64-armors DER bytes into a PEM document with the given label.
 #[cfg(test)]
-unsafe fn der_to_pem(der: &[u8], label: &str) -> TdsResult<Vec<u8>> {
+fn der_to_pem(der: &[u8], label: &str) -> TdsResult<Vec<u8>> {
     let mut needed = 0u32;
     if unsafe {
         CryptBinaryToStringA(
@@ -703,6 +708,11 @@ unsafe fn der_to_pem(der: &[u8], label: &str) -> TdsResult<Vec<u8>> {
 
 /// CryptoAPI `CryptDecodeObjectEx` wrapped with the two-call size pattern. The
 /// returned buffer is self-contained (referenced data is stored inline).
+///
+/// # Safety
+///
+/// `struct_type` must be either a valid, NUL-terminated structure-type string
+/// or a predefined numeric identifier accepted by `CryptDecodeObjectEx`.
 unsafe fn decode_object(struct_type: windows_sys::core::PCSTR, der: &[u8]) -> TdsResult<Vec<u8>> {
     let mut needed = 0u32;
     if unsafe {
@@ -741,6 +751,13 @@ unsafe fn decode_object(struct_type: windows_sys::core::PCSTR, der: &[u8]) -> Td
 }
 
 /// CryptoAPI `CryptEncodeObjectEx` wrapped with the two-call size pattern.
+///
+/// # Safety
+///
+/// `struct_type` must be either a valid, NUL-terminated structure-type string
+/// or a predefined numeric identifier accepted by `CryptEncodeObjectEx`.
+/// `structure` must point to an initialized value of that type, and every
+/// buffer it references must remain valid for the duration of the call.
 #[cfg(test)]
 unsafe fn encode_object(
     struct_type: windows_sys::core::PCSTR,


### PR DESCRIPTION
## Description

Private and crate-visible `unsafe fn`s were outside Clippy's `missing_safety_doc` coverage, leaving the ODBC driver's raw-handle and application-buffer contracts dependent on manual review.

This change:

- enables `check-private-items` from a repository-root `clippy.toml`;
- documents every resulting ODBC safety obligation, including deferred parameter and rowset buffers;
- removes unnecessary `unsafe fn` signatures from six Windows CNG helpers and documents the four boundaries that remain unsafe;
- uses an unaligned read while scanning `SQL_C_WCHAR` data supplied to `SQLPutData`, matching ODBC's unaligned-buffer contract.

No lint allows or exemptions are added.

## Related Issues

Closes #474

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes (`./scripts/bclippy.sh`)
- [ ] `cargo btest` passes - full live-server integration coverage requires a configured SQL Server; the targeted `mssqlodbc` suite passes (1,223 tests)
- [x] New/changed functionality has tests - Clippy is the regression check for private unsafe functions; existing ODBC tests cover the pointer-read path
- [x] Public API changes are documented - N/A, no public API change