### PR TITLE
Implement SQL_ATTR_PARAMSET_SIZE array execution (AB#46576)

### DIFF
--- a/mssql-odbc/docs/attributes_plan.md
+++ b/mssql-odbc/docs/attributes_plan.md
@@ -11,9 +11,11 @@ makes, or by the unfiltered pass-through surface it exposes (§4.10).
 `SQLSetStmtAttrW` L3508, `SQLGetStmtAttrW` L4186).
 
 **Status:** S1–S4, S5a and S6 are shipped. S5b is the only open slice and is
-tracked by AB#47526. Behavior marked *measured* below was observed by running
-the same `mssql-odbc/tests/e2e/tests/attributes_test.cpp` suite against
-msodbcsql18 and against this driver.
+tracked by AB#47526. `SQL_ATTR_PARAMSET_SIZE` array-bound execution (AB#46576)
+is also delivered — see §4.2.3 and the S4 write-up below. Behavior marked
+*measured* below was observed by running the same
+`mssql-odbc/tests/e2e/tests/attributes_test.cpp` suite against msodbcsql18 and
+against this driver.
 
 ---
 
@@ -31,8 +33,7 @@ those attributes drive — that is already split into sibling stories.
 | `{fn}` / `{ts}` / `{call}` translation when NOSCAN is off | AB#46384 ODBC escape sequences |
 | `SQL_ATTR_APP_PARAM_DESC` / `APP_ROW_DESC` as attributes | **46377** |
 | Descriptor handle semantics behind them | AB#46374 Descriptors |
-| `SQL_ATTR_PARAMSET_SIZE` accept/store | **46377** |
-| Array-bound `executemany` execution | AB#46576 Batch insert |
+| `SQL_ATTR_PARAMSET_SIZE` accept/store, layout, and array-bound execution | **46377** — delivered, closing AB#46576 |
 | `SQL_ATTR_RESET_CONNECTION`, `SQL_ATTR_CONNECTION_DEAD` | AB#47317 (Closed) |
 | `SQL_ATTR_AUTOCOMMIT`, `SQL_ATTR_TXN_ISOLATION` | AB#46379 (Closed) |
 | Connection-string keyword parsing | AB#46372 (Closed) |
@@ -82,13 +83,14 @@ their measured not-implemented diagnostic; an unknown identifier returns `HY092`
 | `SQL_ATTR_ROW_ARRAY_SIZE` | ✅ | ✅ |
 | `SQL_ATTR_ROWS_FETCHED_PTR` | ✅ | ✅ |
 | `SQL_ATTR_ROW_STATUS_PTR` / `ROW_BIND_TYPE` | ✅ | ✅ |
-| `SQL_ATTR_PARAMSET_SIZE` | ✅ | ✅ |
+| `SQL_ATTR_PARAMSET_SIZE` | ✅ **enforced** | ✅ |
 | `SQL_ATTR_APP_PARAM_DESC` / `APP_ROW_DESC` | ✅ no-op | ✅ |
 | `SQL_ATTR_IMP_ROW_DESC` / `IMP_PARAM_DESC` | — | ✅ |
 | `SQL_ATTR_MAX_ROWS` | ✅ enforced | ✅ |
 | `SQL_ATTR_MAX_LENGTH`, `NOSCAN`, `RETRIEVE_DATA`, `USE_BOOKMARKS` | ✅ | ✅ |
 | `SQL_ATTR_PARAM_BIND_OFFSET_PTR` | ✅ enforced | ✅ |
-| `SQL_ATTR_PARAM_BIND_TYPE`, `PARAM_STATUS_PTR`, `PARAMS_PROCESSED_PTR`, `ROW_BIND_OFFSET_PTR` | ✅ stored | ✅ |
+| `SQL_ATTR_PARAM_BIND_TYPE`, `PARAM_OPERATION_PTR`, `PARAM_STATUS_PTR`, `PARAMS_PROCESSED_PTR` | ✅ **consumed when `PARAMSET_SIZE > 1`** | ✅ |
+| `SQL_ATTR_ROW_BIND_OFFSET_PTR` | ✅ stored | ✅ |
 | `SQL_ATTR_METADATA_ID` | `SQL_FALSE` ✅; `SQL_TRUE` → `HYC00` | ✅ (`SQL_FALSE`) | identifier mode pending S5b |
 | **`SQL_ATTR_QUERY_TIMEOUT`** | ✅ | ✅ | **delivered by S2** |
 | `SQL_SOPT_SS_*` 1225–1238 | measured per id | measured per id | **delivered by S6** |
@@ -406,8 +408,9 @@ ideal rather than what this driver does.
 | 14 | `ROW_NUMBER` | — | get-only; `24000` unless positioned on a row, else 0 |
 | 15 | `ENABLE_AUTO_IPD` | 0 | stored |
 | 17 | `PARAM_BIND_OFFSET_PTR` | 0 (null) | **enforced**: dereferenced at execute and added to both bound pointers |
-| 16, 18–21, 23–24 | bind/offset/status pointers | 0 | stored |
-| 22 | `PARAMSET_SIZE` | 1 | 1 → success; above 1 → `HYC00` (array binding is a deferred feature) |
+| 16, 23–24 | bookmark/row-offset/row-operation pointers | 0 | stored |
+| 18–21 | `PARAM_BIND_TYPE`, `PARAM_OPERATION_PTR`, `PARAM_STATUS_PTR`, `PARAMS_PROCESSED_PTR` | 0 | stored; **consumed when `PARAMSET_SIZE > 1`** (below) |
+| 22 | `PARAMSET_SIZE` | 1 | **enforced**: any positive value is stored; 0 → `HY024`. Above 1, `SQLExecute`/`SQLExecDirectW` iterate that many rows of the bound arrays |
 | 10014 | `METADATA_ID` | 0 | `SQL_FALSE` accepted; `SQL_TRUE` → `HYC00` |
 | -1 | `CURSOR_SCROLLABLE` | `SQL_NONSCROLLABLE` | the boolean face of `CURSOR_TYPE` |
 | -2 | `CURSOR_SENSITIVITY` | `SQL_INSENSITIVE` | `SQL_UNSPECIFIED` normalises to insensitive, silently |
@@ -449,6 +452,61 @@ Four findings changed the implementation:
   offset is read once per execution, so an application can walk a buffer by
   writing one `SQLLEN` between executes.
 
+#### `SQL_ATTR_PARAMSET_SIZE` array execution (closes AB#46576)
+
+Originally scoped as accept/store-only here, with array-bound `executemany`
+execution left to a separate story (AB#46576, "Batch insert"). Both landed
+together: storing a value above 1 without consuming it would have accepted
+mssql-python's `executemany` batch and then silently executed only row 0,
+which is worse than the `HYC00` this driver used to answer — so the two were
+never separable in practice, and splitting them would have meant shipping the
+accept path ahead of a rejection every real caller was guaranteed to hit.
+
+**The measured contract:**
+
+- `SQLSetStmtAttrW` stores any positive `SqlULen`; 0 is `HY024` and leaves the
+  previous value in place, mirroring `SQL_ATTR_ROW_ARRAY_SIZE`'s reject-on-zero
+  pattern. `SQLGetStmtAttrW` reports the stored value; the ODBC default is 1.
+- Above 1, `SQLExecute`/`SQLExecDirectW` iterate that many rows out of the
+  bound parameter arrays, one execution per row
+  (`exec_common::execute_param_array_loop`, shared by both entry points).
+  Column-wise arrays (`SQL_ATTR_PARAM_BIND_TYPE` — 0, the default) stride each
+  parameter by its C type's element size, or by `BufferLength` for the
+  character/binary/`SQL_C_NUMERIC` family (`BoundParam::for_row`, mirroring
+  `fetch_scroll::element_stride`'s contract for the symmetric `SQLBindCol`
+  direction); row-wise arrays stride every pointer by
+  `SQL_ATTR_PARAM_BIND_TYPE`'s struct size. `SQL_ATTR_PARAM_BIND_OFFSET_PTR`
+  composes additively on top of either.
+- `SQL_ATTR_PARAM_OPERATION_PTR` skips a row (`SQL_PARAM_IGNORE`) without
+  executing it; `SQL_ATTR_PARAM_STATUS_PTR` reports each row's outcome
+  (`SQL_PARAM_SUCCESS` / `_SUCCESS_WITH_INFO` / `_ERROR` / `_UNUSED`) and
+  `SQL_ATTR_PARAMS_PROCESSED_PTR` counts rows looked at, including one that was
+  skipped or that stopped the array. The array stops at the first row that
+  does not succeed — matching mssql-python, which forwards this call's single
+  `SqlReturn` straight to its own caller with no per-row retry — and
+  `SQLRowCount` reports the sum of every row's own count (msodbcsql's
+  "not available", `-1`, is excluded from the sum rather than corrupting it).
+- A row-returning statement (e.g. `INSERT ... OUTPUT`) leaves its cursor open
+  exactly as a scalar execute does; the array loop closes it before the next
+  row runs, since each row behaves as if `SQLExecute` were called separately
+  and the application never gets a chance to close it itself between rows.
+- A data-at-execution parameter combined with `PARAMSET_SIZE > 1` is rejected
+  with `HYC00` (`ERR_OPTIONAL_FEATURE_NOT_IMPLEMENTED`) before any row runs: an
+  array has no way to interleave `SQLPutData` calls per row. Unreachable from
+  mssql-python, whose `executemany` DAE branch never sets `PARAMSET_SIZE` — it
+  loops separate scalar executes instead.
+- A parameterless prepared statement executed with a leftover
+  `PARAMSET_SIZE > 1` runs once rather than `PARAMSET_SIZE` times: there is no
+  array row to walk, and repeating a side-effecting statement nobody asked for
+  is worse than ignoring the leftover attribute.
+
+**Not yet measured against msodbcsql:** MS-TDS supports batching multiple RPC
+calls into one TDS packet (`BatchFlag`, §2.2.6.5); this implementation instead
+sends one RPC per row. Whether msodbcsql does the same or batches at the wire
+level has not been measured, so this is a functional-parity claim (same
+`SQLRowCount`, same per-row status, same stop-on-error behavior) rather than a
+wire-level one.
+
 **Known divergence:** `SQL_ATTR_CURSOR_SCROLLABLE = SQL_SCROLLABLE` succeeds on
 msodbcsql and reports `01S02` here, because scrollable cursors are a deferred
 feature. It is the same single divergence already recorded for
@@ -459,6 +517,7 @@ shared invariant on both drivers and the per-driver state separately.
 `SQL_ATTR_METADATA_ID = SQL_FALSE` succeeds and reads back. `SQL_TRUE` returns
 `HYC00` until S5b wires identifier semantics into catalog matching; silently
 accepting it while forcing pattern mode would return the wrong rows.
+`SQL_ATTR_PARAMSET_SIZE` array execution closes AB#46576 — see above.
 
 **Size:** M. **Depends on:** S1.
 
@@ -732,6 +791,13 @@ the remaining follow-up under AB#47526.
 4. **Parity-sweep cost:** S1's sweep needs a live SQL Server and both drivers
    registered. If `--compare-with-msodbcsql` cannot run in CI, the truth table
    must be captured once and checked in as a fixture.
+5. **`SQL_ATTR_PARAMSET_SIZE` array execution is unmeasured at the wire level.**
+   This driver sends one RPC per row; MS-TDS supports batching multiple RPC
+   calls into a single packet (`BatchFlag`, §2.2.6.5) and msodbcsql may do that
+   instead. The `SQLRowCount`/status/stop-on-error contract is measured against
+   what mssql-python and the ODBC spec require, not against a msodbcsql wire
+   capture — record one before treating per-row semantics as more than
+   functionally equivalent.
 
 ---
 
@@ -742,7 +808,8 @@ now, add a list of what was done & what is pending in this story & create subtas
 for pending attributes."*
 
 - §2 above is the "what is done" list — paste into AB#46377.
-- S1–S4, S5a and S6 are complete.
+- S1–S4, S5a and S6 are complete. `SQL_ATTR_PARAMSET_SIZE` array execution
+  (§4.2.3 / S4, above) closes AB#46576.
 - S5b is the only pending slice and is tracked by AB#47526. Keep AB#46377 active
   only if it is intended to parent that follow-up; otherwise the delivered
   attribute work in this PR is complete.

--- a/mssql-odbc/src/api/exec_common.rs
+++ b/mssql-odbc/src/api/exec_common.rs
@@ -20,10 +20,14 @@ use mssql_tds::message::parameters::rpc_parameters::RpcParameter;
 
 use super::ird::populate_ird;
 use super::sqlstate::*;
+#[cfg(test)]
+use crate::api::odbc_types::SQL_PARAM_BIND_BY_COLUMN;
 use crate::api::odbc_types::{
-    SQL_DATA_AT_EXEC, SQL_ERROR, SQL_LEN_DATA_AT_EXEC_OFFSET, SQL_NEED_DATA, SQL_SUCCESS,
-    SQL_SUCCESS_WITH_INFO, SqlHandle, SqlLen, SqlReturn,
+    SQL_DATA_AT_EXEC, SQL_ERROR, SQL_LEN_DATA_AT_EXEC_OFFSET, SQL_NEED_DATA, SQL_PARAM_ERROR,
+    SQL_PARAM_IGNORE, SQL_PARAM_SUCCESS, SQL_PARAM_SUCCESS_WITH_INFO, SQL_PARAM_UNUSED,
+    SQL_SUCCESS, SQL_SUCCESS_WITH_INFO, SqlHandle, SqlLen, SqlReturn, SqlULen, SqlUSmallInt,
 };
+use crate::api::util::write_if_some;
 use crate::conversion::param_convert::{
     ParamBuildError, bound_param_to_rpc, dae_placeholder_type, is_data_at_exec_indicator,
 };
@@ -602,10 +606,51 @@ pub(super) fn snapshot_bound_params(
 /// `SQL_ATTR_PARAM_BIND_OFFSET_PTR` is non-null, their readable extents begin at
 /// each bound base plus the pointed-to signed byte offset, which may be
 /// negative, so every allocation must cover that displaced range.
+#[cfg(test)]
 pub(super) unsafe fn build_named_params(
     stmt_state: &mut StmtState,
     marker_count: usize,
     op: &str,
+) -> Result<ParamsWithDae, SqlReturn> {
+    unsafe { build_named_params_at(stmt_state, marker_count, op, 0, SQL_PARAM_BIND_BY_COLUMN) }
+}
+
+/// [`build_named_params`] for parameter-array row `row` (0-based) of a
+/// `SQL_ATTR_PARAMSET_SIZE > 1` execution — the form `SQLExecute` and
+/// `SQLExecDirectW` call directly for every execution, including the
+/// ordinary scalar case (`row == 0`, `bind_type == SQL_PARAM_BIND_BY_COLUMN`,
+/// where `BoundParam::for_row` is a no-op regardless of `bind_type`).
+/// `bind_type` is `SQL_ATTR_PARAM_BIND_TYPE`, read once by the caller for the
+/// whole array rather than per row, since it cannot change mid-execution.
+///
+/// Each binding is displaced to `row` (see `BoundParam::for_row`) before the
+/// `SQL_ATTR_PARAM_BIND_OFFSET_PTR` shift already documented on
+/// [`build_named_params`] — the two compose additively, so a caller stepping
+/// the whole array with the offset attribute still lands on the right row.
+///
+/// # Safety
+/// Same contract as [`build_named_params`], extended across every row
+/// `0..=row` that a full array execution will visit: each bound parameter's
+/// readable extent must cover its position at every row the array's
+/// `SQL_ATTR_PARAMSET_SIZE` implies, not just this one.
+pub(super) unsafe fn build_named_params_row(
+    stmt_state: &mut StmtState,
+    marker_count: usize,
+    op: &str,
+    row: usize,
+    bind_type: SqlULen,
+) -> Result<ParamsWithDae, SqlReturn> {
+    unsafe { build_named_params_at(stmt_state, marker_count, op, row, bind_type) }
+}
+
+/// # Safety
+/// Same contract as [`build_named_params`].
+unsafe fn build_named_params_at(
+    stmt_state: &mut StmtState,
+    marker_count: usize,
+    op: &str,
+    row: usize,
+    bind_type: SqlULen,
 ) -> Result<ParamsWithDae, SqlReturn> {
     use mssql_tds::message::parameters::rpc_parameters::StatusFlags;
 
@@ -621,10 +666,13 @@ pub(super) unsafe fn build_named_params(
             post_diag(stmt_state, ERR_UNBOUND_PARAMETER);
             return Err(SQL_ERROR);
         };
-        // Applied before anything reads the binding: ODBC shifts the
-        // indicator pointer alongside the value pointer, so the
-        // data-at-execution check below has to see the shifted indicator.
-        let bound_param = bound_param.with_bind_offset(bind_offset);
+        // Row displacement first, then the flat bind-offset shift: applied
+        // before anything reads the binding, since ODBC shifts the indicator
+        // pointer alongside the value pointer and the data-at-execution check
+        // below has to see the shifted indicator.
+        let bound_param = bound_param
+            .for_row(row, bind_type)
+            .with_bind_offset(bind_offset);
 
         let name = format!("@P{}", i + 1);
 
@@ -852,6 +900,140 @@ pub(super) fn finish_execute(
     } else {
         SQL_SUCCESS
     }
+}
+
+/// Writes one element of `SQL_ATTR_PARAM_STATUS_PTR`, if the application
+/// bound one.
+///
+/// # Safety
+/// `status_ptr`, when non-null, must address an array containing `row + 1`
+/// writable `SqlUSmallInt` elements.
+unsafe fn write_param_status(status_ptr: *mut SqlUSmallInt, row: usize, status: SqlUSmallInt) {
+    if !status_ptr.is_null() {
+        unsafe { write_if_some(status_ptr.wrapping_add(row), status) };
+    }
+}
+
+/// Drives `paramset_size` iterations of a `SQL_ATTR_PARAMSET_SIZE > 1`
+/// parameter array, handling the bookkeeping every array-execution entry
+/// point needs identically: `SQL_ATTR_PARAM_OPERATION_PTR` row skips,
+/// `SQL_ATTR_PARAM_STATUS_PTR` / `SQL_ATTR_PARAMS_PROCESSED_PTR` writes,
+/// row-count aggregation across rows, and closing a cursor a row-returning
+/// statement left open before the next row runs (each array row behaves as
+/// if `SQLExecute` were called separately, so nothing else closes it between
+/// rows). Shared by `SQLExecute` and `SQLExecDirectW` so the two stay in
+/// lockstep the same way the rest of this module does.
+///
+/// `execute_row(row)` performs one row's actual execution — staging plus wire
+/// I/O — and returns its `SqlReturn`. It is only called for rows that are
+/// not skipped via `SQL_ATTR_PARAM_OPERATION_PTR`; the caller is responsible
+/// for reading `SQL_ATTR_PARAM_BIND_TYPE` once (it cannot change mid-array)
+/// and threading it into that closure so each row lands on its own bindings.
+///
+/// Stops at the first row that does not report `SQL_SUCCESS` or
+/// `SQL_SUCCESS_WITH_INFO` — matching the ODBC default (no
+/// `SQL_ATTR_PARAM_OPERATION_PTR`-driven continuation past an error) and
+/// mssql-python's own expectation, which forwards this call's single
+/// `SqlReturn` straight to its caller with no row-level retry.
+///
+/// Row counts accumulate only from rows that report one (`>= 0`); a
+/// row-returning statement (SELECT / INSERT ... OUTPUT) reports `-1` per row,
+/// matching msodbcsql's "not available" convention, so summing every row's
+/// count would corrupt a genuine DML total with a stray `-1`. An array whose
+/// every row is row-returning therefore leaves the aggregate at `-1`.
+///
+/// # Safety
+/// `operation_ptr`, when non-null, must be readable for `paramset_size`
+/// `SqlUSmallInt` elements. `status_ptr`, when non-null, must be writable for
+/// the same extent. `processed_ptr`, when non-null, must be writable for one
+/// `SqlULen`.
+pub(super) unsafe fn execute_param_array_loop(
+    stmt: &StmtHandle,
+    statement_handle: SqlHandle,
+    paramset_size: SqlULen,
+    operation_ptr: *const SqlUSmallInt,
+    status_ptr: *mut SqlUSmallInt,
+    processed_ptr: *mut SqlULen,
+    mut execute_row: impl FnMut(usize) -> SqlReturn,
+) -> SqlReturn {
+    unsafe { write_if_some(processed_ptr, 0) };
+    for row in 0..paramset_size {
+        unsafe { write_param_status(status_ptr, row, SQL_PARAM_UNUSED) };
+    }
+
+    let mut worst = SQL_SUCCESS;
+    let mut total_row_count: i64 = -1;
+
+    for row in 0..paramset_size {
+        unsafe { write_if_some(processed_ptr, row + 1) };
+        if !operation_ptr.is_null()
+            && unsafe { operation_ptr.wrapping_add(row).read_unaligned() } == SQL_PARAM_IGNORE
+        {
+            continue;
+        }
+
+        let rc = execute_row(row);
+        let status = match rc {
+            SQL_SUCCESS => SQL_PARAM_SUCCESS,
+            SQL_SUCCESS_WITH_INFO => {
+                worst = SQL_SUCCESS_WITH_INFO;
+                SQL_PARAM_SUCCESS_WITH_INFO
+            }
+            _ => SQL_PARAM_ERROR,
+        };
+        unsafe { write_param_status(status_ptr, row, status) };
+
+        if let Ok(state) = stmt.inner.lock()
+            && state.row_count >= 0
+        {
+            total_row_count = if total_row_count < 0 {
+                state.row_count
+            } else {
+                total_row_count.saturating_add(state.row_count)
+            };
+        }
+
+        if !matches!(rc, SQL_SUCCESS | SQL_SUCCESS_WITH_INFO) {
+            if let Ok(mut state) = stmt.inner.lock() {
+                state.row_count = total_row_count;
+                state.pending_row_counts.clear();
+            }
+            return rc;
+        }
+
+        // Each array row behaves as if SQLExecute were called separately, so
+        // a row-returning statement's cursor must be closed before the next
+        // row's execute — otherwise it fails with 24000, and it's this loop's
+        // job to open exactly the same statement's cursor next, not the
+        // application's.
+        if row + 1 < paramset_size {
+            let cursor_open = stmt
+                .inner
+                .lock()
+                .map(|state| state.has_state(STMT_STATE_CURSOR_OPEN))
+                .unwrap_or(false);
+            if cursor_open {
+                let close_rc =
+                    unsafe { super::close_cursor::sql_free_stmt_close(statement_handle) };
+                if !matches!(close_rc, SQL_SUCCESS | SQL_SUCCESS_WITH_INFO) {
+                    if let Ok(mut state) = stmt.inner.lock() {
+                        state.row_count = total_row_count;
+                        state.pending_row_counts.clear();
+                    }
+                    return close_rc;
+                }
+                if close_rc == SQL_SUCCESS_WITH_INFO {
+                    worst = SQL_SUCCESS_WITH_INFO;
+                }
+            }
+        }
+    }
+
+    if let Ok(mut state) = stmt.inner.lock() {
+        state.row_count = total_row_count;
+        state.pending_row_counts.clear();
+    }
+    worst
 }
 
 #[cfg(test)]
@@ -1931,5 +2113,251 @@ mod tests {
             ds.active_stmt, None,
             "the connection must be released, or it stays busy forever"
         );
+    }
+
+    mod execute_param_array_loop_tests {
+        use super::*;
+        use crate::api::odbc_types::{
+            SQL_PARAM_ERROR, SQL_PARAM_IGNORE, SQL_PARAM_PROCEED, SQL_PARAM_SUCCESS,
+            SQL_PARAM_SUCCESS_WITH_INFO, SQL_PARAM_UNUSED, SQL_SUCCESS,
+        };
+
+        /// Every row succeeds and reports a DML-style row count: the
+        /// aggregate must be the sum, matching mssql-python's
+        /// `executemany` rowcount contract (`test_rowcount_executemany`:
+        /// 3 one-row inserts sum to `rowcount == 3`).
+        #[test]
+        fn successful_rows_sum_their_row_counts() {
+            let h = TestHandles::with_env_dbc_stmt();
+            let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+
+            let ret = unsafe {
+                execute_param_array_loop(
+                    stmt,
+                    h.stmt,
+                    3,
+                    std::ptr::null(),
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                    |_row| {
+                        stmt.inner.lock().unwrap().row_count = 1;
+                        SQL_SUCCESS
+                    },
+                )
+            };
+
+            assert_eq!(ret, SQL_SUCCESS);
+            assert_eq!(stmt.inner.lock().unwrap().row_count, 3);
+        }
+
+        /// A row-returning statement reports `-1` per row (msodbcsql's "not
+        /// available" convention); summing it in would corrupt a genuine
+        /// total, so an all-row-returning array must leave the aggregate at
+        /// `-1` rather than at `0` or the row count of the last row.
+        #[test]
+        fn row_returning_rows_leave_the_aggregate_at_not_available() {
+            let h = TestHandles::with_env_dbc_stmt();
+            let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+
+            let ret = unsafe {
+                execute_param_array_loop(
+                    stmt,
+                    h.stmt,
+                    2,
+                    std::ptr::null(),
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                    |_row| {
+                        stmt.inner.lock().unwrap().row_count = -1;
+                        SQL_SUCCESS
+                    },
+                )
+            };
+
+            assert_eq!(ret, SQL_SUCCESS);
+            assert_eq!(stmt.inner.lock().unwrap().row_count, -1);
+        }
+
+        /// `SQL_ATTR_PARAMS_PROCESSED_PTR` counts up to and including the
+        /// failing row; `SQL_ATTR_PARAM_STATUS_PTR` marks it `SQL_PARAM_ERROR`
+        /// and every row past it `SQL_PARAM_UNUSED` — the array stops rather
+        /// than continuing past an error, matching the ODBC default (no
+        /// `SQL_ATTR_PARAM_OPERATION_PTR`-driven continuation) and
+        /// mssql-python's single-`SqlReturn` expectation.
+        #[test]
+        fn a_failing_row_stops_the_array_and_marks_later_rows_unused() {
+            let h = TestHandles::with_env_dbc_stmt();
+            let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+            let mut status = [SQL_PARAM_SUCCESS; 4];
+            let mut processed: SqlULen = 0;
+
+            let ret = unsafe {
+                execute_param_array_loop(
+                    stmt,
+                    h.stmt,
+                    4,
+                    std::ptr::null(),
+                    status.as_mut_ptr(),
+                    &raw mut processed,
+                    |row| {
+                        if row == 1 {
+                            // Mirrors what real staging does before every
+                            // attempt (`stage_execution_row` resets
+                            // `row_count = -1` before claiming a connection),
+                            // so a row that fails before producing a count
+                            // must not leave a stale value from an earlier
+                            // row behind for the aggregator to misread.
+                            stmt.inner.lock().unwrap().row_count = -1;
+                            return SQL_ERROR;
+                        }
+                        stmt.inner.lock().unwrap().row_count = 1;
+                        SQL_SUCCESS
+                    },
+                )
+            };
+
+            assert_eq!(ret, SQL_ERROR);
+            assert_eq!(processed, 2, "stopped after the failing row (index 1)");
+            assert_eq!(
+                status,
+                [
+                    SQL_PARAM_SUCCESS,
+                    SQL_PARAM_ERROR,
+                    SQL_PARAM_UNUSED,
+                    SQL_PARAM_UNUSED,
+                ]
+            );
+            // Only row 0's count made it into the aggregate before the stop.
+            assert_eq!(stmt.inner.lock().unwrap().row_count, 1);
+        }
+
+        /// `SQL_ATTR_PARAM_OPERATION_PTR` skips a row entirely: it is never
+        /// passed to `execute_row`, its status stays `SQL_PARAM_UNUSED`, and
+        /// `SQL_ATTR_PARAMS_PROCESSED_PTR` still advances past it — the loop
+        /// looked at the row and decided to skip it, which counts as
+        /// processing it.
+        #[test]
+        fn operation_ptr_ignore_skips_a_row_without_executing_it() {
+            let h = TestHandles::with_env_dbc_stmt();
+            let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+            let operations = [SQL_PARAM_IGNORE, SQL_PARAM_PROCEED, SQL_PARAM_IGNORE];
+            let mut status = [SQL_PARAM_SUCCESS; 3];
+            let mut processed: SqlULen = 0;
+            let mut executed_rows = Vec::new();
+
+            let ret = unsafe {
+                execute_param_array_loop(
+                    stmt,
+                    h.stmt,
+                    3,
+                    operations.as_ptr(),
+                    status.as_mut_ptr(),
+                    &raw mut processed,
+                    |row| {
+                        executed_rows.push(row);
+                        stmt.inner.lock().unwrap().row_count = 1;
+                        SQL_SUCCESS
+                    },
+                )
+            };
+
+            assert_eq!(ret, SQL_SUCCESS);
+            assert_eq!(executed_rows, vec![1], "only the proceed row runs");
+            assert_eq!(processed, 3);
+            assert_eq!(
+                status,
+                [SQL_PARAM_UNUSED, SQL_PARAM_SUCCESS, SQL_PARAM_UNUSED]
+            );
+            // Only the one executed row's count is in the aggregate.
+            assert_eq!(stmt.inner.lock().unwrap().row_count, 1);
+        }
+
+        /// The overall return is the worst status across rows:
+        /// `SQL_SUCCESS_WITH_INFO` if any row warned and none failed.
+        #[test]
+        fn a_warning_row_promotes_the_overall_return_to_success_with_info() {
+            let h = TestHandles::with_env_dbc_stmt();
+            let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+            let mut status = [SQL_PARAM_SUCCESS; 2];
+
+            let ret = unsafe {
+                execute_param_array_loop(
+                    stmt,
+                    h.stmt,
+                    2,
+                    std::ptr::null(),
+                    status.as_mut_ptr(),
+                    std::ptr::null_mut(),
+                    |row| {
+                        stmt.inner.lock().unwrap().row_count = 1;
+                        if row == 0 {
+                            SQL_SUCCESS_WITH_INFO
+                        } else {
+                            SQL_SUCCESS
+                        }
+                    },
+                )
+            };
+
+            assert_eq!(ret, SQL_SUCCESS_WITH_INFO);
+            assert_eq!(status, [SQL_PARAM_SUCCESS_WITH_INFO, SQL_PARAM_SUCCESS]);
+        }
+
+        /// Every row starts out `SQL_PARAM_UNUSED` and
+        /// `SQL_ATTR_PARAMS_PROCESSED_PTR` starts at 0 — an application that
+        /// reads these before the loop advances (or after a 0-row array, if
+        /// one were ever passed) must not see stale memory.
+        #[test]
+        fn status_and_processed_are_initialized_before_any_row_runs() {
+            let h = TestHandles::with_env_dbc_stmt();
+            let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+            let mut status = [99u16; 3];
+            let mut processed: SqlULen = 999;
+
+            unsafe {
+                execute_param_array_loop(
+                    stmt,
+                    h.stmt,
+                    3,
+                    std::ptr::null(),
+                    status.as_mut_ptr(),
+                    &raw mut processed,
+                    |_row| {
+                        stmt.inner.lock().unwrap().row_count = 1;
+                        SQL_SUCCESS
+                    },
+                )
+            };
+
+            assert_eq!(processed, 3);
+            assert_eq!(status, [SQL_PARAM_SUCCESS; 3]);
+        }
+
+        /// Null `operation_ptr` / `status_ptr` / `processed_ptr` — the common
+        /// case, matching mssql-python's own executemany, which never sets
+        /// any of the three — must not be dereferenced.
+        #[test]
+        fn null_bookkeeping_pointers_are_never_dereferenced() {
+            let h = TestHandles::with_env_dbc_stmt();
+            let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+
+            let ret = unsafe {
+                execute_param_array_loop(
+                    stmt,
+                    h.stmt,
+                    5,
+                    std::ptr::null(),
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                    |_row| {
+                        stmt.inner.lock().unwrap().row_count = 2;
+                        SQL_SUCCESS
+                    },
+                )
+            };
+
+            assert_eq!(ret, SQL_SUCCESS);
+            assert_eq!(stmt.inner.lock().unwrap().row_count, 10);
+        }
     }
 }

--- a/mssql-odbc/src/api/exec_direct.rs
+++ b/mssql-odbc/src/api/exec_direct.rs
@@ -10,15 +10,17 @@ use std::time::Instant;
 use mssql_tds::connection::tds_client::{ExecuteOptions, StreamedParamStatus};
 
 use super::exec_common::{
-    ParamsWithDae, build_named_params, claim_connection, deduct_query_timeout, fail_with_tds,
-    finish_execute, flush_pending_unprepare, park_dae_client, query_timeout_expired_error,
-    snapshot_bound_params,
+    ParamsWithDae, build_named_params_row, claim_connection, deduct_query_timeout,
+    execute_param_array_loop, fail_with_tds, finish_execute, flush_pending_unprepare,
+    park_dae_client, query_timeout_expired_error, snapshot_bound_params,
 };
 use super::sqlstate::*;
 use super::txn::begin_transaction_if_manual;
 use super::util::{read_utf16, rewrite_param_markers};
 use crate::api::odbc_types::{
-    SQL_ERROR, SQL_INVALID_HANDLE, SqlHandle, SqlReturn, SqlSmallInt, SqlWChar,
+    SQL_ATTR_PARAM_BIND_TYPE, SQL_ATTR_PARAM_OPERATION_PTR, SQL_ATTR_PARAM_STATUS_PTR,
+    SQL_ATTR_PARAMS_PROCESSED_PTR, SQL_ERROR, SQL_INVALID_HANDLE, SQL_PARAM_BIND_BY_COLUMN,
+    SqlHandle, SqlReturn, SqlSmallInt, SqlULen, SqlUSmallInt, SqlWChar,
 };
 use crate::error::free_errors;
 use crate::error::post_sql_error;
@@ -106,7 +108,140 @@ fn sql_exec_direct_w_safe(
     debug!(sql = %sql, "SQLExecDirectW: executing");
 
     let dbc = stmt.parent_dbc();
+    let (rewritten_sql, marker_count) = rewrite_param_markers(&sql);
 
+    let paramset_size = match stmt.inner.lock() {
+        Ok(state) => state.paramset_size,
+        Err(_) => {
+            error!("SQLExecDirectW: stmt mutex poisoned");
+            return SQL_ERROR;
+        }
+    };
+
+    // See SQLExecute's identical guard (execute.rs): a parameterless
+    // statement has no array rows to walk, so a leftover
+    // SQL_ATTR_PARAMSET_SIZE > 1 runs it exactly once rather than silently
+    // multiplying its side effects.
+    if paramset_size > 1 && marker_count > 0 {
+        return execute_direct_param_array(
+            statement_handle,
+            stmt,
+            dbc,
+            &rewritten_sql,
+            marker_count,
+            paramset_size,
+        );
+    }
+
+    exec_direct_row(
+        statement_handle,
+        stmt,
+        dbc,
+        RowExecution {
+            rewritten_sql: &rewritten_sql,
+            marker_count,
+            row: 0,
+            bind_type: SQL_PARAM_BIND_BY_COLUMN,
+            parameter_array: false,
+        },
+    )
+}
+
+/// Runs `paramset_size` rows of already-rewritten SQL text, one
+/// `SQLExecDirectW` per row (AB#47820) — `SQLExecDirectW`'s equivalent of
+/// `execute.rs`'s `execute_param_array`, sharing the same row-array
+/// bookkeeping (`exec_common::execute_param_array_loop`). Unlike a prepared
+/// statement, there is no server-side handle to carry across rows: each row
+/// independently claims the connection, sends the batch, and finishes.
+fn execute_direct_param_array(
+    statement_handle: SqlHandle,
+    stmt: &StmtHandle,
+    dbc: &crate::handles::DbcHandle,
+    rewritten_sql: &str,
+    marker_count: usize,
+    paramset_size: SqlULen,
+) -> SqlReturn {
+    let (bind_type, operation_ptr, status_ptr, processed_ptr) = match stmt.inner.lock() {
+        Ok(state) => (
+            state
+                .inert_attrs
+                .get(SQL_ATTR_PARAM_BIND_TYPE)
+                .unwrap_or(SQL_PARAM_BIND_BY_COLUMN),
+            state
+                .inert_attrs
+                .get(SQL_ATTR_PARAM_OPERATION_PTR)
+                .unwrap_or(0) as *const SqlUSmallInt,
+            state
+                .inert_attrs
+                .get(SQL_ATTR_PARAM_STATUS_PTR)
+                .unwrap_or(0) as *mut SqlUSmallInt,
+            state
+                .inert_attrs
+                .get(SQL_ATTR_PARAMS_PROCESSED_PTR)
+                .unwrap_or(0) as *mut SqlULen,
+        ),
+        Err(_) => {
+            error!("SQLExecDirectW: stmt mutex poisoned while reading parameter-array attributes");
+            return SQL_ERROR;
+        }
+    };
+
+    unsafe {
+        execute_param_array_loop(
+            stmt,
+            statement_handle,
+            paramset_size,
+            operation_ptr,
+            status_ptr,
+            processed_ptr,
+            |row| {
+                exec_direct_row(
+                    statement_handle,
+                    stmt,
+                    dbc,
+                    RowExecution {
+                        rewritten_sql,
+                        marker_count,
+                        row,
+                        bind_type,
+                        parameter_array: true,
+                    },
+                )
+            },
+        )
+    }
+}
+
+/// Groups one row's execution parameters so `exec_direct_row` stays within
+/// clippy's argument-count limit; `rewritten_sql` and `marker_count` are the
+/// same for every row of an array, `row` and `bind_type` select which row,
+/// and `parameter_array` gates the data-at-execution rejection.
+struct RowExecution<'a> {
+    rewritten_sql: &'a str,
+    marker_count: usize,
+    row: usize,
+    bind_type: SqlULen,
+    parameter_array: bool,
+}
+
+/// Runs one execution of already-rewritten SQL text: the ordinary scalar
+/// case (`row == 0`, `parameter_array == false`), or one row out of a
+/// `SQL_ATTR_PARAMSET_SIZE > 1` array. `parameter_array` gates the
+/// data-at-execution rejection the same way `execute.rs::stage_execution_row`
+/// does — an array has no way to interleave `SQLPutData` calls per row.
+fn exec_direct_row(
+    statement_handle: SqlHandle,
+    stmt: &StmtHandle,
+    dbc: &crate::handles::DbcHandle,
+    exec: RowExecution<'_>,
+) -> SqlReturn {
+    let RowExecution {
+        rewritten_sql,
+        marker_count,
+        row,
+        bind_type,
+        parameter_array,
+    } = exec;
     // Snapshotted before the STMT lock below is taken — this crate never
     // holds a STMT lock while acquiring a DESC lock (see bind_col.rs's
     // rationale). Not applied to `stmt_state.bound_params` until the
@@ -129,7 +264,7 @@ fn sql_exec_direct_w_safe(
     };
 
     // Check STMT state, gather parameter values, and reset prior context.
-    let (named_params, rewritten_sql, marker_count, query_timeout) = {
+    let (named_params, query_timeout) = {
         let Ok(mut stmt_state) = stmt.inner.lock() else {
             error!("SQLExecDirectW: stmt mutex poisoned");
             return SQL_ERROR;
@@ -150,15 +285,27 @@ fn sql_exec_direct_w_safe(
             return SQL_ERROR;
         }
         stmt_state.bound_params = bound_params;
-        // Rewrite markers and read the bound parameter buffers before mutating
-        // any state, so a binding error (07002 / HYC00) leaves the statement
-        // unchanged.
-        let (rewritten_sql, marker_count) = rewrite_param_markers(&sql);
-        let named_params =
-            match unsafe { build_named_params(&mut stmt_state, marker_count, "SQLExecDirectW") } {
-                Ok(params) => params,
-                Err(rc) => return rc,
-            };
+        // Read the bound parameter buffers before mutating any state, so a
+        // binding error (07002 / HYC00) leaves the statement unchanged.
+        let named_params = match unsafe {
+            build_named_params_row(
+                &mut stmt_state,
+                marker_count,
+                "SQLExecDirectW",
+                row,
+                bind_type,
+            )
+        } {
+            Ok(params) => params,
+            Err(rc) => return rc,
+        };
+        if parameter_array && !named_params.dae_params.is_empty() {
+            error!(
+                "SQLExecDirectW: data-at-execution parameters are not supported with SQL_ATTR_PARAMSET_SIZE > 1"
+            );
+            post_diag(&mut stmt_state, ERR_OPTIONAL_FEATURE_NOT_IMPLEMENTED);
+            return SQL_ERROR;
+        }
         // A new execute invalidates prior metadata/context immediately, so a
         // later execute failure cannot expose stale SQLNumResultCols/DescribeCol state.
         stmt_state.clear_state(STMT_STATE_EXEC_CONTEXT);
@@ -173,12 +320,7 @@ fn sql_exec_direct_w_safe(
         stmt_state.parameter_metadata.clear();
         stmt_state.clear_state(STMT_STATE_PREPARED);
         stmt_state.set_state(STMT_STATE_EXEC_STARTED);
-        (
-            named_params,
-            rewritten_sql,
-            marker_count,
-            stmt_state.query_timeout,
-        )
+        (named_params, stmt_state.query_timeout)
     };
 
     let ParamsWithDae { params, dae_params } = named_params;
@@ -238,10 +380,11 @@ fn sql_exec_direct_w_safe(
 
     // Data-at-execution parameters park the half-written RPC on the statement
     // and hand control to SQLParamData / SQLPutData. There is no prepared plan
-    // to restore afterwards, so `None` is passed for it.
+    // to restore afterwards, so `None` is passed for it. Unreachable when
+    // `parameter_array` is true — rejected above.
     if !dae_params.is_empty() {
         let begin_result = dbc.runtime.block_on(client.begin_sp_executesql(
-            rewritten_sql,
+            rewritten_sql.to_string(),
             params,
             ExecuteOptions::new().timeout_secs(query_timeout),
         ));
@@ -266,13 +409,15 @@ fn sql_exec_direct_w_safe(
     }
 
     // Parameterized text runs via sp_executesql (direct execution, no cached
-    // handle); unparameterized text runs as a plain SQL batch. Neither DBC nor
-    // STMT lock is held during I/O. `query_timeout` (already deducted above)
-    // bounds either call; `0` means unlimited, matching the ODBC default.
+    // handle); unparameterized text runs as a plain SQL batch — the two are
+    // byte-identical when there are no markers, so `rewritten_sql` serves
+    // either way. Neither DBC nor STMT lock is held during I/O.
+    // `query_timeout` (already deducted above) bounds either call; `0` means
+    // unlimited, matching the ODBC default.
     let exec_result: Result<(), mssql_tds::error::Error> = if marker_count > 0 {
         dbc.runtime
             .block_on(client.execute_sp_executesql(
-                rewritten_sql,
+                rewritten_sql.to_string(),
                 params,
                 ExecuteOptions::new().timeout_secs(query_timeout),
             ))
@@ -283,7 +428,10 @@ fn sql_exec_direct_w_safe(
         // individually navigable via SQLMoreResults. finish_execute inspects the
         // resulting client state.
         dbc.runtime
-            .block_on(client.execute(sql, ExecuteOptions::new().timeout_secs(query_timeout)))
+            .block_on(client.execute(
+                rewritten_sql.to_string(),
+                ExecuteOptions::new().timeout_secs(query_timeout),
+            ))
             .map(|_| ())
     };
     if let Err(e) = exec_result {
@@ -297,7 +445,12 @@ fn sql_exec_direct_w_safe(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::odbc_types::{SQL_NTS, SQL_NULL_HANDLE};
+    use crate::api::bind_param::sql_bind_parameter;
+    use crate::api::odbc_types::{
+        SQL_ATTR_PARAMSET_SIZE, SQL_C_CHAR, SQL_C_LONG, SQL_DATA_AT_EXEC, SQL_INTEGER, SQL_NTS,
+        SQL_NULL_HANDLE, SQL_PARAM_INPUT, SQL_SUCCESS, SQL_VARCHAR, SqlLen, SqlPointer,
+    };
+    use crate::api::set_stmt_attr::sql_set_stmt_attr_w;
     use crate::handles::DescHandle;
     use crate::test_support::TestHandles;
 
@@ -822,5 +975,242 @@ mod tests {
             ss.pending_fetch_info.is_empty(),
             "the previous query's INFO message must not leak onto the new query"
         );
+    }
+
+    /// See `execute.rs`'s identical test: an array has no way to interleave
+    /// `SQLPutData` calls per row, so a data-at-execution binding combined
+    /// with `SQL_ATTR_PARAMSET_SIZE > 1` must be rejected up front rather
+    /// than silently reading only row 0's DAE indicator.
+    #[test]
+    fn array_execute_rejects_data_at_execution_parameters() {
+        let h = TestHandles::with_env_dbc_stmt();
+        let mut ind: SqlLen = SQL_DATA_AT_EXEC;
+        let bind_ret = unsafe {
+            sql_bind_parameter(
+                h.stmt,
+                1,
+                SQL_PARAM_INPUT,
+                SQL_C_CHAR,
+                SQL_VARCHAR,
+                0,
+                0,
+                std::ptr::null_mut(),
+                0,
+                &mut ind,
+            )
+        };
+        assert_eq!(bind_ret, SQL_SUCCESS);
+        assert_eq!(
+            unsafe { sql_set_stmt_attr_w(h.stmt, SQL_ATTR_PARAMSET_SIZE, 2 as SqlPointer, 0) },
+            SQL_SUCCESS
+        );
+
+        let sql: Vec<u16> = "INSERT INTO t VALUES (?)"
+            .encode_utf16()
+            .chain(std::iter::once(0))
+            .collect();
+        let ret = unsafe { sql_exec_direct_w(h.stmt, sql.as_ptr(), SQL_NTS) };
+
+        assert_eq!(ret, SQL_ERROR);
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        let state = stmt.inner.lock().unwrap();
+        assert_eq!(
+            state.diag_records[0].sql_state,
+            ERR_OPTIONAL_FEATURE_NOT_IMPLEMENTED.state
+        );
+        assert!(!state.has_state(STMT_STATE_EXEC_STARTED));
+    }
+
+    /// A parameterless statement executed with a leftover
+    /// `SQL_ATTR_PARAMSET_SIZE > 1` has no array rows to walk, so it must run
+    /// exactly once — proven by never touching
+    /// `SQL_ATTR_PARAMS_PROCESSED_PTR`, which only the array loop writes.
+    #[test]
+    fn array_size_is_ignored_for_a_parameterless_statement() {
+        let h = TestHandles::with_env_dbc_stmt();
+        assert_eq!(
+            unsafe { sql_set_stmt_attr_w(h.stmt, SQL_ATTR_PARAMSET_SIZE, 5 as SqlPointer, 0) },
+            SQL_SUCCESS
+        );
+        let mut processed: SqlULen = 999;
+        assert_eq!(
+            unsafe {
+                sql_set_stmt_attr_w(
+                    h.stmt,
+                    SQL_ATTR_PARAMS_PROCESSED_PTR,
+                    (&mut processed as *mut SqlULen).cast(),
+                    0,
+                )
+            },
+            SQL_SUCCESS
+        );
+
+        // No live connection: a single ordinary execute fails at
+        // claim_connection with 08003, exactly like the non-array case.
+        let sql: Vec<u16> = "SELECT 1"
+            .encode_utf16()
+            .chain(std::iter::once(0))
+            .collect();
+        let ret = unsafe { sql_exec_direct_w(h.stmt, sql.as_ptr(), SQL_NTS) };
+
+        assert_eq!(ret, SQL_ERROR);
+        assert_eq!(
+            processed, 999,
+            "the array loop must never have run for a parameterless statement"
+        );
+    }
+
+    /// The first row of an array claims the connection like any scalar
+    /// execute; with none available it fails with 08003 exactly once, and
+    /// the bookkeeping reflects that only row 0 was attempted.
+    #[test]
+    fn array_execute_disconnected_fails_on_first_row_with_bookkeeping() {
+        use crate::api::odbc_types::{SQL_PARAM_ERROR, SQL_PARAM_UNUSED, SqlUSmallInt};
+
+        let h = TestHandles::with_env_dbc_stmt();
+        let mut values = [1i32, 2, 3];
+        let mut indicators: [SqlLen; 3] = [0; 3];
+        let bind_ret = unsafe {
+            sql_bind_parameter(
+                h.stmt,
+                1,
+                SQL_PARAM_INPUT,
+                SQL_C_LONG,
+                SQL_INTEGER,
+                0,
+                0,
+                values.as_mut_ptr().cast(),
+                0,
+                indicators.as_mut_ptr(),
+            )
+        };
+        assert_eq!(bind_ret, SQL_SUCCESS);
+        assert_eq!(
+            unsafe { sql_set_stmt_attr_w(h.stmt, SQL_ATTR_PARAMSET_SIZE, 3 as SqlPointer, 0) },
+            SQL_SUCCESS
+        );
+        let mut status: [SqlUSmallInt; 3] = [SQL_SUCCESS as SqlUSmallInt; 3];
+        assert_eq!(
+            unsafe {
+                sql_set_stmt_attr_w(
+                    h.stmt,
+                    SQL_ATTR_PARAM_STATUS_PTR,
+                    status.as_mut_ptr().cast(),
+                    0,
+                )
+            },
+            SQL_SUCCESS
+        );
+        let mut processed: SqlULen = 0;
+        assert_eq!(
+            unsafe {
+                sql_set_stmt_attr_w(
+                    h.stmt,
+                    SQL_ATTR_PARAMS_PROCESSED_PTR,
+                    (&mut processed as *mut SqlULen).cast(),
+                    0,
+                )
+            },
+            SQL_SUCCESS
+        );
+
+        let sql: Vec<u16> = "INSERT INTO t VALUES (?)"
+            .encode_utf16()
+            .chain(std::iter::once(0))
+            .collect();
+        let ret = unsafe { sql_exec_direct_w(h.stmt, sql.as_ptr(), SQL_NTS) };
+
+        assert_eq!(ret, SQL_ERROR);
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        let state = stmt.inner.lock().unwrap();
+        assert_eq!(
+            state.diag_records[0].sql_state,
+            ERR_CONNECTION_DOES_NOT_EXIST.state
+        );
+        assert_eq!(processed, 1, "only row 0 was attempted");
+        assert_eq!(
+            status,
+            [SQL_PARAM_ERROR, SQL_PARAM_UNUSED, SQL_PARAM_UNUSED]
+        );
+    }
+
+    /// End-to-end proof (scripted `TdsClient`, no live server) that a
+    /// parameter array genuinely runs every row and sums their row counts —
+    /// mirroring mssql-python's `executemany` rowcount contract
+    /// (`test_rowcount_executemany`: 3 one-row inserts sum to `rowcount == 3`).
+    /// Each row is a separate `INSERT` scripted to affect one row, so this
+    /// fails if the array collapses to a single execute or double-counts.
+    #[test]
+    fn array_execute_runs_every_row_and_sums_row_counts() {
+        use crate::handles::dbc::DbcHandle;
+        use mssql_tds::test_client_support::{done_no_more_with_count, tds_client_from_tokens};
+
+        const PARAMSET_SIZE: usize = 3;
+
+        let h = TestHandles::with_env_dbc_stmt();
+        h.mark_dbc_connected();
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        let client = tds_client_from_tokens(vec![
+            done_no_more_with_count(1),
+            done_no_more_with_count(1),
+            done_no_more_with_count(1),
+        ]);
+        {
+            let mut ds = dbc.inner.lock().unwrap();
+            ds.client = Some(client);
+        }
+
+        let mut values = [1i32, 2, 3];
+        let mut indicators: [SqlLen; PARAMSET_SIZE] = [0; PARAMSET_SIZE];
+        let bind_ret = unsafe {
+            sql_bind_parameter(
+                h.stmt,
+                1,
+                SQL_PARAM_INPUT,
+                SQL_C_LONG,
+                SQL_INTEGER,
+                0,
+                0,
+                values.as_mut_ptr().cast(),
+                0,
+                indicators.as_mut_ptr(),
+            )
+        };
+        assert_eq!(bind_ret, SQL_SUCCESS);
+        assert_eq!(
+            unsafe {
+                sql_set_stmt_attr_w(
+                    h.stmt,
+                    SQL_ATTR_PARAMSET_SIZE,
+                    PARAMSET_SIZE as SqlPointer,
+                    0,
+                )
+            },
+            SQL_SUCCESS
+        );
+        let mut processed: SqlULen = 0;
+        assert_eq!(
+            unsafe {
+                sql_set_stmt_attr_w(
+                    h.stmt,
+                    SQL_ATTR_PARAMS_PROCESSED_PTR,
+                    (&mut processed as *mut SqlULen).cast(),
+                    0,
+                )
+            },
+            SQL_SUCCESS
+        );
+
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        let ret = sql_exec_direct_w_safe(h.stmt, stmt, "INSERT INTO t VALUES (?)".to_string());
+
+        assert_eq!(
+            ret,
+            SQL_SUCCESS,
+            "diag: {:?}",
+            stmt.inner.lock().unwrap().diag_records
+        );
+        assert_eq!(processed, PARAMSET_SIZE as SqlULen);
+        assert_eq!(stmt.inner.lock().unwrap().row_count, 3);
     }
 }

--- a/mssql-odbc/src/api/execute.rs
+++ b/mssql-odbc/src/api/execute.rs
@@ -14,12 +14,17 @@ use mssql_tds::connection::tds_client::{
 use mssql_tds::message::parameters::rpc_parameters::RpcParameter;
 
 use super::exec_common::{
-    ParamsWithDae, build_named_params, claim_connection, deduct_query_timeout, fail_with_tds,
-    finish_execute, park_dae_client, query_timeout_expired_error, snapshot_bound_params,
+    ParamsWithDae, build_named_params_row, claim_connection, deduct_query_timeout,
+    execute_param_array_loop, fail_with_tds, finish_execute, park_dae_client,
+    query_timeout_expired_error, snapshot_bound_params,
 };
 use super::sqlstate::*;
 use super::txn::begin_transaction_if_manual;
-use crate::api::odbc_types::{SQL_ERROR, SQL_INVALID_HANDLE, SqlHandle, SqlReturn};
+use crate::api::odbc_types::{
+    SQL_ATTR_PARAM_BIND_TYPE, SQL_ATTR_PARAM_OPERATION_PTR, SQL_ATTR_PARAM_STATUS_PTR,
+    SQL_ATTR_PARAMS_PROCESSED_PTR, SQL_ERROR, SQL_INVALID_HANDLE, SQL_PARAM_BIND_BY_COLUMN,
+    SqlHandle, SqlReturn, SqlULen, SqlUSmallInt,
+};
 use crate::error::free_errors;
 use crate::error::post_sql_error;
 use crate::handles::stmt::{
@@ -104,13 +109,41 @@ enum ExecutionStaging {
 }
 
 fn sql_execute_safe(statement_handle: SqlHandle, stmt: &StmtHandle) -> SqlReturn {
-    let dbc = stmt.parent_dbc();
+    let (paramset_size, marker_count) = match stmt.inner.lock() {
+        Ok(state) => (
+            state.paramset_size,
+            state.prepared.as_ref().map(|p| p.marker_count).unwrap_or(0),
+        ),
+        Err(_) => {
+            error!("SQLExecute: stmt mutex poisoned");
+            return SQL_ERROR;
+        }
+    };
 
+    // Only a genuine parameter array is iterated: a parameterless prepared
+    // statement executed with a leftover SQL_ATTR_PARAMSET_SIZE > 1 has no
+    // array rows to walk, so running it once matches the array's single
+    // element rather than silently repeating a side effect nobody asked for.
+    if paramset_size > 1 && marker_count > 0 {
+        return execute_param_array(statement_handle, stmt, paramset_size);
+    }
+
+    let dbc = stmt.parent_dbc();
     let staging = match stage_execution(stmt) {
         Ok(s) => s,
         Err(rc) => return rc,
     };
+    execute_staged(statement_handle, stmt, dbc, staging)
+}
 
+/// Runs one already-staged execution (scalar, or a single row out of a
+/// parameter array) to completion.
+fn execute_staged(
+    statement_handle: SqlHandle,
+    stmt: &StmtHandle,
+    dbc: &crate::handles::DbcHandle,
+    staging: ExecutionStaging,
+) -> SqlReturn {
     match staging {
         ExecutionStaging::Ready(Execution {
             named_params,
@@ -321,10 +354,86 @@ fn sql_execute_safe(statement_handle: SqlHandle, stmt: &StmtHandle) -> SqlReturn
     }
 }
 
+/// Runs `paramset_size` rows out of the bound column-wise or row-wise
+/// parameter arrays, one `SQLExecute` per row (AB#47820).
+///
+/// The shared bookkeeping — `SQL_ATTR_PARAM_OPERATION_PTR` skips,
+/// `SQL_ATTR_PARAM_STATUS_PTR` / `SQL_ATTR_PARAMS_PROCESSED_PTR` writes, row
+/// count aggregation, and closing a cursor left open between rows — lives in
+/// `exec_common::execute_param_array_loop`, shared with `SQLExecDirectW`'s
+/// equivalent. `SQL_ATTR_PARAM_BIND_TYPE` is read once here, outside the loop,
+/// since it cannot change mid-array.
+fn execute_param_array(
+    statement_handle: SqlHandle,
+    stmt: &StmtHandle,
+    paramset_size: SqlULen,
+) -> SqlReturn {
+    let (bind_type, operation_ptr, status_ptr, processed_ptr) = match stmt.inner.lock() {
+        Ok(state) => (
+            state
+                .inert_attrs
+                .get(SQL_ATTR_PARAM_BIND_TYPE)
+                .unwrap_or(SQL_PARAM_BIND_BY_COLUMN),
+            state
+                .inert_attrs
+                .get(SQL_ATTR_PARAM_OPERATION_PTR)
+                .unwrap_or(0) as *const SqlUSmallInt,
+            state
+                .inert_attrs
+                .get(SQL_ATTR_PARAM_STATUS_PTR)
+                .unwrap_or(0) as *mut SqlUSmallInt,
+            state
+                .inert_attrs
+                .get(SQL_ATTR_PARAMS_PROCESSED_PTR)
+                .unwrap_or(0) as *mut SqlULen,
+        ),
+        Err(_) => {
+            error!("SQLExecute: stmt mutex poisoned while reading parameter-array attributes");
+            return SQL_ERROR;
+        }
+    };
+
+    let dbc = stmt.parent_dbc();
+    unsafe {
+        execute_param_array_loop(
+            stmt,
+            statement_handle,
+            paramset_size,
+            operation_ptr,
+            status_ptr,
+            processed_ptr,
+            |row| {
+                let staging = match stage_execution_row(stmt, row, bind_type, true) {
+                    Ok(s) => s,
+                    Err(rc) => return rc,
+                };
+                execute_staged(statement_handle, stmt, dbc, staging)
+            },
+        )
+    }
+}
+
 /// Validates statement state and builds the parameter list under the STMT lock,
 /// setting `EXEC_STARTED` on success. Application value buffers are read here by
 /// reference (no network I/O).
 fn stage_execution(stmt: &StmtHandle) -> Result<ExecutionStaging, SqlReturn> {
+    stage_execution_row(stmt, 0, SQL_PARAM_BIND_BY_COLUMN, false)
+}
+
+/// [`stage_execution`] for parameter-array row `row` (0-based) of a
+/// `SQL_ATTR_PARAMSET_SIZE > 1` execution. `parameter_array` is `false` for
+/// the ordinary scalar path (`stage_execution`, row 0), where a
+/// data-at-execution binding is business as usual, and `true` from
+/// `execute_param_array`, where one is rejected instead — an array of
+/// streamed values has no way to interleave `SQLPutData` calls per row, so
+/// silently reading only the first row's DAE indicator would either hang
+/// waiting for data that never comes or execute the wrong row's value.
+fn stage_execution_row(
+    stmt: &StmtHandle,
+    row: usize,
+    bind_type: SqlULen,
+    parameter_array: bool,
+) -> Result<ExecutionStaging, SqlReturn> {
     // Snapshotted before the STMT lock below is taken — this crate never
     // holds a STMT lock while acquiring a DESC lock (see bind_col.rs's
     // rationale). Not applied to `stmt_state.bound_params` until every
@@ -399,14 +508,23 @@ fn stage_execution(stmt: &StmtHandle) -> Result<ExecutionStaging, SqlReturn> {
         .marker_count;
 
     // All state-sequencing checks passed: this is a real new execute, so the
-    // fresh snapshot now becomes the one `build_named_params` and any DAE
+    // fresh snapshot now becomes the one `build_named_params_row` and any DAE
     // sequence it opens will read for the rest of this execute.
     stmt_state.bound_params = bound_params;
 
     // Scan for data-at-execution parameters.  If any are present, use the
     // streaming path; otherwise, go through the normal prepared-execute path.
-    let ParamsWithDae { params, dae_params } =
-        unsafe { build_named_params(&mut stmt_state, marker_count, "SQLExecute") }?;
+    let ParamsWithDae { params, dae_params } = unsafe {
+        build_named_params_row(&mut stmt_state, marker_count, "SQLExecute", row, bind_type)
+    }?;
+
+    if parameter_array && !dae_params.is_empty() {
+        error!(
+            "SQLExecute: data-at-execution parameters are not supported with SQL_ATTR_PARAMSET_SIZE > 1"
+        );
+        post_diag(&mut stmt_state, ERR_OPTIONAL_FEATURE_NOT_IMPLEMENTED);
+        return Err(SQL_ERROR);
+    }
 
     // All fallible validation passed: move the prepared plan out (written
     // back after the execute) and take any orphaned handle for piggyback drop.
@@ -446,9 +564,10 @@ mod tests {
     use super::*;
     use crate::api::bind_param::sql_bind_parameter;
     use crate::api::odbc_types::{
-        SQL_C_CHAR, SQL_DATA_AT_EXEC, SQL_NULL_HANDLE, SQL_PARAM_INPUT, SQL_SUCCESS, SQL_VARCHAR,
-        SqlLen,
+        SQL_ATTR_PARAMSET_SIZE, SQL_C_CHAR, SQL_C_LONG, SQL_DATA_AT_EXEC, SQL_INTEGER,
+        SQL_NULL_HANDLE, SQL_PARAM_INPUT, SQL_SUCCESS, SQL_VARCHAR, SqlLen, SqlPointer,
     };
+    use crate::api::set_stmt_attr::sql_set_stmt_attr_w;
     use crate::api::util::rewrite_param_markers;
     use crate::handles::DescHandle;
     use crate::test_support::TestHandles;
@@ -839,5 +958,251 @@ mod tests {
             }
             ExecutionStaging::Ready(_) => panic!("expected NeedData staging for DAE param"),
         }
+    }
+
+    /// A data-at-execution parameter cannot combine with
+    /// `SQL_ATTR_PARAMSET_SIZE > 1`: an array has no way to interleave
+    /// `SQLPutData` calls per row, so this must be rejected up front rather
+    /// than silently reading only row 0's DAE indicator. Verified against
+    /// mssql-python: its `executemany` DAE branch never sets
+    /// `SQL_ATTR_PARAMSET_SIZE` — it loops separate scalar executes instead —
+    /// so this rejection can never fire on that path.
+    #[test]
+    fn array_execute_rejects_data_at_execution_parameters() {
+        let h = TestHandles::with_env_dbc_stmt();
+        set_prepared(h.stmt, "INSERT INTO t VALUES (?)");
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+
+        let mut ind: SqlLen = SQL_DATA_AT_EXEC;
+        let bind_ret = unsafe {
+            sql_bind_parameter(
+                h.stmt,
+                1,
+                SQL_PARAM_INPUT,
+                SQL_C_CHAR,
+                SQL_VARCHAR,
+                0,
+                0,
+                std::ptr::null_mut(),
+                0,
+                &mut ind,
+            )
+        };
+        assert_eq!(bind_ret, SQL_SUCCESS);
+        assert_eq!(
+            unsafe { sql_set_stmt_attr_w(h.stmt, SQL_ATTR_PARAMSET_SIZE, 2 as SqlPointer, 0) },
+            SQL_SUCCESS
+        );
+
+        let ret = unsafe { sql_execute(h.stmt) };
+
+        assert_eq!(ret, SQL_ERROR);
+        let state = stmt.inner.lock().unwrap();
+        assert_eq!(
+            state.diag_records[0].sql_state,
+            ERR_OPTIONAL_FEATURE_NOT_IMPLEMENTED.state
+        );
+        assert!(!state.has_state(STMT_STATE_EXEC_STARTED));
+        // Rejected before any I/O: the prepared plan must still be there so
+        // a corrected retry (dropping the array, or the DAE binding) works.
+        assert!(state.prepared.is_some());
+    }
+
+    /// A parameterless prepared statement executed with a leftover
+    /// `SQL_ATTR_PARAMSET_SIZE > 1` has no array rows to walk, so it must run
+    /// exactly once — not `paramset_size` times, which would silently
+    /// multiply a DML statement's side effects. Proven by never touching
+    /// `SQL_ATTR_PARAMS_PROCESSED_PTR`, which only the array loop writes.
+    #[test]
+    fn array_size_is_ignored_for_a_parameterless_statement() {
+        let h = TestHandles::with_env_dbc_stmt();
+        set_prepared(h.stmt, "SELECT 1");
+        assert_eq!(
+            unsafe { sql_set_stmt_attr_w(h.stmt, SQL_ATTR_PARAMSET_SIZE, 5 as SqlPointer, 0) },
+            SQL_SUCCESS
+        );
+        let mut processed: SqlULen = 999;
+        assert_eq!(
+            unsafe {
+                sql_set_stmt_attr_w(
+                    h.stmt,
+                    SQL_ATTR_PARAMS_PROCESSED_PTR,
+                    (&mut processed as *mut SqlULen).cast(),
+                    0,
+                )
+            },
+            SQL_SUCCESS
+        );
+
+        // No live connection: a single ordinary execute fails at
+        // claim_connection with 08003, exactly like the non-array case.
+        let ret = unsafe { sql_execute(h.stmt) };
+
+        assert_eq!(ret, SQL_ERROR);
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        let state = stmt.inner.lock().unwrap();
+        assert_eq!(
+            state.diag_records[0].sql_state,
+            ERR_CONNECTION_DOES_NOT_EXIST.state
+        );
+        assert_eq!(
+            processed, 999,
+            "the array loop must never have run for a parameterless statement"
+        );
+    }
+
+    /// The first row of an array claims the connection like any scalar
+    /// execute; with none available it fails with 08003 exactly once, and
+    /// the bookkeeping reflects that only row 0 was attempted: later rows
+    /// stay `SQL_PARAM_UNUSED` and `SQL_ATTR_PARAMS_PROCESSED_PTR` stops at 1.
+    #[test]
+    fn array_execute_disconnected_fails_on_first_row_with_bookkeeping() {
+        use crate::api::odbc_types::{SQL_PARAM_ERROR, SQL_PARAM_UNUSED, SqlUSmallInt};
+
+        let h = TestHandles::with_env_dbc_stmt();
+        set_prepared(h.stmt, "INSERT INTO t VALUES (?)");
+
+        let mut values = [1i32, 2, 3];
+        let mut indicators: [SqlLen; 3] = [0; 3];
+        let bind_ret = unsafe {
+            sql_bind_parameter(
+                h.stmt,
+                1,
+                SQL_PARAM_INPUT,
+                SQL_C_LONG,
+                SQL_INTEGER,
+                0,
+                0,
+                values.as_mut_ptr().cast(),
+                0,
+                indicators.as_mut_ptr(),
+            )
+        };
+        assert_eq!(bind_ret, SQL_SUCCESS);
+        assert_eq!(
+            unsafe { sql_set_stmt_attr_w(h.stmt, SQL_ATTR_PARAMSET_SIZE, 3 as SqlPointer, 0) },
+            SQL_SUCCESS
+        );
+        let mut status: [SqlUSmallInt; 3] = [SQL_SUCCESS as SqlUSmallInt; 3];
+        assert_eq!(
+            unsafe {
+                sql_set_stmt_attr_w(
+                    h.stmt,
+                    SQL_ATTR_PARAM_STATUS_PTR,
+                    status.as_mut_ptr().cast(),
+                    0,
+                )
+            },
+            SQL_SUCCESS
+        );
+        let mut processed: SqlULen = 0;
+        assert_eq!(
+            unsafe {
+                sql_set_stmt_attr_w(
+                    h.stmt,
+                    SQL_ATTR_PARAMS_PROCESSED_PTR,
+                    (&mut processed as *mut SqlULen).cast(),
+                    0,
+                )
+            },
+            SQL_SUCCESS
+        );
+
+        let ret = unsafe { sql_execute(h.stmt) };
+
+        assert_eq!(ret, SQL_ERROR);
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        let state = stmt.inner.lock().unwrap();
+        assert_eq!(
+            state.diag_records[0].sql_state,
+            ERR_CONNECTION_DOES_NOT_EXIST.state
+        );
+        assert_eq!(processed, 1, "only row 0 was attempted");
+        assert_eq!(
+            status,
+            [SQL_PARAM_ERROR, SQL_PARAM_UNUSED, SQL_PARAM_UNUSED]
+        );
+        assert!(!state.has_state(STMT_STATE_EXEC_STARTED));
+    }
+
+    /// End-to-end proof against a real (mock) `TdsClient` that a parameter
+    /// array genuinely runs every row rather than just the first: each row
+    /// here returns a result set, so a row that leaves its cursor open
+    /// without `execute_param_array_loop` closing it before the next row
+    /// would make row 1 fail with `24000` — this passes only if every row
+    /// reached the server and the cursor was closed in between.
+    #[test]
+    fn array_execute_runs_every_row_against_a_mock_server() {
+        use crate::handles::dbc::DbcHandle;
+        use mssql_mock_tds::QueryResponse;
+
+        const PARAMSET_SIZE: usize = 3;
+        // Registered as a substring of the rewritten prepared text
+        // (`?` → `@P1`), so it matches regardless of the marker's exact
+        // spelling — see mssql_mock_tds::QueryRegistry::get_by_contained_utf16_text.
+        const REGISTER_KEY: &str = "SELECT * FROM T WHERE ID =";
+        const SELECT_SQL: &str = "SELECT * FROM T WHERE ID = ?";
+
+        let h = TestHandles::with_env_dbc_stmt();
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        let _mock_server = crate::test_support::connect_mock_server(
+            dbc,
+            REGISTER_KEY,
+            QueryResponse::select_one(),
+        );
+
+        set_prepared(h.stmt, SELECT_SQL);
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+
+        let mut values = [1i32, 2, 3];
+        let mut indicators: [SqlLen; PARAMSET_SIZE] = [0; PARAMSET_SIZE];
+        let bind_ret = unsafe {
+            sql_bind_parameter(
+                h.stmt,
+                1,
+                SQL_PARAM_INPUT,
+                SQL_C_LONG,
+                SQL_INTEGER,
+                0,
+                0,
+                values.as_mut_ptr().cast(),
+                0,
+                indicators.as_mut_ptr(),
+            )
+        };
+        assert_eq!(bind_ret, SQL_SUCCESS);
+        assert_eq!(
+            unsafe {
+                sql_set_stmt_attr_w(
+                    h.stmt,
+                    SQL_ATTR_PARAMSET_SIZE,
+                    PARAMSET_SIZE as SqlPointer,
+                    0,
+                )
+            },
+            SQL_SUCCESS
+        );
+        let mut processed: SqlULen = 0;
+        assert_eq!(
+            unsafe {
+                sql_set_stmt_attr_w(
+                    h.stmt,
+                    SQL_ATTR_PARAMS_PROCESSED_PTR,
+                    (&mut processed as *mut SqlULen).cast(),
+                    0,
+                )
+            },
+            SQL_SUCCESS
+        );
+
+        let ret = unsafe { sql_execute(h.stmt) };
+
+        assert_eq!(
+            ret,
+            SQL_SUCCESS,
+            "diag: {:?}",
+            stmt.inner.lock().unwrap().diag_records
+        );
+        assert_eq!(processed, PARAMSET_SIZE as SqlULen);
     }
 }

--- a/mssql-odbc/src/api/odbc_types.rs
+++ b/mssql-odbc/src/api/odbc_types.rs
@@ -548,6 +548,28 @@ pub const SQL_ATTR_METADATA_ID: SqlInteger = 10014;
 /// `SQL_ATTR_ROW_BIND_TYPE` value selecting column-wise (array-of-columns)
 /// binding — the mode mssql-python uses.
 pub const SQL_BIND_BY_COLUMN: SqlULen = 0;
+/// `SQL_ATTR_PARAM_BIND_TYPE` value selecting column-wise (array-of-columns)
+/// parameter binding — the mode mssql-python's `executemany` uses. ODBC
+/// headers define this separately from [`SQL_BIND_BY_COLUMN`] even though
+/// both are 0, since they answer the row and parameter attributes
+/// respectively.
+pub const SQL_PARAM_BIND_BY_COLUMN: SqlULen = 0;
+/// `SQL_ATTR_PARAM_OPERATION_PTR` row operation: process this row normally
+/// (the default when the pointer itself is null).
+pub const SQL_PARAM_PROCEED: SqlUSmallInt = 0;
+/// `SQL_ATTR_PARAM_OPERATION_PTR` row operation: skip this row — it is not
+/// sent to the server and its status stays [`SQL_PARAM_UNUSED`].
+pub const SQL_PARAM_IGNORE: SqlUSmallInt = 1;
+/// `SQL_ATTR_PARAM_STATUS_PTR` row outcome: the row executed without warning.
+pub const SQL_PARAM_SUCCESS: SqlUSmallInt = 0;
+/// `SQL_ATTR_PARAM_STATUS_PTR` row outcome: the row executed with a warning
+/// (`SQL_SUCCESS_WITH_INFO`).
+pub const SQL_PARAM_SUCCESS_WITH_INFO: SqlUSmallInt = 6;
+/// `SQL_ATTR_PARAM_STATUS_PTR` row outcome: the row failed.
+pub const SQL_PARAM_ERROR: SqlUSmallInt = 5;
+/// `SQL_ATTR_PARAM_STATUS_PTR` row outcome: never reached, either because an
+/// earlier row failed or because [`SQL_PARAM_IGNORE`] skipped it.
+pub const SQL_PARAM_UNUSED: SqlUSmallInt = 7;
 /// Default `SQL_DESC_ARRAY_SIZE` / `SQL_DESC_ROWSET_SIZE` for a freshly
 /// allocated ARD/APD.
 pub const SQL_ROWSET_SIZE_DEFAULT: SqlULen = 1;

--- a/mssql-odbc/src/api/set_stmt_attr.rs
+++ b/mssql-odbc/src/api/set_stmt_attr.rs
@@ -20,11 +20,11 @@
 //! written; the handful whose reported value msodbcsql pins regardless of the
 //! request (`SQL_ATTR_MAX_LENGTH`, `SQL_ATTR_KEYSET_SIZE`,
 //! `SQL_ATTR_SIMULATE_CURSOR`) substitute and warn with `01S02`.
-//! `SQL_ATTR_PARAMSET_SIZE` accepts the ODBC default of 1 but rejects larger
-//! batches, since parameter arrays are not yet consumed and a silent success
-//! would execute only the first row. `SQL_ATTR_METADATA_ID` accepts its
-//! pattern-mode default (`SQL_FALSE`) but returns `HYC00` for `SQL_TRUE` until
-//! catalog calls implement identifier matching. Unrecognized attribute
+//! `SQL_ATTR_PARAMSET_SIZE` stores the number of parameter sets in each
+//! column-wise or row-wise bound array; `SQLExecute`/`SQLExecDirectW` iterate
+//! that many rows when it is greater than one. `SQL_ATTR_METADATA_ID` accepts
+//! its pattern-mode default (`SQL_FALSE`) but returns `HYC00` for `SQL_TRUE`
+//! until catalog calls implement identifier matching. Unrecognized attribute
 //! identifiers fail with `HY092`.
 //!
 //! The SQL Server vendor attributes (`SQL_SOPT_SS_*`, ids 1225-1238) differ from
@@ -67,8 +67,14 @@ use crate::api::odbc_types::{
 use crate::api::sqlstate::{
     DiagMsg, ERR_FUNCTION_SEQUENCE, ERR_INVALID_ATTRIBUTE_VALUE, ERR_INVALID_CURSOR_STATE,
     ERR_INVALID_USE_OF_AUTO_DESC, ERR_OPTIONAL_FEATURE_NOT_IMPLEMENTED, SQLSTATE_01S02,
-    SQLSTATE_HYC00, WARN_OPTION_VALUE_CHANGED, post_diag,
+    WARN_OPTION_VALUE_CHANGED, post_diag,
 };
+// Only the test module below still exercises this SQLSTATE (msodbcsql
+// parity coverage for an attribute this driver recognizes but does not
+// implement); production code no longer rejects SQL_ATTR_PARAMSET_SIZE > 1
+// with it.
+#[cfg(test)]
+use crate::api::sqlstate::SQLSTATE_HYC00;
 use crate::api::util::{read_utf16_attr, write_if_some, write_wide_attr};
 use crate::error::{free_errors, post_sql_error};
 use crate::handles::desc::DescHandle;
@@ -205,30 +211,21 @@ unsafe fn sql_set_stmt_attr_w_safe(
             SQL_SUCCESS
         }
         SQL_ATTR_PARAMSET_SIZE => {
-            // Parameter arrays are not yet consumed (executemany batch insert is
-            // tracked separately). Accept the ODBC default of 1; reject a larger
-            // batch (HYC00) instead of silently executing only the first row,
-            // and reject 0 as an invalid value (HY024).
-            match value_ptr as SqlULen {
-                1 => SQL_SUCCESS,
-                0 => {
-                    error!("SQLSetStmtAttrW: SQL_ATTR_PARAMSET_SIZE of 0 is invalid");
-                    post_diag(&mut state, ERR_INVALID_ATTRIBUTE_VALUE);
-                    SQL_ERROR
-                }
-                n => {
-                    error!(
-                        paramset_size = n,
-                        "SQLSetStmtAttrW: SQL_ATTR_PARAMSET_SIZE > 1 not supported"
-                    );
-                    post_sql_error(
-                        &mut state,
-                        SQLSTATE_HYC00,
-                        0,
-                        "Parameter arrays (SQL_ATTR_PARAMSET_SIZE > 1) are not supported",
-                    );
-                    SQL_ERROR
-                }
+            // Every positive value is a valid array size; 0 is invalid
+            // (HY024) and leaves the previous value in place, matching the
+            // reject-on-zero pattern already used for SQL_ATTR_ROW_ARRAY_SIZE.
+            let n = value_ptr as SqlULen;
+            if n == 0 {
+                error!("SQLSetStmtAttrW: SQL_ATTR_PARAMSET_SIZE of 0 is invalid");
+                post_diag(&mut state, ERR_INVALID_ATTRIBUTE_VALUE);
+                SQL_ERROR
+            } else {
+                state.paramset_size = n;
+                debug!(
+                    paramset_size = n,
+                    "SQLSetStmtAttrW: SQL_ATTR_PARAMSET_SIZE set"
+                );
+                SQL_SUCCESS
             }
         }
         SQL_ATTR_CURSOR_TYPE => {
@@ -681,15 +678,18 @@ unsafe fn sql_get_stmt_attr_w_safe(
             write_if_some(value_ptr as *mut SqlULen, SQL_NONSCROLLABLE);
         },
         // Recognized attributes we don't store: report their effective ODBC
-        // defaults for this forward-only, read-only, single-paramset driver.
+        // defaults for this forward-only, read-only driver.
         SQL_ATTR_CURSOR_TYPE => unsafe {
             write_if_some(value_ptr as *mut SqlULen, SQL_CURSOR_FORWARD_ONLY);
         },
         SQL_ATTR_CONCURRENCY => unsafe {
             write_if_some(value_ptr as *mut SqlULen, SQL_CONCUR_READ_ONLY);
         },
+        // Stored, unlike the two attributes above: SQL_ATTR_PARAMSET_SIZE
+        // genuinely controls how many array rows SQLExecute/SQLExecDirectW
+        // iterate.
         SQL_ATTR_PARAMSET_SIZE => unsafe {
-            write_if_some(value_ptr as *mut SqlULen, 1);
+            write_if_some(value_ptr as *mut SqlULen, state.paramset_size);
         },
         // ARD/APD report the active association (an explicit descriptor if
         // one was set via SQLSetStmtAttrW, else the implicit default), so
@@ -1201,22 +1201,49 @@ mod tests {
         let ret =
             unsafe { sql_set_stmt_attr_w(h.stmt, SQL_ATTR_PARAMSET_SIZE, 1 as SqlPointer, 0) };
         assert_eq!(ret, SQL_SUCCESS);
+        assert_eq!(get_attr(h.stmt, SQL_ATTR_PARAMSET_SIZE), 1);
     }
 
+    /// A value greater than one is stored and read back, not rejected — array
+    /// execution consumes it (`execute.rs`/`exec_direct.rs`).
     #[test]
-    fn set_paramset_size_greater_than_one_rejected() {
+    fn set_paramset_size_greater_than_one_is_stored_and_returned() {
         let h = TestHandles::with_env_dbc_stmt();
         let ret =
             unsafe { sql_set_stmt_attr_w(h.stmt, SQL_ATTR_PARAMSET_SIZE, 100 as SqlPointer, 0) };
-        assert_eq!(ret, SQL_ERROR);
+        assert_eq!(ret, SQL_SUCCESS);
+        assert_eq!(get_attr(h.stmt, SQL_ATTR_PARAMSET_SIZE), 100);
     }
 
     #[test]
     fn set_paramset_size_zero_rejected() {
         let h = TestHandles::with_env_dbc_stmt();
+        assert_eq!(set_attr(h.stmt, SQL_ATTR_PARAMSET_SIZE, 7), SQL_SUCCESS);
+
         let ret =
             unsafe { sql_set_stmt_attr_w(h.stmt, SQL_ATTR_PARAMSET_SIZE, 0 as SqlPointer, 0) };
         assert_eq!(ret, SQL_ERROR);
+        assert_eq!(stmt_sql_state(h.stmt), SQLSTATE_HY024);
+        assert_eq!(
+            get_attr(h.stmt, SQL_ATTR_PARAMSET_SIZE),
+            7,
+            "a rejected zero must not mutate the prior value"
+        );
+    }
+
+    /// Boundary and repeated-write coverage: every positive value round-trips,
+    /// including a later write shrinking the array back down to one.
+    #[test]
+    fn paramset_size_accepts_boundaries_and_repeated_writes() {
+        let h = TestHandles::with_env_dbc_stmt();
+        for value in [1, 2, 255, 65_536, SqlULen::MAX, 1] {
+            assert_eq!(
+                set_attr(h.stmt, SQL_ATTR_PARAMSET_SIZE, value),
+                SQL_SUCCESS,
+                "set {value}"
+            );
+            assert_eq!(get_attr(h.stmt, SQL_ATTR_PARAMSET_SIZE), value);
+        }
     }
 
     #[test]
@@ -2295,6 +2322,7 @@ mod tests {
             SQL_ATTR_CURSOR_TYPE,
             SQL_ATTR_CONCURRENCY,
             SQL_ATTR_ROW_ARRAY_SIZE,
+            SQL_ATTR_PARAMSET_SIZE,
             SQL_ATTR_METADATA_ID,
             SQL_SOPT_SS_DEFER_PREPARE,
         ] {

--- a/mssql-odbc/src/handles/stmt.rs
+++ b/mssql-odbc/src/handles/stmt.rs
@@ -409,6 +409,13 @@ pub(crate) struct StmtState {
     /// Parameters bound via `SQLBindParameter`, indexed by `(ParameterNumber
     /// - 1)`. `None` slots are gaps left by binding a higher ordinal first.
     pub(crate) bound_params: Vec<Option<BoundParam>>,
+    /// `SQL_ATTR_PARAMSET_SIZE`: number of parameter sets in each column-wise
+    /// or row-wise bound array. `1` (the ODBC default) is ordinary scalar
+    /// execution; a larger value makes `SQLExecute`/`SQLExecDirectW` iterate
+    /// that many rows out of `bound_params`'s arrays, one execution per row,
+    /// aggregating row counts and per-row status the way mssql-python's
+    /// `executemany` expects.
+    pub(crate) paramset_size: SqlULen,
     /// The identity of a prepared statement superseded by a re-prepare / rebind
     /// / `SQLExecDirect`, whose server handle awaits release with `sp_unprepare`.
     /// The drop is deferred to the next point that already holds the TDS client
@@ -1231,6 +1238,7 @@ impl StmtHandle {
                 prepared: None,
                 parameter_metadata: Vec::new(),
                 bound_params: Vec::new(),
+                paramset_size: 1,
                 pending_unprepare: None,
                 row_positioned: false,
                 last_captured: None,

--- a/mssql-odbc/src/params/bound_param.rs
+++ b/mssql-odbc/src/params/bound_param.rs
@@ -2,9 +2,12 @@
 // Licensed under the MIT License.
 
 use std::ffi::c_void;
+use std::mem::size_of;
 
+use crate::api::fetch_scroll::element_stride;
 use crate::api::odbc_types::{
-    SQL_C_DEFAULT, SQL_PARAM_INPUT, SqlLen, SqlPointer, SqlSmallInt, SqlULen,
+    SQL_C_DEFAULT, SQL_PARAM_BIND_BY_COLUMN, SQL_PARAM_INPUT, SqlLen, SqlPointer, SqlSmallInt,
+    SqlULen,
 };
 use crate::api::set_desc_field::datetime_interval_code_for;
 use crate::api::type_rules::{parameter_size_is_precision, resolve_default_c_type};
@@ -78,6 +81,62 @@ impl BoundParam {
         }
         if !self.octet_length_ptr.is_null() {
             self.octet_length_ptr = self.octet_length_ptr.wrapping_byte_offset(offset);
+        }
+        self
+    }
+
+    /// Returns the binding displaced to parameter-array row `row` (0-based),
+    /// for `SQL_ATTR_PARAMSET_SIZE > 1`. Apply [`Self::with_bind_offset`]
+    /// after this — `SQL_ATTR_PARAM_BIND_OFFSET_PTR` shifts every row by the
+    /// same extra amount, on top of the row's own array position.
+    ///
+    /// `bind_type` is `SQL_ATTR_PARAM_BIND_TYPE`:
+    /// [`SQL_PARAM_BIND_BY_COLUMN`] (0) selects column-wise arrays, where each
+    /// parameter's own buffer holds `paramset_size` contiguous values; any
+    /// other value is the row-wise struct size in bytes, where one buffer
+    /// holds `paramset_size` contiguous copies of a struct and every bound
+    /// pointer is a field inside it.
+    ///
+    /// Column-wise: the value buffer advances by this C type's element stride
+    /// ([`element_stride`], shared with the symmetric `SQLBindCol` direction
+    /// in `fetch_scroll.rs`), and the indicator/octet-length buffers advance
+    /// by `sizeof(SQLLEN)` — ODBC keeps those arrays contiguous `SQLLEN`s
+    /// regardless of the value's own width. Row-wise: every pointer advances
+    /// by the same `bind_type` byte count, because all three addresses are
+    /// fields inside one repeated struct.
+    ///
+    /// Row 0 is always the original binding unchanged, regardless of
+    /// `bind_type` — a zero multiplier — so the ordinary scalar-execute path
+    /// (`paramset_size == 1`) can route through this unconditionally without
+    /// behaving any differently than before.
+    pub(crate) fn for_row(mut self, row: usize, bind_type: SqlULen) -> Self {
+        if row == 0 {
+            return self;
+        }
+        let (value_stride, indicator_stride): (usize, usize) =
+            if bind_type == SQL_PARAM_BIND_BY_COLUMN {
+                (
+                    element_stride(self.c_type, self.buffer_length),
+                    size_of::<SqlLen>(),
+                )
+            } else {
+                let row_size = bind_type;
+                (row_size, row_size)
+            };
+        if !self.parameter_value_ptr.is_null() {
+            self.parameter_value_ptr = self
+                .parameter_value_ptr
+                .wrapping_byte_add(row * value_stride);
+        }
+        if !self.strlen_or_ind_ptr.is_null() {
+            self.strlen_or_ind_ptr = self
+                .strlen_or_ind_ptr
+                .wrapping_byte_add(row * indicator_stride);
+        }
+        if !self.octet_length_ptr.is_null() {
+            self.octet_length_ptr = self
+                .octet_length_ptr
+                .wrapping_byte_add(row * indicator_stride);
         }
         self
     }
@@ -298,6 +357,170 @@ mod tests {
         assert_eq!(
             shifted.strlen_or_ind_ptr as usize,
             original.strlen_or_ind_ptr as usize
+        );
+    }
+
+    /// Row 0 must be the original binding, unconditionally: this is what lets
+    /// the ordinary scalar-execute path route through `for_row` without
+    /// changing behavior.
+    #[test]
+    fn for_row_zero_is_unchanged_for_either_bind_type() {
+        let mut buf = [0u8; 32];
+        let mut ind: SqlLen = 4;
+        let original = param(buf.as_mut_ptr().cast(), &raw mut ind);
+        for bind_type in [SQL_PARAM_BIND_BY_COLUMN, 64] {
+            let same = original.for_row(0, bind_type);
+            assert_eq!(
+                same.parameter_value_ptr as usize,
+                original.parameter_value_ptr as usize
+            );
+            assert_eq!(
+                same.strlen_or_ind_ptr as usize,
+                original.strlen_or_ind_ptr as usize
+            );
+        }
+    }
+
+    /// Column-wise: a fixed-width C type strides by its own size, not
+    /// `BufferLength` — mirrors `element_stride`'s contract for `SQLBindCol`.
+    #[test]
+    fn for_row_column_wise_strides_a_fixed_width_c_type_by_its_own_size() {
+        use crate::api::odbc_types::SQL_C_SLONG;
+
+        let mut values = [0i32; 4];
+        let mut indicators = [0 as SqlLen; 4];
+        let base = BoundParam {
+            input_output_type: SQL_PARAM_INPUT,
+            c_type: SQL_C_SLONG,
+            sql_type: SQL_VARCHAR,
+            column_size: 0,
+            decimal_digits: 0,
+            parameter_value_ptr: values.as_mut_ptr().cast(),
+            buffer_length: 0, // ignored for a fixed-width C type
+            strlen_or_ind_ptr: indicators.as_mut_ptr(),
+            octet_length_ptr: indicators.as_mut_ptr(),
+        };
+
+        for row in 0..4usize {
+            let shifted = base.for_row(row, SQL_PARAM_BIND_BY_COLUMN);
+            assert_eq!(
+                shifted.parameter_value_ptr as usize,
+                unsafe { values.as_mut_ptr().add(row) } as usize,
+                "row {row} value pointer"
+            );
+            assert_eq!(
+                shifted.strlen_or_ind_ptr as usize,
+                unsafe { indicators.as_mut_ptr().add(row) } as usize,
+                "row {row} indicator pointer"
+            );
+        }
+    }
+
+    /// Column-wise: a character type strides by `BufferLength`, matching how
+    /// `BindParameterArray` (mssql-python) lays out `SQL_C_WCHAR` arrays.
+    #[test]
+    fn for_row_column_wise_strides_a_character_type_by_buffer_length() {
+        const SLOT: usize = 20; // bytes per array element
+        let mut values = [0u8; SLOT * 3];
+        let base = param(values.as_mut_ptr().cast(), std::ptr::null_mut());
+        let base = BoundParam {
+            buffer_length: SLOT as SqlLen,
+            ..base
+        };
+
+        for row in 0..3usize {
+            let shifted = base.for_row(row, SQL_PARAM_BIND_BY_COLUMN);
+            assert_eq!(
+                shifted.parameter_value_ptr as usize,
+                unsafe { values.as_mut_ptr().add(row * SLOT) } as usize,
+                "row {row}"
+            );
+        }
+    }
+
+    /// Row-wise: every pointer — value, indicator, and octet-length —
+    /// advances by the same struct stride, because all three addresses are
+    /// fields inside one repeated row struct.
+    #[test]
+    fn for_row_row_wise_advances_every_pointer_by_the_struct_size() {
+        const ROW_SIZE: usize = 32;
+        let mut buf = [0u8; ROW_SIZE * 3];
+        let value = buf.as_mut_ptr();
+        let indicator = unsafe { value.add(24) }.cast::<SqlLen>();
+        let base = BoundParam {
+            input_output_type: SQL_PARAM_INPUT,
+            c_type: SQL_C_CHAR,
+            sql_type: SQL_VARCHAR,
+            column_size: 8,
+            decimal_digits: 0,
+            parameter_value_ptr: value.cast(),
+            buffer_length: 8,
+            strlen_or_ind_ptr: indicator,
+            octet_length_ptr: indicator,
+        };
+
+        for row in 0..3usize {
+            let shifted = base.for_row(row, ROW_SIZE as SqlULen);
+            assert_eq!(
+                shifted.parameter_value_ptr as usize,
+                unsafe { value.add(row * ROW_SIZE) } as usize,
+                "row {row} value pointer"
+            );
+            assert_eq!(
+                shifted.strlen_or_ind_ptr as usize,
+                unsafe { indicator.byte_add(row * ROW_SIZE) } as usize,
+                "row {row} indicator pointer"
+            );
+        }
+    }
+
+    /// A null pointer must stay null at every row — there is no buffer to
+    /// address, so shifting it would manufacture a wild pointer exactly as
+    /// `with_bind_offset` already guards against.
+    #[test]
+    fn for_row_leaves_null_pointers_null() {
+        let mut values = [0i32; 4];
+        let base = BoundParam {
+            input_output_type: SQL_PARAM_INPUT,
+            c_type: crate::api::odbc_types::SQL_C_SLONG,
+            sql_type: SQL_VARCHAR,
+            column_size: 0,
+            decimal_digits: 0,
+            parameter_value_ptr: values.as_mut_ptr().cast(),
+            buffer_length: 0,
+            strlen_or_ind_ptr: std::ptr::null_mut(),
+            octet_length_ptr: std::ptr::null_mut(),
+        };
+        let shifted = base.for_row(3, SQL_PARAM_BIND_BY_COLUMN);
+        assert!(shifted.strlen_or_ind_ptr.is_null());
+        assert!(shifted.octet_length_ptr.is_null());
+    }
+
+    /// `for_row` and `with_bind_offset` compose additively: the final address
+    /// is the row's array position plus the flat bind offset, regardless of
+    /// which is applied first.
+    #[test]
+    fn for_row_composes_with_bind_offset() {
+        use crate::api::odbc_types::SQL_C_SLONG;
+
+        let mut values = [0i32; 4];
+        let base = BoundParam {
+            input_output_type: SQL_PARAM_INPUT,
+            c_type: SQL_C_SLONG,
+            sql_type: SQL_VARCHAR,
+            column_size: 0,
+            decimal_digits: 0,
+            parameter_value_ptr: values.as_mut_ptr().cast(),
+            buffer_length: 0,
+            strlen_or_ind_ptr: std::ptr::null_mut(),
+            octet_length_ptr: std::ptr::null_mut(),
+        };
+        let shifted = base
+            .for_row(2, SQL_PARAM_BIND_BY_COLUMN)
+            .with_bind_offset(4);
+        assert_eq!(
+            shifted.parameter_value_ptr as usize,
+            unsafe { values.as_mut_ptr().add(2) } as usize + 4
         );
     }
 

--- a/mssql-tds/src/test_client_support.rs
+++ b/mssql-tds/src/test_client_support.rs
@@ -524,6 +524,16 @@ pub fn done_no_more() -> ScriptedToken {
     }))
 }
 
+/// A terminal DONE token carrying a row count (e.g. a single-statement DML
+/// batch's affected-row count, with no further statements to follow).
+pub fn done_no_more_with_count(row_count: u64) -> ScriptedToken {
+    ScriptedToken(Tokens::Done(DoneToken {
+        status: DoneStatus::FINAL | DoneStatus::COUNT,
+        cur_cmd: CurrentCommand::Insert,
+        row_count,
+    }))
+}
+
 /// A `RollbackTransaction` ENVCHANGE token — the acknowledgement the server
 /// emits for a Transaction Manager rollback request, clearing the client's
 /// transaction descriptor.


### PR DESCRIPTION
## Summary

`SQL_ATTR_PARAMSET_SIZE` previously accepted only `1` and rejected any larger value with `HYC00`. mssql-python's `executemany()` (`SQLExecuteMany_wrap` in `ddbc_bindings.cpp`) sets `PARAMSET_SIZE` to the batch size and calls `SQLExecute` exactly once, with no per-row fallback — so any `cursor.executemany()` call with more than one row hard-failed against this driver.

This closes [AB#46576](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46576) ("Batch insert"), the execution half of [AB#46377](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46377) that `mssql-odbc/docs/attributes_plan.md` had deferred.

## What changed

- **Accept/store**: any positive `SQL_ATTR_PARAMSET_SIZE` is stored and read back; `0` still rejects with `HY024`.
- **`BoundParam::for_row`**: computes each array row's displaced value/indicator/octet-length pointers.
  - Column-wise arrays (`SQL_ATTR_PARAM_BIND_TYPE` = 0, the default and what mssql-python uses) stride each parameter by its C type's element size, or by `BufferLength` for character/binary/`SQL_C_NUMERIC` — sharing `fetch_scroll::element_stride`'s contract with the symmetric `SQLBindCol` direction.
  - Row-wise arrays stride every pointer by `SQL_ATTR_PARAM_BIND_TYPE`'s struct size.
  - Composes additively with `SQL_ATTR_PARAM_BIND_OFFSET_PTR`.
- **`exec_common::execute_param_array_loop`**: shared by `SQLExecute` and `SQLExecDirectW`. Iterates `PARAMSET_SIZE` rows:
  - Honors `SQL_ATTR_PARAM_OPERATION_PTR` row skips (`SQL_PARAM_IGNORE`).
  - Writes `SQL_ATTR_PARAM_STATUS_PTR` (`SUCCESS`/`SUCCESS_WITH_INFO`/`ERROR`/`UNUSED`) and `SQL_ATTR_PARAMS_PROCESSED_PTR`.
  - Sums row counts across rows for `SQLRowCount` — msodbcsql's "not available" (`-1`) is excluded rather than corrupting the sum.
  - Stops at the first row that doesn't succeed, matching mssql-python's single-`SqlReturn`, no-retry expectation.
  - Closes a cursor a row-returning row (e.g. `INSERT ... OUTPUT`) left open before the next row runs — each row behaves as if `SQLExecute` were called separately.
- **Data-at-execution + array = `HYC00`**: an array has no way to interleave `SQLPutData` calls per row. Unreachable from mssql-python — its `executemany` DAE branch never sets `PARAMSET_SIZE`, it loops separate scalar executes instead.
- **Parameterless statement + leftover array size**: runs once, not `PARAMSET_SIZE` times — there's no array row to walk, and multiplying a DML statement's side effects nobody asked for is worse than ignoring the leftover attribute.
- **Test infra**: added `mssql_tds::test_client_support::done_no_more_with_count` (a terminal DONE token carrying a row count) to script row-count summation without a live server.

## Verification

- **3503 tests pass** across `mssql-tds` + `mssql-odbc` (`cargo nextest run -p mssqlodbc -p mssql-tds --lib`), including:
  - Pure aggregation-logic unit tests for `execute_param_array_loop` (summation, `-1`/"not available" handling, IGNORE skipping, stop-on-error, warning promotion, null bookkeeping pointers).
  - Pre-I/O tests (DAE-array rejection, parameterless-array bypass, disconnected-first-row bookkeeping) for both `SQLExecute` and `SQLExecDirectW`.
  - **End-to-end**: a mock-TDS-server test proving 3 row-returning array rows genuinely execute against a real `TdsClient`, closing the cursor between rows (`SQLExecute`/prepared path — mssql-python's actual code path).
  - **End-to-end**: a scripted-`TdsClient` test proving 3 `INSERT` array rows execute and `SQLRowCount` sums to 3 (`SQLExecDirectW` path) — mirroring mssql-python's own `test_rowcount_executemany` (3 one-row inserts → `rowcount == 3`).
- `cargo bfmt` and `cargo bclippy` (workspace, `--all-targets -D warnings`) are clean.
- `mssql-odbc/docs/attributes_plan.md` updated to record the delivered contract and reconcile the [AB#46377](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46377)/[AB#46576](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46576) bookkeeping.

## Known gap

**Wire-level batching is unmeasured against msodbcsql.** MS-TDS supports batching multiple RPC calls into one packet (`BatchFlag`, §2.2.6.5); this implementation sends one RPC per row instead. Whether msodbcsql does the same or batches at the wire level hasn't been measured — recorded as an open risk in `attributes_plan.md` §6. The `SQLRowCount`/status/stop-on-error contract is measured against mssql-python's and the ODBC spec's requirements, not a msodbcsql wire capture, so this is a functional-parity claim rather than a wire-level one.

**C++ e2e parity coverage** (`attributes_test.cpp`) was intentionally not added in this PR: per this repo's own convention, a parity test needs to be measured against a live msodbcsql instance first, which isn't available in this environment. CI's cross-repo mssql-python suite exercises the real array-execute path end-to-end and is the primary validation for this change; a follow-up can add the measured e2e coverage once msodbcsql's array behavior is captured.

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo nextest run -p mssqlodbc -p mssql-tds --lib` passes (3503/3503)
- [x] New/changed functionality has tests
- [x] Public API changes are documented (`attributes_plan.md`)
- [ ] Required CI passes on the latest commit