### PR TITLE
Round legacy DATETIME fetches to milliseconds

### DIFF
--- a/mssql-odbc/src/conversion/fetch_convert.rs
+++ b/mssql-odbc/src/conversion/fetch_convert.rs
@@ -466,14 +466,15 @@ pub(crate) fn extract_datetime_parts(value: &ColumnValues) -> Option<DateTimePar
             // `datetime` time is counted in 1/300-second ticks since midnight.
             let ticks = u64::from(dt.time);
             let secs = ticks / 300;
-            let fraction_ns = ((ticks % 300) * 1_000_000_000 / 300) as u32;
+            // ODBC exposes the legacy type rounded to millisecond precision.
+            let fraction_ms = ((dt.time % 300) * 1_000 + 150) / 300;
             p.year = y;
             p.month = m;
             p.day = day;
             p.hour = (secs / 3600) as u16;
             p.minute = ((secs % 3600) / 60) as u16;
             p.second = (secs % 60) as u16;
-            p.fraction_ns = fraction_ns;
+            p.fraction_ns = fraction_ms * 1_000_000;
             // `datetime` always renders 3 fractional digits.
             p.scale = 3;
             p.has_date = true;
@@ -2307,6 +2308,30 @@ mod tests {
         assert_eq!(out.month, 1);
         assert_eq!(out.day, 1);
         assert_eq!(out.second, 1);
+    }
+
+    #[test]
+    fn datetime_legacy_fraction_rounds_to_milliseconds() {
+        use mssql_tds::datatypes::column_values::SqlDateTime;
+
+        for (ticks, expected_fraction) in [(37, 123_000_000), (38, 127_000_000), (299, 997_000_000)]
+        {
+            let mut out = SqlTimestampStruct::default();
+            let mut ind: SqlLen = 0;
+            unsafe {
+                convert_datetime_c(
+                    &ColumnValues::DateTime(SqlDateTime {
+                        days: 0,
+                        time: ticks,
+                    }),
+                    SQL_C_TYPE_TIMESTAMP,
+                    (&mut out as *mut SqlTimestampStruct).cast(),
+                    &mut ind,
+                )
+            }
+            .unwrap();
+            assert_eq!(out.fraction, expected_fraction, "ticks: {ticks}");
+        }
     }
 
     #[test]

--- a/mssql-odbc/src/conversion/fetch_convert.rs
+++ b/mssql-odbc/src/conversion/fetch_convert.rs
@@ -2314,8 +2314,8 @@ mod tests {
     fn datetime_legacy_fraction_rounds_to_milliseconds() {
         use mssql_tds::datatypes::column_values::SqlDateTime;
 
-        for (ticks, expected_fraction) in [(37, 123_000_000), (38, 127_000_000), (299, 997_000_000)]
-        {
+        for ticks in 0u32..300 {
+            let expected_fraction = ((ticks * 20 + 3) / 6) * 1_000_000;
             let mut out = SqlTimestampStruct::default();
             let mut ind: SqlLen = 0;
             unsafe {

--- a/mssql-odbc/tests/e2e/tests/datetime_types_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/datetime_types_test.cpp
@@ -274,6 +274,58 @@ TEST_F(DateTimeTypesLiveTest, Datetime2ToTimestampTargetViaBoundFetch) {
     SQLCloseCursor(stmt_);
 }
 
+TEST_F(DateTimeTypesLiveTest, LegacyDatetimeRoundsFractionToMillisecondsOnBothPaths) {
+    const std::string query =
+        "SELECT CAST('2024-05-20T12:34:56.127' AS DATETIME) AS c1";
+
+    ASSERT_SQL_OK(ExecDirect(query), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+
+    SQL_TIMESTAMP_STRUCT viaGetData{};
+    SQLLEN getInd = 0;
+    ASSERT_SQL_OK(
+        SQLGetData(stmt_, 1, SQL_C_TYPE_TIMESTAMP, &viaGetData, sizeof(viaGetData), &getInd),
+        SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(2024, viaGetData.year);
+    EXPECT_EQ(5, viaGetData.month);
+    EXPECT_EQ(20, viaGetData.day);
+    EXPECT_EQ(12, viaGetData.hour);
+    EXPECT_EQ(34, viaGetData.minute);
+    EXPECT_EQ(56, viaGetData.second);
+    EXPECT_EQ(127000000u, viaGetData.fraction);
+    EXPECT_EQ(static_cast<SQLLEN>(sizeof(SQL_TIMESTAMP_STRUCT)), getInd);
+    SQLCloseCursor(stmt_);
+
+    ASSERT_SQL_OK(ExecDirect(query), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+
+    constexpr char expectedText[] = "2024-05-20 12:34:56.127";
+    char text[sizeof(expectedText)]{};
+    SQLLEN textInd = 0;
+    ASSERT_SQL_OK(SQLGetData(stmt_, 1, SQL_C_CHAR, text, sizeof(text), &textInd), SQL_HANDLE_STMT,
+                  stmt_);
+    EXPECT_STREQ(expectedText, text);
+    EXPECT_EQ(static_cast<SQLLEN>(sizeof(expectedText) - 1), textInd);
+    SQLCloseCursor(stmt_);
+
+    ASSERT_SQL_OK(ExecDirect(query), SQL_HANDLE_STMT, stmt_);
+
+    SQL_TIMESTAMP_STRUCT bound{};
+    SQLLEN boundInd = 0;
+    ASSERT_SQL_OK(SQLBindCol(stmt_, 1, SQL_C_TYPE_TIMESTAMP, &bound, sizeof(bound), &boundInd),
+                  SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(2024, bound.year);
+    EXPECT_EQ(5, bound.month);
+    EXPECT_EQ(20, bound.day);
+    EXPECT_EQ(12, bound.hour);
+    EXPECT_EQ(34, bound.minute);
+    EXPECT_EQ(56, bound.second);
+    EXPECT_EQ(127000000u, bound.fraction);
+    EXPECT_EQ(static_cast<SQLLEN>(sizeof(SQL_TIMESTAMP_STRUCT)), boundInd);
+    SQLCloseCursor(stmt_);
+}
+
 // A NULL date/time column must report SQL_NULL_DATA and leave the buffer alone,
 // on both paths. Covered once here rather than per type: the NULL path is in
 // the delivery layer, not per-conversion.


### PR DESCRIPTION
## Description

Legacy SQL Server `DATETIME` stores time in 1/300-second ticks, while ODBC exposes the fraction at millisecond precision. Round to the nearest millisecond before filling timestamp structs or rendering character values, matching `Sql/Ntdbms/sqlncli/odbc/sqlccnvt.cpp::ConvertDateTime` in msodbcsql. Unit coverage checks all 300 tick remainders, and E2E coverage verifies a rounding-sensitive `.127` value through `SQLGetData`, `SQLBindCol`, and `SQL_C_CHAR` rendering against both drivers.

The CI-equivalent local mssql-python run used the same containerized driver-swap and per-file pytest strategy as the pipeline. `test_parse_datetime` now passes. Failed/error outcomes fell from 290 in linked test run 3301980 to 276 locally; the upstream suite advanced from `3774fbb` to `08cd24c` and grew from 2,152 to 2,327 tests between those runs.

## Related Issues

[AB#47703](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47703)

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes
- [x] New/changed functionality has tests
- [x] Public API changes are documented (N/A: no public API changes)