### PR TITLE
Report CLR UDT columns as SQL_SS_UDT

### DIFF
--- a/.github/instructions/mssql-odbc.instructions.md
+++ b/.github/instructions/mssql-odbc.instructions.md
@@ -116,13 +116,13 @@ authoritative parity reference for this crate. Its source lives in the
     `BufferLength` 0 is exempt — the documented idiom for a fixed-width target,
     carrying no width claim. Whether these should instead report `01004` with a
     truncated value, closer to msodbcsql, is open and untracked.
-  - A `varbinary` / `image` column bound `SQL_C_DEFAULT` resolves to
-    `SQL_C_BINARY` (`describe_col.rs` → `SQL_VARBINARY` / `SQL_LONGVARBINARY`,
-    then `resolve_default_c_type`), which bound delivery does not implement yet
-    (AB#47239), so it fails per row with `HYC00`. msodbcsql resolves identically
-    and delivers the bytes. Pre-existing for an explicit `SQL_C_BINARY` bind;
-    deferred resolution makes it reachable without the application naming the C
-    type.
+  - A `varbinary` / `image` / CLR UDT column bound `SQL_C_DEFAULT` resolves to
+    `SQL_C_BINARY` (`describe_col.rs` → `SQL_VARBINARY` / `SQL_LONGVARBINARY` /
+    `SQL_SS_UDT`, then `resolve_default_c_type`), which bound delivery does not
+    implement yet (AB#47239), so it fails per row with `HYC00`. msodbcsql
+    resolves identically and delivers the bytes. Pre-existing for an explicit
+    `SQL_C_BINARY` bind; deferred resolution makes it reachable without the
+    application naming the C type.
   - `SQL_C_CHAR` is **UTF-8** in both directions; the driver never reads or
     writes the client code page. msodbcsql uses the client code page -
     `dwClientCodePage = SystemLocale::Singleton().AnsiCP()`

--- a/.github/instructions/mssql-odbc.instructions.md
+++ b/.github/instructions/mssql-odbc.instructions.md
@@ -119,10 +119,12 @@ authoritative parity reference for this crate. Its source lives in the
   - A `varbinary` / `image` / CLR UDT column bound `SQL_C_DEFAULT` resolves to
     `SQL_C_BINARY` (`describe_col.rs` → `SQL_VARBINARY` / `SQL_LONGVARBINARY` /
     `SQL_SS_UDT`, then `resolve_default_c_type`), which bound delivery does not
-    implement yet (AB#47239), so it fails per row with `HYC00`. msodbcsql
-    resolves identically and delivers the bytes. Pre-existing for an explicit
-    `SQL_C_BINARY` bind; deferred resolution makes it reachable without the
-    application naming the C type.
+    implement yet (AB#47239), so it fails per row with `HYC00`. For `varbinary`
+    and `image`, deferred resolution exposes the pre-existing explicit
+    `SQL_C_BINARY` gap without the application naming the C type. A UDT's former
+    `SQL_C_CHAR` default was already unsupported, so the new mapping does not
+    regress observable fetch behavior. msodbcsql resolves all three to
+    `SQL_C_BINARY` and delivers the bytes.
   - `SQL_C_CHAR` is **UTF-8** in both directions; the driver never reads or
     writes the client code page. msodbcsql uses the client code page -
     `dwClientCodePage = SystemLocale::Singleton().AnsiCP()`

--- a/mssql-odbc/src/api/col_attribute.rs
+++ b/mssql-odbc/src/api/col_attribute.rs
@@ -408,6 +408,8 @@ fn display_size(meta: &ColumnMetadata) -> SqlLen {
 /// representation, which for the temporal types is the C struct the driver
 /// hands back, not the TDS payload width.
 pub(super) fn octet_length(meta: &ColumnMetadata) -> SqlLen {
+    // A bounded UDT is still PLP; use its byte limit for binary transfer while
+    // display_size remains zero because the opaque value has no text rendering.
     if meta.data_type == TdsDataType::Udt {
         return desc_length(meta);
     }

--- a/mssql-odbc/src/api/col_attribute.rs
+++ b/mssql-odbc/src/api/col_attribute.rs
@@ -335,7 +335,7 @@ fn binary_precision(meta: &ColumnMetadata) -> Option<SqlSmallInt> {
 /// digits) for a column size of 10, a GUID needs 36, and binary renders as two
 /// hex characters per byte.
 fn display_size(meta: &ColumnMetadata) -> SqlLen {
-    // `*(max)`, xml and json are unbounded; ODBC reports zero.
+    // `*(max)`, xml, json, and opaque UDTs have no fixed character display size.
     if meta.is_plp() {
         return 0;
     }
@@ -408,6 +408,9 @@ fn display_size(meta: &ColumnMetadata) -> SqlLen {
 /// representation, which for the temporal types is the C struct the driver
 /// hands back, not the TDS payload width.
 pub(super) fn octet_length(meta: &ColumnMetadata) -> SqlLen {
+    if meta.data_type == TdsDataType::Udt {
+        return desc_length(meta);
+    }
     if meta.is_plp() {
         return 0;
     }
@@ -632,8 +635,7 @@ fn type_name(meta: &ColumnMetadata) -> &'static str {
     }
 }
 
-// Only `int` column metadata can be built outside the decoder (`int_columns`),
-// so the per-type mapping tables are covered end-to-end by
+// Most per-type mapping tables are covered end-to-end by
 // `tests/e2e/tests/col_attribute_test.cpp` against a live SQL Server.
 #[cfg(test)]
 mod tests {
@@ -646,7 +648,7 @@ mod tests {
     use crate::api::sqlstate::ERR_INVALID_DESCRIPTOR_FIELD;
     use crate::test_support::TestHandles;
     use mssql_tds::datatypes::sqldatatypes::TypeInfo;
-    use mssql_tds::test_client_support::int_columns;
+    use mssql_tds::test_client_support::{int_columns, udt_column};
 
     /// A statement positioned on a result set of `n` nullable `int` columns.
     fn stmt_with_int_columns(h: &TestHandles, n: usize) {
@@ -1387,6 +1389,18 @@ mod tests {
                 .expect("varchar(max) is a PLP type");
         }
         assert_eq!(numeric(&h, 1, SQL_DESC_OCTET_LENGTH), 0);
+    }
+
+    #[test]
+    fn udt_size_attributes_match_bounded_and_unbounded_metadata() {
+        for (max_byte_size, expected_size) in [(u16::MAX, 0), (892, 892)] {
+            let meta = udt_column(max_byte_size);
+
+            assert_eq!(desc_length(&meta), expected_size);
+            assert_eq!(SqlLen::from(precision(&meta)), expected_size);
+            assert_eq!(octet_length(&meta), expected_size);
+            assert_eq!(display_size(&meta), 0);
+        }
     }
 
     /// A `decimal` carries its own precision on the wire, which takes

--- a/mssql-odbc/src/api/describe_col.rs
+++ b/mssql-odbc/src/api/describe_col.rs
@@ -228,12 +228,19 @@ pub(crate) fn odbc_sql_type(meta: &mssql_tds::query::metadata::ColumnMetadata) -
         // reporting the column as character data hides the variant entirely.
         TdsDataType::SsVariant => SQL_SS_VARIANT,
         TdsDataType::Udt => SQL_SS_UDT,
+        // Result delivery does not support SQL_C_SS_VECTOR yet; retaining the
+        // character type keeps SQL_C_DEFAULT fetches on the working text path.
         TdsDataType::Vector => SQL_VARCHAR,
         _ => SQL_UNKNOWN_TYPE,
     }
 }
 
 pub(crate) fn column_size(meta: &mssql_tds::query::metadata::ColumnMetadata) -> u64 {
+    // CLR UDT metadata is PLP even when MAX_BYTE_SIZE is bounded. Only 0xFFFF
+    // carries the unbounded convention used by geography and geometry.
+    if meta.data_type == TdsDataType::Udt && meta.type_info.length != usize::from(u16::MAX) {
+        return meta.type_info.length as u64;
+    }
     // PLP / `*(max)` / xml / json: ColumnSize is "unbounded". Report 0 per ODBC spec
     if meta.is_plp() {
         return 0;
@@ -323,7 +330,7 @@ mod tests {
 
     use super::*;
     use crate::test_support::TestHandles;
-    use mssql_tds::test_client_support::int_columns;
+    use mssql_tds::test_client_support::{int_columns, udt_column};
 
     /// Calls `sql_describe_col_w` with default-ish out pointers. Intended for
     /// error-path tests where the values of the out params are irrelevant.
@@ -354,14 +361,15 @@ mod tests {
     }
 
     #[test]
-    fn udt_column_reports_sql_ss_udt() {
-        let mut metadata = int_columns(1);
-        let meta = metadata.first_mut().unwrap();
-        meta.data_type = TdsDataType::Udt;
-        meta.type_info.tds_type = TdsDataType::Udt;
-        meta.type_info.length = usize::from(u16::MAX);
+    fn udt_column_reports_sql_ss_udt_metadata() {
+        for (max_byte_size, expected_column_size) in [(u16::MAX, 0), (892, 892)] {
+            let meta = udt_column(max_byte_size);
 
-        assert_eq!(odbc_sql_type(meta), SQL_SS_UDT);
+            assert!(meta.is_plp());
+            assert_eq!(odbc_sql_type(&meta), SQL_SS_UDT);
+            assert_eq!(column_size(&meta), expected_column_size);
+            assert_eq!(decimal_digits(&meta), 0);
+        }
     }
 
     #[test]

--- a/mssql-odbc/src/api/describe_col.rs
+++ b/mssql-odbc/src/api/describe_col.rs
@@ -9,10 +9,10 @@ use tracing::{debug, error};
 use crate::api::odbc_types::{
     SQL_BIGINT, SQL_BINARY, SQL_BIT, SQL_CHAR, SQL_DECIMAL, SQL_DOUBLE, SQL_ERROR, SQL_GUID,
     SQL_INTEGER, SQL_INVALID_HANDLE, SQL_LONGVARBINARY, SQL_LONGVARCHAR, SQL_NO_NULLS,
-    SQL_NULLABLE, SQL_REAL, SQL_SMALLINT, SQL_SS_TIME2, SQL_SS_TIMESTAMPOFFSET, SQL_SS_VARIANT,
-    SQL_SUCCESS, SQL_SUCCESS_WITH_INFO, SQL_TINYINT, SQL_TYPE_DATE, SQL_TYPE_TIMESTAMP,
-    SQL_UNKNOWN_TYPE, SQL_VARBINARY, SQL_VARCHAR, SQL_WCHAR, SQL_WLONGVARCHAR, SQL_WVARCHAR,
-    SqlHandle, SqlReturn, SqlSmallInt, SqlUSmallInt, SqlWChar,
+    SQL_NULLABLE, SQL_REAL, SQL_SMALLINT, SQL_SS_TIME2, SQL_SS_TIMESTAMPOFFSET, SQL_SS_UDT,
+    SQL_SS_VARIANT, SQL_SUCCESS, SQL_SUCCESS_WITH_INFO, SQL_TINYINT, SQL_TYPE_DATE,
+    SQL_TYPE_TIMESTAMP, SQL_UNKNOWN_TYPE, SQL_VARBINARY, SQL_VARCHAR, SQL_WCHAR, SQL_WLONGVARCHAR,
+    SQL_WVARCHAR, SqlHandle, SqlReturn, SqlSmallInt, SqlUSmallInt, SqlWChar,
 };
 use crate::api::sqlstate::{
     ERR_FUNCTION_SEQUENCE, ERR_INVALID_DESCRIPTOR_INDEX, WARN_STRING_TRUNCATION, post_diag,
@@ -227,7 +227,8 @@ pub(crate) fn odbc_sql_type(meta: &mssql_tds::query::metadata::ColumnMetadata) -
         // mssql-python keys its sql_variant handling off this exact type, so
         // reporting the column as character data hides the variant entirely.
         TdsDataType::SsVariant => SQL_SS_VARIANT,
-        TdsDataType::Vector | TdsDataType::Udt => SQL_VARCHAR,
+        TdsDataType::Udt => SQL_SS_UDT,
+        TdsDataType::Vector => SQL_VARCHAR,
         _ => SQL_UNKNOWN_TYPE,
     }
 }
@@ -316,11 +317,6 @@ pub(crate) fn decimal_digits(meta: &mssql_tds::query::metadata::ColumnMetadata) 
     }
 }
 
-// Unit tests cover the validation/error paths only. The metadata-driven mapping
-// helpers (`odbc_sql_type`, `column_size`, `decimal_digits`) cannot be exercised
-// here because `mssql_tds::ColumnMetadata::type_info_variant` is `pub(crate)`
-// and there is no public constructor — those branches are covered end-to-end by
-// `tests/e2e/tests/describe_col_test.cpp` against a live SQL Server.
 #[cfg(test)]
 mod tests {
     use std::ptr;
@@ -355,6 +351,17 @@ mod tests {
     fn null_handle_returns_invalid_handle() {
         let rc = unsafe { describe(ptr::null_mut(), 1) };
         assert_eq!(rc, SQL_INVALID_HANDLE);
+    }
+
+    #[test]
+    fn udt_column_reports_sql_ss_udt() {
+        let mut metadata = int_columns(1);
+        let meta = metadata.first_mut().unwrap();
+        meta.data_type = TdsDataType::Udt;
+        meta.type_info.tds_type = TdsDataType::Udt;
+        meta.type_info.length = usize::from(u16::MAX);
+
+        assert_eq!(odbc_sql_type(meta), SQL_SS_UDT);
     }
 
     #[test]

--- a/mssql-odbc/src/api/describe_param.rs
+++ b/mssql-odbc/src/api/describe_param.rs
@@ -538,9 +538,9 @@ fn describe_tds_type(
         }
         TdsDataType::Image => (SQL_LONGVARBINARY, parameter_length(length, false)?, 0),
         TdsDataType::SsVariant => (SQL_SS_VARIANT, 8000, 0),
-        // Unbounded types report a size of 0, the same "unbounded" convention
-        // `describe_col::column_size` already uses for PLP. A table type has no
-        // meaningful column size at all.
+        // Parameter discovery does not include the CLR MAX_BYTE_SIZE carried by
+        // COLMETADATA, so UDT size remains 0. XML is unbounded; a table type has
+        // no meaningful column size at all.
         TdsDataType::Udt => (SQL_SS_UDT, 0, 0),
         TdsDataType::Xml => (SQL_SS_XML, 0, 0),
         TdsDataType::SqlTable => (SQL_SS_TABLE, 0, 0),

--- a/mssql-odbc/src/api/describe_param.rs
+++ b/mssql-odbc/src/api/describe_param.rs
@@ -538,10 +538,11 @@ fn describe_tds_type(
         }
         TdsDataType::Image => (SQL_LONGVARBINARY, parameter_length(length, false)?, 0),
         TdsDataType::SsVariant => (SQL_SS_VARIANT, 8000, 0),
-        // Parameter discovery does not include the CLR MAX_BYTE_SIZE carried by
-        // COLMETADATA, so UDT size remains 0. XML is unbounded; a table type has
-        // no meaningful column size at all.
+        // Although `suggested_tds_length` carries CLR MAX_BYTE_SIZE, retail
+        // msodbcsql 18.6.2.1 reports ParameterSize 0 for bounded and unbounded
+        // UDT parameters. Result columns report the bounded size.
         TdsDataType::Udt => (SQL_SS_UDT, 0, 0),
+        // XML is unbounded; a table type has no meaningful column size at all.
         TdsDataType::Xml => (SQL_SS_XML, 0, 0),
         TdsDataType::SqlTable => (SQL_SS_TABLE, 0, 0),
         // Neither of the next two arms fires against a shipping server. On SQL
@@ -973,6 +974,24 @@ mod tests {
 
         for (row, expected) in cases {
             assert_eq!(parse_parameter_row(&row, 1, true).unwrap().1, expected);
+        }
+    }
+
+    #[test]
+    fn udt_parameter_size_matches_msodbcsql() {
+        for length in [892, -1, i32::from(u16::MAX)] {
+            let (_, description) =
+                parse_parameter_row(&row(1, TdsDataType::Udt, length, 0, 0), 1, true).unwrap();
+
+            assert_eq!(
+                description,
+                ParameterDescription {
+                    data_type: SQL_SS_UDT,
+                    parameter_size: 0,
+                    decimal_digits: 0,
+                    nullable: SQL_NULLABLE,
+                }
+            );
         }
     }
 

--- a/mssql-odbc/src/api/fetch_scroll.rs
+++ b/mssql-odbc/src/api/fetch_scroll.rs
@@ -736,12 +736,13 @@ impl RowWriter for BoundRowWriter<'_> {
 /// the result set also stays unresolved, but never reaches delivery: the fill
 /// loop skips it, matching msodbcsql.
 ///
-/// A `varbinary` / `image` / CLR UDT column resolves to `SQL_C_BINARY`, which
-/// bound delivery does not implement yet (AB#47239), so it fails per row with
-/// `HYC00`. That is pre-existing for an explicit `SQL_C_BINARY` bind; deferred
-/// resolution makes it reachable without the application naming the C type, and
-/// it covers more common column types than the `time` / `datetimeoffset` stride
-/// case. msodbcsql resolves identically and delivers the bytes.
+/// A `varbinary` / `image` column resolves to `SQL_C_BINARY`, which bound
+/// delivery does not implement yet (AB#47239), so it fails per row with `HYC00`.
+/// That is pre-existing for an explicit `SQL_C_BINARY` bind; deferred resolution
+/// makes it reachable without the application naming the C type. A CLR UDT now
+/// resolves to `SQL_C_BINARY` too, but its former `SQL_C_CHAR` default was
+/// already unsupported, so the mapping change introduces no fetch regression.
+/// msodbcsql resolves all three identically and delivers the bytes.
 ///
 /// A resolved fixed-width target is left unresolved as well when the
 /// application declared a `BufferLength` too small to hold it. `BufferLength`

--- a/mssql-odbc/src/api/fetch_scroll.rs
+++ b/mssql-odbc/src/api/fetch_scroll.rs
@@ -710,8 +710,8 @@ impl RowWriter for BoundRowWriter<'_> {
 /// the result set also stays unresolved, but never reaches delivery: the fill
 /// loop skips it, matching msodbcsql.
 ///
-/// A `varbinary` / `image` column resolves to `SQL_C_BINARY`, which bound
-/// delivery does not implement yet (AB#47239), so it fails per row with
+/// A `varbinary` / `image` / CLR UDT column resolves to `SQL_C_BINARY`, which
+/// bound delivery does not implement yet (AB#47239), so it fails per row with
 /// `HYC00`. That is pre-existing for an explicit `SQL_C_BINARY` bind; deferred
 /// resolution makes it reachable without the application naming the C type, and
 /// it covers more common column types than the `time` / `datetimeoffset` stride

--- a/mssql-odbc/tests/e2e/tests/col_attribute_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/col_attribute_test.cpp
@@ -27,7 +27,7 @@
 //   20. VariantTypeOnNonVariantColumn     - HY113
 //   21. VariantUnderlyingTypeAfterProbe   - probe then SQL_CA_SS_VARIANT_TYPE
 //   22. VariantTypeBeforeProbeIsSequenceError - attribute before the value is read
-//   23. ClrUdtTypeFields                   - verbose and concise types are SQL_SS_UDT
+//   23. ClrUdtDescriptorFields             - CLR UDT type and size-bearing fields
 
 #include "odbc_test_fixture.h"
 
@@ -123,13 +123,34 @@ TEST_F(ColAttributeLiveTest, ConciseTypePerColumnType) {
     SQLCloseCursor(stmt_);
 }
 
-TEST_F(ColAttributeLiveTest, ClrUdtTypeFields) {
+TEST_F(ColAttributeLiveTest, ClrUdtDescriptorFields) {
     ExecDirect("SELECT CAST(NULL AS geography) AS geography_col, "
                "CAST(NULL AS geometry) AS geometry_col, "
                "CAST(NULL AS hierarchyid) AS hierarchyid_col");
-    for (SQLUSMALLINT col : {1, 2, 3}) {
-        EXPECT_EQ(SQL_SS_UDT, NumericAttr(stmt_, col, SQL_DESC_TYPE)) << "column " << col;
-        EXPECT_EQ(SQL_SS_UDT, NumericAttr(stmt_, col, SQL_DESC_CONCISE_TYPE)) << "column " << col;
+
+    struct UdtColumn {
+        SQLUSMALLINT ordinal;
+        SQLLEN size;
+    };
+    const UdtColumn columns[] = {
+        {1, 0},
+        {2, 0},
+        {3, 892},
+    };
+
+    for (const auto& column : columns) {
+        EXPECT_EQ(SQL_SS_UDT, NumericAttr(stmt_, column.ordinal, SQL_DESC_TYPE))
+            << "column " << column.ordinal;
+        EXPECT_EQ(SQL_SS_UDT, NumericAttr(stmt_, column.ordinal, SQL_DESC_CONCISE_TYPE))
+            << "column " << column.ordinal;
+        EXPECT_EQ(column.size, NumericAttr(stmt_, column.ordinal, SQL_DESC_LENGTH))
+            << "column " << column.ordinal;
+        EXPECT_EQ(column.size, NumericAttr(stmt_, column.ordinal, SQL_DESC_PRECISION))
+            << "column " << column.ordinal;
+        EXPECT_EQ(column.size, NumericAttr(stmt_, column.ordinal, SQL_DESC_OCTET_LENGTH))
+            << "column " << column.ordinal;
+        EXPECT_EQ(0, NumericAttr(stmt_, column.ordinal, SQL_DESC_DISPLAY_SIZE))
+            << "column " << column.ordinal;
     }
     SQLCloseCursor(stmt_);
 }

--- a/mssql-odbc/tests/e2e/tests/col_attribute_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/col_attribute_test.cpp
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // col_attribute_test.cpp  –  E2E tests for SQLColAttributeW.
 //
-// Unit tests can only build `int` column metadata, so the per-type mapping
-// tables (concise type, type name, radix, and the sql_variant underlying type)
-// are only meaningfully exercised here, against a live server.
+// Per-type mapping tables (concise type, type name, radix, and the sql_variant
+// underlying type) are meaningfully exercised here against live server metadata.
 //
 // Verifies:
 //   1.  NullHandle                        - SQL_NULL_HSTMT → SQL_INVALID_HANDLE
@@ -28,6 +27,7 @@
 //   20. VariantTypeOnNonVariantColumn     - HY113
 //   21. VariantUnderlyingTypeAfterProbe   - probe then SQL_CA_SS_VARIANT_TYPE
 //   22. VariantTypeBeforeProbeIsSequenceError - attribute before the value is read
+//   23. ClrUdtTypeFields                   - verbose and concise types are SQL_SS_UDT
 
 #include "odbc_test_fixture.h"
 
@@ -40,6 +40,9 @@
 #endif
 #ifndef SQL_SS_VARIANT
 #define SQL_SS_VARIANT (-150)
+#endif
+#ifndef SQL_SS_UDT
+#define SQL_SS_UDT (-151)
 #endif
 
 class ColAttributeLiveTest : public ODBCTest {
@@ -117,6 +120,17 @@ TEST_F(ColAttributeLiveTest, ConciseTypePerColumnType) {
     EXPECT_EQ(SQL_VARCHAR, NumericAttr(stmt_, 2, SQL_DESC_CONCISE_TYPE));
     EXPECT_EQ(SQL_WVARCHAR, NumericAttr(stmt_, 3, SQL_DESC_CONCISE_TYPE));
     EXPECT_EQ(SQL_DECIMAL, NumericAttr(stmt_, 4, SQL_DESC_CONCISE_TYPE));
+    SQLCloseCursor(stmt_);
+}
+
+TEST_F(ColAttributeLiveTest, ClrUdtTypeFields) {
+    ExecDirect("SELECT CAST(NULL AS geography) AS geography_col, "
+               "CAST(NULL AS geometry) AS geometry_col, "
+               "CAST(NULL AS hierarchyid) AS hierarchyid_col");
+    for (SQLUSMALLINT col : {1, 2, 3}) {
+        EXPECT_EQ(SQL_SS_UDT, NumericAttr(stmt_, col, SQL_DESC_TYPE)) << "column " << col;
+        EXPECT_EQ(SQL_SS_UDT, NumericAttr(stmt_, col, SQL_DESC_CONCISE_TYPE)) << "column " << col;
+    }
     SQLCloseCursor(stmt_);
 }
 

--- a/mssql-odbc/tests/e2e/tests/describe_col_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/describe_col_test.cpp
@@ -11,12 +11,17 @@
 //   7.  NullableFlag                        - sys.objects.name (NOT NULL) vs principal_id (NULL)
 //   8.  DateTime2AndDateTimeOffset          - datetime2 → SQL_TYPE_TIMESTAMP, datetimeoffset → -155
 //   9.  NVarCharColumnSizeIsCharCount       - NVARCHAR(100) → colSize=100 (chars, not bytes)
+//  10.  ClrUdtColumnsReportSqlSsUdt          - geography/geometry/hierarchyid → SQL_SS_UDT
 
 #include "odbc_test_fixture.h"
 
 // SQL Server-specific types not in standard <sqlext.h>.
 #ifndef SQL_SS_TIMESTAMPOFFSET
 #define SQL_SS_TIMESTAMPOFFSET (-155)
+#endif
+
+#ifndef SQL_SS_UDT
+#define SQL_SS_UDT (-151)
 #endif
 
 // SQLDescribeColW with SQL_NULL_HSTMT — DM rejects before driver.
@@ -224,6 +229,22 @@ TEST_F(DescribeColLiveTest, NVarCharColumnSizeIsCharCount) {
     ASSERT_SQL_OK(rc, SQL_HANDLE_STMT, stmt_);
     EXPECT_EQ(SQL_WVARCHAR, dataType);
     EXPECT_EQ(100u, colSize);
+
+    SQLCloseCursor(stmt_);
+}
+
+TEST_F(DescribeColLiveTest, ClrUdtColumnsReportSqlSsUdt) {
+    ExecDirect("SELECT CAST(NULL AS geography) AS geography_col, "
+               "CAST(NULL AS geometry) AS geometry_col, "
+               "CAST(NULL AS hierarchyid) AS hierarchyid_col");
+
+    for (SQLUSMALLINT column : {SQLUSMALLINT{1}, SQLUSMALLINT{2}, SQLUSMALLINT{3}}) {
+        SQLSMALLINT dataType = 0;
+        SQLRETURN rc = SQLDescribeCol(
+            stmt_, column, nullptr, 0, nullptr, &dataType, nullptr, nullptr, nullptr);
+        ASSERT_SQL_OK(rc, SQL_HANDLE_STMT, stmt_);
+        EXPECT_EQ(SQL_SS_UDT, dataType) << "column=" << column;
+    }
 
     SQLCloseCursor(stmt_);
 }

--- a/mssql-odbc/tests/e2e/tests/describe_col_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/describe_col_test.cpp
@@ -11,7 +11,7 @@
 //   7.  NullableFlag                        - sys.objects.name (NOT NULL) vs principal_id (NULL)
 //   8.  DateTime2AndDateTimeOffset          - datetime2 → SQL_TYPE_TIMESTAMP, datetimeoffset → -155
 //   9.  NVarCharColumnSizeIsCharCount       - NVARCHAR(100) → colSize=100 (chars, not bytes)
-//  10.  ClrUdtColumnsReportSqlSsUdt          - geography/geometry/hierarchyid → SQL_SS_UDT
+//  10.  ClrUdtColumnsReportSqlSsUdt          - CLR UDT type, size, scale, and nullability
 
 #include "odbc_test_fixture.h"
 
@@ -238,12 +238,36 @@ TEST_F(DescribeColLiveTest, ClrUdtColumnsReportSqlSsUdt) {
                "CAST(NULL AS geometry) AS geometry_col, "
                "CAST(NULL AS hierarchyid) AS hierarchyid_col");
 
-    for (SQLUSMALLINT column : {SQLUSMALLINT{1}, SQLUSMALLINT{2}, SQLUSMALLINT{3}}) {
+    struct UdtColumn {
+        SQLUSMALLINT ordinal;
+        SQLULEN size;
+    };
+    const UdtColumn columns[] = {
+        {1, 0},
+        {2, 0},
+        {3, 892},
+    };
+
+    for (const auto& column : columns) {
         SQLSMALLINT dataType = 0;
+        SQLULEN colSize = 0;
+        SQLSMALLINT decDigits = -1;
+        SQLSMALLINT nullable = SQL_NULLABLE_UNKNOWN;
         SQLRETURN rc = SQLDescribeCol(
-            stmt_, column, nullptr, 0, nullptr, &dataType, nullptr, nullptr, nullptr);
+            stmt_,
+            column.ordinal,
+            nullptr,
+            0,
+            nullptr,
+            &dataType,
+            &colSize,
+            &decDigits,
+            &nullable);
         ASSERT_SQL_OK(rc, SQL_HANDLE_STMT, stmt_);
-        EXPECT_EQ(SQL_SS_UDT, dataType) << "column=" << column;
+        EXPECT_EQ(SQL_SS_UDT, dataType) << "column=" << column.ordinal;
+        EXPECT_EQ(column.size, colSize) << "column=" << column.ordinal;
+        EXPECT_EQ(0, decDigits) << "column=" << column.ordinal;
+        EXPECT_EQ(SQL_NULLABLE, nullable) << "column=" << column.ordinal;
     }
 
     SQLCloseCursor(stmt_);

--- a/mssql-odbc/tests/e2e/tests/describe_param_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/describe_param_test.cpp
@@ -6,6 +6,10 @@
 #include <array>
 #include <string>
 
+#ifndef SQL_SS_UDT
+#define SQL_SS_UDT (-151)
+#endif
+
 namespace {
 
 struct ParamDescription {
@@ -117,6 +121,28 @@ TEST_F(DescribeParamLiveTest, ReportsRepresentativeMetadata) {
         {SQL_VARBINARY, 16, 0, SQL_NULLABLE},
         {SQL_DECIMAL, 12, 3, SQL_NULLABLE},
         {SQL_TYPE_TIMESTAMP, 24, 4, SQL_NULLABLE},
+    }};
+
+    for (SQLUSMALLINT ordinal = 1; ordinal <= expected.size(); ++ordinal) {
+        ParamDescription actual;
+        ASSERT_TRUE(Describe(ordinal, actual)) << "ordinal " << ordinal;
+        const ParamDescription& wanted = expected[ordinal - 1];
+        EXPECT_EQ(wanted.data_type, actual.data_type) << "ordinal " << ordinal;
+        EXPECT_EQ(wanted.size, actual.size) << "ordinal " << ordinal;
+        EXPECT_EQ(wanted.scale, actual.scale) << "ordinal " << ordinal;
+        EXPECT_EQ(wanted.nullable, actual.nullable) << "ordinal " << ordinal;
+    }
+}
+
+TEST_F(DescribeParamLiveTest, DescribesClrUdtMetadata) {
+    ASSERT_SQL_OK(
+        Prepare("SELECT CAST(? AS geography), CAST(? AS geometry), CAST(? AS hierarchyid)"),
+        SQL_HANDLE_STMT, stmt_);
+
+    const std::array<ParamDescription, 3> expected = {{
+        {SQL_SS_UDT, 0, 0, SQL_NULLABLE},
+        {SQL_SS_UDT, 0, 0, SQL_NULLABLE},
+        {SQL_SS_UDT, 0, 0, SQL_NULLABLE},
     }};
 
     for (SQLUSMALLINT ordinal = 1; ordinal <= expected.size(); ++ordinal) {

--- a/mssql-tds/src/test_client_support.rs
+++ b/mssql-tds/src/test_client_support.rs
@@ -432,6 +432,20 @@ pub fn int_columns(n: usize) -> Vec<ColumnMetadata> {
         .collect()
 }
 
+/// A nullable CLR UDT column with the wire-declared maximum byte size.
+pub fn udt_column(max_byte_size: u16) -> ColumnMetadata {
+    ColumnMetadata {
+        user_type: 0,
+        flags: 0x01,
+        type_info: TypeInfo::partial_len(TdsDataType::Udt, usize::from(max_byte_size), None)
+            .expect("UDT is a PLP type"),
+        data_type: TdsDataType::Udt,
+        column_name: "udt".to_string(),
+        multi_part_name: None,
+        crypto_metadata: None,
+    }
+}
+
 /// Inline integer columns followed by one deferred `nvarchar(max)` column.
 pub fn mixed_lob_columns(prefix_columns: usize) -> Vec<ColumnMetadata> {
     let mut columns = int_columns(prefix_columns);


### PR DESCRIPTION
<!--
Thank you for your interest in this project!

This repository is not currently accepting external pull requests. If you've found
a bug or have a feature request, please open an issue instead.

If you are a Microsoft team member, please follow the instructions in the internal
contribution guide.
-->

## Description

<!-- Briefly describe the change. -->

SQL Server CLR UDT columns were exposed by `SQLDescribeCol` as `SQL_VARCHAR`, causing consumers such as mssql-python to select character bindings for binary UDT values.

Map `TdsDataType::Udt` to the SQL Server-specific `SQL_SS_UDT` type and report the wire-declared maximum byte size for bounded UDTs. Live parity coverage checks `SQLDescribeCol` type, size, scale, and nullability plus `SQLColAttribute` fields `SQL_DESC_TYPE`, `SQL_DESC_CONCISE_TYPE`, `SQL_DESC_LENGTH`, `SQL_DESC_PRECISION`, `SQL_DESC_OCTET_LENGTH`, and `SQL_DESC_DISPLAY_SIZE` for `geography`, `geometry`, and `hierarchyid`. This matches retail msodbcsql: the unbounded spatial types report zero size, while `hierarchyid` reports 892 for length, precision, and octet length and zero display size.

`odbc_sql_type` also drives fetch-side `SQL_C_DEFAULT` resolution, so a UDT now resolves to `SQL_C_BINARY` instead of `SQL_C_CHAR`. Observable bound-fetch behavior remains `HYC00` before and after because binary PLP delivery is not implemented yet ([AB#47239](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47239)); actual UDT value delivery remains outside this work item.

Vector deliberately retains its existing `SQL_VARCHAR` mapping. Vector values currently have a working character-rendering path, while result delivery for `SQL_C_SS_VECTOR` is not implemented; changing the advertised type here would regress `SQL_C_DEFAULT` bound fetches to `HYC00` and needs dedicated vector result-delivery coverage.

**Validation**

- `cargo bfmt`
- `cargo bclippy`
- Focused Rust UDT metadata and descriptor-size unit tests
- `cargo btest -E "not (test(connectivity))"`: 3,761 passed, 40 skipped
- Full C++ ODBC suite: 38/38 binaries passed against both the Rust driver and retail msodbcsql 18.6.2.1 (`SQL_DRIVER_VER=18.06.0002`), with zero parity divergences
- Targeted mssql-python metadata tests: 3 failures before, 3 passes after
- Full mssql-python suite: failures/errors reduced from 253 to 250; only the geography, geometry, and hierarchyid metadata tests were resolved, with no new or missing tests

## Related Issues

<!--
Required: link a GitHub issue OR an Azure DevOps work item. The PR check will
fail without one.
GitHub issue: Fixes #123 (or https://github.com/microsoft/mssql-rs/issues/123)
ADO work item: https://sqlclientdrivers.visualstudio.com/<...>/_workitems/edit/<ID>
  (any project/collection path is accepted, e.g. .../<project>/_workitems/edit/123
  or .../DefaultCollection/<project>/_workitems/edit/123)
-->

Fixes [AB#47541](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47541)

https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47541

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes
- [x] New/changed functionality has tests
- [x] Public API changes are documented (N/A: no public API changes)