### PR TITLE
perf(lab): advance baseline to 6712b803 to lock in the decode and row-iteration gains

### DIFF
--- a/mssql-tds-bench/perf-lab/baseline-commit.txt
+++ b/mssql-tds-bench/perf-lab/baseline-commit.txt
@@ -7,4 +7,4 @@
 #
 # Exactly one full 40-character commit SHA on its own line. Lines starting with
 # '#' and blank lines are ignored.
-ecd8d6cb596a0175651f7dee918de01b2e1c1855
+6712b8038c123d8169f1504c9df432303582bded


### PR DESCRIPTION
## Description

Advances the perf-lab baseline to `6712b803`, locking in the decode and row-iteration gains landed since the previous baseline (`ecd8d6cb`).

Both weekly perf-lab runs are green at the **same** commit, `6712b8038c123d8169f1504c9df432303582bded`, which is the current tip of GitHub `main`. Each platform reports verified improvements — wins that were re-measured 4x interleaved and reproduced in at least 3 of 4 re-runs, so they are real rather than first-pass artifacts:

- **Linux**: `temporal/decode` 4/4 (up to 1.22x faster), `select_n_rows/100` 4/4 (1.20x), `select_n_rows/1000` 3/4 (1.08x).
- **Windows**: `row_iteration_throughput/next_row` 4/4 (up to 1.51x faster), `select_n_rows/10000` 4/4 (1.34x), `temporal/decode` 4/4 (1.30x).

No benchmark on either platform is more than 5% slower than the outgoing baseline. The worst drift is +4.0% (`strings` and `stored_procedure_output` on Linux, `stored_procedure_output` on Windows), all well inside the gate. On Linux, `single_insert` tripped the 5% threshold on the first pass but reproduced in only 2 of 4 re-runs (worst +6%), so the quorum cleared it as noise and its published median is +2.5%.

Advancing the baseline makes these numbers the new floor: a later change that gives the gains back trips the gate instead of silently settling at the old level.

- Linux: [173078](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build/results?buildId=173078)
- Windows: [173084](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build/results?buildId=173084)

## Changes

`mssql-tds-bench/perf-lab/baseline-commit.txt`: `ecd8d6cb596a0175651f7dee918de01b2e1c1855` -> `6712b8038c123d8169f1504c9df432303582bded`.

Only the SHA line changes; the comment header is untouched.

## Validation

- Both weekly lab runs above completed green against the outgoing baseline, at the same `sourceVersion`.
- `6712b803` confirmed an ancestor of GitHub `main` (it is the current tip).
- Triaged per [`mssql-tds-bench/perf-lab/MONITORING.md`](https://github.com/microsoft/mssql-rs/blob/main/mssql-tds-bench/perf-lab/MONITORING.md); all four lock-in criteria hold.

---

# Linux — build 173078

**✅ No benchmark consistently slower by >=5% vs baseline**

### Change vs baseline

_🟩 faster · 🟥 slower · 1 square ≈ 1% (drawn only for |Δ| ≥ 1%) · ⟳ re-measured (median of re-runs)_

| Benchmark | faster ◄ | Δ% | ► slower |
|---|--:|:--:|:--|
| `temporal/decode` ⟳ | 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 | -13.0 |  |
| `select_n_rows/100` ⟳ | 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 | -12.3 |  |
| `primitives/decode` | 🟩🟩🟩🟩🟩🟩 | -5.7 |  |
| `prepared_prepexec` | 🟩🟩🟩🟩🟩 | -4.8 |  |
| `select_n_rows/1000` ⟳ | 🟩🟩🟩🟩🟩 | -4.8 |  |
| `select_n_rows/10000` | 🟩🟩🟩🟩 | -3.8 |  |
| `scalars/decode` | 🟩🟩🟩🟩 | -3.8 |  |
| `stored_procedure` | 🟩🟩🟩 | -2.9 |  |
| `connect_close` | 🟩🟩 | -2.0 |  |
| `packet_size_sensitivity/4096` | 🟩🟩 | -2.0 |  |
| `row_iteration_throughput/next_row` | 🟩🟩 | -2.0 |  |
| `prepared_execute` |  | -1.0 |  |
| `lob/1048576` |  | ±0.0 |  |
| `lob/20971520` |  | ±0.0 |  |
| `bulk_insert/500` |  | ±0.0 |  |
| `packet_size_sensitivity/8192` |  | ±0.0 |  |
| `parameterized_sp_executesql` |  | ±0.0 |  |
| `concurrent_connects/100` |  | +1.0 | 🟥 |
| `simple_select_one_row` |  | +1.0 | 🟥 |
| `packet_size_sensitivity/32768` |  | +1.0 | 🟥 |
| `concurrent_connects/50` |  | +1.0 | 🟥 |
| `single_insert` ⟳ |  | +2.5 | 🟥🟥 |
| `bulk_insert/5000` |  | +3.0 | 🟥🟥🟥 |
| `batched_statements` |  | +3.0 | 🟥🟥🟥 |
| `strings` |  | +4.0 | 🟥🟥🟥🟥 |
| `stored_procedure_output` |  | +4.0 | 🟥🟥🟥🟥 |

### Raw first-pass measurements

```
group                                base                                     candidate
-----                                ----                                     ---------
batched_statements                   1.00    235.6±2.51µs        ? ?/sec      1.03    243.2±4.74µs        ? ?/sec
bulk_insert/500                      1.00     38.6±0.75ms 253.0 KElem/sec     1.00     38.7±0.42ms 252.6 KElem/sec
bulk_insert/5000                     1.00     10.2±0.14ms 960.7 KElem/sec     1.03     10.5±0.07ms 932.1 KElem/sec
concurrent_connects/100              1.00     75.0±2.07ms  1333 Elem/sec      1.01     75.9±6.60ms  1318 Elem/sec
concurrent_connects/50               1.00     39.7±0.82ms  1258 Elem/sec      1.01     40.1±1.24ms  1247 Elem/sec
connect_close                        1.02      6.1±0.11ms        ? ?/sec      1.00      5.9±0.07ms        ? ?/sec
lob/1048576                          1.00      3.0±0.04ms   334.5 MB/sec      1.00      3.0±0.05ms   333.3 MB/sec
lob/20971520                         1.00     54.7±0.29ms   365.8 MB/sec      1.00     54.6±0.36ms   366.3 MB/sec
packet_size_sensitivity/32768        1.00     27.6±0.38ms   579.1 MB/sec      1.01     28.0±0.46ms   572.0 MB/sec
packet_size_sensitivity/4096         1.02     76.5±0.85ms   209.2 MB/sec      1.00     74.8±0.57ms   213.8 MB/sec
packet_size_sensitivity/8192         1.00     43.6±0.47ms   366.6 MB/sec      1.00     43.5±0.66ms   367.5 MB/sec
parameterized_sp_executesql          1.00    148.5±4.26µs        ? ?/sec      1.00    148.3±4.98µs        ? ?/sec
prepared_execute                     1.01    139.7±2.78µs        ? ?/sec      1.00    137.9±2.31µs        ? ?/sec
prepared_prepexec                    1.05   289.9±12.07µs        ? ?/sec      1.00    276.8±5.66µs        ? ?/sec
primitives/decode                    1.06   728.7±12.18µs 1340.2 KElem/sec    1.00   690.3±17.51µs 1414.6 KElem/sec
row_iteration_throughput/next_row    1.02     19.9±0.68ms  2.4 MElem/sec      1.00     19.5±0.09ms  2.4 MElem/sec
scalars/decode                       1.04   814.3±70.07µs 1199.3 KElem/sec    1.00   784.8±16.01µs 1244.4 KElem/sec
select_n_rows/100                    1.11   304.0±19.16µs 321.2 KElem/sec     1.00    272.9±7.25µs 357.9 KElem/sec
select_n_rows/1000                   1.08   828.0±18.22µs 1179.4 KElem/sec    1.00    768.9±9.63µs 1270.0 KElem/sec
select_n_rows/10000                  1.04      5.9±0.03ms 1652.2 KElem/sec    1.00      5.7±0.03ms 1714.4 KElem/sec
simple_select_one_row                1.00    201.5±5.58µs        ? ?/sec      1.01    202.7±7.45µs        ? ?/sec
single_insert                        1.00    307.1±5.78µs        ? ?/sec      1.05    322.6±8.12µs        ? ?/sec
stored_procedure                     1.03   161.3±12.93µs        ? ?/sec      1.00    157.1±3.73µs        ? ?/sec
stored_procedure_output              1.00    158.3±4.35µs        ? ?/sec      1.04    164.1±4.01µs        ? ?/sec
strings                              1.00    316.9±3.87µs        ? ?/sec      1.04    330.1±5.61µs        ? ?/sec
temporal/decode                      1.12   696.7±10.74µs 1401.8 KElem/sec    1.00   619.6±14.09µs 1576.1 KElem/sec
```

### Regressions (auto-confirm)

Initially tripped: `single_insert`

| benchmark | re-runs tripped | worst |
|-----------|-----------------|-------|
| single_insert | 2/4 | +6% |

_Confirmed (tripped in >= 3/4): none_

### Large improvements (verification)

_5 benchmark(s) qualified; the largest 3 were re-measured (`BENCH_IMPROVEMENT_VERIFY_MAX`). The other 2 keep their first-pass numbers in the chart, unverified._

| benchmark | reproduced | best |
|-----------|------------|------|
| temporal/decode | 4/4 | 1.22x faster |
| select_n_rows/100 | 4/4 | 1.20x faster |
| select_n_rows/1000 | 3/4 | 1.08x faster |

_Verified (reproduced in >= 3/4): select_n_rows/100, select_n_rows/1000, temporal/decode_

---

# Windows — build 173084

**✅ No benchmark consistently slower by >=5% vs baseline**

Nothing tripped the gate on this platform, so there is no auto-confirm section.

### Change vs baseline

_🟩 faster · 🟥 slower · 1 square ≈ 1% (drawn only for |Δ| ≥ 1%) · ⟳ re-measured (median of re-runs)_

_The Windows step log mangles the summary's UTF-8, so this table is reconstructed from the raw Δ% values below, per the runbook._

| Benchmark | faster ◄ | Δ% | ► slower |
|---|--:|:--:|:--|
| `row_iteration_throughput/next_row` ⟳ | 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 | -32.2 |  |
| `select_n_rows/10000` ⟳ | 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 | -24.0 |  |
| `temporal/decode` ⟳ | 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 | -23.1 |  |
| `select_n_rows/1000` | 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 | -21.9 |  |
| `scalars/decode` | 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 | -19.4 |  |
| `primitives/decode` | 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 | -17.4 |  |
| `select_n_rows/100` | 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 | -10.7 |  |
| `prepared_prepexec` |  | -1.0 |  |
| `parameterized_sp_executesql` |  | -1.0 |  |
| `lob/20971520` |  | -1.0 |  |
| `packet_size_sensitivity/32768` |  | -1.0 |  |
| `strings` |  | ±0.0 |  |
| `batched_statements` |  | ±0.0 |  |
| `lob/1048576` |  | ±0.0 |  |
| `concurrent_connects/50` |  | ±0.0 |  |
| `prepared_execute` |  | ±0.0 |  |
| `packet_size_sensitivity/8192` |  | ±0.0 |  |
| `single_insert` |  | +1.0 | 🟥 |
| `stored_procedure` |  | +1.0 | 🟥 |
| `bulk_insert/500` |  | +1.0 | 🟥 |
| `bulk_insert/5000` |  | +1.0 | 🟥 |
| `concurrent_connects/100` |  | +1.0 | 🟥 |
| `packet_size_sensitivity/4096` |  | +1.0 | 🟥 |
| `simple_select_one_row` |  | +2.0 | 🟥🟥 |
| `connect_close` |  | +3.0 | 🟥🟥🟥 |
| `stored_procedure_output` |  | +4.0 | 🟥🟥🟥🟥 |

### Raw first-pass measurements

```
group                                base                                     candidate
-----                                ----                                     ---------
batched_statements                   1.00    237.2±5.86µs        ? ?/sec      1.00    238.0±5.11µs        ? ?/sec
bulk_insert/500                      1.00     38.1±0.16ms 256.6 KElem/sec     1.01     38.2±0.19ms 255.3 KElem/sec
bulk_insert/5000                     1.00     10.7±0.13ms 909.8 KElem/sec     1.01     10.9±0.04ms 899.6 KElem/sec
concurrent_connects/100              1.00       2.4±0.13s    41 Elem/sec      1.01       2.4±0.13s    41 Elem/sec
concurrent_connects/50               1.00  1349.6±87.91ms    37 Elem/sec      1.00  1347.3±113.95ms    37 Elem/sec
connect_close                        1.00    154.7±0.87ms        ? ?/sec      1.03    159.9±5.44ms        ? ?/sec
lob/1048576                          1.00  1784.1±20.94µs   560.5 MB/sec      1.00  1787.8±20.52µs   559.4 MB/sec
lob/20971520                         1.01     33.5±0.44ms   596.9 MB/sec      1.00     33.3±0.29ms   601.1 MB/sec
packet_size_sensitivity/32768        1.01     20.5±0.58ms   780.0 MB/sec      1.00     20.3±0.61ms   788.5 MB/sec
packet_size_sensitivity/4096         1.00     42.9±0.59ms   373.0 MB/sec      1.01     43.2±0.86ms   370.6 MB/sec
packet_size_sensitivity/8192         1.00     26.9±0.54ms   594.0 MB/sec      1.00     27.0±0.38ms   592.6 MB/sec
parameterized_sp_executesql          1.01    129.0±3.08µs        ? ?/sec      1.00    127.6±4.90µs        ? ?/sec
prepared_execute                     1.00    110.6±1.85µs        ? ?/sec      1.00    111.0±2.63µs        ? ?/sec
prepared_prepexec                    1.01    230.9±3.88µs        ? ?/sec      1.00   228.7±13.50µs        ? ?/sec
primitives/decode                    1.21   816.2±11.61µs 1196.4 KElem/sec    1.00   673.0±10.17µs 1451.0 KElem/sec
row_iteration_throughput/next_row    1.49     26.0±0.09ms 1877.5 KElem/sec    1.00     17.4±0.26ms  2.7 MElem/sec
scalars/decode                       1.24   778.5±16.33µs 1254.4 KElem/sec    1.00    627.9±7.57µs 1555.4 KElem/sec
select_n_rows/100                    1.12    298.9±5.10µs 326.7 KElem/sec     1.00    266.0±3.34µs 367.1 KElem/sec
select_n_rows/1000                   1.28   955.7±20.21µs 1021.8 KElem/sec    1.00   748.4±18.00µs 1304.9 KElem/sec
select_n_rows/10000                  1.34      7.3±0.05ms 1342.2 KElem/sec    1.00      5.4±0.04ms 1801.7 KElem/sec
simple_select_one_row                1.00    193.1±7.26µs        ? ?/sec      1.02    196.2±7.50µs        ? ?/sec
single_insert                        1.00    298.6±6.01µs        ? ?/sec      1.01    301.0±5.49µs        ? ?/sec
stored_procedure                     1.00    133.3±2.09µs        ? ?/sec      1.01    135.1±5.77µs        ? ?/sec
stored_procedure_output              1.00    137.2±2.10µs        ? ?/sec      1.04    142.2±4.66µs        ? ?/sec
strings                              1.00    289.9±6.60µs        ? ?/sec      1.00    290.9±6.61µs        ? ?/sec
temporal/decode                      1.33   778.8±17.81µs 1253.9 KElem/sec    1.00    587.3±9.91µs 1662.7 KElem/sec
```

### Large improvements (verification)

_7 benchmark(s) qualified; the largest 3 were re-measured (`BENCH_IMPROVEMENT_VERIFY_MAX`). The other 4 keep their first-pass numbers in the chart, unverified._

| benchmark | reproduced | best |
|-----------|------------|------|
| row_iteration_throughput/next_row | 4/4 | 1.51x faster |
| select_n_rows/10000 | 4/4 | 1.34x faster |
| temporal/decode | 4/4 | 1.30x faster |

_Verified (reproduced in >= 3/4): temporal/decode, select_n_rows/10000, row_iteration_throughput/next_row_

---

## Related Issues

[AB#46061](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46061)

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes — N/A: no Rust source changed; this is a one-line data file
- [x] New/changed functionality has tests — N/A: baseline pointer change; validated by the two lab runs above
- [x] Public API changes are documented — N/A: no public API changes