### PR TITLE
Fix nvarchar(max) to SQL_C_CHAR PLP buffer overflow on surrogate straddle

### DIFF
--- a/mssql-odbc/src/api/get_data.rs
+++ b/mssql-odbc/src/api/get_data.rs
@@ -181,6 +181,7 @@ fn sql_get_data_safe(
         let prepared_stream = (
             active_plp.encoding,
             active_plp.pending_units.len(),
+            active_plp.pending_utf8.len(),
             active_plp.narrow_to_wide.is_some(),
         );
         return stream_active_plp_chunk(
@@ -1465,7 +1466,7 @@ fn stream_active_plp_chunk<'a>(
     buffer_length: SqlLen,
     strlen_or_ind_ptr: *mut SqlLen,
     starting_new_stream: bool,
-    prepared_stream: Option<(PlpEncoding, usize, bool)>,
+    prepared_stream: Option<(PlpEncoding, usize, usize, bool)>,
     mut retained_stmt_state: Option<MutexGuard<'a, StmtState>>,
 ) -> SqlReturn {
     if target_type != SQL_C_CHAR && target_type != SQL_C_WCHAR {
@@ -1487,8 +1488,12 @@ fn stream_active_plp_chunk<'a>(
         return SQL_ERROR;
     }
 
-    let (plp_encoding, widen_carry_len) = if let Some((encoding, widen_carry_len, widening_ready)) =
-        prepared_stream
+    let (plp_encoding, widen_carry_len, utf8_carry_len) = if let Some((
+        encoding,
+        widen_carry_len,
+        utf8_carry_len,
+        widening_ready,
+    )) = prepared_stream
     {
         let compatible = match (target_type, encoding) {
             (SQL_C_WCHAR, PlpEncoding::Utf16Text) => true,
@@ -1517,7 +1522,7 @@ fn stream_active_plp_chunk<'a>(
             }
             return SQL_ERROR;
         }
-        (Some(encoding), widen_carry_len)
+        (Some(encoding), widen_carry_len, utf8_carry_len)
     } else {
         let mut stmt_state = match retained_stmt_state.take() {
             Some(state) => state,
@@ -1621,6 +1626,7 @@ fn stream_active_plp_chunk<'a>(
         let stream_state = (
             stream.map(|s| s.encoding),
             stream.map_or(0, |s| s.pending_units.len()),
+            stream.map_or(0, |s| s.pending_utf8.len()),
         );
         retained_stmt_state = Some(stmt_state);
         stream_state
@@ -1675,12 +1681,7 @@ fn stream_active_plp_chunk<'a>(
         // Whole UTF-16 code units only.
         payload_capacity & !1
     } else if transcode_utf16_to_utf8 {
-        // One BMP UTF-16 code unit expands to at most 3 UTF-8 bytes, so read at
-        // most (cap / 3) code units per chunk. Keeping the byte count even means
-        // a code unit is never split mid-read; surrogate pairs that straddle a
-        // chunk boundary are carried explicitly. This conservative sizing
-        // guarantees the transcoded output always fits the caller's buffer.
-        ((payload_capacity / 3) * 2) & !1
+        utf16le_max_read(payload_capacity, utf8_carry_len)
     } else {
         payload_capacity
     };
@@ -1694,18 +1695,10 @@ fn stream_active_plp_chunk<'a>(
     // available and 01004 are reported as usual. msodbcsql answers this shape
     // the same way.
     //
-    // Payload room too small to carry one whole character is a different case:
-    // the buffer is not a probe, and the conservative sizing above cannot use
-    // the room it has, so every retry would report truncation without
-    // consuming anything and an application looping on an unchanged buffer
-    // would never terminate. That stays HY090.
-    //
-    // Reached by a SQL_C_CHAR buffer of 2-3 bytes transcoding from UTF-16,
-    // where one character needs up to 3, and by a SQL_C_WCHAR buffer of 1 or 3
-    // bytes: one cannot hold even the terminator, the other has a spare byte
-    // that no whole code unit fits in. msodbcsql instead delivers one byte per
-    // call here; matching that needs an unflushed-tail buffer in
-    // `ActivePlpStream` and is tracked separately.
+    // Payload room too small to carry one whole wide character is a different
+    // case: a SQL_C_WCHAR buffer of 1 or 3 bytes cannot make progress and is
+    // rejected with HY090. UTF-8 output has a byte carry, so any SQL_C_CHAR
+    // buffer with payload room can make progress.
     //
     // A probe is exactly two shapes: a zero-length buffer, and one sized for
     // the terminator alone. Everything else that cannot make progress is an
@@ -1716,6 +1709,8 @@ fn stream_active_plp_chunk<'a>(
     let is_length_probe = buffer_length == 0 || buffer_length as usize == terminator_bytes;
     let makes_no_progress = if widen_narrow_to_utf16 {
         widen_out_units == 0
+    } else if transcode_utf16_to_utf8 {
+        max_read == 0 && utf8_carry_len == 0
     } else {
         max_read == 0
     };
@@ -2039,35 +2034,41 @@ fn stream_active_plp_chunk<'a>(
         unsafe { write_if_some(strlen_or_ind_ptr, usable as SqlLen) };
     } else if transcode_utf16_to_utf8 {
         // NVARCHAR PLP wire bytes are UTF-16LE; transcode to UTF-8 for
-        // SQL_C_CHAR, carrying a split code unit or surrogate pair across the
-        // chunk boundary so the value is never corrupted.
-        let utf8 = {
+        // SQL_C_CHAR, carrying split input and output across calls.
+        {
             let Ok(mut ss) = stmt.inner.lock() else {
                 return SQL_ERROR;
             };
             let Some(stream) = ss.active_plp.as_mut() else {
                 return SQL_ERROR;
             };
-            utf16le_chunk_to_utf8(
+            let ActivePlpStream {
+                pending_byte,
+                pending_high_surrogate,
+                pending_utf8,
+                ..
+            } = stream;
+            let emit = transcode_utf16le_into_pending(
                 &payload[..read],
                 reached_end,
-                &mut stream.pending_byte,
-                &mut stream.pending_high_surrogate,
-            )
+                pending_byte,
+                pending_high_surrogate,
+                pending_utf8,
+                payload_capacity,
+            );
+            unsafe {
+                copy_with_nul(
+                    target_value_ptr as *mut u8,
+                    buffer_length as usize,
+                    &pending_utf8[..emit],
+                );
+                write_if_some(
+                    strlen_or_ind_ptr,
+                    SqlLen::try_from(emit).unwrap_or(SqlLen::MAX),
+                );
+            }
+            pending_utf8.drain(..emit);
         };
-        let utf8_bytes = utf8.as_bytes();
-        let truncated = unsafe {
-            copy_with_nul(
-                target_value_ptr as *mut u8,
-                buffer_length as usize,
-                utf8_bytes,
-            )
-        };
-        // Conservative max_read sizing guarantees the transcoded chunk fits.
-        debug_assert!(!truncated, "transcoded PLP chunk overflowed caller buffer");
-        unsafe {
-            write_if_some(strlen_or_ind_ptr, utf8_bytes.len() as SqlLen);
-        }
     } else {
         // SQL_C_CHAR delivery of a non-UTF-16 text PLP column: the wire bytes are
         // copied verbatim. `SingleByteText` and `Utf8Text` have identical bodies
@@ -2121,15 +2122,14 @@ fn stream_active_plp_chunk<'a>(
         }
     };
 
-    // The wire being exhausted is not the same as the value being delivered: the
-    // widening path can still hold decoded units the caller's buffer had no room
-    // for. Ending the stream here would drop them and report success.
-    let widen_units_still_held = stmt_state
+    // The wire being exhausted is not the same as the value being delivered:
+    // converted output can remain after the caller's buffer fills.
+    let converted_data_still_held = stmt_state
         .active_plp
         .as_ref()
-        .is_some_and(|s| !s.pending_units.is_empty());
+        .is_some_and(|s| !s.pending_units.is_empty() || !s.pending_utf8.is_empty());
 
-    if reached_end && !widen_units_still_held {
+    if reached_end && !converted_data_still_held {
         if let Some(mut stream) = stmt_state.active_plp.take() {
             let buffer = stream.take_prefetch_buffer();
             if buffer.capacity() > stmt_state.plp_prefetch_scratch.capacity() {
@@ -2234,6 +2234,33 @@ pub(crate) fn widen_into_pending(
         pending.truncate(base + written);
     }
     out_units.min(pending.len())
+}
+
+/// Chooses an even UTF-16LE wire read size for the available UTF-8 output room.
+///
+/// Two code units are the minimum non-zero read so a surrogate pair can produce
+/// output in one call. Surplus UTF-8 bytes remain in `pending_utf8`.
+fn utf16le_max_read(payload_capacity: usize, pending_utf8_len: usize) -> usize {
+    let remaining = payload_capacity.saturating_sub(pending_utf8_len);
+    if remaining == 0 {
+        0
+    } else {
+        remaining.div_ceil(3).saturating_mul(2).max(4)
+    }
+}
+
+/// Appends one transcoded UTF-16LE chunk and returns the UTF-8 prefix that fits.
+fn transcode_utf16le_into_pending(
+    new_bytes: &[u8],
+    reached_end: bool,
+    pending_byte: &mut Option<u8>,
+    pending_high_surrogate: &mut Option<u16>,
+    pending_utf8: &mut Vec<u8>,
+    out_bytes: usize,
+) -> usize {
+    let utf8 = utf16le_chunk_to_utf8(new_bytes, reached_end, pending_byte, pending_high_surrogate);
+    pending_utf8.extend_from_slice(utf8.as_bytes());
+    out_bytes.min(pending_utf8.len())
 }
 
 /// Transcodes a chunk of UTF-16LE PLP wire bytes to UTF-8 for SQL_C_CHAR
@@ -3014,6 +3041,96 @@ mod tests {
         let second = utf16le_chunk_to_utf8(low, true, &mut pb, &mut ph);
         assert_eq!(second, "😀");
         assert!(pb.is_none() && ph.is_none());
+    }
+
+    #[test]
+    fn utf16_transcode_retains_surrogate_straddle_overflow() {
+        let wire = utf16le("A\u{10437}你");
+        let mut pending_byte = None;
+        let mut pending_high = None;
+        let mut pending_utf8 = Vec::new();
+        let mut delivered = Vec::new();
+        let payload_capacity = 6;
+
+        let first_read = utf16le_max_read(payload_capacity, pending_utf8.len());
+        assert_eq!(first_read, 4);
+        let first_emit = transcode_utf16le_into_pending(
+            &wire[..first_read],
+            false,
+            &mut pending_byte,
+            &mut pending_high,
+            &mut pending_utf8,
+            payload_capacity,
+        );
+        delivered.extend_from_slice(&pending_utf8[..first_emit]);
+        pending_utf8.drain(..first_emit);
+        assert_eq!(delivered, b"A");
+
+        let second_read = utf16le_max_read(payload_capacity, pending_utf8.len());
+        assert_eq!(second_read, 4);
+        let second_emit = transcode_utf16le_into_pending(
+            &wire[first_read..first_read + second_read],
+            true,
+            &mut pending_byte,
+            &mut pending_high,
+            &mut pending_utf8,
+            payload_capacity,
+        );
+        assert_eq!(pending_utf8.len(), 7);
+        assert_eq!(second_emit, payload_capacity);
+        delivered.extend_from_slice(&pending_utf8[..second_emit]);
+        pending_utf8.drain(..second_emit);
+        assert_eq!(pending_utf8.len(), 1);
+
+        let final_emit = transcode_utf16le_into_pending(
+            &[],
+            true,
+            &mut pending_byte,
+            &mut pending_high,
+            &mut pending_utf8,
+            payload_capacity,
+        );
+        delivered.extend_from_slice(&pending_utf8[..final_emit]);
+        pending_utf8.drain(..final_emit);
+
+        assert_eq!(String::from_utf8(delivered).unwrap(), "A\u{10437}你");
+        assert!(pending_utf8.is_empty());
+    }
+
+    #[test]
+    fn utf16_transcode_drains_multibyte_output_one_byte_at_a_time() {
+        let wire = utf16le("你");
+        let mut pending_byte = None;
+        let mut pending_high = None;
+        let mut pending_utf8 = Vec::new();
+        let mut delivered = Vec::new();
+
+        let emit = transcode_utf16le_into_pending(
+            &wire,
+            true,
+            &mut pending_byte,
+            &mut pending_high,
+            &mut pending_utf8,
+            1,
+        );
+        delivered.extend_from_slice(&pending_utf8[..emit]);
+        pending_utf8.drain(..emit);
+
+        while !pending_utf8.is_empty() {
+            assert_eq!(utf16le_max_read(1, pending_utf8.len()), 0);
+            let emit = transcode_utf16le_into_pending(
+                &[],
+                true,
+                &mut pending_byte,
+                &mut pending_high,
+                &mut pending_utf8,
+                1,
+            );
+            delivered.extend_from_slice(&pending_utf8[..emit]);
+            pending_utf8.drain(..emit);
+        }
+
+        assert_eq!(String::from_utf8(delivered).unwrap(), "你");
     }
 
     /// A dangling half code unit at true end-of-stream is genuinely malformed

--- a/mssql-odbc/src/api/get_data.rs
+++ b/mssql-odbc/src/api/get_data.rs
@@ -2243,11 +2243,14 @@ pub(crate) fn widen_into_pending(
 
 /// Picks how many UTF-16LE wire bytes to read for the UTF-8 room still free.
 ///
-/// Even, so a read never splits a code unit, and never below two code units so
-/// a surrogate pair (both halves are needed to form one character) can
-/// transcode in a single call. This is only a target: a pair yields a 4-byte
-/// character, so the output can still overrun the room and spill into
-/// `pending_utf8`.
+/// Two wire bytes make one UTF-16 code unit, and a Basic Multilingual Plane
+/// code unit is at most three UTF-8 bytes, so about `room / 3` code units --
+/// two wire bytes each -- is the most that fits. Kept even so a read never
+/// splits a code unit, and never below two code units so a surrogate pair (the
+/// two code units UTF-16 uses for characters outside that plane, such as emoji)
+/// can transcode in one call. Still only a target: a surrogate pair is four
+/// UTF-8 bytes, one past what the `/ 3` sizing assumes, so output can overrun
+/// the room and spill into `pending_utf8`.
 fn utf16le_max_read(payload_capacity: usize, pending_utf8_len: usize) -> usize {
     let remaining = payload_capacity.saturating_sub(pending_utf8_len);
     if remaining == 0 {

--- a/mssql-odbc/src/api/get_data.rs
+++ b/mssql-odbc/src/api/get_data.rs
@@ -2033,8 +2033,13 @@ fn stream_active_plp_chunk<'a>(
         // writable for one `SqlLen`.
         unsafe { write_if_some(strlen_or_ind_ptr, usable as SqlLen) };
     } else if transcode_utf16_to_utf8 {
-        // NVARCHAR PLP wire bytes are UTF-16LE; transcode to UTF-8 for
-        // SQL_C_CHAR, carrying split input and output across calls.
+        // The wire carries nvarchar as UTF-16; the caller asked for UTF-8
+        // (SQL_C_CHAR). A code unit or a surrogate pair split across a chunk
+        // boundary is carried on the input side (pending_byte /
+        // pending_high_surrogate). Output can overrun too: a surrogate pair
+        // becomes a 4-byte character, so a chunk may transcode to more UTF-8
+        // than the buffer holds. Transcode the whole chunk, copy only what
+        // fits, and keep the rest in pending_utf8 for the next call.
         {
             let Ok(mut ss) = stmt.inner.lock() else {
                 return SQL_ERROR;
@@ -2236,10 +2241,13 @@ pub(crate) fn widen_into_pending(
     out_units.min(pending.len())
 }
 
-/// Chooses an even UTF-16LE wire read size for the available UTF-8 output room.
+/// Picks how many UTF-16LE wire bytes to read for the UTF-8 room still free.
 ///
-/// Two code units are the minimum non-zero read so a surrogate pair can produce
-/// output in one call. Surplus UTF-8 bytes remain in `pending_utf8`.
+/// Even, so a read never splits a code unit, and never below two code units so
+/// a surrogate pair (both halves are needed to form one character) can
+/// transcode in a single call. This is only a target: a pair yields a 4-byte
+/// character, so the output can still overrun the room and spill into
+/// `pending_utf8`.
 fn utf16le_max_read(payload_capacity: usize, pending_utf8_len: usize) -> usize {
     let remaining = payload_capacity.saturating_sub(pending_utf8_len);
     if remaining == 0 {

--- a/mssql-odbc/src/api/get_data.rs
+++ b/mssql-odbc/src/api/get_data.rs
@@ -2244,19 +2244,22 @@ pub(crate) fn widen_into_pending(
 /// Picks how many UTF-16LE wire bytes to read for the UTF-8 room still free.
 ///
 /// Two wire bytes make one UTF-16 code unit, and a Basic Multilingual Plane
-/// code unit is at most three UTF-8 bytes, so about `room / 3` code units --
-/// two wire bytes each -- is the most that fits. Kept even so a read never
-/// splits a code unit, and never below two code units so a surrogate pair (the
-/// two code units UTF-16 uses for characters outside that plane, such as emoji)
-/// can transcode in one call. Still only a target: a surrogate pair is four
-/// UTF-8 bytes, one past what the `/ 3` sizing assumes, so output can overrun
-/// the room and spill into `pending_utf8`.
+/// code unit is at most three UTF-8 bytes, so `room / 3` code units (floored,
+/// two wire bytes each) is the most whose output still fits -- which keeps whole
+/// characters inside a single returned buffer instead of splitting one across
+/// calls. Never below two code units, so a surrogate pair (the two code units
+/// UTF-16 uses for characters outside that plane, such as emoji) can assemble in
+/// one call even when the room is a byte or two.
+///
+/// `pending_utf8` still absorbs the two shapes that overshoot the room anyway: a
+/// surrogate pair is four UTF-8 bytes, one past the three the `/ 3` floor budgets
+/// per unit, and the two-unit floor over-reads any room under six bytes.
 fn utf16le_max_read(payload_capacity: usize, pending_utf8_len: usize) -> usize {
     let remaining = payload_capacity.saturating_sub(pending_utf8_len);
     if remaining == 0 {
         0
     } else {
-        remaining.div_ceil(3).saturating_mul(2).max(4)
+        (remaining / 3).saturating_mul(2).max(4)
     }
 }
 

--- a/mssql-odbc/src/api/get_data.rs
+++ b/mssql-odbc/src/api/get_data.rs
@@ -2073,6 +2073,14 @@ fn stream_active_plp_chunk<'a>(
                 );
             }
             pending_utf8.drain(..emit);
+            // Forward progress, mirroring the widening branch's guard. The
+            // extra read > 0 term is the UTF-16 difference: a chunk can be a
+            // lone carried high surrogate (the #211 straddle), consuming wire
+            // input while emitting nothing yet -- progress, not a stall.
+            debug_assert!(
+                emit > 0 || read > 0 || reached_end || payload_capacity == 0,
+                "UTF-16 to UTF-8 transcode made no forward progress"
+            );
         };
     } else {
         // SQL_C_CHAR delivery of a non-UTF-16 text PLP column: the wire bytes are
@@ -3154,6 +3162,33 @@ mod tests {
         }
 
         assert_eq!(String::from_utf8(delivered).unwrap(), "你");
+    }
+
+    #[test]
+    fn utf16le_max_read_floors_to_whole_characters() {
+        // (payload_capacity, pending_utf8_len) -> expected wire bytes to read.
+        // Floor sizing bounds a read to whole characters; the sizes not
+        // divisible by three (7, 8191) would read two bytes more under the old
+        // div_ceil, so they pin floor-vs-ceil. The rest pin the .max(4) two-unit
+        // floor and the carry shrinking the room (or filling it, draining only).
+        let cases = [
+            ((1, 0), 4),
+            ((3, 0), 4),
+            ((5, 0), 4),
+            ((6, 0), 4),
+            ((7, 0), 4),       // div_ceil would read 6
+            ((8191, 0), 5460), // div_ceil would read 5462
+            ((10, 4), 4),      // carry shrinks the room to 6
+            ((3, 3), 0),       // carry fills the room: drain only
+            ((3, 5), 0),       // carry over-fills, saturating to no read
+        ];
+        for ((capacity, carry), expected) in cases {
+            assert_eq!(
+                utf16le_max_read(capacity, carry),
+                expected,
+                "utf16le_max_read({capacity}, {carry})"
+            );
+        }
     }
 
     /// A dangling half code unit at true end-of-stream is genuinely malformed

--- a/mssql-odbc/src/api/get_data.rs
+++ b/mssql-odbc/src/api/get_data.rs
@@ -2249,7 +2249,10 @@ pub(crate) fn widen_into_pending(
 /// characters inside a single returned buffer instead of splitting one across
 /// calls. Never below two code units, so a surrogate pair (the two code units
 /// UTF-16 uses for characters outside that plane, such as emoji) can assemble in
-/// one call even when the room is a byte or two.
+/// one call even when the room is a byte or two. That two-unit floor is also
+/// what makes good on "any SQL_C_CHAR buffer with payload room can make
+/// progress": without it a two- or three-byte buffer would read zero with no
+/// carry to drain and fall into the HY090 no-progress branch.
 ///
 /// `pending_utf8` still absorbs the two shapes that overshoot the room anyway: a
 /// surrogate pair is four UTF-8 bytes, one past the three the `/ 3` floor budgets
@@ -3130,6 +3133,7 @@ mod tests {
         delivered.extend_from_slice(&pending_utf8[..emit]);
         pending_utf8.drain(..emit);
 
+        let mut iterations = 0;
         while !pending_utf8.is_empty() {
             assert_eq!(utf16le_max_read(1, pending_utf8.len()), 0);
             let emit = transcode_utf16le_into_pending(
@@ -3142,6 +3146,11 @@ mod tests {
             );
             delivered.extend_from_slice(&pending_utf8[..emit]);
             pending_utf8.drain(..emit);
+            iterations += 1;
+            assert!(
+                iterations < 10_000,
+                "transcode drain made no forward progress"
+            );
         }
 
         assert_eq!(String::from_utf8(delivered).unwrap(), "你");

--- a/mssql-odbc/src/handles/stmt.rs
+++ b/mssql-odbc/src/handles/stmt.rs
@@ -36,8 +36,10 @@ pub(crate) struct ActivePlpStream {
     /// High surrogate whose low half lands in the next chunk. Held back so the
     /// pair is transcoded together instead of each half becoming U+FFFD.
     pub(crate) pending_high_surrogate: Option<u16>,
-    /// UTF-8 bytes produced from UTF-16LE input that did not fit in the previous
-    /// `SQL_C_CHAR` buffer. Kept until later calls deliver them.
+    /// Transcoded UTF-8 that did not fit in the caller's `SQL_C_CHAR` buffer,
+    /// held until later calls deliver it. Output can exceed the buffer because a
+    /// UTF-16 surrogate pair becomes a 4-byte UTF-8 character, so a chunk is
+    /// transcoded whole and only the bytes that fit are copied out.
     pub(crate) pending_utf8: Vec<u8>,
     /// Incremental decoder for the narrow-text -> `SQL_C_WCHAR` widening path
     /// (`varchar(max)`/`json` delivered as UTF-16LE). `None` for every other

--- a/mssql-odbc/src/handles/stmt.rs
+++ b/mssql-odbc/src/handles/stmt.rs
@@ -36,6 +36,9 @@ pub(crate) struct ActivePlpStream {
     /// High surrogate whose low half lands in the next chunk. Held back so the
     /// pair is transcoded together instead of each half becoming U+FFFD.
     pub(crate) pending_high_surrogate: Option<u16>,
+    /// UTF-8 bytes produced from UTF-16LE input that did not fit in the previous
+    /// `SQL_C_CHAR` buffer. Kept until later calls deliver them.
+    pub(crate) pending_utf8: Vec<u8>,
     /// Incremental decoder for the narrow-text -> `SQL_C_WCHAR` widening path
     /// (`varchar(max)`/`json` delivered as UTF-16LE). `None` for every other
     /// combination.
@@ -92,6 +95,7 @@ impl ActivePlpStream {
             encoding,
             pending_byte: None,
             pending_high_surrogate: None,
+            pending_utf8: Vec::new(),
             narrow_to_wide,
             pending_units: Vec::new(),
             prefetched_wire: Vec::new(),
@@ -186,6 +190,7 @@ impl std::fmt::Debug for ActivePlpStream {
             .field("encoding", &self.encoding)
             .field("pending_byte", &self.pending_byte)
             .field("pending_high_surrogate", &self.pending_high_surrogate)
+            .field("pending_utf8", &self.pending_utf8.len())
             .field("narrow_to_wide", &self.narrow_to_wide.is_some())
             .field("pending_units", &self.pending_units.len())
             .field(

--- a/mssql-odbc/tests/e2e/tests/get_data_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/get_data_test.cpp
@@ -1010,6 +1010,27 @@ TEST_F(GetDataLiveTest, NvarcharMaxToCharChunkedAstralRoundTrip) {
     SQLCloseCursor(stmt_);
 }
 
+// A carried high surrogate can make the next UTF-16LE read emit more UTF-8
+// bytes than its input-only expansion budget. A 7-byte buffer leaves 6 payload
+// bytes: the second read transcodes U+10437 plus U+4F60 to 7 bytes.
+//
+// Benefits-from-mock-tds: force the exact PLP wire chunks and assert that the
+// final UTF-8 tail remains pending after the wire is exhausted.
+TEST_F(GetDataLiveTest, NvarcharMaxToCharSurrogateStraddleRetainsUtf8Tail) {
+    SKIP_IF_COMPARING_MSODBCSQL();
+    const std::string expected = "A\xF0\x90\x90\xB7\xE4\xBD\xA0";
+    ASSERT_SQL_OK(
+        ExecDirect(
+            "SELECT CAST(N'A' + NCHAR(0xD801) + NCHAR(0xDC37) + NCHAR(0x4F60) AS NVARCHAR(MAX)) "
+            "AS c1"),
+        SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+
+    EXPECT_EQ(expected, ReadCharDataInChunks(stmt_, 1, 7));
+
+    SQLCloseCursor(stmt_);
+}
+
 
 // A buffer with room for the terminator but no payload is a length probe, not a
 // caller error. It must report the available length with 01004 and leave the
@@ -1296,37 +1317,20 @@ TEST_F(GetDataLiveTest, VarcharMaxAstralToWcharSurrogatePairBuffer) {
 // The two shapes either side of the probe boundary, which differ by one byte of
 // payload room.
 //
-// A buffer with payload room too small to carry one whole character cannot make
-// progress: the conservative read sizing rounds it to zero, so returning
-// truncation would let an application looping on an unchanged buffer spin
-// forever. That is HY090, not a probe.
+// A UTF-8 tail buffer lets SQL_C_CHAR make progress one byte at a time without
+// dropping output. A buffer with no payload room remains a probe. The ASCII case
+// runs on the msodbcsql comparison leg because both drivers deliver one byte per
+// call here.
 //
-// A buffer with no payload room at all is a probe, and is answered.
-//
-// msodbcsql instead delivers one payload byte per call for the first shape --
-// 'a' as 0x61, 'e-acute' as 0xE9, CJK as 0x3F ('?') -- because it converts
-// SQL_C_CHAR to the client codepage, and the codepage measured here is
-// single-byte, so every character is one byte (and unrepresentable ones are
-// best-fit away, losing data). mssql-odbc delivers UTF-8, where a character is
-// 1-4 bytes. Matching it needs an unflushed-tail buffer in ActivePlpStream;
-// tracked separately. Hence the skip on the comparison leg.
-TEST_F(GetDataLiveTest, PlpSubMinimalBufferIsRejectedButProbeIsAnswered) {
-    SKIP_IF_COMPARING_MSODBCSQL();
+// Benefits-from-mock-tds: assert that alternate calls drain the UTF-8 tail
+// without consuming more wire data.
+TEST_F(GetDataLiveTest, PlpSubMinimalBufferDrainsWithoutLossAndProbeIsAnswered) {
     ASSERT_SQL_OK(
         ExecDirect("SELECT REPLICATE(CAST(N'abcd' AS NVARCHAR(MAX)), 50) AS c1"),
         SQL_HANDLE_STMT, stmt_);
     ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
 
-    // 2 bytes for SQL_C_CHAR: one payload byte once the terminator is reserved,
-    // which cannot hold a complete transcoded character.
-    SQLCHAR tiny[2] = {0xFF, 0xFF};
-    SQLLEN ind = 0;
-    SQLRETURN rc = SQLGetData(stmt_, 1, SQL_C_CHAR, tiny, sizeof(tiny), &ind);
-    EXPECT_EQ(SQL_ERROR, rc) << "a buffer that cannot make progress must not report truncation";
-    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "HY090");
-
-    // The rejection consumed nothing, so the value still reads back in full.
-    EXPECT_EQ(RepeatToken("abcd", 50), ReadCharDataInChunks(stmt_, 1, 8192));
+    EXPECT_EQ(RepeatToken("abcd", 50), ReadCharDataInChunks(stmt_, 1, 2));
 
     SQLCloseCursor(stmt_);
 

--- a/mssql-odbc/tests/e2e/tests/get_data_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/get_data_test.cpp
@@ -1319,8 +1319,10 @@ TEST_F(GetDataLiveTest, VarcharMaxAstralToWcharSurrogatePairBuffer) {
 //
 // A UTF-8 tail buffer lets SQL_C_CHAR make progress one byte at a time without
 // dropping output. A buffer with no payload room remains a probe. The ASCII case
-// runs on the msodbcsql comparison leg because both drivers deliver one byte per
-// call here.
+// deliberately keeps SKIP_IF_COMPARING_MSODBCSQL off so the comparison leg
+// (retail msodbcsql 18.6.2.1, SQL_DRIVER_VER 18.06.0002) measures the parity
+// rather than assuming it: both drivers drain a 2-byte SQL_C_CHAR buffer over
+// nvarchar(max) one byte per call, delivering the whole value without loss.
 //
 // Benefits-from-mock-tds: assert that alternate calls drain the UTF-8 tail
 // without consuming more wire data.

--- a/mssql-odbc/tests/e2e/tests/get_data_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/get_data_test.cpp
@@ -1014,6 +1014,10 @@ TEST_F(GetDataLiveTest, NvarcharMaxToCharChunkedAstralRoundTrip) {
 // bytes than its input-only expansion budget. A 7-byte buffer leaves 6 payload
 // bytes: the second read transcodes U+10437 plus U+4F60 to 7 bytes.
 //
+// The msodbcsql leg is skipped: on Windows it best-fits U+10437 into the client
+// ANSI codepage (which has no representation for it), so a byte-for-byte
+// comparison against our UTF-8 output cannot hold.
+//
 // Benefits-from-mock-tds: force the exact PLP wire chunks and assert that the
 // final UTF-8 tail remains pending after the wire is exhausted.
 TEST_F(GetDataLiveTest, NvarcharMaxToCharSurrogateStraddleRetainsUtf8Tail) {

--- a/mssql-odbc/tests/e2e/tests/get_data_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/get_data_test.cpp
@@ -1329,14 +1329,22 @@ TEST_F(GetDataLiveTest, VarcharMaxAstralToWcharSurrogatePairBuffer) {
 // nvarchar(max) one byte per call, delivering the whole value without loss.
 //
 // Benefits-from-mock-tds: assert that alternate calls drain the UTF-8 tail
-// without consuming more wire data.
+// without consuming more wire data, and that the final call reports the
+// delivered byte count rather than SQL_NO_TOTAL.
 TEST_F(GetDataLiveTest, PlpSubMinimalBufferDrainsWithoutLossAndProbeIsAnswered) {
     ASSERT_SQL_OK(
         ExecDirect("SELECT REPLICATE(CAST(N'abcd' AS NVARCHAR(MAX)), 50) AS c1"),
         SQL_HANDLE_STMT, stmt_);
     ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
 
-    EXPECT_EQ(RepeatToken("abcd", 50), ReadCharDataInChunks(stmt_, 1, 2));
+    SQLLEN final_ind = -999;
+    EXPECT_EQ(RepeatToken("abcd", 50),
+              ReadCharDataInChunks(stmt_, 1, 2, &final_ind));
+    // Truncated calls report SQL_NO_TOTAL; the final SQL_SUCCESS call keeps the
+    // delivered byte count instead (finish_get_data leaves the indicator
+    // alone). With a 2-byte buffer that final byte count is one.
+    EXPECT_NE(SQL_NO_TOTAL, final_ind);
+    EXPECT_EQ(1, final_ind);
 
     SQLCloseCursor(stmt_);
 


### PR DESCRIPTION
## Description

On the `nvarchar(max)` -> `SQL_C_CHAR` chunked PLP delivery path, `max_read` was sized on the assumption that each UTF-16 code unit read this chunk expands to at most 3 UTF-8 bytes: `((payload_capacity / 3) * 2) & !1`. That assumption breaks when a high surrogate is carried across a chunk boundary: the carried surrogate pairs off into a 4-byte astral sequence, so `utf16le_chunk_to_utf8` can emit one more unit than it read, and the transcoded output overruns the caller's buffer. `copy_with_nul` then truncated mid-sequence, and because the wire position had already advanced the dropped bytes were lost from the stream (silent corruption with an over-reported `StrLen_or_Ind`). In debug builds the `debug_assert!(!truncated, ...)` turned this into a panic across the FFI boundary.

The fix adopts the long-term approach the issue recommended: a `pending_utf8` tail buffer on `ActivePlpStream`. Each chunk is transcoded in full, only the bytes that fit are delivered, and the remainder is retained and flushed on later calls. The stream stays alive past wire EOF until the tail drains, mirroring the existing `pending_units` widening path (`varchar(max)` -> `SQL_C_WCHAR`).

Because output is now byte-addressable, this also removes the sub-minimal-buffer `HY090` divergence from msodbcsql: a `SQL_C_CHAR` buffer with any payload room now makes progress one byte per call instead of being rejected. Read sizing (`utf16le_max_read`) subtracts the carried tail and keeps a 2-code-unit floor so a surrogate pair can always assemble in one call. The transcode path still reports `SQL_NO_TOTAL` rather than a byte count, unchanged.

Coverage:
- Two Rust unit tests for the sizing/carry helpers: the surrogate-straddle overflow retains its UTF-8 tail across calls, and multibyte output drains one byte at a time from a 1-byte buffer.
- A C++ e2e regression (`NvarcharMaxToCharSurrogateStraddleRetainsUtf8Tail`) reproducing the exact `N'A' + NCHAR(0xD801)+NCHAR(0xDC37) + NCHAR(0x4F60)` case in a 7-byte buffer.
- The former `PlpSubMinimalBufferIsRejectedButProbeIsAnswered` test is updated to `PlpSubMinimalBufferDrainsWithoutLossAndProbeIsAnswered`, asserting a 2-byte buffer now drains losslessly and runs on the msodbcsql comparison leg for the ASCII case.

## Related Issues

Fixes #211

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes (all 1345 mssql-odbc unit tests, including the two new ones, pass locally; the added C++ e2e case and mssql-tds integration tests run in CI against a live SQL Server)
- [x] New/changed functionality has tests
- [ ] Public API changes are documented (N/A - no public API changes; new helpers are private and `pending_utf8` is `pub(crate)`)