### PR TITLE
mssql-odbc: declare and bound data-at-execution parameters from ParameterType

### DIFF
--- a/.github/instructions/mssql-odbc.instructions.md
+++ b/.github/instructions/mssql-odbc.instructions.md
@@ -123,6 +123,31 @@ authoritative parity reference for this crate. Its source lives in the
     and delivers the bytes. Pre-existing for an explicit `SQL_C_BINARY` bind;
     deferred resolution makes it reachable without the application naming the C
     type.
+  - **`SQLParamData` offers a mixed data-at-execution sequence buffered-first,
+    not in bind order.** A parameter whose `ParameterType` has no PLP form
+    (`char(n)`, `int`, …) has to be collected whole before its declaration is
+    known, and the RPC cannot open until every such value is in hand — so
+    visiting them first is what lets the PLP-capable parameters stream instead
+    of also being held in memory (`DaeState::deferred`). msodbcsql offers them
+    in bind order, because `Sql2Srv` gives it a declaration without seeing the
+    value. ODBC specifies no order: `SQLParamData` returns "the next parameter
+    for which data is needed" and the application identifies it by the returned
+    `ParameterValuePtr` token, not by position — so an application that compares
+    tokens is unaffected, while one that *counts* calls and assumes bind order
+    supplies the wrong value with no diagnostic. Only sequences that mix the two
+    plans are reordered; an all-streamed or all-buffered sequence keeps bind
+    order (`sort_by_key` is stable). Anchored by
+    `MixedDataAtExecutionStreamsThePlpParameter` (AB#47590).
+  - **A fixed-width target may be supplied across several `SQLPutData` calls.**
+    msodbcsql refuses the second call with `HY019` — `ValidatePutDataLength`'s
+    `default:` arm ("Processing of fixed length targets cannot be spread over
+    multiple calls to SQLPutData", `odbc/sqlccmd.cpp`), with the first call
+    exempted at its call site. This driver collects the chunks and converts the
+    concatenation, which is the permissive direction: the value it produces is
+    the one a single buffer would have produced, so nothing an application does
+    today breaks. Already observable in
+    `CrossFamilyDataAtExecutionConvertsToInteger`, which records msodbcsql
+    answering `HY019` where this driver converts.
   - `SQL_C_CHAR` is **UTF-8** in both directions; the driver never reads or
     writes the client code page. msodbcsql uses the client code page -
     `dwClientCodePage = SystemLocale::Singleton().AnsiCP()`

--- a/mssql-odbc/src/api/cancel.rs
+++ b/mssql-odbc/src/api/cancel.rs
@@ -85,19 +85,13 @@ unsafe fn sql_cancel_impl(statement_handle: SqlHandle) -> SqlReturn {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::odbc_types::{SQL_C_CHAR, SQL_INVALID_HANDLE, SQL_VARCHAR};
+    use crate::api::odbc_types::SQL_INVALID_HANDLE;
     use crate::handles::stmt::{DaeParam, DaeState, STMT_STATE_EXEC_STARTED};
     use crate::test_support::TestHandles;
 
     fn dae_with_one_param(cursor: Option<usize>) -> DaeState {
         DaeState::for_test(
-            vec![DaeParam {
-                value_ptr: std::ptr::null_mut(),
-                expected_len: None,
-                needs_transcode: false,
-                c_type: SQL_C_CHAR,
-                sql_type: SQL_VARCHAR,
-            }],
+            vec![DaeParam::unbounded(0, std::ptr::null_mut(), None)],
             cursor,
         )
     }

--- a/mssql-odbc/src/api/exec_common.rs
+++ b/mssql-odbc/src/api/exec_common.rs
@@ -102,11 +102,17 @@ pub(super) fn park_dae_client(
     let collation = client.get_collation();
     for param in &mut dae_params {
         if !param.plan.is_buffered() {
-            param.transcode = Some(DaeTranscode::new(
-                param.binding.c_type,
-                param.binding.sql_type,
-                collation,
-            ));
+            let transcode =
+                DaeTranscode::new(param.binding.c_type, param.binding.sql_type, collation);
+            // A pairing whose buffer bytes already are the wire's bytes keeps
+            // `None`, so `SQLPutData` forwards its chunks borrowed instead of
+            // copying each one through a conversion that would return them
+            // unchanged. Skipping the transcode also skips the close-time
+            // flush, which is right: a passthrough parameter never holds back a
+            // partial character to carry.
+            if !transcode.is_passthrough() {
+                param.transcode = Some(transcode);
+            }
         }
     }
     let Ok(mut stmt_state) = stmt.inner.lock() else {
@@ -678,7 +684,21 @@ pub(super) unsafe fn build_named_params(
                     // The body is PLP whatever `ColumnSize` says, but the
                     // variable it lands in is declared from `ParameterType`,
                     // matching the materialized path and msodbcsql (AB#47590).
-                    match dae_streamed_declaration(bound_param.sql_type, bound_param.column_size) {
+                    //
+                    // Only narrowed when the bound above can actually be
+                    // enforced. A streamed parameter never reaches a close-time
+                    // conversion, so an unenforced bound would have the client
+                    // declare `varchar(n)` and then stream past it, leaving the
+                    // overflow to the server instead of the `22001` the
+                    // declaration implies. Staying `max` keeps the value intact
+                    // until the bound is measurable on this path too
+                    // (AB#47590).
+                    let declaration = if length_limit.is_some() {
+                        dae_streamed_declaration(bound_param.sql_type, bound_param.column_size)
+                    } else {
+                        Ok(None)
+                    };
+                    match declaration {
                         Ok(Some(declaration)) => param.with_streamed_declaration(declaration),
                         Ok(None) => param,
                         Err(e) => {
@@ -1717,6 +1737,59 @@ mod tests {
         assert_eq!(dae.dae_params.len(), 1);
         assert_eq!(dae.dae_params[0].bound_index, 0);
         assert_eq!(dae.dae_params[0].expected_len, Some(7));
+    }
+
+    /// A streamed parameter is only declared at a narrowed length when the
+    /// bound that length implies is one `SQLPutData` can actually enforce.
+    ///
+    /// The two decisions are made independently, and for a wideness-mismatched
+    /// pairing they disagree: `dae_length_limit` cannot measure a wide buffer
+    /// against a narrow declaration, while `dae_streamed_declaration` would
+    /// happily narrow it. Narrowing there would have the client declare
+    /// `varchar(10)` and then stream past it -- a bound promised to the server
+    /// and kept by nobody, since a streamed value never reaches the close-time
+    /// conversion that bounds a buffered one.
+    #[test]
+    fn build_named_params_only_narrows_a_declaration_it_can_enforce() {
+        for (c_type, sql_type, expect_narrowed) in [
+            // Same unit on both sides: measurable, so narrowing is honoured.
+            (SQL_C_CHAR, SQL_VARCHAR, true),
+            // Wide buffer, narrow declaration: not measurable, so `max` stands.
+            (crate::api::odbc_types::SQL_C_WCHAR, SQL_VARCHAR, false),
+            // And the mirror image.
+            (SQL_C_CHAR, crate::api::odbc_types::SQL_WVARCHAR, false),
+        ] {
+            let h = TestHandles::with_env_dbc_stmt();
+            let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+
+            let mut ind: SqlLen = SQL_DATA_AT_EXEC;
+            let mut state = stmt.inner.lock().unwrap();
+            state.bound_params.push(Some(BoundParam {
+                input_output_type: SQL_PARAM_INPUT,
+                c_type,
+                sql_type,
+                column_size: 10,
+                decimal_digits: 0,
+                parameter_value_ptr: std::ptr::null_mut(),
+                buffer_length: 0,
+                strlen_or_ind_ptr: &mut ind as *mut SqlLen,
+                octet_length_ptr: &mut ind as *mut SqlLen,
+            }));
+
+            let dae = unsafe { build_named_params(&mut state, 1, "test") }.unwrap();
+            let bounded = dae.dae_params[0].length_limit.is_some();
+            assert_eq!(
+                bounded, expect_narrowed,
+                "{c_type} -> {sql_type}: the bound decides whether narrowing is honest"
+            );
+            // The declaration is only narrowed when the bound backs it, so the
+            // two travel together rather than being decided apart.
+            let narrowed = format!("{:?}", dae.params[0]).contains("streamed_declaration: Some");
+            assert_eq!(
+                narrowed, expect_narrowed,
+                "{c_type} -> {sql_type}: declaration narrowing must follow the bound"
+            );
+        }
     }
 
     /// Without an indicator pointer there is nothing to carry a

--- a/mssql-odbc/src/api/exec_common.rs
+++ b/mssql-odbc/src/api/exec_common.rs
@@ -139,7 +139,7 @@ pub(super) fn park_deferred_dae(
     prepared: Option<PreparedPlan>,
     orphaned: Option<StatementId>,
     dae_params: Vec<DaeParam>,
-    marker_count: usize,
+    prebuilt: Vec<RpcParameter>,
     sql: Option<String>,
     timeout_secs: u32,
     op: &str,
@@ -149,11 +149,7 @@ pub(super) fn park_deferred_dae(
         return SQL_ERROR;
     };
     stmt_state.dae = Some(
-        DaeState::new(client, prepared, orphaned, dae_params).deferred(
-            marker_count,
-            sql,
-            timeout_secs,
-        ),
+        DaeState::new(client, prepared, orphaned, dae_params).deferred(prebuilt, sql, timeout_secs),
     );
     SQL_NEED_DATA
 }
@@ -743,59 +739,55 @@ pub(super) unsafe fn build_named_params(
     Ok(ParamsWithDae { params, dae_params })
 }
 
-/// Rebuilds the whole RPC parameter list once every data-at-execution value has
-/// been collected, for a sequence that deferred its execute.
+/// Rebuilds the RPC parameter list once every data-at-execution value has been
+/// collected, for a sequence that deferred its execute.
 ///
-/// Non-streamed parameters are re-read from the application's buffers, which
-/// ODBC requires to stay valid until execution completes, and the buffered ones
-/// are converted from their collected bytes by [`buffered_dae_to_rpc`]. Both
-/// therefore go through the same conversion the materialized path uses, so a
-/// value supplied in chunks is declared and bounded exactly like one supplied in
-/// a single buffer (AB#47590).
+/// Only the data-at-execution slots are rebuilt, from the bytes
+/// [`buffered_dae_to_rpc`] converts; every other parameter is the one
+/// `build_named_params` already materialized at execute time and is kept
+/// verbatim. A buffered value therefore still goes through the same conversion
+/// the materialized path uses, so it is declared and bounded exactly like a
+/// value supplied in a single buffer (AB#47590).
 ///
-/// # Safety
-/// Each bound parameter's value/indicator pointers must still satisfy the
-/// `SQLBindParameter` contract.
-pub(super) unsafe fn rebuild_deferred_params(
+/// Nothing here reads application memory. Re-reading it would be unsound rather
+/// than merely redundant: `bound_params` is an execute-time snapshot that
+/// `SQLFreeStmt(SQL_RESET_PARAMS)` leaves in place while releasing the bindings
+/// it describes, so an application that resets its parameters mid-sequence --
+/// which this driver explicitly supports -- would have freed buffers
+/// dereferenced here.
+pub(super) fn rebuild_deferred_params(
     stmt_state: &mut StmtState,
-    marker_count: usize,
+    prebuilt: Vec<RpcParameter>,
     collected: &[(usize, Vec<u8>, bool)],
     dae_params: &[DaeParam],
     op: &str,
 ) -> Result<Vec<RpcParameter>, SqlReturn> {
-    let mut params = Vec::with_capacity(marker_count);
-    let bind_offset = unsafe { stmt_state.inert_attrs.param_bind_offset() };
+    let mut params = prebuilt;
 
-    for i in 0..marker_count {
-        let name = format!("@P{}", i + 1);
-
-        let built =
-            if let Some((_, bytes, is_null)) = collected.iter().find(|(index, _, _)| *index == i) {
-                let Some(dae) = dae_params.iter().find(|p| p.bound_index == i) else {
-                    error!(
-                        "{op}: collected value for parameter {} has no binding",
-                        i + 1
-                    );
-                    post_diag(stmt_state, ERR_UNBOUND_PARAMETER);
-                    return Err(SQL_ERROR);
-                };
-                buffered_dae_to_rpc(name, &dae.binding, bytes, *is_null)
-            } else {
-                let Some(Some(bound_param)) = stmt_state.bound_params.get(i) else {
-                    error!("{op}: parameter {} has no bound value", i + 1);
-                    post_diag(stmt_state, ERR_UNBOUND_PARAMETER);
-                    return Err(SQL_ERROR);
-                };
-                let bound_param = bound_param.with_bind_offset(bind_offset);
-                unsafe { bound_param_to_rpc(name, &bound_param) }
-            };
-
-        match built {
-            Ok(param) => params.push(param),
+    for (index, bytes, is_null) in collected {
+        let Some(dae) = dae_params.iter().find(|p| p.bound_index == *index) else {
+            error!(
+                "{op}: collected value for parameter {} has no binding",
+                index + 1
+            );
+            post_diag(stmt_state, ERR_UNBOUND_PARAMETER);
+            return Err(SQL_ERROR);
+        };
+        let Some(slot) = params.get_mut(*index) else {
+            error!(
+                "{op}: collected value for parameter {} has no slot",
+                index + 1
+            );
+            post_diag(stmt_state, ERR_UNBOUND_PARAMETER);
+            return Err(SQL_ERROR);
+        };
+        let name = format!("@P{}", index + 1);
+        match buffered_dae_to_rpc(name, &dae.binding, bytes, *is_null) {
+            Ok(param) => *slot = param,
             Err(e) => {
                 error!(
                     "{op}: parameter {} conversion failed: {}",
-                    i + 1,
+                    index + 1,
                     e.diag().text
                 );
                 post_diag(stmt_state, e.diag());

--- a/mssql-odbc/src/api/exec_common.rs
+++ b/mssql-odbc/src/api/exec_common.rs
@@ -1742,22 +1742,23 @@ mod tests {
     /// A streamed parameter is only declared at a narrowed length when the
     /// bound that length implies is one `SQLPutData` can actually enforce.
     ///
-    /// The two decisions are made independently, and for a wideness-mismatched
-    /// pairing they disagree: `dae_length_limit` cannot measure a wide buffer
-    /// against a narrow declaration, while `dae_streamed_declaration` would
-    /// happily narrow it. Narrowing there would have the client declare
-    /// `varchar(10)` and then stream past it -- a bound promised to the server
-    /// and kept by nobody, since a streamed value never reaches the close-time
-    /// conversion that bounds a buffered one.
+    /// The two decisions are made independently, so nothing but this guard stops
+    /// them disagreeing. Where they would, the cost is real: a streamed value
+    /// never reaches the close-time conversion that bounds a buffered one, so a
+    /// narrowed declaration with no bound behind it has the client promise the
+    /// server a length and then stream past it.
     #[test]
     fn build_named_params_only_narrows_a_declaration_it_can_enforce() {
         for (c_type, sql_type, expect_narrowed) in [
             // Same unit on both sides: measurable, so narrowing is honoured.
             (SQL_C_CHAR, SQL_VARCHAR, true),
-            // Wide buffer, narrow declaration: not measurable, so `max` stands.
-            (crate::api::odbc_types::SQL_C_WCHAR, SQL_VARCHAR, false),
-            // And the mirror image.
-            (SQL_C_CHAR, crate::api::odbc_types::SQL_WVARCHAR, false),
+            // A wideness mismatch is measurable too - the unit is the
+            // declaration's and the count is of the source.
+            (crate::api::odbc_types::SQL_C_WCHAR, SQL_VARCHAR, true),
+            (SQL_C_CHAR, crate::api::odbc_types::SQL_WVARCHAR, true),
+            // Cross-family is not: a binary byte is not a character, so the
+            // declaration stays `max` rather than claiming a bound.
+            (SQL_C_CHAR, crate::api::odbc_types::SQL_VARBINARY, false),
         ] {
             let h = TestHandles::with_env_dbc_stmt();
             let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };

--- a/mssql-odbc/src/api/exec_common.rs
+++ b/mssql-odbc/src/api/exec_common.rs
@@ -16,7 +16,7 @@ use mssql_tds::connection::tds_client::{
     CursorPoll, ExecuteOptions, ResultSet, StatementId, TdsClient,
 };
 use mssql_tds::error::{Error as TdsError, TimeoutErrorType};
-use mssql_tds::message::parameters::rpc_parameters::RpcParameter;
+use mssql_tds::message::parameters::rpc_parameters::{RpcParameter, StreamedSqlType};
 
 use super::ird::populate_ird;
 use super::sqlstate::*;
@@ -25,7 +25,8 @@ use crate::api::odbc_types::{
     SQL_SUCCESS_WITH_INFO, SqlHandle, SqlLen, SqlReturn,
 };
 use crate::conversion::param_convert::{
-    ParamBuildError, bound_param_to_rpc, dae_placeholder_type, is_data_at_exec_indicator,
+    DaePlan, DaeTranscode, ParamBuildError, bound_param_to_rpc, buffered_dae_to_rpc,
+    dae_length_limit, dae_plan, dae_streamed_declaration, is_data_at_exec_indicator,
 };
 use crate::error::post_sql_error;
 use crate::handles::dbc::ConnectionState;
@@ -91,9 +92,23 @@ pub(super) fn park_dae_client(
     client: TdsClient,
     prepared: Option<PreparedPlan>,
     orphaned: Option<StatementId>,
-    dae_params: Vec<DaeParam>,
+    mut dae_params: Vec<DaeParam>,
     op: &str,
 ) -> SqlReturn {
+    // The wire encoding of a narrow target comes from the database collation,
+    // which is only knowable with the connection in hand — `write_streamed_chunk`
+    // writes bytes verbatim, so the re-encoding has to happen before them
+    // (AB#47590).
+    let collation = client.get_collation();
+    for param in &mut dae_params {
+        if !param.plan.is_buffered() {
+            param.transcode = Some(DaeTranscode::new(
+                param.binding.c_type,
+                param.binding.sql_type,
+                collation,
+            ));
+        }
+    }
     let Ok(mut stmt_state) = stmt.inner.lock() else {
         // The client has nowhere to go: the statement that owns it is
         // unreachable and the DBC still records it as busy.
@@ -101,6 +116,39 @@ pub(super) fn park_dae_client(
         return SQL_ERROR;
     };
     stmt_state.dae = Some(DaeState::new(client, prepared, orphaned, dae_params));
+    SQL_NEED_DATA
+}
+
+/// Parks a sequence whose execute is deferred: at least one parameter buffers,
+/// so no RPC has been opened and the client sits idle on the statement until
+/// the last `SQLParamData` builds the complete parameter list and runs it.
+///
+/// The connection still counts as busy for the duration, exactly as the
+/// streaming sequence does, so an application cannot start another command on it
+/// mid-sequence.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn park_deferred_dae(
+    stmt: &StmtHandle,
+    client: TdsClient,
+    prepared: Option<PreparedPlan>,
+    orphaned: Option<StatementId>,
+    dae_params: Vec<DaeParam>,
+    marker_count: usize,
+    sql: Option<String>,
+    timeout_secs: u32,
+    op: &str,
+) -> SqlReturn {
+    let Ok(mut stmt_state) = stmt.inner.lock() else {
+        error!("{op}: stmt mutex poisoned while parking deferred DAE state");
+        return SQL_ERROR;
+    };
+    stmt_state.dae = Some(
+        DaeState::new(client, prepared, orphaned, dae_params).deferred(
+            marker_count,
+            sql,
+            timeout_secs,
+        ),
+    );
     SQL_NEED_DATA
 }
 
@@ -582,11 +630,11 @@ pub(super) unsafe fn build_named_params(
         };
 
         if let Some(indicator) = dae_indicator {
-            let dae_stream = match dae_placeholder_type(bound_param.c_type, bound_param.sql_type) {
-                Ok(t) => t,
+            let plan = match dae_plan(bound_param.c_type, bound_param.sql_type) {
+                Ok(plan) => plan,
                 Err(e) => {
                     error!(
-                        "{op}: parameter {} DAE type not streamable: {}",
+                        "{op}: parameter {} cannot be supplied at execution: {}",
                         i + 1,
                         e.diag().text
                     );
@@ -594,15 +642,62 @@ pub(super) unsafe fn build_named_params(
                     return Err(SQL_ERROR);
                 }
             };
-            let rpc =
-                RpcParameter::data_at_exec(Some(name), StatusFlags::NONE, dae_stream.sql_type);
-            dae_params.push(DaeParam {
-                value_ptr: bound_param.parameter_value_ptr,
-                expected_len: dae_expected_length(indicator),
-                needs_transcode: dae_stream.needs_transcode,
-                c_type: bound_param.c_type,
-                sql_type: bound_param.sql_type,
-            });
+            // A bound that can be measured in buffer bytes is applied as the
+            // chunks arrive, so an overflow is reported by the `SQLPutData`
+            // that carries it rather than at close (msodbcsql parity).
+            let length_limit = match dae_length_limit(
+                bound_param.c_type,
+                bound_param.sql_type,
+                bound_param.column_size,
+            ) {
+                Ok(limit) => limit,
+                Err(e) => {
+                    error!(
+                        "{op}: parameter {} ColumnSize invalid: {}",
+                        i + 1,
+                        e.diag().text
+                    );
+                    post_diag(stmt_state, e.diag());
+                    return Err(SQL_ERROR);
+                }
+            };
+            dae_params.push(DaeParam::new(
+                i,
+                dae_expected_length(indicator),
+                plan,
+                length_limit,
+                bound_param,
+            ));
+            // Nothing to declare for a buffered parameter yet: its bytes are
+            // not in, so its type and length are not known. The slot is filled
+            // to keep parameter positions lined up and is rebuilt by
+            // `rebuild_deferred_params` before anything reaches the wire.
+            let rpc = match plan {
+                DaePlan::Stream(streamed) => {
+                    let param = RpcParameter::data_at_exec(Some(name), StatusFlags::NONE, streamed);
+                    // The body is PLP whatever `ColumnSize` says, but the
+                    // variable it lands in is declared from `ParameterType`,
+                    // matching the materialized path and msodbcsql (AB#47590).
+                    match dae_streamed_declaration(bound_param.sql_type, bound_param.column_size) {
+                        Ok(Some(declaration)) => param.with_streamed_declaration(declaration),
+                        Ok(None) => param,
+                        Err(e) => {
+                            error!(
+                                "{op}: parameter {} declaration invalid: {}",
+                                i + 1,
+                                e.diag().text
+                            );
+                            post_diag(stmt_state, e.diag());
+                            return Err(SQL_ERROR);
+                        }
+                    }
+                }
+                DaePlan::Buffer => RpcParameter::data_at_exec(
+                    Some(name),
+                    StatusFlags::NONE,
+                    StreamedSqlType::VarBinaryMax,
+                ),
+            };
             params.push(rpc);
         } else {
             match unsafe { bound_param_to_rpc(name, &bound_param) } {
@@ -626,6 +721,70 @@ pub(super) unsafe fn build_named_params(
     }
 
     Ok(ParamsWithDae { params, dae_params })
+}
+
+/// Rebuilds the whole RPC parameter list once every data-at-execution value has
+/// been collected, for a sequence that deferred its execute.
+///
+/// Non-streamed parameters are re-read from the application's buffers, which
+/// ODBC requires to stay valid until execution completes, and the buffered ones
+/// are converted from their collected bytes by [`buffered_dae_to_rpc`]. Both
+/// therefore go through the same conversion the materialized path uses, so a
+/// value supplied in chunks is declared and bounded exactly like one supplied in
+/// a single buffer (AB#47590).
+///
+/// # Safety
+/// Each bound parameter's value/indicator pointers must still satisfy the
+/// `SQLBindParameter` contract.
+pub(super) unsafe fn rebuild_deferred_params(
+    stmt_state: &mut StmtState,
+    marker_count: usize,
+    collected: &[(usize, Vec<u8>, bool)],
+    dae_params: &[DaeParam],
+    op: &str,
+) -> Result<Vec<RpcParameter>, SqlReturn> {
+    let mut params = Vec::with_capacity(marker_count);
+    let bind_offset = unsafe { stmt_state.inert_attrs.param_bind_offset() };
+
+    for i in 0..marker_count {
+        let name = format!("@P{}", i + 1);
+
+        let built =
+            if let Some((_, bytes, is_null)) = collected.iter().find(|(index, _, _)| *index == i) {
+                let Some(dae) = dae_params.iter().find(|p| p.bound_index == i) else {
+                    error!(
+                        "{op}: collected value for parameter {} has no binding",
+                        i + 1
+                    );
+                    post_diag(stmt_state, ERR_UNBOUND_PARAMETER);
+                    return Err(SQL_ERROR);
+                };
+                buffered_dae_to_rpc(name, &dae.binding, bytes, *is_null)
+            } else {
+                let Some(Some(bound_param)) = stmt_state.bound_params.get(i) else {
+                    error!("{op}: parameter {} has no bound value", i + 1);
+                    post_diag(stmt_state, ERR_UNBOUND_PARAMETER);
+                    return Err(SQL_ERROR);
+                };
+                let bound_param = bound_param.with_bind_offset(bind_offset);
+                unsafe { bound_param_to_rpc(name, &bound_param) }
+            };
+
+        match built {
+            Ok(param) => params.push(param),
+            Err(e) => {
+                error!(
+                    "{op}: parameter {} conversion failed: {}",
+                    i + 1,
+                    e.diag().text
+                );
+                post_diag(stmt_state, e.diag());
+                return Err(SQL_ERROR);
+            }
+        }
+    }
+
+    Ok(params)
 }
 
 /// Captures result metadata after a successful execution and finalizes the
@@ -1527,16 +1686,9 @@ mod tests {
 
         let dae = unsafe { build_named_params(&mut state, 3, "test") }.unwrap();
         assert_eq!(dae.params.len(), 3);
-        assert_eq!(
-            dae.dae_params,
-            vec![DaeParam {
-                value_ptr: std::ptr::null_mut(),
-                expected_len: None,
-                needs_transcode: false,
-                c_type: SQL_C_CHAR,
-                sql_type: SQL_VARCHAR
-            }]
-        );
+        assert_eq!(dae.dae_params.len(), 1);
+        assert_eq!(dae.dae_params[0].bound_index, 1);
+        assert_eq!(dae.dae_params[0].expected_len, None);
     }
 
     /// `SQL_LEN_DATA_AT_EXEC(n)` promises `n` bytes, which the closing
@@ -1562,16 +1714,9 @@ mod tests {
         }));
 
         let dae = unsafe { build_named_params(&mut state, 1, "test") }.unwrap();
-        assert_eq!(
-            dae.dae_params,
-            vec![DaeParam {
-                value_ptr: std::ptr::null_mut(),
-                expected_len: Some(7),
-                needs_transcode: false,
-                c_type: SQL_C_CHAR,
-                sql_type: SQL_VARCHAR
-            }]
-        );
+        assert_eq!(dae.dae_params.len(), 1);
+        assert_eq!(dae.dae_params[0].bound_index, 0);
+        assert_eq!(dae.dae_params[0].expected_len, Some(7));
     }
 
     /// Without an indicator pointer there is nothing to carry a

--- a/mssql-odbc/src/api/exec_direct.rs
+++ b/mssql-odbc/src/api/exec_direct.rs
@@ -11,8 +11,8 @@ use mssql_tds::connection::tds_client::{ExecuteOptions, StreamedParamStatus};
 
 use super::exec_common::{
     ParamsWithDae, build_named_params, claim_connection, deduct_query_timeout, fail_with_tds,
-    finish_execute, flush_pending_unprepare, park_dae_client, query_timeout_expired_error,
-    snapshot_bound_params,
+    finish_execute, flush_pending_unprepare, park_dae_client, park_deferred_dae,
+    query_timeout_expired_error, snapshot_bound_params,
 };
 use super::sqlstate::*;
 use super::txn::begin_transaction_if_manual;
@@ -222,6 +222,23 @@ fn sql_exec_direct_w_safe(
     // and hand control to SQLParamData / SQLPutData. There is no prepared plan
     // to restore afterwards, so `None` is passed for it.
     if !dae_params.is_empty() {
+        // A buffered parameter cannot be declared until its bytes are all in,
+        // so no RPC is opened: the sequence collects its values and runs
+        // `sp_executesql` from the last `SQLParamData` (AB#47590).
+        if dae_params.iter().any(|param| param.plan.is_buffered()) {
+            let marker_count = params.len();
+            return park_deferred_dae(
+                stmt,
+                client,
+                None,
+                None,
+                dae_params,
+                marker_count,
+                Some(rewritten_sql),
+                query_timeout,
+                "SQLExecDirectW",
+            );
+        }
         let begin_result = dbc.runtime.block_on(client.begin_sp_executesql(
             rewritten_sql,
             params,

--- a/mssql-odbc/src/api/exec_direct.rs
+++ b/mssql-odbc/src/api/exec_direct.rs
@@ -226,14 +226,13 @@ fn sql_exec_direct_w_safe(
         // so no RPC is opened: the sequence collects its values and runs
         // `sp_executesql` from the last `SQLParamData` (AB#47590).
         if dae_params.iter().any(|param| param.plan.is_buffered()) {
-            let marker_count = params.len();
             return park_deferred_dae(
                 stmt,
                 client,
                 None,
                 None,
                 dae_params,
-                marker_count,
+                params,
                 Some(rewritten_sql),
                 query_timeout,
                 "SQLExecDirectW",

--- a/mssql-odbc/src/api/execute.rs
+++ b/mssql-odbc/src/api/execute.rs
@@ -259,14 +259,13 @@ fn sql_execute_safe(statement_handle: SqlHandle, stmt: &StmtHandle) -> SqlReturn
             // with no request in flight and run the execute from the last
             // `SQLParamData`, once every value can be built (AB#47590).
             if dae_params.iter().any(|param| param.plan.is_buffered()) {
-                let marker_count = params.len();
                 return park_deferred_dae(
                     stmt,
                     client,
                     Some(prepared),
                     orphaned,
                     dae_params,
-                    marker_count,
+                    params,
                     None,
                     query_timeout,
                     "SQLExecute",

--- a/mssql-odbc/src/api/execute.rs
+++ b/mssql-odbc/src/api/execute.rs
@@ -15,7 +15,8 @@ use mssql_tds::message::parameters::rpc_parameters::RpcParameter;
 
 use super::exec_common::{
     ParamsWithDae, build_named_params, claim_connection, deduct_query_timeout, fail_with_tds,
-    finish_execute, park_dae_client, query_timeout_expired_error, snapshot_bound_params,
+    finish_execute, park_dae_client, park_deferred_dae, query_timeout_expired_error,
+    snapshot_bound_params,
 };
 use super::sqlstate::*;
 use super::txn::begin_transaction_if_manual;
@@ -252,6 +253,25 @@ fn sql_execute_safe(statement_handle: SqlHandle, stmt: &StmtHandle) -> SqlReturn
                     );
                 }
             };
+
+            // A buffered parameter's declaration is not known until its bytes
+            // are all in, so the RPC cannot be opened yet: park the sequence
+            // with no request in flight and run the execute from the last
+            // `SQLParamData`, once every value can be built (AB#47590).
+            if dae_params.iter().any(|param| param.plan.is_buffered()) {
+                let marker_count = params.len();
+                return park_deferred_dae(
+                    stmt,
+                    client,
+                    Some(prepared),
+                    orphaned,
+                    dae_params,
+                    marker_count,
+                    None,
+                    query_timeout,
+                    "SQLExecute",
+                );
+            }
 
             // Data-at-execution keeps the prepared path: `begin_execute_prepared`
             // streams the values into the same `sp_execute` / `sp_prepexec` RPC a
@@ -809,16 +829,9 @@ mod tests {
         match staging {
             ExecutionStaging::NeedData(dae) => {
                 // The single param is DAE: its index is in dae_indices.
-                assert_eq!(
-                    dae.dae_params,
-                    vec![DaeParam {
-                        value_ptr: std::ptr::null_mut(),
-                        expected_len: None,
-                        needs_transcode: false,
-                        c_type: SQL_C_CHAR,
-                        sql_type: SQL_VARCHAR
-                    }]
-                );
+                assert_eq!(dae.dae_params.len(), 1);
+                assert_eq!(dae.dae_params[0].bound_index, 0);
+                assert_eq!(dae.dae_params[0].expected_len, None);
                 assert_eq!(dae.params.len(), 1, "one param in list");
             }
             ExecutionStaging::Ready(_) => panic!("expected NeedData staging for DAE param"),

--- a/mssql-odbc/src/api/param_data.rs
+++ b/mssql-odbc/src/api/param_data.rs
@@ -28,15 +28,16 @@
 
 use tracing::{debug, error};
 
-use mssql_tds::connection::tds_client::{StatementResult, StreamedParamStatus};
+use mssql_tds::connection::tds_client::{ExecuteOptions, StatementResult, StreamedParamStatus};
 
-use super::exec_common::{abort_dae_with_diag, fail_with_tds, finish_execute, return_client_idle};
+use super::exec_common::{
+    abort_dae_with_diag, fail_with_tds, finish_execute, rebuild_deferred_params, return_client_idle,
+};
 use super::sqlstate::*;
 use super::util::write_if_some;
 use crate::api::odbc_types::{
     SQL_ERROR, SQL_INVALID_HANDLE, SQL_NEED_DATA, SqlHandle, SqlPointer, SqlReturn,
 };
-use crate::conversion::param_convert::transcode_dae_bytes;
 use crate::error::free_errors;
 use crate::handles::stmt::STMT_STATE_EXEC_STARTED;
 use crate::handles::{HandleType, StmtHandle, handle_from_raw};
@@ -155,27 +156,57 @@ fn sql_param_data_safe(
         return abort_dae_with_diag(dbc, stmt, statement_handle, diag);
     }
 
+    // ── Deferred sequence: no request is open ───────────────────────────────
+    // The parameter closes into its buffer rather than onto the wire, and the
+    // execute runs once the last one is in (AB#47590).
+    let is_deferred = {
+        let Ok(stmt_state) = stmt.inner.lock() else {
+            error!("SQLParamData: stmt mutex poisoned checking deferred mode");
+            return SQL_ERROR;
+        };
+        stmt_state.dae.as_ref().is_some_and(|dae| dae.deferred)
+    };
+    if is_deferred {
+        let (has_more, next_ptr) = {
+            let Ok(mut stmt_state) = stmt.inner.lock() else {
+                error!("SQLParamData: stmt mutex poisoned closing a buffered parameter");
+                return SQL_ERROR;
+            };
+            let Some(dae) = stmt_state.dae.as_mut() else {
+                error!("SQLParamData: DAE sequence vanished closing a buffered parameter");
+                return SQL_ERROR;
+            };
+            let Some(bound_index) = dae.current_param().map(|param| param.bound_index) else {
+                error!("SQLParamData: no open parameter to close");
+                return SQL_ERROR;
+            };
+            let bytes = std::mem::take(&mut dae.progress.buffer);
+            let is_null = dae.progress.is_null;
+            dae.buffered.push((bound_index, bytes, is_null));
+            dae.advance();
+            let has_more = dae.current_param().is_some();
+            (has_more, stmt_state.dae_current_value_ptr())
+        };
+
+        // More parameters to collect: hand back the next token.
+        if has_more {
+            unsafe { write_if_some(value_ptr_ptr, next_ptr) };
+            return SQL_NEED_DATA;
+        }
+        return run_deferred_execute(dbc, stmt, statement_handle);
+    }
+
     // ── Subsequent calls: close current parameter and advance ───────────────
-    // Snapshot what's needed to transcode the parameter being closed -- when
-    // its C type and SQL type disagreed on wideness, `SQLPutData` buffered its
-    // bytes instead of streaming them (see `dae_placeholder_type`) -- and take
-    // the TDS client out of stmt_state while we do I/O. `c_type`/`sql_type`
-    // come from the `DaeParam` snapshot taken at execution time, not a fresh
-    // `bound_params` lookup: `SQLFreeStmt(SQL_RESET_PARAMS)` can clear that
-    // binding while this sequence is still open, and a rebind could change the
-    // encoding after the wire placeholder was already fixed, so re-reading it
-    // here could silently commit an empty value instead of the buffered one.
-    let (mut client, transcode) = {
+    // Take the TDS client out of stmt_state while we do I/O.
+    let (mut client, trailing) = {
         let Ok(mut stmt_state) = stmt.inner.lock() else {
             error!("SQLParamData: stmt mutex poisoned taking dae_client");
             return SQL_ERROR;
         };
-
-        // Checked out before `pending_bytes` is taken: if this fails (a
-        // concurrent call already holds the client), the sequence stays open
-        // for a retry with the buffered value still intact rather than
-        // silently discarded, mirroring the same ordering `SQLPutData`'s
-        // buffered branch uses for the same reason.
+        // Checked out before the carry is drained: if this fails (a concurrent
+        // call already holds the client), the sequence stays open for a retry
+        // with the partial character still intact rather than silently
+        // discarded.
         let client = match stmt_state
             .dae
             .as_mut()
@@ -189,52 +220,35 @@ fn sql_param_data_safe(
             }
         };
 
-        let transcode = stmt_state.dae.as_mut().and_then(|dae| {
-            if dae.progress.is_null || dae.progress.pending_bytes.is_empty() {
-                return None;
-            }
-            let (c_type, sql_type) = {
-                let param = dae.current_param()?;
-                if !param.needs_transcode {
-                    return None;
+        // A value that ended part-way through a character leaves bytes in the
+        // carry that no further chunk will complete. Flush them before the
+        // terminator so they reach the wire lossily rather than vanishing.
+        let trailing = stmt_state
+            .dae
+            .as_mut()
+            .map(|dae| match dae.current_param().and_then(|p| p.transcode) {
+                Some(transcode) => {
+                    let mut carry = std::mem::take(&mut dae.progress.carry);
+                    let out = transcode.finish(&mut carry);
+                    dae.progress.carry = carry;
+                    out
                 }
-                (param.c_type, param.sql_type)
-            };
-            // Free to take rather than clone: the client is already checked
-            // out above, so a failed checkout could not have left this call
-            // to take bytes it can no longer deliver. `advance()` resets
-            // `progress` wholesale before the next parameter, and every
-            // failure arm below tears the whole sequence down, so nothing
-            // reads `pending_bytes` again after this.
-            Some((
-                c_type,
-                sql_type,
-                std::mem::take(&mut dae.progress.pending_bytes),
-            ))
-        });
-        (client, transcode)
+                None => Vec::new(),
+            })
+            .unwrap_or_default();
+        (client, trailing)
     };
 
-    // The buffered value is written as a single chunk, once, before the
-    // stream is told the parameter is complete. Nothing about this differs
-    // from an application that called `SQLPutData` once with the whole value
-    // -- the wire never sees the untranscoded bytes.
-    if let Some((c_type, sql_type, pending_bytes)) = transcode {
-        let db_collation = client.get_collation();
-        let wire_bytes = transcode_dae_bytes(c_type, sql_type, pending_bytes, db_collation);
-        if let Err(e) = dbc
-            .runtime
-            .block_on(client.write_streamed_chunk(&wire_bytes))
-        {
-            error!(%e, "SQLParamData: writing transcoded DAE value failed");
-            dbc.runtime.block_on(client.cancel_streamed_write());
-            if let Ok(mut stmt_state) = stmt.inner.lock() {
-                let parked = stmt_state.take_dae();
-                debug_assert!(parked.is_none(), "the client was checked out above");
-                stmt_state.clear_state(STMT_STATE_EXEC_STARTED);
-            }
-            return fail_with_tds(dbc, stmt, statement_handle, client, &e);
+    if !trailing.is_empty()
+        && let Err(e) = dbc.runtime.block_on(client.write_streamed_chunk(&trailing))
+    {
+        error!(%e, "SQLParamData: flushing the transcoder tail failed");
+        if let Ok(mut stmt_state) = stmt.inner.lock() {
+            let parked = stmt_state.take_dae();
+            debug_assert!(parked.is_none(), "the client is checked out by this call");
+            stmt_state.clear_state(STMT_STATE_EXEC_STARTED);
         }
+        return fail_with_tds(dbc, stmt, statement_handle, client, &e);
     }
 
     let end_result = dbc.runtime.block_on(client.end_streamed_param());
@@ -340,22 +354,132 @@ fn sql_param_data_safe(
     }
 }
 
+/// Runs the execute a data-at-execution sequence deferred, now that every value
+/// has been collected.
+///
+/// The whole parameter list is rebuilt from the application's bindings and the
+/// collected buffers, so the values go out declared and bounded by the same
+/// conversion a materialized execute uses; the request itself is then the
+/// ordinary `sp_execute` / `sp_executesql` one, not a streamed variant
+/// (AB#47590).
+fn run_deferred_execute(
+    dbc: &crate::handles::DbcHandle,
+    stmt: &StmtHandle,
+    statement_handle: SqlHandle,
+) -> SqlReturn {
+    // Take everything the execute needs, and end the sequence, in one critical
+    // section: a statement observed between the two would look idle but
+    // unprepared.
+    let taken = {
+        let Ok(mut stmt_state) = stmt.inner.lock() else {
+            error!("SQLParamData: stmt mutex poisoned starting the deferred execute");
+            return SQL_ERROR;
+        };
+        let Some(dae) = stmt_state.dae.as_mut() else {
+            error!("SQLParamData: DAE sequence vanished before the deferred execute");
+            return SQL_ERROR;
+        };
+        let collected = std::mem::take(&mut dae.buffered);
+        let dae_params = dae.params().to_vec();
+        let marker_count = dae.marker_count;
+        let sql = dae.sql.take();
+        let timeout_secs = dae.timeout_secs;
+        let prepared = dae.take_prepared();
+        let mut orphaned = dae.take_orphaned();
+
+        let params = match unsafe {
+            rebuild_deferred_params(
+                &mut stmt_state,
+                marker_count,
+                &collected,
+                &dae_params,
+                "SQLParamData",
+            )
+        } {
+            Ok(params) => params,
+            Err(rc) => {
+                // Nothing was sent, so the statement goes back to being merely
+                // prepared rather than needing a cancel.
+                let client = stmt_state.take_dae();
+                stmt_state.prepared = prepared;
+                stmt_state.pending_unprepare = orphaned.take();
+                stmt_state.clear_state(STMT_STATE_EXEC_STARTED);
+                drop(stmt_state);
+                if let Some(client) = client {
+                    return_client_idle(dbc, statement_handle, client);
+                }
+                return rc;
+            }
+        };
+
+        let client = stmt_state.take_dae();
+        stmt_state.clear_state(STMT_STATE_EXEC_STARTED);
+        (client, params, prepared, orphaned, sql, timeout_secs)
+    };
+
+    let (client, params, mut prepared, mut orphaned, sql, timeout_secs) = taken;
+    let Some(mut client) = client else {
+        error!("SQLParamData: deferred sequence has no client to execute on");
+        return SQL_ERROR;
+    };
+
+    let options = ExecuteOptions::new().timeout_secs(timeout_secs);
+    let was_prepared = prepared.is_some();
+    let exec_result: Result<Option<StatementResult>, mssql_tds::error::Error> =
+        match (prepared.as_mut(), sql) {
+            (Some(plan), _) => dbc
+                .runtime
+                .block_on(client.execute_prepared(&mut plan.stmt, params, &mut orphaned, options))
+                .map(Some),
+            (None, Some(sql)) => dbc
+                .runtime
+                .block_on(client.execute_sp_executesql(sql, params, options))
+                .map(|_| None),
+            (None, None) => {
+                error!("SQLParamData: deferred sequence has neither a plan nor SQL text");
+                return_client_idle(dbc, statement_handle, client);
+                return SQL_ERROR;
+            }
+        };
+
+    // Give the plan back before reporting either outcome, exactly as the
+    // immediate path does: a failure must still leave the statement prepared.
+    if let Ok(mut stmt_state) = stmt.inner.lock() {
+        stmt_state.prepared = prepared;
+        stmt_state.pending_unprepare = orphaned;
+    }
+
+    let stmt_result = match exec_result {
+        Ok(result) => result,
+        Err(e) => {
+            error!(%e, "SQLParamData: deferred execute failed");
+            return fail_with_tds(dbc, stmt, statement_handle, client, &e);
+        }
+    };
+
+    // Same contract as the immediate prepared arm: a no-row prepared result has
+    // its trailing tokens drained rather than leaving a 0-column cursor open.
+    if was_prepared
+        && !matches!(stmt_result, Some(StatementResult::Rows))
+        && let Err(e) = dbc.runtime.block_on(client.advance_to_rows())
+    {
+        error!(%e, "SQLParamData: draining a no-row deferred result failed");
+        return fail_with_tds(dbc, stmt, statement_handle, client, &e);
+    }
+
+    finish_execute(dbc, stmt, statement_handle, client, "SQLParamData")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::odbc_types::{SQL_C_CHAR, SQL_NULL_HANDLE, SQL_VARCHAR};
+    use crate::api::odbc_types::{SQL_C_CHAR, SQL_NULL_HANDLE};
     use crate::handles::stmt::{DaeParam, DaeState};
     use crate::test_support::TestHandles;
 
     fn open_dae(expected_len: Option<usize>) -> DaeState {
         DaeState::for_test(
-            vec![DaeParam {
-                value_ptr: std::ptr::null_mut(),
-                expected_len,
-                needs_transcode: false,
-                c_type: SQL_C_CHAR,
-                sql_type: SQL_VARCHAR,
-            }],
+            vec![DaeParam::unbounded(0, std::ptr::null_mut(), expected_len)],
             Some(0),
         )
     }
@@ -387,13 +511,7 @@ mod tests {
         {
             let mut state = stmt.inner.lock().unwrap();
             state.dae = Some(DaeState::for_test(
-                vec![DaeParam {
-                    value_ptr: token_ptr,
-                    expected_len: None,
-                    needs_transcode: false,
-                    c_type: SQL_C_CHAR,
-                    sql_type: SQL_VARCHAR,
-                }],
+                vec![DaeParam::unbounded(0, token_ptr, None)],
                 None,
             ));
         }
@@ -425,28 +543,26 @@ mod tests {
     /// A concurrent call on the same statement can hold the client when this
     /// one tries to close a transcoded parameter (`checkout_client` returns
     /// `None`, the same condition `DaeState::for_test`'s parked-client-free
-    /// setup exercises here). The client is checked out *before*
-    /// `pending_bytes` is taken, so this failure must not lose the buffered
-    /// value: a retry once the concurrent call finishes has to see the same
-    /// bytes it would have seen if this call had never happened.
+    /// setup exercises here). The client is checked out *before* the carry is
+    /// drained, so this failure must not lose the partial character a retry
+    /// would need: it has to see the same bytes it would have seen if this
+    /// call had never happened.
     #[test]
-    fn failed_checkout_leaves_pending_bytes_and_the_sequence_intact() {
+    fn failed_checkout_leaves_the_carry_and_the_sequence_intact() {
         let h = TestHandles::with_env_dbc_stmt();
         let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
         {
             let mut state = stmt.inner.lock().unwrap();
-            let mut dae = DaeState::for_test(
-                vec![DaeParam {
-                    value_ptr: std::ptr::null_mut(),
-                    expected_len: None,
-                    needs_transcode: true,
-                    c_type: SQL_C_CHAR,
-                    sql_type: SQL_VARCHAR,
-                }],
-                Some(0),
-            );
+            let mut param = DaeParam::unbounded(0, std::ptr::null_mut(), None);
+            param.transcode = Some(crate::conversion::param_convert::DaeTranscode::new(
+                SQL_C_CHAR,
+                crate::api::odbc_types::SQL_WVARCHAR,
+                mssql_tds::token::tokens::SqlCollation::default(),
+            ));
+            let mut dae = DaeState::for_test(vec![param], Some(0));
             dae.progress.put_data_called = true;
-            dae.progress.pending_bytes = b"a\0b\0".to_vec();
+            // A lead byte whose continuation has not arrived yet.
+            dae.progress.carry = vec![0xC3];
             state.dae = Some(dae);
         }
 
@@ -458,9 +574,9 @@ mod tests {
         assert_eq!(state.diag_records[0].sql_state, ERR_FUNCTION_SEQUENCE.state);
         assert!(state.needs_data(), "sequence must stay open for a retry");
         assert_eq!(
-            state.dae.as_ref().unwrap().progress.pending_bytes,
-            b"a\0b\0",
-            "the buffered value must survive a failed checkout"
+            state.dae.as_ref().unwrap().progress.carry,
+            vec![0xC3],
+            "the pending partial character must survive a failed checkout"
         );
     }
 

--- a/mssql-odbc/src/api/param_data.rs
+++ b/mssql-odbc/src/api/param_data.rs
@@ -414,14 +414,22 @@ fn open_deferred_rpc(
             Err(rc) => {
                 // Nothing was sent, so the statement goes back to being merely
                 // prepared rather than needing a cancel.
-                let client = stmt_state.take_dae();
+                //
+                // The client checked out above is returned directly rather than
+                // through `take_dae`: a checked-out client is no longer on the
+                // sequence, so `take_dae` reports `None` for it and disposing of
+                // it is this function's obligation (see `checkout_client`).
+                // `take_dae` still runs, for the sequence teardown it performs.
+                let parked = stmt_state.take_dae();
+                debug_assert!(
+                    parked.is_none(),
+                    "the client was checked out above, so the sequence cannot hold one"
+                );
                 stmt_state.prepared = prepared;
                 stmt_state.pending_unprepare = orphaned;
                 stmt_state.clear_state(STMT_STATE_EXEC_STARTED);
                 drop(stmt_state);
-                if let Some(client) = client {
-                    return_client_idle(dbc, statement_handle, client);
-                }
+                return_client_idle(dbc, statement_handle, client);
                 return Some(rc);
             }
         };
@@ -456,15 +464,22 @@ fn open_deferred_rpc(
         Ok(StreamedParamStatus::NeedData { .. }) => {
             let Ok(mut stmt_state) = stmt.inner.lock() else {
                 error!("SQLParamData: stmt mutex poisoned parking the opened RPC");
+                abandon_open_rpc(dbc, statement_handle, client);
                 return Some(SQL_ERROR);
             };
             stmt_state.prepared = prepared;
             stmt_state.pending_unprepare = orphaned;
-            let Some(dae) = stmt_state.dae.as_mut() else {
+            // Taken rather than borrowed: the failure arm has to release the
+            // guard before it can dispose of `client`, which a borrow held
+            // across a `let ... else` would forbid. Put back below on success.
+            let Some(mut dae) = stmt_state.dae.take() else {
                 error!("SQLParamData: DAE sequence vanished with its RPC open");
+                drop(stmt_state);
+                abandon_open_rpc(dbc, statement_handle, client);
                 return Some(SQL_ERROR);
             };
             dae.begin_streaming_phase(client, collation);
+            stmt_state.dae = Some(dae);
             None
         }
         Ok(StreamedParamStatus::Complete(_)) => {
@@ -492,6 +507,28 @@ fn open_deferred_rpc(
             Some(fail_with_tds(dbc, stmt, statement_handle, client, &e))
         }
     }
+}
+
+/// Disposes of a client whose RPC is open but which has nowhere left to be
+/// parked, so the connection is usable again rather than wedged.
+///
+/// The transport is mid-write once the RPC is open, so the parked request has to
+/// be discarded before the client can serve another command — the same disposal
+/// [`unwind_dae`](super::exec_common::unwind_dae) performs, without the
+/// statement half, which neither caller can do: one has a poisoned mutex and the
+/// other has already lost the sequence that teardown would read.
+///
+/// Reached only through internal-state corruption. It exists because dropping
+/// the client instead would leave the DBC holding `active_stmt` with no client
+/// to give, which fails every later operation on that connection rather than
+/// just this one.
+fn abandon_open_rpc(
+    dbc: &crate::handles::DbcHandle,
+    statement_handle: SqlHandle,
+    mut client: mssql_tds::connection::tds_client::TdsClient,
+) {
+    dbc.runtime.block_on(client.cancel_streamed_write());
+    return_client_idle(dbc, statement_handle, client);
 }
 
 /// Runs the execute a data-at-execution sequence deferred, now that every value
@@ -747,5 +784,96 @@ mod tests {
             ERR_DAE_LENGTH_MISMATCH.state
         );
         assert!(!state.needs_data());
+    }
+
+    /// A collected value that cannot be converted fails the whole sequence, and
+    /// the client `open_deferred_rpc` checked out has to reach the connection on
+    /// the way out.
+    ///
+    /// Dropping it instead leaves the DBC holding `active_stmt` with `client ==
+    /// None`, which fails every later operation on that *connection* rather than
+    /// just this statement — the failure is one statement's, so the blast radius
+    /// must be too. `take_dae` cannot supply it: a checked-out client is no
+    /// longer on the sequence, so `take_dae` answers `None` for it.
+    ///
+    /// The sequence has to be **mixed** to reach that branch at all:
+    /// `open_deferred_rpc` only runs once every remaining parameter streams
+    /// (`buffered_phase_complete`), so a lone buffered parameter closes through
+    /// `run_deferred_execute` instead and never checks a client out here.
+    /// The conversion is failed with a `varchar(1)` declaration against two
+    /// non-blank bytes, which `buffered_dae_to_rpc` rejects as `22001`.
+    #[test]
+    fn a_failed_deferred_rebuild_returns_the_client_to_the_connection() {
+        use crate::api::odbc_types::SQL_VARCHAR;
+        use crate::conversion::param_convert::DaePlan;
+        use mssql_tds::message::parameters::rpc_parameters::{
+            RpcParameter, StatusFlags, StreamedSqlType,
+        };
+        use mssql_tds::test_client_support::tds_client_from_tokens;
+
+        let h = TestHandles::with_env_dbc_stmt();
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        let dbc = stmt.parent_dbc();
+
+        let mut token = 0u8;
+        let token_ptr: SqlPointer = (&raw mut token).cast();
+
+        {
+            // Busy on this statement with no client of its own: the sequence
+            // holds it, exactly as a parked DAE sequence leaves the connection.
+            let mut dbc_state = dbc.inner.lock().unwrap();
+            dbc_state.active_stmt = Some(h.stmt);
+            dbc_state.client = None;
+        }
+        {
+            let mut state = stmt.inner.lock().unwrap();
+            // Parameter 0 buffers: one character declared, two supplied,
+            // neither a blank, so the conversion answers 22001.
+            let mut buffered =
+                DaeParam::unbounded(0, token_ptr, None).with_binding_types(SQL_C_CHAR, SQL_VARCHAR);
+            buffered.binding.column_size = 1;
+            buffered.plan = DaePlan::Buffer;
+            // Parameter 1 streams, which is what makes the buffered phase
+            // "complete" once parameter 0 closes and sends this through
+            // `open_deferred_rpc`.
+            let streamed = DaeParam::unbounded(1, token_ptr, None);
+
+            let mut dae = DaeState::for_test_with_client(
+                vec![buffered, streamed],
+                Some(0),
+                tds_client_from_tokens(vec![]),
+            );
+            dae.deferred = true;
+            dae.prebuilt = vec![
+                RpcParameter::data_at_exec(
+                    Some("@P1".to_string()),
+                    StatusFlags::NONE,
+                    StreamedSqlType::VarcharMax,
+                ),
+                RpcParameter::data_at_exec(
+                    Some("@P2".to_string()),
+                    StatusFlags::NONE,
+                    StreamedSqlType::VarBinaryMax,
+                ),
+            ];
+            dae.sql = Some("SELECT ?, ?".to_string());
+            dae.progress.put_data_called = true;
+            dae.progress.buffer = b"ab".to_vec();
+            state.dae = Some(dae);
+        }
+
+        let mut p: SqlPointer = std::ptr::null_mut();
+        let ret = unsafe { sql_param_data(h.stmt, &mut p) };
+        assert_eq!(ret, SQL_ERROR);
+
+        let dbc_state = dbc.inner.lock().unwrap();
+        assert!(
+            dbc_state.client.is_some(),
+            "the checked-out client must be returned, not dropped"
+        );
+        assert_eq!(
+            dbc_state.active_stmt, None,
+            "the busy claim must be released with it"
+        );
     }
 }

--- a/mssql-odbc/src/api/param_data.rs
+++ b/mssql-odbc/src/api/param_data.rs
@@ -474,6 +474,11 @@ fn open_deferred_rpc(
             // across a `let ... else` would forbid. Put back below on success.
             let Some(mut dae) = stmt_state.dae.take() else {
                 error!("SQLParamData: DAE sequence vanished with its RPC open");
+                // Cleared while the guard is still held, so the statement is
+                // reusable rather than stuck mid-execute — the same thing the
+                // no-plan-no-SQL arm above does through `clear_exec_started`.
+                // The poisoned-mutex arm cannot: it never got a guard.
+                stmt_state.clear_state(STMT_STATE_EXEC_STARTED);
                 drop(stmt_state);
                 abandon_open_rpc(dbc, statement_handle, client);
                 return Some(SQL_ERROR);

--- a/mssql-odbc/src/api/param_data.rs
+++ b/mssql-odbc/src/api/param_data.rs
@@ -31,7 +31,8 @@ use tracing::{debug, error};
 use mssql_tds::connection::tds_client::{ExecuteOptions, StatementResult, StreamedParamStatus};
 
 use super::exec_common::{
-    abort_dae_with_diag, fail_with_tds, finish_execute, rebuild_deferred_params, return_client_idle,
+    abort_dae_with_diag, clear_exec_started, fail_with_tds, finish_execute,
+    rebuild_deferred_params, return_client_idle,
 };
 use super::sqlstate::*;
 use super::util::write_if_some;
@@ -413,13 +414,19 @@ fn run_deferred_execute(
         };
 
         let client = stmt_state.take_dae();
-        stmt_state.clear_state(STMT_STATE_EXEC_STARTED);
+        // `EXEC_STARTED` deliberately stays set across the execute below, exactly
+        // as the immediate path holds it for its whole round trip and lets
+        // `finish_execute` / `fail_with_tds` clear it. Clearing it here would
+        // open a window in which a concurrent `SQLPrepareW` passes its
+        // active-execute guard and installs a plan that the `prepared` restore
+        // after the execute would then silently overwrite.
         (client, params, prepared, orphaned, sql, timeout_secs)
     };
 
     let (client, params, mut prepared, mut orphaned, sql, timeout_secs) = taken;
     let Some(mut client) = client else {
         error!("SQLParamData: deferred sequence has no client to execute on");
+        clear_exec_started(stmt);
         return SQL_ERROR;
     };
 
@@ -438,6 +445,7 @@ fn run_deferred_execute(
             (None, None) => {
                 error!("SQLParamData: deferred sequence has neither a plan nor SQL text");
                 return_client_idle(dbc, statement_handle, client);
+                clear_exec_started(stmt);
                 return SQL_ERROR;
             }
         };

--- a/mssql-odbc/src/api/param_data.rs
+++ b/mssql-odbc/src/api/param_data.rs
@@ -168,7 +168,7 @@ fn sql_param_data_safe(
         stmt_state.dae.as_ref().is_some_and(|dae| dae.deferred)
     };
     if is_deferred {
-        let (has_more, next_ptr) = {
+        let (has_more, buffered_phase_done, next_ptr) = {
             let Ok(mut stmt_state) = stmt.inner.lock() else {
                 error!("SQLParamData: stmt mutex poisoned closing a buffered parameter");
                 return SQL_ERROR;
@@ -186,8 +186,17 @@ fn sql_param_data_safe(
             dae.buffered.push((bound_index, bytes, is_null));
             dae.advance();
             let has_more = dae.current_param().is_some();
-            (has_more, stmt_state.dae_current_value_ptr())
+            let buffered_done = dae.buffered_phase_complete();
+            (has_more, buffered_done, stmt_state.dae_current_value_ptr())
         };
+
+        // Every remaining parameter streams, so the collected values are
+        // complete and the RPC can be opened now. The rest of the sequence goes
+        // onto the wire as it arrives instead of being collected whole, which is
+        // the whole point of data-at-execution for a LOB.
+        if buffered_phase_done && let Some(rc) = open_deferred_rpc(dbc, stmt, statement_handle) {
+            return rc;
+        }
 
         // More parameters to collect: hand back the next token.
         if has_more {
@@ -355,6 +364,136 @@ fn sql_param_data_safe(
     }
 }
 
+/// Opens the RPC for a deferred sequence whose buffered parameters are all
+/// collected, so the streamed ones that remain go onto the wire as their chunks
+/// arrive.
+///
+/// Returns `Some(rc)` only on failure; success leaves the sequence open with its
+/// cursor untouched, so the caller hands back the next parameter's token exactly
+/// as it would have.
+///
+/// Without this the whole sequence stays deferred and every parameter is
+/// collected whole, so one fixed-width value alongside a `varbinary(max)` would
+/// cost memory proportional to the LOB — the opposite of what data-at-execution
+/// is for (AB#47590).
+fn open_deferred_rpc(
+    dbc: &crate::handles::DbcHandle,
+    stmt: &StmtHandle,
+    statement_handle: SqlHandle,
+) -> Option<SqlReturn> {
+    let taken = {
+        let Ok(mut stmt_state) = stmt.inner.lock() else {
+            error!("SQLParamData: stmt mutex poisoned opening the deferred RPC");
+            return Some(SQL_ERROR);
+        };
+        let Some(dae) = stmt_state.dae.as_mut() else {
+            error!("SQLParamData: DAE sequence vanished opening the deferred RPC");
+            return Some(SQL_ERROR);
+        };
+        let collected = std::mem::take(&mut dae.buffered);
+        let dae_params = dae.params().to_vec();
+        let prebuilt = std::mem::take(&mut dae.prebuilt);
+        let sql = dae.sql.take();
+        let timeout_secs = dae.timeout_secs;
+        let prepared = dae.take_prepared();
+        let orphaned = dae.take_orphaned();
+        let Some(client) = dae.checkout_client() else {
+            error!("SQLParamData: DAE sequence has no client to open its RPC on");
+            post_diag(&mut stmt_state, ERR_FUNCTION_SEQUENCE);
+            return Some(SQL_ERROR);
+        };
+
+        let params = match rebuild_deferred_params(
+            &mut stmt_state,
+            prebuilt,
+            &collected,
+            &dae_params,
+            "SQLParamData",
+        ) {
+            Ok(params) => params,
+            Err(rc) => {
+                // Nothing was sent, so the statement goes back to being merely
+                // prepared rather than needing a cancel.
+                let client = stmt_state.take_dae();
+                stmt_state.prepared = prepared;
+                stmt_state.pending_unprepare = orphaned;
+                stmt_state.clear_state(STMT_STATE_EXEC_STARTED);
+                drop(stmt_state);
+                if let Some(client) = client {
+                    return_client_idle(dbc, statement_handle, client);
+                }
+                return Some(rc);
+            }
+        };
+        (client, params, prepared, orphaned, sql, timeout_secs)
+    };
+
+    let (mut client, params, mut prepared, mut orphaned, sql, timeout_secs) = taken;
+    let collation = client.get_collation();
+    let options = ExecuteOptions::new().timeout_secs(timeout_secs);
+
+    let begin_result = match (prepared.as_mut(), sql) {
+        (Some(plan), _) => dbc.runtime.block_on(client.begin_execute_prepared(
+            &mut plan.stmt,
+            params,
+            &mut orphaned,
+            options,
+        )),
+        (None, Some(sql)) => dbc
+            .runtime
+            .block_on(client.begin_sp_executesql(sql, params, options)),
+        (None, None) => {
+            error!("SQLParamData: deferred sequence has neither a plan nor SQL text");
+            return_client_idle(dbc, statement_handle, client);
+            clear_exec_started(stmt);
+            return Some(SQL_ERROR);
+        }
+    };
+
+    // The plan goes back before either outcome is reported, exactly as the
+    // immediate path does: a failure must still leave the statement prepared.
+    match begin_result {
+        Ok(StreamedParamStatus::NeedData { .. }) => {
+            let Ok(mut stmt_state) = stmt.inner.lock() else {
+                error!("SQLParamData: stmt mutex poisoned parking the opened RPC");
+                return Some(SQL_ERROR);
+            };
+            stmt_state.prepared = prepared;
+            stmt_state.pending_unprepare = orphaned;
+            let Some(dae) = stmt_state.dae.as_mut() else {
+                error!("SQLParamData: DAE sequence vanished with its RPC open");
+                return Some(SQL_ERROR);
+            };
+            dae.begin_streaming_phase(client, collation);
+            None
+        }
+        Ok(StreamedParamStatus::Complete(_)) => {
+            // Unreachable: this runs only while a streamed parameter is still
+            // open, so the RPC cannot have completed.
+            error!("SQLParamData: deferred RPC completed despite a streamed parameter");
+            if let Ok(mut stmt_state) = stmt.inner.lock() {
+                stmt_state.prepared = prepared;
+                stmt_state.pending_unprepare = orphaned;
+            }
+            Some(finish_execute(
+                dbc,
+                stmt,
+                statement_handle,
+                client,
+                "SQLParamData",
+            ))
+        }
+        Err(e) => {
+            error!(%e, "SQLParamData: opening the deferred RPC failed");
+            if let Ok(mut stmt_state) = stmt.inner.lock() {
+                stmt_state.prepared = prepared;
+                stmt_state.pending_unprepare = orphaned;
+            }
+            Some(fail_with_tds(dbc, stmt, statement_handle, client, &e))
+        }
+    }
+}
+
 /// Runs the execute a data-at-execution sequence deferred, now that every value
 /// has been collected.
 ///
@@ -382,21 +521,19 @@ fn run_deferred_execute(
         };
         let collected = std::mem::take(&mut dae.buffered);
         let dae_params = dae.params().to_vec();
-        let marker_count = dae.marker_count;
+        let prebuilt = std::mem::take(&mut dae.prebuilt);
         let sql = dae.sql.take();
         let timeout_secs = dae.timeout_secs;
         let prepared = dae.take_prepared();
         let mut orphaned = dae.take_orphaned();
 
-        let params = match unsafe {
-            rebuild_deferred_params(
-                &mut stmt_state,
-                marker_count,
-                &collected,
-                &dae_params,
-                "SQLParamData",
-            )
-        } {
+        let params = match rebuild_deferred_params(
+            &mut stmt_state,
+            prebuilt,
+            &collected,
+            &dae_params,
+            "SQLParamData",
+        ) {
             Ok(params) => params,
             Err(rc) => {
                 // Nothing was sent, so the statement goes back to being merely

--- a/mssql-odbc/src/api/put_data.rs
+++ b/mssql-odbc/src/api/put_data.rs
@@ -414,10 +414,19 @@ unsafe fn sql_put_data_safe(
         // that this chunk ended part-way through. An untranscoded one is already
         // the wire's bytes, so it is forwarded borrowed.
         let transcode = dae.current_param().and_then(|param| param.transcode);
+        // `push` consumes the carry it is handed, so the checkout below can fail
+        // after the partial character it held is already gone -- and that
+        // failure is the retriable "something else holds this sequence" one, so
+        // the retry would decode the continuation bytes alone and emit U+FFFD.
+        // The carry is at most one incomplete character, so keeping a copy
+        // across the checkout costs a few bytes and makes the failure free of
+        // side effects.
+        let mut carry_restore: Option<Vec<u8>> = None;
         let outgoing: Cow<'_, [u8]> = match transcode {
             Some(transcode) => match stmt_state.dae.as_mut() {
                 Some(dae) => {
                     let mut carry = std::mem::take(&mut dae.progress.carry);
+                    carry_restore = Some(carry.clone());
                     let out = transcode.push(&mut carry, fitted);
                     dae.progress.carry = carry;
                     Cow::Owned(out)
@@ -440,6 +449,11 @@ unsafe fn sql_put_data_safe(
             {
                 Some(client) => Some(client),
                 None => {
+                    // Put the partial character back, so a retry sees exactly
+                    // the state this call found.
+                    if let (Some(restore), Some(dae)) = (carry_restore, stmt_state.dae.as_mut()) {
+                        dae.progress.carry = restore;
+                    }
                     error!("SQLPutData: DAE client is unavailable — internal state corruption");
                     post_diag(&mut stmt_state, ERR_FUNCTION_SEQUENCE);
                     return SQL_ERROR;

--- a/mssql-odbc/src/api/put_data.rs
+++ b/mssql-odbc/src/api/put_data.rs
@@ -10,6 +10,8 @@
 //! parameter as SQL `NULL` (no chunks); any other valid value is a byte count
 //! for `data_ptr`.
 
+use std::borrow::Cow;
+
 use tracing::{debug, error};
 
 use super::exec_common::{abort_dae_with_diag, fail_with_tds, return_client_idle};
@@ -303,9 +305,9 @@ unsafe fn sql_put_data_safe(
                 ERR_ATTEMPT_TO_CONCATENATE_NULL,
             );
         }
-        let new_total = dae.progress.bytes_sent.saturating_add(byte_count);
+        let app_total = dae.progress.bytes_sent.saturating_add(byte_count);
         if let Some(expected) = dae.current_param().and_then(|param| param.expected_len)
-            && new_total > expected
+            && app_total > expected
         {
             drop(stmt_state);
             error!("SQLPutData: DAE data exceeds SQL_LEN_DATA_AT_EXEC length");
@@ -365,21 +367,28 @@ unsafe fn sql_put_data_safe(
         // buffer - exactly where msodbcsql applies `ValidatePutDataLength`
         // (`odbc/sqlccmd.cpp:4571`), so the `22001` lands on the `SQLPutData`
         // that overflows rather than at close (AB#47590).
-        let sent_before = dae.progress.bytes_sent;
-        let fitted: Vec<u8> = match dae.current_param().and_then(|param| param.length_limit) {
-            Some(limit) if !chunk.is_empty() => match limit.fit(chunk, sent_before) {
-                Ok(fitted) => fitted.to_vec(),
+        //
+        // Measured against the *retained* running total, not the application's:
+        // trimmed padding must not consume the declaration's budget. The two
+        // totals are tracked separately because the declared-length promise
+        // above counts what the application supplied.
+        let retained_before = dae.progress.retained_bytes;
+        // Borrowed, not copied: `fit` returns a prefix of `chunk`, and the
+        // buffered branch copies it straight into the capacity reserved above,
+        // so a chunk is never materialized into a second heap buffer that the
+        // `try_reserve` guard does not cover and that would double peak usage.
+        let fitted: &[u8] = match dae.current_param().and_then(|param| param.length_limit) {
+            Some(limit) if !chunk.is_empty() => match limit.fit(chunk, retained_before) {
+                Ok(fitted) => fitted,
                 Err(e) => {
                     drop(stmt_state);
                     error!("SQLPutData: value exceeds ColumnSize (22001)");
                     return abort_dae_with_diag(dbc, stmt, statement_handle, e.diag());
                 }
             },
-            _ => chunk.to_vec(),
+            _ => chunk,
         };
-        // The total advances by the retained count, so padding trimmed away
-        // does not consume the declaration's budget.
-        let new_total = sent_before.saturating_add(fitted.len());
+        let retained_total = retained_before.saturating_add(fitted.len());
 
         // A buffered parameter never touches the wire here: it accumulates and
         // is converted whole when `SQLParamData` closes it. In a deferred
@@ -387,30 +396,32 @@ unsafe fn sql_put_data_safe(
         // accumulates, whatever its own plan says.
         if will_buffer {
             if let Some(dae) = stmt_state.dae.as_mut() {
-                dae.progress.buffer.extend_from_slice(&fitted);
-                dae.progress.bytes_sent = new_total;
+                dae.progress.buffer.extend_from_slice(fitted);
+                dae.progress.bytes_sent = app_total;
+                dae.progress.retained_bytes = retained_total;
                 dae.progress.put_data_called = true;
             }
             return SQL_SUCCESS;
         }
 
         // A transcoded stream converts on the way out, holding back a character
-        // that this chunk ended part-way through.
+        // that this chunk ended part-way through. An untranscoded one is already
+        // the wire's bytes, so it is forwarded borrowed.
         let transcode = dae.current_param().and_then(|param| param.transcode);
-        let outgoing: Vec<u8> = match transcode {
+        let outgoing: Cow<'_, [u8]> = match transcode {
             Some(transcode) => match stmt_state.dae.as_mut() {
                 Some(dae) => {
                     let mut carry = std::mem::take(&mut dae.progress.carry);
-                    let out = transcode.push(&mut carry, &fitted);
+                    let out = transcode.push(&mut carry, fitted);
                     dae.progress.carry = carry;
-                    out
+                    Cow::Owned(out)
                 }
                 None => {
                     error!("SQLPutData: DAE sequence ended between locks");
                     return SQL_ERROR;
                 }
             },
-            None => fitted,
+            None => Cow::Borrowed(fitted),
         };
 
         let client = if outgoing.is_empty() {
@@ -431,7 +442,8 @@ unsafe fn sql_put_data_safe(
         };
 
         if let Some(dae) = stmt_state.dae.as_mut() {
-            dae.progress.bytes_sent = new_total;
+            dae.progress.bytes_sent = app_total;
+            dae.progress.retained_bytes = retained_total;
             dae.progress.put_data_called = true;
         }
         client.map(|client| (client, outgoing))
@@ -747,6 +759,60 @@ mod tests {
     /// this sequence" state `failed_client_checkout_leaves_progress_untouched`
     /// covers for the untranscoded path, and a rejected call must leave the
     /// parameter's counters and carry where they were.
+    /// `SQL_LEN_DATA_AT_EXEC(n)` promises `n` *application* bytes, while
+    /// `ColumnSize` bounds what survives trimming. Conflating the two makes a
+    /// value that satisfies both fail at close: `"ab  "` is four bytes the
+    /// application really did supply, and two after the overflowing blanks are
+    /// trimmed to `varchar(2)`, so a single counter would report `2 != 4` and
+    /// reject a correct sequence. The totals are tracked separately.
+    #[test]
+    fn trimmed_padding_does_not_break_the_declared_length_promise() {
+        let limit = crate::conversion::param_convert::dae_length_limit(
+            crate::api::odbc_types::SQL_C_CHAR,
+            SQL_VARCHAR,
+            2,
+        )
+        .expect("varchar(2) is a bounded declaration")
+        .expect("and therefore has a limit");
+
+        let h = TestHandles::with_env_dbc_stmt();
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        {
+            let mut state = stmt.inner.lock().unwrap();
+            state.dae = Some(DaeState::for_test(
+                vec![
+                    DaeParam::unbounded(0, std::ptr::null_mut(), Some(4))
+                        .with_binding_types(crate::api::odbc_types::SQL_C_CHAR, SQL_VARCHAR)
+                        .with_length_limit(limit),
+                ],
+                Some(0),
+            ));
+        }
+        // Buffered rather than streamed, so the chunk lands in the accumulator
+        // without needing a parked client.
+        {
+            let mut state = stmt.inner.lock().unwrap();
+            let dae = state.dae.as_mut().unwrap();
+            dae.deferred = true;
+        }
+
+        let mut chunk = *b"ab  ";
+        let ret = unsafe { sql_put_data(h.stmt, chunk.as_mut_ptr().cast(), 4) };
+        assert_eq!(ret, SQL_SUCCESS, "four supplied bytes satisfy the promise");
+
+        let state = stmt.inner.lock().unwrap();
+        let dae = state.dae.as_ref().expect("sequence still active");
+        assert_eq!(
+            dae.progress.bytes_sent, 4,
+            "the declared-length promise counts what the application supplied"
+        );
+        assert_eq!(
+            dae.progress.retained_bytes, 2,
+            "the ColumnSize budget counts only what survived trimming"
+        );
+        assert_eq!(dae.progress.buffer, b"ab", "the blanks were trimmed away");
+    }
+
     #[test]
     fn transcoded_param_without_a_client_returns_hy010() {
         let h = TestHandles::with_env_dbc_stmt();

--- a/mssql-odbc/src/api/put_data.rs
+++ b/mssql-odbc/src/api/put_data.rs
@@ -147,6 +147,23 @@ unsafe fn sql_put_data_safe(
             }
         }
 
+        // A deferred sequence has no open request to signal NULL on: the flag is
+        // recorded and `SQLParamData` builds a typed NULL from it, exactly as a
+        // materialized parameter with a `SQL_NULL_DATA` indicator produces one.
+        {
+            let Ok(mut stmt_state) = stmt.inner.lock() else {
+                error!("SQLPutData: stmt mutex poisoned marking a buffered parameter NULL");
+                return SQL_ERROR;
+            };
+            if let Some(dae) = stmt_state.dae.as_mut()
+                && dae.deferred
+            {
+                dae.progress.put_data_called = true;
+                dae.progress.is_null = true;
+                return SQL_SUCCESS;
+            }
+        }
+
         let write_result = {
             let Ok(mut stmt_state) = stmt.inner.lock() else {
                 error!("SQLPutData: stmt mutex poisoned taking the DAE client for a null write");
@@ -295,87 +312,108 @@ unsafe fn sql_put_data_safe(
             return abort_dae_with_diag(dbc, stmt, statement_handle, ERR_DAE_LENGTH_MISMATCH);
         }
 
-        let needs_transcode = dae
-            .current_param()
-            .is_some_and(|param| param.needs_transcode);
+        let plan = dae.current_param().map(|param| param.plan);
+        let Some(plan) = plan else {
+            error!("SQLPutData: open data-at-execution parameter has no plan");
+            post_diag(&mut stmt_state, ERR_FUNCTION_SEQUENCE);
+            return SQL_ERROR;
+        };
 
-        let client = if byte_count == 0 {
-            None
-        } else if needs_transcode {
-            // Checked before the checkout below: `SQL_DATA_AT_EXEC` declares
-            // no total, so nothing bounds how large this buffer grows, and
-            // `extend_from_slice`'s infallible allocation would abort the
-            // whole host process on an allocation failure it can't recover
-            // from. `try_reserve` turns that into a diagnostic the
-            // application can act on instead -- checked against `byte_count`
-            // directly, so a reservation this large never has to construct
-            // an unsafe slice claiming that many bytes are valid just to
-            // read its length back out, and never has to check out (and
-            // then dispose of) a client it turns out not to need. No client
-            // is checked out by this call yet, so `abort_dae_with_diag` tears
-            // the sequence down the same way the `is_null` / `expected_len`
-            // checks above do, rather than the "something else is using this
-            // sequence" retriable failure `checkout_client` returning `None`
-            // represents below. This only bounds accumulation, not the
-            // transform `SQLParamData` runs at close, which still allocates
-            // infallibly -- see `transcode_dae_bytes`'s doc comment.
-            if stmt_state
-                .dae
-                .as_mut()
-                .is_some_and(|dae| dae.progress.pending_bytes.try_reserve(byte_count).is_err())
-            {
+        let will_buffer = plan.is_buffered() || dae.deferred;
+
+        // `SQL_DATA_AT_EXEC` declares no total, so nothing bounds how large a
+        // chunk can claim to be, and every allocation that follows --
+        // `extend_from_slice` on the accumulator, the conversion buffer inside
+        // `DaeTranscode::push` -- allocates infallibly and would abort the whole
+        // host process on a failure it cannot report. `try_reserve` turns that
+        // into a diagnostic the application can act on instead. Checked against
+        // `byte_count` directly and before the slice below is built, so a length
+        // this process could never satisfy never has to construct a slice
+        // claiming that many bytes are valid just to read its length back out,
+        // and before any client is checked out, so an unsatisfiable reservation
+        // abandons the sequence the way the `is_null` and `expected_len` guards
+        // above do rather than looking like the retriable "something else holds
+        // this sequence" failure further down. Reserved on whichever accumulator
+        // receives the bytes: `buffer` for a value converted whole at close,
+        // `carry` for one converted on the way out -- `push` moves that capacity
+        // into its own conversion buffer.
+        if byte_count > 0 {
+            let target = if will_buffer {
+                &mut dae.progress.buffer
+            } else {
+                &mut dae.progress.carry
+            };
+            if target.try_reserve(byte_count).is_err() {
                 drop(stmt_state);
                 error!(
-                    "SQLPutData: failed to reserve {byte_count} bytes for a buffered DAE value (HY001)"
+                    "SQLPutData: failed to reserve {byte_count} bytes for a data-at-execution value (HY001)"
                 );
                 return abort_dae_with_diag(dbc, stmt, statement_handle, ERR_MEMORY_ALLOCATION);
             }
+        }
 
-            // The declared C type and SQL type disagree on wideness (see
-            // `dae_placeholder_type`), so a chunk transcoded in isolation
-            // could split a multi-byte character across two calls. Buffer
-            // the raw bytes instead; the whole value is transcoded once,
-            // when the parameter closes (`sql_param_data_safe`).
-            //
-            // Still checked out and immediately returned, exactly like the
-            // streaming branch below: `checkout_client` is this sequence's
-            // only mutual-exclusion signal against a concurrent
-            // `SQLParamData`, which checks the client out for the whole
-            // close and snapshots `pending_bytes` to transcode under the
-            // same lock. Skipping the checkout here would let this call
-            // append after that snapshot and still report success, so the
-            // bytes it appended would be silently discarded rather than
-            // sent.
-            //
-            // Checkout and append share one `dae` borrow rather than
-            // re-fetching `stmt_state.dae.as_mut()` for the append: a
-            // second fetch that came back `None` would silently drop the
-            // checked-out client instead of returning it. Provably
-            // unreachable -- nothing between the two fetches can clear
-            // `dae` -- but sharing the borrow removes the possibility
-            // structurally instead of relying on that argument.
-            let Some(dae) = stmt_state.dae.as_mut() else {
-                error!("SQLPutData: DAE client is unavailable — internal state corruption");
-                post_diag(&mut stmt_state, ERR_FUNCTION_SEQUENCE);
-                return SQL_ERROR;
-            };
-            match dae.checkout_client() {
-                Some(client) => {
-                    // Safety: caller guarantees data_ptr is readable for
-                    // byte_count bytes, and byte_count > 0 here, so
-                    // data_ptr is non-null (the null+nonzero-length
-                    // combination was already rejected above).
-                    let chunk =
-                        unsafe { std::slice::from_raw_parts(data_ptr as *const u8, byte_count) };
-                    dae.progress.pending_bytes.extend_from_slice(chunk);
-                    dae.return_client(client);
+        // Safety: the caller guarantees `data_ptr` is readable for `byte_count`
+        // bytes; the null and zero cases returned above.
+        let chunk: &[u8] = if byte_count == 0 {
+            &[]
+        } else {
+            unsafe { std::slice::from_raw_parts(data_ptr as *const u8, byte_count) }
+        };
+
+        // `ColumnSize` bounds the accumulated value, and it is applied here -
+        // before the streamed/buffered split and against the *application*
+        // buffer - exactly where msodbcsql applies `ValidatePutDataLength`
+        // (`odbc/sqlccmd.cpp:4571`), so the `22001` lands on the `SQLPutData`
+        // that overflows rather than at close (AB#47590).
+        let sent_before = dae.progress.bytes_sent;
+        let fitted: Vec<u8> = match dae.current_param().and_then(|param| param.length_limit) {
+            Some(limit) if !chunk.is_empty() => match limit.fit(chunk, sent_before) {
+                Ok(fitted) => fitted.to_vec(),
+                Err(e) => {
+                    drop(stmt_state);
+                    error!("SQLPutData: value exceeds ColumnSize (22001)");
+                    return abort_dae_with_diag(dbc, stmt, statement_handle, e.diag());
+                }
+            },
+            _ => chunk.to_vec(),
+        };
+        // The total advances by the retained count, so padding trimmed away
+        // does not consume the declaration's budget.
+        let new_total = sent_before.saturating_add(fitted.len());
+
+        // A buffered parameter never touches the wire here: it accumulates and
+        // is converted whole when `SQLParamData` closes it. In a deferred
+        // sequence there is no open request at all, so every parameter
+        // accumulates, whatever its own plan says.
+        if will_buffer {
+            if let Some(dae) = stmt_state.dae.as_mut() {
+                dae.progress.buffer.extend_from_slice(&fitted);
+                dae.progress.bytes_sent = new_total;
+                dae.progress.put_data_called = true;
+            }
+            return SQL_SUCCESS;
+        }
+
+        // A transcoded stream converts on the way out, holding back a character
+        // that this chunk ended part-way through.
+        let transcode = dae.current_param().and_then(|param| param.transcode);
+        let outgoing: Vec<u8> = match transcode {
+            Some(transcode) => match stmt_state.dae.as_mut() {
+                Some(dae) => {
+                    let mut carry = std::mem::take(&mut dae.progress.carry);
+                    let out = transcode.push(&mut carry, &fitted);
+                    dae.progress.carry = carry;
+                    out
                 }
                 None => {
-                    error!("SQLPutData: DAE client is unavailable — internal state corruption");
-                    post_diag(&mut stmt_state, ERR_FUNCTION_SEQUENCE);
+                    error!("SQLPutData: DAE sequence ended between locks");
                     return SQL_ERROR;
                 }
-            }
+            },
+            None => fitted,
+        };
+
+        let client = if outgoing.is_empty() {
             None
         } else {
             match stmt_state
@@ -396,21 +434,17 @@ unsafe fn sql_put_data_safe(
             dae.progress.bytes_sent = new_total;
             dae.progress.put_data_called = true;
         }
-        client
+        client.map(|client| (client, outgoing))
     };
 
-    let Some(mut client) = checked_out else {
-        // Zero-length chunk with a non-null pointer supplies an empty value.
-        // NULL/0 is handled above as SQL NULL to match msodbcsql. A buffered
-        // (`needs_transcode`) chunk was appended above with no network write
-        // of its own.
+    let Some((mut client, outgoing)) = checked_out else {
+        // Zero-length chunk with a non-null pointer supplies an empty value, as
+        // does one held entirely in the transcoder pending its continuation.
+        // NULL/0 is handled above as SQL NULL to match msodbcsql.
         return SQL_SUCCESS;
     };
 
-    // Safety: caller guarantees data_ptr is readable for byte_count bytes.
-    let chunk = unsafe { std::slice::from_raw_parts(data_ptr as *const u8, byte_count) };
-
-    let write_result = dbc.runtime.block_on(client.write_streamed_chunk(chunk));
+    let write_result = dbc.runtime.block_on(client.write_streamed_chunk(&outgoing));
 
     match write_result {
         Ok(()) => {
@@ -465,15 +499,16 @@ mod tests {
     use crate::test_support::TestHandles;
 
     /// A sequence with one parameter, already opened by `SQLParamData`.
+    ///
+    /// Bound narrow-to-narrow so `SQL_NTS` sizing has a single-byte C type to
+    /// read, which is what `nts_uses_the_snapshotted_c_type_with_bound_params_cleared`
+    /// checks the snapshot supplies.
     fn open_dae(expected_len: Option<usize>) -> DaeState {
         DaeState::for_test(
-            vec![DaeParam {
-                value_ptr: std::ptr::null_mut(),
-                expected_len,
-                needs_transcode: false,
-                c_type: SQL_C_CHAR,
-                sql_type: SQL_VARCHAR,
-            }],
+            vec![
+                DaeParam::unbounded(0, std::ptr::null_mut(), expected_len)
+                    .with_binding_types(SQL_C_CHAR, SQL_VARCHAR),
+            ],
             Some(0),
         )
     }
@@ -659,13 +694,13 @@ mod tests {
             {
                 let mut state = stmt.inner.lock().unwrap();
                 state.dae = Some(DaeState::for_test(
-                    vec![DaeParam {
-                        value_ptr: std::ptr::null_mut(),
-                        expected_len: Some(declared),
-                        needs_transcode: false,
-                        c_type: crate::api::odbc_types::SQL_C_WCHAR,
-                        sql_type: crate::api::odbc_types::SQL_WVARCHAR,
-                    }],
+                    vec![
+                        DaeParam::unbounded(0, std::ptr::null_mut(), Some(declared))
+                            .with_binding_types(
+                                crate::api::odbc_types::SQL_C_WCHAR,
+                                crate::api::odbc_types::SQL_WVARCHAR,
+                            ),
+                    ],
                     Some(0),
                 ));
             }
@@ -706,31 +741,26 @@ mod tests {
 
     /// A parameter whose C type and SQL type disagree on wideness still needs
     /// the checked-out client as this sequence's only mutual-exclusion signal
-    /// against a concurrent `SQLParamData` -- even though the buffered write
-    /// itself never touches the network. `SQLParamData` checks the client out
-    /// for the whole close and snapshots `pending_bytes` to transcode under
-    /// the same lock; skipping the checkout here would let a buffered chunk
-    /// land after that snapshot and still report success, silently discarding
-    /// the bytes it appended. No client to check out is therefore the same
-    /// "something else is using this sequence" state
-    /// `failed_client_checkout_leaves_progress_untouched` covers for the
-    /// streaming path.
+    /// against a concurrent `SQLParamData` -- the transcoded write still needs
+    /// the client, because its output goes to the wire like any other chunk.
+    /// No client to check out is therefore the same "something else is using
+    /// this sequence" state `failed_client_checkout_leaves_progress_untouched`
+    /// covers for the untranscoded path, and a rejected call must leave the
+    /// parameter's counters and carry where they were.
     #[test]
     fn transcoded_param_without_a_client_returns_hy010() {
         let h = TestHandles::with_env_dbc_stmt();
         let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
         {
             let mut state = stmt.inner.lock().unwrap();
-            state.dae = Some(DaeState::for_test(
-                vec![DaeParam {
-                    value_ptr: std::ptr::null_mut(),
-                    expected_len: None,
-                    needs_transcode: true,
-                    c_type: crate::api::odbc_types::SQL_C_WCHAR,
-                    sql_type: SQL_VARCHAR,
-                }],
-                Some(0),
+            let mut param = DaeParam::unbounded(0, std::ptr::null_mut(), None)
+                .with_binding_types(crate::api::odbc_types::SQL_C_WCHAR, SQL_VARCHAR);
+            param.transcode = Some(crate::conversion::param_convert::DaeTranscode::new(
+                crate::api::odbc_types::SQL_C_WCHAR,
+                SQL_VARCHAR,
+                mssql_tds::token::tokens::SqlCollation::default(),
             ));
+            state.dae = Some(DaeState::for_test(vec![param], Some(0)));
         }
 
         let mut bytes: Vec<u8> = "ab".encode_utf16().flat_map(u16::to_le_bytes).collect();
@@ -742,18 +772,19 @@ mod tests {
         let dae = state.dae.as_ref().expect("sequence still active");
         assert_eq!(dae.progress.bytes_sent, 0);
         assert!(!dae.progress.put_data_called);
-        assert!(dae.progress.pending_bytes.is_empty());
+        assert!(dae.progress.carry.is_empty());
     }
 
     /// `SQL_DATA_AT_EXEC` declares no total, so nothing bounds how large
-    /// `pending_bytes` can grow for a mismatched-wideness parameter. A
-    /// reservation this call can never satisfy must fail cleanly with
-    /// `HY001` instead of letting `Vec`'s default infallible allocation
-    /// abort the process this driver is loaded into. Checked before any
-    /// client is checked out, so this doesn't need one parked: a byte count
-    /// near `usize::MAX` fails `try_reserve` on any real system without
-    /// actually exhausting its memory, and `data_ptr` is never read at that
-    /// length -- the call returns before the unsafe slice is constructed.
+    /// The accumulator behind a data-at-execution parameter can grow to
+    /// whatever `SQLPutData` claims. A reservation this call can never satisfy
+    /// must fail cleanly with `HY001` instead of letting `Vec`'s default
+    /// infallible allocation abort the process this driver is loaded into.
+    /// Checked before any client is checked out, so this doesn't need one
+    /// parked: a byte count near `usize::MAX` fails `try_reserve` on any real
+    /// system without actually exhausting its memory, and `data_ptr` is never
+    /// read at that length -- the call returns before the unsafe slice is
+    /// constructed.
     #[test]
     fn oversized_transcoded_chunk_returns_hy001_without_aborting() {
         let h = TestHandles::with_env_dbc_stmt();
@@ -761,13 +792,10 @@ mod tests {
         {
             let mut state = stmt.inner.lock().unwrap();
             state.dae = Some(DaeState::for_test(
-                vec![DaeParam {
-                    value_ptr: std::ptr::null_mut(),
-                    expected_len: None,
-                    needs_transcode: true,
-                    c_type: crate::api::odbc_types::SQL_C_WCHAR,
-                    sql_type: SQL_VARCHAR,
-                }],
+                vec![
+                    DaeParam::unbounded(0, std::ptr::null_mut(), None)
+                        .with_binding_types(crate::api::odbc_types::SQL_C_WCHAR, SQL_VARCHAR),
+                ],
                 Some(0),
             ));
         }

--- a/mssql-odbc/src/api/put_data.rs
+++ b/mssql-odbc/src/api/put_data.rs
@@ -372,23 +372,29 @@ unsafe fn sql_put_data_safe(
         // trimmed padding must not consume the declaration's budget. The two
         // totals are tracked separately because the declared-length promise
         // above counts what the application supplied.
-        let retained_before = dae.progress.retained_bytes;
+        //
+        // Counted in the bound's own unit, which is not always bytes -- a
+        // `SQL_C_CHAR` buffer is measured in the UTF-16 units the materialized
+        // path uses -- so the running total accumulates what `fit` reports
+        // rather than the length of what it kept.
+        let retained_before = dae.progress.retained_units;
         // Borrowed, not copied: `fit` returns a prefix of `chunk`, and the
         // buffered branch copies it straight into the capacity reserved above,
         // so a chunk is never materialized into a second heap buffer that the
         // `try_reserve` guard does not cover and that would double peak usage.
-        let fitted: &[u8] = match dae.current_param().and_then(|param| param.length_limit) {
-            Some(limit) if !chunk.is_empty() => match limit.fit(chunk, retained_before) {
-                Ok(fitted) => fitted,
-                Err(e) => {
-                    drop(stmt_state);
-                    error!("SQLPutData: value exceeds ColumnSize (22001)");
-                    return abort_dae_with_diag(dbc, stmt, statement_handle, e.diag());
-                }
-            },
-            _ => chunk,
-        };
-        let retained_total = retained_before.saturating_add(fitted.len());
+        let (fitted, consumed): (&[u8], usize) =
+            match dae.current_param().and_then(|param| param.length_limit) {
+                Some(limit) if !chunk.is_empty() => match limit.fit(chunk, retained_before) {
+                    Ok(fitted) => fitted,
+                    Err(e) => {
+                        drop(stmt_state);
+                        error!("SQLPutData: value exceeds ColumnSize (22001)");
+                        return abort_dae_with_diag(dbc, stmt, statement_handle, e.diag());
+                    }
+                },
+                _ => (chunk, chunk.len()),
+            };
+        let retained_total = retained_before.saturating_add(consumed);
 
         // A buffered parameter never touches the wire here: it accumulates and
         // is converted whole when `SQLParamData` closes it. In a deferred
@@ -398,7 +404,7 @@ unsafe fn sql_put_data_safe(
             if let Some(dae) = stmt_state.dae.as_mut() {
                 dae.progress.buffer.extend_from_slice(fitted);
                 dae.progress.bytes_sent = app_total;
-                dae.progress.retained_bytes = retained_total;
+                dae.progress.retained_units = retained_total;
                 dae.progress.put_data_called = true;
             }
             return SQL_SUCCESS;
@@ -443,7 +449,7 @@ unsafe fn sql_put_data_safe(
 
         if let Some(dae) = stmt_state.dae.as_mut() {
             dae.progress.bytes_sent = app_total;
-            dae.progress.retained_bytes = retained_total;
+            dae.progress.retained_units = retained_total;
             dae.progress.put_data_called = true;
         }
         client.map(|client| (client, outgoing))
@@ -807,7 +813,7 @@ mod tests {
             "the declared-length promise counts what the application supplied"
         );
         assert_eq!(
-            dae.progress.retained_bytes, 2,
+            dae.progress.retained_units, 2,
             "the ColumnSize budget counts only what survived trimming"
         );
         assert_eq!(dae.progress.buffer, b"ab", "the blanks were trimmed away");

--- a/mssql-odbc/src/conversion/param_convert.rs
+++ b/mssql-odbc/src/conversion/param_convert.rs
@@ -327,9 +327,22 @@ pub(crate) fn dae_length_limit(
     };
 
     // Only a pairing whose buffer unit *is* the declaration's unit can be
-    // measured here. A narrow buffer against a wide declaration (or the
-    // reverse) counts different things on each side, so it is left to
-    // `convert_character_sql`, which measures both in UTF-16 units.
+    // measured here: a narrow buffer against a wide declaration (or the
+    // reverse) counts different things on each side.
+    //
+    // What happens to an unmeasurable bound depends on how the value travels.
+    // A *buffered* parameter is converted whole at close, so `ColumnSize` is
+    // still applied there by `convert_character_sql`, which measures both sides
+    // in UTF-16 units. A *streamed* one never reaches that conversion, so
+    // returning `None` here leaves it genuinely unbounded -- which is why
+    // `build_named_params` declines to narrow its declaration in that case
+    // rather than promising a bound nothing enforces.
+    //
+    // msodbcsql does bound this pairing: `ValidatePutDataLength`'s `SQL_C_WCHAR`
+    // arm (`odbc/sqlccmd.cpp:10931`) converts the chunk to the server code page
+    // precisely so it can measure the narrow length, and only `fIsVarMax`
+    // disables the check. Matching that needs the encoded length at this layer;
+    // tracked under AB#47590.
     let same_unit = match c_type {
         SQL_C_BINARY => sql_family(sql_type) == Some(SqlFamily::Binary),
         SQL_C_WCHAR => is_wide_character_sql_type(sql_type),
@@ -1834,6 +1847,55 @@ mod tests {
         assert_eq!(second, 0, "the continuation is already paid for");
         // One unit consumed in total, so a second character still fits.
         assert_eq!(limit.fit(b"z", first + second).unwrap().1, 1);
+    }
+
+    /// The pairings `park_dae_client` leaves without a transcode, so
+    /// `SQLPutData` forwards their chunks borrowed instead of copying each one
+    /// through a conversion that returns them unchanged. Binary is the case
+    /// that matters most: streaming a large `varbinary(max)` is the canonical
+    /// reason to use data-at-execution at all, and it never needs conversion.
+    #[test]
+    fn a_passthrough_pairing_needs_no_transcode() {
+        let collation = SqlCollation::default();
+        for (c_type, sql_type) in [
+            (SQL_C_BINARY, SQL_VARBINARY),
+            (SQL_C_BINARY, SQL_LONGVARBINARY),
+            (SQL_C_WCHAR, SQL_WVARCHAR),
+        ] {
+            assert!(
+                DaeTranscode::new(c_type, sql_type, collation).is_passthrough(),
+                "{c_type} -> {sql_type} is already the wire's bytes"
+            );
+        }
+
+        // A wideness mismatch does convert, so it keeps its transcode.
+        assert!(
+            !DaeTranscode::new(SQL_C_WCHAR, SQL_VARCHAR, collation).is_passthrough(),
+            "a wide buffer against a narrow target has to be re-encoded"
+        );
+    }
+
+    /// A wideness-mismatched pairing cannot be measured in the buffer's own
+    /// unit, so no bound is produced. Pinned because the streamed path has no
+    /// close-time conversion to fall back on: `build_named_params` reads this
+    /// `None` as the signal to leave the declaration at `max` rather than
+    /// narrowing it to a length nothing would enforce.
+    #[test]
+    fn dae_length_limit_is_absent_for_a_wideness_mismatch() {
+        for (c_type, sql_type) in [
+            (SQL_C_WCHAR, SQL_VARCHAR),
+            (SQL_C_WCHAR, SQL_CHAR),
+            (SQL_C_WCHAR, SQL_LONGVARCHAR),
+            (SQL_C_CHAR, SQL_WVARCHAR),
+            (SQL_C_CHAR, SQL_WCHAR),
+            (SQL_C_CHAR, SQL_WLONGVARCHAR),
+        ] {
+            assert_eq!(
+                dae_length_limit(c_type, sql_type, 10).unwrap(),
+                None,
+                "{c_type} -> {sql_type} counts different units on each side"
+            );
+        }
     }
 
     /// Once the budget is spent every later chunk must be padding, and the

--- a/mssql-odbc/src/conversion/param_convert.rs
+++ b/mssql-odbc/src/conversion/param_convert.rs
@@ -199,18 +199,49 @@ pub(crate) fn is_data_at_exec_indicator(indicator: SqlLen) -> bool {
     indicator == SQL_DATA_AT_EXEC || indicator <= SQL_LEN_DATA_AT_EXEC_OFFSET
 }
 
+/// UTF-16 code units contributed by a single UTF-8 byte.
+///
+/// Classified from the byte alone, which is what lets the bound below survive a
+/// character split across two `SQLPutData` calls without carrying state: a
+/// continuation byte belongs to a character already counted at its lead, and a
+/// four-byte lead is exactly the one that decodes to a surrogate pair. A
+/// sequence broken across chunks therefore has its lead counted in the first and
+/// its continuations counted as nothing in the second, for the same total.
+fn utf16_units_of_utf8_byte(byte: u8) -> usize {
+    if byte & 0b1100_0000 == 0b1000_0000 {
+        0
+    } else if byte & 0b1111_1000 == 0b1111_0000 {
+        2
+    } else {
+        1
+    }
+}
+
+/// The unit a declaration's `ColumnSize` is counted in, and how much of it fits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DaeBound {
+    /// Application-buffer bytes. Binary counts them directly, and a
+    /// `SQL_C_WCHAR` character is a fixed two of them, so both are exact.
+    Bytes(usize),
+    /// UTF-16 code units of a UTF-8 buffer. `SQL_C_CHAR` bytes are not
+    /// characters, and the materialized path measures every character input in
+    /// UTF-16 units (`trim_blank_overflow`), so counting bytes here would reject
+    /// a value -- one non-ASCII character against `varchar(1)` -- that the same
+    /// binding materialized accepts. The unit is an approximation of collation
+    /// bytes on both paths; making it exact is AB#47584.
+    Utf16Units(usize),
+}
+
 /// How much a buffered parameter may accept, and what its overflow is allowed
 /// to be made of.
 ///
-/// Held in application-buffer bytes so `SQLPutData` can compare it against a raw
-/// chunk length. Only produced for a same-family pairing, where the C type fixes
-/// the unit width unambiguously; a cross-family value's units do not correspond
-/// (a UTF-8 byte is not a character), so its bound is left to the close-time
-/// converter instead.
+/// Only produced for a same-family pairing, where the C type fixes the unit
+/// unambiguously; a cross-family value's units do not correspond, so its bound
+/// is left to the close-time converter instead.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct DaeLengthLimit {
-    /// Maximum total the parameter may accept, in application-buffer bytes.
-    max_bytes: usize,
+    /// Maximum total the parameter may accept, in the unit named by the bound.
+    bound: DaeBound,
     /// One unit of padding whose overflow is dropped rather than reported:
     /// `0x00` for binary, a blank for character, in the buffer's own encoding.
     pad_unit: &'static [u8],
@@ -218,7 +249,10 @@ pub(crate) struct DaeLengthLimit {
 
 impl DaeLengthLimit {
     /// Applies the limit to one chunk given the total already accepted,
-    /// returning the prefix that may be kept.
+    /// returning the prefix that may be kept and the units it consumed.
+    ///
+    /// `already` and the returned count are both in the bound's own unit, so a
+    /// caller accumulates the return value rather than the kept byte length.
     ///
     /// Mirrors every same-family arm of msodbcsql's `SQLPutData`
     /// (`sqlccmd.cpp:10985-11218`): the bound is compared against the
@@ -229,13 +263,39 @@ impl DaeLengthLimit {
     pub(crate) fn fit<'a>(
         &self,
         chunk: &'a [u8],
-        already_sent: usize,
-    ) -> Result<&'a [u8], ParamBuildError> {
-        let keep = self.max_bytes.saturating_sub(already_sent);
-        if chunk.len() <= keep {
-            return Ok(chunk);
-        }
-        let overflow = &chunk[keep..];
+        already: usize,
+    ) -> Result<(&'a [u8], usize), ParamBuildError> {
+        let (split, consumed) = match self.bound {
+            DaeBound::Bytes(max) => {
+                let keep = max.saturating_sub(already);
+                if chunk.len() <= keep {
+                    return Ok((chunk, chunk.len()));
+                }
+                (keep, keep)
+            }
+            DaeBound::Utf16Units(max) => {
+                let keep = max.saturating_sub(already);
+                let mut units = 0;
+                let mut split = chunk.len();
+                for (i, &byte) in chunk.iter().enumerate() {
+                    let cost = utf16_units_of_utf8_byte(byte);
+                    // A continuation byte costs nothing, so it always stays with
+                    // the lead that paid for it rather than starting an overflow
+                    // of its own.
+                    if units + cost > keep {
+                        split = i;
+                        break;
+                    }
+                    units += cost;
+                }
+                if split == chunk.len() {
+                    return Ok((chunk, units));
+                }
+                (split, units)
+            }
+        };
+
+        let overflow = &chunk[split..];
         // A partial trailing unit cannot be padding, so it is left to fail the
         // comparison below rather than being rounded away.
         if !overflow
@@ -244,7 +304,7 @@ impl DaeLengthLimit {
         {
             return Err(ParamBuildError::StringTruncation);
         }
-        Ok(&chunk[..keep])
+        Ok((&chunk[..split], consumed))
     }
 }
 
@@ -309,7 +369,14 @@ pub(crate) fn dae_length_limit(
     };
 
     Ok(units.map(|units| DaeLengthLimit {
-        max_bytes: units.saturating_mul(unit_bytes),
+        // `SQL_C_CHAR` is the one buffer whose bytes are not its units: it holds
+        // UTF-8, so the declaration's character count is measured in UTF-16
+        // units to agree with the materialized path. The other two have a fixed
+        // byte width per unit and stay exact.
+        bound: match c_type {
+            SQL_C_CHAR => DaeBound::Utf16Units(units),
+            _ => DaeBound::Bytes(units.saturating_mul(unit_bytes)),
+        },
         pad_unit,
     }))
 }
@@ -1603,20 +1670,22 @@ mod tests {
         let limit = dae_length_limit(SQL_C_BINARY, SQL_VARBINARY, 2)
             .unwrap()
             .expect("a bounded varbinary is limited");
-        assert_eq!(limit.max_bytes, 2);
+        assert_eq!(limit.bound, DaeBound::Bytes(2));
         assert_eq!(limit.pad_unit, [0u8]);
 
+        // A narrow character buffer is measured in the UTF-16 units the
+        // materialized path uses, not in its UTF-8 bytes.
         let limit = dae_length_limit(SQL_C_CHAR, SQL_VARCHAR, 4)
             .unwrap()
             .expect("a bounded varchar is limited");
-        assert_eq!(limit.max_bytes, 4);
+        assert_eq!(limit.bound, DaeBound::Utf16Units(4));
         assert_eq!(limit.pad_unit, *b" ");
 
         // Four characters of nvarchar are eight bytes of SQL_C_WCHAR buffer.
         let limit = dae_length_limit(SQL_C_WCHAR, SQL_WVARCHAR, 4)
             .unwrap()
             .expect("a bounded nvarchar is limited");
-        assert_eq!(limit.max_bytes, 8);
+        assert_eq!(limit.bound, DaeBound::Bytes(8));
         assert_eq!(limit.pad_unit, [b' ', 0]);
     }
 
@@ -1649,12 +1718,12 @@ mod tests {
         let limit = dae_length_limit(SQL_C_BINARY, SQL_LONGVARBINARY, 3)
             .unwrap()
             .expect("image is bounded by ColumnSize");
-        assert_eq!(limit.max_bytes, 3);
+        assert_eq!(limit.bound, DaeBound::Bytes(3));
 
         let limit = dae_length_limit(SQL_C_CHAR, SQL_LONGVARCHAR, 3)
             .unwrap()
             .expect("text is bounded by ColumnSize");
-        assert_eq!(limit.max_bytes, 3);
+        assert_eq!(limit.bound, DaeBound::Utf16Units(3));
     }
 
     /// A zero `ColumnSize` is the `max` spelling for the variable-width types
@@ -1682,7 +1751,7 @@ mod tests {
             .unwrap();
 
         // Each chunk is under the limit on its own; together they exceed it.
-        assert_eq!(limit.fit(&[1, 2, 3], 0).unwrap(), &[1, 2, 3]);
+        assert_eq!(limit.fit(&[1, 2, 3], 0).unwrap(), (&[1, 2, 3][..], 3));
         assert_eq!(
             limit.fit(&[4, 5, 6], 3).unwrap_err(),
             ParamBuildError::StringTruncation
@@ -1698,7 +1767,7 @@ mod tests {
         let binary = dae_length_limit(SQL_C_BINARY, SQL_VARBINARY, 2)
             .unwrap()
             .unwrap();
-        assert_eq!(binary.fit(&[1, 2, 0, 0], 0).unwrap(), &[1, 2]);
+        assert_eq!(binary.fit(&[1, 2, 0, 0], 0).unwrap(), (&[1, 2][..], 2));
         assert_eq!(
             binary.fit(&[1, 2, 0, 3], 0).unwrap_err(),
             ParamBuildError::StringTruncation
@@ -1707,7 +1776,7 @@ mod tests {
         let narrow = dae_length_limit(SQL_C_CHAR, SQL_VARCHAR, 2)
             .unwrap()
             .unwrap();
-        assert_eq!(narrow.fit(b"ab  ", 0).unwrap(), b"ab");
+        assert_eq!(narrow.fit(b"ab  ", 0).unwrap(), (&b"ab"[..], 2));
         assert_eq!(
             narrow.fit(b"abcd", 0).unwrap_err(),
             ParamBuildError::StringTruncation
@@ -1717,11 +1786,54 @@ mod tests {
         let wide = dae_length_limit(SQL_C_WCHAR, SQL_WVARCHAR, 1)
             .unwrap()
             .unwrap();
-        assert_eq!(wide.fit(&[b'a', 0, b' ', 0], 0).unwrap(), &[b'a', 0]);
+        assert_eq!(
+            wide.fit(&[b'a', 0, b' ', 0], 0).unwrap(),
+            (&[b'a', 0][..], 2)
+        );
         assert_eq!(
             wide.fit(&[b'a', 0, b'b', 0], 0).unwrap_err(),
             ParamBuildError::StringTruncation
         );
+    }
+
+    /// A `SQL_C_CHAR` buffer holds UTF-8, so its bytes are not its units. The
+    /// materialized path measures every character input in UTF-16 units
+    /// (`trim_blank_overflow`), and counting bytes here instead would reject a
+    /// value the same binding materialized accepts -- one non-ASCII character
+    /// against `varchar(1)` is two bytes but one unit.
+    #[test]
+    fn dae_limit_fit_measures_a_narrow_buffer_in_utf16_units() {
+        let limit = dae_length_limit(SQL_C_CHAR, SQL_VARCHAR, 1)
+            .unwrap()
+            .unwrap();
+        // U+00E9, two UTF-8 bytes, one UTF-16 unit: it fits `varchar(1)`.
+        assert_eq!(limit.fit("é".as_bytes(), 0).unwrap(), ("é".as_bytes(), 1));
+
+        let limit = dae_length_limit(SQL_C_CHAR, SQL_VARCHAR, 4)
+            .unwrap()
+            .unwrap();
+        // Four characters, six bytes: a byte count would have rejected these.
+        assert_eq!(limit.fit("café".as_bytes(), 0).unwrap().1, 4);
+        // U+1D11E is four UTF-8 bytes and a surrogate pair, so it costs two of
+        // the four units, exactly as the materialized path counts it.
+        assert_eq!(limit.fit("𝄞ab".as_bytes(), 0).unwrap().1, 4);
+    }
+
+    /// The unit count is taken from each byte on its own, so a character split
+    /// across two `SQLPutData` calls is counted once, at its lead, without the
+    /// limit carrying any decode state between chunks.
+    #[test]
+    fn dae_limit_fit_counts_a_split_character_once() {
+        let limit = dae_length_limit(SQL_C_CHAR, SQL_VARCHAR, 2)
+            .unwrap()
+            .unwrap();
+        // "é" arrives as its lead byte and then its continuation byte.
+        let (_, first) = limit.fit(&[0xC3], 0).unwrap();
+        assert_eq!(first, 1, "the lead pays for the character");
+        let (_, second) = limit.fit(&[0xA9], first).unwrap();
+        assert_eq!(second, 0, "the continuation is already paid for");
+        // One unit consumed in total, so a second character still fits.
+        assert_eq!(limit.fit(b"z", first + second).unwrap().1, 1);
     }
 
     /// Once the budget is spent every later chunk must be padding, and the
@@ -1732,7 +1844,7 @@ mod tests {
         let limit = dae_length_limit(SQL_C_BINARY, SQL_VARBINARY, 2)
             .unwrap()
             .unwrap();
-        assert!(limit.fit(&[0, 0], 2).unwrap().is_empty());
+        assert!(limit.fit(&[0, 0], 2).unwrap().0.is_empty());
         assert_eq!(
             limit.fit(&[0, 1], 2).unwrap_err(),
             ParamBuildError::StringTruncation

--- a/mssql-odbc/src/conversion/param_convert.rs
+++ b/mssql-odbc/src/conversion/param_convert.rs
@@ -326,30 +326,26 @@ pub(crate) fn dae_length_limit(
         other => return Err(ParamBuildError::UnsupportedCType(other)),
     };
 
-    // Only a pairing whose buffer unit *is* the declaration's unit can be
-    // measured here: a narrow buffer against a wide declaration (or the
-    // reverse) counts different things on each side.
+    // A pairing can be measured here when the declaration's unit and the
+    // buffer's unit are the same thing. Within the character family they always
+    // are, whatever the wideness: `convert_character_sql` derives its limit from
+    // `sql_type` and `ColumnSize` alone and hands it to `trim_blank_overflow`,
+    // which measures the *source* in UTF-16 units -- the C type never enters
+    // into the unit. So `varchar(n)` and `nvarchar(n)` both bound n UTF-16 units
+    // of whatever buffer was bound, and a wideness mismatch is measurable on
+    // exactly the same terms as a matched pair.
     //
-    // What happens to an unmeasurable bound depends on how the value travels.
-    // A *buffered* parameter is converted whole at close, so `ColumnSize` is
-    // still applied there by `convert_character_sql`, which measures both sides
-    // in UTF-16 units. A *streamed* one never reaches that conversion, so
-    // returning `None` here leaves it genuinely unbounded -- which is why
-    // `build_named_params` declines to narrow its declaration in that case
-    // rather than promising a bound nothing enforces.
+    // Cross-*family* is the case that genuinely does not correspond: a binary
+    // byte is not a character, so its bound is left to the close-time
+    // conversion.
     //
-    // msodbcsql does bound this pairing: `ValidatePutDataLength`'s `SQL_C_WCHAR`
-    // arm (`odbc/sqlccmd.cpp:10931`) converts the chunk to the server code page
-    // precisely so it can measure the narrow length, and only `fIsVarMax`
-    // disables the check. Matching that needs the encoded length at this layer;
-    // tracked under AB#47590.
+    // The unit is an approximation of collation bytes on both paths -- msodbcsql
+    // converts to the server code page to measure exactly
+    // (`ValidatePutDataLength`, `odbc/sqlccmd.cpp:10931`), and closing that gap
+    // is AB#47584. Agreeing with the materialized path is what matters here.
     let same_unit = match c_type {
         SQL_C_BINARY => sql_family(sql_type) == Some(SqlFamily::Binary),
-        SQL_C_WCHAR => is_wide_character_sql_type(sql_type),
-        SQL_C_CHAR => {
-            sql_family(sql_type) == Some(SqlFamily::Character)
-                && !is_wide_character_sql_type(sql_type)
-        }
+        SQL_C_CHAR | SQL_C_WCHAR => sql_family(sql_type) == Some(SqlFamily::Character),
         _ => false,
     };
     if !same_unit {
@@ -1875,25 +1871,54 @@ mod tests {
         );
     }
 
-    /// A wideness-mismatched pairing cannot be measured in the buffer's own
-    /// unit, so no bound is produced. Pinned because the streamed path has no
-    /// close-time conversion to fall back on: `build_named_params` reads this
-    /// `None` as the signal to leave the declaration at `max` rather than
-    /// narrowing it to a length nothing would enforce.
+    /// A wideness mismatch inside the character family *is* measurable, because
+    /// the unit is the declaration's and the count is of the source: both
+    /// `varchar(n)` and `nvarchar(n)` bound n UTF-16 units, exactly as
+    /// `convert_character_sql` bounds them on the materialized path. Only the
+    /// buffer's own width changes how those units are counted.
     #[test]
-    fn dae_length_limit_is_absent_for_a_wideness_mismatch() {
+    fn dae_length_limit_measures_a_wideness_mismatch() {
+        // UTF-8 source against a wide declaration: counted in UTF-16 units.
+        for sql_type in [SQL_WVARCHAR, SQL_WCHAR, SQL_WLONGVARCHAR] {
+            assert_eq!(
+                dae_length_limit(SQL_C_CHAR, sql_type, 10).unwrap(),
+                Some(DaeLengthLimit {
+                    bound: DaeBound::Utf16Units(10),
+                    pad_unit: b" ",
+                }),
+                "SQL_C_CHAR -> {sql_type} bounds 10 UTF-16 units of UTF-8"
+            );
+        }
+
+        // UTF-16 source against a narrow declaration: a unit is a fixed two
+        // bytes, so the byte bound is exact.
+        for sql_type in [SQL_VARCHAR, SQL_CHAR, SQL_LONGVARCHAR] {
+            assert_eq!(
+                dae_length_limit(SQL_C_WCHAR, sql_type, 10).unwrap(),
+                Some(DaeLengthLimit {
+                    bound: DaeBound::Bytes(20),
+                    pad_unit: &[b' ', 0],
+                }),
+                "SQL_C_WCHAR -> {sql_type} bounds 10 units as 20 buffer bytes"
+            );
+        }
+    }
+
+    /// Cross-*family* is the pairing that genuinely cannot be measured here: a
+    /// binary byte is not a character, so the two sides count different things
+    /// and the bound is left to the close-time conversion.
+    #[test]
+    fn dae_length_limit_is_absent_across_families() {
         for (c_type, sql_type) in [
-            (SQL_C_WCHAR, SQL_VARCHAR),
-            (SQL_C_WCHAR, SQL_CHAR),
-            (SQL_C_WCHAR, SQL_LONGVARCHAR),
-            (SQL_C_CHAR, SQL_WVARCHAR),
-            (SQL_C_CHAR, SQL_WCHAR),
-            (SQL_C_CHAR, SQL_WLONGVARCHAR),
+            (SQL_C_BINARY, SQL_VARCHAR),
+            (SQL_C_BINARY, SQL_WVARCHAR),
+            (SQL_C_CHAR, SQL_VARBINARY),
+            (SQL_C_WCHAR, SQL_VARBINARY),
         ] {
             assert_eq!(
                 dae_length_limit(c_type, sql_type, 10).unwrap(),
                 None,
-                "{c_type} -> {sql_type} counts different units on each side"
+                "{c_type} -> {sql_type} counts different things on each side"
             );
         }
     }

--- a/mssql-odbc/src/conversion/param_convert.rs
+++ b/mssql-odbc/src/conversion/param_convert.rs
@@ -7,13 +7,14 @@
 //! Which C/SQL pairings reach this module is decided at bind time by
 //! [`crate::api::type_rules`] and [`crate::params::conversion_matrix`];
 //! `SQL_C_DEFAULT` has already been resolved to a concrete C type by then.
-//! Cross-*family* data-at-execution (character streamed against binary, or
-//! vice versa) is rejected with `HYC00`; a same-family wideness mismatch
-//! (`SQL_C_WCHAR` streamed against a narrow SQL type, or the reverse) is
-//! buffered and transcoded once instead of being rejected -- see
-//! [`dae_placeholder_type`] and [`transcode_dae_bytes`]. `SQL_DEFAULT_PARAM`
-//! is rejected with `07S01`, and an invalid negative `StrLen_or_Ind` with
-//! `HY090`.
+//! A data-at-execution parameter is declared from its SQL type, not its C
+//! type: a PLP-able target streams, and anything else is collected and
+//! converted whole through the ordinary materializing path -- see
+//! [`dae_plan`]. A wideness mismatch (`SQL_C_WCHAR` streamed against a narrow
+//! SQL type, or the reverse) is transcoded chunk by chunk, carrying a
+//! character split across two `SQLPutData` calls -- see [`DaeTranscode`].
+//! `SQL_DEFAULT_PARAM` is rejected with `07S01`, and an invalid negative
+//! `StrLen_or_Ind` with `HY090`.
 //!
 //! A `SQL_NULL_DATA` parameter is materialised as a typed TDS NULL from
 //! `sql_type` -- see [`typed_null`].
@@ -31,8 +32,8 @@ use mssql_tds::token::tokens::SqlCollation;
 use crate::api::odbc_types::{
     SQL_BIGINT, SQL_BINARY, SQL_BIT, SQL_C_BINARY, SQL_C_CHAR, SQL_C_WCHAR, SQL_CHAR,
     SQL_DATA_AT_EXEC, SQL_DECIMAL, SQL_DOUBLE, SQL_FLOAT, SQL_GUID, SQL_INTEGER,
-    SQL_LEN_DATA_AT_EXEC_OFFSET, SQL_LONGVARBINARY, SQL_LONGVARCHAR, SQL_NUMERIC, SQL_REAL,
-    SQL_SMALLINT, SQL_SS_TIME2, SQL_SS_TIMESTAMPOFFSET, SQL_SS_VARIANT, SQL_SS_VECTOR,
+    SQL_LEN_DATA_AT_EXEC_OFFSET, SQL_LONGVARBINARY, SQL_LONGVARCHAR, SQL_NULL_DATA, SQL_NUMERIC,
+    SQL_REAL, SQL_SMALLINT, SQL_SS_TIME2, SQL_SS_TIMESTAMPOFFSET, SQL_SS_VARIANT, SQL_SS_VECTOR,
     SQL_SS_VECTOR_ELEMENT_SIZE, SQL_SS_XML, SQL_TINYINT, SQL_TYPE_DATE, SQL_TYPE_TIME,
     SQL_TYPE_TIMESTAMP, SQL_VARBINARY, SQL_VARCHAR, SQL_WCHAR, SQL_WLONGVARCHAR, SQL_WVARCHAR,
     SqlLen, SqlSmallInt, SqlSsVectorLayout,
@@ -198,166 +199,389 @@ pub(crate) fn is_data_at_exec_indicator(indicator: SqlLen) -> bool {
     indicator == SQL_DATA_AT_EXEC || indicator <= SQL_LEN_DATA_AT_EXEC_OFFSET
 }
 
-/// What a data-at-execution parameter streams as on the wire, and whether the
-/// bytes `SQLPutData` supplies need transcoding before they get there.
+/// How much a buffered parameter may accept, and what its overflow is allowed
+/// to be made of.
+///
+/// Held in application-buffer bytes so `SQLPutData` can compare it against a raw
+/// chunk length. Only produced for a same-family pairing, where the C type fixes
+/// the unit width unambiguously; a cross-family value's units do not correspond
+/// (a UTF-8 byte is not a character), so its bound is left to the close-time
+/// converter instead.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct DaeStream {
-    pub(crate) sql_type: StreamedSqlType,
-    /// `true` when the declared C type's encoding does not match the target
-    /// `ParameterType`'s (e.g. `SQL_C_WCHAR` bound to a narrow SQL type).
-    /// `SQLPutData` cannot transcode a chunk in isolation -- a multi-byte
-    /// character can straddle two calls -- so a caller buffers every chunk
-    /// instead of streaming it to the wire, and transcodes the whole value
-    /// once when the parameter closes, via [`transcode_dae_bytes`].
-    pub(crate) needs_transcode: bool,
+pub(crate) struct DaeLengthLimit {
+    /// Maximum total the parameter may accept, in application-buffer bytes.
+    max_bytes: usize,
+    /// One unit of padding whose overflow is dropped rather than reported:
+    /// `0x00` for binary, a blank for character, in the buffer's own encoding.
+    pad_unit: &'static [u8],
 }
 
-/// Builds the streaming placeholder type for a data-at-execution bound
-/// parameter. The actual bytes arrive later via `SQLPutData`.
-///
-/// The wire type follows `ParameterType`'s family and wideness -- that is what
-/// the column actually is -- not the C type's. A same-family pairing whose
-/// wideness disagrees with the C type (e.g. `SQL_C_WCHAR` bound to a narrow
-/// SQL type) is accepted with `needs_transcode` set: the caller buffers every
-/// `SQLPutData` chunk instead of writing it to the wire untranscoded, and
-/// transcodes the complete value once the parameter closes. A cross-*family*
-/// pairing (character streamed against a binary SQL type, or the reverse) has
-/// no such recovery -- there is nothing it could mean other than one side
-/// declaring one encoding and sending another -- so it is still rejected here
-/// rather than risking silent corruption (AB#47590). `ColumnSize` is likewise
-/// unenforceable: every streamed type is a `max`.
-///
-/// Deliberate deviation from msodbcsql: `needs_transcode` buffers the whole
-/// value and transcodes it once (`transcode_dae_bytes`), rather than
-/// transcoding each `SQLPutData` chunk incrementally. Source reading
-/// suggested msodbcsql's `ProcessDAEColumnData` carries a code-point residual
-/// across calls (`sqlccmd.cpp:3864`, `:3899-3901`; `ConvertLongData`,
-/// `sqlccnvt.cpp:938-990`; residual flushed at `sqlccmd.cpp:5999-6001`).
-/// A msodbcsql parity run for a UTF-8 character split across two
-/// `SQLPutData` calls measured 5 UTF-16 code units instead of the correct 4
-/// (see `NarrowCTypeAgainstWideSqlTypeDataAtExecutionTranscodesASplitCharacter`),
-/// reproducing identically across retries -- but this is very likely `AppText`'s
-/// documented divergence from msodbcsql, not a residual-carrying failure:
-/// msodbcsql reads `SQL_C_CHAR` bytes in the client code page rather than
-/// UTF-8, so on the parity leg's Windows default code page the two split
-/// bytes (`0xC3 0xA9`) each decode as their own Windows-1252 character
-/// instead of the one UTF-8 character they encode together -- a mismatch that
-/// would reproduce for a single-chunk value too, not only a split one, so it
-/// says nothing about whether msodbcsql carries a residual across calls.
-/// Not confirmed at the code-point level (the failing assertion aborted
-/// before the actual units were logged), so this is the more likely
-/// explanation, not a settled one; tracked under AB#47565 (client code page
-/// support), separately from this whole-value-buffering deviation. Either
-/// way, whole-value buffering costs memory proportional to the value on a
-/// path whose purpose is to avoid exactly that, and is not a regression --
-/// this pairing previously failed outright -- but it is real cost, taken
-/// because a per-chunk carry is meaningfully more machinery (correctly
-/// splitting a UTF-16 surrogate pair or a multi-byte narrow sequence across
-/// calls) than this driver has today. It also means a mismatched value whose
-/// total size exceeds `u32::MAX` bytes -- `SQL_LEN_DATA_AT_EXEC` declares no
-/// upper bound -- fails late, with a clean `UsageError` from
-/// `write_streamed_chunk`'s own chunk-length check, rather than at the first
-/// oversized `SQLPutData` call.
-/// Tracked under AB#47590 alongside this file's other DAE-transcoding gaps.
-///
-/// Known residual, also AB#47590: a same-family pairing whose wideness
-/// *matches* the C type (`needs_transcode: false`, e.g. `SQL_C_CHAR` bound to
-/// `SQL_VARCHAR`) still streams its chunks to the wire untranscoded. That is
-/// correct for the wide case -- `SQL_C_WCHAR` is already UTF-16LE, the wire
-/// encoding -- but not for the narrow one: this driver's `SQL_C_CHAR` is
-/// UTF-8 by convention, not a wire encoding, so a non-ASCII value streamed
-/// under a non-UTF8 collation round-trips as mojibake, the same defect
-/// `transcode_dae_bytes` fixes for the wideness-mismatched case. Extending
-/// `needs_transcode` to cover it needs the connection's collation at this
-/// function's call site (`build_named_params`, execute time), which it does
-/// not have today.
-pub(crate) fn dae_placeholder_type(
+impl DaeLengthLimit {
+    /// Applies the limit to one chunk given the total already accepted,
+    /// returning the prefix that may be kept.
+    ///
+    /// Mirrors every same-family arm of msodbcsql's `SQLPutData`
+    /// (`sqlccmd.cpp:10985-11218`): the bound is compared against the
+    /// *accumulated* length rather than the chunk alone, an overflow made
+    /// entirely of padding is trimmed away, and any other overflow is `22001`.
+    /// Applying it here rather than at close is what puts the diagnostic on the
+    /// same call msodbcsql puts it on.
+    pub(crate) fn fit<'a>(
+        &self,
+        chunk: &'a [u8],
+        already_sent: usize,
+    ) -> Result<&'a [u8], ParamBuildError> {
+        let keep = self.max_bytes.saturating_sub(already_sent);
+        if chunk.len() <= keep {
+            return Ok(chunk);
+        }
+        let overflow = &chunk[keep..];
+        // A partial trailing unit cannot be padding, so it is left to fail the
+        // comparison below rather than being rounded away.
+        if !overflow
+            .chunks(self.pad_unit.len())
+            .all(|unit| unit == self.pad_unit)
+        {
+            return Err(ParamBuildError::StringTruncation);
+        }
+        Ok(&chunk[..keep])
+    }
+}
+
+/// The `ColumnSize` bound a buffered parameter is held to as its chunks arrive,
+/// or `None` when the bound cannot be expressed in buffer bytes and is left to
+/// the close-time conversion.
+pub(crate) fn dae_length_limit(
     c_type: SqlSmallInt,
     sql_type: SqlSmallInt,
-) -> Result<DaeStream, ParamBuildError> {
-    let c_family = match c_type {
-        SQL_C_CHAR | SQL_C_WCHAR => SqlFamily::Character,
-        SQL_C_BINARY => SqlFamily::Binary,
+    column_size: usize,
+) -> Result<Option<DaeLengthLimit>, ParamBuildError> {
+    /// UTF-16LE blank, the pad unit for a `SQL_C_WCHAR` buffer.
+    const BLANK_UTF16: &[u8] = &[b' ', 0];
+
+    let (unit_bytes, pad_unit) = match c_type {
+        SQL_C_WCHAR => (size_of::<u16>(), BLANK_UTF16),
+        SQL_C_CHAR => (1, b" ".as_slice()),
+        SQL_C_BINARY => (1, [0u8].as_slice()),
         other => return Err(ParamBuildError::UnsupportedCType(other)),
     };
-    if sql_family(sql_type) != Some(c_family) {
-        return Err(ParamBuildError::ConversionNotImplemented);
-    }
-    let (sql_type, needs_transcode) = match c_family {
-        SqlFamily::Character => {
-            let wide = is_wide_character_sql_type(sql_type);
-            let streamed = if wide {
-                StreamedSqlType::NVarcharMax
-            } else {
-                StreamedSqlType::VarcharMax
-            };
-            (streamed, wide != (c_type == SQL_C_WCHAR))
+
+    // Only a pairing whose buffer unit *is* the declaration's unit can be
+    // measured here. A narrow buffer against a wide declaration (or the
+    // reverse) counts different things on each side, so it is left to
+    // `convert_character_sql`, which measures both in UTF-16 units.
+    let same_unit = match c_type {
+        SQL_C_BINARY => sql_family(sql_type) == Some(SqlFamily::Binary),
+        SQL_C_WCHAR => is_wide_character_sql_type(sql_type),
+        SQL_C_CHAR => {
+            sql_family(sql_type) == Some(SqlFamily::Character)
+                && !is_wide_character_sql_type(sql_type)
         }
-        SqlFamily::Binary => (StreamedSqlType::VarBinaryMax, false),
-        // Unreachable: `c_family` above only ever produces `Character` or
-        // `Binary`. An explicit error rather than `unreachable!()`, since this
-        // runs behind an FFI boundary.
-        SqlFamily::Integer => return Err(ParamBuildError::UnsupportedCType(c_type)),
+        _ => false,
     };
-    Ok(DaeStream {
-        sql_type,
-        needs_transcode,
+    if !same_unit {
+        return Ok(None);
+    }
+
+    // The ceiling each declaration imposes, in its own unit. `char`/`binary`
+    // reject a zero `ColumnSize` where the variable-width types read it as the
+    // `max` spelling, so both go through the same helpers the materialized path
+    // uses rather than a second reading of the rules.
+    let units = match sql_type {
+        SQL_CHAR => Some(usize::from(fixed_length(
+            column_size,
+            SQL_PREC_BIGCHARBINARY,
+        )?)),
+        SQL_WCHAR => Some(usize::from(fixed_length(column_size, SQL_PREC_NCHAR)?)),
+        SQL_BINARY => Some(usize::from(fixed_length(
+            column_size,
+            SQL_PREC_BIGCHARBINARY,
+        )?)),
+        SQL_VARCHAR => variable_length(column_size, SQL_PREC_BIGCHARBINARY).map(usize::from),
+        SQL_WVARCHAR => variable_length(column_size, SQL_PREC_NCHAR).map(usize::from),
+        SQL_VARBINARY => variable_length(column_size, SQL_PREC_BIGCHARBINARY).map(usize::from),
+        // `text`/`ntext`/`image` carry no declared length but are still bounded
+        // by `ColumnSize`, as they are on the materialized path.
+        SQL_LONGVARCHAR => Some(column_size.min(SQL_PREC_TEXTIMAGE)),
+        SQL_WLONGVARCHAR => Some(column_size.min(SQL_PREC_NTEXT)),
+        SQL_LONGVARBINARY => Some(column_size.min(SQL_PREC_TEXTIMAGE)),
+        other => return Err(ParamBuildError::UnsupportedSqlType(other)),
+    };
+
+    Ok(units.map(|units| DaeLengthLimit {
+        max_bytes: units.saturating_mul(unit_bytes),
+        pad_unit,
+    }))
+}
+
+/// Builds the RPC parameter for a data-at-execution value that was buffered
+/// rather than streamed, from the bytes `SQLPutData` collected.
+///
+/// Routed through [`bound_param_to_rpc`] over a binding that points at the
+/// collected buffer, so a streamed value is declared and converted by exactly
+/// the code a materialized one is: `ParameterType` picks the declaration,
+/// `ColumnSize` bounds it with the same trim-or-`22001` rule, and a cross-family
+/// pairing transcodes instead of being refused (AB#47590).
+///
+/// `is_null` carries a parameter that `SQLPutData` marked `SQL_NULL_DATA`, which
+/// must produce a typed NULL rather than an empty value.
+pub(crate) fn buffered_dae_to_rpc(
+    name: String,
+    binding: &BoundParam,
+    buffer: &[u8],
+    is_null: bool,
+) -> Result<RpcParameter, ParamBuildError> {
+    let mut indicator: SqlLen = if is_null {
+        SQL_NULL_DATA
+    } else {
+        SqlLen::try_from(buffer.len()).map_err(|_| ParamBuildError::StringTruncation)?
+    };
+    let mut synthetic = *binding;
+    // Points at the collected bytes for the duration of this call only, which
+    // is where the ODBC contract the materialized path relies on is met: the
+    // buffer outlives the conversion and is not aliased while it runs.
+    //
+    // Both indicator pointers are repointed. `read_indicator` takes NULL from
+    // `strlen_or_ind_ptr` and the *length* from `octet_length_ptr`, so leaving
+    // the latter aimed at the application's buffer would hand the conversion
+    // the `SQL_DATA_AT_EXEC` marker that started this sequence and it would
+    // reject the value as unstaged.
+    synthetic.parameter_value_ptr = buffer.as_ptr().cast_mut().cast();
+    synthetic.buffer_length = indicator.max(0);
+    synthetic.strlen_or_ind_ptr = &raw mut indicator;
+    synthetic.octet_length_ptr = &raw mut indicator;
+    unsafe { bound_param_to_rpc(name, &synthetic) }
+}
+
+/// How a data-at-execution parameter reaches the wire.
+///
+/// PLP framing is what makes streaming possible: the value body is an
+/// unknown-length opener followed by length-prefixed chunks, so the parameter
+/// header can go out before the total length is known. The types that can be
+/// framed that way are exactly msodbcsql's `IsPartialLenType`
+/// (`odbc/sqlcprot.h:1421`), and it keys the same decision on the *SQL type
+/// alone* - `ColumnSize` does not enter into it, because a bounded declaration
+/// is carried in the `@params` string while the value body stays a `max`
+/// (AB#47590).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DaePlan {
+    /// Streamed as PLP chunks, each transcoded on the way out.
+    Stream(StreamedSqlType),
+    /// Not PLP-framable: collect the chunks and convert the value whole, as
+    /// msodbcsql's `WriteToExtBuffer` branch does for a fixed-length or
+    /// small-maximum target (`odbc/sqlccmd.cpp:4913`).
+    Buffer,
+}
+
+impl DaePlan {
+    pub(crate) fn is_buffered(self) -> bool {
+        matches!(self, Self::Buffer)
+    }
+}
+
+/// Chooses how a data-at-execution parameter reaches the wire.
+///
+/// Mirrors msodbcsql's `PutParamData` (`odbc/sqlccmd.cpp:4385`): a partial-length
+/// SQL type streams its chunks, and everything else is cached until the value is
+/// complete. The encoding difference between the buffer and the wire is handled
+/// by [`DaeTranscode`] rather than by refusing to stream.
+pub(crate) fn dae_plan(
+    c_type: SqlSmallInt,
+    sql_type: SqlSmallInt,
+) -> Result<DaePlan, ParamBuildError> {
+    if !matches!(c_type, SQL_C_CHAR | SQL_C_WCHAR | SQL_C_BINARY) {
+        return Err(ParamBuildError::UnsupportedCType(c_type));
+    }
+    sql_family(sql_type).ok_or(ParamBuildError::UnsupportedSqlType(sql_type))?;
+
+    Ok(match sql_type {
+        SQL_VARCHAR | SQL_LONGVARCHAR => DaePlan::Stream(StreamedSqlType::VarcharMax),
+        SQL_WVARCHAR | SQL_WLONGVARCHAR => DaePlan::Stream(StreamedSqlType::NVarcharMax),
+        SQL_VARBINARY | SQL_LONGVARBINARY => DaePlan::Stream(StreamedSqlType::VarBinaryMax),
+        _ => DaePlan::Buffer,
     })
 }
 
-/// Transcodes a fully-buffered data-at-execution value, once, from the C
-/// type's encoding to the target's -- the counterpart to
-/// [`dae_placeholder_type`] reporting `needs_transcode`. Mirrors the inline
-/// (non-DAE) conversion [`AppText::transcode`] already performs per
-/// `SQLBindParameter` call; applying that same transform to the whole
-/// streamed value at once, rather than to one `SQLPutData` chunk, is what
-/// makes it safe to call -- see `sql_param_data_safe` in `api::param_data`.
+/// The `@params` declaration a streamed parameter is given, or `None` when
+/// `ColumnSize` names the `max` spelling and the declaration the streamed type
+/// already carries is right.
 ///
-/// A wide result is already UTF-16LE, the wire encoding `write_streamed_chunk`
-/// expects verbatim. A narrow result is not: `AppText::transcode` produces
-/// UTF-8, which is this driver's own C-side convention, not a wire encoding,
-/// so `encode_narrow` re-encodes it through `db_collation` before the bytes
-/// reach the wire, or a non-ASCII value round-trips as mojibake under a
-/// non-UTF8 collation. `encode_narrow` matches `get_encoding_type`'s
-/// `collation.utf8()` check, not the materialized path's serializer arm
-/// (`tds_value_serializer.rs`'s `VARCHAR | CHAR | TEXT`): that arm predates
-/// the UTF-8-collation flag and always encodes through the single-byte LCID
-/// codepage, so under a UTF8 collation the streamed and materialized paths
-/// now disagree on the wire bytes for the same value -- a new instance of
-/// the same "two ways to bind disagree" shape as the narrow/narrow residual
-/// below, just with the streamed side on the correct end this time. Tracked
-/// under AB#47590 alongside this file's other DAE-transcoding gaps.
-///
-/// `SQLPutData`'s `try_reserve` guard against an unbounded `SQL_DATA_AT_EXEC`
-/// value stops here: `decode_utf16le`, `String::from_utf8_lossy`, and
-/// `encode_narrow`'s `encoding_rs::encode` (up to 10 bytes per character for
-/// an NCR substitution the target codepage can't represent -- measured
-/// `&#1114111;` for U+10FFFF, the maximum scalar value) all allocate their
-/// output infallibly, so a value that just fit under that guard can still
-/// abort the process during this transform -- arguably a wider window, since
-/// the guard checks per chunk and this is one allocation for the whole value.
-/// Not fixed here: `AppText`/`decode_utf16le` are shared with the
-/// materialized (non-DAE) path (`convert_character_sql`), so bounding them
-/// would be a broader change than this file's DAE-specific scope. Tracked
-/// under AB#47590.
-pub(crate) fn transcode_dae_bytes(
-    c_type: SqlSmallInt,
+/// The value body stays PLP-framed either way: only the variable it is assigned
+/// to narrows. `text`/`ntext`/`image` keep their `max` substitution for the same
+/// reason the materialized path does (AB#47592).
+pub(crate) fn dae_streamed_declaration(
     sql_type: SqlSmallInt,
-    bytes: Vec<u8>,
-    db_collation: SqlCollation,
-) -> Vec<u8> {
-    let source = if c_type == SQL_C_WCHAR {
-        AppText::Utf16(bytes)
-    } else {
-        AppText::Utf8(bytes)
-    };
-    match source.transcode(is_wide_character_sql_type(sql_type)) {
-        AppText::Utf16(bytes) => bytes,
-        AppText::Utf8(bytes) => {
-            let text = String::from_utf8_lossy(&bytes);
-            encode_narrow(&text, db_collation)
+    column_size: usize,
+) -> Result<Option<SqlType>, ParamBuildError> {
+    Ok(match sql_type {
+        SQL_VARCHAR => variable_length(column_size, SQL_PREC_BIGCHARBINARY)
+            .map(|length| SqlType::Varchar(None, length)),
+        SQL_WVARCHAR => variable_length(column_size, SQL_PREC_NCHAR)
+            .map(|length| SqlType::NVarchar(None, length)),
+        SQL_VARBINARY => variable_length(column_size, SQL_PREC_BIGCHARBINARY)
+            .map(|length| SqlType::VarBinary(None, length)),
+        SQL_LONGVARCHAR | SQL_WLONGVARCHAR | SQL_LONGVARBINARY => None,
+        other => return Err(ParamBuildError::UnsupportedSqlType(other)),
+    })
+}
+
+/// The encoding of the application buffer feeding a streamed parameter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DaeSource {
+    /// Bytes with no character structure.
+    Raw,
+    /// `SQL_C_CHAR`, read as UTF-8 (see [`AppText`]).
+    Utf8,
+    /// `SQL_C_WCHAR`, UTF-16LE.
+    Utf16,
+}
+
+/// The encoding the streamed chunks have to arrive in on the wire.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DaeTarget {
+    /// `varbinary(max)`: no re-encoding.
+    Raw,
+    /// `nvarchar(max)`: UTF-16LE, fixed by the type.
+    Utf16,
+    /// `varchar(max)`: the database collation's code page, applied by
+    /// [`encode_narrow`] so an unmappable LCID falls back the same way the
+    /// materialized path's does.
+    Narrow(SqlCollation),
+}
+
+/// Converts one streamed chunk from the application's encoding into the wire's.
+///
+/// `write_streamed_chunk` writes bytes verbatim, so a narrow target's code page
+/// has to be applied here - streaming a `SQL_C_CHAR` buffer straight into a
+/// single-byte collation is what made `caf\u{e9}` arrive as two characters. This
+/// is the same job msodbcsql gives `ConvertLongData` (`odbc/sqlccnvt.cpp:841`),
+/// which likewise transcodes each chunk before pushing it (AB#47590).
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DaeTranscode {
+    source: DaeSource,
+    target: DaeTarget,
+}
+
+impl DaeTranscode {
+    /// The conversion a streamed parameter needs, given the connection's
+    /// collation. A UTF-8 collation needs no re-encoding for a narrow target
+    /// beyond the decode the source already implies.
+    pub(crate) fn new(c_type: SqlSmallInt, sql_type: SqlSmallInt, collation: SqlCollation) -> Self {
+        let source = match c_type {
+            SQL_C_WCHAR => DaeSource::Utf16,
+            SQL_C_CHAR => DaeSource::Utf8,
+            _ => DaeSource::Raw,
+        };
+        let target = match sql_family(sql_type) {
+            Some(SqlFamily::Character) if is_wide_character_sql_type(sql_type) => DaeTarget::Utf16,
+            Some(SqlFamily::Character) => DaeTarget::Narrow(collation),
+            _ => DaeTarget::Raw,
+        };
+        Self { source, target }
+    }
+
+    /// `true` when the buffer's bytes are already the wire's bytes, so a chunk
+    /// can be written without being copied or carried.
+    pub(crate) fn is_passthrough(&self) -> bool {
+        match (self.source, self.target) {
+            (DaeSource::Raw, _) => true,
+            (DaeSource::Utf16, DaeTarget::Utf16) => true,
+            // A UTF-8 collation wants exactly the bytes `SQL_C_CHAR` already
+            // holds.
+            (DaeSource::Utf8, DaeTarget::Narrow(collation)) => collation.utf8(),
+            _ => false,
         }
     }
+
+    /// Converts everything in `chunk` that completes a character, moving a
+    /// trailing partial one into `carry` for the next call.
+    pub(crate) fn push(&self, carry: &mut Vec<u8>, chunk: &[u8]) -> Vec<u8> {
+        if self.is_passthrough() {
+            return chunk.to_vec();
+        }
+        let mut buf = std::mem::take(carry);
+        buf.extend_from_slice(chunk);
+        let split = buf.len() - self.incomplete_tail(&buf);
+        carry.extend_from_slice(&buf[split..]);
+        self.encode(&self.decode(&buf[..split]))
+    }
+
+    /// Converts what a value ended part-way through. The bytes cannot be
+    /// completed, so they decode lossily, as the materialized path would.
+    pub(crate) fn finish(&self, carry: &mut Vec<u8>) -> Vec<u8> {
+        if carry.is_empty() {
+            return Vec::new();
+        }
+        let tail = std::mem::take(carry);
+        self.encode(&self.decode(&tail))
+    }
+
+    /// How many trailing bytes begin a character that is not finished yet.
+    fn incomplete_tail(&self, buf: &[u8]) -> usize {
+        match self.source {
+            DaeSource::Raw => 0,
+            DaeSource::Utf8 => incomplete_utf8_tail(buf),
+            DaeSource::Utf16 => incomplete_utf16_tail(buf),
+        }
+    }
+
+    fn decode(&self, bytes: &[u8]) -> String {
+        match self.source {
+            DaeSource::Utf16 => decode_utf16le(bytes),
+            _ => String::from_utf8_lossy(bytes).into_owned(),
+        }
+    }
+
+    fn encode(&self, text: &str) -> Vec<u8> {
+        match self.target {
+            DaeTarget::Utf16 => text.encode_utf16().flat_map(u16::to_le_bytes).collect(),
+            // The same helper the materialized narrow path uses, so an LCID
+            // this crate cannot map falls back identically on both.
+            DaeTarget::Narrow(collation) => encode_narrow(text, collation),
+            DaeTarget::Raw => text.as_bytes().to_vec(),
+        }
+    }
+}
+
+/// Length of the trailing bytes of `buf` that begin a UTF-8 sequence which is
+/// not finished yet. A sequence is at most four bytes, so only the last three
+/// can be partial.
+fn incomplete_utf8_tail(buf: &[u8]) -> usize {
+    for back in 1..=3.min(buf.len()) {
+        let byte = buf[buf.len() - back];
+        if byte < 0x80 {
+            // ASCII: a complete sequence on its own.
+            return 0;
+        }
+        if byte >= 0xC0 {
+            // A lead byte: complete only once all of its continuations landed.
+            let needed = if byte >= 0xF0 {
+                4
+            } else if byte >= 0xE0 {
+                3
+            } else {
+                2
+            };
+            return if back < needed { back } else { 0 };
+        }
+        // A continuation byte; keep walking back for the lead.
+    }
+    0
+}
+
+/// Length of the trailing bytes of `buf` that begin a UTF-16LE character which
+/// is not finished yet: half a code unit, and a high surrogate still waiting for
+/// its low half.
+fn incomplete_utf16_tail(buf: &[u8]) -> usize {
+    let odd = buf.len() % 2;
+    let units_end = buf.len() - odd;
+    if units_end >= 2 {
+        let last = u16::from_le_bytes([buf[units_end - 2], buf[units_end - 1]]);
+        if (0xD800..0xDC00).contains(&last) {
+            return odd + 2;
+        }
+    }
+    odd
 }
 
 /// The SQL-side axis of the conversion matrix.
@@ -1189,89 +1413,385 @@ mod tests {
         assert_eq!(err.diag().state, ERR_INVALID_STRING_OR_BUFFER_LENGTH.state);
     }
 
-    /// The three C types `SQLPutData` can stream, and the rejection every other
-    /// binding gets. `SQLBindParameter` accepts data-at-execution for any C
-    /// type, so the refusal lands at execute time.
+    /// The three C types a value can be supplied in, and the rejection every
+    /// other binding gets. `SQLBindParameter` accepts data-at-execution for any
+    /// C type, so the refusal lands at execute time.
     #[test]
-    fn dae_placeholder_type_covers_the_streamable_c_types() {
-        assert!(matches!(
-            dae_placeholder_type(SQL_C_CHAR, SQL_VARCHAR),
-            Ok(DaeStream {
-                sql_type: StreamedSqlType::VarcharMax,
-                needs_transcode: false
-            })
-        ));
-        assert!(matches!(
-            dae_placeholder_type(SQL_C_WCHAR, SQL_WVARCHAR),
-            Ok(DaeStream {
-                sql_type: StreamedSqlType::NVarcharMax,
-                needs_transcode: false
-            })
-        ));
-        assert!(matches!(
-            dae_placeholder_type(SQL_C_BINARY, SQL_VARBINARY),
-            Ok(DaeStream {
-                sql_type: StreamedSqlType::VarBinaryMax,
-                needs_transcode: false
-            })
-        ));
+    fn dae_plan_covers_the_supported_c_types() {
+        assert_eq!(
+            dae_plan(SQL_C_CHAR, SQL_VARCHAR),
+            Ok(DaePlan::Stream(StreamedSqlType::VarcharMax))
+        );
+        assert_eq!(
+            dae_plan(SQL_C_WCHAR, SQL_WVARCHAR),
+            Ok(DaePlan::Stream(StreamedSqlType::NVarcharMax))
+        );
+        assert_eq!(
+            dae_plan(SQL_C_BINARY, SQL_VARBINARY),
+            Ok(DaePlan::Stream(StreamedSqlType::VarBinaryMax))
+        );
 
-        let err = dae_placeholder_type(SQL_C_LONG, SQL_VARCHAR).unwrap_err();
+        let err = dae_plan(SQL_C_LONG, SQL_VARCHAR).unwrap_err();
         assert!(matches!(err, ParamBuildError::UnsupportedCType(SQL_C_LONG)));
         assert_eq!(err.diag().state, ERR_PARAM_C_TYPE_NOT_IMPLEMENTED.state);
     }
 
-    /// A genuine cross-*family* pairing (character streamed against binary, or
-    /// the reverse) has to be refused: there is nothing it could mean other
-    /// than one side declaring one encoding and sending another (AB#47590).
+    /// The streamed set is the PLP-framable one, and it does not depend on
+    /// `ColumnSize`: a bounded `varchar(10)` still streams its body and carries
+    /// its length in the declaration instead. This is msodbcsql's
+    /// `IsPartialLenType` (`odbc/sqlcprot.h:1421`) driving the same branch in
+    /// `PutParamData` (AB#47590).
     #[test]
-    fn cross_family_dae_is_rejected() {
+    fn dae_plan_streams_every_partial_length_type() {
         for (c_type, sql_type) in [
-            (SQL_C_BINARY, SQL_VARCHAR),
-            (SQL_C_CHAR, SQL_VARBINARY),
-            // Newly bindable as of the cross conversions, so the refusal moves
-            // from bind time to here.
-            (SQL_C_CHAR, SQL_INTEGER),
-            (SQL_C_WCHAR, SQL_BIGINT),
+            (SQL_C_CHAR, SQL_VARCHAR),
+            (SQL_C_CHAR, SQL_LONGVARCHAR),
+            (SQL_C_WCHAR, SQL_WVARCHAR),
+            (SQL_C_WCHAR, SQL_WLONGVARCHAR),
+            (SQL_C_BINARY, SQL_VARBINARY),
+            (SQL_C_BINARY, SQL_LONGVARBINARY),
         ] {
-            let err = dae_placeholder_type(c_type, sql_type).unwrap_err();
-            assert_eq!(
-                err,
-                ParamBuildError::ConversionNotImplemented,
-                "{c_type} -> {sql_type} should not stream"
+            assert!(
+                matches!(dae_plan(c_type, sql_type), Ok(DaePlan::Stream(_))),
+                "{c_type}/{sql_type} is PLP-framable and should stream"
             );
-            assert_eq!(err.diag().state, *b"HYC00");
         }
     }
 
-    /// Same-family pairings always stream, whether or not the declared type is
-    /// itself a `max`. Matching wideness streams untranscoded; a mismatch is
-    /// still accepted but flagged so the caller buffers and transcodes once
-    /// (`wideness_mismatched_dae_needs_transcode`) rather than corrupting a
-    /// chunk streamed as-is.
+    /// Everything that cannot be PLP-framed is collected and converted whole,
+    /// the branch msodbcsql serves with `WriteToExtBuffer`
+    /// (`odbc/sqlccmd.cpp:4913`).
     #[test]
-    fn same_family_dae_always_streams() {
-        for (c_type, sql_type, streamed) in [
-            (SQL_C_CHAR, SQL_CHAR, StreamedSqlType::VarcharMax),
-            (SQL_C_CHAR, SQL_LONGVARCHAR, StreamedSqlType::VarcharMax),
-            (SQL_C_WCHAR, SQL_WCHAR, StreamedSqlType::NVarcharMax),
-            (SQL_C_WCHAR, SQL_WLONGVARCHAR, StreamedSqlType::NVarcharMax),
-            (SQL_C_BINARY, SQL_BINARY, StreamedSqlType::VarBinaryMax),
-            (
-                SQL_C_BINARY,
-                SQL_LONGVARBINARY,
-                StreamedSqlType::VarBinaryMax,
-            ),
+    fn dae_plan_buffers_what_cannot_be_plp_framed() {
+        for (c_type, sql_type) in [
+            (SQL_C_CHAR, SQL_CHAR),
+            (SQL_C_WCHAR, SQL_WCHAR),
+            (SQL_C_BINARY, SQL_BINARY),
+            (SQL_C_CHAR, SQL_INTEGER),
+            (SQL_C_WCHAR, SQL_BIGINT),
         ] {
             assert_eq!(
-                dae_placeholder_type(c_type, sql_type),
-                Ok(DaeStream {
-                    sql_type: streamed,
-                    needs_transcode: false
-                }),
-                "{c_type} -> {sql_type} should stream untranscoded"
+                dae_plan(c_type, sql_type),
+                Ok(DaePlan::Buffer),
+                "{c_type}/{sql_type} cannot be PLP-framed"
             );
         }
+    }
+
+    /// A bounded declaration narrows the `@params` entry while the value body
+    /// stays PLP; `ColumnSize` 0 is the `max` spelling and needs none.
+    #[test]
+    fn dae_streamed_declaration_narrows_only_a_bounded_parameter() {
+        assert_eq!(dae_streamed_declaration(SQL_VARCHAR, 0), Ok(None));
+        assert_eq!(
+            dae_streamed_declaration(SQL_VARCHAR, 10),
+            Ok(Some(SqlType::Varchar(None, 10)))
+        );
+        assert_eq!(
+            dae_streamed_declaration(SQL_WVARCHAR, 10),
+            Ok(Some(SqlType::NVarchar(None, 10)))
+        );
+        assert_eq!(
+            dae_streamed_declaration(SQL_VARBINARY, 10),
+            Ok(Some(SqlType::VarBinary(None, 10)))
+        );
+        // `text`/`ntext`/`image` keep the `max` substitution they get on the
+        // materialized path (AB#47592).
+        assert_eq!(dae_streamed_declaration(SQL_LONGVARCHAR, 10), Ok(None));
+    }
+
+    /// A UTF-8 sequence split across two chunks is reassembled rather than
+    /// decoding to replacement characters: chunk boundaries are chosen by the
+    /// application and have nothing to do with character boundaries.
+    #[test]
+    fn transcode_carries_a_split_utf8_sequence_into_the_next_chunk() {
+        let transcode = DaeTranscode::new(SQL_C_CHAR, SQL_WVARCHAR, SqlCollation::default());
+        let mut carry = Vec::new();
+        // "caf" + the first byte of U+00E9.
+        let first = transcode.push(&mut carry, &[b'c', b'a', b'f', 0xC3]);
+        assert_eq!(
+            first,
+            b"c\0a\0f\0".to_vec(),
+            "the partial byte is held back"
+        );
+        let second = transcode.push(&mut carry, &[0xA9]);
+        assert_eq!(second, vec![0xE9, 0x00], "the completed sequence follows");
+        assert!(transcode.finish(&mut carry).is_empty());
+    }
+
+    /// Every UTF-8 sequence width can straddle a boundary, including a 4-byte
+    /// one that becomes a surrogate pair.
+    #[test]
+    fn transcode_carries_every_utf8_sequence_width() {
+        let transcode = DaeTranscode::new(SQL_C_CHAR, SQL_WVARCHAR, SqlCollation::default());
+        for split in 1..4 {
+            let mut carry = Vec::new();
+            // U+1F600, four bytes, one surrogate pair.
+            let full = "\u{1F600}".as_bytes();
+            let mut out = transcode.push(&mut carry, &full[..split]);
+            out.extend(transcode.push(&mut carry, &full[split..]));
+            out.extend(transcode.finish(&mut carry));
+            assert_eq!(
+                out,
+                vec![0x3D, 0xD8, 0x00, 0xDE],
+                "split after {split} byte(s)"
+            );
+        }
+    }
+
+    /// A wide buffer feeding a narrow target has its own boundaries: half a
+    /// code unit, and a surrogate pair split down the middle.
+    ///
+    /// Asserted as boundary-independence rather than against fixed bytes: what
+    /// the collation makes of an unmappable character is the encoder's business
+    /// (and matches the materialized path), but *where the chunks were split*
+    /// must not change the answer.
+    #[test]
+    fn transcode_carries_a_split_utf16_unit() {
+        let transcode = DaeTranscode::new(SQL_C_WCHAR, SQL_VARCHAR, SqlCollation::default());
+        let mut carry = Vec::new();
+        // U+00E9 as UTF-16LE, split between its two bytes.
+        assert!(transcode.push(&mut carry, &[0xE9]).is_empty());
+        assert_eq!(transcode.push(&mut carry, &[0x00]), vec![0xE9]);
+        assert!(transcode.finish(&mut carry).is_empty());
+
+        // A surrogate pair, whole and then split at every offset.
+        let pair = [0x3D, 0xD8, 0x00, 0xDE];
+        let mut whole_carry = Vec::new();
+        let whole = transcode.push(&mut whole_carry, &pair);
+        assert!(transcode.finish(&mut whole_carry).is_empty());
+        for split in 1..pair.len() {
+            let mut carry = Vec::new();
+            let mut out = transcode.push(&mut carry, &pair[..split]);
+            out.extend(transcode.push(&mut carry, &pair[split..]));
+            out.extend(transcode.finish(&mut carry));
+            assert_eq!(out, whole, "split after {split} byte(s) changed the value");
+        }
+    }
+
+    /// A value that ends part-way through a character has no continuation
+    /// coming, so the held bytes are flushed lossily rather than dropped.
+    #[test]
+    fn transcode_flushes_a_truncated_tail_as_a_replacement() {
+        let transcode = DaeTranscode::new(SQL_C_CHAR, SQL_WVARCHAR, SqlCollation::default());
+        let mut carry = Vec::new();
+        assert!(transcode.push(&mut carry, &[0xC3]).is_empty());
+        assert_eq!(transcode.finish(&mut carry), vec![0xFD, 0xFF], "U+FFFD");
+    }
+
+    /// A pairing whose buffer bytes are already the wire's bytes copies rather
+    /// than decoding, so the large-value path keeps its cost.
+    #[test]
+    fn transcode_passes_matching_encodings_through() {
+        let collation = SqlCollation::default();
+        assert!(DaeTranscode::new(SQL_C_BINARY, SQL_VARBINARY, collation).is_passthrough());
+        assert!(DaeTranscode::new(SQL_C_WCHAR, SQL_WVARCHAR, collation).is_passthrough());
+        // A narrow buffer into a wide target always re-encodes.
+        assert!(!DaeTranscode::new(SQL_C_CHAR, SQL_WVARCHAR, collation).is_passthrough());
+    }
+
+    /// `ColumnSize` bounds a streamed parameter as the chunks arrive, rather
+    /// than being left to the declaration: the value body is PLP-framed and so
+    /// carries no length of its own, and the bound has to be reported by the
+    /// `SQLPutData` that breaches it (AB#47590).
+    ///
+    /// The unit is the declaration's, so the byte budget scales with the C
+    /// buffer's element width - a `SQL_C_WCHAR` character is two bytes where a
+    /// binary or narrow one is a single byte.
+    #[test]
+    fn dae_length_limit_scales_column_size_by_the_buffer_unit() {
+        let limit = dae_length_limit(SQL_C_BINARY, SQL_VARBINARY, 2)
+            .unwrap()
+            .expect("a bounded varbinary is limited");
+        assert_eq!(limit.max_bytes, 2);
+        assert_eq!(limit.pad_unit, [0u8]);
+
+        let limit = dae_length_limit(SQL_C_CHAR, SQL_VARCHAR, 4)
+            .unwrap()
+            .expect("a bounded varchar is limited");
+        assert_eq!(limit.max_bytes, 4);
+        assert_eq!(limit.pad_unit, *b" ");
+
+        // Four characters of nvarchar are eight bytes of SQL_C_WCHAR buffer.
+        let limit = dae_length_limit(SQL_C_WCHAR, SQL_WVARCHAR, 4)
+            .unwrap()
+            .expect("a bounded nvarchar is limited");
+        assert_eq!(limit.max_bytes, 8);
+        assert_eq!(limit.pad_unit, [b' ', 0]);
+    }
+
+    /// A `max` declaration has no length to enforce. `SQLDescribeParam` reports
+    /// `ColumnSize` 0 for one, and a size past the non-`max` ceiling widens to
+    /// `max` rather than erroring - the same reading [`variable_length`] gives
+    /// the materialized path.
+    #[test]
+    fn dae_length_limit_is_absent_for_the_max_declarations() {
+        for (c_type, sql_type, column_size) in [
+            (SQL_C_BINARY, SQL_VARBINARY, 0),
+            (SQL_C_CHAR, SQL_VARCHAR, 0),
+            (SQL_C_WCHAR, SQL_WVARCHAR, 0),
+            (SQL_C_BINARY, SQL_VARBINARY, SQL_PREC_BIGCHARBINARY + 1),
+            (SQL_C_CHAR, SQL_VARCHAR, SQL_PREC_BIGCHARBINARY + 1),
+            (SQL_C_WCHAR, SQL_WVARCHAR, SQL_PREC_NCHAR + 1),
+        ] {
+            assert_eq!(
+                dae_length_limit(c_type, sql_type, column_size).unwrap(),
+                None,
+                "{c_type} -> {sql_type} at {column_size} should be unbounded"
+            );
+        }
+    }
+
+    /// `text`/`ntext`/`image` carry no declared length but are still bounded by
+    /// `ColumnSize`, exactly as they are when the value is materialized.
+    #[test]
+    fn dae_length_limit_bounds_the_long_types_by_column_size() {
+        let limit = dae_length_limit(SQL_C_BINARY, SQL_LONGVARBINARY, 3)
+            .unwrap()
+            .expect("image is bounded by ColumnSize");
+        assert_eq!(limit.max_bytes, 3);
+
+        let limit = dae_length_limit(SQL_C_CHAR, SQL_LONGVARCHAR, 3)
+            .unwrap()
+            .expect("text is bounded by ColumnSize");
+        assert_eq!(limit.max_bytes, 3);
+    }
+
+    /// A zero `ColumnSize` is the `max` spelling for the variable-width types
+    /// but invalid T-SQL for the fixed-width ones, which have no `max` form.
+    /// The streamed path reads it the same way the materialized path does.
+    #[test]
+    fn dae_length_limit_rejects_a_zero_size_on_the_fixed_width_types() {
+        for (c_type, sql_type) in [
+            (SQL_C_BINARY, SQL_BINARY),
+            (SQL_C_CHAR, SQL_CHAR),
+            (SQL_C_WCHAR, SQL_WCHAR),
+        ] {
+            let err = dae_length_limit(c_type, sql_type, 0).unwrap_err();
+            assert!(matches!(err, ParamBuildError::InvalidParameterSize(0)));
+        }
+    }
+
+    /// The bound applies to the accumulated value, not to each chunk: an
+    /// overflow can first appear on a chunk that is individually well inside
+    /// the declaration. A per-chunk check would pass both of these.
+    #[test]
+    fn dae_limit_fit_measures_the_accumulated_total() {
+        let limit = dae_length_limit(SQL_C_BINARY, SQL_VARBINARY, 4)
+            .unwrap()
+            .unwrap();
+
+        // Each chunk is under the limit on its own; together they exceed it.
+        assert_eq!(limit.fit(&[1, 2, 3], 0).unwrap(), &[1, 2, 3]);
+        assert_eq!(
+            limit.fit(&[4, 5, 6], 3).unwrap_err(),
+            ParamBuildError::StringTruncation
+        );
+    }
+
+    /// An overflow made entirely of padding is dropped rather than reported -
+    /// the streamed counterpart of [`trim_zero_overflow`] and
+    /// [`trim_blank_overflow`]. Anything else in the overflow is `22001`,
+    /// wherever in it the first non-pad byte sits.
+    #[test]
+    fn dae_limit_fit_trims_padding_and_reports_anything_else() {
+        let binary = dae_length_limit(SQL_C_BINARY, SQL_VARBINARY, 2)
+            .unwrap()
+            .unwrap();
+        assert_eq!(binary.fit(&[1, 2, 0, 0], 0).unwrap(), &[1, 2]);
+        assert_eq!(
+            binary.fit(&[1, 2, 0, 3], 0).unwrap_err(),
+            ParamBuildError::StringTruncation
+        );
+
+        let narrow = dae_length_limit(SQL_C_CHAR, SQL_VARCHAR, 2)
+            .unwrap()
+            .unwrap();
+        assert_eq!(narrow.fit(b"ab  ", 0).unwrap(), b"ab");
+        assert_eq!(
+            narrow.fit(b"abcd", 0).unwrap_err(),
+            ParamBuildError::StringTruncation
+        );
+
+        // The wide pad is a whole UTF-16 blank, so a lone 0x20 byte is not one.
+        let wide = dae_length_limit(SQL_C_WCHAR, SQL_WVARCHAR, 1)
+            .unwrap()
+            .unwrap();
+        assert_eq!(wide.fit(&[b'a', 0, b' ', 0], 0).unwrap(), &[b'a', 0]);
+        assert_eq!(
+            wide.fit(&[b'a', 0, b'b', 0], 0).unwrap_err(),
+            ParamBuildError::StringTruncation
+        );
+    }
+
+    /// Once the budget is spent every later chunk must be padding, and the
+    /// trimmed length is what the total advances by - so padding dropped at the
+    /// boundary does not consume the declaration's remaining room.
+    #[test]
+    fn dae_limit_fit_admits_only_padding_past_the_budget() {
+        let limit = dae_length_limit(SQL_C_BINARY, SQL_VARBINARY, 2)
+            .unwrap()
+            .unwrap();
+        assert!(limit.fit(&[0, 0], 2).unwrap().is_empty());
+        assert_eq!(
+            limit.fit(&[0, 1], 2).unwrap_err(),
+            ParamBuildError::StringTruncation
+        );
+    }
+
+    /// A trailing byte that is not a whole pad unit cannot be padding, so it is
+    /// reported rather than rounded away - the wide buffer's odd-length case.
+    #[test]
+    fn dae_limit_fit_rejects_a_partial_pad_unit() {
+        let wide = dae_length_limit(SQL_C_WCHAR, SQL_WVARCHAR, 1)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            wide.fit(&[b'a', 0, b' '], 0).unwrap_err(),
+            ParamBuildError::StringTruncation
+        );
+    }
+
+    /// Every pairing the materialized path can convert is now supplyable at
+    /// execution: the ones whose encoding cannot be settled chunk-wise buffer
+    /// and take that path rather than being refused (AB#47590).
+    #[test]
+    fn cross_family_dae_is_accepted() {
+        // A cross-family pairing whose target is PLP-framable streams, with the
+        // encoding difference handled per chunk by `DaeTranscode`.
+        for (c_type, sql_type) in [
+            (SQL_C_CHAR, SQL_WVARCHAR),
+            (SQL_C_CHAR, SQL_WLONGVARCHAR),
+            (SQL_C_WCHAR, SQL_VARCHAR),
+            (SQL_C_WCHAR, SQL_LONGVARCHAR),
+            (SQL_C_BINARY, SQL_VARCHAR),
+            (SQL_C_CHAR, SQL_VARBINARY),
+        ] {
+            assert!(
+                matches!(dae_plan(c_type, sql_type), Ok(DaePlan::Stream(_))),
+                "{c_type} -> {sql_type} should stream"
+            );
+        }
+
+        // The rest are collected and converted whole, rather than refused as
+        // they were before.
+        for (c_type, sql_type) in [
+            (SQL_C_CHAR, SQL_WCHAR),
+            (SQL_C_WCHAR, SQL_CHAR),
+            (SQL_C_CHAR, SQL_INTEGER),
+            (SQL_C_WCHAR, SQL_BIGINT),
+        ] {
+            assert_eq!(
+                dae_plan(c_type, sql_type),
+                Ok(DaePlan::Buffer),
+                "{c_type} -> {sql_type} should buffer"
+            );
+        }
+
+        // An unsupported wire type is still refused, since no conversion exists
+        // for it on either path.
+        let err = dae_plan(SQL_C_CHAR, SQL_SS_VECTOR).unwrap_err();
+        assert_eq!(err.diag().state, ERR_PARAM_SQL_TYPE_NOT_IMPLEMENTED.state);
     }
 
     /// The pairing this driver used to reject with `HYC00`: a wide C type
@@ -1279,8 +1799,11 @@ mod tests {
     /// every character parameter's data-at-execution path as `SQL_C_WCHAR`,
     /// including narrow (ASCII) values, so this is the ordinary shape for any
     /// bound string over ~4000 characters (AB#47709's follow-up).
+    ///
+    /// It streams like any other PLP-framable pairing; the encoding difference
+    /// is handled per chunk by [`DaeTranscode`] rather than by refusing it.
     #[test]
-    fn wideness_mismatched_dae_needs_transcode() {
+    fn wideness_mismatched_dae_streams_and_transcodes() {
         for (c_type, sql_type, streamed) in [
             (SQL_C_WCHAR, SQL_VARCHAR, StreamedSqlType::VarcharMax),
             (SQL_C_WCHAR, SQL_LONGVARCHAR, StreamedSqlType::VarcharMax),
@@ -1288,12 +1811,13 @@ mod tests {
             (SQL_C_CHAR, SQL_WLONGVARCHAR, StreamedSqlType::NVarcharMax),
         ] {
             assert_eq!(
-                dae_placeholder_type(c_type, sql_type),
-                Ok(DaeStream {
-                    sql_type: streamed,
-                    needs_transcode: true
-                }),
+                dae_plan(c_type, sql_type),
+                Ok(DaePlan::Stream(streamed)),
                 "{c_type} -> {sql_type}"
+            );
+            assert!(
+                !DaeTranscode::new(c_type, sql_type, utf8_collation()).is_passthrough(),
+                "{c_type} -> {sql_type} must re-encode rather than pass through"
             );
         }
     }
@@ -1302,16 +1826,21 @@ mod tests {
     /// otherwise a narrow column would receive UTF-16LE bytes under a wide
     /// declaration, or vice versa, regardless of transcoding.
     #[test]
-    fn transcode_dae_bytes_wide_round_trips() {
+    fn transcode_wide_round_trips() {
         let wide_bytes: Vec<u8> = "caf\u{e9}"
             .encode_utf16()
             .flat_map(u16::to_le_bytes)
             .collect();
-        let narrow = transcode_dae_bytes(SQL_C_WCHAR, SQL_VARCHAR, wide_bytes, utf8_collation());
+        let transcode = DaeTranscode::new(SQL_C_WCHAR, SQL_VARCHAR, utf8_collation());
+        let mut carry = Vec::new();
+        let mut narrow = transcode.push(&mut carry, &wide_bytes);
+        narrow.extend(transcode.finish(&mut carry));
         assert_eq!(String::from_utf8(narrow).unwrap(), "caf\u{e9}");
 
-        let narrow_bytes = "caf\u{e9}".as_bytes().to_vec();
-        let wide = transcode_dae_bytes(SQL_C_CHAR, SQL_WVARCHAR, narrow_bytes, utf8_collation());
+        let transcode = DaeTranscode::new(SQL_C_CHAR, SQL_WVARCHAR, utf8_collation());
+        let mut carry = Vec::new();
+        let mut wide = transcode.push(&mut carry, "caf\u{e9}".as_bytes());
+        wide.extend(transcode.finish(&mut carry));
         let wide_units: Vec<u16> = wide
             .chunks_exact(2)
             .map(|p| u16::from_le_bytes([p[0], p[1]]))
@@ -1326,17 +1855,23 @@ mod tests {
     /// passthrough would instead send 0xC3 0xA9, mojibake to a server
     /// expecting Windows-1252.
     #[test]
-    fn transcode_dae_bytes_narrow_uses_the_connection_collation() {
+    fn transcode_narrow_uses_the_connection_collation() {
         let wide_bytes: Vec<u8> = "caf\u{e9}"
             .encode_utf16()
             .flat_map(u16::to_le_bytes)
             .collect();
-        let narrow = transcode_dae_bytes(
-            SQL_C_WCHAR,
-            SQL_VARCHAR,
-            wide_bytes,
-            windows_1252_collation(),
-        );
+        let transcode = DaeTranscode::new(SQL_C_WCHAR, SQL_VARCHAR, windows_1252_collation());
+        let mut carry = Vec::new();
+        let mut narrow = transcode.push(&mut carry, &wide_bytes);
+        narrow.extend(transcode.finish(&mut carry));
+        assert_eq!(narrow, b"caf\xe9");
+
+        // Same for a narrow C buffer: `SQL_C_CHAR` is UTF-8 by this driver's
+        // convention, which is not a wire encoding.
+        let transcode = DaeTranscode::new(SQL_C_CHAR, SQL_VARCHAR, windows_1252_collation());
+        let mut carry = Vec::new();
+        let mut narrow = transcode.push(&mut carry, "caf\u{e9}".as_bytes());
+        narrow.extend(transcode.finish(&mut carry));
         assert_eq!(narrow, b"caf\xe9");
     }
 

--- a/mssql-odbc/src/handles/stmt.rs
+++ b/mssql-odbc/src/handles/stmt.rs
@@ -738,15 +738,31 @@ impl DaeParam {
         self.binding.sql_type = sql_type;
         self
     }
+
+    /// Same, with a `ColumnSize` bound attached, for the tests that exercise
+    /// trimming against the declared-length promise.
+    #[cfg(test)]
+    pub(crate) fn with_length_limit(mut self, limit: DaeLengthLimit) -> Self {
+        self.length_limit = Some(limit);
+        self
+    }
 }
 
 /// How much of the open data-at-execution parameter the application has
 /// supplied. Reset as a unit whenever the cursor advances.
 #[derive(Debug, Default)]
 pub(crate) struct DaeProgress {
-    /// Bytes supplied by `SQLPutData`, counted before any server-side
-    /// conversion to match msodbcsql's `cbDataAppGiven`.
+    /// Bytes supplied by `SQLPutData`, counted before any trimming or
+    /// conversion to match msodbcsql's `cbDataAppGiven`. This is the total the
+    /// `SQL_LEN_DATA_AT_EXEC(n)` promise is checked against, so it has to count
+    /// what the application handed over rather than what survived.
     pub(crate) bytes_sent: usize,
+    /// Bytes kept after `ColumnSize` trimming -- msodbcsql's
+    /// `cbDataSentToServer`. Padding trimmed away does not consume the
+    /// declaration's budget, so this trails `bytes_sent` whenever a chunk was
+    /// trimmed, and the two must not be conflated: the declared-length check
+    /// reads the first, the `ColumnSize` bound the second.
+    pub(crate) retained_bytes: usize,
     /// Set by the first `SQLPutData` for this parameter, including zero-length
     /// and NULL writes. Closing a parameter without one is a sequence error in
     /// msodbcsql.

--- a/mssql-odbc/src/handles/stmt.rs
+++ b/mssql-odbc/src/handles/stmt.rs
@@ -757,12 +757,14 @@ pub(crate) struct DaeProgress {
     /// `SQL_LEN_DATA_AT_EXEC(n)` promise is checked against, so it has to count
     /// what the application handed over rather than what survived.
     pub(crate) bytes_sent: usize,
-    /// Bytes kept after `ColumnSize` trimming -- msodbcsql's
+    /// Units kept after `ColumnSize` trimming -- msodbcsql's
     /// `cbDataSentToServer`. Padding trimmed away does not consume the
     /// declaration's budget, so this trails `bytes_sent` whenever a chunk was
     /// trimmed, and the two must not be conflated: the declared-length check
-    /// reads the first, the `ColumnSize` bound the second.
-    pub(crate) retained_bytes: usize,
+    /// reads the first, the `ColumnSize` bound the second. Counted in the
+    /// bound's own unit, which is UTF-16 code units for a `SQL_C_CHAR` buffer
+    /// and bytes otherwise.
+    pub(crate) retained_units: usize,
     /// Set by the first `SQLPutData` for this parameter, including zero-length
     /// and NULL writes. Closing a parameter without one is a sequence error in
     /// msodbcsql.

--- a/mssql-odbc/src/handles/stmt.rs
+++ b/mssql-odbc/src/handles/stmt.rs
@@ -16,6 +16,7 @@ use crate::api::odbc_types::{
     self, SQL_DESC_ALLOC_AUTO, SqlInteger, SqlLen, SqlPointer, SqlSmallInt, SqlULen, SqlUSmallInt,
 };
 use crate::api::set_desc_field::datetime_interval_code_for;
+use crate::conversion::param_convert::{DaeLengthLimit, DaePlan, DaeTranscode};
 use crate::error::{DiagRecord, HasDiagnostics};
 use crate::params::BoundParam;
 use mssql_tds::datatypes::column_values::ColumnValues;
@@ -648,35 +649,95 @@ impl InertStmtAttrs {
 }
 
 /// One data-at-execution parameter: the token `SQLParamData` returns, how
-/// many bytes the application promised for it, and the C/SQL type pairing
-/// `dae_placeholder_type` resolved at execute time.
+/// many bytes the application promised for it, and the plan `dae_plan`
+/// resolved from the binding at execute time.
 ///
 /// Keeping these fields together means the execution-time token and declared
 /// length cannot drift away from the binding they describe.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct DaeParam {
+    /// 0-based index into [`StmtState::bound_params`], and equally the
+    /// parameter's position in the RPC list, which is built in the same order.
+    pub(crate) bound_index: usize,
     /// `ParameterValuePtr` with the execution's bind offset already applied.
     pub(crate) value_ptr: SqlPointer,
     /// Total byte count declared by `SQL_LEN_DATA_AT_EXEC(n)`; `None` for
     /// `SQL_DATA_AT_EXEC`, where the application promised no total.
     pub(crate) expected_len: Option<usize>,
-    /// Set from `dae_placeholder_type`'s report at the same time the streamed
-    /// wire type was decided. `SQLPutData` buffers this parameter's chunks in
-    /// [`DaeProgress::pending_bytes`] instead of writing them to the wire, and
-    /// they are transcoded once, as a whole, when the parameter closes.
-    pub(crate) needs_transcode: bool,
-    /// `BoundParam::c_type` / `BoundParam::sql_type`, snapshotted here at the
-    /// same time as `needs_transcode` rather than re-read from
-    /// `StmtState::bound_params` at close time. `SQLFreeStmt(SQL_RESET_PARAMS)`
-    /// can clear a binding while its data-at-execution sequence is still open,
-    /// and a rebind could change the encoding after the wire placeholder was
-    /// already fixed; the snapshot can neither vanish nor drift underneath the
-    /// sequence it describes. This is the *only* place the sequence reads
-    /// either type from -- no consumer indexes back into `bound_params`, so
-    /// there is one source of truth for the whole sequence, not two that
-    /// could disagree.
-    pub(crate) c_type: SqlSmallInt,
-    pub(crate) sql_type: SqlSmallInt,
+    /// Whether the value streams to the wire or is collected first.
+    pub(crate) plan: DaePlan,
+    /// `ColumnSize` applied to the accumulated chunk total as the chunks
+    /// arrive, so the `22001` lands on the same `SQLPutData` msodbcsql puts it
+    /// on. `None` when the bound is left to the close-time conversion.
+    pub(crate) length_limit: Option<DaeLengthLimit>,
+    /// The binding as of this execution, kept so a buffered value can be
+    /// declared and converted from `ParameterType` when it closes.
+    pub(crate) binding: BoundParam,
+    /// How a streamed chunk is re-encoded on its way to the wire. Filled in
+    /// when the sequence is parked, where the connection's collation is known.
+    pub(crate) transcode: Option<DaeTranscode>,
+}
+
+impl DaeParam {
+    /// Opens a data-at-execution parameter. Named rather than built as a
+    /// literal so a field added later cannot break a construction site written
+    /// in parallel.
+    pub(crate) fn new(
+        bound_index: usize,
+        expected_len: Option<usize>,
+        plan: DaePlan,
+        length_limit: Option<DaeLengthLimit>,
+        binding: BoundParam,
+    ) -> Self {
+        Self {
+            bound_index,
+            value_ptr: binding.parameter_value_ptr,
+            expected_len,
+            plan,
+            length_limit,
+            binding,
+            transcode: None,
+        }
+    }
+
+    /// A streamed parameter with no `ColumnSize` bound, for the tests that only
+    /// exercise the sequencing and declared-length rules.
+    #[cfg(test)]
+    pub(crate) fn unbounded(
+        bound_index: usize,
+        value_ptr: SqlPointer,
+        expected_len: Option<usize>,
+    ) -> Self {
+        use mssql_tds::message::parameters::rpc_parameters::StreamedSqlType;
+        let binding = BoundParam {
+            input_output_type: crate::api::odbc_types::SQL_PARAM_INPUT,
+            c_type: crate::api::odbc_types::SQL_C_BINARY,
+            sql_type: crate::api::odbc_types::SQL_VARBINARY,
+            column_size: 0,
+            decimal_digits: 0,
+            parameter_value_ptr: value_ptr,
+            buffer_length: 0,
+            strlen_or_ind_ptr: std::ptr::null_mut(),
+            octet_length_ptr: std::ptr::null_mut(),
+        };
+        Self::new(
+            bound_index,
+            expected_len,
+            DaePlan::Stream(StreamedSqlType::VarBinaryMax),
+            None,
+            binding,
+        )
+    }
+
+    /// Same, with the binding's C and SQL types set, for the tests that depend
+    /// on the pairing — `SQL_NTS` sizing reads the C type, and the transcode is
+    /// derived from both.
+    #[cfg(test)]
+    pub(crate) fn with_binding_types(mut self, c_type: SqlSmallInt, sql_type: SqlSmallInt) -> Self {
+        self.binding.c_type = c_type;
+        self.binding.sql_type = sql_type;
+        self
+    }
 }
 
 /// How much of the open data-at-execution parameter the application has
@@ -693,11 +754,12 @@ pub(crate) struct DaeProgress {
     /// The parameter was supplied as SQL NULL, so the declared-length check is
     /// skipped, as in msodbcsql.
     pub(crate) is_null: bool,
-    /// Raw `SQLPutData` bytes accumulated so far, in the C type's own
-    /// encoding. Only appended to -- instead of being streamed to the wire
-    /// immediately -- when [`DaeParam::needs_transcode`] is set; empty and
-    /// unused otherwise.
-    pub(crate) pending_bytes: Vec<u8>,
+    /// Chunks collected for a [`DaePlan::Buffer`] parameter, converted when it
+    /// closes. Empty for a streamed one.
+    pub(crate) buffer: Vec<u8>,
+    /// Bytes of a character split across two `SQLPutData` calls, held until the
+    /// chunk that completes it arrives.
+    pub(crate) carry: Vec<u8>,
 }
 
 /// A data-at-execution sequence in progress: everything the statement holds
@@ -730,6 +792,22 @@ pub(crate) struct DaeState {
     pub(crate) cursor: Option<usize>,
     /// Progress on the parameter named by `cursor`.
     pub(crate) progress: DaeProgress,
+    /// Set when at least one parameter is [`DaePlan::Buffer`]. No RPC is open
+    /// for the sequence: the values are collected as their parameters close and
+    /// the execute runs from the last `SQLParamData`, because a buffered
+    /// parameter's declaration is not known until its bytes are all in.
+    pub(crate) deferred: bool,
+    /// Collected values for buffered parameters as `(bound index, bytes,
+    /// is_null)`, in close order.
+    pub(crate) buffered: Vec<(usize, Vec<u8>, bool)>,
+    /// Marker count for the deferred execute's parameter rebuild.
+    pub(crate) marker_count: usize,
+    /// Rewritten SQL for a deferred `SQLExecDirect`, which runs ad-hoc
+    /// `sp_executesql` and has no prepared plan to execute instead.
+    pub(crate) sql: Option<String>,
+    /// Remaining `SQL_ATTR_QUERY_TIMEOUT` budget captured at execute time, so
+    /// the deferred execute is charged the same allowance as an immediate one.
+    pub(crate) timeout_secs: u32,
 }
 
 impl DaeState {
@@ -747,7 +825,43 @@ impl DaeState {
             params,
             cursor: None,
             progress: DaeProgress::default(),
+            deferred: false,
+            buffered: Vec::new(),
+            marker_count: 0,
+            sql: None,
+            timeout_secs: 0,
         }
+    }
+
+    /// Marks the sequence as one whose execute runs when the last parameter
+    /// closes, rather than one already streaming into an open RPC.
+    pub(crate) fn deferred(
+        mut self,
+        marker_count: usize,
+        sql: Option<String>,
+        timeout_secs: u32,
+    ) -> Self {
+        self.deferred = true;
+        self.marker_count = marker_count;
+        self.sql = sql;
+        self.timeout_secs = timeout_secs;
+        self
+    }
+
+    /// The parameters, for the deferred execute's rebuild.
+    pub(crate) fn params(&self) -> &[DaeParam] {
+        &self.params
+    }
+
+    /// Takes the prepared plan back out when the deferred execute runs.
+    pub(crate) fn take_prepared(&mut self) -> Option<PreparedPlan> {
+        self.prepared.take()
+    }
+
+    /// Takes the orphaned handle so the deferred execute can piggyback its
+    /// release, exactly as an immediate execute does.
+    pub(crate) fn take_orphaned(&mut self) -> Option<StatementId> {
+        self.orphaned.take()
     }
 
     /// Checks the client out for a network write, so no lock is held across the
@@ -799,6 +913,11 @@ impl DaeState {
             params,
             cursor,
             progress: DaeProgress::default(),
+            deferred: false,
+            buffered: Vec::new(),
+            marker_count: 0,
+            sql: None,
+            timeout_secs: 0,
         }
     }
 
@@ -1164,13 +1283,15 @@ impl StmtState {
     }
 
     /// The C type of the open DAE parameter, which `SQLPutData` needs to size
-    /// an `SQL_NTS` chunk. Reads [`DaeParam::c_type`] -- the snapshot taken at
-    /// execute time -- rather than `bound_params`, so it agrees with the type
-    /// `SQLParamData` transcodes with even if `SQLFreeStmt(SQL_RESET_PARAMS)`
-    /// or a rebind changes or clears the live binding while the sequence is
-    /// open.
+    /// an `SQL_NTS` chunk. Reads the binding snapshot taken at execute time
+    /// rather than `bound_params`, so it agrees with the type the chunks are
+    /// transcoded with even if `SQLFreeStmt(SQL_RESET_PARAMS)` or a rebind
+    /// changes or clears the live binding while the sequence is open.
     pub(crate) fn dae_current_c_type(&self) -> Option<SqlSmallInt> {
-        self.dae.as_ref()?.current_param().map(|param| param.c_type)
+        self.dae
+            .as_ref()?
+            .current_param()
+            .map(|param| param.binding.c_type)
     }
 }
 

--- a/mssql-odbc/src/handles/stmt.rs
+++ b/mssql-odbc/src/handles/stmt.rs
@@ -988,6 +988,19 @@ impl DaeState {
     pub(crate) fn set_call_in_flight(&mut self, in_flight: bool) {
         self.call_in_flight = in_flight;
     }
+
+    /// Same as [`Self::for_test`], with a parked client, for the tests that
+    /// exercise a path which checks one out and must dispose of it.
+    #[cfg(test)]
+    pub(crate) fn for_test_with_client(
+        params: Vec<DaeParam>,
+        cursor: Option<usize>,
+        client: TdsClient,
+    ) -> Self {
+        let mut state = Self::for_test(params, cursor);
+        state.client = Some(client);
+        state
+    }
 }
 
 /// How msodbcsql validates a vendor statement attribute's value.

--- a/mssql-odbc/src/handles/stmt.rs
+++ b/mssql-odbc/src/handles/stmt.rs
@@ -22,7 +22,9 @@ use crate::params::BoundParam;
 use mssql_tds::datatypes::column_values::ColumnValues;
 use mssql_tds::datatypes::sqldatatypes::TdsDataType;
 use mssql_tds::encoding_rs::Decoder;
+use mssql_tds::message::parameters::rpc_parameters::RpcParameter;
 use mssql_tds::query::metadata::{ColumnMetadata, PlpEncoding};
+use mssql_tds::token::tokens::SqlCollation;
 
 /// State for a PLP column being streamed across repeated SQLGetData calls.
 pub(crate) struct ActivePlpStream {
@@ -818,8 +820,16 @@ pub(crate) struct DaeState {
     /// Collected values for buffered parameters as `(bound index, bytes,
     /// is_null)`, in close order.
     pub(crate) buffered: Vec<(usize, Vec<u8>, bool)>,
-    /// Marker count for the deferred execute's parameter rebuild.
-    pub(crate) marker_count: usize,
+    /// The RPC parameters as `build_named_params` materialized them at execute
+    /// time, data-at-execution slots included as placeholders. The deferred
+    /// execute replaces only those slots and keeps the rest verbatim.
+    ///
+    /// Held rather than re-read because `bound_params` is itself an
+    /// execute-time snapshot that `SQLFreeStmt(SQL_RESET_PARAMS)` does not
+    /// clear: an application that releases its bindings mid-sequence -- which
+    /// that call invites -- would otherwise have its freed buffers dereferenced
+    /// when the last `SQLParamData` rebuilt the list.
+    pub(crate) prebuilt: Vec<RpcParameter>,
     /// Rewritten SQL for a deferred `SQLExecDirect`, which runs ad-hoc
     /// `sp_executesql` and has no prepared plan to execute instead.
     pub(crate) sql: Option<String>,
@@ -845,7 +855,7 @@ impl DaeState {
             progress: DaeProgress::default(),
             deferred: false,
             buffered: Vec::new(),
-            marker_count: 0,
+            prebuilt: Vec::new(),
             sql: None,
             timeout_secs: 0,
         }
@@ -855,15 +865,50 @@ impl DaeState {
     /// closes, rather than one already streaming into an open RPC.
     pub(crate) fn deferred(
         mut self,
-        marker_count: usize,
+        prebuilt: Vec<RpcParameter>,
         sql: Option<String>,
         timeout_secs: u32,
     ) -> Self {
         self.deferred = true;
-        self.marker_count = marker_count;
+        self.prebuilt = prebuilt;
         self.sql = sql;
         self.timeout_secs = timeout_secs;
+        // Buffered parameters are visited first so the RPC can open as soon as
+        // their values are known: a materialized parameter has to be on the wire
+        // before any streamed one, so anything still uncollected at that point
+        // would have to be collected whole. Visiting them first lets every
+        // PLP-capable parameter stream, whatever order they were bound in.
+        //
+        // ODBC leaves the order `SQLParamData` hands parameters back to the
+        // driver -- it returns "the next parameter for which data is needed" --
+        // and the application identifies each one by the token it returns, not
+        // by position. `sort_by_key` is stable, so parameters keep their
+        // relative order within each group.
+        self.params.sort_by_key(|param| !param.plan.is_buffered());
         self
+    }
+
+    /// Every parameter still to be visited is streamed, so the collected values
+    /// are complete and the RPC can be opened.
+    pub(crate) fn buffered_phase_complete(&self) -> bool {
+        self.current_param()
+            .is_some_and(|param| !param.plan.is_buffered())
+    }
+
+    /// Switches the sequence from collecting to streaming once its RPC is open,
+    /// giving each remaining parameter the transcode its chunks need.
+    pub(crate) fn begin_streaming_phase(&mut self, client: TdsClient, collation: SqlCollation) {
+        for param in &mut self.params {
+            if !param.plan.is_buffered() && param.transcode.is_none() {
+                let transcode =
+                    DaeTranscode::new(param.binding.c_type, param.binding.sql_type, collation);
+                if !transcode.is_passthrough() {
+                    param.transcode = Some(transcode);
+                }
+            }
+        }
+        self.deferred = false;
+        self.return_client(client);
     }
 
     /// The parameters, for the deferred execute's rebuild.
@@ -933,7 +978,7 @@ impl DaeState {
             progress: DaeProgress::default(),
             deferred: false,
             buffered: Vec::new(),
-            marker_count: 0,
+            prebuilt: Vec::new(),
             sql: None,
             timeout_secs: 0,
         }

--- a/mssql-odbc/tests/e2e/tests/execute_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/execute_test.cpp
@@ -178,6 +178,103 @@ TEST_F(PrepareExecuteLiveTest, DataAtExecutionInterleavesWithBoundParams) {
 // that reaches the advance branch in SQLParamData (dae_current_idx += 1) and so
 // the only one that can catch the driver stalling on the first parameter,
 // skipping the second, or handing back the wrong token.
+// A mixed sequence -- one parameter that must be collected whole (a fixed-width
+// target has no PLP form) alongside one that streams. The collected one is
+// offered first so the RPC can open as soon as its value is known, leaving the
+// PLP-capable parameter to stream rather than be held in memory. Parameters are
+// identified by the token SQLParamData returns, which is what ODBC specifies, so
+// the order they are offered in is the driver's to choose.
+TEST_F(PrepareExecuteLiveTest, MixedDataAtExecutionStreamsThePlpParameter) {
+    ASSERT_SQL_OK(Prepare("SELECT ? AS a, ? AS b"), SQL_HANDLE_STMT, stmt_);
+
+    SQLLEN streamed_ind = SQL_DATA_AT_EXEC;
+    SQLLEN buffered_ind = SQL_DATA_AT_EXEC;
+    SQLCHAR token_streamed = 0;
+    SQLCHAR token_buffered = 0;
+
+    // Parameter 1 is PLP-capable (varchar(max)) and streams; parameter 2 is
+    // fixed-width (char(4)) and must be collected. Bound in that order, so the
+    // buffered one is offered second by position but first by plan.
+    ASSERT_SQL_OK(SQLBindParameter(stmt_, 1, SQL_PARAM_INPUT, SQL_C_CHAR,
+                                   SQL_VARCHAR, 0, 0, &token_streamed, 0,
+                                   &streamed_ind),
+                  SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLBindParameter(stmt_, 2, SQL_PARAM_INPUT, SQL_C_CHAR,
+                                   SQL_CHAR, 4, 0, &token_buffered, 0,
+                                   &buffered_ind),
+                  SQL_HANDLE_STMT, stmt_);
+
+    ASSERT_EQ(SQL_NEED_DATA, SQLExecute(stmt_));
+
+    SQLPOINTER value_ptr = nullptr;
+    SQLRETURN rc = SQLParamData(stmt_, &value_ptr);
+    int iterations = 0;
+    bool sent_streamed = false;
+    bool sent_buffered = false;
+    bool buffered_came_first = false;
+
+    while (rc == SQL_NEED_DATA) {
+        ASSERT_LT(++iterations, 10) << "SQLParamData did not terminate";
+        if (value_ptr == &token_streamed) {
+            EXPECT_FALSE(sent_streamed) << "streamed token offered twice";
+            if (!sent_buffered) {
+                buffered_came_first = false;
+            }
+            sent_streamed = true;
+            // Two chunks, so the streamed value genuinely spans calls.
+            const char first[] = "ab";
+            const char second[] = "cd";
+            ASSERT_SQL_OK(SQLPutData(stmt_, const_cast<char*>(first), 2),
+                          SQL_HANDLE_STMT, stmt_);
+            ASSERT_SQL_OK(SQLPutData(stmt_, const_cast<char*>(second), 2),
+                          SQL_HANDLE_STMT, stmt_);
+        } else if (value_ptr == &token_buffered) {
+            EXPECT_FALSE(sent_buffered) << "buffered token offered twice";
+            if (!sent_streamed) {
+                buffered_came_first = true;
+            }
+            sent_buffered = true;
+            const char chunk[] = "wxyz";
+            ASSERT_SQL_OK(SQLPutData(stmt_, const_cast<char*>(chunk), 4),
+                          SQL_HANDLE_STMT, stmt_);
+        } else {
+            FAIL() << "SQLParamData returned an unrecognised token";
+        }
+        rc = SQLParamData(stmt_, &value_ptr);
+    }
+
+    ASSERT_SQL_OK(rc, SQL_HANDLE_STMT, stmt_);
+    EXPECT_TRUE(sent_streamed);
+    EXPECT_TRUE(sent_buffered);
+    // Only this driver promises the order. msodbcsql offers parameters in bind
+    // order because it can declare a fixed-width target without seeing its
+    // value; this driver derives the declaration from the collected bytes, so it
+    // has to visit the collected ones first to open the RPC at all. The values
+    // below are asserted on both drivers -- that is the part that must agree.
+    {
+        const char* target = std::getenv("ODBC_TEST_TARGET");
+        if (!target || std::string(target) != "msodbcsql") {
+            EXPECT_TRUE(buffered_came_first)
+                << "the collected parameter must be offered before the streamed "
+                   "one, or the streamed one cannot reach the wire as it "
+                   "arrives";
+        }
+    }
+
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    SQLCHAR a[32] = {0};
+    SQLCHAR b[32] = {0};
+    SQLLEN a_len = 0;
+    SQLLEN b_len = 0;
+    ASSERT_SQL_OK(SQLGetData(stmt_, 1, SQL_C_CHAR, a, sizeof(a), &a_len),
+                  SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLGetData(stmt_, 2, SQL_C_CHAR, b, sizeof(b), &b_len),
+                  SQL_HANDLE_STMT, stmt_);
+    EXPECT_STREQ(reinterpret_cast<const char*>(a), "abcd");
+    EXPECT_STREQ(reinterpret_cast<const char*>(b), "wxyz");
+    EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
+}
+
 TEST_F(PrepareExecuteLiveTest, DataAtExecutionLoopsOverMultipleStreamedParams) {
     ASSERT_SQL_OK(Prepare("SELECT ? + ? + ? + ? AS v"), SQL_HANDLE_STMT, stmt_);
 

--- a/mssql-odbc/tests/e2e/tests/execute_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/execute_test.cpp
@@ -850,7 +850,18 @@ TEST_F(PrepareExecuteLiveTest, WideCTypeAgainstNarrowSqlTypeDataAtExecutionTrans
 // non-UTF8 collation. Every streamed chunk now goes through the connection's
 // collation on its way out, so this pairing encodes like the materialized path
 // (AB#47590's narrow-to-narrow half).
+//
+// Skipped in the parity run because the two drivers disagree by construction,
+// not by defect: msodbcsql reads `SQL_C_CHAR` as the client's ANSI codepage and
+// passes those bytes through, so it round-trips these five UTF-8 bytes as five
+// characters ("caf" + U+00C3 + U+00A9), while this driver decodes them as one
+// character ("caf" + U+00E9). The divergence is the driver-wide `SQL_C_CHAR`
+// convention, which the materialized path already follows; it is not specific
+// to the streamed path this test covers. Only visible under a non-UTF8
+// collation -- under a UTF8 one, transcode and passthrough are byte-identical.
 TEST_F(PrepareExecuteLiveTest, NarrowCTypeAgainstNarrowSqlTypeDataAtExecutionTranscodes) {
+    SKIP_IF_COMPARING_MSODBCSQL();
+
     ASSERT_SQL_OK(Prepare("SELECT ? AS v"), SQL_HANDLE_STMT, stmt_);
 
     SQLLEN ind = SQL_DATA_AT_EXEC;

--- a/mssql-odbc/tests/e2e/tests/execute_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/execute_test.cpp
@@ -843,21 +843,14 @@ TEST_F(PrepareExecuteLiveTest, WideCTypeAgainstNarrowSqlTypeDataAtExecutionTrans
     EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
 }
 
-// Same-wideness narrow pairing (needs_transcode: false): SQLPutData streams
-// SQL_C_CHAR bytes to the wire untranscoded, on the assumption they are
-// already the wire encoding. They are not -- this driver's SQL_C_CHAR is
-// UTF-8 by convention, not a wire encoding -- so a non-ASCII value round-trips
-// as mojibake under a non-UTF8 collation (AB#47590's narrow-to-narrow half,
-// left open by this PR: only the wideness-mismatch half above closes here).
-// Written as the passing assertions AB#47590 would need to satisfy, with an
-// unconditional skip at the top: pins the gap's location for whoever picks
-// that up, and removing the skip is the whole activation step once fixed,
-// rather than writing this test from scratch then.
-TEST_F(PrepareExecuteLiveTest, NarrowCTypeAgainstNarrowSqlTypeDataAtExecutionStillMisencodesNonAscii) {
-    GTEST_SKIP() << "known gap, not fixed by this PR: same-wideness narrow "
-                    "DAE streams SQL_C_CHAR bytes as UTF-8 regardless of the "
-                    "connection's actual collation (AB#47590)";
-
+// Same-wideness narrow pairing. `SQLPutData` used to stream `SQL_C_CHAR` bytes
+// to the wire untranscoded, on the assumption they were already the wire
+// encoding. They are not -- this driver's `SQL_C_CHAR` is UTF-8 by convention,
+// not a wire encoding -- so a non-ASCII value round-tripped as mojibake under a
+// non-UTF8 collation. Every streamed chunk now goes through the connection's
+// collation on its way out, so this pairing encodes like the materialized path
+// (AB#47590's narrow-to-narrow half).
+TEST_F(PrepareExecuteLiveTest, NarrowCTypeAgainstNarrowSqlTypeDataAtExecutionTranscodes) {
     ASSERT_SQL_OK(Prepare("SELECT ? AS v"), SQL_HANDLE_STMT, stmt_);
 
     SQLLEN ind = SQL_DATA_AT_EXEC;
@@ -894,29 +887,26 @@ TEST_F(PrepareExecuteLiveTest, NarrowCTypeAgainstNarrowSqlTypeDataAtExecutionSti
     EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
 }
 
-// A genuine cross-*family* pairing -- character streamed against an integer
-// SQL type -- has no transcode to fall back on: there is nothing it could
-// mean other than one side declaring one encoding and sending another, so it
-// is still refused at execute rather than risking corruption.
+// A cross-*family* pairing -- character supplied at execution against an
+// integer SQL type -- is no longer refused. It cannot be PLP-framed, so the
+// chunks are collected and the complete value is converted by the same code a
+// materialized parameter uses, which already parses text into an integer
+// (AB#47590).
 //
 // SQL_C_CHAR -> SQL_INTEGER is reachable here (rather than failing at bind,
 // like SQL_C_CHAR -> a binary type still does) specifically because the
-// integer/character cross-conversions feature made it a valid *materialized*
-// binding; DAE has no equivalent, so the refusal for this one pairing moves
-// from bind time to here.
+// integer/character cross-conversions feature made it a valid materialized
+// binding; supplying it at execution now goes through that same conversion.
 //
-// msodbcsql returns SQL_NEED_DATA for this pairing at SQLExecute (see
-// param_cross_conversions_test.cpp/CrossFamilyDataAtExecutionIsRejectedAtExecute),
-// but does not actually stream it: SQLPutData itself then rejects with
-// HY019 ("Processing of fixed length targets cannot be spread over multiple
-// calls to SQLPutData"). Both drivers agree the pairing cannot stream
-// through -- they just detect it one call apart, this driver at SQLExecute
-// -- so the parity run stays skipped rather than comparing error codes that
-// differ by construction.
-TEST_F(PrepareExecuteLiveTest, CrossFamilyDataAtExecutionIsRejected) {
+// msodbcsql accepts the pairing at SQLExecute and then rejects at SQLPutData
+// with HY019 ("Processing of fixed length targets cannot be spread over
+// multiple calls to SQLPutData"), so the parity run stays skipped: the two
+// drivers genuinely differ here rather than differing only in which call
+// reports it.
+TEST_F(PrepareExecuteLiveTest, CrossFamilyDataAtExecutionConvertsToInteger) {
     SKIP_IF_COMPARING_MSODBCSQL();
 
-    ASSERT_SQL_OK(Prepare("SELECT ? AS v"), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(Prepare("SELECT ? + 1"), SQL_HANDLE_STMT, stmt_);
 
     SQLLEN ind = SQL_DATA_AT_EXEC;
     SQLCHAR token = 0;
@@ -924,15 +914,25 @@ TEST_F(PrepareExecuteLiveTest, CrossFamilyDataAtExecutionIsRejected) {
                                    SQL_INTEGER, 0, 0, &token, 0, &ind),
                   SQL_HANDLE_STMT, stmt_);
 
-    EXPECT_EQ(SQL_ERROR, SQLExecute(stmt_));
-    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "HYC00");
+    ASSERT_EQ(SQL_NEED_DATA, SQLExecute(stmt_));
+    SQLPOINTER returned = nullptr;
+    ASSERT_EQ(SQL_NEED_DATA, SQLParamData(stmt_, &returned));
 
-    // The refusal happens while building the parameter list, before any RPC is
-    // opened, so no streaming sequence is left half-started: the statement takes
-    // a new binding without an intervening SQLCancel.
+    const SQLCHAR digits[] = {'4', '1'};
+    ASSERT_SQL_OK(SQLPutData(stmt_, const_cast<SQLCHAR*>(digits), sizeof(digits)),
+                  SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLParamData(stmt_, &returned), SQL_HANDLE_STMT, stmt_);
+
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ("42", GetColumnChar(1));
+    EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
+
+    // The statement is reusable straight afterwards: the sequence completed
+    // rather than being torn down, so no SQLCancel is needed in between.
     ASSERT_SQL_OK(SQLFreeStmt(stmt_, SQL_RESET_PARAMS), SQL_HANDLE_STMT, stmt_);
     std::vector<SQLCHAR> value = {'o', 'k', '\0'};
     SQLLEN value_ind = SQL_NTS;
+    ASSERT_SQL_OK(Prepare("SELECT ? AS v"), SQL_HANDLE_STMT, stmt_);
     ASSERT_SQL_OK(BindChar(1, value, value_ind), SQL_HANDLE_STMT, stmt_);
     ASSERT_SQL_OK(SQLExecute(stmt_), SQL_HANDLE_STMT, stmt_);
     ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);

--- a/mssql-odbc/tests/e2e/tests/param_binary_conversions_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/param_binary_conversions_test.cpp
@@ -329,26 +329,92 @@ TEST_F(BinaryConversionLiveTest, TwoBinaryParamsKeepSeparateDeclarations) {
     EXPECT_EQ("1122|33445566", ExecuteAndReadBack());
 }
 
-// Divergence: ColumnSize does not bound a data-at-execution value here, and it
-// does in msodbcsql. dae_placeholder_type declares varbinary(max) from the C
-// type alone, so a streamed value is never length-checked; msodbcsql applies the
-// same cbMaxPrec bound and CheckTrailingZeros rule to each SQLPutData chunk,
-// accumulating cbDataSentToServer across calls (sqlccmd.cpp:11192-11218), and
-// answers 22001 for the binding below. Measured on retail 18.6.2.1.
+// ColumnSize bounds a data-at-execution value exactly as it bounds a
+// materialized one, and the parameter is declared varbinary(2) to match: the
+// value body is still PLP framing opened before the length is known, but the
+// variable it is assigned to carries the declared length.
 //
-// Not narrowed to binary: the character DAE path has the same gap, and closing
-// either needs ColumnSize threaded into the placeholder type plus a running
-// total in SQLPutData. Tracked as AB#47590; skipped here rather than left
-// asserting the wrong direction.
-TEST_F(BinaryConversionLiveTest, DataAtExecutionIgnoresColumnSize) {
-    SKIP_IF_COMPARING_MSODBCSQL();
-
+// Runs on both legs: msodbcsql applies the same cbMaxPrec bound and
+// CheckTrailingZeros rule to each SQLPutData call, accumulating
+// cbDataSentToServer across them (sqlccmd.cpp:11192-11218).
+TEST_F(BinaryConversionLiveTest, DataAtExecutionOverflowingColumnSizeIsRejected) {
     ASSERT_SQL_OK(Prepare("SELECT CONVERT(VARCHAR(32), ?, 2)"), SQL_HANDLE_STMT, stmt_);
 
     SQLLEN streamed_ind = SQL_DATA_AT_EXEC;
     SQLCHAR token = 0;
-    // ColumnSize 2 against a 4-byte streamed value: no 22001.
+    // ColumnSize 2 against a 4-byte streamed value whose overflow carries data.
     ASSERT_SQL_OK(SQLBindParameter(stmt_, 1, SQL_PARAM_INPUT, SQL_C_BINARY, SQL_VARBINARY, 2,
+                                   0, &token, 0, &streamed_ind),
+                  SQL_HANDLE_STMT, stmt_);
+
+    ASSERT_EQ(SQL_NEED_DATA, SQLExecute(stmt_));
+    SQLPOINTER value_ptr = nullptr;
+    ASSERT_EQ(SQL_NEED_DATA, SQLParamData(stmt_, &value_ptr));
+
+    const SQLCHAR chunk[] = {0xAA, 0xBB, 0xCC, 0xDD};
+    EXPECT_EQ(SQL_ERROR, SQLPutData(stmt_, const_cast<SQLCHAR*>(chunk), sizeof(chunk)));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "22001");
+}
+
+// The other half of the rule: an overflow made only of the pad byte is dropped
+// rather than reported, so the value still lands trimmed to ColumnSize. This is
+// the streamed counterpart of BinaryColumnSizeTrimsZeroOverflow.
+TEST_F(BinaryConversionLiveTest, DataAtExecutionTrimsZeroOverflowToColumnSize) {
+    ASSERT_SQL_OK(Prepare("SELECT CONVERT(VARCHAR(32), ?, 2)"), SQL_HANDLE_STMT, stmt_);
+
+    SQLLEN streamed_ind = SQL_DATA_AT_EXEC;
+    SQLCHAR token = 0;
+    ASSERT_SQL_OK(SQLBindParameter(stmt_, 1, SQL_PARAM_INPUT, SQL_C_BINARY, SQL_VARBINARY, 2,
+                                   0, &token, 0, &streamed_ind),
+                  SQL_HANDLE_STMT, stmt_);
+
+    ASSERT_EQ(SQL_NEED_DATA, SQLExecute(stmt_));
+    SQLPOINTER value_ptr = nullptr;
+    ASSERT_EQ(SQL_NEED_DATA, SQLParamData(stmt_, &value_ptr));
+
+    const SQLCHAR chunk[] = {0xAA, 0xBB, 0x00, 0x00};
+    ASSERT_SQL_OK(SQLPutData(stmt_, const_cast<SQLCHAR*>(chunk), sizeof(chunk)),
+                  SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLParamData(stmt_, &value_ptr), SQL_HANDLE_STMT, stmt_);
+
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ("AABB", GetColumnChar());
+    EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
+}
+
+// The bound is against the accumulated value, not each chunk. Both chunks below
+// fit ColumnSize on their own; only their total exceeds it, which is the case a
+// per-chunk check would pass.
+TEST_F(BinaryConversionLiveTest, DataAtExecutionColumnSizeSpansChunks) {
+    ASSERT_SQL_OK(Prepare("SELECT CONVERT(VARCHAR(32), ?, 2)"), SQL_HANDLE_STMT, stmt_);
+
+    SQLLEN streamed_ind = SQL_DATA_AT_EXEC;
+    SQLCHAR token = 0;
+    ASSERT_SQL_OK(SQLBindParameter(stmt_, 1, SQL_PARAM_INPUT, SQL_C_BINARY, SQL_VARBINARY, 4,
+                                   0, &token, 0, &streamed_ind),
+                  SQL_HANDLE_STMT, stmt_);
+
+    ASSERT_EQ(SQL_NEED_DATA, SQLExecute(stmt_));
+    SQLPOINTER value_ptr = nullptr;
+    ASSERT_EQ(SQL_NEED_DATA, SQLParamData(stmt_, &value_ptr));
+
+    const SQLCHAR first[] = {0x11, 0x22, 0x33};
+    ASSERT_SQL_OK(SQLPutData(stmt_, const_cast<SQLCHAR*>(first), sizeof(first)),
+                  SQL_HANDLE_STMT, stmt_);
+    // 3 + 3 = 6 against varbinary(4), and the overflow is not padding.
+    const SQLCHAR second[] = {0x44, 0x55, 0x66};
+    EXPECT_EQ(SQL_ERROR, SQLPutData(stmt_, const_cast<SQLCHAR*>(second), sizeof(second)));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "22001");
+}
+
+// A max declaration has no length to enforce, so a streamed value of any size
+// still goes out whole. ColumnSize 0 is how SQLDescribeParam reports one.
+TEST_F(BinaryConversionLiveTest, DataAtExecutionMaxDeclarationIsUnbounded) {
+    ASSERT_SQL_OK(Prepare("SELECT CONVERT(VARCHAR(32), ?, 2)"), SQL_HANDLE_STMT, stmt_);
+
+    SQLLEN streamed_ind = SQL_DATA_AT_EXEC;
+    SQLCHAR token = 0;
+    ASSERT_SQL_OK(SQLBindParameter(stmt_, 1, SQL_PARAM_INPUT, SQL_C_BINARY, SQL_VARBINARY, 0,
                                    0, &token, 0, &streamed_ind),
                   SQL_HANDLE_STMT, stmt_);
 
@@ -363,5 +429,38 @@ TEST_F(BinaryConversionLiveTest, DataAtExecutionIgnoresColumnSize) {
 
     ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
     EXPECT_EQ("AABBCCDD", GetColumnChar());
+    EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
+}
+
+// `binary(n)` is not one of the PLP-framable types, so its value cannot be
+// streamed as chunks: it is collected across the SQLPutData calls and converted
+// whole when SQLParamData closes the parameter, the branch msodbcsql serves
+// with WriteToExtBuffer (sqlccmd.cpp:4913). The zero padding to the declared
+// width is what proves it went out as `binary(4)` rather than a `max`.
+TEST_F(BinaryConversionLiveTest, DataAtExecutionFixedWidthIsCollectedAndDeclaredBinary) {
+    ASSERT_SQL_OK(Prepare("SELECT CONVERT(VARCHAR(32), ?, 2)"), SQL_HANDLE_STMT, stmt_);
+
+    SQLLEN streamed_ind = SQL_DATA_AT_EXEC;
+    SQLCHAR token = 0;
+    ASSERT_SQL_OK(SQLBindParameter(stmt_, 1, SQL_PARAM_INPUT, SQL_C_BINARY, SQL_BINARY, 4, 0,
+                                   &token, 0, &streamed_ind),
+                  SQL_HANDLE_STMT, stmt_);
+
+    ASSERT_EQ(SQL_NEED_DATA, SQLExecute(stmt_));
+    SQLPOINTER value_ptr = nullptr;
+    ASSERT_EQ(SQL_NEED_DATA, SQLParamData(stmt_, &value_ptr));
+
+    // Two chunks: the value only exists once both have been collected.
+    const SQLCHAR first[] = {0x11};
+    const SQLCHAR second[] = {0x22};
+    ASSERT_SQL_OK(SQLPutData(stmt_, const_cast<SQLCHAR*>(first), sizeof(first)),
+                  SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLPutData(stmt_, const_cast<SQLCHAR*>(second), sizeof(second)),
+                  SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLParamData(stmt_, &value_ptr), SQL_HANDLE_STMT, stmt_);
+
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    // `binary(4)` zero-pads the two supplied bytes out to its declared width.
+    EXPECT_EQ("11220000", GetColumnChar());
     EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
 }

--- a/mssql-odbc/tests/e2e/tests/param_char_conversions_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/param_char_conversions_test.cpp
@@ -1005,6 +1005,55 @@ TEST_F(CharConversionLiveTest, DataAtExecutionOverflowingColumnSizeIsRejected) {
     EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "22001");
 }
 
+// A wideness-mismatched pairing is bounded on the same terms as a matched one.
+// ColumnSize names the declaration's unit and the count is of the source, so
+// nvarchar(2) bounds two UTF-16 units of the bound buffer whichever width that
+// buffer has. Both directions are covered: without the bound the client would
+// declare a length and then stream past it, since a streamed value never
+// reaches the close-time conversion that bounds a materialized one.
+TEST_F(CharConversionLiveTest, DataAtExecutionBoundsAWidenessMismatch) {
+    // Narrow buffer against a wide declaration.
+    {
+        ASSERT_SQL_OK(Prepare("SELECT ? AS v"), SQL_HANDLE_STMT, stmt_);
+
+        SQLLEN streamed_ind = SQL_DATA_AT_EXEC;
+        SQLCHAR token = 0;
+        ASSERT_SQL_OK(SQLBindParameter(stmt_, 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_WVARCHAR, 2, 0,
+                                       &token, 0, &streamed_ind),
+                      SQL_HANDLE_STMT, stmt_);
+
+        ASSERT_EQ(SQL_NEED_DATA, SQLExecute(stmt_));
+        SQLPOINTER value_ptr = nullptr;
+        ASSERT_EQ(SQL_NEED_DATA, SQLParamData(stmt_, &value_ptr));
+
+        SQLCHAR chunk[] = {'a', 'b', 'c', 'd'};
+        EXPECT_EQ(SQL_ERROR, SQLPutData(stmt_, chunk, sizeof(chunk)));
+        EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "22001");
+    }
+
+    ASSERT_SQL_OK(SQLFreeStmt(stmt_, SQL_CLOSE), SQL_HANDLE_STMT, stmt_);
+
+    // Wide buffer against a narrow declaration.
+    {
+        ASSERT_SQL_OK(Prepare("SELECT ? AS v"), SQL_HANDLE_STMT, stmt_);
+
+        SQLLEN streamed_ind = SQL_DATA_AT_EXEC;
+        SQLCHAR token = 0;
+        ASSERT_SQL_OK(SQLBindParameter(stmt_, 1, SQL_PARAM_INPUT, SQL_C_WCHAR, SQL_VARCHAR, 2, 0,
+                                       &token, 0, &streamed_ind),
+                      SQL_HANDLE_STMT, stmt_);
+
+        ASSERT_EQ(SQL_NEED_DATA, SQLExecute(stmt_));
+        SQLPOINTER value_ptr = nullptr;
+        ASSERT_EQ(SQL_NEED_DATA, SQLParamData(stmt_, &value_ptr));
+
+        // Four UTF-16 units against nvarchar-equivalent room for two.
+        SQLWCHAR wide[] = {'a', 'b', 'c', 'd'};
+        EXPECT_EQ(SQL_ERROR, SQLPutData(stmt_, wide, sizeof(wide)));
+        EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "22001");
+    }
+}
+
 // The other half of the rule for the character family: an overflow of blanks is
 // dropped rather than reported, so the value lands trimmed to ColumnSize. The
 // pad byte differs from the binary path -- a blank, not a zero.

--- a/mssql-odbc/tests/e2e/tests/param_char_conversions_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/param_char_conversions_test.cpp
@@ -977,3 +977,144 @@ TEST_F(CharConversionLiveTest, SerializationFailureAfterAFlushLeavesTheConnectio
 
     ExpectSameSessionStillUsable(spid);
 }
+
+// ColumnSize bounds a streamed character value exactly as it bounds a
+// materialized one, and the bound is against the accumulated total rather than
+// each chunk (AB#47590). The parameter is declared varchar(2) to match: the
+// value body is still PLP framing opened before the length is known, but the
+// variable it is assigned to carries the declared length.
+//
+// Runs on both legs: msodbcsql applies the same cchMaxPrec bound and
+// CheckTrailingChars rule to each call, accumulating cbDataSentToServer across
+// them (sqlccmd.cpp:11085-11108).
+TEST_F(CharConversionLiveTest, DataAtExecutionOverflowingColumnSizeIsRejected) {
+    ASSERT_SQL_OK(Prepare("SELECT ? AS v"), SQL_HANDLE_STMT, stmt_);
+
+    SQLLEN streamed_ind = SQL_DATA_AT_EXEC;
+    SQLCHAR token = 0;
+    ASSERT_SQL_OK(SQLBindParameter(stmt_, 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 2, 0,
+                                   &token, 0, &streamed_ind),
+                  SQL_HANDLE_STMT, stmt_);
+
+    ASSERT_EQ(SQL_NEED_DATA, SQLExecute(stmt_));
+    SQLPOINTER value_ptr = nullptr;
+    ASSERT_EQ(SQL_NEED_DATA, SQLParamData(stmt_, &value_ptr));
+
+    SQLCHAR chunk[] = {'a', 'b', 'c', 'd'};
+    EXPECT_EQ(SQL_ERROR, SQLPutData(stmt_, chunk, sizeof(chunk)));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "22001");
+}
+
+// The other half of the rule for the character family: an overflow of blanks is
+// dropped rather than reported, so the value lands trimmed to ColumnSize. The
+// pad byte differs from the binary path -- a blank, not a zero.
+TEST_F(CharConversionLiveTest, DataAtExecutionTrimsBlankOverflowToColumnSize) {
+    ASSERT_SQL_OK(Prepare("SELECT ? AS v"), SQL_HANDLE_STMT, stmt_);
+
+    SQLLEN streamed_ind = SQL_DATA_AT_EXEC;
+    SQLCHAR token = 0;
+    ASSERT_SQL_OK(SQLBindParameter(stmt_, 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 3, 0,
+                                   &token, 0, &streamed_ind),
+                  SQL_HANDLE_STMT, stmt_);
+
+    ASSERT_EQ(SQL_NEED_DATA, SQLExecute(stmt_));
+    SQLPOINTER value_ptr = nullptr;
+    ASSERT_EQ(SQL_NEED_DATA, SQLParamData(stmt_, &value_ptr));
+
+    SQLCHAR chunk[] = {'a', 'b', 'c', ' ', ' '};
+    ASSERT_SQL_OK(SQLPutData(stmt_, chunk, sizeof(chunk)), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLParamData(stmt_, &value_ptr), SQL_HANDLE_STMT, stmt_);
+
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ("abc", GetColumnChar(1));
+    EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
+}
+
+// A wide streamed parameter is measured in characters, so its byte budget is
+// twice ColumnSize. Two chunks of one character each fit nvarchar(2); a third
+// does not, and the overflow is not a blank.
+TEST_F(CharConversionLiveTest, DataAtExecutionWideColumnSizeCountsCharacters) {
+    ASSERT_SQL_OK(Prepare("SELECT ? AS v"), SQL_HANDLE_STMT, stmt_);
+
+    SQLLEN streamed_ind = SQL_DATA_AT_EXEC;
+    SQLCHAR token = 0;
+    ASSERT_SQL_OK(SQLBindParameter(stmt_, 1, SQL_PARAM_INPUT, SQL_C_WCHAR, SQL_WVARCHAR, 2, 0,
+                                   &token, 0, &streamed_ind),
+                  SQL_HANDLE_STMT, stmt_);
+
+    ASSERT_EQ(SQL_NEED_DATA, SQLExecute(stmt_));
+    SQLPOINTER value_ptr = nullptr;
+    ASSERT_EQ(SQL_NEED_DATA, SQLParamData(stmt_, &value_ptr));
+
+    SQLWCHAR first[] = {'a'};
+    ASSERT_SQL_OK(SQLPutData(stmt_, first, sizeof(first)), SQL_HANDLE_STMT, stmt_);
+    SQLWCHAR second[] = {'b'};
+    ASSERT_SQL_OK(SQLPutData(stmt_, second, sizeof(second)), SQL_HANDLE_STMT, stmt_);
+    // Two characters already sent against nvarchar(2): a third overflows.
+    SQLWCHAR third[] = {'c'};
+    EXPECT_EQ(SQL_ERROR, SQLPutData(stmt_, third, sizeof(third)));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "22001");
+}
+
+// A max declaration has no length to enforce, so a streamed value of any size
+// still goes out whole. ColumnSize 0 is how SQLDescribeParam reports one.
+TEST_F(CharConversionLiveTest, DataAtExecutionMaxDeclarationIsUnbounded) {
+    ASSERT_SQL_OK(Prepare("SELECT ? AS v"), SQL_HANDLE_STMT, stmt_);
+
+    SQLLEN streamed_ind = SQL_DATA_AT_EXEC;
+    SQLCHAR token = 0;
+    ASSERT_SQL_OK(SQLBindParameter(stmt_, 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 0, 0,
+                                   &token, 0, &streamed_ind),
+                  SQL_HANDLE_STMT, stmt_);
+
+    ASSERT_EQ(SQL_NEED_DATA, SQLExecute(stmt_));
+    SQLPOINTER value_ptr = nullptr;
+    ASSERT_EQ(SQL_NEED_DATA, SQLParamData(stmt_, &value_ptr));
+
+    SQLCHAR chunk[] = {'a', 'b', 'c', 'd'};
+    ASSERT_SQL_OK(SQLPutData(stmt_, chunk, sizeof(chunk)), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLParamData(stmt_, &value_ptr), SQL_HANDLE_STMT, stmt_);
+
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ("abcd", GetColumnChar(1));
+    EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
+}
+
+// `char(n)` is not one of the PLP-framable types, so its value cannot be
+// streamed as chunks: it is collected across the SQLPutData calls and converted
+// whole when SQLParamData closes the parameter, which is the branch msodbcsql
+// serves with WriteToExtBuffer (sqlccmd.cpp:4913). The declaration and the
+// blank padding are what prove it went out as `char(8)` rather than a `max`.
+TEST_F(CharConversionLiveTest, DataAtExecutionFixedWidthIsCollectedAndDeclaredChar) {
+    ASSERT_SQL_OK(Prepare("SELECT CAST(SQL_VARIANT_PROPERTY(CAST(? AS SQL_VARIANT),"
+                          " 'BaseType') AS VARCHAR(32)) + '/' + CAST(LEN(?) AS VARCHAR(8))"),
+                  SQL_HANDLE_STMT, stmt_);
+
+    SQLLEN streamed_ind = SQL_DATA_AT_EXEC;
+    SQLCHAR token = 0;
+    std::vector<SQLCHAR> echo = {'a', 'b', 'c'};
+    SQLLEN echo_ind = static_cast<SQLLEN>(echo.size());
+    ASSERT_SQL_OK(SQLBindParameter(stmt_, 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_CHAR, 8, 0,
+                                   &token, 0, &streamed_ind),
+                  SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLBindParameter(stmt_, 2, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_CHAR, 8,
+                                   0, echo.data(), echo_ind, &echo_ind),
+                  SQL_HANDLE_STMT, stmt_);
+
+    ASSERT_EQ(SQL_NEED_DATA, SQLExecute(stmt_));
+    SQLPOINTER value_ptr = nullptr;
+    ASSERT_EQ(SQL_NEED_DATA, SQLParamData(stmt_, &value_ptr));
+
+    // Two chunks: the value only exists once both have been collected.
+    SQLCHAR first[] = {'a'};
+    SQLCHAR second[] = {'b', 'c'};
+    ASSERT_SQL_OK(SQLPutData(stmt_, first, sizeof(first)), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLPutData(stmt_, second, sizeof(second)), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLParamData(stmt_, &value_ptr), SQL_HANDLE_STMT, stmt_);
+
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    // `char(8)` blank-pads, so LEN() of the materialized sibling is 3 while the
+    // streamed one is declared the same fixed-width type.
+    EXPECT_EQ("char/3", GetColumnChar(1));
+    EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
+}

--- a/mssql-odbc/tests/e2e/tests/param_cross_conversions_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/param_cross_conversions_test.cpp
@@ -494,31 +494,46 @@ TEST_F(CrossConversionLiveTest, WideDecimalLiteralReportsTruncation) {
     EXPECT_EQ("7", ExecuteAndReadBack());
 }
 
-// The cross-family pairings are bindable now, so a data-at-execution indicator
-// on one is refused at execute rather than at bind: the DAE indicator is only
-// read when the parameter list is built.
+// A character C buffer against an integer wire type is supplied at execution
+// like any other pairing: it cannot be PLP-framed, so the chunks are collected
+// and the complete value is converted by the same code the materialized path
+// uses. Text parses to an integer here exactly as it does when bound directly
+// (AB#47590).
 //
-// msodbcsql returns SQL_NEED_DATA for this pairing at SQLExecute, but does not
-// actually stream it: SQLPutData itself then rejects with HY019 ("Processing
-// of fixed length targets cannot be spread over multiple calls to
-// SQLPutData"). Both drivers agree the pairing cannot stream through -- they
-// just detect it one call apart -- so the parity run stays skipped rather
-// than comparing error codes that differ by construction.
-TEST_F(CrossConversionLiveTest, CrossFamilyDataAtExecutionIsRejectedAtExecute) {
+// msodbcsql returns SQL_NEED_DATA for this pairing at SQLExecute but does not
+// actually stream it: SQLPutData then rejects with HY019 ("Processing of fixed
+// length targets cannot be spread over multiple calls to SQLPutData"), so the
+// parity run stays skipped.
+TEST_F(CrossConversionLiveTest, CrossFamilyDataAtExecutionConvertsToInteger) {
     SKIP_IF_COMPARING_MSODBCSQL();
 
     for (SQLSMALLINT c_type : {SQL_C_CHAR, SQL_C_WCHAR}) {
-        ASSERT_SQL_OK(Prepare("SELECT ? AS v"), SQL_HANDLE_STMT, stmt_);
+        ASSERT_SQL_OK(Prepare("SELECT ? + 1"), SQL_HANDLE_STMT, stmt_);
 
-        SQLLEN ind = SQL_DATA_AT_EXEC;
+        SQLLEN ind = SQL_LEN_DATA_AT_EXEC(0);
         SQLCHAR token = 0;
-        // The bind itself is accepted - that is the change from before.
         ASSERT_SQL_OK(SQLBindParameter(stmt_, 1, SQL_PARAM_INPUT, c_type, SQL_INTEGER,
                                        0, 0, &token, 0, &ind),
                       SQL_HANDLE_STMT, stmt_);
 
-        EXPECT_EQ(SQL_ERROR, SQLExecute(stmt_)) << "c type " << c_type;
-        EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "HYC00");
+        ASSERT_EQ(SQL_NEED_DATA, SQLExecute(stmt_)) << "c type " << c_type;
+        SQLPOINTER returned = nullptr;
+        ASSERT_EQ(SQL_NEED_DATA, SQLParamData(stmt_, &returned));
+
+        if (c_type == SQL_C_WCHAR) {
+            const SQLCHAR wide[] = {'4', 0, '1', 0};
+            ASSERT_SQL_OK(SQLPutData(stmt_, const_cast<SQLCHAR*>(wide), sizeof(wide)),
+                          SQL_HANDLE_STMT, stmt_);
+        } else {
+            const SQLCHAR narrow[] = {'4', '1'};
+            ASSERT_SQL_OK(SQLPutData(stmt_, const_cast<SQLCHAR*>(narrow), sizeof(narrow)),
+                          SQL_HANDLE_STMT, stmt_);
+        }
+
+        ASSERT_SQL_OK(SQLParamData(stmt_, &returned), SQL_HANDLE_STMT, stmt_);
+        ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+        EXPECT_EQ("42", GetColumnChar(1)) << "c type " << c_type;
+        EXPECT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
         ResetParams();
     }
 }

--- a/mssql-tds/src/message/parameters/rpc_parameters.rs
+++ b/mssql-tds/src/message/parameters/rpc_parameters.rs
@@ -105,6 +105,10 @@ pub(crate) struct EncryptedRpcValue {
 /// written before the total value length is known. Callers buffer any other type
 /// and send it materialized.
 ///
+/// This selects the *wire* type only. The `@params` declaration can be narrowed
+/// independently - see [`RpcParameter::with_streamed_declaration`] - so a
+/// `varchar(10)` parameter still streams its body as `varchar(max)`.
+///
 /// TODO: extend to the remaining PLP types (`xml`, `json`, `udt`, `text`, `ntext`,
 /// `image`) for parity with the incremental read path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -118,7 +122,9 @@ pub enum StreamedSqlType {
 }
 
 impl StreamedSqlType {
-    /// Declaration name for the `sp_executesql` `@params` string. Delegates to
+    /// Default declaration name for the `sp_executesql` `@params` string, used
+    /// when the caller supplied no narrower one via
+    /// [`RpcParameter::with_streamed_declaration`]. Delegates to
     /// [`RpcParameter::get_sql_name_impl`] on the equivalent materialized
     /// [`SqlType`] rather than duplicating the `nvarchar(MAX)` / `varchar(MAX)`
     /// / `varbinary(MAX)` strings, so the two can't drift apart.
@@ -165,6 +171,10 @@ pub struct RpcParameter {
     /// Applied to both the SQL declaration and the wire `TYPE_INFO`.
     type_metadata: Option<RpcTypeMetadata>,
 
+    /// Declaration for a streamed parameter whose `@params` type is narrower
+    /// than its PLP body. See [`RpcParameter::with_streamed_declaration`].
+    streamed_declaration: Option<SqlType>,
+
     /// When present, the parameter is sent encrypted (Always Encrypted): the
     /// ciphertext is serialized as a BIGVARBINARY with the ENCRYPTED status flag
     /// and a trailing CryptoMetaData block, bypassing the plaintext `value`.
@@ -187,6 +197,7 @@ impl RpcParameter {
             options,
             value: RpcValue::Materialized(value),
             type_metadata: None,
+            streamed_declaration: None,
             encrypted: None,
             force_column_encryption: false,
         }
@@ -203,9 +214,27 @@ impl RpcParameter {
             options,
             value: RpcValue::Streamed(sql_type),
             type_metadata: None,
+            streamed_declaration: None,
             encrypted: None,
             force_column_encryption: false,
         }
+    }
+
+    /// Declares a streamed parameter as `declaration` in the `@params` string
+    /// while its value body stays PLP-framed.
+    ///
+    /// The two are independent: PLP framing needs an unknown-length opener, so
+    /// the wire `TYPE_INFO` is always a `max`, but the variable the value is
+    /// assigned to can still be a bounded `varchar(n)`. That is how a streamed
+    /// parameter honours `ColumnSize` without giving up chunking, and it is
+    /// what msodbcsql sends (`odbc/sqlccmd.cpp:4676` passes `cbColDef`
+    /// alongside `VARMAX_INDICATOR`).
+    ///
+    /// Ignored for a materialized parameter, whose declaration comes from its
+    /// own value.
+    pub fn with_streamed_declaration(mut self, declaration: SqlType) -> Self {
+        self.streamed_declaration = Some(declaration);
+        self
     }
 
     /// Returns `true` if this parameter's value is supplied via the
@@ -246,7 +275,10 @@ impl RpcParameter {
     pub(crate) fn sql_declaration(&self) -> TdsResult<String> {
         match &self.value {
             RpcValue::Materialized(value) => Self::get_sql_name(value, self.type_metadata),
-            RpcValue::Streamed(streamed) => streamed.sql_name(),
+            RpcValue::Streamed(streamed) => match &self.streamed_declaration {
+                Some(declaration) => Self::get_sql_name(declaration, self.type_metadata),
+                None => streamed.sql_name(),
+            },
         }
     }
 


### PR DESCRIPTION
## Description

`SQLBindParameter`'s `ParameterType` and `ColumnSize` were ignored for data-at-execution parameters: every DAE value was streamed as a `max` type regardless of what the application declared, and no length bound was enforced. This aligns the DAE path with msodbcsql on both counts.

**Declaration follows `ParameterType`.** `dae_plan` decides stream-vs-buffer from the SQL type's PLP-ability, mirroring msodbcsql's `IsPartialLenType` (`sqlcprot.h:1421`), which keys on the SQL type alone rather than on `ColumnSize`. Only `VARCHAR`/`WVARCHAR`/`VARBINARY` and their `LONG` spellings stream; a fixed-width target (`CHAR`, `BINARY`, `INTEGER`, ...) is now collected and converted whole through the ordinary materializing path instead of being forced into a `max` stream it cannot represent.

**`ColumnSize` bounds the value.** `dae_streamed_declaration` narrows the `@params` declaration (`varchar(n)` rather than `varchar(max)`), and `dae_length_limit` enforces the accumulated total in `SQLPutData`. The bound is applied before the streamed/buffered split and against the application buffer, matching where msodbcsql runs `ValidatePutDataLength` (`sqlccmd.cpp:4571`) — so `22001` lands on the `SQLPutData` that overflows rather than at close. Trailing pad units are trimmed rather than rejected, and trimmed padding does not consume the declaration's budget.

**Transcoding is streamed, not deferred.** `DaeTranscode` converts each chunk on the way out, carrying a trailing partial character (`incomplete_utf8_tail` / `incomplete_utf16_tail`, including a lone high surrogate) into the next call — the same shape as msodbcsql's `ConvertLongData` (`sqlccnvt.cpp:841`) with its `cbTruncatedCharsInConvBuf` carry and end-of-value flush (`sqlccmd.cpp:5999-6001`). Narrow encoding reuses `encode_narrow` from #444, so the streamed and materialized paths agree on the wire bytes. This closes the gap #444 documented as `...StillMisencodesNonAscii`; that test is un-skipped and renamed `...Transcodes`.

`text`/`ntext`/`image` keep their `max` substitution, tracked separately under [AB#47592](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47592).

### Notes for reviewers

- Rebased onto `main` after #444 merged. The `try_reserve` OOM guard added in #444 is preserved and re-sited onto whichever accumulator receives the bytes — `buffer` for a value converted at close, `carry` for one converted on the way out.
- Two integration bugs surfaced only in combination with #444 and neither branch exhibits them alone: `buffered_dae_to_rpc` must repoint **both** `strlen_or_ind_ptr` and `octet_length_ptr` (#444 split the indicator from the length, so repointing only the first left `SQL_DATA_AT_EXEC` on the synthesized binding).
- **Pre-existing, not from this change:** re-preparing a statement after a failed DAE execute panics with `orphan_prepared_handle: a pending unprepare already exists`. Verified by stashing this branch and reproducing on a clean tree. A Rust panic unwinding through the C ABI is UB and deserves its own work item.

## Related Issues

https://sqlclientdrivers.visualstudio.com/DefaultCollection/mssql-rs/_workitems/edit/47590

[AB#47590](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47590)

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes (workspace + `mssql-tds` + `mssql-py-core`)
- [x] `cargo btest` passes (1301 `mssqlodbc`, 2100 `mssql-tds`)
- [x] New/changed functionality has tests
- [x] Public API changes are documented

### Validation

- All 41 e2e suites pass against this driver.
- msodbcsql parity leg: `param_binary` 25, `param_char` 22, `param_cross` 17, `execute` 59, `session_recovery` 1.
