### PR TITLE
Add ESRP crate publishing pipeline

### DIFF
--- a/.pipeline/OneBranch/NonOfficialPythonWheelsPublish.yml
+++ b/.pipeline/OneBranch/NonOfficialPythonWheelsPublish.yml
@@ -1,7 +1,7 @@
 #################################################################################
 #                        OneBranch Pipelines - NonOfficial                      #
-# Builds Python wheels from PyO3 bindings across 5 platforms and packages      #
-# them into a NuGet archive published to Azure Artifacts.                      #
+# Builds Python wheels and Rust crates. Packages the wheels into a NuGet       #
+# archive published to Azure Artifacts and retains crates as build artifacts.  #
 # Documentation:  https://aka.ms/obpipelines                                    #
 # Yaml Schema:    https://aka.ms/obpipelines/yaml/schema                        #
 # Retail Tasks:   https://aka.ms/obpipelines/tasks                              #
@@ -76,5 +76,6 @@ extends:
         buildAllTargets: true
         buildPythonWheels: true
         buildOdbcNative: ${{ parameters.buildOdbcNative }}
+        buildRustCrates: true
         isOfficial: false
         publishToFeed: ${{ parameters.publishToFeed }}

--- a/.pipeline/OneBranch/OfficialPythonWheelsBuild.yml
+++ b/.pipeline/OneBranch/OfficialPythonWheelsBuild.yml
@@ -1,7 +1,7 @@
 #################################################################################
 #                        OneBranch Pipelines - Official                         #
-# Official build pipeline for Python wheels. Builds across all platforms       #
-# with SDL enforcement (BinSkim, CredScan, PoliCheck) and approval gates.     #
+# Official build pipeline for Python wheels and Rust crates. Builds across     #
+# all platforms with SDL enforcement and approval gates.                       #
 # This pipeline does NOT publish to any feed — publishing is handled by a      #
 # separate Release pipeline.                                                    #
 # Documentation:  https://aka.ms/obpipelines                                    #
@@ -51,4 +51,5 @@ extends:
         buildAllTargets: true
         buildPythonWheels: true
         buildOdbcNative: true
+        buildRustCrates: true
         isOfficial: true

--- a/.pipeline/OneBranch/OfficialPythonWheelsRelease.yml
+++ b/.pipeline/OneBranch/OfficialPythonWheelsRelease.yml
@@ -45,7 +45,7 @@ parameters:
     default: false
 
   - name: tagRelease
-    displayName: 'Create git tag and release branch'
+    displayName: 'Create mssql-py-core git tag and release branch'
     type: boolean
     default: false  # Safety: default to false
 
@@ -327,17 +327,12 @@ extends:
               displayName: 'Verify mssql-mock-tds on crates.io'
 
     ###########################################################################
-    # Stage 3: Tag the source commit and create release branch
+    # Stage 3: Tag the mssql-py-core release source
     ###########################################################################
-    - ${{ if and(eq(parameters.tagRelease, true), ne(parameters.validateCratesOnly, true)) }}:
+    - ${{ if eq(parameters.tagRelease, true) }}:
       - stage: Tag
-        displayName: 'Tag Release and Create Branch'
-        ${{ if or(eq(parameters.publishMssqlTds, true), eq(parameters.publishMssqlMockTds, true)) }}:
-          dependsOn:
-          - Release
-          - ReleaseCrates
-        ${{ else }}:
-          dependsOn: Release
+        displayName: 'Tag mssql-py-core Release'
+        dependsOn: Release
         jobs:
         - job: TagAndBranch
           displayName: 'Git tag + release branch'

--- a/.pipeline/OneBranch/OfficialPythonWheelsRelease.yml
+++ b/.pipeline/OneBranch/OfficialPythonWheelsRelease.yml
@@ -329,7 +329,7 @@ extends:
     ###########################################################################
     # Stage 3: Tag the source commit and create release branch
     ###########################################################################
-    - ${{ if eq(parameters.tagRelease, true) }}:
+    - ${{ if and(eq(parameters.tagRelease, true), ne(parameters.validateCratesOnly, true)) }}:
       - stage: Tag
         displayName: 'Tag Release and Create Branch'
         ${{ if or(eq(parameters.publishMssqlTds, true), eq(parameters.publishMssqlMockTds, true)) }}:

--- a/.pipeline/OneBranch/OfficialPythonWheelsRelease.yml
+++ b/.pipeline/OneBranch/OfficialPythonWheelsRelease.yml
@@ -230,12 +230,12 @@ extends:
             value: '$(Build.ArtifactStagingDirectory)'
           steps:
           - download: officialBuild
-            artifact: 'drop_Build_RustCrates_rust_crates'
+            artifact: 'drop_Build_RustCrates'
             displayName: 'Download Rust crate artifacts'
 
           - pwsh: >
               .pipeline/scripts/validate-crate-release-artifact.ps1
-              -ArtifactDirectory '$(Pipeline.Workspace)\officialBuild\drop_Build_RustCrates_rust_crates'
+              -ArtifactDirectory '$(Pipeline.Workspace)\officialBuild\drop_Build_RustCrates'
             displayName: 'Validate Rust crate release artifact'
 
           - ${{ if eq(parameters.publishMssqlTds, true) }}:
@@ -268,7 +268,7 @@ extends:
                 intent: 'PackageDistribution'
                 contenttype: 'Rust'
                 contentsource: 'Folder'
-                folderlocation: '$(Pipeline.Workspace)\officialBuild\drop_Build_RustCrates_rust_crates\mssql-tds'
+                folderlocation: '$(Pipeline.Workspace)\officialBuild\drop_Build_RustCrates\mssql-tds'
                 waitforreleasecompletion: true
                 owners: '$(owner)'
                 approvers: '$(approver)'
@@ -304,7 +304,7 @@ extends:
                 intent: 'PackageDistribution'
                 contenttype: 'Rust'
                 contentsource: 'Folder'
-                folderlocation: '$(Pipeline.Workspace)\officialBuild\drop_Build_RustCrates_rust_crates\mssql-mock-tds'
+                folderlocation: '$(Pipeline.Workspace)\officialBuild\drop_Build_RustCrates\mssql-mock-tds'
                 waitforreleasecompletion: true
                 owners: '$(owner)'
                 approvers: '$(approver)'

--- a/.pipeline/OneBranch/OfficialPythonWheelsRelease.yml
+++ b/.pipeline/OneBranch/OfficialPythonWheelsRelease.yml
@@ -39,6 +39,11 @@ parameters:
     type: boolean
     default: false  # Safety: default to false to prevent accidental releases
 
+  - name: validateCratesOnly
+    displayName: 'Validate Rust crate artifacts without publishing'
+    type: boolean
+    default: false
+
   - name: tagRelease
     displayName: 'Create git tag and release branch'
     type: boolean
@@ -212,7 +217,7 @@ extends:
     ###########################################################################
     # Stage 2: Publish Rust crates through ESRP
     ###########################################################################
-    - ${{ if or(eq(parameters.publishMssqlTds, true), eq(parameters.publishMssqlMockTds, true)) }}:
+    - ${{ if or(eq(parameters.publishMssqlTds, true), eq(parameters.publishMssqlMockTds, true), eq(parameters.validateCratesOnly, true)) }}:
       - stage: ReleaseCrates
         displayName: 'Release Rust Crates'
         dependsOn: Release
@@ -229,6 +234,8 @@ extends:
           - name: ob_outputDirectory
             value: '$(Build.ArtifactStagingDirectory)'
           steps:
+          - checkout: self
+
           - download: officialBuild
             artifact: 'drop_Build_RustCrates'
             displayName: 'Download Rust crate artifacts'
@@ -238,7 +245,7 @@ extends:
               -ArtifactDirectory '$(Pipeline.Workspace)\officialBuild\drop_Build_RustCrates'
             displayName: 'Validate Rust crate release artifact'
 
-          - ${{ if eq(parameters.publishMssqlTds, true) }}:
+          - ${{ if or(eq(parameters.publishMssqlTds, true), eq(parameters.validateCratesOnly, true)) }}:
             - pwsh: >
                 .pipeline/scripts/test-cratesio-package.ps1
                 -CrateName 'mssql-tds'
@@ -247,7 +254,7 @@ extends:
                 -MaxAttempts 1
               displayName: 'Preflight mssql-tds version'
 
-          - ${{ if eq(parameters.publishMssqlMockTds, true) }}:
+          - ${{ if or(eq(parameters.publishMssqlMockTds, true), eq(parameters.validateCratesOnly, true)) }}:
             - pwsh: >
                 .pipeline/scripts/test-cratesio-package.ps1
                 -CrateName 'mssql-mock-tds'

--- a/.pipeline/OneBranch/OfficialPythonWheelsRelease.yml
+++ b/.pipeline/OneBranch/OfficialPythonWheelsRelease.yml
@@ -1,8 +1,8 @@
 #################################################################################
 #                        OneBranch Pipelines - Official Release                 #
-# Downloads NuGet wheel artifacts from the Official Build pipeline and         #
-# publishes them to Azure Artifacts. Also tags the source commit and           #
-# creates a release branch.                                                     #
+# Downloads artifacts from the Official Build pipeline, publishes the wheel    #
+# NuGet package to Azure Artifacts, and can publish Rust crates to crates.io.   #
+# It can also tag the source commit and create a release branch.                #
 #                                                                               #
 # This pipeline does NOT build anything — it consumes artifacts produced by    #
 # OfficialBuild.yml.                                                            #
@@ -26,6 +26,16 @@ pr: none
 parameters:
   - name: publishNuGet
     displayName: 'Publish NuGet package to Azure Artifacts'
+    type: boolean
+    default: false  # Safety: default to false to prevent accidental releases
+
+  - name: publishMssqlTds
+    displayName: 'Publish mssql-tds to crates.io'
+    type: boolean
+    default: false  # Safety: default to false to prevent accidental releases
+
+  - name: publishMssqlMockTds
+    displayName: 'Publish mssql-mock-tds to crates.io'
     type: boolean
     default: false  # Safety: default to false to prevent accidental releases
 
@@ -200,12 +210,127 @@ extends:
           displayName: 'Verify NuGet package'
 
     ###########################################################################
-    # Stage 2: Tag the source commit and create release branch
+    # Stage 2: Publish Rust crates through ESRP
+    ###########################################################################
+    - ${{ if or(eq(parameters.publishMssqlTds, true), eq(parameters.publishMssqlMockTds, true)) }}:
+      - stage: ReleaseCrates
+        displayName: 'Release Rust Crates'
+        dependsOn: Release
+        jobs:
+        - job: PublishRustCrates
+          displayName: 'Publish Rust crates to crates.io'
+          templateContext:
+            type: releaseJob
+            isProduction: true
+          pool:
+            type: windows
+          variables:
+          - group: 'ESRP Federated Creds (AME)'
+          - name: ob_outputDirectory
+            value: '$(Build.ArtifactStagingDirectory)'
+          steps:
+          - download: officialBuild
+            artifact: 'drop_Build_RustCrates_rust_crates'
+            displayName: 'Download Rust crate artifacts'
+
+          - pwsh: >
+              .pipeline/scripts/validate-crate-release-artifact.ps1
+              -ArtifactDirectory '$(Pipeline.Workspace)\officialBuild\drop_Build_RustCrates_rust_crates'
+            displayName: 'Validate Rust crate release artifact'
+
+          - ${{ if eq(parameters.publishMssqlTds, true) }}:
+            - pwsh: >
+                .pipeline/scripts/test-cratesio-package.ps1
+                -CrateName 'mssql-tds'
+                -Version '$(mssqlTdsCrateVersion)'
+                -ExpectedState Absent
+                -MaxAttempts 1
+              displayName: 'Preflight mssql-tds version'
+
+          - ${{ if eq(parameters.publishMssqlMockTds, true) }}:
+            - pwsh: >
+                .pipeline/scripts/test-cratesio-package.ps1
+                -CrateName 'mssql-mock-tds'
+                -Version '$(mssqlMockTdsCrateVersion)'
+                -ExpectedState Absent
+                -MaxAttempts 1
+              displayName: 'Preflight mssql-mock-tds version'
+
+          - ${{ if eq(parameters.publishMssqlTds, true) }}:
+            - task: EsrpRelease@12
+              displayName: 'Publish mssql-tds to crates.io'
+              inputs:
+                connectedservicename: 'ESRP Managed Identity federated auth - AME tenant-mssql-rs'
+                usemanagedidentity: true
+                keyvaultname: '$(AuthAKVName)'
+                signcertname: '$(AuthSignCertName)'
+                clientid: '$(EsrpClientId)'
+                intent: 'PackageDistribution'
+                contenttype: 'Rust'
+                contentsource: 'Folder'
+                folderlocation: '$(Pipeline.Workspace)\officialBuild\drop_Build_RustCrates_rust_crates\mssql-tds'
+                waitforreleasecompletion: true
+                owners: '$(owner)'
+                approvers: '$(approver)'
+                serviceendpointurl: 'https://api.esrp.microsoft.com'
+                mainpublisher: 'ESRPRELPACMAN'
+                domaintenantid: '975f013f-7f24-47e8-a7d3-abc4752bf346'
+
+            - pwsh: >
+                .pipeline/scripts/test-cratesio-package.ps1
+                -CrateName 'mssql-tds'
+                -Version '$(mssqlTdsCrateVersion)'
+                -ExpectedState Available
+              displayName: 'Wait for mssql-tds on crates.io'
+
+          - ${{ if and(eq(parameters.publishMssqlMockTds, true), ne(parameters.publishMssqlTds, true)) }}:
+            - pwsh: >
+                .pipeline/scripts/test-cratesio-package.ps1
+                -CrateName 'mssql-tds'
+                -Version '$(mssqlTdsCrateVersion)'
+                -ExpectedState Available
+                -MaxAttempts 1
+              displayName: 'Verify mssql-tds dependency is published'
+
+          - ${{ if eq(parameters.publishMssqlMockTds, true) }}:
+            - task: EsrpRelease@12
+              displayName: 'Publish mssql-mock-tds to crates.io'
+              inputs:
+                connectedservicename: 'ESRP Managed Identity federated auth - AME tenant-mssql-rs'
+                usemanagedidentity: true
+                keyvaultname: '$(AuthAKVName)'
+                signcertname: '$(AuthSignCertName)'
+                clientid: '$(EsrpClientId)'
+                intent: 'PackageDistribution'
+                contenttype: 'Rust'
+                contentsource: 'Folder'
+                folderlocation: '$(Pipeline.Workspace)\officialBuild\drop_Build_RustCrates_rust_crates\mssql-mock-tds'
+                waitforreleasecompletion: true
+                owners: '$(owner)'
+                approvers: '$(approver)'
+                serviceendpointurl: 'https://api.esrp.microsoft.com'
+                mainpublisher: 'ESRPRELPACMAN'
+                domaintenantid: '975f013f-7f24-47e8-a7d3-abc4752bf346'
+
+            - pwsh: >
+                .pipeline/scripts/test-cratesio-package.ps1
+                -CrateName 'mssql-mock-tds'
+                -Version '$(mssqlMockTdsCrateVersion)'
+                -ExpectedState Available
+              displayName: 'Verify mssql-mock-tds on crates.io'
+
+    ###########################################################################
+    # Stage 3: Tag the source commit and create release branch
     ###########################################################################
     - ${{ if eq(parameters.tagRelease, true) }}:
       - stage: Tag
         displayName: 'Tag Release and Create Branch'
-        dependsOn: Release
+        ${{ if or(eq(parameters.publishMssqlTds, true), eq(parameters.publishMssqlMockTds, true)) }}:
+          dependsOn:
+          - Release
+          - ReleaseCrates
+        ${{ else }}:
+          dependsOn: Release
         jobs:
         - job: TagAndBranch
           displayName: 'Git tag + release branch'

--- a/.pipeline/OneBranch/OfficialPythonWheelsRelease.yml
+++ b/.pipeline/OneBranch/OfficialPythonWheelsRelease.yml
@@ -40,7 +40,7 @@ parameters:
     default: false  # Safety: default to false to prevent accidental releases
 
   - name: validateCratesOnly
-    displayName: 'Validate Rust crate artifacts without publishing'
+    displayName: 'Validate selected Rust crates without publishing'
     type: boolean
     default: false
 
@@ -245,7 +245,7 @@ extends:
               -ArtifactDirectory '$(Pipeline.Workspace)\officialBuild\drop_Build_RustCrates'
             displayName: 'Validate Rust crate release artifact'
 
-          - ${{ if or(eq(parameters.publishMssqlTds, true), eq(parameters.validateCratesOnly, true)) }}:
+          - ${{ if eq(parameters.publishMssqlTds, true) }}:
             - pwsh: >
                 .pipeline/scripts/test-cratesio-package.ps1
                 -CrateName 'mssql-tds'
@@ -254,7 +254,7 @@ extends:
                 -MaxAttempts 1
               displayName: 'Preflight mssql-tds version'
 
-          - ${{ if or(eq(parameters.publishMssqlMockTds, true), eq(parameters.validateCratesOnly, true)) }}:
+          - ${{ if eq(parameters.publishMssqlMockTds, true) }}:
             - pwsh: >
                 .pipeline/scripts/test-cratesio-package.ps1
                 -CrateName 'mssql-mock-tds'
@@ -263,7 +263,7 @@ extends:
                 -MaxAttempts 1
               displayName: 'Preflight mssql-mock-tds version'
 
-          - ${{ if eq(parameters.publishMssqlTds, true) }}:
+          - ${{ if and(eq(parameters.publishMssqlTds, true), ne(parameters.validateCratesOnly, true)) }}:
             - task: EsrpRelease@12
               displayName: 'Publish mssql-tds to crates.io'
               inputs:
@@ -299,7 +299,7 @@ extends:
                 -MaxAttempts 1
               displayName: 'Verify mssql-tds dependency is published'
 
-          - ${{ if eq(parameters.publishMssqlMockTds, true) }}:
+          - ${{ if and(eq(parameters.publishMssqlMockTds, true), ne(parameters.validateCratesOnly, true)) }}:
             - task: EsrpRelease@12
               displayName: 'Publish mssql-mock-tds to crates.io'
               inputs:

--- a/.pipeline/OneBranch/stages.yml
+++ b/.pipeline/OneBranch/stages.yml
@@ -99,7 +99,7 @@ stages:
         displayName: 'Publish Rust crate artifacts'
         inputs:
           targetPath: '$(ob_outputDirectory)\rust-crates'
-          artifact: 'drop_Build_RustCrates_rust_crates'
+          artifact: 'drop_Build_RustCrates'
           publishLocation: 'pipeline'
 
   #########################################################################

--- a/.pipeline/OneBranch/stages.yml
+++ b/.pipeline/OneBranch/stages.yml
@@ -72,7 +72,6 @@ stages:
           - imageOverride -equals RUST-W22-SQL25
       variables:
         ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
-        CARGO_TARGET_DIR: C:\cargo_target_dir
       steps:
       - template: /.pipeline/templates/cargo-authenticate-template.yml
         parameters:

--- a/.pipeline/OneBranch/stages.yml
+++ b/.pipeline/OneBranch/stages.yml
@@ -37,10 +37,15 @@ parameters:
   default: false
   displayName: 'Also build mssql-odbc native driver'
 
+- name: buildRustCrates
+  type: boolean
+  default: false
+  displayName: 'Create publishable Rust crate artifacts'
+
 - name: isOfficial
   type: boolean
   default: false
-  displayName: 'Official pipeline (clean release on manual trigger)'
+  displayName: 'Official pipeline (clean release versions)'
 
 - name: publishToFeed
   type: boolean
@@ -53,6 +58,50 @@ stages:
 #############################################################################
 - stage: Build
   jobs:
+  #########################################################################
+  # Publishable Rust crates
+  #########################################################################
+  - ${{ if eq(parameters.buildRustCrates, true) }}:
+    - job: RustCrates
+      displayName: 'Package Rust crates'
+      pool:
+        type: windows
+        isCustom: true
+        name: RUST-X64-WUS3
+        demands:
+          - imageOverride -equals RUST-W22-SQL25
+      variables:
+        ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
+        CARGO_TARGET_DIR: C:\cargo_target_dir
+      steps:
+      - template: /.pipeline/templates/cargo-authenticate-template.yml
+        parameters:
+          osType: Windows
+      - template: /.pipeline/templates/install-dependencies.yml
+        parameters:
+          osType: Windows
+          skipPythonSetup: true
+          skipRustupInstall: false
+          enableJsDeps: false
+      - pwsh: >
+          .pipeline/scripts/stamp-crate-versions.ps1
+          -BuildReason '$(Build.Reason)'
+          -BuildId '$(Build.BuildId)'
+          -IsOfficial '${{ parameters.isOfficial }}'
+        displayName: 'Stamp Rust crate versions'
+      - pwsh: >
+          .pipeline/scripts/package-rust-crates.ps1
+          -OutputDirectory '$(ob_outputDirectory)\rust-crates'
+          -TargetDirectory '$(Agent.TempDirectory)\rust-crate-target'
+          -Version '$(crateVersion)'
+        displayName: 'Create Rust crate artifacts'
+      - task: PublishPipelineArtifact@1
+        displayName: 'Publish Rust crate artifacts'
+        inputs:
+          targetPath: '$(ob_outputDirectory)\rust-crates'
+          artifact: 'drop_Build_RustCrates_rust_crates'
+          publishLocation: 'pipeline'
+
   #########################################################################
   # Windows x64
   #########################################################################

--- a/.pipeline/scripts/package-rust-crates.ps1
+++ b/.pipeline/scripts/package-rust-crates.ps1
@@ -32,16 +32,17 @@ $manifestEntries = @()
 Push-Location $RepositoryRoot
 try {
     foreach ($crateName in $crateNames) {
-        # The dependent crate cannot be verified until mssql-tds reaches crates.io.
-        # Workspace validation runs separately, so package without a generated lockfile.
         $arguments = @(
             'package'
             '--package', $crateName
-            '--no-verify'
             '--allow-dirty'
             '--exclude-lockfile'
             '--target-dir', $TargetDirectory
         )
+        if ($crateName -eq 'mssql-mock-tds') {
+            # Verification requires its mssql-tds version to exist on crates.io.
+            $arguments += '--no-verify'
+        }
 
         & cargo @arguments
         if ($LASTEXITCODE -ne 0) {

--- a/.pipeline/scripts/package-rust-crates.ps1
+++ b/.pipeline/scripts/package-rust-crates.ps1
@@ -1,0 +1,84 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+<#
+.SYNOPSIS
+  Creates the Rust crate artifacts consumed by the official release pipeline.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$OutputDirectory,
+    [Parameter(Mandatory = $true)][string]$Version,
+    [string]$TargetDirectory = (Join-Path ([System.IO.Path]::GetTempPath()) 'mssql-rs-crate-target'),
+    [string]$RepositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '../..'))
+)
+
+$ErrorActionPreference = 'Stop'
+$crateNames = @('mssql-tds', 'mssql-mock-tds')
+
+if (Test-Path $OutputDirectory) {
+    $existing = @(Get-ChildItem $OutputDirectory -Force)
+    if ($existing.Count -ne 0) {
+        throw "Crate output directory is not empty: $OutputDirectory"
+    }
+}
+else {
+    New-Item -ItemType Directory -Path $OutputDirectory -Force | Out-Null
+}
+
+New-Item -ItemType Directory -Path $TargetDirectory -Force | Out-Null
+$manifestEntries = @()
+
+Push-Location $RepositoryRoot
+try {
+    foreach ($crateName in $crateNames) {
+        # The dependent crate cannot be verified until mssql-tds reaches crates.io.
+        # Workspace validation runs separately, so package without a generated lockfile.
+        $arguments = @(
+            'package'
+            '--package', $crateName
+            '--no-verify'
+            '--allow-dirty'
+            '--exclude-lockfile'
+            '--target-dir', $TargetDirectory
+        )
+
+        & cargo @arguments
+        if ($LASTEXITCODE -ne 0) {
+            throw "cargo package failed for $crateName with exit code $LASTEXITCODE"
+        }
+
+        $fileName = "$crateName-$Version.crate"
+        $source = Join-Path $TargetDirectory "package/$fileName"
+        if (-not (Test-Path $source -PathType Leaf)) {
+            throw "cargo package did not create the expected file: $source"
+        }
+
+        $crateDirectory = Join-Path $OutputDirectory $crateName
+        New-Item -ItemType Directory -Path $crateDirectory -Force | Out-Null
+        $destination = Join-Path $crateDirectory $fileName
+        Copy-Item $source $destination
+
+        $manifestEntries += [ordered]@{
+            name = $crateName
+            version = $Version
+            file = "$crateName/$fileName"
+            sha256 = (Get-FileHash $destination -Algorithm SHA256).Hash.ToLowerInvariant()
+        }
+    }
+}
+finally {
+    Pop-Location
+}
+
+$releaseManifest = [ordered]@{
+    schemaVersion = 1
+    crates = $manifestEntries
+}
+$manifestPath = Join-Path $OutputDirectory 'release-manifest.json'
+$releaseManifest | ConvertTo-Json -Depth 4 | Set-Content $manifestPath
+
+Write-Host 'Created Rust crate artifacts:'
+Get-ChildItem $OutputDirectory -Recurse -File | ForEach-Object {
+    Write-Host "  $($_.FullName)"
+}

--- a/.pipeline/scripts/package-rust-crates.ps1
+++ b/.pipeline/scripts/package-rust-crates.ps1
@@ -67,6 +67,49 @@ try {
             sha256 = (Get-FileHash $destination -Algorithm SHA256).Hash.ToLowerInvariant()
         }
     }
+
+    $verificationDirectory = Join-Path $TargetDirectory 'package-verification'
+    New-Item -ItemType Directory -Path $verificationDirectory -Force | Out-Null
+    foreach ($crateName in $crateNames) {
+        $cratePath = Join-Path $TargetDirectory "package/$crateName-$Version.crate"
+        & tar -xzf $cratePath -C $verificationDirectory
+        if ($LASTEXITCODE -ne 0) {
+            throw "Could not extract $cratePath for verification"
+        }
+    }
+
+    $tdsPackageDirectory = Join-Path $verificationDirectory "mssql-tds-$Version"
+    $mockPackageDirectory = Join-Path $verificationDirectory "mssql-mock-tds-$Version"
+    $mockManifestPath = Join-Path $mockPackageDirectory 'Cargo.toml'
+    $mockManifest = Get-Content $mockManifestPath -Raw
+    $dependency = [regex]::Match(
+        $mockManifest,
+        '(?ms)^\[dependencies\.mssql-tds\]\s*$(?<body>.*?)(?=^\[|\z)'
+    )
+    if (-not $dependency.Success) {
+        throw 'Packaged mssql-mock-tds has no mssql-tds dependency'
+    }
+    if ($dependency.Groups['body'].Value -match '(?m)^\s*path\s*=') {
+        throw 'Packaged mssql-mock-tds unexpectedly contains an mssql-tds path dependency'
+    }
+
+    $relativeTdsPath = [System.IO.Path]::GetRelativePath(
+        $mockPackageDirectory,
+        $tdsPackageDirectory
+    ).Replace('\', '/')
+    $patchedDependency = $dependency.Value.TrimEnd() + "`npath = `"$relativeTdsPath`"`n`n"
+    $mockManifest = $mockManifest.Substring(0, $dependency.Index) +
+        $patchedDependency +
+        $mockManifest.Substring($dependency.Index + $dependency.Length)
+    Set-Content $mockManifestPath $mockManifest -NoNewline
+
+    & cargo check `
+        --manifest-path $mockManifestPath `
+        --target-dir (Join-Path $TargetDirectory 'package-verification-target')
+    if ($LASTEXITCODE -ne 0) {
+        throw "Packaged mssql-mock-tds failed cargo check with exit code $LASTEXITCODE"
+    }
+    Write-Host 'Verified packaged mssql-mock-tds against packaged mssql-tds.'
 }
 finally {
     Pop-Location

--- a/.pipeline/scripts/pin-mssql-tds-dep-version.ps1
+++ b/.pipeline/scripts/pin-mssql-tds-dep-version.ps1
@@ -84,9 +84,9 @@ foreach ($entry in @(
     }
     else {
         $replacement = "{ $key = `"$value`", ".Replace('$', '$$')
-        $dependency = [regex]::Replace(
+        $openBracePattern = [regex]'\{\s*'
+        $dependency = $openBracePattern.Replace(
             $dependency,
-            '\{\s*',
             $replacement,
             1
         )

--- a/.pipeline/scripts/pin-mssql-tds-dep-version.ps1
+++ b/.pipeline/scripts/pin-mssql-tds-dep-version.ps1
@@ -6,10 +6,8 @@
   SANDBOX / TEST-ONLY helper. Pins the mssql-tds path dependency to a version.
 
 .DESCRIPTION
-  The mssql-tds path dependency in mssql-mock-tds/Cargo.toml has no version, which
-  cargo publish rejects ("all dependencies must have a version"). This adds the
-  stamped version while keeping the path (cargo uses the version on publish and the
-  path for local verify builds).
+  Updates the mssql-tds dependency to the stamped version while keeping the path
+  (cargo uses the version on publish and the path for local verify builds).
 
   A version alone is not enough: cargo records a dependency with no registry as
   coming from crates.io, where mssql-tds does not exist. Consumers of the feed then
@@ -58,21 +56,46 @@ $index = if ($IndexUrl -match '^sparse\+') { $IndexUrl } else { "sparse+$IndexUr
 
 $path = 'mssql-mock-tds/Cargo.toml'
 $c = Get-Content $path -Raw
-$c = $c -replace 'mssql-tds\s*=\s*\{\s*path\s*=\s*"\.\./mssql-tds"',
-                 "mssql-tds = { path = `"../mssql-tds`", version = `"$Version`", registry-index = `"$index`""
 
-# -replace changes nothing when the dependency line drifts from the shape above
-# (keys reordered, workspace = true), so without this the script would exit 0 having
-# done nothing and the run would fail much later, in cargo publish -p mssql-mock-tds
-# -- after cargo-publish-mock.ps1 has already put mssql-tds@$Version on the feed.
-# Feed versions are immutable, so that burns the version and the retry cannot
-# succeed. Counting rather than merely testing for presence also catches a second
-# run appending a duplicate set of keys, which TOML rejects.
-$dep = [regex]::Match($c, '(?m)^\s*mssql-tds\s*=\s*\{[^}]*\}')
-if (-not $dep.Success) {
-    Write-Error "No mssql-tds dependency line found in $path"
+$dependencyPattern = [regex]'(?m)^\s*mssql-tds\s*=\s*\{[^}\r\n]*\}\s*$'
+$dependencyMatches = $dependencyPattern.Matches($c)
+if ($dependencyMatches.Count -ne 1) {
+    Write-Error "Expected one mssql-tds dependency in ${path}, found $($dependencyMatches.Count)"
     exit 1
 }
+
+$dependency = $dependencyMatches[0].Value
+foreach ($entry in @(
+    @{ Key = 'version'; Value = $Version },
+    @{ Key = 'registry-index'; Value = $index }
+)) {
+    $key = $entry.Key
+    $value = $entry.Value
+    $keyPattern = [regex]"(?<![\w-])$key\s*=\s*`"[^`"]*`""
+    $keyMatches = $keyPattern.Matches($dependency)
+    if ($keyMatches.Count -gt 1) {
+        Write-Error "Expected at most one '$key' in the mssql-tds dependency of ${path}, found $($keyMatches.Count)"
+        exit 1
+    }
+
+    if ($keyMatches.Count -eq 1) {
+        $dependency = $keyPattern.Replace($dependency, "$key = `"$value`"", 1)
+    }
+    else {
+        $dependency = [regex]::Replace(
+            $dependency,
+            '\{\s*',
+            "{ $key = `"$value`", ",
+            1
+        )
+    }
+}
+
+$c = $c.Substring(0, $dependencyMatches[0].Index) +
+    $dependency +
+    $c.Substring($dependencyMatches[0].Index + $dependencyMatches[0].Length)
+
+$dep = $dependencyPattern.Match($c)
 foreach ($key in 'version', 'registry-index') {
     $n = ([regex]::Matches($dep.Value, "(?<![\w-])$key\s*=")).Count
     if ($n -ne 1) {

--- a/.pipeline/scripts/pin-mssql-tds-dep-version.ps1
+++ b/.pipeline/scripts/pin-mssql-tds-dep-version.ps1
@@ -79,13 +79,15 @@ foreach ($entry in @(
     }
 
     if ($keyMatches.Count -eq 1) {
-        $dependency = $keyPattern.Replace($dependency, "$key = `"$value`"", 1)
+        $replacement = "$key = `"$value`"".Replace('$', '$$')
+        $dependency = $keyPattern.Replace($dependency, $replacement, 1)
     }
     else {
+        $replacement = "{ $key = `"$value`", ".Replace('$', '$$')
         $dependency = [regex]::Replace(
             $dependency,
             '\{\s*',
-            "{ $key = `"$value`", ",
+            $replacement,
             1
         )
     }

--- a/.pipeline/scripts/stamp-crate-versions-sandbox.ps1
+++ b/.pipeline/scripts/stamp-crate-versions-sandbox.ps1
@@ -37,7 +37,17 @@ function Set-PackageVersion {
     $section = [regex]'(?ms)^\[package\].*?(?=^\[|\z)'
     $m = $section.Match($content)
     if (-not $m.Success) { Write-Error "No [package] section in $Path"; exit 1 }
-    $patched = [regex]::Replace($m.Value, '(?m)^(version\s*=\s*)"[^"]+"', "`${1}`"$Version`"", 1)
+    $versionPattern = [regex]'(?m)^(version\s*=\s*)"[^"]+"'
+    $versionMatches = $versionPattern.Matches($m.Value)
+    if ($versionMatches.Count -ne 1) {
+        Write-Error "Expected one package version in ${Path}, found $($versionMatches.Count)"
+        exit 1
+    }
+    $versionMatch = $versionMatches[0]
+    $replacement = $versionMatch.Groups[1].Value + "`"$Version`""
+    $patched = $m.Value.Substring(0, $versionMatch.Index) +
+        $replacement +
+        $m.Value.Substring($versionMatch.Index + $versionMatch.Length)
     $content = $content.Substring(0, $m.Index) + $patched + $content.Substring($m.Index + $m.Length)
     Set-Content $Path $content -NoNewline
     Write-Host "Stamped $Path -> version = `"$Version`""

--- a/.pipeline/scripts/stamp-crate-versions.ps1
+++ b/.pipeline/scripts/stamp-crate-versions.ps1
@@ -82,12 +82,12 @@ function Set-MssqlTdsDependencyVersion {
     )
 
     $pattern = [regex]'(?m)^(?<prefix>\s*mssql-tds\s*=\s*\{[^\r\n}]*?\bversion\s*=\s*)"[^"]+"(?<suffix>[^\r\n}]*\}\s*)$'
-    $matches = $pattern.Matches($Content)
-    if ($matches.Count -ne 1) {
-        throw "Expected one versioned mssql-tds dependency in ${Path}, found $($matches.Count)"
+    $depMatches = $pattern.Matches($Content)
+    if ($depMatches.Count -ne 1) {
+        throw "Expected one versioned mssql-tds dependency in ${Path}, found $($depMatches.Count)"
     }
 
-    $match = $matches[0]
+    $match = $depMatches[0]
     $replacement = $match.Groups['prefix'].Value + "`"$Version`"" + $match.Groups['suffix'].Value
     return $Content.Substring(0, $match.Index) +
         $replacement +

--- a/.pipeline/scripts/stamp-crate-versions.ps1
+++ b/.pipeline/scripts/stamp-crate-versions.ps1
@@ -57,17 +57,16 @@ function Set-PackageVersion {
         throw "No [package] section found in $Path"
     }
 
-    $versionMatches = [regex]::Matches($packageSection.Value, '(?m)^version\s*=\s*"[^"]+"')
+    $versionMatches = [regex]::Matches($packageSection.Value, '(?m)^(version\s*=\s*)"[^"]+"')
     if ($versionMatches.Count -ne 1) {
         throw "Expected one package version in ${Path}, found $($versionMatches.Count)"
     }
 
-    $updatedSection = [regex]::Replace(
-        $packageSection.Value,
-        '(?m)^(version\s*=\s*)"[^"]+"',
-        "`${1}`"$Version`"",
-        1
-    )
+    $versionMatch = $versionMatches[0]
+    $replacement = $versionMatch.Groups[1].Value + "`"$Version`""
+    $updatedSection = $packageSection.Value.Substring(0, $versionMatch.Index) +
+        $replacement +
+        $packageSection.Value.Substring($versionMatch.Index + $versionMatch.Length)
 
     return $Content.Substring(0, $packageSection.Index) +
         $updatedSection +

--- a/.pipeline/scripts/stamp-crate-versions.ps1
+++ b/.pipeline/scripts/stamp-crate-versions.ps1
@@ -1,97 +1,147 @@
-# stamp-crate-versions.ps1
-# Patches Cargo.toml version fields for publishable crates before cargo publish.
-# Uses the same versioning scheme as the NuGet wheel packaging.
-#
-# Usage (in pipeline):
-#   pwsh .pipeline/scripts/stamp-crate-versions.ps1 -BuildReason "$(Build.Reason)" -BuildId "$(Build.BuildId)" -IsOfficial $false
-#
-# Usage (local testing):
-#   pwsh .pipeline/scripts/stamp-crate-versions.ps1 -BuildReason "IndividualCI" -BuildId "99999" -IsOfficial $false -WhatIf
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
+<#
+.SYNOPSIS
+  Stamps publishable crate manifests with the version for the current build.
+
+.DESCRIPTION
+  Official builds retain the source version. Non-official scheduled builds use a
+  nightly version, while other non-official builds use a unique dev version.
+  mssql-mock-tds is kept aligned with mssql-tds, including its dependency version.
+#>
+[CmdletBinding()]
 param(
-    [Parameter(Mandatory=$true)]
+    [Parameter(Mandatory = $true)]
     [string]$BuildReason,
 
-    [Parameter(Mandatory=$true)]
+    [Parameter(Mandatory = $true)]
     [string]$BuildId,
 
-    [Parameter(Mandatory=$false)]
-    [bool]$IsOfficial = $false,
+    [string]$IsOfficial = 'False',
 
-    [Parameter(Mandatory=$false)]
-    [string[]]$Crates = @("mssql-tds", "mssql-mock-tds"),
+    [string[]]$Crates = @('mssql-tds', 'mssql-mock-tds'),
 
-    [Parameter(Mandatory=$false)]
-    [switch]$WhatIf
+    [switch]$WhatIf,
+
+    [string]$RepositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '../..'))
 )
 
 $ErrorActionPreference = 'Stop'
 
-# Read base version from the first crate
-$cargoTomlPath = Join-Path $PSScriptRoot "../../$($Crates[0])/Cargo.toml"
-$cargoToml = Get-Content $cargoTomlPath -Raw
-# Match the first `version = "..."` at the start of a line (multiline mode).
-# This targets the [package] version, which appears before any dependency versions.
-if ($cargoToml -match '(?m)^version\s*=\s*"([^"]+)"') {
-    $baseVersion = $Matches[1]
-} else {
-    Write-Error "Could not extract version from $cargoTomlPath"
-    exit 1
+function Get-PackageVersion {
+    param([Parameter(Mandatory = $true)][string]$Content, [Parameter(Mandatory = $true)][string]$Path)
+
+    $packageSection = [regex]::Match($Content, '(?ms)^\[package\].*?(?=^\[|\z)')
+    if (-not $packageSection.Success) {
+        throw "No [package] section found in $Path"
+    }
+
+    $version = [regex]::Match($packageSection.Value, '(?m)^version\s*=\s*"([^"]+)"')
+    if (-not $version.Success) {
+        throw "No package version found in $Path"
+    }
+
+    return $version.Groups[1].Value
 }
 
-$dateStamp = Get-Date -Format "yyyyMMdd"
+function Set-PackageVersion {
+    param(
+        [Parameter(Mandatory = $true)][string]$Content,
+        [Parameter(Mandatory = $true)][string]$Version,
+        [Parameter(Mandatory = $true)][string]$Path
+    )
 
-# Build.Reason is set by Azure Pipelines to indicate how the run was triggered:
-#   Schedule      - cron-scheduled run          -> nightly prerelease
-#   Manual        - user clicked "Run pipeline" -> release (official) or dev (non-official)
-#   IndividualCI  - push to a monitored branch  -> dev prerelease
-#   BatchedCI     - batched push trigger         -> dev prerelease
-#   PullRequest   - PR validation (publish is skipped at the stage level)
-switch ($BuildReason) {
-    'Schedule' {
-        $crateVersion = "$baseVersion-nightly.$dateStamp"
-        Write-Host "Nightly build detected"
+    $packageSection = [regex]::Match($Content, '(?ms)^\[package\].*?(?=^\[|\z)')
+    if (-not $packageSection.Success) {
+        throw "No [package] section found in $Path"
     }
-    'Manual' {
-        if ($IsOfficial) {
-            $crateVersion = $baseVersion
-            Write-Host "Official release build detected"
-        } else {
-            $crateVersion = "$baseVersion-dev.$dateStamp.$BuildId"
-            Write-Host "Non-official manual build detected"
-        }
+
+    $versionMatches = [regex]::Matches($packageSection.Value, '(?m)^version\s*=\s*"[^"]+"')
+    if ($versionMatches.Count -ne 1) {
+        throw "Expected one package version in ${Path}, found $($versionMatches.Count)"
     }
-    default {
-        $crateVersion = "$baseVersion-dev.$dateStamp.$BuildId"
-        Write-Host "CI build detected (reason: $BuildReason)"
-    }
+
+    $updatedSection = [regex]::Replace(
+        $packageSection.Value,
+        '(?m)^(version\s*=\s*)"[^"]+"',
+        "`${1}`"$Version`"",
+        1
+    )
+
+    return $Content.Substring(0, $packageSection.Index) +
+        $updatedSection +
+        $Content.Substring($packageSection.Index + $packageSection.Length)
 }
 
-Write-Host "Base version: $baseVersion"
+function Set-MssqlTdsDependencyVersion {
+    param(
+        [Parameter(Mandatory = $true)][string]$Content,
+        [Parameter(Mandatory = $true)][string]$Version,
+        [Parameter(Mandatory = $true)][string]$Path
+    )
+
+    $pattern = [regex]'(?m)^(?<prefix>\s*mssql-tds\s*=\s*\{[^\r\n}]*?\bversion\s*=\s*)"[^"]+"(?<suffix>[^\r\n}]*\}\s*)$'
+    $matches = $pattern.Matches($Content)
+    if ($matches.Count -ne 1) {
+        throw "Expected one versioned mssql-tds dependency in ${Path}, found $($matches.Count)"
+    }
+
+    $match = $matches[0]
+    $replacement = $match.Groups['prefix'].Value + "`"$Version`"" + $match.Groups['suffix'].Value
+    return $Content.Substring(0, $match.Index) +
+        $replacement +
+        $Content.Substring($match.Index + $match.Length)
+}
+
+$isOfficialBuild = $false
+if (-not [bool]::TryParse($IsOfficial, [ref]$isOfficialBuild)) {
+    throw "IsOfficial must be True or False, got '$IsOfficial'"
+}
+
+$cargoTomlPath = Join-Path $RepositoryRoot "$($Crates[0])/Cargo.toml"
+$baseVersion = Get-PackageVersion -Content (Get-Content $cargoTomlPath -Raw) -Path $cargoTomlPath
+if ($baseVersion -match '-(?:dev|nightly)\.\d{8}(?:\.|$)') {
+    throw "Source manifest is already stamped with build version $baseVersion"
+}
+$dateStamp = Get-Date -Format 'yyyyMMdd'
+
+if ($isOfficialBuild) {
+    $crateVersion = $baseVersion
+    Write-Host 'Official build detected'
+}
+elseif ($BuildReason -eq 'Schedule') {
+    $crateVersion = "$baseVersion-nightly.$dateStamp"
+    Write-Host 'Non-official nightly build detected'
+}
+else {
+    $crateVersion = "$baseVersion-dev.$dateStamp.$BuildId"
+    Write-Host "Non-official build detected (reason: $BuildReason)"
+}
+
+Write-Host "Base version:  $baseVersion"
 Write-Host "Crate version: $crateVersion"
 
 foreach ($crate in $Crates) {
-    $path = Join-Path $PSScriptRoot "../../$crate/Cargo.toml"
-    $path = Resolve-Path $path
+    $path = Join-Path $RepositoryRoot "$crate/Cargo.toml"
     $content = Get-Content $path -Raw
-
-    # Replace only the first version = "..." line (the [package] version)
-    $updated = $content -replace '(?m)^(version\s*=\s*)"[^"]+"', "`$1`"$crateVersion`""
-
-    if ($content -eq $updated) {
-        Write-Warning "No version field found or already at target in $path"
-        continue
+    $updated = Set-PackageVersion -Content $content -Version $crateVersion -Path $path
+    if ($crate -eq 'mssql-mock-tds') {
+        $updated = Set-MssqlTdsDependencyVersion -Content $updated -Version $crateVersion -Path $path
     }
 
     if ($WhatIf) {
         Write-Host "[WhatIf] Would patch $path -> version = `"$crateVersion`""
-    } else {
+    }
+    elseif ($content -ne $updated) {
         Set-Content $path $updated -NoNewline
         Write-Host "Patched $path -> version = `"$crateVersion`""
     }
+    else {
+        Write-Host "$path already uses version `"$crateVersion`""
+    }
 }
 
-# Set pipeline variable for downstream steps
 if (-not $WhatIf) {
     Write-Host "##vso[task.setvariable variable=crateVersion]$crateVersion"
     Write-Host "##vso[task.setvariable variable=crateVersion;isOutput=true]$crateVersion"

--- a/.pipeline/scripts/test-cratesio-package.ps1
+++ b/.pipeline/scripts/test-cratesio-package.ps1
@@ -1,0 +1,59 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+<#
+.SYNOPSIS
+  Verifies that a crate version is absent from or available on crates.io.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$CrateName,
+    [Parameter(Mandatory = $true)][string]$Version,
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('Absent', 'Available')]
+    [string]$ExpectedState,
+    [ValidateRange(1, 100)][int]$MaxAttempts = 40,
+    [ValidateRange(1, 300)][int]$DelaySeconds = 15
+)
+
+$ErrorActionPreference = 'Stop'
+$uri = "https://crates.io/api/v1/crates/$CrateName/$Version"
+$headers = @{
+    'User-Agent' = 'mssql-rs-release-pipeline (https://github.com/microsoft/mssql-rs)'
+}
+
+for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+    try {
+        $response = Invoke-WebRequest -Uri $uri -Headers $headers -SkipHttpErrorCheck -TimeoutSec 30
+    }
+    catch {
+        throw "Failed to query crates.io for ${CrateName}@${Version}: $($_.Exception.Message)"
+    }
+
+    $statusCode = [int]$response.StatusCode
+    if ($ExpectedState -eq 'Absent') {
+        if ($statusCode -eq 404) {
+            Write-Host "$CrateName@$Version is not published."
+            return
+        }
+        if ($statusCode -eq 200) {
+            throw "$CrateName@$Version is already published and cannot be overwritten."
+        }
+        throw "crates.io returned HTTP $statusCode for $uri"
+    }
+
+    if ($statusCode -eq 200) {
+        Write-Host "$CrateName@$Version is available on crates.io."
+        return
+    }
+    if ($statusCode -ne 404) {
+        throw "crates.io returned HTTP $statusCode for $uri"
+    }
+
+    if ($attempt -lt $MaxAttempts) {
+        Write-Host "Waiting for $CrateName@$Version on crates.io ($attempt/$MaxAttempts)..."
+        Start-Sleep -Seconds $DelaySeconds
+    }
+}
+
+throw "$CrateName@$Version was not available on crates.io after $MaxAttempts attempts."

--- a/.pipeline/scripts/test-cratesio-package.ps1
+++ b/.pipeline/scripts/test-cratesio-package.ps1
@@ -27,7 +27,12 @@ for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
         $response = Invoke-WebRequest -Uri $uri -Headers $headers -SkipHttpErrorCheck -TimeoutSec 30
     }
     catch {
-        throw "Failed to query crates.io for ${CrateName}@${Version}: $($_.Exception.Message)"
+        if ($ExpectedState -eq 'Absent' -or $attempt -eq $MaxAttempts) {
+            throw "Failed to query crates.io for ${CrateName}@${Version}: $($_.Exception.Message)"
+        }
+        Write-Host "Transient crates.io request failure: $($_.Exception.Message)"
+        Start-Sleep -Seconds $DelaySeconds
+        continue
     }
 
     $statusCode = [int]$response.StatusCode
@@ -46,12 +51,17 @@ for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
         Write-Host "$CrateName@$Version is available on crates.io."
         return
     }
-    if ($statusCode -ne 404) {
+    if ($statusCode -ne 404 -and $statusCode -ne 429 -and $statusCode -lt 500) {
         throw "crates.io returned HTTP $statusCode for $uri"
     }
 
     if ($attempt -lt $MaxAttempts) {
-        Write-Host "Waiting for $CrateName@$Version on crates.io ($attempt/$MaxAttempts)..."
+        if ($statusCode -eq 404) {
+            Write-Host "Waiting for $CrateName@$Version on crates.io ($attempt/$MaxAttempts)..."
+        }
+        else {
+            Write-Host "Transient HTTP $statusCode from crates.io; retrying ($attempt/$MaxAttempts)..."
+        }
         Start-Sleep -Seconds $DelaySeconds
     }
 }

--- a/.pipeline/scripts/validate-crate-release-artifact.ps1
+++ b/.pipeline/scripts/validate-crate-release-artifact.ps1
@@ -67,6 +67,39 @@ for ($index = 0; $index -lt $expectedNames.Count; $index++) {
     }
     $expectedFiles += $cratePath
 
+    if ($expectedName -eq 'mssql-mock-tds') {
+        $packagedManifestPath = "$expectedName-$($entry.version)/Cargo.toml"
+        $packagedManifest = (& tar -xOf $cratePath $packagedManifestPath) -join "`n"
+        if ($LASTEXITCODE -ne 0) {
+            throw "Could not read $packagedManifestPath from $expectedFileName"
+        }
+
+        $dependency = [regex]::Match(
+            $packagedManifest,
+            '(?ms)^\[dependencies\.mssql-tds\]\s*$(?<body>.*?)(?=^\[|\z)'
+        )
+        if (-not $dependency.Success) {
+            throw "$expectedFileName has no mssql-tds dependency"
+        }
+
+        $dependencyVersion = [regex]::Match(
+            $dependency.Groups['body'].Value,
+            '(?m)^\s*version\s*=\s*"([^"]+)"'
+        )
+        if (-not $dependencyVersion.Success -or $dependencyVersion.Groups[1].Value -ne $entry.version) {
+            $actualVersion = if ($dependencyVersion.Success) {
+                $dependencyVersion.Groups[1].Value
+            }
+            else {
+                '<missing>'
+            }
+            throw "$expectedFileName records mssql-tds dependency version '$actualVersion', expected '$($entry.version)'"
+        }
+        if ($dependency.Groups['body'].Value -match '(?m)^\s*(path|registry|registry-index)\s*=') {
+            throw "$expectedFileName does not resolve mssql-tds from crates.io"
+        }
+    }
+
     $variableName = if ($expectedName -eq 'mssql-tds') {
         'mssqlTdsCrateVersion'
     }

--- a/.pipeline/scripts/validate-crate-release-artifact.ps1
+++ b/.pipeline/scripts/validate-crate-release-artifact.ps1
@@ -1,0 +1,89 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+<#
+.SYNOPSIS
+  Validates a Rust crate artifact before an ESRP release.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$ArtifactDirectory
+)
+
+$ErrorActionPreference = 'Stop'
+$manifestPath = Join-Path $ArtifactDirectory 'release-manifest.json'
+if (-not (Test-Path $manifestPath -PathType Leaf)) {
+    throw "Crate release manifest not found: $manifestPath"
+}
+
+$manifest = Get-Content $manifestPath -Raw | ConvertFrom-Json
+if ($manifest.schemaVersion -ne 1) {
+    throw "Unsupported crate release manifest schema: $($manifest.schemaVersion)"
+}
+
+$entries = @($manifest.crates)
+$expectedNames = @('mssql-tds', 'mssql-mock-tds')
+if ($entries.Count -ne $expectedNames.Count) {
+    throw "Expected $($expectedNames.Count) crates, found $($entries.Count)"
+}
+if ($entries[0].version -ne $entries[1].version) {
+    throw "Crate versions must match: $($entries[0].version) != $($entries[1].version)"
+}
+
+$artifactRoot = [System.IO.Path]::GetFullPath($ArtifactDirectory).TrimEnd(
+    [System.IO.Path]::DirectorySeparatorChar,
+    [System.IO.Path]::AltDirectorySeparatorChar
+)
+$expectedFiles = @()
+
+for ($index = 0; $index -lt $expectedNames.Count; $index++) {
+    $entry = $entries[$index]
+    $expectedName = $expectedNames[$index]
+    if ($entry.name -ne $expectedName) {
+        throw "Expected crate $expectedName at release position $index, found $($entry.name)"
+    }
+    if ([string]::IsNullOrWhiteSpace($entry.version)) {
+        throw "No version recorded for $expectedName"
+    }
+
+    $cratePath = [System.IO.Path]::GetFullPath(
+        (Join-Path $artifactRoot ($entry.file -replace '/', [System.IO.Path]::DirectorySeparatorChar))
+    )
+    if (-not $cratePath.StartsWith("$artifactRoot$([System.IO.Path]::DirectorySeparatorChar)")) {
+        throw "Crate path escapes the artifact directory: $($entry.file)"
+    }
+    if (-not (Test-Path $cratePath -PathType Leaf)) {
+        throw "Crate file not found: $cratePath"
+    }
+
+    $expectedFileName = "$expectedName-$($entry.version).crate"
+    if ([System.IO.Path]::GetFileName($cratePath) -ne $expectedFileName) {
+        throw "Expected crate file $expectedFileName, found $([System.IO.Path]::GetFileName($cratePath))"
+    }
+
+    $actualHash = (Get-FileHash $cratePath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actualHash -ne $entry.sha256) {
+        throw "SHA-256 mismatch for $expectedFileName"
+    }
+    $expectedFiles += $cratePath
+
+    $variableName = if ($expectedName -eq 'mssql-tds') {
+        'mssqlTdsCrateVersion'
+    }
+    else {
+        'mssqlMockTdsCrateVersion'
+    }
+    Write-Host "##vso[task.setvariable variable=$variableName]$($entry.version)"
+}
+
+$actualFiles = @(Get-ChildItem $artifactRoot -Recurse -Filter *.crate -File).FullName
+if ($actualFiles.Count -ne $expectedFiles.Count) {
+    throw "Expected $($expectedFiles.Count) .crate files, found $($actualFiles.Count)"
+}
+foreach ($actualFile in $actualFiles) {
+    if ($actualFile -notin $expectedFiles) {
+        throw "Unexpected crate file in release artifact: $actualFile"
+    }
+}
+
+Write-Host 'Rust crate release artifact is valid.'

--- a/mssql-mock-tds/Cargo.toml
+++ b/mssql-mock-tds/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 description = "Mock TDS server library and CLI for testing SQL Server clients"
 license = "MIT"
+license-file = "../LICENSE"
 repository = "https://github.com/microsoft/mssql-rs"
 
 [lints]

--- a/mssql-mock-tds/Cargo.toml
+++ b/mssql-mock-tds/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 description = "Mock TDS server library and CLI for testing SQL Server clients"
 license = "MIT"
+repository = "https://github.com/microsoft/mssql-rs"
 
 [lints]
 workspace = true

--- a/mssql-mock-tds/Cargo.toml
+++ b/mssql-mock-tds/Cargo.toml
@@ -21,7 +21,7 @@ default = []
 vendored-openssl = ["openssl/vendored"]
 
 [dependencies]
-mssql-tds = { path = "../mssql-tds", default-features = false }
+mssql-tds = { path = "../mssql-tds", version = "0.1.0", default-features = false }
 tokio = { version = "1.48.0", features = ["full"] }
 tokio-util = { version = "0.7.17", features = ["full"] }
 bytes = "1.11.0"

--- a/mssql-tds/Cargo.toml
+++ b/mssql-tds/Cargo.toml
@@ -4,11 +4,12 @@ version = "0.1.0"
 edition = "2024"
 description = "Rust implementation of the TDS (Tabular Data Stream) protocol for SQL Server"
 license = "MIT"
+license-file = "../LICENSE"
 readme = "README.md"
 repository = "https://github.com/microsoft/mssql-rs"
 keywords = ["sql-server", "tds", "mssql", "database", "async"]
 categories = ["database", "network-programming"]
-exclude = [".env", "tests/**", "benches/**"]
+exclude = ["**/.env*", "tests/**", "benches/**"]
 
 [features]
 default = ["integrated-auth", "tls-schannel-direct-on-windows"]

--- a/mssql-tds/Cargo.toml
+++ b/mssql-tds/Cargo.toml
@@ -5,8 +5,10 @@ edition = "2024"
 description = "Rust implementation of the TDS (Tabular Data Stream) protocol for SQL Server"
 license = "MIT"
 readme = "README.md"
+repository = "https://github.com/microsoft/mssql-rs"
 keywords = ["sql-server", "tds", "mssql", "database", "async"]
 categories = ["database", "network-programming"]
+exclude = [".env", "tests/**", "benches/**"]
 
 [features]
 default = ["integrated-auth", "tls-schannel-direct-on-windows"]


### PR DESCRIPTION
## Description

- Package `mssql-tds` and `mssql-mock-tds` in both official and non-official OneBranch builds.
- Publish a dedicated Rust crate artifact with ordered release metadata and SHA-256 hashes.
- Add opt-in `EsrpRelease@12` publishing for each crate, with preflight checks, dependency ordering, crates.io availability polling, and independent switches for partial-run recovery.
- Add a `validateCratesOnly` mode that runs artifact validation and selected-crate preflights without invoking ESRP or publishing immutable crate versions; the existing `mssql-py-core` tag flow remains independent.
- Add the required registry version to the local `mssql-tds` dependency so `mssql-mock-tds` can be packaged for crates.io, then compile the packaged mock against the packaged core before emitting the artifact.
- Add source-repository and license-file metadata to both crates and exclude `.env*`, integration tests, and benchmarks from the immutable `mssql-tds` package.

## Related Issues

Fixes #514

## Validation

- `cargo bfmt`
- `cargo bclippy`
- `cargo nextest run --frozen --package mssql-tds --package mssql-mock-tds --lib --no-fail-fast --profile ci` (2,131 passed)
- Official and non-official `.crate` creation, release-manifest validation, normalized dependency metadata, and crates.io preflight behavior exercised locally
- [Current-head OneBranch run 20260909.8](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build/results?buildId=173691) succeeded against `1d66060b`: `mssql-tds` passed package verification, the exact packaged mock passed `cargo check` against the exact packaged core, and the emitted artifact retained valid hashes and normalized dependency metadata
- Both final `.crate` files contain repository metadata and root MIT license text; `.env*`, `tests/**`, and `benches/**` are absent
- Focused regression checks cover sandbox dependency upserts, transient crates.io responses, packaged dependency validation, and count-limited version stamping
- Full `cargo btest` was attempted but requires the live SQL Server integration environment unavailable on this machine

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [ ] `cargo btest` passes
- [ ] New/changed functionality has tests
- [x] Public API changes are documented