### PR TITLE
Test GitHub-hosted macOS ARM64 runner

### DIFF
--- a/.github/workflows/macos-arm64-experiment.yml
+++ b/.github/workflows/macos-arm64-experiment.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Install nextest
         run: ./.pipeline/scripts/install-coverage-tools-macos.sh
 
+      - name: Fetch locked dependencies
+        run: cargo fetch --locked
+
       - name: Build Rust workspace
         run: cargo build --workspace --frozen --all-targets
 

--- a/.github/workflows/macos-arm64-experiment.yml
+++ b/.github/workflows/macos-arm64-experiment.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Install nextest
         run: ./.pipeline/scripts/install-coverage-tools-macos.sh
 
-      - name: Fetch locked dependencies
-        run: cargo fetch --locked
+      - name: Fetch dependencies
+        run: cargo fetch
 
       - name: Build Rust workspace
         run: cargo build --workspace --frozen --all-targets

--- a/.github/workflows/macos-arm64-experiment.yml
+++ b/.github/workflows/macos-arm64-experiment.yml
@@ -1,0 +1,58 @@
+name: macOS ARM64 Experiment
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: macos-arm64-experiment-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  arm64-build-test:
+    if: github.head_ref == 'dev/saurabh/github-macos-arm-test'
+    runs-on: macos-15
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Report runner architecture
+        run: |
+          echo "runner.arch=${{ runner.arch }}"
+          echo "uname -m=$(uname -m)"
+          uname -a
+          sw_vers
+          system_profiler SPHardwareDataType
+
+          test "${{ runner.arch }}" = "ARM64"
+          test "$(uname -m)" = "arm64"
+
+      - name: Report Rust toolchain
+        run: |
+          rustc --version --verbose
+          cargo --version --verbose
+          rustup show active-toolchain
+
+      - name: Install nextest
+        run: ./.pipeline/scripts/install-coverage-tools-macos.sh
+
+      - name: Build Rust workspace
+        run: cargo build --workspace --frozen --all-targets
+
+      - name: Generate mock server certificates
+        run: ./scripts/generate_mock_tds_server_certs.sh
+
+      - name: Run non-connectivity tests
+        env:
+          CERT_HOST_NAME: sql1
+          RUST_BACKTRACE: full
+        run: >-
+          cargo nextest run --workspace --frozen --all-targets
+          --no-fail-fast --profile ci --success-output immediate
+          -E 'not test(connectivity)'

--- a/.github/workflows/macos-arm64-experiment.yml
+++ b/.github/workflows/macos-arm64-experiment.yml
@@ -51,11 +51,12 @@ jobs:
       - name: Generate mock server certificates
         run: ./scripts/generate_mock_tds_server_certs.sh
 
-      - name: Run non-connectivity tests
+      - name: Run unit and mock server tests
         env:
           CERT_HOST_NAME: sql1
           RUST_BACKTRACE: full
         run: >-
           cargo nextest run --workspace --frozen --all-targets
           --no-fail-fast --profile ci --success-output immediate
-          -E 'not test(connectivity)'
+          -E 'kind(lib) | binary(test_mock_server) |
+          binary(test_mock_server_fedauth) | binary(test_mock_server_tls)'


### PR DESCRIPTION
## Description

Throwaway experiment to verify actual Rust build and test work on GitHub's hosted `macos-15` ARM64 runner. This PR is **not intended to merge**.

The PR-scoped workflow records `runner.arch`, `uname -m`, macOS and hardware details, builds the complete Rust workspace, and runs all workspace library tests plus the mock-TDS, FedAuth, and TLS integration suites. Live SQL Server/connectivity tests are excluded because the GitHub-hosted runner has no database infrastructure. The experiment does not use Docker or nested virtualization.

### Experiment result

[GitHub Actions run 33933482371](https://github.com/microsoft/mssql-rs/actions/runs/33933482371) passed on `runner.arch=ARM64` / `uname -m=arm64` (virtual Apple M1, macOS 15.7.9). The complete workspace built successfully in 2m 05s, and nextest passed all 3,425 selected unit and mock-server tests in 27s.

## Related Issues

N/A — this throwaway experiment intentionally has no linked issue or work item.

## Checklist

- [ ] `cargo bfmt` passes — N/A; no Rust source changed
- [ ] `cargo bclippy` passes — N/A; no Rust source changed
- [ ] `cargo btest` passes — N/A; the experiment passed targeted unit and mock-server nextest suites on macOS ARM64
- [x] New/changed functionality has tests — the workflow performs the build/test experiment it introduces
- [x] Public API changes are documented — N/A; no public API change