### PR TITLE
Report NUMERIC result columns as SQL_NUMERIC

### DIFF
--- a/mssql-odbc/src/api/describe_col.rs
+++ b/mssql-odbc/src/api/describe_col.rs
@@ -196,8 +196,9 @@ pub(crate) fn odbc_sql_type(meta: &mssql_tds::query::metadata::ColumnMetadata) -
             8 => SQL_DOUBLE,
             _ => SQL_UNKNOWN_TYPE,
         },
-        TdsDataType::Decimal | TdsDataType::DecimalN => SQL_DECIMAL,
-        TdsDataType::Numeric | TdsDataType::NumericN => SQL_NUMERIC,
+        TdsDataType::DecimalN => SQL_DECIMAL,
+        // msodbcsql's rgbSRV2SQLTYPE maps the legacy fixed SQLDECIMAL token to SQL_NUMERIC.
+        TdsDataType::Decimal | TdsDataType::Numeric | TdsDataType::NumericN => SQL_NUMERIC,
         TdsDataType::Money | TdsDataType::Money4 | TdsDataType::MoneyN => SQL_DECIMAL,
         TdsDataType::DateN => SQL_TYPE_DATE,
         // SQL Server's `time` supports up to 7-digit fractional seconds; SQL_TYPE_TIME

--- a/mssql-odbc/src/api/describe_col.rs
+++ b/mssql-odbc/src/api/describe_col.rs
@@ -315,9 +315,8 @@ pub(crate) fn decimal_digits(meta: &mssql_tds::query::metadata::ColumnMetadata) 
     }
 }
 
-// Unit tests cover the validation/error paths only. The metadata-driven mapping
-// helpers (`odbc_sql_type`, `column_size`, `decimal_digits`) cannot be exercised
-// here because `mssql_tds::ColumnMetadata::type_info_variant` is `pub(crate)`
+// Precision- and scale-dependent branches in `column_size` and `decimal_digits` cannot
+// be exercised here because `mssql_tds::ColumnMetadata::type_info_variant` is `pub(crate)`
 // and there is no public constructor — those branches are covered end-to-end by
 // `tests/e2e/tests/describe_col_test.cpp` against a live SQL Server.
 #[cfg(test)]
@@ -354,6 +353,28 @@ mod tests {
     fn null_handle_returns_invalid_handle() {
         let rc = unsafe { describe(ptr::null_mut(), 1) };
         assert_eq!(rc, SQL_INVALID_HANDLE);
+    }
+
+    #[test]
+    fn decimal_numeric_and_money_types_match_msodbcsql() {
+        let mut columns = int_columns(1);
+        let meta = &mut columns[0];
+
+        for (tds_type, length, sql_type) in [
+            (TdsDataType::Decimal, 17, SQL_NUMERIC),
+            (TdsDataType::DecimalN, 17, SQL_DECIMAL),
+            (TdsDataType::Numeric, 17, SQL_NUMERIC),
+            (TdsDataType::NumericN, 17, SQL_NUMERIC),
+            (TdsDataType::Money, 8, SQL_DECIMAL),
+            (TdsDataType::Money4, 4, SQL_DECIMAL),
+            (TdsDataType::MoneyN, 8, SQL_DECIMAL),
+        ] {
+            meta.data_type = tds_type;
+            meta.type_info.tds_type = tds_type;
+            meta.type_info.length = length;
+
+            assert_eq!(odbc_sql_type(meta), sql_type, "{tds_type:?}");
+        }
     }
 
     #[test]

--- a/mssql-odbc/src/api/describe_col.rs
+++ b/mssql-odbc/src/api/describe_col.rs
@@ -9,10 +9,10 @@ use tracing::{debug, error};
 use crate::api::odbc_types::{
     SQL_BIGINT, SQL_BINARY, SQL_BIT, SQL_CHAR, SQL_DECIMAL, SQL_DOUBLE, SQL_ERROR, SQL_GUID,
     SQL_INTEGER, SQL_INVALID_HANDLE, SQL_LONGVARBINARY, SQL_LONGVARCHAR, SQL_NO_NULLS,
-    SQL_NULLABLE, SQL_REAL, SQL_SMALLINT, SQL_SS_TIME2, SQL_SS_TIMESTAMPOFFSET, SQL_SS_VARIANT,
-    SQL_SUCCESS, SQL_SUCCESS_WITH_INFO, SQL_TINYINT, SQL_TYPE_DATE, SQL_TYPE_TIMESTAMP,
-    SQL_UNKNOWN_TYPE, SQL_VARBINARY, SQL_VARCHAR, SQL_WCHAR, SQL_WLONGVARCHAR, SQL_WVARCHAR,
-    SqlHandle, SqlReturn, SqlSmallInt, SqlUSmallInt, SqlWChar,
+    SQL_NULLABLE, SQL_NUMERIC, SQL_REAL, SQL_SMALLINT, SQL_SS_TIME2, SQL_SS_TIMESTAMPOFFSET,
+    SQL_SS_VARIANT, SQL_SUCCESS, SQL_SUCCESS_WITH_INFO, SQL_TINYINT, SQL_TYPE_DATE,
+    SQL_TYPE_TIMESTAMP, SQL_UNKNOWN_TYPE, SQL_VARBINARY, SQL_VARCHAR, SQL_WCHAR, SQL_WLONGVARCHAR,
+    SQL_WVARCHAR, SqlHandle, SqlReturn, SqlSmallInt, SqlUSmallInt, SqlWChar,
 };
 use crate::api::sqlstate::{
     ERR_FUNCTION_SEQUENCE, ERR_INVALID_DESCRIPTOR_INDEX, WARN_STRING_TRUNCATION, post_diag,
@@ -196,10 +196,8 @@ pub(crate) fn odbc_sql_type(meta: &mssql_tds::query::metadata::ColumnMetadata) -
             8 => SQL_DOUBLE,
             _ => SQL_UNKNOWN_TYPE,
         },
-        TdsDataType::Decimal
-        | TdsDataType::DecimalN
-        | TdsDataType::Numeric
-        | TdsDataType::NumericN => SQL_DECIMAL,
+        TdsDataType::Decimal | TdsDataType::DecimalN => SQL_DECIMAL,
+        TdsDataType::Numeric | TdsDataType::NumericN => SQL_NUMERIC,
         TdsDataType::Money | TdsDataType::Money4 | TdsDataType::MoneyN => SQL_DECIMAL,
         TdsDataType::DateN => SQL_TYPE_DATE,
         // SQL Server's `time` supports up to 7-digit fractional seconds; SQL_TYPE_TIME

--- a/mssql-odbc/tests/e2e/tests/describe_col_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/describe_col_test.cpp
@@ -7,7 +7,7 @@
 //   3.  BasicMetadata                       - INT/VARCHAR/NVARCHAR cols → name + type + size
 //   4.  NameTruncationReturnsInfo           - short name buf → SUCCESS_WITH_INFO + 01004 + full length
 //   5.  InvalidColumnOrdinal                - column 0 (bookmark) and past-end → 07009
-//   6.  DecimalPrecisionAndScale            - DECIMAL(10,2) → SQL_DECIMAL, colSize=10, decDigits=2
+//   6.  DecimalAndNumericPrecisionAndScale  - DECIMAL/NUMERIC preserve distinct SQL type codes
 //   7.  NullableFlag                        - sys.objects.name (NOT NULL) vs principal_id (NULL)
 //   8.  DateTime2AndDateTimeOffset          - datetime2 → SQL_TYPE_TIMESTAMP, datetimeoffset → -155
 //   9.  NVarCharColumnSizeIsCharCount       - NVARCHAR(100) → colSize=100 (chars, not bytes)
@@ -142,8 +142,8 @@ TEST_F(DescribeColLiveTest, InvalidColumnOrdinal) {
     SQLCloseCursor(stmt_);
 }
 
-TEST_F(DescribeColLiveTest, DecimalPrecisionAndScale) {
-    ExecDirect("SELECT CAST(3.14 AS DECIMAL(10,2)) AS d");
+TEST_F(DescribeColLiveTest, DecimalAndNumericPrecisionAndScale) {
+    ExecDirect("SELECT CAST(3.14 AS DECIMAL(10,2)) AS d, CAST(6.28 AS NUMERIC(12,3)) AS n");
 
     SQLSMALLINT dataType = 0;
     SQLULEN colSize = 0;
@@ -156,6 +156,13 @@ TEST_F(DescribeColLiveTest, DecimalPrecisionAndScale) {
     EXPECT_EQ(SQL_DECIMAL, dataType);
     EXPECT_EQ(10u, colSize);
     EXPECT_EQ(2, decDigits);
+
+    rc = SQLDescribeCol(
+        stmt_, 2, nullptr, 0, nullptr, &dataType, &colSize, &decDigits, &nullable);
+    ASSERT_SQL_OK(rc, SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(SQL_NUMERIC, dataType);
+    EXPECT_EQ(12u, colSize);
+    EXPECT_EQ(3, decDigits);
 
     SQLCloseCursor(stmt_);
 }

--- a/mssql-odbc/tests/e2e/tests/describe_col_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/describe_col_test.cpp
@@ -143,7 +143,9 @@ TEST_F(DescribeColLiveTest, InvalidColumnOrdinal) {
 }
 
 TEST_F(DescribeColLiveTest, DecimalAndNumericPrecisionAndScale) {
-    ExecDirect("SELECT CAST(3.14 AS DECIMAL(10,2)) AS d, CAST(6.28 AS NUMERIC(12,3)) AS n");
+    ExecDirect(
+        "SELECT CAST(3.14 AS DECIMAL(10,2)) AS d, CAST(6.28 AS NUMERIC(12,3)) AS n, 1.5 AS "
+        "literal");
 
     SQLSMALLINT dataType = 0;
     SQLULEN colSize = 0;
@@ -163,6 +165,13 @@ TEST_F(DescribeColLiveTest, DecimalAndNumericPrecisionAndScale) {
     EXPECT_EQ(SQL_NUMERIC, dataType);
     EXPECT_EQ(12u, colSize);
     EXPECT_EQ(3, decDigits);
+
+    rc = SQLDescribeCol(
+        stmt_, 3, nullptr, 0, nullptr, &dataType, &colSize, &decDigits, &nullable);
+    ASSERT_SQL_OK(rc, SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(SQL_NUMERIC, dataType);
+    EXPECT_EQ(2u, colSize);
+    EXPECT_EQ(1, decDigits);
 
     SQLCloseCursor(stmt_);
 }


### PR DESCRIPTION
<!--
Thank you for your interest in this project!

This repository is not currently accepting external pull requests. If you've found
a bug or have a feature request, please open an issue instead.

If you are a Microsoft team member, please follow the instructions in the internal
contribution guide.
-->

## Description

<!-- Briefly describe the change. -->

`SQLDescribeColW` now reports SQL Server `NUMERIC` result columns, including uncast decimal literals that SQL Server infers as `NUMERIC`, as `SQL_NUMERIC` while preserving `SQL_DECIMAL` for `DECIMALN` and money types. For full msodbcsql parity, the legacy fixed `SQLDECIMAL` token also reports `SQL_NUMERIC`. This restores exact SQL-type output-converter dispatch in mssql-python.

The mapping matches `Sql/Ntdbms/sqlncli/odbc/sqlcmisc.cpp` in msodbcsql. The bundled msodbcsql 18.6.2.1 reference driver (`SQL_DRIVER_VER=18.06.0002`) and the fixed Rust driver both pass the two affected mssql-python tests. Unit coverage anchors the legacy and nullable decimal, numeric, and money mappings; the live e2e case covers explicit decimal/numeric columns and uncast decimal literals.

Validation:
- `cargo bfmt`
- `cargo bclippy`
- `cargo btest -E 'not binary(connectivity)'` (3,760 tests passed)
- `cargo nextest run -p mssqlodbc decimal_numeric_and_money_types_match_msodbcsql`
- The two affected `tests/test_003_connection.py` pytest cases (2 passed)

The unfiltered `cargo btest` run has four unrelated `mssql-tds::connectivity` failures that require Azure identity or certificate-specific test conditions.

## Related Issues

<!--
Required: link a GitHub issue OR an Azure DevOps work item. The PR check will
fail without one.
GitHub issue: Fixes #123 (or https://github.com/microsoft/mssql-rs/issues/123)
ADO work item: https://sqlclientdrivers.visualstudio.com/<...>/_workitems/edit/<ID>
  (any project/collection path is accepted, e.g. .../<project>/_workitems/edit/123
  or .../DefaultCollection/<project>/_workitems/edit/123)
-->

[AB#47818](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47818)

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes
- [x] New/changed functionality has tests
- [x] Public API changes are documented (N/A - no public API change)