### PR TITLE
Restore single-row bound fetch performance

### DIFF
--- a/mssql-odbc/src/api/bind_col.rs
+++ b/mssql-odbc/src/api/bind_col.rs
@@ -116,7 +116,7 @@ fn sql_bind_col_safe(
     // `free_desc` already walks DBC→STMT in the other direction to reset a
     // freed descriptor's associations, and holding both here in the opposite
     // order would be a classic ABBA deadlock.
-    let (ard, canonical_type) = {
+    let (ard, ard_is_explicit, canonical_type) = {
         let Ok(mut stmt_state) = stmt.inner.lock() else {
             error!("SQLBindCol: stmt mutex poisoned");
             return SQL_ERROR;
@@ -161,8 +161,9 @@ fn sql_bind_col_safe(
         // the column from the row cursor and run validation msodbcsql never reaches.
         if target_value_ptr.is_null() {
             let ard = stmt_state.effective_ard(stmt);
+            let ard_is_explicit = stmt_state.active_ard.is_some();
             drop(stmt_state);
-            let Ok(()) = unbind_ard_column(ard, column_number) else {
+            let Ok(()) = unbind_ard_column(ard, ard_is_explicit, column_number) else {
                 error!("SQLBindCol: ard mutex poisoned; unbind failed");
                 if let Ok(mut stmt_state) = stmt.inner.lock() {
                     post_sql_error(
@@ -198,7 +199,11 @@ fn sql_bind_col_safe(
             return SQL_ERROR;
         }
 
-        (stmt_state.effective_ard(stmt), canonical_type)
+        (
+            stmt_state.effective_ard(stmt),
+            stmt_state.active_ard.is_some(),
+            canonical_type,
+        )
     };
 
     let binding = ColumnBinding {
@@ -214,7 +219,7 @@ fn sql_bind_col_safe(
         // SQLSetDescFieldW/SQLSetDescRec.
         octet_length_ptr: strlen_or_ind_ptr,
     };
-    let Ok(()) = bind_ard_column(ard, binding) else {
+    let Ok(()) = bind_ard_column(ard, ard_is_explicit, binding) else {
         error!("SQLBindCol: ard mutex poisoned or missing record after growth");
         if let Ok(mut stmt_state) = stmt.inner.lock() {
             post_sql_error(
@@ -245,8 +250,12 @@ fn sql_bind_col_safe(
 /// conversion here is not expected to fail in practice — but this still
 /// reports it as an error rather than panicking or silently truncating to the
 /// wrong record.
-fn bind_ard_column(ard: SqlHandle, binding: ColumnBinding) -> Result<(), ()> {
-    if crate::handles::live_type(ard) != Some(HandleType::Desc) {
+fn bind_ard_column(
+    ard: SqlHandle,
+    ard_is_explicit: bool,
+    binding: ColumnBinding,
+) -> Result<(), ()> {
+    if ard_is_explicit && crate::handles::live_type(ard) != Some(HandleType::Desc) {
         return Err(());
     }
     let desc = unsafe { handle_from_raw::<DescHandle>(ard) };
@@ -275,8 +284,12 @@ fn bind_ard_column(ard: SqlHandle, binding: ColumnBinding) -> Result<(), ()> {
 /// descriptor: reporting `SQL_SUCCESS` here would tell the application an
 /// unbind happened when it didn't, and a stale bound column would keep
 /// writing through a possibly-freed application buffer on the next fetch.
-fn unbind_ard_column(ard: SqlHandle, column_number: SqlUSmallInt) -> Result<(), ()> {
-    if crate::handles::live_type(ard) != Some(HandleType::Desc) {
+fn unbind_ard_column(
+    ard: SqlHandle,
+    ard_is_explicit: bool,
+    column_number: SqlUSmallInt,
+) -> Result<(), ()> {
+    if ard_is_explicit && crate::handles::live_type(ard) != Some(HandleType::Desc) {
         return Err(());
     }
     let desc = unsafe { handle_from_raw::<DescHandle>(ard) };
@@ -318,7 +331,7 @@ pub(crate) unsafe fn sql_free_stmt_unbind(statement_handle: SqlHandle) -> SqlRet
 }
 
 fn sql_free_stmt_unbind_safe(stmt: &StmtHandle) -> SqlReturn {
-    let ard = {
+    let (ard, ard_is_explicit) = {
         let Ok(mut stmt_state) = stmt.inner.lock() else {
             error!("SQLFreeStmt(SQL_UNBIND): stmt mutex poisoned");
             return SQL_ERROR;
@@ -329,10 +342,13 @@ fn sql_free_stmt_unbind_safe(stmt: &StmtHandle) -> SqlReturn {
             post_diag(&mut stmt_state, ERR_FUNCTION_SEQUENCE);
             return SQL_ERROR;
         }
-        stmt_state.effective_ard(stmt)
+        (
+            stmt_state.effective_ard(stmt),
+            stmt_state.active_ard.is_some(),
+        )
     };
 
-    if crate::handles::live_type(ard) != Some(HandleType::Desc) {
+    if ard_is_explicit && crate::handles::live_type(ard) != Some(HandleType::Desc) {
         error!("SQLFreeStmt(SQL_UNBIND): ard freed concurrently; unbind failed");
         if let Ok(mut stmt_state) = stmt.inner.lock() {
             post_sql_error(
@@ -890,7 +906,7 @@ mod tests {
             strlen_or_ind_ptr: ptr::null_mut(),
             octet_length_ptr: ptr::null_mut(),
         };
-        assert!(bind_ard_column(explicit_ard, binding).is_err());
+        assert!(bind_ard_column(explicit_ard, true, binding).is_err());
     }
 
     /// Same race, same guard, for `unbind_ard_column`.
@@ -899,6 +915,6 @@ mod tests {
         let mut h = TestHandles::with_env_dbc_stmt();
         let explicit_ard = h.alloc_explicit_desc();
         assert_eq!(h.free_explicit_desc(explicit_ard), SQL_SUCCESS);
-        assert!(unbind_ard_column(explicit_ard, 1).is_err());
+        assert!(unbind_ard_column(explicit_ard, true, 1).is_err());
     }
 }

--- a/mssql-odbc/src/api/bind_col.rs
+++ b/mssql-odbc/src/api/bind_col.rs
@@ -116,7 +116,7 @@ fn sql_bind_col_safe(
     // `free_desc` already walks DBC→STMT in the other direction to reset a
     // freed descriptor's associations, and holding both here in the opposite
     // order would be a classic ABBA deadlock.
-    let (ard, ard_is_explicit, canonical_type) = {
+    let (ard, canonical_type) = {
         let Ok(mut stmt_state) = stmt.inner.lock() else {
             error!("SQLBindCol: stmt mutex poisoned");
             return SQL_ERROR;
@@ -161,9 +161,8 @@ fn sql_bind_col_safe(
         // the column from the row cursor and run validation msodbcsql never reaches.
         if target_value_ptr.is_null() {
             let ard = stmt_state.effective_ard(stmt);
-            let ard_is_explicit = stmt_state.active_ard.is_some();
             drop(stmt_state);
-            let Ok(()) = unbind_ard_column(ard, ard_is_explicit, column_number) else {
+            let Ok(()) = unbind_ard_column(ard, column_number) else {
                 error!("SQLBindCol: ard mutex poisoned; unbind failed");
                 if let Ok(mut stmt_state) = stmt.inner.lock() {
                     post_sql_error(
@@ -199,11 +198,7 @@ fn sql_bind_col_safe(
             return SQL_ERROR;
         }
 
-        (
-            stmt_state.effective_ard(stmt),
-            stmt_state.active_ard.is_some(),
-            canonical_type,
-        )
+        (stmt_state.effective_ard(stmt), canonical_type)
     };
 
     let binding = ColumnBinding {
@@ -219,7 +214,7 @@ fn sql_bind_col_safe(
         // SQLSetDescFieldW/SQLSetDescRec.
         octet_length_ptr: strlen_or_ind_ptr,
     };
-    let Ok(()) = bind_ard_column(ard, ard_is_explicit, binding) else {
+    let Ok(()) = bind_ard_column(ard, binding) else {
         error!("SQLBindCol: ard mutex poisoned or missing record after growth");
         if let Ok(mut stmt_state) = stmt.inner.lock() {
             post_sql_error(
@@ -250,12 +245,8 @@ fn sql_bind_col_safe(
 /// conversion here is not expected to fail in practice — but this still
 /// reports it as an error rather than panicking or silently truncating to the
 /// wrong record.
-fn bind_ard_column(
-    ard: SqlHandle,
-    ard_is_explicit: bool,
-    binding: ColumnBinding,
-) -> Result<(), ()> {
-    if ard_is_explicit && crate::handles::live_type(ard) != Some(HandleType::Desc) {
+fn bind_ard_column(ard: SqlHandle, binding: ColumnBinding) -> Result<(), ()> {
+    if crate::handles::live_type(ard) != Some(HandleType::Desc) {
         return Err(());
     }
     let desc = unsafe { handle_from_raw::<DescHandle>(ard) };
@@ -284,12 +275,8 @@ fn bind_ard_column(
 /// descriptor: reporting `SQL_SUCCESS` here would tell the application an
 /// unbind happened when it didn't, and a stale bound column would keep
 /// writing through a possibly-freed application buffer on the next fetch.
-fn unbind_ard_column(
-    ard: SqlHandle,
-    ard_is_explicit: bool,
-    column_number: SqlUSmallInt,
-) -> Result<(), ()> {
-    if ard_is_explicit && crate::handles::live_type(ard) != Some(HandleType::Desc) {
+fn unbind_ard_column(ard: SqlHandle, column_number: SqlUSmallInt) -> Result<(), ()> {
+    if crate::handles::live_type(ard) != Some(HandleType::Desc) {
         return Err(());
     }
     let desc = unsafe { handle_from_raw::<DescHandle>(ard) };
@@ -331,7 +318,7 @@ pub(crate) unsafe fn sql_free_stmt_unbind(statement_handle: SqlHandle) -> SqlRet
 }
 
 fn sql_free_stmt_unbind_safe(stmt: &StmtHandle) -> SqlReturn {
-    let (ard, ard_is_explicit) = {
+    let ard = {
         let Ok(mut stmt_state) = stmt.inner.lock() else {
             error!("SQLFreeStmt(SQL_UNBIND): stmt mutex poisoned");
             return SQL_ERROR;
@@ -342,13 +329,10 @@ fn sql_free_stmt_unbind_safe(stmt: &StmtHandle) -> SqlReturn {
             post_diag(&mut stmt_state, ERR_FUNCTION_SEQUENCE);
             return SQL_ERROR;
         }
-        (
-            stmt_state.effective_ard(stmt),
-            stmt_state.active_ard.is_some(),
-        )
+        stmt_state.effective_ard(stmt)
     };
 
-    if ard_is_explicit && crate::handles::live_type(ard) != Some(HandleType::Desc) {
+    if crate::handles::live_type(ard) != Some(HandleType::Desc) {
         error!("SQLFreeStmt(SQL_UNBIND): ard freed concurrently; unbind failed");
         if let Ok(mut stmt_state) = stmt.inner.lock() {
             post_sql_error(
@@ -906,7 +890,7 @@ mod tests {
             strlen_or_ind_ptr: ptr::null_mut(),
             octet_length_ptr: ptr::null_mut(),
         };
-        assert!(bind_ard_column(explicit_ard, true, binding).is_err());
+        assert!(bind_ard_column(explicit_ard, binding).is_err());
     }
 
     /// Same race, same guard, for `unbind_ard_column`.
@@ -915,6 +899,6 @@ mod tests {
         let mut h = TestHandles::with_env_dbc_stmt();
         let explicit_ard = h.alloc_explicit_desc();
         assert_eq!(h.free_explicit_desc(explicit_ard), SQL_SUCCESS);
-        assert!(unbind_ard_column(explicit_ard, true, 1).is_err());
+        assert!(unbind_ard_column(explicit_ard, 1).is_err());
     }
 }

--- a/mssql-odbc/src/api/fetch_scroll.rs
+++ b/mssql-odbc/src/api/fetch_scroll.rs
@@ -971,6 +971,12 @@ fn fetch_scroll_safe(
                 error!("SQLFetchScroll: env mutex poisoned");
                 if let Ok(mut stmt_state) = stmt.inner.lock() {
                     stmt_state.clear_state(STMT_STATE_FETCH_IN_PROGRESS);
+                    post_sql_error(
+                        &mut stmt_state,
+                        SQLSTATE_HY000,
+                        0,
+                        "Internal error reading column bindings",
+                    );
                 }
                 return SQL_ERROR;
             };

--- a/mssql-odbc/src/api/fetch_scroll.rs
+++ b/mssql-odbc/src/api/fetch_scroll.rs
@@ -18,6 +18,7 @@
 //! shot at a fixed-size buffer and reports `01004` if the value does not fit.
 
 use std::borrow::Cow;
+use std::sync::Arc;
 
 use tracing::{debug, error};
 
@@ -29,7 +30,7 @@ use mssql_tds::datatypes::column_values::{
 use mssql_tds::datatypes::decoder::DecimalParts;
 use mssql_tds::datatypes::row_writer::RowWriter;
 use mssql_tds::datatypes::sql_json::SqlJson;
-use mssql_tds::datatypes::sql_string::{EncodingType, SqlString, get_encoding_type};
+use mssql_tds::datatypes::sql_string::{EncodingType, SqlString};
 use mssql_tds::datatypes::sql_vector::SqlVector;
 use mssql_tds::datatypes::sqldatatypes::TdsDataType;
 use mssql_tds::error::Error as TdsError;
@@ -64,16 +65,10 @@ use crate::conversion::fetch_convert::{
 use crate::error::{free_errors, post_sql_error};
 use crate::handles::OdbcVersion;
 use crate::handles::stmt::{
-    BufferedGetDataRow, ColumnBinding, STMT_STATE_CURSOR_OPEN, STMT_STATE_FETCH_IN_PROGRESS,
-    StmtState,
+    BufferedGetDataRow, ColumnBinding, PlpColumnInfo, STMT_STATE_CURSOR_OPEN,
+    STMT_STATE_FETCH_IN_PROGRESS, StmtState,
 };
 use crate::handles::{DescHandle, HandleType, StmtHandle, handle_from_raw};
-
-#[derive(Clone, Copy)]
-struct PlpColumnInfo {
-    wire_encoding: PlpEncoding,
-    text_encoding: Option<EncodingType>,
-}
 
 impl BufferedGetDataRow {
     /// Creates an empty row, reusing the supplied row's allocations when its
@@ -805,38 +800,20 @@ fn fetch_scroll_safe(
     fetch_orientation: SqlSmallInt,
     _fetch_offset: SqlLen,
 ) -> SqlReturn {
-    // The declared ODBC version selects the SQL_C_DEFAULT table. Read it before
-    // the stmt lock to preserve parent-before-child lock ordering (the same
-    // order as `bind_param.rs` and `catalog.rs`).
-    //
-    // Read per fetch, deliberately, not cached on the DBC at alloc. Gating it on
-    // "does any binding use SQL_C_DEFAULT" would need the bindings first, which
-    // inverts the lock order; caching at alloc would instead bake in a value
-    // that `SQLSetEnvAttr` can still overwrite afterwards. It is an uncontended
-    // read of one `Copy` field, taken before validation so there is exactly one
-    // acquisition site rather than one per early-return path.
-    let odbc_version = {
-        let env = stmt.parent_dbc().parent_env();
-        let Ok(env_state) = env.inner.lock() else {
-            error!("SQLFetchScroll: env mutex poisoned");
-            return SQL_ERROR;
-        };
-        env_state.odbc_version
-    };
-
     // Snapshot the rowset controls and the effective ARD, then release the
     // statement lock: the fill loop below blocks on the network and must not
     // hold it. The application is not allowed to rebind concurrently with a
     // fetch on the same statement, so the snapshot cannot go stale under us.
     let (
         ard,
-        column_sql_types,
+        ard_is_explicit,
         row_array_size,
         rows_fetched_ptr,
         row_status_ptr,
         column_count,
         row_bind_offset_ptr,
         trailing_utf16_plp,
+        plp_columns,
     ) = {
         let Ok(mut stmt_state) = stmt.inner.lock() else {
             error!("SQLFetchScroll: stmt mutex poisoned");
@@ -917,15 +894,7 @@ fn fetch_scroll_safe(
         // "Locking rules": a STMT lock must never be held while acquiring a
         // DESC lock.
         let ard = stmt_state.effective_ard(stmt);
-        // Resolving SQL_C_DEFAULT needs this result set's SQL types, which live
-        // under the STMT lock, but the bindings it applies to are read from the
-        // ARD after this lock is released. Snapshot the types here and carry
-        // them out rather than re-locking the statement.
-        let column_sql_types: Vec<SqlSmallInt> = stmt_state
-            .column_metadata
-            .iter()
-            .map(odbc_sql_type)
-            .collect();
+        let ard_is_explicit = stmt_state.active_ard.is_some();
         // Claiming the statement here is what stops a concurrent SQLBindCol
         // from freeing an application buffer the fill loop is still reading
         // through after this lock is released; the mutating entry points
@@ -938,13 +907,14 @@ fn fetch_scroll_safe(
             == Some(PlpEncoding::Utf16Text);
         (
             ard,
-            column_sql_types,
+            ard_is_explicit,
             stmt_state.row_array_size,
             stmt_state.rows_fetched_ptr,
             stmt_state.row_status_ptr,
             stmt_state.column_metadata.len(),
             stmt_state.row_bind_offset_ptr,
             trailing_utf16_plp,
+            stmt_state.plp_columns.clone(),
         )
     };
 
@@ -956,13 +926,15 @@ fn fetch_scroll_safe(
     // statement is not left permanently stuck mid-fetch: silently treating it
     // as "nothing bound" would advance the cursor and report success for a
     // rowset the application never actually got the columns it asked for.
-    let bindings: Vec<ColumnBinding> = {
+    let mut bindings: Vec<ColumnBinding> = {
         // `ard` can be an explicit descriptor resolved under the STMT lock,
         // already dropped by now — re-check liveness right before
         // dereferencing to narrow (not fully close) the race against a
         // concurrent `SQLFreeHandle(SQL_HANDLE_DESC)` on that same
         // descriptor.
-        if crate::handles::live_type(ard) != Some(crate::handles::HandleType::Desc) {
+        if ard_is_explicit
+            && crate::handles::live_type(ard) != Some(crate::handles::HandleType::Desc)
+        {
             error!("SQLFetchScroll: ard freed concurrently; failing the fetch");
             if let Ok(mut stmt_state) = stmt.inner.lock() {
                 stmt_state.clear_state(STMT_STATE_FETCH_IN_PROGRESS);
@@ -989,11 +961,38 @@ fn fetch_scroll_safe(
             }
             return SQL_ERROR;
         };
-        let mut bindings = ColumnBinding::all_from_ard_state(&desc_state);
-        drop(desc_state);
-        resolve_default_bindings(&mut bindings, &column_sql_types, odbc_version);
-        bindings
+        ColumnBinding::all_from_ard_state(&desc_state)
     };
+    if bindings
+        .iter()
+        .any(|binding| binding.target_type == SQL_C_DEFAULT)
+    {
+        // These locks are needed only for deferred default bindings and are
+        // acquired sequentially, after the ARD snapshot has been released.
+        let odbc_version = {
+            let env = stmt.parent_dbc().parent_env();
+            let Ok(env_state) = env.inner.lock() else {
+                error!("SQLFetchScroll: env mutex poisoned");
+                if let Ok(mut stmt_state) = stmt.inner.lock() {
+                    stmt_state.clear_state(STMT_STATE_FETCH_IN_PROGRESS);
+                }
+                return SQL_ERROR;
+            };
+            env_state.odbc_version
+        };
+        let column_sql_types: Vec<SqlSmallInt> = {
+            let Ok(stmt_state) = stmt.inner.lock() else {
+                error!("SQLFetchScroll: stmt mutex poisoned reading column metadata");
+                return SQL_ERROR;
+            };
+            stmt_state
+                .column_metadata
+                .iter()
+                .map(odbc_sql_type)
+                .collect()
+        };
+        resolve_default_bindings(&mut bindings, &column_sql_types, odbc_version);
+    }
     let get_data_fetch = row_array_size == 1 && bindings.is_empty();
     let reusable_get_data_row = if get_data_fetch {
         let Ok(mut stmt_state) = stmt.inner.lock() else {
@@ -1017,6 +1016,7 @@ fn fetch_scroll_safe(
         row_bind_offset_ptr,
         reusable_get_data_row,
         buffer_trailing_utf16_plp,
+        plp_columns,
     );
 
     // Single clearing point for the guard, so every early return inside the
@@ -1040,6 +1040,7 @@ fn fill_rowset(
     row_bind_offset_ptr: *mut SqlULen,
     mut reusable_get_data_row: Option<BufferedGetDataRow>,
     buffer_trailing_utf16_plp: bool,
+    plp_columns: Option<Arc<[Option<PlpColumnInfo>]>>,
 ) -> SqlReturn {
     // The application asked for at most `SQL_ATTR_MAX_ROWS` rows from this
     // result set. Once that many have been returned the cursor stops without
@@ -1135,35 +1136,6 @@ fn fill_rowset(
     let mut last_column_read = 0usize;
     let mut buffered_get_data_row = None;
 
-    // Snapshot the per-column PLP encodings once. Taking the statement lock
-    // inside the fill loop would make a poisoned mutex indistinguishable from a
-    // column that simply is not PLP, which would silently downgrade a supported
-    // column to "unsupported" and drain it.
-    let plp_columns: Vec<Option<PlpColumnInfo>> = {
-        let Ok(ss) = stmt.inner.lock() else {
-            error!("SQLFetchScroll: stmt mutex poisoned reading column metadata");
-            if let Ok(mut ds) = dbc.inner.lock() {
-                ds.client = Some(client);
-            }
-            return SQL_ERROR;
-        };
-        ss.column_metadata
-            .iter()
-            .map(|metadata| {
-                let wire_encoding = metadata.plp_encoding()?;
-                let text_encoding = match wire_encoding {
-                    PlpEncoding::Utf16Text => Some(EncodingType::Utf16),
-                    PlpEncoding::Utf8Text => Some(EncodingType::Utf8),
-                    PlpEncoding::SingleByteText => Some(get_encoding_type(metadata)),
-                    PlpEncoding::Binary => None,
-                };
-                Some(PlpColumnInfo {
-                    wire_encoding,
-                    text_encoding,
-                })
-            })
-            .collect()
-    };
     // Allocate only if a bound PLP value is actually reached. Fixed rowsets,
     // especially row-array size 1, otherwise paid this zero-fill per fetch.
     let mut plp_scratch = None;
@@ -1364,7 +1336,11 @@ fn fill_rowset(
                                 binding,
                                 rows_filled as usize,
                                 bind_offset,
-                                plp_columns.get(column - 1).copied().flatten(),
+                                plp_columns
+                                    .as_ref()
+                                    .and_then(|columns| columns.get(column - 1))
+                                    .copied()
+                                    .flatten(),
                                 scratch,
                             )
                         };

--- a/mssql-odbc/src/api/fetch_scroll.rs
+++ b/mssql-odbc/src/api/fetch_scroll.rs
@@ -806,7 +806,6 @@ fn fetch_scroll_safe(
     // fetch on the same statement, so the snapshot cannot go stale under us.
     let (
         ard,
-        ard_is_explicit,
         row_array_size,
         rows_fetched_ptr,
         row_status_ptr,
@@ -894,7 +893,6 @@ fn fetch_scroll_safe(
         // "Locking rules": a STMT lock must never be held while acquiring a
         // DESC lock.
         let ard = stmt_state.effective_ard(stmt);
-        let ard_is_explicit = stmt_state.active_ard.is_some();
         // Claiming the statement here is what stops a concurrent SQLBindCol
         // from freeing an application buffer the fill loop is still reading
         // through after this lock is released; the mutating entry points
@@ -907,7 +905,6 @@ fn fetch_scroll_safe(
             == Some(PlpEncoding::Utf16Text);
         (
             ard,
-            ard_is_explicit,
             stmt_state.row_array_size,
             stmt_state.rows_fetched_ptr,
             stmt_state.row_status_ptr,
@@ -927,14 +924,13 @@ fn fetch_scroll_safe(
     // as "nothing bound" would advance the cursor and report success for a
     // rowset the application never actually got the columns it asked for.
     let mut bindings: Vec<ColumnBinding> = {
-        // `ard` can be an explicit descriptor resolved under the STMT lock,
-        // already dropped by now — re-check liveness right before
-        // dereferencing to narrow (not fully close) the race against a
-        // concurrent `SQLFreeHandle(SQL_HANDLE_DESC)` on that same
-        // descriptor.
-        if ard_is_explicit
-            && crate::handles::live_type(ard) != Some(crate::handles::HandleType::Desc)
-        {
+        // `ard` was resolved under the STMT lock and may already be dropped by
+        // now — re-check liveness right before dereferencing to narrow (not
+        // fully close) the race against a concurrent
+        // `SQLFreeHandle(SQL_HANDLE_DESC)` on an explicit descriptor, or a
+        // `SQLDisconnect` that frees the statement along with the four
+        // implicit descriptors it owns.
+        if crate::handles::live_type(ard) != Some(crate::handles::HandleType::Desc) {
             error!("SQLFetchScroll: ard freed concurrently; failing the fetch");
             if let Ok(mut stmt_state) = stmt.inner.lock() {
                 stmt_state.clear_state(STMT_STATE_FETCH_IN_PROGRESS);

--- a/mssql-odbc/src/api/fetch_scroll.rs
+++ b/mssql-odbc/src/api/fetch_scroll.rs
@@ -1690,15 +1690,17 @@ unsafe fn deliver_bound_plp(
 ) -> Result<RowOutcome, TdsError> {
     // Unreachable today, kept as a guard rather than an `unreachable!()`.
     // Getting here means the cursor classified this column as
-    // `CursorColumn::PlpStreaming` while `plp_encoding()` answered `None` for
-    // the same column. Both decide on `ColumnMetadata::is_plp()` over the same
-    // COLMETADATA (`plp_columns` snapshots the statement's copy, whose length
-    // also fixes `column_count`, so the lookup is always in range), and
-    // `plp_encoding` maps every PLP type to `Some` -- new ones included, via its
-    // catch-all to `Binary`. So the two cannot disagree unless a future type
-    // makes PLP-ness visible only in the wire framing and not in TYPE_INFO.
-    // Draining keeps the row synchronized if that day comes; a panic would take
-    // the application down for a column it could simply refuse.
+    // `CursorColumn::PlpStreaming` while the cache answered `None` for the same
+    // column. Both decide on `ColumnMetadata::is_plp()` over the same
+    // COLMETADATA (`plp_columns` is built from the statement's copy, and is
+    // `Some` only when some column is PLP -- when it is, its length matches
+    // `column_count`, and when it is `None` no column reaches this path at
+    // all), and `plp_encoding` maps every PLP type to `Some` -- new ones
+    // included, via its catch-all to `Binary`. So the two cannot disagree
+    // unless a future type makes PLP-ness visible only in the wire framing and
+    // not in TYPE_INFO. Draining keeps the row synchronized if that day comes;
+    // a panic would take the application down for a column it could simply
+    // refuse.
     let Some(column_info) = column_info else {
         drain_plp_to_end(client, runtime, scratch)?;
         return Ok(RowOutcome::Error(RowIssue::Unsupported));

--- a/mssql-odbc/src/handles/stmt.rs
+++ b/mssql-odbc/src/handles/stmt.rs
@@ -3,7 +3,7 @@
 
 use std::collections::VecDeque;
 use std::ffi::c_void;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use tracing::error;
 
@@ -19,9 +19,16 @@ use crate::api::set_desc_field::datetime_interval_code_for;
 use crate::error::{DiagRecord, HasDiagnostics};
 use crate::params::BoundParam;
 use mssql_tds::datatypes::column_values::ColumnValues;
+use mssql_tds::datatypes::sql_string::{EncodingType, get_encoding_type};
 use mssql_tds::datatypes::sqldatatypes::TdsDataType;
 use mssql_tds::encoding_rs::Decoder;
 use mssql_tds::query::metadata::{ColumnMetadata, PlpEncoding};
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PlpColumnInfo {
+    pub(crate) wire_encoding: PlpEncoding,
+    pub(crate) text_encoding: Option<EncodingType>,
+}
 
 /// State for a PLP column being streamed across repeated SQLGetData calls.
 pub(crate) struct ActivePlpStream {
@@ -334,6 +341,8 @@ pub(crate) struct StmtState {
     pub(crate) column_metadata: Vec<ColumnMetadata>,
     /// UTF-16 column names built once when result metadata changes.
     pub(crate) column_names_utf16: Vec<Vec<u16>>,
+    /// Bound-fetch metadata for result sets containing PLP columns.
+    pub(crate) plp_columns: Option<Arc<[Option<PlpColumnInfo>]>>,
     /// Reused by bounded PLP read-ahead so each MAX value does not allocate a
     /// fresh carry buffer.
     pub(crate) plp_prefetch_scratch: Vec<u8>,
@@ -1052,12 +1061,35 @@ impl StmtState {
                 .iter()
                 .map(|column| column.column_name.encode_utf16().collect()),
         );
+        self.plp_columns = self
+            .column_metadata
+            .iter()
+            .any(ColumnMetadata::is_plp)
+            .then(|| {
+                self.column_metadata
+                    .iter()
+                    .map(|metadata| {
+                        let wire_encoding = metadata.plp_encoding()?;
+                        let text_encoding = match wire_encoding {
+                            PlpEncoding::Utf16Text => Some(EncodingType::Utf16),
+                            PlpEncoding::Utf8Text => Some(EncodingType::Utf8),
+                            PlpEncoding::SingleByteText => Some(get_encoding_type(metadata)),
+                            PlpEncoding::Binary => None,
+                        };
+                        Some(PlpColumnInfo {
+                            wire_encoding,
+                            text_encoding,
+                        })
+                    })
+                    .collect::<Arc<[_]>>()
+            });
     }
 
     /// Clears result metadata and every cache derived from it.
     pub(crate) fn clear_result_metadata(&mut self) {
         self.column_metadata.clear();
         self.column_names_utf16.clear();
+        self.plp_columns = None;
     }
 
     /// Makes `metadata` the first result set of a new execution.
@@ -1223,6 +1255,7 @@ impl StmtHandle {
                 diag_records: Vec::new(),
                 column_metadata: Vec::new(),
                 column_names_utf16: Vec::new(),
+                plp_columns: None,
                 plp_prefetch_scratch: Vec::new(),
                 result_set_exhausted: false,
                 batch_exhausted: false,

--- a/mssql-odbc/src/handles/stmt.rs
+++ b/mssql-odbc/src/handles/stmt.rs
@@ -1336,7 +1336,7 @@ mod tests {
     use super::*;
     use crate::api::odbc_types::{SQL_C_CHAR, SQL_C_SLONG};
     use crate::handles::desc::{DescHeader, DescKind};
-    use mssql_tds::test_client_support::int_columns;
+    use mssql_tds::test_client_support::{int_columns, mixed_lob_columns};
 
     fn binding(column_number: SqlUSmallInt, target_type: SqlSmallInt) -> ColumnBinding {
         ColumnBinding {
@@ -1513,6 +1513,37 @@ mod tests {
 
             assert!(s.column_metadata.is_empty());
             assert!(s.column_names_utf16.is_empty());
+        });
+    }
+
+    /// The fill loop reads this cache instead of re-deriving encodings from
+    /// `column_metadata`, so an entry surviving into a later result set would
+    /// silently mis-decode a bound LOB rather than fail. Covers the rebuild,
+    /// the explicit clear, and the non-PLP result set that follows a PLP one —
+    /// that last transition is the one where a stale cache would be consulted.
+    #[test]
+    fn plp_column_cache_does_not_outlive_its_result_set() {
+        with_state(|s| {
+            s.begin_result_set(mixed_lob_columns(2));
+            let cached = s
+                .plp_columns
+                .clone()
+                .expect("the nvarchar(max) column is PLP");
+            assert_eq!(cached.len(), 3);
+            assert!(cached[0].is_none(), "int columns are not PLP");
+            assert_eq!(
+                cached[2].expect("the lob column is PLP").wire_encoding,
+                PlpEncoding::Utf16Text
+            );
+
+            s.clear_result_metadata();
+            assert!(s.plp_columns.is_none());
+
+            s.begin_result_set(int_columns(2));
+            assert!(
+                s.plp_columns.is_none(),
+                "a non-PLP result set must not inherit the previous set's cache"
+            );
         });
     }
 


### PR DESCRIPTION
## Description

Perf pipeline run `20260905.1` (buildId 172669) flagged a confirmed regression against the pinned `mssql-odbc` baseline, isolated to rowset size 1: `bound_rowset_1` was 16.7% slower and `bind_cycle_rowset_1` 13.2% slower, while the rowset 64 and 1000 variants stayed flat. The reported `execute_ms` and `metadata_bind_ms` phases were unchanged, which places the cost in the fixed per-call setup of `SQLFetchScroll` -- work that is amortized across a wide rowset but paid once per row at rowset 1.

This PR removes two such fixed costs. Both were previously paid on every fetch regardless of the result set's shape, including on the all-fixed-width benchmarks where neither had anything to do.

**Make `SQL_C_DEFAULT` resolution conditional.** Deferred `SQL_C_DEFAULT` resolution acquired the ENV mutex and heap-allocated a `Vec<SqlSmallInt>` of per-column SQL types on every fetch, whether or not any binding was actually left at `SQL_C_DEFAULT`. Both now happen only when some binding needs them. The original code did this unconditionally on the grounds that gating on the bindings would invert the lock order, but it does not: the ARD lock is released before the ENV and STMT locks are taken, so no lock is held while acquiring another and the STMT-before-DESC rule is preserved.

**Cache PLP metadata per result set.** `fill_rowset` re-locked the STMT and rebuilt a `Vec<Option<PlpColumnInfo>>` on every call, ungated, so a 15-column fixed-width result set allocated and filled a 15-element vector of `None` per fetch. This restores the cache that `e8c4ffa4` added and the revert at `49f2ccb4` lost, now storing the resolved text encoding too so `get_encoding_type` is hoisted out of the hot path. It is populated in `refresh_metadata_caches` only when the result set actually has PLP columns, and cleared in `clear_result_metadata`.

## Results

Measured by perf run `20260906.2` (buildId 172991) against the pinned baseline. The regression gate passed: no confirmed benchmark had at least 5% higher wall time.

| Benchmark | Before (run 172669) | After (run 172991) |
| --- | --- | --- |
| `fetch/rowset_100k_c15_fixed/bound_rowset_1` | +16.7% | +4.17% |
| `fetch/rowset_20k_c15_fixed/bind_cycle_rowset_1` | +13.2% | +6.22%, not confirmed (2/4) |

No other benchmark regressed; the rowset 64/1000 and `getdata/*` families are flat or improved.

### What this PR does not recover

An earlier revision also skipped the `LIVE_HANDLES` registry lookup when the ARD is the statement's own implicit descriptor. Review showed that to be unsafe and it has been withdrawn: `SQLDisconnect` is a call on the connection rather than the statement, so nothing serializes it against an in-flight fetch, and `disconnect.rs:96-99` documents that it frees statements while operations on them are still running. Since `StmtHandle::new` registers all four implicit descriptors and `StmtHandle::drop` removes them from `LIVE_HANDLES`, the lookup genuinely does narrow that window for implicit descriptors, exactly as it does for explicit ones. The check is unconditional again and `bind_col.rs` is untouched by this PR.

That is where most of the `bind_cycle` gain lived -- that workload pays 17 lookups per row at rowset size 1 -- which is why `bind_cycle_rowset_1` remains the weakest benchmark here. The follow-up worth doing is making `LIVE_HANDLES` itself cheap rather than skipping it: it is a single process-global `Mutex<HashMap<usize, HandleType>>` hashing pointer keys with SipHash, so a faster hasher and/or an `RwLock` would cut the cost while leaving the guard exactly as strict. I would rather do that separately than widen this PR.

## Related Issues

Related to #507

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes -- `cargo nextest run -p mssqlodbc` is green at 1344/1344, but the full workspace run cannot complete locally: the `mssql-tds` integration tests need a live SQL Server. Relying on PR validation, which is green on this head.
- [x] New/changed functionality has tests -- `plp_column_cache_does_not_outlive_its_result_set` covers the cache lifecycle including the PLP-to-non-PLP transition; mutation-checked by removing the reset from `clear_result_metadata` and confirming it fails.
- [x] Public API changes are documented -- no public API change. `PlpColumnInfo` and `StmtState::plp_columns` are `pub(crate)`.
