### PR TITLE
DO NOT MERGE: validate the vendored macOS docker toolchain on a real agent

### DIFF
--- a/.pipeline/macos-docker-toolchain-pipeline.yml
+++ b/.pipeline/macos-docker-toolchain-pipeline.yml
@@ -1,0 +1,79 @@
+# Publishes the macOS docker toolchain (docker CLI, colima, lima and the guest
+# disk image colima boots) as a Universal Package per architecture, so macOS CI
+# jobs install it from our own feed instead of reaching Homebrew, ghcr.io and
+# github.com at job time.
+#
+# Background: Homebrew stopped bottling the docker CLI for Intel macOS at 29.8.0,
+# so `brew install docker` began source-building it (and Go with it, ~8 min),
+# timing out Test MacOS. Colima also downloads a ~350 MB guest image from a
+# personal GitHub repo on every run, which has independently failed on DNS.
+#
+# Manual trigger by design: bumping the toolchain should be a deliberate act with
+# a reviewed version, not something an agent's Homebrew state decides.
+#
+# The build runs on Linux -- it only fetches, verifies and repacks; nothing in
+# the payload is executed here. build-macos-docker-toolchain.py checks the Mach-O
+# architecture of every binary it packs, so a mis-resolved bottle fails the build
+# rather than shipping.
+
+trigger: none
+pr: none
+
+parameters:
+# Versioning is about the payload, not the tools inside it -- manifest.json is
+# the record of which docker/colima/lima/image versions a package contains:
+#   MAJOR  the directory layout changed, so consumers must change with it
+#   MINOR  component versions changed (a colima or docker bump)
+#   PATCH  same components, rebuilt
+- name: packageVersion
+  displayName: 'Package version, e.g. 1.2.0 (SemVer, immutable once published)'
+  type: string
+
+- name: publishX64
+  displayName: 'Publish x86_64 package'
+  type: boolean
+  default: true
+
+- name: publishArm64
+  displayName: 'Publish arm64 package'
+  type: boolean
+  default: true
+
+- name: dryRun
+  displayName: 'Dry run (build and inspect, do not publish)'
+  type: boolean
+  default: false
+
+- name: macosMajorFloor
+  displayName: 'Oldest macOS major version the payload must run on'
+  type: number
+  default: 14
+
+# A parameter rather than a variable: the job template consumes it at compile
+# time, where runtime variables are not available.
+- name: feed
+  displayName: 'Azure Artifacts feed to publish to'
+  type: string
+  default: 'public/mssql-rs_Public'
+
+stages:
+- stage: Publish_macOS_Docker_Toolchain
+  displayName: 'Publish macOS docker toolchain'
+  jobs:
+  - ${{ if eq(parameters.publishX64, true) }}:
+    - template: templates/macos-toolchain-job.yml
+      parameters:
+        arch: x86_64
+        packageVersion: ${{ parameters.packageVersion }}
+        macosMajorFloor: ${{ parameters.macosMajorFloor }}
+        dryRun: ${{ parameters.dryRun }}
+        feed: ${{ parameters.feed }}
+
+  - ${{ if eq(parameters.publishArm64, true) }}:
+    - template: templates/macos-toolchain-job.yml
+      parameters:
+        arch: arm64
+        packageVersion: ${{ parameters.packageVersion }}
+        macosMajorFloor: ${{ parameters.macosMajorFloor }}
+        dryRun: ${{ parameters.dryRun }}
+        feed: ${{ parameters.feed }}

--- a/.pipeline/scripts/README.md
+++ b/.pipeline/scripts/README.md
@@ -101,6 +101,35 @@ runs, the bottled path took 29s median and failed 1% of the time, the
 source-build path took 441s median (774s max) and failed 36%. `colima` and
 `lima` are still bottled on Intel and install normally.
 
+### build-macos-docker-toolchain.py
+Assembles the macOS docker toolchain payload for one architecture: the install
+prefixes of the `docker`, `colima` and `lima` Homebrew bottles, plus the Ubuntu
+guest disk image colima boots, plus a `manifest.json` recording versions, source
+URLs and digests. Published as a Universal Package by
+`.pipeline/macos-docker-toolchain-pipeline.yml`, so macOS jobs install the
+toolchain from our own feed rather than reaching Homebrew, ghcr.io and
+github.com at job time.
+
+The whole prefix is packaged, not just `bin/`: `limactl` resolves
+`../share/lima/lima-guestagent.*` and `../libexec/lima/*` relative to itself, so
+a bin-only payload yields a lima that cannot boot a VM. The build fails if the
+guest agent is missing rather than shipping one that would.
+
+The guest image is not hard-coded. colima embeds a table of
+`<arch> <runtime> <url> <sha512> <filename>` for the image release it expects, so
+both the image and the checksum to verify it against are read out of the binary
+being packaged — colima 0.10.3 wants colima-core v0.10.4, which a hand-maintained
+mapping would get wrong.
+
+Runs on Linux and cross-builds both macOS payloads, so it verifies the Mach-O
+architecture of every binary it packs; a mis-resolved bottle fails the build
+instead of shipping.
+
+**Usage:** `build-macos-docker-toolchain.py --arch x86_64|arm64 --out <dir>`
+`--macos-major` sets the oldest macOS the payload must run on (default 14);
+bottles built for an older macOS run on newer hosts, so this is a compatibility
+floor rather than a target.
+
 ### install-brew-bottle.py
 Installs the newest Homebrew bottle of a formula that exists for the running
 platform, by reading Homebrew's OCI registry on ghcr.io directly. Used as the
@@ -112,7 +141,11 @@ registry advertises rather than a checksum vendored here. Bottles built for an
 older macOS are accepted (they run on newer hosts) but never a newer one.
 
 **Usage:** `install-brew-bottle.py <formula> <dest-bin-dir>`; prints the resolved
-version. Test overrides: `BOTTLE_ARCH_OVERRIDE`, `BOTTLE_MACOS_MAJOR_OVERRIDE`.
+version. `extract_bin` flattens just the executables (what the docker CLI
+fallback needs); `extract_prefix` keeps the whole install tree (what a packaged
+lima needs). `BOTTLE_ARCH_OVERRIDE` and `BOTTLE_MACOS_MAJOR_OVERRIDE` select a
+platform other than the running one — used by the toolchain producer to
+cross-build both macOS payloads from Linux, and handy for testing.
 
 Each `colima start` is bounded by `COLIMA_START_TIMEOUT_SECONDS` so a wedged
 boot still reaches the delete/retry path rather than running until the pipeline

--- a/.pipeline/scripts/README.md
+++ b/.pipeline/scripts/README.md
@@ -91,16 +91,41 @@ Installs Docker + Colima on a hosted macOS agent and boots the VM, retrying on
 the transient lima hostagent boot failures seen in ~3% of runs. VM size stays at
 the long-standing 4 GiB / 4 CPU.
 
+The docker CLI is installed with `brew install --force-bottle`, which uses
+Homebrew's bottle when one exists for the platform and *fails* rather than
+falling back to a source build. When it fails, `install-brew-bottle.py` installs
+the newest version that *is* bottled for this platform, taken straight from
+Homebrew's own registry. As of 29.8.0 there is no Intel macOS bottle, so a bare
+`brew install docker` compiles the CLI and builds Go to do it: measured over 147
+runs, the bottled path took 29s median and failed 1% of the time, the
+source-build path took 441s median (774s max) and failed 36%. `colima` and
+`lima` are still bottled on Intel and install normally.
+
+### install-brew-bottle.py
+Installs the newest Homebrew bottle of a formula that exists for the running
+platform, by reading Homebrew's OCI registry on ghcr.io directly. Used as the
+docker CLI fallback above, and generic enough to cover `colima` or `lima` if they
+lose their Intel bottles too.
+
+Bottles are content-addressed, so the download is verified against the digest the
+registry advertises rather than a checksum vendored here. Bottles built for an
+older macOS are accepted (they run on newer hosts) but never a newer one.
+
+**Usage:** `install-brew-bottle.py <formula> <dest-bin-dir>`; prints the resolved
+version. Test overrides: `BOTTLE_ARCH_OVERRIDE`, `BOTTLE_MACOS_MAJOR_OVERRIDE`.
+
 Each `colima start` is bounded by `COLIMA_START_TIMEOUT_SECONDS` so a wedged
 boot still reaches the delete/retry path rather than running until the pipeline
-step timeout. That bound sits above the slowest healthy boot observed over 113
-runs (509s; p95 366s) — the real failures give up within seconds, so a shorter
-bound would only kill slow-but-healthy boots. `COLIMA_BUDGET_SECONDS` then caps
-the retries as a whole.
+step timeout. That bound sits above the slowest healthy boot observed (509s over
+113 runs in 2026-08; re-measured 2026-09 at max 453s over 123 runs) — the real
+failures give up within seconds, so a shorter bound would only kill
+slow-but-healthy boots. `COLIMA_BUDGET_SECONDS` then caps the retries as a
+whole, and the install phase has its own `INSTALL_TIMEOUT_SECONDS`.
 
 **Environment overrides:** `COLIMA_CPU`, `COLIMA_MEMORY`, `COLIMA_DISK`,
 `COLIMA_START_ATTEMPTS` (3), `COLIMA_START_TIMEOUT_SECONDS` (540),
-`COLIMA_BUDGET_SECONDS` (480).
+`COLIMA_BUDGET_SECONDS` (480), `INSTALL_TIMEOUT_SECONDS` (300),
+`DOCKER_CLI_DIR`.
 
 ### start-sql-server-macos.sh
 Starts the SQL Server test container inside the Colima VM. Retries the image

--- a/.pipeline/scripts/build-macos-docker-toolchain.py
+++ b/.pipeline/scripts/build-macos-docker-toolchain.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Assemble the macOS docker toolchain payload for one architecture.
+
+Collects everything a hosted macOS agent needs to run containers, so the job
+itself touches nothing but our own feed:
+
+  bin/     docker, colima, limactl and lima's helpers, from Homebrew bottles
+  image/   the Ubuntu guest disk image colima boots
+  manifest.json  what went in, where it came from, and its digests
+
+The guest image reference is not hard-coded. colima embeds a table of
+"<arch> <runtime> <url> <sha512> <filename>" for the image release it expects,
+so the image and the checksum to verify it against are read out of the very
+binary being packaged. colima 0.10.3 wants colima-core v0.10.4, which any
+hand-maintained mapping would get wrong.
+
+Runs on Linux: nothing here is executed, only fetched, checked and repacked.
+
+Usage: build-macos-docker-toolchain.py --arch x86_64|arm64 --out <dir>
+"""
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+import re
+import shutil
+import struct
+import sys
+import time
+import urllib.error
+import urllib.request
+
+FORMULAE = ("docker", "colima", "lima")
+ARCH_TO_COLIMA = {"x86_64": "amd64", "arm64": "arm64"}
+MACHO_MAGIC_64 = 0xFEEDFACF
+MACHO_CPU_TYPE = {"x86_64": 0x01000007, "arm64": 0x0100000C}
+# Bottles built for an older macOS run on newer hosts, so target the oldest
+# release we might schedule on and stay compatible with everything above it.
+DEFAULT_MACOS_MAJOR = 14
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def load_bottle_helper():
+    path = os.path.join(HERE, "install-brew-bottle.py")
+    spec = importlib.util.spec_from_file_location("install_brew_bottle", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def verify_macho(path, arch):
+    """Guard against packaging the wrong slice: this cross-builds on Linux."""
+    with open(path, "rb") as handle:
+        header = handle.read(8)
+    if len(header) < 8:
+        raise RuntimeError(f"{path}: too short to be a Mach-O binary")
+    magic, cpu_type = struct.unpack("<II", header)
+    if magic != MACHO_MAGIC_64:
+        raise RuntimeError(f"{path}: not a 64-bit Mach-O binary (magic {magic:#x})")
+    if cpu_type != MACHO_CPU_TYPE[arch]:
+        wrong = next((k for k, v in MACHO_CPU_TYPE.items() if v == cpu_type), hex(cpu_type))
+        raise RuntimeError(f"{path}: built for {wrong}, expected {arch}")
+
+
+def image_entry(colima_binary, arch):
+    """Read colima's embedded (arch, runtime) -> image URL + sha512 table."""
+    with open(colima_binary, "rb") as handle:
+        blob = handle.read()
+    pattern = (
+        rb"(" + ARCH_TO_COLIMA[arch].encode() + rb")\s+docker\s+"
+        rb"(https://\S+\.raw\.gz)\s+([0-9a-f]{128})\s+(\S+\.raw\.gz)"
+    )
+    match = re.search(pattern, blob)
+    if not match:
+        raise RuntimeError(
+            f"colima binary has no docker image entry for {arch}; "
+            "the embedded image table may have changed format"
+        )
+    return {
+        "url": match.group(2).decode(),
+        "sha512": match.group(3).decode(),
+        "filename": match.group(4).decode(),
+    }
+
+
+def download_verified(url, sha512, dest, attempts=3):
+    """Stream to disk, hashing as we go -- the image is ~350 MB."""
+    for attempt in range(attempts):
+        digest = hashlib.sha512()
+        try:
+            with urllib.request.urlopen(url, timeout=300) as resp, open(dest, "wb") as out:
+                while True:
+                    chunk = resp.read(1 << 20)
+                    if not chunk:
+                        break
+                    digest.update(chunk)
+                    out.write(chunk)
+        except (urllib.error.URLError, TimeoutError) as exc:
+            if attempt == attempts - 1:
+                raise RuntimeError(f"downloading {url} failed: {exc}") from None
+            time.sleep(10 * (attempt + 1))
+            continue
+
+        actual = digest.hexdigest()
+        if actual == sha512:
+            return os.path.getsize(dest)
+        raise RuntimeError(
+            f"{url}: sha512 mismatch against colima's own manifest\n"
+            f"  expected {sha512}\n  actual   {actual}"
+        )
+    raise RuntimeError(f"downloading {url} failed after {attempts} attempts")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--arch", required=True, choices=sorted(ARCH_TO_COLIMA))
+    parser.add_argument("--out", required=True)
+    parser.add_argument(
+        "--macos-major",
+        type=int,
+        default=DEFAULT_MACOS_MAJOR,
+        help="oldest macOS major version the payload must run on (default: %(default)s)",
+    )
+    args = parser.parse_args()
+
+    helper = load_bottle_helper()
+    os.environ["BOTTLE_ARCH_OVERRIDE"] = args.arch
+    os.environ["BOTTLE_MACOS_MAJOR_OVERRIDE"] = str(args.macos_major)
+
+    bin_dir = os.path.join(args.out, "bin")
+    image_dir = os.path.join(args.out, "image")
+    if os.path.exists(args.out):
+        shutil.rmtree(args.out)
+    os.makedirs(bin_dir)
+    os.makedirs(image_dir)
+
+    components = {}
+    for formula in FORMULAE:
+        token = helper.anonymous_token(formula)
+        version, manifest_digest, ref = helper.find_bottle(formula, token)
+        blob = helper.download_blob(formula, token, manifest_digest)
+        # Whole prefix, not just bin/: limactl reaches for ../share/lima and
+        # ../libexec/lima, so a bin-only copy cannot boot a VM.
+        extracted = helper.extract_prefix(blob, formula, version, args.out)
+        components[formula] = {
+            "version": version,
+            "bottle_tag": ref,
+            "bottle_digest": manifest_digest,
+            "files": len(extracted),
+        }
+        print(f"{formula:8s} {version:10s} {ref:24s} -> {len(extracted)} files")
+
+    for name in ("docker", "colima", "limactl"):
+        verify_macho(os.path.join(bin_dir, name), args.arch)
+    print(f"verified {args.arch} Mach-O binaries")
+
+    # limactl resolves the guest agent relative to its own location, so its
+    # absence is a boot failure on the agent rather than a build failure here.
+    guest_agent = os.path.join(args.out, "share", "lima")
+    agents = [f for f in os.listdir(guest_agent) if f.startswith("lima-guestagent")] \
+        if os.path.isdir(guest_agent) else []
+    if not agents:
+        raise RuntimeError("payload has no share/lima/lima-guestagent.*; lima could not boot a VM")
+    print(f"guest agent present: {', '.join(agents)}")
+
+    entry = image_entry(os.path.join(bin_dir, "colima"), args.arch)
+    image_path = os.path.join(image_dir, entry["filename"])
+    size = download_verified(entry["url"], entry["sha512"], image_path)
+    print(f"image    {entry['filename']} ({size / 1e6:.0f} MB) sha512 verified")
+
+    manifest = {
+        "arch": args.arch,
+        "macos_major_floor": args.macos_major,
+        "components": components,
+        "image": {
+            **entry,
+            "size": size,
+            # colima looks the image up in its cache by sha256 of the URL, so the
+            # consumer can seed it without colima ever reaching the network.
+            "cache_filename": hashlib.sha256(entry["url"].encode()).hexdigest(),
+        },
+    }
+    with open(os.path.join(args.out, "manifest.json"), "w") as out:
+        json.dump(manifest, out, indent=2, sort_keys=True)
+
+    versions = "-".join(f"{name}{components[name]['version']}" for name in FORMULAE)
+    print(f"\npayload ready: {args.out}")
+    print(f"  contents: {versions}, image {entry['url'].split('/')[-2]}")
+    print(f"  cache filename: {manifest['image']['cache_filename']}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except RuntimeError as exc:
+        print(f"##[error]{exc}")
+        sys.exit(1)

--- a/.pipeline/scripts/install-brew-bottle.py
+++ b/.pipeline/scripts/install-brew-bottle.py
@@ -167,33 +167,78 @@ def download_blob(formula, token, manifest_digest):
     return blob
 
 
+def _members(tar, root):
+    """Files under root/, rejecting anything whose path escapes it."""
+    for member in tar.getmembers():
+        if not (member.isfile() or member.issym()):
+            continue
+        name = os.path.normpath(member.name)
+        if not name.startswith(root) or ".." in name.split("/"):
+            continue
+        yield member, name[len(root):]
+
+
 def extract_bin(blob, formula, version, dest_dir):
+    """Extract just the executables, flattened into dest_dir."""
     os.makedirs(dest_dir, exist_ok=True)
-    wanted = f"{formula}/{version}/bin/"
+    root = f"{formula}/{version}/bin/"
     installed = []
     with tempfile.NamedTemporaryFile(suffix=".tar.gz") as tmp:
         tmp.write(blob)
         tmp.flush()
         with tarfile.open(tmp.name, "r:gz") as tar:
-            for member in tar.getmembers():
-                # Only regular files directly under the formula's bin/, and never
-                # a path that escapes it -- the archive is untrusted input.
-                name = os.path.normpath(member.name)
-                if not member.isfile() or not name.startswith(wanted):
-                    continue
-                if os.path.basename(name) != name[len(wanted):]:
+            for member, relative in _members(tar, root):
+                if "/" in relative or not member.isfile():
                     continue
                 src = tar.extractfile(member)
                 if src is None:
                     continue
-                target = os.path.join(dest_dir, os.path.basename(name))
+                target = os.path.join(dest_dir, relative)
                 with open(target, "wb") as out:
                     shutil.copyfileobj(src, out)
                 os.chmod(target, 0o755)
-                installed.append(os.path.basename(name))
+                installed.append(relative)
     if not installed:
         raise RuntimeError(f"bottle for {formula} {version} contained no bin/ entries")
     return installed
+
+
+def extract_prefix(blob, formula, version, dest_root):
+    """Extract the whole install prefix, merging into dest_root.
+
+    lima is not self-contained in bin/: limactl reaches for
+    ../share/lima/lima-guestagent.* and ../libexec/lima/*, so a bin-only copy
+    produces a lima that cannot boot a VM.
+    """
+    root = f"{formula}/{version}/"
+    extracted = []
+    with tempfile.NamedTemporaryFile(suffix=".tar.gz") as tmp:
+        tmp.write(blob)
+        tmp.flush()
+        with tarfile.open(tmp.name, "r:gz") as tar:
+            for member, relative in _members(tar, root):
+                if relative.startswith(".brew/"):
+                    continue
+                target = os.path.join(dest_root, relative)
+                os.makedirs(os.path.dirname(target), exist_ok=True)
+                if member.issym():
+                    link = os.path.normpath(os.path.join(os.path.dirname(relative), member.linkname))
+                    if link.startswith("..") or os.path.isabs(member.linkname):
+                        continue
+                    if os.path.lexists(target):
+                        os.unlink(target)
+                    os.symlink(member.linkname, target)
+                else:
+                    src = tar.extractfile(member)
+                    if src is None:
+                        continue
+                    with open(target, "wb") as out:
+                        shutil.copyfileobj(src, out)
+                    os.chmod(target, member.mode or 0o644)
+                extracted.append(relative)
+    if not extracted:
+        raise RuntimeError(f"bottle for {formula} {version} extracted nothing")
+    return extracted
 
 
 def main():

--- a/.pipeline/scripts/install-brew-bottle.py
+++ b/.pipeline/scripts/install-brew-bottle.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Install the newest Homebrew bottle of a formula that exists for this platform.
+
+Homebrew publishes bottles as OCI artifacts on ghcr.io, readable anonymously.
+When `brew install --force-bottle` fails because the *current* formula version
+has no bottle for the running platform (docker 29.8.0 ships arm64 macOS and
+Linux only), the previous version usually still does. This walks the registry
+newest-first, finds a version bottled for this platform, and extracts its
+binaries.
+
+The bottle blob is content-addressed: the layer digest is its SHA-256, so the
+download is verified against the digest the registry advertises rather than a
+checksum vendored here that someone has to remember to bump.
+
+Usage: install-brew-bottle.py <formula> <dest-bin-dir>
+Prints the resolved version to stdout.
+"""
+
+import hashlib
+import json
+import os
+import platform
+import re
+import shutil
+import sys
+import tarfile
+import tempfile
+import time
+import urllib.error
+import urllib.request
+
+REGISTRY = "https://ghcr.io"
+REPO_PREFIX = "homebrew/core"
+
+# Oldest to newest. A bottle built for an older macOS runs on a newer one, so a
+# tag is usable when its index is <= the running OS, and higher is preferred.
+MACOS_CODENAMES = [
+    "el_capitan", "sierra", "high_sierra", "mojave", "catalina",
+    "big_sur", "monterey", "ventura", "sonoma", "sequoia", "tahoe",
+]
+MACOS_CODENAMES_BY_MAJOR = {
+    12: "monterey", 13: "ventura", 14: "sonoma", 15: "sequoia", 26: "tahoe",
+}
+
+
+def _get(url, token=None, accept=None, binary=False, attempts=3):
+    req = urllib.request.Request(url)
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    if accept:
+        req.add_header("Accept", accept)
+    last = None
+    for attempt in range(attempts):
+        try:
+            with urllib.request.urlopen(req, timeout=120) as resp:
+                body = resp.read()
+                return (body if binary else json.loads(body)), resp.headers
+        except urllib.error.HTTPError as exc:
+            # 4xx other than rate limiting is a permanent answer; retrying it
+            # only burns the install budget.
+            if 400 <= exc.code < 500 and exc.code not in (408, 429):
+                raise RuntimeError(f"GET {url} failed: HTTP {exc.code}") from None
+            last = exc
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+            last = exc
+        if attempt < attempts - 1:
+            time.sleep(5 * (attempt + 1))
+    raise RuntimeError(f"GET {url} failed after {attempts} attempts: {last}")
+
+
+def anonymous_token(formula):
+    scope = f"repository:{REPO_PREFIX}/{formula}:pull"
+    data, _ = _get(f"{REGISTRY}/token?service=ghcr.io&scope={scope}")
+    return data["token"]
+
+
+def list_versions(formula, token):
+    url = f"{REGISTRY}/v2/{REPO_PREFIX}/{formula}/tags/list?n=100"
+    tags = []
+    while url:
+        data, headers = _get(url, token=token)
+        tags.extend(data.get("tags", []))
+        link = headers.get("Link")
+        match = re.search(r"<([^>]+)>", link) if link else None
+        url = REGISTRY + match.group(1) if match else None
+    return tags
+
+
+def version_key(tag):
+    match = re.match(r"^(\d+)\.(\d+)\.(\d+)(?:[._-](\d+))?$", tag)
+    return tuple(int(part) for part in match.groups(default=0)) if match else None
+
+
+def current_os_rank():
+    override = os.environ.get("BOTTLE_MACOS_MAJOR_OVERRIDE")
+    major = int(override or platform.mac_ver()[0].split(".")[0] or 0)
+    codename = MACOS_CODENAMES_BY_MAJOR.get(major)
+    if codename is None:
+        # Unknown/newer macOS: accept the newest tag rather than nothing.
+        return len(MACOS_CODENAMES) - 1
+    return MACOS_CODENAMES.index(codename)
+
+
+def platform_prefix():
+    machine = os.environ.get("BOTTLE_ARCH_OVERRIDE") or platform.machine()
+    return "arm64_" if machine in ("arm64", "aarch64") else ""
+
+
+def usable_tag_rank(ref_name, version, prefix, max_rank):
+    """Rank of a bottle tag for this platform, or None if unusable."""
+    if not ref_name.startswith(f"{version}."):
+        return None
+    tag = ref_name[len(version) + 1:]
+    if "linux" in tag:
+        return None
+    if prefix:
+        if not tag.startswith(prefix):
+            return None
+        tag = tag[len(prefix):]
+    elif tag.startswith("arm64_"):
+        return None
+    if tag not in MACOS_CODENAMES:
+        return None
+    rank = MACOS_CODENAMES.index(tag)
+    return rank if rank <= max_rank else None
+
+
+def find_bottle(formula, token):
+    versions = [t for t in list_versions(formula, token) if version_key(t)]
+    versions.sort(key=version_key, reverse=True)
+    prefix = platform_prefix()
+    max_rank = current_os_rank()
+
+    for version in versions:
+        index, _ = _get(
+            f"{REGISTRY}/v2/{REPO_PREFIX}/{formula}/manifests/{version}",
+            token=token,
+            accept="application/vnd.oci.image.index.v1+json",
+        )
+        best = None
+        for manifest in index.get("manifests", []):
+            ref = manifest.get("annotations", {}).get("org.opencontainers.image.ref.name", "")
+            rank = usable_tag_rank(ref, version, prefix, max_rank)
+            if rank is not None and (best is None or rank > best[0]):
+                best = (rank, manifest["digest"], ref)
+        if best:
+            return version, best[1], best[2]
+    raise RuntimeError(f"no {formula} bottle found for this platform")
+
+
+def download_blob(formula, token, manifest_digest):
+    manifest, _ = _get(
+        f"{REGISTRY}/v2/{REPO_PREFIX}/{formula}/manifests/{manifest_digest}",
+        token=token,
+        accept="application/vnd.oci.image.manifest.v1+json",
+    )
+    layer = manifest["layers"][0]["digest"]
+    blob, _ = _get(
+        f"{REGISTRY}/v2/{REPO_PREFIX}/{formula}/blobs/{layer}",
+        token=token,
+        binary=True,
+    )
+    expected = layer.split(":", 1)[1]
+    actual = hashlib.sha256(blob).hexdigest()
+    if actual != expected:
+        raise RuntimeError(f"bottle digest mismatch: expected {expected}, got {actual}")
+    return blob
+
+
+def extract_bin(blob, formula, version, dest_dir):
+    os.makedirs(dest_dir, exist_ok=True)
+    wanted = f"{formula}/{version}/bin/"
+    installed = []
+    with tempfile.NamedTemporaryFile(suffix=".tar.gz") as tmp:
+        tmp.write(blob)
+        tmp.flush()
+        with tarfile.open(tmp.name, "r:gz") as tar:
+            for member in tar.getmembers():
+                # Only regular files directly under the formula's bin/, and never
+                # a path that escapes it -- the archive is untrusted input.
+                name = os.path.normpath(member.name)
+                if not member.isfile() or not name.startswith(wanted):
+                    continue
+                if os.path.basename(name) != name[len(wanted):]:
+                    continue
+                src = tar.extractfile(member)
+                if src is None:
+                    continue
+                target = os.path.join(dest_dir, os.path.basename(name))
+                with open(target, "wb") as out:
+                    shutil.copyfileobj(src, out)
+                os.chmod(target, 0o755)
+                installed.append(os.path.basename(name))
+    if not installed:
+        raise RuntimeError(f"bottle for {formula} {version} contained no bin/ entries")
+    return installed
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+    formula, dest_dir = sys.argv[1], sys.argv[2]
+
+    try:
+        token = anonymous_token(formula)
+        version, manifest_digest, ref = find_bottle(formula, token)
+        blob = download_blob(formula, token, manifest_digest)
+        installed = extract_bin(blob, formula, version, dest_dir)
+    except RuntimeError as exc:
+        print(f"##[error]{exc}")
+        return 1
+
+    print(f"{formula} {version} ({ref}) -> {dest_dir}: {', '.join(installed)}", file=sys.stderr)
+    print(version)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.pipeline/scripts/start-colima-macos.sh
+++ b/.pipeline/scripts/start-colima-macos.sh
@@ -25,9 +25,50 @@ COLIMA_START_TIMEOUT_SECONDS=${COLIMA_START_TIMEOUT_SECONDS:-540}
 # The macOS job only gets 60 minutes, so cap the retries by wall clock rather
 # than letting three boots of an unhealthy agent eat the test budget.
 COLIMA_BUDGET_SECONDS=${COLIMA_BUDGET_SECONDS:-480}
+# `brew install docker` is deliberately not used bare. Homebrew ships no bottle
+# for the docker CLI on Intel macOS as of 29.8.0, so a bare install compiles it
+# from source and builds Go (~8 min) to do so. Measured over 147 runs: agents
+# that resolved the bottled 29.7.2 finished this phase in 29s median and failed
+# 1% of the time, while agents that built 29.8.0 took 441s median (774s max) and
+# failed 36% — the build alone exhausted the step timeout.
+#
+# `--force-bottle` makes brew fail rather than fall back to source. When it does
+# fail, install-brew-bottle.py takes the newest version that *is* bottled for
+# this platform straight from Homebrew's registry, so there is no version to pin
+# by hand and no third-party download. Both paths therefore install exactly what
+# Homebrew would have, and this self-heals once the current version is bottled
+# again — which on arm64 it already is.
+DOCKER_CLI_DIR=${DOCKER_CLI_DIR:-$HOME/.docker-cli/bin}
+# Bounded so a slow install fails here with a message rather than silently
+# consuming the step budget and surfacing as an opaque "task has timed out".
+INSTALL_TIMEOUT_SECONDS=${INSTALL_TIMEOUT_SECONDS:-300}
 
-brew update
-brew install docker colima
+install_tooling() {
+  brew update
+  brew install colima
+
+  if brew install --force-bottle docker; then
+    return 0
+  fi
+  echo "##[warning]No docker CLI bottle for the current version on this platform; falling back to the newest bottled version"
+  python3 "$(dirname "$0")/install-brew-bottle.py" docker "$DOCKER_CLI_DIR"
+}
+
+# A leftover directory would make the "did we fall back?" check below lie.
+rm -rf "$DOCKER_CLI_DIR"
+
+if ! run_bounded "$INSTALL_TIMEOUT_SECONDS" install_tooling; then
+  echo "##[error]Installing colima and the docker CLI did not finish within ${INSTALL_TIMEOUT_SECONDS}s"
+  exit 1
+fi
+
+# Only the fallback populates DOCKER_CLI_DIR; brew's own docker is already on PATH.
+# prependpath only affects later steps, so also fix PATH for this one.
+if [ -x "$DOCKER_CLI_DIR/docker" ]; then
+  export PATH="$DOCKER_CLI_DIR:$PATH"
+  echo "##vso[task.prependpath]$DOCKER_CLI_DIR"
+fi
+docker --version
 
 start_time=$(date +%s)
 deadline=$((start_time + COLIMA_BUDGET_SECONDS))

--- a/.pipeline/templates/macos-toolchain-job.yml
+++ b/.pipeline/templates/macos-toolchain-job.yml
@@ -1,0 +1,68 @@
+# Builds and publishes the macOS docker toolchain payload for one architecture.
+# See macos-docker-toolchain-pipeline.yml for why this exists.
+
+parameters:
+- name: arch
+  type: string
+  values:
+  - x86_64
+  - arm64
+- name: packageVersion
+  type: string
+- name: macosMajorFloor
+  type: number
+- name: dryRun
+  type: boolean
+- name: feed
+  type: string
+
+jobs:
+- job: Build_${{ parameters.arch }}
+  displayName: 'Build and publish ${{ parameters.arch }}'
+  timeoutInMinutes: 30
+  # Downloads, verifies and repacks ~400 MB; nothing is compiled, so the cheap
+  # util pool is enough.
+  pool:
+    name: RUST-UTIL-WUS3
+    demands:
+      - imageOverride -equals RUST-UBUSLIM
+  steps:
+  - checkout: self
+
+  - script: |
+      set -euo pipefail
+      python3 .pipeline/scripts/build-macos-docker-toolchain.py \
+        --arch ${{ parameters.arch }} \
+        --macos-major ${{ parameters.macosMajorFloor }} \
+        --out "$(Build.ArtifactStagingDirectory)/${{ parameters.arch }}"
+    displayName: 'Assemble payload'
+
+  - script: |
+      set -euo pipefail
+      payload="$(Build.ArtifactStagingDirectory)/${{ parameters.arch }}"
+      echo "##[group]manifest.json"
+      cat "$payload/manifest.json"
+      echo "##[endgroup]"
+      echo "payload size: $(du -sh "$payload" | cut -f1)"
+    displayName: 'Show manifest'
+
+  # Published even on a dry run: the manifest is the record of what a given
+  # package version actually contains.
+  - task: PublishPipelineArtifact@1
+    displayName: 'Publish manifest as a build artifact'
+    inputs:
+      targetPath: '$(Build.ArtifactStagingDirectory)/${{ parameters.arch }}/manifest.json'
+      artifact: 'manifest-${{ parameters.arch }}'
+
+  - ${{ if eq(parameters.dryRun, false) }}:
+    - task: UniversalPackages@0
+      displayName: 'Publish macos-docker-toolchain-${{ parameters.arch }} ${{ parameters.packageVersion }}'
+      inputs:
+        command: publish
+        publishDirectory: '$(Build.ArtifactStagingDirectory)/${{ parameters.arch }}'
+        feedsToUsePublish: 'internal'
+        vstsFeedPublish: '${{ parameters.feed }}'
+        vstsFeedPackagePublish: 'macos-docker-toolchain-${{ parameters.arch }}'
+        versionOption: 'custom'
+        versionPublish: '${{ parameters.packageVersion }}'
+        packagePublishDescription: 'docker CLI, colima, lima and colima guest image for macOS ${{ parameters.arch }}'

--- a/.pipeline/templates/macos-toolchain-smoke-template.yml
+++ b/.pipeline/templates/macos-toolchain-smoke-template.yml
@@ -1,0 +1,155 @@
+# TEMPORARY validation stage for the vendored macOS docker toolchain.
+#
+# Proves the parts that cannot be checked on Linux: that the packaged binaries
+# actually run on a macOS agent, that seeding colima's cache stops it fetching
+# the ~350 MB guest image, and that lima's guest agent (which lives outside
+# bin/) is complete enough to boot a VM. The payload is moved as a pipeline
+# artifact rather than a Universal Package so this loop stays fast and does not
+# publish throwaway versions into the feed; feed publish/download is a separate
+# question.
+#
+# Ends by running the real start-sql-server-macos.sh: if SQL Server comes up on
+# a vendored toolchain, the whole chain is proven, not just the daemon.
+
+parameters:
+- name: utilPoolName
+  type: string
+
+jobs:
+- job: Toolchain_Build_Payloads
+  displayName: 'Build toolchain payloads (Linux)'
+  timeoutInMinutes: 30
+  pool:
+    name: ${{ parameters.utilPoolName }}
+    demands:
+      - imageOverride -equals RUST-UBUSLIM
+  steps:
+  - checkout: self
+
+  - ${{ each arch in split('x86_64,arm64', ',') }}:
+    - script: |
+        set -euo pipefail
+        python3 .pipeline/scripts/build-macos-docker-toolchain.py \
+          --arch ${{ arch }} \
+          --out "$(Build.ArtifactStagingDirectory)/${{ arch }}"
+        du -sh "$(Build.ArtifactStagingDirectory)/${{ arch }}"
+      displayName: 'Assemble ${{ arch }} payload'
+
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish ${{ arch }} payload artifact'
+      inputs:
+        targetPath: '$(Build.ArtifactStagingDirectory)/${{ arch }}'
+        artifact: 'toolchain-${{ arch }}'
+
+- job: Toolchain_Consume_MacOS
+  displayName: 'Install and boot from payload (macOS)'
+  dependsOn: Toolchain_Build_Payloads
+  timeoutInMinutes: 45
+  pool:
+    name: Azure Pipelines
+    vmImage: macOS-latest
+  variables:
+    toolchainRoot: '$(Agent.TempDirectory)/macos-toolchain'
+  steps:
+  - checkout: self
+
+  - script: |
+      set -euo pipefail
+      arch=$(uname -m)
+      echo "agent architecture: $arch"
+      if [ "$arch" != "x86_64" ]; then
+        echo "##[error]This smoke test downloads the x86_64 payload; agent reports $arch."
+        echo "##[error]Switch the artifact below to toolchain-arm64 once the pool moves."
+        exit 1
+      fi
+    displayName: 'Confirm agent architecture'
+
+  - task: DownloadPipelineArtifact@2
+    displayName: 'Download x86_64 payload'
+    inputs:
+      artifact: 'toolchain-x86_64'
+      path: '$(toolchainRoot)'
+
+  - script: |
+      set -euo pipefail
+      cd "$(toolchainRoot)"
+      chmod +x bin/* libexec/lima/* 2>/dev/null || true
+      echo "##[group]payload"
+      du -sh . bin share libexec image
+      cat manifest.json
+      echo "##[endgroup]"
+
+      echo "##vso[task.prependpath]$(toolchainRoot)/bin"
+      export PATH="$(toolchainRoot)/bin:$PATH"
+
+      # The packaged binaries must run at all -- the producer only checked their
+      # Mach-O headers, which a corrupt or truncated download would still pass.
+      docker --version
+      colima version
+      limactl --version
+    displayName: 'Install payload and prove the binaries run'
+
+  - script: |
+      set -euo pipefail
+      cd "$(toolchainRoot)"
+      cache_name=$(python3 -c "import json;print(json.load(open('manifest.json'))['image']['cache_filename'])")
+      image=$(python3 -c "import json;print(json.load(open('manifest.json'))['image']['filename'])")
+      dest="$HOME/Library/Caches/colima/caches"
+      mkdir -p "$dest"
+      cp "image/$image" "$dest/$cache_name"
+      # Recorded so the next step can prove colima used this file rather than
+      # replacing it with a fresh download.
+      stat -f '%m' "$dest/$cache_name" > "$(Agent.TempDirectory)/seed-mtime"
+      ls -la "$dest"
+    displayName: 'Seed colima image cache'
+
+  - script: |
+      set -euo pipefail
+      export PATH="$(toolchainRoot)/bin:$PATH"
+      start=$(date +%s)
+      colima start --cpu 4 --memory 4 --disk 50 2>&1 | tee "$(Agent.TempDirectory)/colima.log"
+      echo "colima start took $(( $(date +%s) - start ))s"
+
+      cache_name=$(python3 -c "import json;print(json.load(open('$(toolchainRoot)/manifest.json'))['image']['cache_filename'])")
+      seeded=$(cat "$(Agent.TempDirectory)/seed-mtime")
+      now=$(stat -f '%m' "$HOME/Library/Caches/colima/caches/$cache_name")
+      if [ "$seeded" != "$now" ]; then
+        echo "##[error]colima replaced the seeded image, so it still downloaded ~350 MB"
+        exit 1
+      fi
+      echo "seeded image was reused (mtime unchanged): the guest image download is gone"
+
+      docker context use colima >/dev/null || true
+      docker version
+      docker info | head -20
+    displayName: 'Boot colima from the seeded image'
+
+  - template: generate-sql-password-template.yml
+    parameters:
+      osType: MacOS
+
+  # The real workload: a container actually has to run on this toolchain.
+  - script: bash .pipeline/scripts/start-sql-server-macos.sh
+    displayName: 'Start SQL Server on the vendored toolchain'
+    timeoutInMinutes: 22
+    env:
+      SQL_PASSWORD: $(SQL_PASSWORD)
+
+  - script: |
+      set -euo pipefail
+      export PATH="$(toolchainRoot)/bin:$PATH"
+      docker exec sqlserver /opt/mssql-tools18/bin/sqlcmd \
+        -S localhost -U SA -P "$SQL_PASSWORD" -C -b -Q "SELECT @@VERSION"
+    displayName: 'Query SQL Server'
+    env:
+      SQL_PASSWORD: $(SQL_PASSWORD)
+
+  - script: |
+      set +e
+      export PATH="$(toolchainRoot)/bin:$PATH"
+      echo "=== colima log ==="; cat "$(Agent.TempDirectory)/colima.log"
+      echo "=== containers ==="; docker ps -a
+      colima delete --force
+      exit 0
+    displayName: 'Diagnostics and cleanup'
+    condition: always()

--- a/.pipeline/templates/sql-setup-template.yml
+++ b/.pipeline/templates/sql-setup-template.yml
@@ -262,7 +262,7 @@ steps:
   # job caps at 60 minutes and SQL setup must not be what exhausts it.
   - script: bash .pipeline/scripts/start-colima-macos.sh
     displayName: 'Install and start Colima-based Docker'
-    timeoutInMinutes: 13
+    timeoutInMinutes: 15
 
   - script: bash .pipeline/scripts/start-sql-server-macos.sh
     displayName: 'Start SQL Server (Docker, no TLS certs)'

--- a/.pipeline/templates/test-mssql-python-macos-template.yml
+++ b/.pipeline/templates/test-mssql-python-macos-template.yml
@@ -101,7 +101,7 @@ steps:
 # caps at 60 minutes and SQL setup must not be what exhausts it.
 - script: bash .pipeline/scripts/start-colima-macos.sh
   displayName: 'Install and start Colima-based Docker'
-  timeoutInMinutes: 13
+  timeoutInMinutes: 15
 
 # ── 5. Start SQL Server (no TLS certs) ──────────────────────────────────────
 - script: bash .pipeline/scripts/start-sql-server-macos.sh

--- a/.pipeline/validation-pipeline.yml
+++ b/.pipeline/validation-pipeline.yml
@@ -1,70 +1,21 @@
-# CI trigger only on development. Main-branch builds are produced by the
-# Official pipeline (OneBranch/OfficialPythonWheelsBuild.yml) on merge.
-trigger:
-- development
+# ############################################################################
+# THROWAWAY. This file has been gutted on branch david/macos-toolchain-producer
+# so PR validation runs nothing but the vendored macOS toolchain smoke test.
+#
+# Restore this file from main before merging anything. Nothing else in the
+# branch touches it, and validation-stages.yml is untouched.
+# ############################################################################
 
-parameters:
-- name: buildType
-  displayName: Type of the build to produce
-  type: string
-  values:
-  - Both
-  - Debug
-  - Release
-  default: Both
-
-- name: RunFuzz
-  displayName: Run Fuzz Tests (30 min)
-  type: boolean
-  default: false
-
-- name: RunLongHaul
-  displayName: Run Long-Haul BCP Test (30 min)
-  type: boolean
-  default: false
-
-- name: sqlInstanceMode
-  displayName: SQL host cardinality for ARM test stages
-  type: string
-  values:
-  - shared
-  - per-job
-  default: shared
-
-- name: sqlImageTag
-  displayName: SQL Server docker image tag for ARM test stages
-  type: string
-  default: '2025-latest'
-
-variables:
-  # msodbcsql18 reference-driver version for the ODBC C++ e2e parity comparison.
-  # Pinned so an upstream release can't silently change what the parity table
-  # compares against. Consumed on Windows by install-msodbcsql.ps1 and on Linux
-  # by containerized-odbc-e2e.sh (which appends the Debian package revision).
-  msodbcsqlVersion: '18.6.2.1'
+trigger: none
 
 stages:
-- template: templates/validation-stages.yml
-  parameters:
-    buildType: ${{ parameters.buildType }}
-    RunFuzz: ${{ parameters.RunFuzz }}
-    RunLongHaul: ${{ parameters.RunLongHaul }}
-    sqlInstanceMode: ${{ parameters.sqlInstanceMode }}
-    sqlImageTag: ${{ parameters.sqlImageTag }}
-    # This file is shared by TWO pipeline definitions: 2267 in the `public`
-    # project (GitHub PRs, i.e. unreviewed code) and 2204 in `mssql-rs` (the ADO
-    # mirror). Pool names must resolve at compile time, so this is a template
-    # rather than a runtime variable. The pools are project-scoped, so a wrong
-    # branch here fails with "pool not found" rather than putting unreviewed
-    # code on a trusted agent.
-    ${{ if eq(variables['System.TeamProject'], 'public') }}:
-      poolName: RUST-PUBLIC-X64-WUS3
-      armPoolName: RUST-PUBLIC-ARM64-WUS3
-      utilPoolName: RUST-PUBLIC-UTIL-WUS3
-    ${{ else }}:
-      poolName: RUST-X64-WUS3
-      armPoolName: RUST-ARM64-WUS3
-      utilPoolName: RUST-UTIL-WUS3
-    # PR validation for internal ADO and GitHub PRs. GitHub PRs run in the public
-    # project, which lacks 'Magnitude Test', so exclude the infra stages here.
-    includeInfraStages: false
+- stage: Toolchain_Smoke
+  displayName: macOS vendored-toolchain smoke test
+  jobs:
+  - template: templates/macos-toolchain-smoke-template.yml
+    parameters:
+      # GitHub PRs build in the `public` project, which has its own pools.
+      ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        utilPoolName: RUST-PUBLIC-UTIL-WUS3
+      ${{ else }}:
+        utilPoolName: RUST-UTIL-WUS3


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — validation only

This PR exists to prove the vendored macOS toolchain works on a real agent. It **replaces the entire PR validation stage set** with a single smoke test while `RunToolchainSmoke` is true, so a run costs one Linux job and one macOS job instead of the full matrix.

Two things must be reverted before any of this merges:
- `RunToolchainSmoke` default back to `false`
- the stage selection in `validation-pipeline.yml`

Both are confined to `validation-pipeline.yml`; `validation-stages.yml` is untouched.

Relates to #499 and builds on #500.

## What it proves

The producer (`build-macos-docker-toolchain.py`) runs on Linux and can only check Mach-O headers. It cannot show that:

- the packaged binaries actually **run** on macOS (a truncated download passes a header check)
- seeding colima's cache genuinely **stops** the ~350 MB guest image download
- lima's guest agent — which lives in `share/`, outside `bin/`, and **was missing from an earlier revision of this payload** — is complete enough to boot a VM

That third one is the reason this PR exists. The first version of the producer extracted only `bin/`, dropping `share/lima/lima-guestagent.Linux-x86_64.gz` (8.1 MB) and `libexec/lima/` (7.6 MB). It would have published cleanly, installed cleanly, and failed at VM boot. It is fixed, but the fix is verified only structurally.

## How

**Linux job** builds both arch payloads and publishes them as pipeline artifacts — not Universal Packages, to keep the loop fast and avoid throwaway versions in the feed. Feed publish and download sizing is a separate question, deliberately not answered here.

**macOS job** then:

1. downloads the x86_64 payload and runs `docker --version`, `colima version`, `limactl --version`
2. seeds `~/Library/Caches/colima/caches/<sha256-of-image-url>` from the payload, recording the file's mtime
3. `colima start`, then **asserts the mtime is unchanged** — if colima had re-downloaded the image, the file would have been replaced
4. runs the real `start-sql-server-macos.sh` and queries `@@VERSION`

Step 4 is the point: a passing run means a container actually ran on a vendored toolchain, not merely that the docker daemon answered.

## What a pass tells us

| Question | Answered |
| --- | --- |
| Do the packaged binaries run on macOS? | yes |
| Is the lima payload complete enough to boot a VM? | yes |
| Does cache seeding remove the 358 MB download? | yes, via the mtime assertion |
| Does a container actually run? | yes, SQL Server starts and answers a query |
| Will a ~415 MB Universal Package publish and download? | **no — separate test** |

## Timings to watch

The macOS job logs artifact download time and `colima start` duration. Current baselines to compare against: brew install ~29s on the bottled path, colima boot p50 265s, guest image fetch+decompress p50 21s.
