### PR TITLE
Capture code-review skill drift at review time

### DIFF
--- a/.github/ISSUE_TEMPLATE/code_review_skill_drift.yml
+++ b/.github/ISSUE_TEMPLATE/code_review_skill_drift.yml
@@ -1,0 +1,95 @@
+name: Code Review Skill Drift
+description: Record something a review learned that the code-review skill got wrong, missed, or no longer matches
+title: "[review-skill] "
+labels: ["skill:code-review"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For observations about `.github/skills/code-review/SKILL.md` itself — not about the code under review.
+        File one issue per observation so each can be judged on its own evidence.
+
+        These issues are the queue a periodic maintenance pass reads when proposing skill edits, so
+        favor a precise observation with evidence over a polished suggestion.
+
+  - type: dropdown
+    id: class
+    attributes:
+      label: Drift class
+      options:
+        - Wrong finding — raised, then retracted or downgraded after checking
+        - Missed defect — the skill's checklist should have caught it and didn't
+        - Stale fact — a constant, path, or behavior in the skill no longer matches the repo
+        - Wasted step — cost review time without changing the outcome
+        - Mechanizable — this finding class recurs and a lint, test, or CI check could catch it
+    validations:
+      required: true
+
+  - type: input
+    id: source
+    attributes:
+      label: Where it happened
+      description: PR, review thread, or comment URL.
+    validations:
+      required: true
+
+  - type: textarea
+    id: says
+    attributes:
+      label: What the skill says today
+      description: >-
+        Quote the bullet or section, or state that nothing covers this. If the skill is silent,
+        say what a reviewer would reasonably have assumed instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: observed
+    attributes:
+      label: What actually turned out to be true
+      description: The observation that contradicts it, in the terms a future reviewer would need.
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: >-
+        `file:line`, the command you ran and its output, the reference-driver source, or the
+        thread where it was settled. An assertion without one of these can't be promoted.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: cost
+    attributes:
+      label: What it cost
+      description: Sets the bar for acting on a single occurrence rather than waiting for a repeat.
+      options:
+        - A retracted blocking finding
+        - A retracted or downgraded non-blocking finding
+        - A defect reached main
+        - Review time only
+        - Nothing yet — noticed before it mattered
+    validations:
+      required: true
+
+  - type: textarea
+    id: recurrence
+    attributes:
+      label: Prior occurrences
+      description: Links to earlier instances, if you know of any. Recurrence is what promotes an entry.
+    validations:
+      required: false
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: >-
+        Optional. If prose, name the section it belongs in and what it would replace — the skill is
+        read on every review and has a size budget, so additions are traded against removals. If a
+        check would catch it instead, say which one and skip the prose.
+    validations:
+      required: false

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -11,8 +11,8 @@ affected code — do not critique pre-existing code outside the PR's scope.
 Every concrete number, constant, and known-failure list below is a dated observation,
 not a standing truth. Prefer the command that re-derives a fact over the value written
 here. If what you observe contradicts this file, trust the observation and report the
-drift separately — an issue or PR against this skill, not the summary of whatever PR
-you happen to be reviewing. Skill maintenance is not that author's problem.
+drift separately — see "Reporting Skill Drift", not the summary of whatever PR you
+happen to be reviewing. Skill maintenance is not that author's problem.
 
 ## Process
 
@@ -344,6 +344,46 @@ than `gh pr review`, diff-hunk anchoring, `--paginate` when verifying — are in
 3. Each finding for a specific `file:line` gives a concrete fix or a focused code
    snippet — not just "this is wrong." Leave the comment at that line so it carries
    context and can be tracked to resolution.
+4. **Skill drift** — one line per observation, or `none`. Report it every time; a
+   section left off is indistinguishable from one nobody checked. This is a note to
+   the human, not part of the posted review.
+
+## Reporting Skill Drift
+
+You are the only reader who sees both this file and what the code actually did, and
+that pairing is gone the moment the review ends. Reconstructing it later from the
+thread is far more expensive than a line written now.
+
+Report when:
+
+- You retracted or downgraded a finding after checking it — most of all one this file
+  told you to check anyway.
+- A defect got past the checks in this file, whether CI, a human, or a later PR caught
+  it.
+- A fact here no longer matches the repo: a constant, a path, a workflow behavior, a
+  known-failure list.
+- A step cost time without changing the outcome, or you raised a class of finding that
+  a lint, test, or CI check could have caught before review.
+
+File each one separately, with the evidence rather than a conclusion:
+
+```bash
+gh issue create --repo microsoft/mssql-rs --label skill:code-review \
+  --title "[review-skill] <one-line drift>"
+```
+
+The `Code Review Skill Drift` issue form prompts for the same fields. These issues are
+the queue a periodic maintenance pass reads, so one that isn't acted on immediately is
+still doing its job. The bar is whether a future review would repeat the mistake — a
+one-off you could not have anticipated is not drift. Search the label before filing;
+recurrence belongs on the existing issue, where it is the evidence that promotes it:
+
+```bash
+gh issue list --repo microsoft/mssql-rs --label skill:code-review --state all --search "<symbol>"
+```
+
+Unattended runs file these too — it is the one write worth making when no human is
+watching, since nothing else preserves the observation.
 
 ## Principles
 

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -365,24 +365,46 @@ Report when:
 - A step cost time without changing the outcome, or you raised a class of finding that
   a lint, test, or CI check could have caught before review.
 
-File each one separately, with the evidence rather than a conclusion:
+File each one separately, with the evidence rather than a conclusion. Interactively, use
+the form so it prompts you for the fields:
+
+<https://github.com/microsoft/mssql-rs/issues/new?template=code_review_skill_drift.yml>
+
+`gh issue create` does not apply the form, so write the body yourself with the same
+headings. An issue missing them is a note, not something a later pass can promote:
+
+```markdown
+### Drift class
+wrong finding | missed defect | stale fact | wasted step | mechanizable
+### Where it happened
+<PR, review thread, or comment URL>
+### What the skill says today
+<quote the bullet, or state that nothing covers this>
+### What actually turned out to be true
+<the observation, in the terms a future reviewer would need>
+### Evidence
+<file:line, the command and its output, or the thread where it was settled>
+### What it cost
+retracted blocking finding | retracted lesser finding | defect reached main |
+review time only | nothing yet
+```
 
 ```bash
 gh issue create --repo microsoft/mssql-rs --label skill:code-review \
-  --title "[review-skill] <one-line drift>"
+  --title "[review-skill] <one-line drift>" --body-file <path>
 ```
 
-The `Code Review Skill Drift` issue form prompts for the same fields. These issues are
-the queue a periodic maintenance pass reads, so one that isn't acted on immediately is
-still doing its job. The bar is whether a future review would repeat the mistake — a
-one-off you could not have anticipated is not drift. Search the label before filing;
-recurrence belongs on the existing issue, where it is the evidence that promotes it:
+Search the label before filing; recurrence belongs on the existing issue, where it is the
+evidence that promotes it:
 
 ```bash
 gh issue list --repo microsoft/mssql-rs --label skill:code-review --state all --search "<symbol>"
 ```
 
-Unattended runs file these too — it is the one write worth making when no human is
+These issues are the queue a periodic maintenance pass reads, so one that isn't acted on
+immediately is still doing its job. The bar is whether a future review would repeat the
+mistake — a one-off you could not have anticipated is not drift. Unattended runs file
+these too, with the same body; it is the one write worth making when no human is
 watching, since nothing else preserves the observation.
 
 ## Principles


### PR DESCRIPTION
## Description

Step 1 of the feedback loop in #496: make a review's own learning survive the review.

`.github/skills/code-review/SKILL.md` already tells reviewers that a fact contradicting the file should be reported as "an issue or PR against this skill." That instruction has no destination, no format, and nothing that aggregates the results, so in practice every improvement to the skill (#332, #378, #407, #410) has come from a human remembering a bad review afterward and reconstructing it. The reviewing agent is the only reader that sees both the skill text and what the code actually did, and that pairing is gone the moment the review ends.

Three changes:

**`.github/ISSUE_TEMPLATE/code_review_skill_drift.yml`** — a new issue form, labeled `skill:code-review`. Its fields are chosen to be what a later maintenance pass needs in order to promote an observation into skill text, not what is pleasant to write: drift class, where it happened, what the skill says today, what turned out to be true, evidence, and what it cost. Evidence and cost are required — an assertion without a `file:line`, a command, or a settled thread can't be acted on, and cost is what justifies acting on a single occurrence instead of waiting for a repeat. The optional "proposed change" field points at mechanization first and notes that the skill has a size budget, so a proposal to add prose is a proposal to remove some.

**`SKILL.md` — a required item 4 in `Output Format`.** One line per observation, or `none`, every review. Reporting `none` explicitly costs a line and buys the ability to tell a clean review from an inattentive one; without a denominator, a later retraction-rate metric means nothing. It is a note to the human, not part of the posted review.

**`SKILL.md` — a new `Reporting Skill Drift` section.** Defines the four qualifying classes (a finding you retracted or downgraded, a defect the checklist should have caught, a fact that no longer matches the repo, a step that wasted time or a class a lint could catch), gives the `gh issue create` invocation, and requires a label search before filing so that a second occurrence lands on the existing issue — recurrence is the evidence that promotes an entry, and it only accumulates if duplicates converge. Unattended runs file these too; it is the one write worth making when no human is watching. The preamble's vague pointer now names this section.

The `skill:code-review` label has been created on the repo, so the form applies it on first use.

## Related Issues

Part of #496

## Checklist

- [x] `cargo bfmt` passes — n/a, no Rust changed
- [x] `cargo bclippy` passes — n/a, no Rust changed
- [x] `cargo btest` passes — n/a, no Rust changed
- [x] New/changed functionality has tests — n/a, documentation and issue-template only; the YAML was parsed to confirm it loads and carries the expected field ids
- [x] Public API changes are documented — n/a, no API change