### PR TITLE
Install the newest bottled docker CLI instead of source-building it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,7 @@ crash-*
 .venv-pycore/mssql-py-core/pytest-smoke-results.xml
 
 ghcookies.txt
+
+# Python bytecode
+__pycache__/
+*.py[cod]

--- a/.pipeline/scripts/README.md
+++ b/.pipeline/scripts/README.md
@@ -91,16 +91,41 @@ Installs Docker + Colima on a hosted macOS agent and boots the VM, retrying on
 the transient lima hostagent boot failures seen in ~3% of runs. VM size stays at
 the long-standing 4 GiB / 4 CPU.
 
+The docker CLI is installed with `brew install --force-bottle`, which uses
+Homebrew's bottle when one exists for the platform and *fails* rather than
+falling back to a source build. When it fails, `install-brew-bottle.py` installs
+the newest version that *is* bottled for this platform, taken straight from
+Homebrew's own registry. As of 29.8.0 there is no Intel macOS bottle, so a bare
+`brew install docker` compiles the CLI and builds Go to do it: measured over 147
+runs, the bottled path took 29s median and failed 1% of the time, the
+source-build path took 441s median (774s max) and failed 36%. `colima` and
+`lima` are still bottled on Intel and install normally.
+
+### install-brew-bottle.py
+Installs the newest Homebrew bottle of a formula that exists for the running
+platform, by reading Homebrew's OCI registry on ghcr.io directly. Used as the
+docker CLI fallback above, and generic enough to cover `colima` or `lima` if they
+lose their Intel bottles too.
+
+Bottles are content-addressed, so the download is verified against the digest the
+registry advertises rather than a checksum vendored here. Bottles built for an
+older macOS are accepted (they run on newer hosts) but never a newer one.
+
+**Usage:** `install-brew-bottle.py <formula> <dest-bin-dir>`; prints the resolved
+version. Test overrides: `BOTTLE_ARCH_OVERRIDE`, `BOTTLE_MACOS_MAJOR_OVERRIDE`.
+
 Each `colima start` is bounded by `COLIMA_START_TIMEOUT_SECONDS` so a wedged
 boot still reaches the delete/retry path rather than running until the pipeline
-step timeout. That bound sits above the slowest healthy boot observed over 113
-runs (509s; p95 366s) — the real failures give up within seconds, so a shorter
-bound would only kill slow-but-healthy boots. `COLIMA_BUDGET_SECONDS` then caps
-the retries as a whole.
+step timeout. That bound sits above the slowest healthy boot observed (509s over
+113 runs in 2026-08; re-measured 2026-09 at max 453s over 123 runs) — the real
+failures give up within seconds, so a shorter bound would only kill
+slow-but-healthy boots. `COLIMA_BUDGET_SECONDS` then caps the retries as a
+whole, and the install phase has its own `INSTALL_TIMEOUT_SECONDS`.
 
 **Environment overrides:** `COLIMA_CPU`, `COLIMA_MEMORY`, `COLIMA_DISK`,
 `COLIMA_START_ATTEMPTS` (3), `COLIMA_START_TIMEOUT_SECONDS` (540),
-`COLIMA_BUDGET_SECONDS` (480).
+`COLIMA_BUDGET_SECONDS` (480), `INSTALL_TIMEOUT_SECONDS` (300),
+`DOCKER_CLI_DIR`.
 
 ### start-sql-server-macos.sh
 Starts the SQL Server test container inside the Colima VM. Retries the image

--- a/.pipeline/scripts/README.md
+++ b/.pipeline/scripts/README.md
@@ -101,6 +101,21 @@ runs, the bottled path took 29s median and failed 1% of the time, the
 source-build path took 441s median (774s max) and failed 36%. `colima` and
 `lima` are still bottled on Intel and install normally.
 
+The whole install phase (`brew update`, `colima`, the docker CLI) is bounded by
+`INSTALL_TIMEOUT_SECONDS` so a slow install fails here with a message rather than
+surfacing as an opaque step timeout. Each `colima start` is bounded by
+`COLIMA_START_TIMEOUT_SECONDS` so a wedged boot still reaches the delete/retry
+path rather than running until the pipeline step timeout. That bound sits above
+the slowest healthy boot observed (509s over 113 runs in 2026-08; re-measured
+2026-09 at max 453s over 123 runs) — the real failures give up within seconds, so
+a shorter bound would only kill slow-but-healthy boots. `COLIMA_BUDGET_SECONDS`
+then caps the retries as a whole.
+
+**Environment overrides:** `COLIMA_CPU`, `COLIMA_MEMORY`, `COLIMA_DISK`,
+`COLIMA_START_ATTEMPTS` (3), `COLIMA_START_TIMEOUT_SECONDS` (540),
+`COLIMA_BUDGET_SECONDS` (480), `INSTALL_TIMEOUT_SECONDS` (300),
+`DOCKER_CLI_DIR`.
+
 ### install-brew-bottle.py
 Installs the newest Homebrew bottle of a formula that exists for the running
 platform, by reading Homebrew's OCI registry on ghcr.io directly. Used as the
@@ -109,23 +124,21 @@ lose their Intel bottles too.
 
 Bottles are content-addressed, so the download is verified against the digest the
 registry advertises rather than a checksum vendored here. Bottles built for an
-older macOS are accepted (they run on newer hosts) but never a newer one.
+older macOS are accepted (they run on newer hosts) but never a newer one; a macOS
+major the script doesn't recognize is an error rather than a guess, because
+guessing means handing the agent a binary it can't run. Formulas bottled `:all`
+are not selected — the CLIs installed here aren't, and taking one blindly is
+worse than reporting no match.
+
+Homebrew spells a formula revision two ways: the registry tag is `29.7.2-1` but
+the ref names inside it read `29.7.2.<platform>.1`, so the two are matched
+separately. Only the newest `MAX_VERSIONS_SCANNED` (15) versions are examined —
+each costs a registry round-trip, and this keeps a no-match failure from eating
+the caller's install budget before it reports.
 
 **Usage:** `install-brew-bottle.py <formula> <dest-bin-dir>`; prints the resolved
 version. Test overrides: `BOTTLE_ARCH_OVERRIDE`, `BOTTLE_MACOS_MAJOR_OVERRIDE`.
-
-Each `colima start` is bounded by `COLIMA_START_TIMEOUT_SECONDS` so a wedged
-boot still reaches the delete/retry path rather than running until the pipeline
-step timeout. That bound sits above the slowest healthy boot observed (509s over
-113 runs in 2026-08; re-measured 2026-09 at max 453s over 123 runs) — the real
-failures give up within seconds, so a shorter bound would only kill
-slow-but-healthy boots. `COLIMA_BUDGET_SECONDS` then caps the retries as a
-whole, and the install phase has its own `INSTALL_TIMEOUT_SECONDS`.
-
-**Environment overrides:** `COLIMA_CPU`, `COLIMA_MEMORY`, `COLIMA_DISK`,
-`COLIMA_START_ATTEMPTS` (3), `COLIMA_START_TIMEOUT_SECONDS` (540),
-`COLIMA_BUDGET_SECONDS` (480), `INSTALL_TIMEOUT_SECONDS` (300),
-`DOCKER_CLI_DIR`.
+Covered by `test_install_brew_bottle.py`.
 
 ### start-sql-server-macos.sh
 Starts the SQL Server test container inside the Colima VM. Retries the image

--- a/.pipeline/scripts/install-brew-bottle.py
+++ b/.pipeline/scripts/install-brew-bottle.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Install the newest Homebrew bottle of a formula that exists for this platform.
+
+Homebrew publishes bottles as OCI artifacts on ghcr.io, readable anonymously.
+When `brew install --force-bottle` fails because the *current* formula version
+has no bottle for the running platform (docker 29.8.0 ships arm64 macOS and
+Linux only), the previous version usually still does. This walks the registry
+newest-first, finds a version bottled for this platform, and extracts its
+binaries.
+
+The bottle blob is content-addressed: the layer digest is its SHA-256, so the
+download is verified against the digest the registry advertises rather than a
+checksum vendored here that someone has to remember to bump.
+
+Usage: install-brew-bottle.py <formula> <dest-bin-dir>
+Prints the resolved version to stdout.
+"""
+
+import hashlib
+import json
+import os
+import platform
+import re
+import shutil
+import sys
+import tarfile
+import tempfile
+import time
+import urllib.error
+import urllib.request
+
+REGISTRY = "https://ghcr.io"
+REPO_PREFIX = "homebrew/core"
+
+# Oldest to newest. A bottle built for an older macOS runs on a newer one, so a
+# tag is usable when its index is <= the running OS, and higher is preferred.
+MACOS_CODENAMES = [
+    "el_capitan", "sierra", "high_sierra", "mojave", "catalina",
+    "big_sur", "monterey", "ventura", "sonoma", "sequoia", "tahoe",
+]
+MACOS_CODENAMES_BY_MAJOR = {
+    12: "monterey", 13: "ventura", 14: "sonoma", 15: "sequoia", 26: "tahoe",
+}
+
+
+def _get(url, token=None, accept=None, binary=False, attempts=3):
+    req = urllib.request.Request(url)
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    if accept:
+        req.add_header("Accept", accept)
+    last = None
+    for attempt in range(attempts):
+        try:
+            with urllib.request.urlopen(req, timeout=120) as resp:
+                body = resp.read()
+                return (body if binary else json.loads(body)), resp.headers
+        except urllib.error.HTTPError as exc:
+            # 4xx other than rate limiting is a permanent answer; retrying it
+            # only burns the install budget.
+            if 400 <= exc.code < 500 and exc.code not in (408, 429):
+                raise RuntimeError(f"GET {url} failed: HTTP {exc.code}") from None
+            last = exc
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+            last = exc
+        if attempt < attempts - 1:
+            time.sleep(5 * (attempt + 1))
+    raise RuntimeError(f"GET {url} failed after {attempts} attempts: {last}")
+
+
+def anonymous_token(formula):
+    scope = f"repository:{REPO_PREFIX}/{formula}:pull"
+    data, _ = _get(f"{REGISTRY}/token?service=ghcr.io&scope={scope}")
+    return data["token"]
+
+
+def list_versions(formula, token):
+    url = f"{REGISTRY}/v2/{REPO_PREFIX}/{formula}/tags/list?n=100"
+    tags = []
+    while url:
+        data, headers = _get(url, token=token)
+        tags.extend(data.get("tags", []))
+        link = headers.get("Link")
+        match = re.search(r"<([^>]+)>", link) if link else None
+        url = REGISTRY + match.group(1) if match else None
+    return tags
+
+
+def version_key(tag):
+    match = re.match(r"^(\d+)\.(\d+)\.(\d+)(?:[._-](\d+))?$", tag)
+    return tuple(int(part) for part in match.groups(default=0)) if match else None
+
+
+def current_os_rank():
+    override = os.environ.get("BOTTLE_MACOS_MAJOR_OVERRIDE")
+    major = int(override or platform.mac_ver()[0].split(".")[0] or 0)
+    codename = MACOS_CODENAMES_BY_MAJOR.get(major)
+    if codename is None:
+        # Unknown/newer macOS: accept the newest tag rather than nothing.
+        return len(MACOS_CODENAMES) - 1
+    return MACOS_CODENAMES.index(codename)
+
+
+def platform_prefix():
+    machine = os.environ.get("BOTTLE_ARCH_OVERRIDE") or platform.machine()
+    return "arm64_" if machine in ("arm64", "aarch64") else ""
+
+
+def usable_tag_rank(ref_name, version, prefix, max_rank):
+    """Rank of a bottle tag for this platform, or None if unusable."""
+    if not ref_name.startswith(f"{version}."):
+        return None
+    tag = ref_name[len(version) + 1:]
+    if "linux" in tag:
+        return None
+    if prefix:
+        if not tag.startswith(prefix):
+            return None
+        tag = tag[len(prefix):]
+    elif tag.startswith("arm64_"):
+        return None
+    if tag not in MACOS_CODENAMES:
+        return None
+    rank = MACOS_CODENAMES.index(tag)
+    return rank if rank <= max_rank else None
+
+
+def find_bottle(formula, token):
+    versions = [t for t in list_versions(formula, token) if version_key(t)]
+    versions.sort(key=version_key, reverse=True)
+    prefix = platform_prefix()
+    max_rank = current_os_rank()
+
+    for version in versions:
+        index, _ = _get(
+            f"{REGISTRY}/v2/{REPO_PREFIX}/{formula}/manifests/{version}",
+            token=token,
+            accept="application/vnd.oci.image.index.v1+json",
+        )
+        best = None
+        for manifest in index.get("manifests", []):
+            ref = manifest.get("annotations", {}).get("org.opencontainers.image.ref.name", "")
+            rank = usable_tag_rank(ref, version, prefix, max_rank)
+            if rank is not None and (best is None or rank > best[0]):
+                best = (rank, manifest["digest"], ref)
+        if best:
+            return version, best[1], best[2]
+    raise RuntimeError(f"no {formula} bottle found for this platform")
+
+
+def download_blob(formula, token, manifest_digest):
+    manifest, _ = _get(
+        f"{REGISTRY}/v2/{REPO_PREFIX}/{formula}/manifests/{manifest_digest}",
+        token=token,
+        accept="application/vnd.oci.image.manifest.v1+json",
+    )
+    layer = manifest["layers"][0]["digest"]
+    blob, _ = _get(
+        f"{REGISTRY}/v2/{REPO_PREFIX}/{formula}/blobs/{layer}",
+        token=token,
+        binary=True,
+    )
+    expected = layer.split(":", 1)[1]
+    actual = hashlib.sha256(blob).hexdigest()
+    if actual != expected:
+        raise RuntimeError(f"bottle digest mismatch: expected {expected}, got {actual}")
+    return blob
+
+
+def extract_bin(blob, formula, version, dest_dir):
+    os.makedirs(dest_dir, exist_ok=True)
+    wanted = f"{formula}/{version}/bin/"
+    installed = []
+    with tempfile.NamedTemporaryFile(suffix=".tar.gz") as tmp:
+        tmp.write(blob)
+        tmp.flush()
+        with tarfile.open(tmp.name, "r:gz") as tar:
+            for member in tar.getmembers():
+                # Only regular files directly under the formula's bin/, and never
+                # a path that escapes it -- the archive is untrusted input.
+                name = os.path.normpath(member.name)
+                if not member.isfile() or not name.startswith(wanted):
+                    continue
+                if os.path.basename(name) != name[len(wanted):]:
+                    continue
+                src = tar.extractfile(member)
+                if src is None:
+                    continue
+                target = os.path.join(dest_dir, os.path.basename(name))
+                with open(target, "wb") as out:
+                    shutil.copyfileobj(src, out)
+                os.chmod(target, 0o755)
+                installed.append(os.path.basename(name))
+    if not installed:
+        raise RuntimeError(f"bottle for {formula} {version} contained no bin/ entries")
+    return installed
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+    formula, dest_dir = sys.argv[1], sys.argv[2]
+
+    try:
+        token = anonymous_token(formula)
+        version, manifest_digest, ref = find_bottle(formula, token)
+        blob = download_blob(formula, token, manifest_digest)
+        installed = extract_bin(blob, formula, version, dest_dir)
+    except RuntimeError as exc:
+        print(f"##[error]{exc}")
+        return 1
+
+    print(f"{formula} {version} ({ref}) -> {dest_dir}: {', '.join(installed)}", file=sys.stderr)
+    print(version)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.pipeline/scripts/install-brew-bottle.py
+++ b/.pipeline/scripts/install-brew-bottle.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Install the newest Homebrew bottle of a formula that exists for this platform.
 
 Homebrew publishes bottles as OCI artifacts on ghcr.io, readable anonymously.
@@ -17,6 +20,7 @@ Prints the resolved version to stdout.
 """
 
 import hashlib
+import io
 import json
 import os
 import platform
@@ -24,13 +28,17 @@ import re
 import shutil
 import sys
 import tarfile
-import tempfile
 import time
 import urllib.error
 import urllib.request
 
 REGISTRY = "https://ghcr.io"
 REPO_PREFIX = "homebrew/core"
+
+# Every extra version costs a registry round-trip, and the answer is always in
+# the newest few. Bounds the no-match path so it reports failure while the
+# caller's install budget is still intact instead of walking the whole tag list.
+MAX_VERSIONS_SCANNED = 15
 
 # Oldest to newest. A bottle built for an older macOS runs on a newer one, so a
 # tag is usable when its index is <= the running OS, and higher is preferred.
@@ -39,8 +47,11 @@ MACOS_CODENAMES = [
     "big_sur", "monterey", "ventura", "sonoma", "sequoia", "tahoe",
 ]
 MACOS_CODENAMES_BY_MAJOR = {
-    12: "monterey", 13: "ventura", 14: "sonoma", 15: "sequoia", 26: "tahoe",
+    11: "big_sur", 12: "monterey", 13: "ventura", 14: "sonoma",
+    15: "sequoia", 26: "tahoe",
 }
+
+TAG_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:[._-](\d+))?$")
 
 
 def _get(url, token=None, accept=None, binary=False, attempts=3):
@@ -77,28 +88,54 @@ def anonymous_token(formula):
 def list_versions(formula, token):
     url = f"{REGISTRY}/v2/{REPO_PREFIX}/{formula}/tags/list?n=100"
     tags = []
-    while url:
+    seen = set()
+    while url and url not in seen:
+        seen.add(url)
         data, headers = _get(url, token=token)
         tags.extend(data.get("tags", []))
         link = headers.get("Link")
         match = re.search(r"<([^>]+)>", link) if link else None
-        url = REGISTRY + match.group(1) if match else None
+        if not match:
+            break
+        # `Link` is relative on ghcr.io, but the spec permits an absolute URL.
+        # `seen` stops a registry that keeps handing back the same page.
+        target = match.group(1)
+        url = target if target.startswith("http") else REGISTRY + target
     return tags
 
 
 def version_key(tag):
-    match = re.match(r"^(\d+)\.(\d+)\.(\d+)(?:[._-](\d+))?$", tag)
+    match = TAG_RE.match(tag)
     return tuple(int(part) for part in match.groups(default=0)) if match else None
+
+
+def ref_parts(tag):
+    """The `<base>` and `<revision>` a version tag's ref names are built from.
+
+    Homebrew spells a formula revision as `29.7.2-1` in the registry tag but as
+    `29.7.2.<platform>.1` in the ref names inside that tag's index, so the tag
+    cannot be matched against a ref name directly.
+    """
+    match = TAG_RE.match(tag)
+    return ".".join(match.group(1, 2, 3)), match.group(4)
 
 
 def current_os_rank():
     override = os.environ.get("BOTTLE_MACOS_MAJOR_OVERRIDE")
-    major = int(override or platform.mac_ver()[0].split(".")[0] or 0)
+    raw = override or platform.mac_ver()[0].split(".")[0]
+    if not raw.isdigit():
+        raise RuntimeError(f"cannot determine the macOS major version (got {raw!r})")
+    major = int(raw)
     codename = MACOS_CODENAMES_BY_MAJOR.get(major)
-    if codename is None:
-        # Unknown/newer macOS: accept the newest tag rather than nothing.
+    if codename is not None:
+        return MACOS_CODENAMES.index(codename)
+    if major > max(MACOS_CODENAMES_BY_MAJOR):
+        # Newer than anything mapped: every published bottle predates it, so all
+        # of them run here.
         return len(MACOS_CODENAMES) - 1
-    return MACOS_CODENAMES.index(codename)
+    # An unmapped major below the newest known release can't be ranked, and
+    # guessing risks picking a bottle too new for the host to run.
+    raise RuntimeError(f"unrecognized macOS major version {major}")
 
 
 def platform_prefix():
@@ -106,11 +143,16 @@ def platform_prefix():
     return "arm64_" if machine in ("arm64", "aarch64") else ""
 
 
-def usable_tag_rank(ref_name, version, prefix, max_rank):
-    """Rank of a bottle tag for this platform, or None if unusable."""
-    if not ref_name.startswith(f"{version}."):
+def usable_tag_rank(ref_name, base, revision, prefix, max_rank):
+    """Rank of a bottle ref name for this platform, or None if unusable."""
+    if not ref_name.startswith(f"{base}."):
         return None
-    tag = ref_name[len(version) + 1:]
+    tag = ref_name[len(base) + 1:]
+    if revision is not None:
+        suffix = f".{revision}"
+        if not tag.endswith(suffix):
+            return None
+        tag = tag[: -len(suffix)]
     if "linux" in tag:
         return None
     if prefix:
@@ -131,21 +173,30 @@ def find_bottle(formula, token):
     prefix = platform_prefix()
     max_rank = current_os_rank()
 
-    for version in versions:
-        index, _ = _get(
-            f"{REGISTRY}/v2/{REPO_PREFIX}/{formula}/manifests/{version}",
-            token=token,
-            accept="application/vnd.oci.image.index.v1+json",
-        )
+    for version in versions[:MAX_VERSIONS_SCANNED]:
+        try:
+            index, _ = _get(
+                f"{REGISTRY}/v2/{REPO_PREFIX}/{formula}/manifests/{version}",
+                token=token,
+                accept="application/vnd.oci.image.index.v1+json",
+            )
+        except RuntimeError as exc:
+            # A tag can be listed but unreadable (deleted, or an upload that
+            # never completed). The next-newest version is just as good.
+            print(f"##[warning]skipping {formula} {version}: {exc}", file=sys.stderr)
+            continue
+        base, revision = ref_parts(version)
         best = None
         for manifest in index.get("manifests", []):
             ref = manifest.get("annotations", {}).get("org.opencontainers.image.ref.name", "")
-            rank = usable_tag_rank(ref, version, prefix, max_rank)
+            rank = usable_tag_rank(ref, base, revision, prefix, max_rank)
             if rank is not None and (best is None or rank > best[0]):
                 best = (rank, manifest["digest"], ref)
         if best:
             return version, best[1], best[2]
-    raise RuntimeError(f"no {formula} bottle found for this platform")
+    raise RuntimeError(
+        f"no {formula} bottle for this platform in the newest {MAX_VERSIONS_SCANNED} versions"
+    )
 
 
 def download_blob(formula, token, manifest_digest):
@@ -169,28 +220,26 @@ def download_blob(formula, token, manifest_digest):
 
 def extract_bin(blob, formula, version, dest_dir):
     os.makedirs(dest_dir, exist_ok=True)
-    wanted = f"{formula}/{version}/bin/"
+    base, _ = ref_parts(version)
+    wanted = f"{formula}/{base}/bin/"
     installed = []
-    with tempfile.NamedTemporaryFile(suffix=".tar.gz") as tmp:
-        tmp.write(blob)
-        tmp.flush()
-        with tarfile.open(tmp.name, "r:gz") as tar:
-            for member in tar.getmembers():
-                # Only regular files directly under the formula's bin/, and never
-                # a path that escapes it -- the archive is untrusted input.
-                name = os.path.normpath(member.name)
-                if not member.isfile() or not name.startswith(wanted):
-                    continue
-                if os.path.basename(name) != name[len(wanted):]:
-                    continue
-                src = tar.extractfile(member)
-                if src is None:
-                    continue
-                target = os.path.join(dest_dir, os.path.basename(name))
-                with open(target, "wb") as out:
-                    shutil.copyfileobj(src, out)
-                os.chmod(target, 0o755)
-                installed.append(os.path.basename(name))
+    with tarfile.open(fileobj=io.BytesIO(blob), mode="r:gz") as tar:
+        for member in tar.getmembers():
+            # Only regular files directly under the formula's bin/, and never
+            # a path that escapes it -- the archive is untrusted input.
+            name = os.path.normpath(member.name).replace(os.sep, "/")
+            if not member.isfile() or not name.startswith(wanted):
+                continue
+            if os.path.basename(name) != name[len(wanted):]:
+                continue
+            src = tar.extractfile(member)
+            if src is None:
+                continue
+            target = os.path.join(dest_dir, os.path.basename(name))
+            with open(target, "wb") as out:
+                shutil.copyfileobj(src, out)
+            os.chmod(target, 0o755)
+            installed.append(os.path.basename(name))
     if not installed:
         raise RuntimeError(f"bottle for {formula} {version} contained no bin/ entries")
     return installed

--- a/.pipeline/scripts/start-colima-macos.sh
+++ b/.pipeline/scripts/start-colima-macos.sh
@@ -44,21 +44,29 @@ DOCKER_CLI_DIR=${DOCKER_CLI_DIR:-$HOME/.docker-cli/bin}
 INSTALL_TIMEOUT_SECONDS=${INSTALL_TIMEOUT_SECONDS:-300}
 
 install_tooling() {
-  brew update
-  brew install colima
+  # `set -e` is suppressed inside a function called from a conditional, so every
+  # prerequisite has to report failure explicitly or a broken brew would look
+  # like a successful install and only surface as a confusing colima failure.
+  brew update || return 1
+  brew install colima || return 1
 
   if brew install --force-bottle docker; then
     return 0
   fi
   echo "##[warning]No docker CLI bottle for the current version on this platform; falling back to the newest bottled version"
-  python3 "$(dirname "$0")/install-brew-bottle.py" docker "$DOCKER_CLI_DIR"
+  python3 "$(dirname "$0")/install-brew-bottle.py" docker "$DOCKER_CLI_DIR" || return 1
 }
 
 # A leftover directory would make the "did we fall back?" check below lie.
 rm -rf "$DOCKER_CLI_DIR"
 
-if ! run_bounded "$INSTALL_TIMEOUT_SECONDS" install_tooling; then
+install_status=0
+run_bounded "$INSTALL_TIMEOUT_SECONDS" install_tooling || install_status=$?
+if [ "$install_status" -eq 124 ]; then
   echo "##[error]Installing colima and the docker CLI did not finish within ${INSTALL_TIMEOUT_SECONDS}s"
+  exit 1
+elif [ "$install_status" -ne 0 ]; then
+  echo "##[error]Installing colima and the docker CLI failed (exit $install_status)"
   exit 1
 fi
 

--- a/.pipeline/scripts/start-colima-macos.sh
+++ b/.pipeline/scripts/start-colima-macos.sh
@@ -25,9 +25,50 @@ COLIMA_START_TIMEOUT_SECONDS=${COLIMA_START_TIMEOUT_SECONDS:-540}
 # The macOS job only gets 60 minutes, so cap the retries by wall clock rather
 # than letting three boots of an unhealthy agent eat the test budget.
 COLIMA_BUDGET_SECONDS=${COLIMA_BUDGET_SECONDS:-480}
+# `brew install docker` is deliberately not used bare. Homebrew ships no bottle
+# for the docker CLI on Intel macOS as of 29.8.0, so a bare install compiles it
+# from source and builds Go (~8 min) to do so. Measured over 147 runs: agents
+# that resolved the bottled 29.7.2 finished this phase in 29s median and failed
+# 1% of the time, while agents that built 29.8.0 took 441s median (774s max) and
+# failed 36% — the build alone exhausted the step timeout.
+#
+# `--force-bottle` makes brew fail rather than fall back to source. When it does
+# fail, install-brew-bottle.py takes the newest version that *is* bottled for
+# this platform straight from Homebrew's registry, so there is no version to pin
+# by hand and no third-party download. Both paths therefore install exactly what
+# Homebrew would have, and this self-heals once the current version is bottled
+# again — which on arm64 it already is.
+DOCKER_CLI_DIR=${DOCKER_CLI_DIR:-$HOME/.docker-cli/bin}
+# Bounded so a slow install fails here with a message rather than silently
+# consuming the step budget and surfacing as an opaque "task has timed out".
+INSTALL_TIMEOUT_SECONDS=${INSTALL_TIMEOUT_SECONDS:-300}
 
-brew update
-brew install docker colima
+install_tooling() {
+  brew update
+  brew install colima
+
+  if brew install --force-bottle docker; then
+    return 0
+  fi
+  echo "##[warning]No docker CLI bottle for the current version on this platform; falling back to the newest bottled version"
+  python3 "$(dirname "$0")/install-brew-bottle.py" docker "$DOCKER_CLI_DIR"
+}
+
+# A leftover directory would make the "did we fall back?" check below lie.
+rm -rf "$DOCKER_CLI_DIR"
+
+if ! run_bounded "$INSTALL_TIMEOUT_SECONDS" install_tooling; then
+  echo "##[error]Installing colima and the docker CLI did not finish within ${INSTALL_TIMEOUT_SECONDS}s"
+  exit 1
+fi
+
+# Only the fallback populates DOCKER_CLI_DIR; brew's own docker is already on PATH.
+# prependpath only affects later steps, so also fix PATH for this one.
+if [ -x "$DOCKER_CLI_DIR/docker" ]; then
+  export PATH="$DOCKER_CLI_DIR:$PATH"
+  echo "##vso[task.prependpath]$DOCKER_CLI_DIR"
+fi
+docker --version
 
 start_time=$(date +%s)
 deadline=$((start_time + COLIMA_BUDGET_SECONDS))

--- a/.pipeline/scripts/test_install_brew_bottle.py
+++ b/.pipeline/scripts/test_install_brew_bottle.py
@@ -1,0 +1,193 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Offline tests for the Homebrew bottle installer's selection rules.
+
+This script only runs when a macOS agent has no bottle for the current formula
+version, so a mistake in it stays invisible until CI is already degraded. The
+parts worth testing are the ones that silently pick the wrong artifact rather
+than crashing: Homebrew spelling a revision as `29.7.2-1` in the registry tag
+but `29.7.2.<platform>.1` in the ref names inside it, a bottle newer than the
+running macOS being accepted, an arm64 bottle being taken on Intel, and a tar
+member escaping the formula's bin/ directory.
+
+Everything here is synthetic - no network and no macOS required.
+
+Run with ``python -m unittest discover .pipeline/scripts``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import os
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALLER = REPO_ROOT / ".pipeline" / "scripts" / "install-brew-bottle.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("install_brew_bottle", INSTALLER)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+bottle = _load()
+
+SEQUOIA = bottle.MACOS_CODENAMES.index("sequoia")
+
+# Ref names as ghcr.io actually annotates them, captured from
+# homebrew/core/docker. The revision index is the case the tag itself cannot be
+# matched against.
+PLAIN_REFS = [
+    "29.7.2.arm64_linux", "29.7.2.arm64_sequoia", "29.7.2.arm64_sonoma",
+    "29.7.2.arm64_tahoe", "29.7.2.sonoma", "29.7.2.x86_64_linux",
+]
+REVISION_REFS = [
+    "29.7.2.arm64_linux.1", "29.7.2.arm64_sequoia.1", "29.7.2.arm64_sonoma.1",
+    "29.7.2.arm64_tahoe.1", "29.7.2.sonoma.1", "29.7.2.x86_64_linux.1",
+]
+
+
+def best_ref(refs, tag, prefix, max_rank):
+    """Mirror of find_bottle's inner selection, minus the registry."""
+    base, revision = bottle.ref_parts(tag)
+    ranked = [
+        (bottle.usable_tag_rank(ref, base, revision, prefix, max_rank), ref)
+        for ref in refs
+    ]
+    usable = [(rank, ref) for rank, ref in ranked if rank is not None]
+    return max(usable)[1] if usable else None
+
+
+class VersionOrdering(unittest.TestCase):
+    def test_revision_sorts_above_its_base(self):
+        self.assertGreater(bottle.version_key("29.7.2-1"), bottle.version_key("29.7.2"))
+        self.assertGreater(bottle.version_key("29.8.0"), bottle.version_key("29.7.2-1"))
+
+    def test_non_version_tags_are_rejected(self):
+        for tag in ("latest", "29.7", "29.7.2-beta"):
+            self.assertIsNone(bottle.version_key(tag), tag)
+
+    def test_ref_parts_splits_the_revision_off_the_tag(self):
+        self.assertEqual(bottle.ref_parts("29.7.2-1"), ("29.7.2", "1"))
+        self.assertEqual(bottle.ref_parts("29.7.2"), ("29.7.2", None))
+
+
+class BottleSelection(unittest.TestCase):
+    def test_revision_index_is_matched_by_its_base_and_revision(self):
+        # The tag is `29.7.2-1` but the refs read `29.7.2.sonoma.1`; matching the
+        # tag against the ref name directly would discard the whole version.
+        self.assertEqual(best_ref(REVISION_REFS, "29.7.2-1", "", SEQUOIA), "29.7.2.sonoma.1")
+
+    def test_revision_refs_are_not_accepted_for_the_unrevised_tag(self):
+        self.assertIsNone(best_ref(REVISION_REFS, "29.7.2", "", SEQUOIA))
+
+    def test_intel_never_takes_an_arm64_bottle(self):
+        self.assertEqual(best_ref(PLAIN_REFS, "29.7.2", "", SEQUOIA), "29.7.2.sonoma")
+        arm_only = ["29.8.0.arm64_sequoia", "29.8.0.arm64_tahoe", "29.8.0.x86_64_linux"]
+        self.assertIsNone(best_ref(arm_only, "29.8.0", "", SEQUOIA))
+
+    def test_arm64_prefers_the_newest_compatible_codename(self):
+        self.assertEqual(
+            best_ref(PLAIN_REFS, "29.7.2", "arm64_", SEQUOIA), "29.7.2.arm64_sequoia"
+        )
+
+    def test_bottle_newer_than_the_host_is_rejected(self):
+        sonoma = bottle.MACOS_CODENAMES.index("sonoma")
+        self.assertEqual(best_ref(PLAIN_REFS, "29.7.2", "arm64_", sonoma), "29.7.2.arm64_sonoma")
+        tahoe_only = ["29.7.2.arm64_tahoe"]
+        self.assertIsNone(best_ref(tahoe_only, "29.7.2", "arm64_", sonoma))
+
+    def test_linux_bottles_are_never_selected(self):
+        linux_only = ["29.7.2.arm64_linux", "29.7.2.x86_64_linux"]
+        for prefix in ("", "arm64_"):
+            self.assertIsNone(best_ref(linux_only, "29.7.2", prefix, SEQUOIA), prefix)
+
+    def test_all_platform_bottles_are_not_selected(self):
+        # `:all` bottles carry a `.all` ref. Out of scope for the CLIs this
+        # installs, and taking one blindly is worse than reporting no match.
+        self.assertIsNone(best_ref(["1.2.3.all"], "1.2.3", "", SEQUOIA))
+
+
+class HostRanking(unittest.TestCase):
+    def setUp(self):
+        self.addCleanup(os.environ.pop, "BOTTLE_MACOS_MAJOR_OVERRIDE", None)
+
+    def rank_for(self, major):
+        os.environ["BOTTLE_MACOS_MAJOR_OVERRIDE"] = major
+        return bottle.current_os_rank()
+
+    def test_known_majors_map_to_their_codename(self):
+        self.assertEqual(self.rank_for("15"), bottle.MACOS_CODENAMES.index("sequoia"))
+        self.assertEqual(self.rank_for("11"), bottle.MACOS_CODENAMES.index("big_sur"))
+
+    def test_major_above_the_newest_known_accepts_anything(self):
+        self.assertEqual(self.rank_for("27"), len(bottle.MACOS_CODENAMES) - 1)
+
+    def test_unmapped_major_below_the_newest_is_an_error(self):
+        # Falling forward here would hand a macOS 26 bottle to an older host.
+        with self.assertRaises(RuntimeError):
+            self.rank_for("16")
+
+    def test_unparsable_version_is_an_error(self):
+        with self.assertRaises(RuntimeError):
+            self.rank_for("not-a-version")
+
+
+def make_bottle(entries):
+    """A gzipped tar of `(name, is_file)` members, as the registry serves them."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for name, is_file in entries:
+            if is_file:
+                payload = b"#!/bin/sh\n"
+                info = tarfile.TarInfo(name)
+                info.size = len(payload)
+                tar.addfile(info, io.BytesIO(payload))
+            else:
+                info = tarfile.TarInfo(name)
+                info.type = tarfile.SYMTYPE
+                info.linkname = "../elsewhere"
+                tar.addfile(info)
+    return buf.getvalue()
+
+
+class Extraction(unittest.TestCase):
+    def extract(self, entries, version="29.7.2"):
+        dest = tempfile.mkdtemp()
+        installed = bottle.extract_bin(make_bottle(entries), "docker", version, dest)
+        return installed, sorted(os.listdir(dest))
+
+    def test_only_regular_files_directly_under_bin_are_installed(self):
+        installed, on_disk = self.extract([
+            ("docker/29.7.2/bin/docker", True),
+            ("docker/29.7.2/bin/nested/helper", True),
+            ("docker/29.7.2/README.md", True),
+            ("docker/29.7.2/libexec/internal", True),
+            ("docker/29.7.2/bin/link", False),
+        ])
+        self.assertEqual(installed, ["docker"])
+        self.assertEqual(on_disk, ["docker"])
+
+    def test_revision_tag_reads_the_unrevised_cellar_directory(self):
+        # Homebrew keeps the bottle root at the plain version even for a revision.
+        installed, _ = self.extract([("docker/29.7.2/bin/docker", True)], version="29.7.2-1")
+        self.assertEqual(installed, ["docker"])
+
+    def test_traversal_outside_the_formula_is_refused(self):
+        with self.assertRaises(RuntimeError):
+            self.extract([("docker/29.7.2/bin/../../../../tmp/evil", True)])
+
+    def test_a_bottle_without_bin_entries_is_an_error(self):
+        with self.assertRaises(RuntimeError):
+            self.extract([("docker/29.7.2/README.md", True)])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.pipeline/templates/sql-setup-template.yml
+++ b/.pipeline/templates/sql-setup-template.yml
@@ -262,7 +262,7 @@ steps:
   # job caps at 60 minutes and SQL setup must not be what exhausts it.
   - script: bash .pipeline/scripts/start-colima-macos.sh
     displayName: 'Install and start Colima-based Docker'
-    timeoutInMinutes: 13
+    timeoutInMinutes: 15
 
   - script: bash .pipeline/scripts/start-sql-server-macos.sh
     displayName: 'Start SQL Server (Docker, no TLS certs)'

--- a/.pipeline/templates/test-mssql-python-macos-template.yml
+++ b/.pipeline/templates/test-mssql-python-macos-template.yml
@@ -101,7 +101,7 @@ steps:
 # caps at 60 minutes and SQL setup must not be what exhausts it.
 - script: bash .pipeline/scripts/start-colima-macos.sh
   displayName: 'Install and start Colima-based Docker'
-  timeoutInMinutes: 13
+  timeoutInMinutes: 15
 
 # ── 5. Start SQL Server (no TLS certs) ──────────────────────────────────────
 - script: bash .pipeline/scripts/start-sql-server-macos.sh

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -259,9 +259,8 @@ stages:
           osType: Linux
       - bash: |
           set -euo pipefail
-          python3 -m unittest discover -s .pipeline/scripts \
-            -p 'test_compare_odbc_benchmarks.py' -v
-        displayName: Test ODBC benchmark comparison policy
+          python3 -m unittest discover -s .pipeline/scripts -p 'test_*.py' -v
+        displayName: Test pipeline helper scripts
       - template: build-template-container.yml
         parameters:
           architecture: x64


### PR DESCRIPTION
## Description

`Test MacOS` has been failing ~56% of the time. 92% of the failures are the `Install and start Colima-based Docker` step ending in `The task has timed out.` at ~790s — its 13-minute step timeout.

**Colima is not the cause.** Homebrew ships no bottle for the docker CLI on Intel macOS as of 29.8.0, so `brew install docker` compiles it from source and builds Go to do it:

```
==> ./make.bash                                    468s
🍺 /usr/local/Cellar/go/1.27.1: 15,577 files, 245.2MB, built in 8 minutes
```

Measured across 147 recent runs of the step, split by how each agent's Homebrew resolved the formula:

| docker install mode | n | brew phase | failed |
| --- | --- | --- | --- |
| Bottle 29.7.2 | 83 | 29s median, 138s max | 1% |
| Source-build 29.8.0 | 64 | **441s median, 774s max** | **36%** |

Agents differ only in which version their Homebrew resolves, and that flipped over a single day — 0/82 unbottled on Sept 3, 66/68 on Sept 4. That step change is why this looked intermittent, and why the rate should be expected to settle near the source-build rate rather than stay mixed. Colima itself was being killed mid-boot while healthy: the logs show all three lima requirements satisfied and the guest agent running, seconds from ready.

Fixes #499

## What changed

`docker` is now installed with **`brew install --force-bottle`**, which uses a bottle when one exists and *fails* rather than falling back to a source build. On that failure, **`.pipeline/scripts/install-brew-bottle.py`** resolves the newest version that *is* bottled for the running platform, reading Homebrew's own OCI registry on ghcr.io, and extracts it.

Both paths therefore install exactly what Homebrew would have. There is no version and no checksum pinned by hand, and no third-party download: bottles are content-addressed, so the blob is verified against the digest the registry advertises. It also self-heals — on arm64 the current version *is* bottled, so the fallback never runs there.

The helper is generic over the formula name deliberately: `colima` and `lima` still have Intel bottles today, but both sit at the same versions as August and are one bump away from the same problem.

`colima` and `lima` continue to install normally via brew.

### Selection rules

Homebrew spells a formula revision two ways — the registry tag is `29.7.2-1`, but the ref names inside that tag's index read `29.7.2.<platform>.1` — so the tag cannot be matched against a ref name directly and the two parts are matched separately.

Bottles built for an older macOS are accepted (they run forward); newer-than-host never are. A macOS major the helper doesn't recognize is an error rather than a guess, since guessing means handing the agent a binary it can't run. Only the newest 15 versions are examined, so a no-match failure reports while the install budget is still intact rather than walking the whole tag list.

## Bounds

Unchanged except where noted — the Colima bounds were re-measured on current data and are still correct (boot phase p50 265s / max 453s over 123 runs, **0 exceeding** the 540s bound).

| Bound | Default | Note |
| --- | --- | --- |
| `INSTALL_TIMEOUT_SECONDS` | 300s | new — the install phase was previously unbounded, which is why this regression surfaced as an opaque ADO timeout with no diagnostics |
| `COLIMA_START_TIMEOUT_SECONDS` | 540s | unchanged |
| `COLIMA_BUDGET_SECONDS` | 480s | unchanged |
| Colima step `timeoutInMinutes` | 13 → **15** | so the script's own bounds always fire before ADO's |

Only status 124 is reported as a timeout; any other nonzero install status keeps its own diagnostics, so a registry 404, a digest mismatch, or a failed brew command is not mislabelled.

## Testing

`.pipeline/scripts/test_install_brew_bottle.py` covers the selection and extraction rules offline — no network, no macOS. The existing unittest discovery in `validation-stages.yml` was broadened from the single ODBC benchmark module to `test_*.py`, so both suites run in `Build Linux` and future script tests are picked up automatically.

Selection logic, verified against the live registry:

| Host | Selected | Why correct |
| --- | --- | --- |
| macOS 14 Intel | `29.7.2-1` (`29.7.2.sonoma.1`) | newest Intel-bottled, **including the revision** |
| macOS 14 arm64 | `29.8.0.arm64_sonoma` | not sequoia/tahoe |
| macOS 15 arm64 | `29.8.0.arm64_sequoia` | **not tahoe** |
| macOS 26 arm64 | `29.8.0.arm64_tahoe` | newest allowed |
| macOS 11 Intel | *no match, clean failure* | never falls forward onto a bottle it can't run |

A naive "newest tag" would have installed a macOS 26 bottle on a macOS 15 agent, and matching the registry tag against ref names directly would have silently skipped every revision release.

Also verified: the helper resolves `colima` and `lima` equally well; a nonexistent formula fails cleanly in 0s (4xx is not retried); and end to end through the shell, a present bottle uses brew without invoking the helper, while an absent one falls back, prepends `PATH` and yields a working `docker`. A failing `brew update` or `brew install colima` was confirmed to abort the step rather than fall through — `set -e` is suppressed inside a function called from a conditional, so those now report explicitly.

`bash -n`, `py_compile` and YAML parse all pass.

## Residual risk

The digest comes from the registry rather than being pinned in-tree, so a compromised ghcr.io could serve different content. That is the same trust `brew install` already places in ghcr.io on every run, so it is not a regression — but it is weaker than a hand-pinned checksum. Vendoring these artifacts into an Azure Artifacts feed would close it properly; this helper is the right source for that producer pipeline.

Separately, Colima still downloads a 358 MB guest image from `github.com/abiosoft/colima-core` on every run, which has independently caused failures. Out of scope here, noted in #499.

## Checklist

- [ ] `cargo bfmt` passes — N/A, no Rust code changed
- [ ] `cargo bclippy` passes — N/A, no Rust code changed
- [ ] `cargo btest` passes — N/A, no Rust code changed
- [x] New/changed functionality has tests — `test_install_brew_bottle.py`, wired into `Build Linux`
- [ ] Public API changes are documented — N/A, no public API change

## Breaking changes

None. Pipeline-only; no driver code, public API, schema or config surface is affected.