### PR TITLE
Test macOS architecture across Azure pipelines

### DIFF
--- a/.pipeline/OneBranch/NonOfficialPythonWheelsPublish.yml
+++ b/.pipeline/OneBranch/NonOfficialPythonWheelsPublish.yml
@@ -71,10 +71,24 @@ extends:
       - name: public/mssql-rs_Public
         continueOnConflict: true
     stages:
-    - template: /.pipeline/OneBranch/stages.yml@self
-      parameters:
-        buildAllTargets: true
-        buildPythonWheels: true
-        buildOdbcNative: ${{ parameters.buildOdbcNative }}
-        isOfficial: false
-        publishToFeed: ${{ parameters.publishToFeed }}
+    - stage: Build
+      jobs:
+      - job: MacOS_Architecture
+        displayName: macOS architecture
+        timeoutInMinutes: 15
+        pool:
+          type: linux
+          isCustom: true
+          name: Azure Pipelines
+          vmImage: 'macOS-latest'
+        variables:
+          ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
+        steps:
+        - pwsh: |
+            $machine = & uname -m
+            Write-Host "Reason: $(Build.Reason)"
+            Write-Host "Branch: $(Build.SourceBranch)"
+            Write-Host "Operating System: $(Agent.OS)"
+            Write-Host "Architecture: $(Agent.OSArchitecture)"
+            Write-Host "Machine: $machine"
+          displayName: Debug information

--- a/.pipeline/validation-pipeline.yml
+++ b/.pipeline/validation-pipeline.yml
@@ -4,67 +4,23 @@ trigger:
 - development
 
 parameters:
-- name: buildType
-  displayName: Type of the build to produce
+- name: githubBranch
+  displayName: GitHub branch
   type: string
-  values:
-  - Both
-  - Debug
-  - Release
-  default: Both
+  default: '$(Build.SourceBranch)'
 
-- name: RunFuzz
-  displayName: Run Fuzz Tests (30 min)
-  type: boolean
-  default: false
-
-- name: RunLongHaul
-  displayName: Run Long-Haul BCP Test (30 min)
-  type: boolean
-  default: false
-
-- name: sqlInstanceMode
-  displayName: SQL host cardinality for ARM test stages
-  type: string
-  values:
-  - shared
-  - per-job
-  default: shared
-
-- name: sqlImageTag
-  displayName: SQL Server docker image tag for ARM test stages
-  type: string
-  default: '2025-latest'
-
-variables:
-  # msodbcsql18 reference-driver version for the ODBC C++ e2e parity comparison.
-  # Pinned so an upstream release can't silently change what the parity table
-  # compares against. Consumed on Windows by install-msodbcsql.ps1 and on Linux
-  # by containerized-odbc-e2e.sh (which appends the Debian package revision).
-  msodbcsqlVersion: '18.6.2.1'
-
-stages:
-- template: templates/validation-stages.yml
-  parameters:
-    buildType: ${{ parameters.buildType }}
-    RunFuzz: ${{ parameters.RunFuzz }}
-    RunLongHaul: ${{ parameters.RunLongHaul }}
-    sqlInstanceMode: ${{ parameters.sqlInstanceMode }}
-    sqlImageTag: ${{ parameters.sqlImageTag }}
-    # This file is shared by TWO pipeline definitions: 2267 in the `public`
-    # project (GitHub PRs, i.e. unreviewed code) and 2204 in `mssql-rs` (the ADO
-    # mirror). Pool names must resolve at compile time, so this is a template
-    # rather than a runtime variable. The pools are project-scoped, so a wrong
-    # branch here fails with "pool not found" rather than putting unreviewed
-    # code on a trusted agent.
-    ${{ if eq(variables['System.TeamProject'], 'public') }}:
-      poolName: RUST-PUBLIC-X64-WUS3
-      armPoolName: RUST-PUBLIC-ARM64-WUS3
-      utilPoolName: RUST-PUBLIC-UTIL-WUS3
-    ${{ else }}:
-      poolName: RUST-X64-WUS3
-      armPoolName: RUST-ARM64-WUS3
-      utilPoolName: RUST-UTIL-WUS3
-    # PR validation for internal ADO and GitHub PRs. GitHub PRs run in the public
-    # project, which lacks 'Magnitude Test', so exclude the infra stages here.
-    includeInfraStages: false
+jobs:
+- job: Build
+  timeoutInMinutes: 15
+  pool:
+    type: linux
+    isCustom: true
+    name: Azure Pipelines
+    vmImage: 'macOS-14-arm64'
+  steps:
+  - pwsh: |
+      Write-Host "Reason: $(Build.Reason)"
+      Write-Host "Branch: ${{ parameters.githubBranch }}"
+      Write-Host "Operating System: $(Agent.OS)"
+      Write-Host "Architecture: $(Agent.OSArchitecture)"
+    displayName: Debug information

--- a/.pipeline/validation-pipeline.yml
+++ b/.pipeline/validation-pipeline.yml
@@ -16,7 +16,7 @@ jobs:
     type: linux
     isCustom: true
     name: Azure Pipelines
-    vmImage: 'macOS-14-arm64'
+    vmImage: 'macOS-latest'
   steps:
   - pwsh: |
       Write-Host "Reason: $(Build.Reason)"


### PR DESCRIPTION
## Description

Throwaway PR comparing the macOS agent selected by the standard PR pipeline and the non-official OneBranch pipeline.

Results:

- Standard PR pipeline with `Azure Pipelines` / `macOS-latest`: `Agent.OSArchitecture = X64`.
- `OneBranch.NonOfficial.CrossPlat` with the same custom pool configuration: `Agent.OSArchitecture = X64` and `uname -m = x86_64`.

The pipeline entry points are temporarily reduced to 15-minute architecture probes, so duplicate-PR evaluation and the full validation suites do not run. This PR is not intended to merge.

## Related Issues

N/A — throwaway pipeline experiment requested without an issue.

## Checklist

- [ ] `cargo bfmt` passes — N/A (pipeline-only experiment)
- [ ] `cargo bclippy` passes — N/A (pipeline-only experiment)
- [ ] `cargo btest` passes — N/A (pipeline-only experiment)
- [ ] New/changed functionality has tests — N/A
- [ ] Public API changes are documented — N/A