### PR TITLE
Rename combined Python wheel distribution

### DIFF
--- a/.pipeline/OneBranch/NonOfficialPythonWheelsPublish.yml
+++ b/.pipeline/OneBranch/NonOfficialPythonWheelsPublish.yml
@@ -34,7 +34,7 @@ parameters:
 - name: buildOdbcNative
   displayName: 'Also build mssql-odbc native driver'
   type: boolean
-  default: false
+  default: true
 
 variables:
   CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)]  # For onebranch.pipeline.version task

--- a/.pipeline/OneBranch/OfficialPythonWheelsRelease.yml
+++ b/.pipeline/OneBranch/OfficialPythonWheelsRelease.yml
@@ -158,10 +158,16 @@ extends:
             $wheels | Copy-Item -Destination $wheelsDir -Force
             Write-Host "Collected $($wheels.Count) wheels"
 
+            $pyprojectToml = Get-Content "$(Build.SourcesDirectory)/mssql-py-core/pyproject.toml" -Raw
+            if ($pyprojectToml -match '(?ms)^\[project\]\s*$.*?^version\s*=\s*"([^"]+)"') {
+              $pythonVersion = $Matches[1]
+            } else {
+              throw "Could not extract [project].version from mssql-py-core/pyproject.toml"
+            }
             & "$(Build.SourcesDirectory)/.pipeline/scripts/verify-python-wheels.ps1" `
               -WheelsDir $wheelsDir `
               -ExpectedName "mssql-python-rs" `
-              -ExpectedVersion "0.1.0" `
+              -ExpectedVersion $pythonVersion `
               -ExpectedCount 34 `
               -RequireOdbc:$true
 

--- a/.pipeline/OneBranch/OfficialPythonWheelsRelease.yml
+++ b/.pipeline/OneBranch/OfficialPythonWheelsRelease.yml
@@ -158,14 +158,21 @@ extends:
             $wheels | Copy-Item -Destination $wheelsDir -Force
             Write-Host "Collected $($wheels.Count) wheels"
 
+            & "$(Build.SourcesDirectory)/.pipeline/scripts/verify-python-wheels.ps1" `
+              -WheelsDir $wheelsDir `
+              -ExpectedName "mssql-python-rs" `
+              -ExpectedVersion "0.1.0" `
+              -ExpectedCount 34 `
+              -RequireOdbc
+
             # Create .nuspec
             $nuspecContent = @"
             <?xml version="1.0"?>
             <package>
               <metadata>
-                <id>mssql-py-core-wheels</id>
+                <id>mssql-python-rs-wheels</id>
                 <version>$packageVersion</version>
-                <description>Python wheels for mssql-py-core (official release). Commit: $shortSha. Build: $(resources.pipeline.officialBuild.runID)</description>
+                <description>Python wheels containing the mssql-python-rs TDS core and ODBC driver. Commit: $shortSha. Build: $(resources.pipeline.officialBuild.runID)</description>
                 <authors>SqlClientDrivers</authors>
               </metadata>
               <files>
@@ -174,7 +181,7 @@ extends:
             </package>
             "@
 
-            $nuspecPath = "$(Build.StagingDirectory)/mssql-py-core-wheels.nuspec"
+            $nuspecPath = "$(Build.StagingDirectory)/mssql-python-rs-wheels.nuspec"
             $nuspecContent | Out-File -FilePath $nuspecPath -Encoding utf8
             Write-Host "Created nuspec: $nuspecPath"
           displayName: 'Prepare release NuGet package'
@@ -183,7 +190,7 @@ extends:
           displayName: 'Create NuGet package'
           inputs:
             command: pack
-            packagesToPack: '$(Build.StagingDirectory)/mssql-py-core-wheels.nuspec'
+            packagesToPack: '$(Build.StagingDirectory)/mssql-python-rs-wheels.nuspec'
             packDestination: '$(ob_outputDirectory)/packages'
             basePath: '$(Build.StagingDirectory)'
 

--- a/.pipeline/OneBranch/OfficialPythonWheelsRelease.yml
+++ b/.pipeline/OneBranch/OfficialPythonWheelsRelease.yml
@@ -185,11 +185,7 @@ extends:
             $wheels | Copy-Item -Destination $wheelsDir -Force
             Write-Host "Collected $($wheels.Count) wheels"
 
-            $validatorPath = Join-Path "$(Build.StagingDirectory)" "verify-python-wheels.ps1"
-            $validator = Get-BuildSourceFile ".pipeline/scripts/verify-python-wheels.ps1"
-            [System.IO.File]::WriteAllText($validatorPath, $validator)
-
-            & $validatorPath `
+            & "$(Build.SourcesDirectory)/.pipeline/scripts/verify-python-wheels.ps1" `
               -WheelsDir $wheelsDir `
               -ExpectedName $distributionName `
               -ExpectedVersion $pythonVersion `

--- a/.pipeline/OneBranch/OfficialPythonWheelsRelease.yml
+++ b/.pipeline/OneBranch/OfficialPythonWheelsRelease.yml
@@ -158,12 +158,19 @@ extends:
             $wheels | Copy-Item -Destination $wheelsDir -Force
             Write-Host "Collected $($wheels.Count) wheels"
 
-            $pyprojectToml = Get-Content "$(Build.SourcesDirectory)/mssql-py-core/pyproject.toml" -Raw
-            if ($pyprojectToml -match '(?ms)^\[project\]\s*$.*?^version\s*=\s*"([^"]+)"') {
-              $pythonVersion = $Matches[1]
-            } else {
-              throw "Could not extract [project].version from mssql-py-core/pyproject.toml"
+            $pythonVersions = @(
+              $wheels | ForEach-Object {
+                if ($_.Name -notmatch '^mssql_python_rs-([^-]+)-cp\d+-cp\d+-.+\.whl$') {
+                  throw "Unexpected wheel filename: $($_.Name)"
+                }
+                $Matches[1]
+              } | Sort-Object -Unique
+            )
+            if ($pythonVersions.Count -ne 1) {
+              throw "Expected one Python distribution version, found: $($pythonVersions -join ', ')"
             }
+            $pythonVersion = $pythonVersions[0]
+
             & "$(Build.SourcesDirectory)/.pipeline/scripts/verify-python-wheels.ps1" `
               -WheelsDir $wheelsDir `
               -ExpectedName "mssql-python-rs" `

--- a/.pipeline/OneBranch/OfficialPythonWheelsRelease.yml
+++ b/.pipeline/OneBranch/OfficialPythonWheelsRelease.yml
@@ -90,6 +90,10 @@ extends:
           ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
           ob_nugetPublishing_enabled: ${{ parameters.publishNuGet }}
         steps:
+        - checkout: self
+          persistCredentials: true
+          fetchDepth: 0
+
         #####################################################################
         # Step 1: Download NuGet artifact from the Official Build pipeline
         #####################################################################
@@ -127,17 +131,40 @@ extends:
         - pwsh: |
             $ErrorActionPreference = 'Stop'
 
-            $cargoToml = Get-Content "$(Build.SourcesDirectory)/mssql-py-core/Cargo.toml" -Raw
-            if ($cargoToml -match 'version\s*=\s*"([^"]+)"') {
-              $version = $Matches[1]
-            } else {
-              Write-Error "Could not extract version from Cargo.toml"
-              exit 1
+            $commitSha = "$(resources.pipeline.officialBuild.sourceCommit)"
+            $sourceBranch = "$(resources.pipeline.officialBuild.sourceBranch)"
+            git fetch origin $sourceBranch
+            if ($LASTEXITCODE -ne 0) {
+              throw "Could not fetch selected build branch $sourceBranch"
+            }
+            git cat-file -e "${commitSha}^{commit}"
+            if ($LASTEXITCODE -ne 0) {
+              throw "Selected build commit $commitSha was not found on $sourceBranch"
+            }
+            function Get-BuildSourceFile {
+              param([string]$Path)
+
+              $content = & git show "${commitSha}:$Path"
+              if ($LASTEXITCODE -ne 0) {
+                throw "Could not read $Path from selected build commit $commitSha"
+              }
+              return $content -join "`n"
             }
 
+            $cargoToml = Get-BuildSourceFile "mssql-py-core/Cargo.toml"
+            if ($cargoToml -notmatch '(?ms)^\[package\]\s*$.*?^version\s*=\s*"([^"]+)"') {
+              throw "Could not extract [package].version from selected build commit"
+            }
             # Official release: clean semver, no prerelease suffix
-            $packageVersion = $version
-            $commitSha = "$(resources.pipeline.officialBuild.sourceCommit)"
+            $packageVersion = $Matches[1]
+
+            $pyprojectToml = Get-BuildSourceFile "mssql-py-core/pyproject.toml"
+            if ($pyprojectToml -notmatch '(?ms)^\[project\]\s*$.*?^name\s*=\s*"([^"]+)".*?^version\s*=\s*"([^"]+)"') {
+              throw "Could not extract [project] name and version from selected build commit"
+            }
+            $distributionName = $Matches[1]
+            $pythonVersion = $Matches[2]
+
             $shortSha = $commitSha.Substring(0, 8)
 
             Write-Host "Release version: $packageVersion"
@@ -158,24 +185,14 @@ extends:
             $wheels | Copy-Item -Destination $wheelsDir -Force
             Write-Host "Collected $($wheels.Count) wheels"
 
-            $pythonVersions = @(
-              $wheels | ForEach-Object {
-                if ($_.Name -notmatch '^mssql_python_rs-([^-]+)-cp\d+-cp\d+-.+\.whl$') {
-                  throw "Unexpected wheel filename: $($_.Name)"
-                }
-                $Matches[1]
-              } | Sort-Object -Unique
-            )
-            if ($pythonVersions.Count -ne 1) {
-              throw "Expected one Python distribution version, found: $($pythonVersions -join ', ')"
-            }
-            $pythonVersion = $pythonVersions[0]
+            $validatorPath = Join-Path "$(Build.StagingDirectory)" "verify-python-wheels.ps1"
+            $validator = Get-BuildSourceFile ".pipeline/scripts/verify-python-wheels.ps1"
+            [System.IO.File]::WriteAllText($validatorPath, $validator)
 
-            & "$(Build.SourcesDirectory)/.pipeline/scripts/verify-python-wheels.ps1" `
+            & $validatorPath `
               -WheelsDir $wheelsDir `
-              -ExpectedName "mssql-python-rs" `
+              -ExpectedName $distributionName `
               -ExpectedVersion $pythonVersion `
-              -ExpectedCount 34 `
               -RequireOdbc:$true
 
             # Create .nuspec
@@ -185,7 +202,7 @@ extends:
               <metadata>
                 <id>mssql-python-rs-wheels</id>
                 <version>$packageVersion</version>
-                <description>Python wheels containing the mssql-python-rs TDS core and ODBC driver. Commit: $shortSha. Build: $(resources.pipeline.officialBuild.runID)</description>
+                <description>Python wheels containing the $distributionName TDS core and ODBC driver. Commit: $shortSha. Build: $(resources.pipeline.officialBuild.runID)</description>
                 <authors>SqlClientDrivers</authors>
               </metadata>
               <files>
@@ -236,19 +253,31 @@ extends:
           steps:
           - checkout: self
             persistCredentials: true
+            fetchDepth: 0
 
           - pwsh: |
               $ErrorActionPreference = 'Stop'
 
-              $cargoToml = Get-Content "$(Build.SourcesDirectory)/mssql-py-core/Cargo.toml" -Raw
-              if ($cargoToml -match 'version\s*=\s*"([^"]+)"') {
+              $commitSha = "$(resources.pipeline.officialBuild.sourceCommit)"
+              $sourceBranch = "$(resources.pipeline.officialBuild.sourceBranch)"
+              git fetch origin $sourceBranch
+              if ($LASTEXITCODE -ne 0) {
+                throw "Could not fetch selected build branch $sourceBranch"
+              }
+              git cat-file -e "${commitSha}^{commit}"
+              if ($LASTEXITCODE -ne 0) {
+                throw "Selected build commit $commitSha was not found on $sourceBranch"
+              }
+              $cargoToml = & git show "${commitSha}:mssql-py-core/Cargo.toml"
+              if ($LASTEXITCODE -ne 0) {
+                throw "Could not read Cargo.toml from selected build commit $commitSha"
+              }
+              if (($cargoToml -join "`n") -match '(?ms)^\[package\]\s*$.*?^version\s*=\s*"([^"]+)"') {
                 $version = $Matches[1]
               } else {
-                Write-Error "Could not extract version from Cargo.toml"
-                exit 1
+                throw "Could not extract [package].version from selected build commit"
               }
 
-              $commitSha = "$(resources.pipeline.officialBuild.sourceCommit)"
               $tagName = "v$version"
               $branchName = "release/$version"
 

--- a/.pipeline/OneBranch/OfficialPythonWheelsRelease.yml
+++ b/.pipeline/OneBranch/OfficialPythonWheelsRelease.yml
@@ -163,7 +163,7 @@ extends:
               -ExpectedName "mssql-python-rs" `
               -ExpectedVersion "0.1.0" `
               -ExpectedCount 34 `
-              -RequireOdbc
+              -RequireOdbc:$true
 
             # Create .nuspec
             $nuspecContent = @"

--- a/.pipeline/OneBranch/stages.yml
+++ b/.pipeline/OneBranch/stages.yml
@@ -461,7 +461,6 @@ stages:
             -WheelsDir "$(Build.StagingDirectory)/wheels" `
             -ExpectedName "mssql-python-rs" `
             -ExpectedVersion $pythonVersion `
-            -ExpectedCount 34 `
             -RequireOdbc:$requireOdbc
         displayName: 'Validate wheel metadata and ODBC payloads'
 

--- a/.pipeline/OneBranch/stages.yml
+++ b/.pipeline/OneBranch/stages.yml
@@ -451,10 +451,16 @@ stages:
 
       - pwsh: |
           $requireOdbc = "${{ parameters.buildOdbcNative }}" -eq "True"
+          $pyprojectToml = Get-Content "$(Build.SourcesDirectory)/mssql-py-core/pyproject.toml" -Raw
+          if ($pyprojectToml -match '(?ms)^\[project\]\s*$.*?^version\s*=\s*"([^"]+)"') {
+            $pythonVersion = $Matches[1]
+          } else {
+            throw "Could not extract [project].version from mssql-py-core/pyproject.toml"
+          }
           & "$(Build.SourcesDirectory)/.pipeline/scripts/verify-python-wheels.ps1" `
             -WheelsDir "$(Build.StagingDirectory)/wheels" `
             -ExpectedName "mssql-python-rs" `
-            -ExpectedVersion "0.1.0" `
+            -ExpectedVersion $pythonVersion `
             -ExpectedCount 34 `
             -RequireOdbc:$requireOdbc
         displayName: 'Validate wheel metadata and ODBC payloads'
@@ -509,6 +515,12 @@ stages:
           Write-Host "Build reason: $buildReason | Official: $isOfficial"
           Write-Host "##vso[task.setvariable variable=nugetVersion]$packageVersion"
 
+          $packageContents = if ("${{ parameters.buildOdbcNative }}" -eq "True") {
+            "the mssql-python-rs TDS core and ODBC driver"
+          } else {
+            "the mssql-python-rs TDS core"
+          }
+
           # Create .nuspec
           $nuspecContent = @"
           <?xml version="1.0"?>
@@ -516,7 +528,7 @@ stages:
             <metadata>
               <id>mssql-python-rs-wheels</id>
               <version>$packageVersion</version>
-              <description>Python wheels containing the mssql-python-rs TDS core and ODBC driver. Commit: $shortSha. Build: $(Build.BuildNumber)</description>
+              <description>Python wheels containing $packageContents. Commit: $shortSha. Build: $(Build.BuildNumber)</description>
               <authors>SqlClientDrivers</authors>
             </metadata>
             <files>

--- a/.pipeline/OneBranch/stages.yml
+++ b/.pipeline/OneBranch/stages.yml
@@ -450,12 +450,13 @@ stages:
         displayName: 'List collected wheels'
 
       - pwsh: |
+          $requireOdbc = "${{ parameters.buildOdbcNative }}" -eq "True"
           & "$(Build.SourcesDirectory)/.pipeline/scripts/verify-python-wheels.ps1" `
             -WheelsDir "$(Build.StagingDirectory)/wheels" `
             -ExpectedName "mssql-python-rs" `
             -ExpectedVersion "0.1.0" `
             -ExpectedCount 34 `
-            -RequireOdbc
+            -RequireOdbc:$requireOdbc
         displayName: 'Validate wheel metadata and ODBC payloads'
 
       - pwsh: |

--- a/.pipeline/OneBranch/stages.yml
+++ b/.pipeline/OneBranch/stages.yml
@@ -450,6 +450,15 @@ stages:
         displayName: 'List collected wheels'
 
       - pwsh: |
+          & "$(Build.SourcesDirectory)/.pipeline/scripts/verify-python-wheels.ps1" `
+            -WheelsDir "$(Build.StagingDirectory)/wheels" `
+            -ExpectedName "mssql-python-rs" `
+            -ExpectedVersion "0.1.0" `
+            -ExpectedCount 34 `
+            -RequireOdbc
+        displayName: 'Validate wheel metadata and ODBC payloads'
+
+      - pwsh: |
           $ErrorActionPreference = 'Stop'
 
           # Extract version from mssql-py-core/Cargo.toml
@@ -504,9 +513,9 @@ stages:
           <?xml version="1.0"?>
           <package>
             <metadata>
-              <id>mssql-py-core-wheels</id>
+              <id>mssql-python-rs-wheels</id>
               <version>$packageVersion</version>
-              <description>Python wheels for mssql-py-core across all platforms. Commit: $shortSha. Build: $(Build.BuildNumber)</description>
+              <description>Python wheels containing the mssql-python-rs TDS core and ODBC driver. Commit: $shortSha. Build: $(Build.BuildNumber)</description>
               <authors>SqlClientDrivers</authors>
             </metadata>
             <files>
@@ -515,7 +524,7 @@ stages:
           </package>
           "@
 
-          $nuspecPath = "$(Build.StagingDirectory)/mssql-py-core-wheels.nuspec"
+          $nuspecPath = "$(Build.StagingDirectory)/mssql-python-rs-wheels.nuspec"
           $nuspecContent | Out-File -FilePath $nuspecPath -Encoding utf8
           Write-Host "Created nuspec at $nuspecPath"
         displayName: 'Generate NuGet package metadata'
@@ -524,7 +533,7 @@ stages:
         displayName: 'Create NuGet package'
         inputs:
           command: pack
-          packagesToPack: '$(Build.StagingDirectory)/mssql-py-core-wheels.nuspec'
+          packagesToPack: '$(Build.StagingDirectory)/mssql-python-rs-wheels.nuspec'
           packDestination: '$(ob_outputDirectory)/packages'
           basePath: '$(Build.StagingDirectory)'
 

--- a/.pipeline/scripts/verify-python-wheels.ps1
+++ b/.pipeline/scripts/verify-python-wheels.ps1
@@ -55,6 +55,30 @@ function Get-ExpectedOdbcMembers {
     }
 }
 
+function Get-ExpectedWheelNames {
+    param([string]$Prefix, [string]$Version)
+
+    $pythonTags = 'cp310', 'cp311', 'cp312', 'cp313', 'cp314'
+    $platforms = @(
+        'win_amd64',
+        'linux_x86_64',
+        'linux_aarch64',
+        'musllinux_1_2_x86_64',
+        'musllinux_1_2_aarch64',
+        'macosx_15_0_universal2'
+    )
+
+    $expected = foreach ($pythonTag in $pythonTags) {
+        foreach ($platform in $platforms) {
+            "$Prefix-$Version-$pythonTag-$pythonTag-$platform.whl"
+        }
+    }
+    foreach ($pythonTag in $pythonTags | Where-Object { $_ -ne 'cp310' }) {
+        "$Prefix-$Version-$pythonTag-$pythonTag-win_arm64.whl"
+    }
+    return @($expected)
+}
+
 $wheels = @(Get-ChildItem -Path $WheelsDir -Filter '*.whl' -File)
 if ($wheels.Count -ne $ExpectedCount) {
     throw "Expected $ExpectedCount wheels, found $($wheels.Count)"
@@ -63,6 +87,13 @@ if ($wheels.Count -ne $ExpectedCount) {
 $canonicalExpectedName = ConvertTo-CanonicalName $ExpectedName
 $filenamePrefix = $ExpectedName.Replace('-', '_')
 $expectedFilenamePrefix = "$filenamePrefix-$ExpectedVersion-"
+$expectedWheelNames = @(Get-ExpectedWheelNames $filenamePrefix $ExpectedVersion)
+$actualWheelNames = @($wheels | ForEach-Object { $_.Name })
+$missingWheels = @($expectedWheelNames | Where-Object { $actualWheelNames -notcontains $_ })
+$unexpectedWheels = @($actualWheelNames | Where-Object { $expectedWheelNames -notcontains $_ })
+if ($missingWheels.Count -gt 0 -or $unexpectedWheels.Count -gt 0) {
+    throw "Wheel matrix mismatch. Missing: $($missingWheels -join ', '); Unexpected: $($unexpectedWheels -join ', ')"
+}
 
 foreach ($wheel in $wheels) {
     if (-not $wheel.Name.StartsWith($expectedFilenamePrefix)) {

--- a/.pipeline/scripts/verify-python-wheels.ps1
+++ b/.pipeline/scripts/verify-python-wheels.ps1
@@ -1,0 +1,120 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$WheelsDir,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedName,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedVersion,
+
+    [Parameter(Mandatory = $true)]
+    [int]$ExpectedCount,
+
+    [switch]$RequireOdbc
+)
+
+$ErrorActionPreference = 'Stop'
+
+function ConvertTo-CanonicalName {
+    param([string]$Name)
+    return [regex]::Replace($Name.ToLowerInvariant(), '[-_.]+', '-')
+}
+
+function Get-ExpectedOdbcMembers {
+    param([string]$WheelName)
+
+    switch -Wildcard ($WheelName) {
+        '*-win_amd64.whl' {
+            return @('mssql_py_core/libs/windows/x64/mssqlodbc.dll')
+        }
+        '*-win_arm64.whl' {
+            return @('mssql_py_core/libs/windows/arm64/mssqlodbc.dll')
+        }
+        '*-musllinux_*_x86_64.whl' {
+            return @('mssql_py_core/libs/linux/musl/x86_64/lib/mssqlodbc.so')
+        }
+        '*-musllinux_*_aarch64.whl' {
+            return @('mssql_py_core/libs/linux/musl/arm64/lib/mssqlodbc.so')
+        }
+        '*-macosx_*_universal2.whl' {
+            return @(
+                'mssql_py_core/libs/macos/x86_64/lib/mssqlodbc.dylib',
+                'mssql_py_core/libs/macos/arm64/lib/mssqlodbc.dylib'
+            )
+        }
+        '*_x86_64.whl' {
+            return @('mssql_py_core/libs/linux/glibc/x86_64/lib/mssqlodbc.so')
+        }
+        '*_aarch64.whl' {
+            return @('mssql_py_core/libs/linux/glibc/arm64/lib/mssqlodbc.so')
+        }
+        default {
+            throw "Unsupported wheel platform: $WheelName"
+        }
+    }
+}
+
+$wheels = @(Get-ChildItem -Path $WheelsDir -Filter '*.whl' -File)
+if ($wheels.Count -ne $ExpectedCount) {
+    throw "Expected $ExpectedCount wheels, found $($wheels.Count)"
+}
+
+$canonicalExpectedName = ConvertTo-CanonicalName $ExpectedName
+$filenamePrefix = $ExpectedName.Replace('-', '_')
+$expectedFilenamePrefix = "$filenamePrefix-$ExpectedVersion-"
+
+foreach ($wheel in $wheels) {
+    if (-not $wheel.Name.StartsWith($expectedFilenamePrefix)) {
+        throw "$($wheel.Name): expected filename prefix $expectedFilenamePrefix"
+    }
+
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($wheel.FullName)
+    try {
+        $members = @($archive.Entries | ForEach-Object { $_.FullName })
+        $metadataEntries = @(
+            $archive.Entries | Where-Object { $_.FullName.EndsWith('.dist-info/METADATA') }
+        )
+        if ($metadataEntries.Count -ne 1) {
+            throw "$($wheel.Name): expected one METADATA file, found $($metadataEntries.Count)"
+        }
+
+        $reader = [System.IO.StreamReader]::new($metadataEntries[0].Open())
+        try {
+            $metadata = $reader.ReadToEnd()
+        }
+        finally {
+            $reader.Dispose()
+        }
+
+        $nameMatch = [regex]::Match($metadata, '(?m)^Name:\s*(.+?)\r?$')
+        $versionMatch = [regex]::Match($metadata, '(?m)^Version:\s*(.+?)\r?$')
+        if (-not $nameMatch.Success) {
+            throw "$($wheel.Name): METADATA has no Name field"
+        }
+        if (-not $versionMatch.Success) {
+            throw "$($wheel.Name): METADATA has no Version field"
+        }
+
+        $actualName = ConvertTo-CanonicalName $nameMatch.Groups[1].Value
+        if ($actualName -ne $canonicalExpectedName) {
+            throw "$($wheel.Name): metadata Name is '$($nameMatch.Groups[1].Value)', expected '$ExpectedName'"
+        }
+        if ($versionMatch.Groups[1].Value -ne $ExpectedVersion) {
+            throw "$($wheel.Name): metadata Version is '$($versionMatch.Groups[1].Value)', expected '$ExpectedVersion'"
+        }
+
+        if ($RequireOdbc) {
+            foreach ($expectedMember in Get-ExpectedOdbcMembers $wheel.Name) {
+                if ($members -notcontains $expectedMember) {
+                    throw "$($wheel.Name): missing ODBC driver: $expectedMember"
+                }
+            }
+        }
+    }
+    finally {
+        $archive.Dispose()
+    }
+}
+
+Write-Host "Validated $($wheels.Count) $ExpectedName wheels"

--- a/.pipeline/scripts/verify-python-wheels.ps1
+++ b/.pipeline/scripts/verify-python-wheels.ps1
@@ -8,9 +8,6 @@ param(
     [Parameter(Mandatory = $true)]
     [string]$ExpectedVersion,
 
-    [Parameter(Mandatory = $true)]
-    [int]$ExpectedCount,
-
     [switch]$RequireOdbc
 )
 
@@ -79,15 +76,14 @@ function Get-ExpectedWheelNames {
     return @($expected)
 }
 
-$wheels = @(Get-ChildItem -Path $WheelsDir -Filter '*.whl' -File)
-if ($wheels.Count -ne $ExpectedCount) {
-    throw "Expected $ExpectedCount wheels, found $($wheels.Count)"
-}
-
 $canonicalExpectedName = ConvertTo-CanonicalName $ExpectedName
 $filenamePrefix = $ExpectedName.Replace('-', '_')
 $expectedFilenamePrefix = "$filenamePrefix-$ExpectedVersion-"
 $expectedWheelNames = @(Get-ExpectedWheelNames $filenamePrefix $ExpectedVersion)
+$wheels = @(Get-ChildItem -Path $WheelsDir -Filter '*.whl' -File)
+if ($wheels.Count -ne $expectedWheelNames.Count) {
+    throw "Expected $($expectedWheelNames.Count) wheels, found $($wheels.Count)"
+}
 $actualWheelNames = @($wheels | ForEach-Object { $_.Name })
 $missingWheels = @($expectedWheelNames | Where-Object { $actualWheelNames -notcontains $_ })
 $unexpectedWheels = @($actualWheelNames | Where-Object { $expectedWheelNames -notcontains $_ })

--- a/.pipeline/scripts/verify-python-wheels.ps1
+++ b/.pipeline/scripts/verify-python-wheels.ps1
@@ -85,8 +85,8 @@ if ($wheels.Count -ne $expectedWheelNames.Count) {
     throw "Expected $($expectedWheelNames.Count) wheels, found $($wheels.Count)"
 }
 $actualWheelNames = @($wheels | ForEach-Object { $_.Name })
-$missingWheels = @($expectedWheelNames | Where-Object { $actualWheelNames -notcontains $_ })
-$unexpectedWheels = @($actualWheelNames | Where-Object { $expectedWheelNames -notcontains $_ })
+$missingWheels = @($expectedWheelNames | Where-Object { $actualWheelNames -cnotcontains $_ })
+$unexpectedWheels = @($actualWheelNames | Where-Object { $expectedWheelNames -cnotcontains $_ })
 if ($missingWheels.Count -gt 0 -or $unexpectedWheels.Count -gt 0) {
     throw "Wheel matrix mismatch. Missing: $($missingWheels -join ', '); Unexpected: $($unexpectedWheels -join ', ')"
 }
@@ -133,7 +133,7 @@ foreach ($wheel in $wheels) {
 
         if ($RequireOdbc) {
             foreach ($expectedMember in Get-ExpectedOdbcMembers $wheel.Name) {
-                if ($members -notcontains $expectedMember) {
+                if ($members -cnotcontains $expectedMember) {
                     throw "$($wheel.Name): missing ODBC driver: $expectedMember"
                 }
             }

--- a/.pipeline/templates/private-link-smoke-template.yml
+++ b/.pipeline/templates/private-link-smoke-template.yml
@@ -20,7 +20,7 @@ parameters:
 - name: wheelPattern
   displayName: Glob to find the .whl inside the artifact
   type: string
-  default: 'mssql_py_core-*-cp314-*-linux*.whl'
+  default: 'mssql_python_rs-*-cp314-*-linux*.whl'
 
 - name: acrName
   type: string

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -124,13 +124,12 @@ stages:
       - template: install-dependencies.yml
         parameters:
           osType: Windows
-      # Unit-test the ODBC wheel-injection script on PR runs; the injection
-      # pipeline steps themselves are non-PR gated, so this is the only part of
-      # that change PR validation can exercise.
+      # Unit-test wheel packaging scripts on PR runs; the packaging pipeline
+      # steps themselves are non-PR gated.
       - pwsh: |
           python -m pip install --quiet pytest
-          python -m pytest scripts/test_inject_odbc.py -q
-        displayName: 'Unit test ODBC wheel injection script'
+          python -m pytest scripts/test_inject_odbc.py scripts/test_verify_python_wheels.py -q
+        displayName: 'Unit test Python wheel packaging scripts'
       - template: build-template.yml
         parameters:
           osType: Windows

--- a/docs/release-management.md
+++ b/docs/release-management.md
@@ -32,8 +32,8 @@ PyPI: mssql-python
 |---|---|---|---|---|---|
 | Windows x64 (`win_amd64`) | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Windows ARM64 (`win_arm64`) | — | ✅ | ✅ | ✅ | ✅ |
-| Linux glibc x64 (`manylinux_2_28_x86_64`) | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Linux glibc ARM64 (`manylinux_2_28_aarch64`) | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Linux glibc x64 (`linux_x86_64`) | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Linux glibc ARM64 (`linux_aarch64`) | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Linux musl x64 (`musllinux_1_2_x86_64`) | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Linux musl ARM64 (`musllinux_1_2_aarch64`) | ✅ | ✅ | ✅ | ✅ | ✅ |
 | macOS universal2 (`macosx_15_0_universal2`) | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -284,8 +284,8 @@ mssql-python-rs-wheels.0.1.10.nupkg
 ├── mssql-python-rs-wheels.nuspec
 └── wheels/
   ├── mssql_python_rs-0.1.0-cp310-cp310-win_amd64.whl
-  ├── mssql_python_rs-0.1.0-cp310-cp310-manylinux_2_28_x86_64.whl
-  ├── mssql_python_rs-0.1.0-cp310-cp310-manylinux_2_28_aarch64.whl
+  ├── mssql_python_rs-0.1.0-cp310-cp310-linux_x86_64.whl
+  ├── mssql_python_rs-0.1.0-cp310-cp310-linux_aarch64.whl
   ├── mssql_python_rs-0.1.0-cp310-cp310-musllinux_1_2_x86_64.whl
   ├── mssql_python_rs-0.1.0-cp310-cp310-musllinux_1_2_aarch64.whl
   ├── mssql_python_rs-0.1.0-cp310-cp310-macosx_15_0_universal2.whl

--- a/docs/release-management.md
+++ b/docs/release-management.md
@@ -1,4 +1,4 @@
-# mssql-py-core Release Management
+# mssql-python-rs Release Management
 
 How changes in `mssql-rs` (Rust) flow to `mssql-python` (Python) through the wheel build and NuGet publishing pipeline.
 
@@ -11,7 +11,7 @@ mssql-rs repo (Rust)
 └── .pipeline/OneBranch/ ← Builds wheels, packages into NuGet
 
         │  builds 34 wheels (5 Python × 7 platforms)
-        │  packages into NuGet: mssql-py-core-wheels
+        │  packages into NuGet: mssql-python-rs-wheels
         ▼
 
 Azure Artifacts feed: mssql-rs/mssql-rs
@@ -44,7 +44,12 @@ PyPI: mssql-python
 
 ## Version Scheme
 
-The NuGet package version is derived from `mssql-py-core/Cargo.toml` with a prerelease suffix:
+The Rust crate and NuGet transport package share the version from
+`mssql-py-core/Cargo.toml`. The `mssql-python-rs` Python distribution has an
+independent version in `mssql-py-core/pyproject.toml`. For example, NuGet
+`mssql-python-rs-wheels 0.1.10` can contain `mssql_python_rs-0.1.0-*.whl`.
+
+The NuGet prerelease suffix depends on the build type:
 
 | Build Type | Version Format | Example |
 |---|---|---|
@@ -71,7 +76,7 @@ NuGet SemVer 2.0 ordering: `dev` < `nightly` < release (no suffix).
 3. Publish stage:
    - Extracts version from mssql-py-core/Cargo.toml (e.g., 0.2.0)
    - Appends -nightly.YYYYMMDD suffix
-   - Packs wheels into NuGet: mssql-py-core-wheels.0.2.0-nightly.20260217
+  - Packs wheels into NuGet: mssql-python-rs-wheels.0.2.0-nightly.20260217
    - OneBranch auto-publishes to mssql-rs/mssql-rs feed
 4. mssql-python CI (next run) picks up the latest nightly
 ```
@@ -82,13 +87,13 @@ In its pipeline or `pyproject.toml` build script, `mssql-python` references the 
 
 ```
 # Download latest nightly wheels NuGet
-nuget install mssql-py-core-wheels -Version 0.2.0-nightly.* -Source mssql-rs/mssql-rs -Prerelease
+nuget install mssql-python-rs-wheels -Version 0.2.0-nightly.* -Source mssql-rs/mssql-rs -Prerelease
 ```
 
 Or pin a specific nightly:
 
 ```
-nuget install mssql-py-core-wheels -Version 0.2.0-nightly.20260217 -Source mssql-rs/mssql-rs
+nuget install mssql-python-rs-wheels -Version 0.2.0-nightly.20260217 -Source mssql-rs/mssql-rs
 ```
 
 ### Key properties
@@ -109,7 +114,7 @@ nuget install mssql-py-core-wheels -Version 0.2.0-nightly.20260217 -Source mssql
 1. Developer merges PR to main or development
 2. CI trigger fires immediately
 3. Pipeline builds 34 wheels
-4. Publish stage produces: mssql-py-core-wheels.0.2.0-dev.20260217.140071
+4. Publish stage produces: mssql-python-rs-wheels.0.2.0-dev.20260217.140071
    (BuildId ensures uniqueness even with multiple merges per day)
 5. Developer tells mssql-python to use this specific version
 ```
@@ -119,7 +124,7 @@ nuget install mssql-py-core-wheels -Version 0.2.0-nightly.20260217 -Source mssql
 ```
 1. Developer triggers pipeline manually from any branch
 2. Pipeline builds 34 wheels
-3. Publish stage produces: mssql-py-core-wheels.0.2.0-dev.20260217.140095
+3. Publish stage produces: mssql-python-rs-wheels.0.2.0-dev.20260217.140095
 4. Developer uses this version in mssql-python for testing
 ```
 
@@ -130,7 +135,7 @@ nuget install mssql-py-core-wheels -Version 0.2.0-nightly.20260217 -Source mssql
 
 ```powershell
 # Download the specific dev wheels
-nuget install mssql-py-core-wheels -Version 0.2.0-dev.20260217.140071 -Source mssql-rs/mssql-rs
+nuget install mssql-python-rs-wheels -Version 0.2.0-dev.20260217.140071 -Source mssql-rs/mssql-rs
 # Extract wheels and run mssql-python tests against them
 ```
 
@@ -145,7 +150,7 @@ nuget install mssql-py-core-wheels -Version 0.2.0-dev.20260217.140071 -Source ms
 
 ---
 
-## Scenario 3: Upgrading mssql-python to a New mssql-py-core Version
+## Scenario 3: Upgrading mssql-python to a New Native Package Version
 
 **Purpose**: When `mssql-python` needs to adopt a new version of the native core (e.g., new features, bug fixes).
 
@@ -155,8 +160,8 @@ nuget install mssql-py-core-wheels -Version 0.2.0-dev.20260217.140071 -Source ms
 2. **Bump version** in `mssql-py-core/Cargo.toml` (and `mssql-tds/Cargo.toml` if changed)
    - First code change in a sprint bumps the version
    - Subsequent changes in the same sprint do NOT bump again
-3. **Merge PR** — CI produces `mssql-py-core-wheels.0.2.1-dev.YYYYMMDD.BuildId`
-4. **Nightly** picks it up: `mssql-py-core-wheels.0.2.1-nightly.YYYYMMDD`
+3. **Merge PR** — CI produces `mssql-python-rs-wheels.0.2.1-dev.YYYYMMDD.BuildId`
+4. **Nightly** picks it up: `mssql-python-rs-wheels.0.2.1-nightly.YYYYMMDD`
 
 ### Steps in mssql-python
 
@@ -169,7 +174,7 @@ nuget install mssql-py-core-wheels -Version 0.2.0-dev.20260217.140071 -Source ms
     command: restore
     # Update from 0.2.0 to 0.2.1 (or use -nightly.* for latest)
     restoreSource: mssql-rs/mssql-rs
-    packages: mssql-py-core-wheels@0.2.1-nightly.*
+    packages: mssql-python-rs-wheels@0.2.1-nightly.*
 ```
 
 2. **Update any Python-side bindings** if the native API changed (new functions, changed signatures)
@@ -194,7 +199,7 @@ Week 2:
   mssql-python: tests against 0.2.1-nightly.20260310 ✅
 
 Sprint end:
-  mssql-rs: Official release → mssql-py-core-wheels.0.2.1 (clean)
+  mssql-rs: Official release → mssql-python-rs-wheels.0.2.1 (clean)
   mssql-python: pins to 0.2.1 release, does its own release
 ```
 
@@ -202,7 +207,7 @@ Sprint end:
 
 ## Scenario 4: Release Activities
 
-**Purpose**: Produce a production-quality, signed, immutable release of `mssql-py-core-wheels`.
+**Purpose**: Produce a production-quality, signed, immutable release of `mssql-python-rs-wheels`.
 
 ### Pre-release checklist (mssql-rs)
 
@@ -214,7 +219,7 @@ Sprint end:
 ### Release build
 
 1. **Trigger the Official pipeline manually** with `isOfficial: true`
-   - This produces a clean semver NuGet: `mssql-py-core-wheels.0.2.1`
+  - This produces a clean semver NuGet: `mssql-python-rs-wheels.0.2.1`
    - OneBranch runs full SDL scanning (BinSkim, Clippy, AV)
    - Package is published to `mssql-rs/mssql-rs` feed
 
@@ -234,7 +239,7 @@ git push origin release/0.2.1
 
 ### Post-release in mssql-python
 
-1. Update NuGet reference to the clean release version: `mssql-py-core-wheels@0.2.1`
+1. Update NuGet reference to the clean release version: `mssql-python-rs-wheels@0.2.1`
 2. Run full test suite
 3. Update `mssql-python` version (e.g., bump to `1.4.0`)
 4. Publish to PyPI
@@ -249,7 +254,7 @@ main            ──●──●──●──●──  (sprint 43 work cont
 release/0.2.1   ───────●── cherry-pick fix
                        │
                        └── bump to 0.2.2, trigger Official pipeline
-                           → mssql-py-core-wheels.0.2.2
+                           → mssql-python-rs-wheels.0.2.2
                            → tag v0.2.2
 ```
 
@@ -275,19 +280,19 @@ Steps:
 ## NuGet Package Structure
 
 ```
-mssql-py-core-wheels.0.2.1.nupkg
-├── mssql-py-core-wheels.nuspec
+mssql-python-rs-wheels.0.1.10.nupkg
+├── mssql-python-rs-wheels.nuspec
 └── wheels/
-    ├── mssql_py_core-0.2.1-cp310-cp310-win_amd64.whl
-    ├── mssql_py_core-0.2.1-cp310-cp310-manylinux_2_28_x86_64.whl
-    ├── mssql_py_core-0.2.1-cp310-cp310-manylinux_2_28_aarch64.whl
-    ├── mssql_py_core-0.2.1-cp310-cp310-musllinux_1_2_x86_64.whl
-    ├── mssql_py_core-0.2.1-cp310-cp310-musllinux_1_2_aarch64.whl
-    ├── mssql_py_core-0.2.1-cp310-cp310-macosx_15_0_universal2.whl
-    ├── mssql_py_core-0.2.1-cp311-cp311-win_amd64.whl
-    ├── mssql_py_core-0.2.1-cp311-cp311-win_arm64.whl
+  ├── mssql_python_rs-0.1.0-cp310-cp310-win_amd64.whl
+  ├── mssql_python_rs-0.1.0-cp310-cp310-manylinux_2_28_x86_64.whl
+  ├── mssql_python_rs-0.1.0-cp310-cp310-manylinux_2_28_aarch64.whl
+  ├── mssql_python_rs-0.1.0-cp310-cp310-musllinux_1_2_x86_64.whl
+  ├── mssql_python_rs-0.1.0-cp310-cp310-musllinux_1_2_aarch64.whl
+  ├── mssql_python_rs-0.1.0-cp310-cp310-macosx_15_0_universal2.whl
+  ├── mssql_python_rs-0.1.0-cp311-cp311-win_amd64.whl
+  ├── mssql_python_rs-0.1.0-cp311-cp311-win_arm64.whl
     ├── ... (34 wheels total)
-    └── mssql_py_core-0.2.1-cp314-cp314-macosx_15_0_universal2.whl
+  └── mssql_python_rs-0.1.0-cp314-cp314-macosx_15_0_universal2.whl
 ```
 
 ## Traceability
@@ -297,8 +302,8 @@ Every NuGet package description includes:
 - Azure DevOps build number
 
 ```
-mssql-py-core-wheels 0.2.1
-Description: Python wheels for mssql-py-core across all platforms. Commit: a1b2c3d4. Build: 20260217.1
+mssql-python-rs-wheels 0.1.10
+Description: Python wheels containing the mssql-python-rs TDS core and ODBC driver. Commit: a1b2c3d4. Build: 20260217.1
 ```
 
 This creates: **NuGet version → git tag → exact source commit → pipeline run with logs**.

--- a/mssql-py-core/pyproject.toml
+++ b/mssql-py-core/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["maturin>=1.0,<2.0"]
 build-backend = "maturin"
 
 [project]
-name = "mssql-py-core"
+name = "mssql-python-rs"
 version = "0.1.0"
 requires-python = ">=3.8"
 classifiers = [

--- a/scripts/test_inject_odbc.py
+++ b/scripts/test_inject_odbc.py
@@ -44,9 +44,9 @@ def test_drivers_for_platform_tag(tag, expected):
 
 def test_musl_and_glibc_do_not_collide():
     # The whole design rests on these two resolving to different drivers.
-    assert inject.drivers_for_platform_tag("musllinux_1_2_x86_64") != inject.drivers_for_platform_tag(
-        "linux_x86_64"
-    )
+    assert inject.drivers_for_platform_tag(
+        "musllinux_1_2_x86_64"
+    ) != inject.drivers_for_platform_tag("linux_x86_64")
 
 
 @pytest.mark.parametrize("tag", ["win_ia64", "linux_riscv64", "any", ""])
@@ -57,9 +57,15 @@ def test_unrecognized_tag_returns_empty(tag):
 @pytest.mark.parametrize(
     "wheel_name, expected_tag",
     [
-        ("mssql_py_core-0.1.0-cp312-cp312-win_amd64.whl", "win_amd64"),
-        ("mssql_py_core-0.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", "musllinux_1_2_aarch64"),
-        ("mssql_py_core-0.1.0-cp311-cp311-macosx_15_0_universal2.whl", "macosx_15_0_universal2"),
+        ("mssql_python_rs-0.1.0-cp312-cp312-win_amd64.whl", "win_amd64"),
+        (
+            "mssql_python_rs-0.1.0-cp313-cp313-musllinux_1_2_aarch64.whl",
+            "musllinux_1_2_aarch64",
+        ),
+        (
+            "mssql_python_rs-0.1.0-cp311-cp311-macosx_15_0_universal2.whl",
+            "macosx_15_0_universal2",
+        ),
     ],
 )
 def test_platform_tag_of(wheel_name, expected_tag):
@@ -79,8 +85,8 @@ def _make_wheel(path: Path) -> None:
     with zipfile.ZipFile(path, "w") as zf:
         zf.writestr("mssql_py_core/__init__.py", b"# core\n")
         zf.writestr(
-            "mssql_py_core-0.1.0.dist-info/RECORD",
-            "mssql_py_core/__init__.py,,\nmssql_py_core-0.1.0.dist-info/RECORD,,\n",
+            "mssql_python_rs-0.1.0.dist-info/RECORD",
+            "mssql_py_core/__init__.py,,\n" "mssql_python_rs-0.1.0.dist-info/RECORD,,\n",
         )
 
 
@@ -90,7 +96,7 @@ def test_inject_roundtrip(tmp_path):
     driver_bytes = b"\x4d\x5aFAKE-DLL"
     (drivers / "windows" / "x64" / "mssqlodbc.dll").write_bytes(driver_bytes)
 
-    wheel = tmp_path / "mssql_py_core-0.1.0-cp312-cp312-win_amd64.whl"
+    wheel = tmp_path / "mssql_python_rs-0.1.0-cp312-cp312-win_amd64.whl"
     _make_wheel(wheel)
 
     inject.inject_wheel(wheel, drivers)
@@ -100,11 +106,11 @@ def test_inject_roundtrip(tmp_path):
         names = zf.namelist()
         assert arc in names
         assert zf.read(arc) == driver_bytes
-        record = zf.read("mssql_py_core-0.1.0.dist-info/RECORD").decode("utf-8")
+        record = zf.read("mssql_python_rs-0.1.0.dist-info/RECORD").decode("utf-8")
 
     assert inject._record_line(arc, driver_bytes) in record.splitlines()
     # RECORD's own line stays hash-less.
-    assert "mssql_py_core-0.1.0.dist-info/RECORD,," in record
+    assert "mssql_python_rs-0.1.0.dist-info/RECORD,," in record
 
 
 def test_inject_preserves_entry_modes(tmp_path):
@@ -112,14 +118,14 @@ def test_inject_preserves_entry_modes(tmp_path):
     (drivers / "windows" / "x64").mkdir(parents=True)
     (drivers / "windows" / "x64" / "mssqlodbc.dll").write_bytes(b"MZ")
 
-    wheel = tmp_path / "mssql_py_core-0.1.0-cp312-cp312-win_amd64.whl"
+    wheel = tmp_path / "mssql_python_rs-0.1.0-cp312-cp312-win_amd64.whl"
     with zipfile.ZipFile(wheel, "w") as zf:
         exe = zipfile.ZipInfo("mssql_py_core/_core.pyd")
         exe.external_attr = 0o755 << 16
         zf.writestr(exe, b"\x4d\x5a")
         zf.writestr(
-            "mssql_py_core-0.1.0.dist-info/RECORD",
-            "mssql_py_core/_core.pyd,,\nmssql_py_core-0.1.0.dist-info/RECORD,,\n",
+            "mssql_python_rs-0.1.0.dist-info/RECORD",
+            "mssql_py_core/_core.pyd,,\n" "mssql_python_rs-0.1.0.dist-info/RECORD,,\n",
         )
 
     inject.inject_wheel(wheel, drivers)
@@ -138,14 +144,14 @@ def test_inject_preserves_entry_modes(tmp_path):
 
 
 def test_inject_missing_driver_fails(tmp_path):
-    wheel = tmp_path / "mssql_py_core-0.1.0-cp312-cp312-win_amd64.whl"
+    wheel = tmp_path / "mssql_python_rs-0.1.0-cp312-cp312-win_amd64.whl"
     _make_wheel(wheel)
     with pytest.raises(SystemExit):
         inject.inject_wheel(wheel, tmp_path / "empty-drivers")
 
 
 def test_inject_unknown_tag_fails(tmp_path):
-    wheel = tmp_path / "mssql_py_core-0.1.0-cp312-cp312-win_ia64.whl"
+    wheel = tmp_path / "mssql_python_rs-0.1.0-cp312-cp312-win_ia64.whl"
     _make_wheel(wheel)
     with pytest.raises(SystemExit):
         inject.inject_wheel(wheel, tmp_path / "drivers")

--- a/scripts/test_verify_python_wheels.py
+++ b/scripts/test_verify_python_wheels.py
@@ -62,7 +62,6 @@ def write_wheel_matrix(directory: Path) -> list[Path]:
 
 def run_validator(
     wheels_dir: Path,
-    expected_count: int,
     *,
     require_odbc: bool = True,
 ) -> subprocess.CompletedProcess[str]:
@@ -77,8 +76,6 @@ def run_validator(
         "mssql-python-rs",
         "-ExpectedVersion",
         "0.1.0",
-        "-ExpectedCount",
-        str(expected_count),
     ]
     if require_odbc:
         command.append("-RequireOdbc")
@@ -91,9 +88,9 @@ def run_validator(
 
 
 def test_validator_accepts_expected_wheel_matrix(tmp_path: Path) -> None:
-    wheels = write_wheel_matrix(tmp_path)
+    write_wheel_matrix(tmp_path)
 
-    result = run_validator(tmp_path, len(wheels))
+    result = run_validator(tmp_path)
 
     assert result.returncode == 0, result.stderr
     assert "Validated 34 mssql-python-rs wheels" in result.stdout
@@ -104,7 +101,7 @@ def test_validator_rejects_missing_odbc_driver(tmp_path: Path) -> None:
     wheels[0].unlink()
     write_wheel(tmp_path, "win_amd64", python_tag="cp310", include_odbc=False)
 
-    result = run_validator(tmp_path, 34)
+    result = run_validator(tmp_path)
 
     assert result.returncode != 0
     assert "missing ODBC driver" in result.stderr
@@ -118,7 +115,7 @@ def test_validator_allows_matrix_without_odbc_when_not_required(tmp_path: Path) 
         python_tag = wheel_path.name.split("-")[2]
         write_wheel(tmp_path, platform, python_tag=python_tag, include_odbc=False)
 
-    result = run_validator(tmp_path, 34, require_odbc=False)
+    result = run_validator(tmp_path, require_odbc=False)
 
     assert result.returncode == 0, result.stderr
 
@@ -128,7 +125,7 @@ def test_validator_rejects_legacy_filename(tmp_path: Path) -> None:
     wheels[0].unlink()
     write_wheel(tmp_path, "win_amd64", python_tag="cp310", distribution="mssql_py_core")
 
-    result = run_validator(tmp_path, 34)
+    result = run_validator(tmp_path)
 
     assert result.returncode != 0
     assert "Wheel matrix mismatch" in result.stderr
@@ -138,7 +135,7 @@ def test_validator_rejects_legacy_filename(tmp_path: Path) -> None:
 def test_validator_rejects_incomplete_matrix(tmp_path: Path) -> None:
     write_wheel(tmp_path, "win_amd64")
 
-    result = run_validator(tmp_path, 34)
+    result = run_validator(tmp_path)
 
     assert result.returncode != 0
     assert "Expected 34 wheels, found 1" in result.stderr
@@ -149,7 +146,7 @@ def test_validator_rejects_same_count_with_unexpected_wheel(tmp_path: Path) -> N
     wheels[0].unlink()
     write_wheel(tmp_path, "win_amd64", python_tag="cp400")
 
-    result = run_validator(tmp_path, 34)
+    result = run_validator(tmp_path)
 
     assert result.returncode != 0
     assert "Wheel matrix mismatch" in result.stderr

--- a/scripts/test_verify_python_wheels.py
+++ b/scripts/test_verify_python_wheels.py
@@ -1,0 +1,111 @@
+"""Tests for final mssql-python-rs wheel validation."""
+
+from __future__ import annotations
+
+import subprocess
+import zipfile
+from pathlib import Path
+
+_VALIDATOR = (
+    Path(__file__).parents[1]
+    / ".pipeline"
+    / "scripts"
+    / "verify-python-wheels.ps1"
+)
+
+_LIBS = "mssql_py_core/libs"
+_PLATFORM_DRIVERS = {
+    "win_amd64": (f"{_LIBS}/windows/x64/mssqlodbc.dll",),
+    "win_arm64": (f"{_LIBS}/windows/arm64/mssqlodbc.dll",),
+    "linux_x86_64": (f"{_LIBS}/linux/glibc/x86_64/lib/mssqlodbc.so",),
+    "linux_aarch64": (f"{_LIBS}/linux/glibc/arm64/lib/mssqlodbc.so",),
+    "musllinux_1_2_x86_64": (f"{_LIBS}/linux/musl/x86_64/lib/mssqlodbc.so",),
+    "musllinux_1_2_aarch64": (f"{_LIBS}/linux/musl/arm64/lib/mssqlodbc.so",),
+    "macosx_15_0_universal2": (
+        f"{_LIBS}/macos/x86_64/lib/mssqlodbc.dylib",
+        f"{_LIBS}/macos/arm64/lib/mssqlodbc.dylib",
+    ),
+}
+
+
+def write_wheel(
+    directory: Path,
+    platform: str,
+    *,
+    distribution: str = "mssql_python_rs",
+    include_odbc: bool = True,
+) -> Path:
+    wheel_path = directory / f"{distribution}-0.1.0-cp313-cp313-{platform}.whl"
+    with zipfile.ZipFile(wheel_path, "w") as wheel:
+        wheel.writestr(
+            "mssql_python_rs-0.1.0.dist-info/METADATA",
+            "Metadata-Version: 2.4\nName: mssql-python-rs\nVersion: 0.1.0\n",
+        )
+        wheel.writestr("mssql_py_core/__init__.py", "")
+        if include_odbc:
+            for driver in _PLATFORM_DRIVERS[platform]:
+                wheel.writestr(driver, b"driver")
+    return wheel_path
+
+
+def run_validator(
+    wheels_dir: Path,
+    expected_count: int,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "pwsh",
+            "-NoProfile",
+            "-File",
+            str(_VALIDATOR),
+            "-WheelsDir",
+            str(wheels_dir),
+            "-ExpectedName",
+            "mssql-python-rs",
+            "-ExpectedVersion",
+            "0.1.0",
+            "-ExpectedCount",
+            str(expected_count),
+            "-RequireOdbc",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_validator_accepts_all_platform_payloads(tmp_path: Path) -> None:
+    for platform in _PLATFORM_DRIVERS:
+        write_wheel(tmp_path, platform)
+
+    result = run_validator(tmp_path, len(_PLATFORM_DRIVERS))
+
+    assert result.returncode == 0, result.stderr
+    assert "Validated 7 mssql-python-rs wheels" in result.stdout
+
+
+def test_validator_rejects_missing_odbc_driver(tmp_path: Path) -> None:
+    write_wheel(tmp_path, "win_amd64", include_odbc=False)
+
+    result = run_validator(tmp_path, 1)
+
+    assert result.returncode != 0
+    assert "missing ODBC driver" in result.stderr
+
+
+def test_validator_rejects_legacy_filename(tmp_path: Path) -> None:
+    write_wheel(tmp_path, "win_amd64", distribution="mssql_py_core")
+
+    result = run_validator(tmp_path, 1)
+
+    assert result.returncode != 0
+    assert "expected filename prefix" in result.stderr
+
+
+def test_validator_rejects_incomplete_matrix(tmp_path: Path) -> None:
+    write_wheel(tmp_path, "win_amd64")
+
+    result = run_validator(tmp_path, 34)
+
+    assert result.returncode != 0
+    assert "Expected 34 wheels, found 1" in result.stderr

--- a/scripts/test_verify_python_wheels.py
+++ b/scripts/test_verify_python_wheels.py
@@ -31,6 +31,7 @@ def write_wheel(
     python_tag: str = "cp313",
     distribution: str = "mssql_python_rs",
     include_odbc: bool = True,
+    uppercase_odbc: bool = False,
 ) -> Path:
     wheel_path = directory / f"{distribution}-0.1.0-{python_tag}-{python_tag}-{platform}.whl"
     with zipfile.ZipFile(wheel_path, "w") as wheel:
@@ -41,6 +42,8 @@ def write_wheel(
         wheel.writestr("mssql_py_core/__init__.py", "")
         if include_odbc:
             for driver in _PLATFORM_DRIVERS[platform]:
+                if uppercase_odbc:
+                    driver = driver.upper()
                 wheel.writestr(driver, b"driver")
     return wheel_path
 
@@ -107,6 +110,19 @@ def test_validator_rejects_missing_odbc_driver(tmp_path: Path) -> None:
     assert "missing ODBC driver" in result.stderr
 
 
+def test_validator_rejects_wrong_case_odbc_driver(tmp_path: Path) -> None:
+    wheels = write_wheel_matrix(tmp_path)
+    linux_wheel = next(wheel for wheel in wheels if "cp310-cp310-linux_x86_64" in wheel.name)
+    linux_wheel.unlink()
+    write_wheel(tmp_path, "linux_x86_64", python_tag="cp310", uppercase_odbc=True)
+
+    result = run_validator(tmp_path)
+
+    assert result.returncode != 0
+    assert "missing ODBC driver" in result.stderr
+    assert "mssqlodbc.so" in result.stderr
+
+
 def test_validator_allows_matrix_without_odbc_when_not_required(tmp_path: Path) -> None:
     wheels = write_wheel_matrix(tmp_path)
     for wheel_path in wheels:
@@ -152,3 +168,15 @@ def test_validator_rejects_same_count_with_unexpected_wheel(tmp_path: Path) -> N
     assert "Wheel matrix mismatch" in result.stderr
     assert "cp310-cp310-win_amd64" in result.stderr
     assert "cp400-cp400-win_amd64" in result.stderr
+
+
+def test_validator_rejects_wrong_case_wheel_filename(tmp_path: Path) -> None:
+    wheels = write_wheel_matrix(tmp_path)
+    linux_wheel = next(wheel for wheel in wheels if "cp310-cp310-linux_x86_64" in wheel.name)
+    uppercase_name = linux_wheel.name.replace("linux", "LINUX")
+    linux_wheel.rename(linux_wheel.with_name(uppercase_name))
+
+    result = run_validator(tmp_path)
+
+    assert result.returncode != 0
+    assert "Wheel matrix mismatch" in result.stderr

--- a/scripts/test_verify_python_wheels.py
+++ b/scripts/test_verify_python_wheels.py
@@ -6,12 +6,7 @@ import subprocess
 import zipfile
 from pathlib import Path
 
-_VALIDATOR = (
-    Path(__file__).parents[1]
-    / ".pipeline"
-    / "scripts"
-    / "verify-python-wheels.ps1"
-)
+_VALIDATOR = Path(__file__).parents[1] / ".pipeline" / "scripts" / "verify-python-wheels.ps1"
 
 _LIBS = "mssql_py_core/libs"
 _PLATFORM_DRIVERS = {
@@ -26,16 +21,18 @@ _PLATFORM_DRIVERS = {
         f"{_LIBS}/macos/arm64/lib/mssqlodbc.dylib",
     ),
 }
+_PYTHON_TAGS = ("cp310", "cp311", "cp312", "cp313", "cp314")
 
 
 def write_wheel(
     directory: Path,
     platform: str,
     *,
+    python_tag: str = "cp313",
     distribution: str = "mssql_python_rs",
     include_odbc: bool = True,
 ) -> Path:
-    wheel_path = directory / f"{distribution}-0.1.0-cp313-cp313-{platform}.whl"
+    wheel_path = directory / f"{distribution}-0.1.0-{python_tag}-{python_tag}-{platform}.whl"
     with zipfile.ZipFile(wheel_path, "w") as wheel:
         wheel.writestr(
             "mssql_python_rs-0.1.0.dist-info/METADATA",
@@ -48,58 +45,94 @@ def write_wheel(
     return wheel_path
 
 
+def write_wheel_matrix(directory: Path) -> list[Path]:
+    wheels = [
+        write_wheel(directory, platform, python_tag=python_tag)
+        for python_tag in _PYTHON_TAGS
+        for platform in _PLATFORM_DRIVERS
+        if platform != "win_arm64"
+    ]
+    wheels.extend(
+        write_wheel(directory, "win_arm64", python_tag=python_tag)
+        for python_tag in _PYTHON_TAGS
+        if python_tag != "cp310"
+    )
+    return wheels
+
+
 def run_validator(
     wheels_dir: Path,
     expected_count: int,
+    *,
+    require_odbc: bool = True,
 ) -> subprocess.CompletedProcess[str]:
+    command = [
+        "pwsh",
+        "-NoProfile",
+        "-File",
+        str(_VALIDATOR),
+        "-WheelsDir",
+        str(wheels_dir),
+        "-ExpectedName",
+        "mssql-python-rs",
+        "-ExpectedVersion",
+        "0.1.0",
+        "-ExpectedCount",
+        str(expected_count),
+    ]
+    if require_odbc:
+        command.append("-RequireOdbc")
     return subprocess.run(
-        [
-            "pwsh",
-            "-NoProfile",
-            "-File",
-            str(_VALIDATOR),
-            "-WheelsDir",
-            str(wheels_dir),
-            "-ExpectedName",
-            "mssql-python-rs",
-            "-ExpectedVersion",
-            "0.1.0",
-            "-ExpectedCount",
-            str(expected_count),
-            "-RequireOdbc",
-        ],
+        command,
         capture_output=True,
         text=True,
         check=False,
     )
 
 
-def test_validator_accepts_all_platform_payloads(tmp_path: Path) -> None:
-    for platform in _PLATFORM_DRIVERS:
-        write_wheel(tmp_path, platform)
+def test_validator_accepts_expected_wheel_matrix(tmp_path: Path) -> None:
+    wheels = write_wheel_matrix(tmp_path)
 
-    result = run_validator(tmp_path, len(_PLATFORM_DRIVERS))
+    result = run_validator(tmp_path, len(wheels))
 
     assert result.returncode == 0, result.stderr
-    assert "Validated 7 mssql-python-rs wheels" in result.stdout
+    assert "Validated 34 mssql-python-rs wheels" in result.stdout
 
 
 def test_validator_rejects_missing_odbc_driver(tmp_path: Path) -> None:
-    write_wheel(tmp_path, "win_amd64", include_odbc=False)
+    wheels = write_wheel_matrix(tmp_path)
+    wheels[0].unlink()
+    write_wheel(tmp_path, "win_amd64", python_tag="cp310", include_odbc=False)
 
-    result = run_validator(tmp_path, 1)
+    result = run_validator(tmp_path, 34)
 
     assert result.returncode != 0
     assert "missing ODBC driver" in result.stderr
 
 
-def test_validator_rejects_legacy_filename(tmp_path: Path) -> None:
-    write_wheel(tmp_path, "win_amd64", distribution="mssql_py_core")
+def test_validator_allows_matrix_without_odbc_when_not_required(tmp_path: Path) -> None:
+    wheels = write_wheel_matrix(tmp_path)
+    for wheel_path in wheels:
+        platform = wheel_path.stem.rsplit("-", 1)[1]
+        wheel_path.unlink()
+        python_tag = wheel_path.name.split("-")[2]
+        write_wheel(tmp_path, platform, python_tag=python_tag, include_odbc=False)
 
-    result = run_validator(tmp_path, 1)
+    result = run_validator(tmp_path, 34, require_odbc=False)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_validator_rejects_legacy_filename(tmp_path: Path) -> None:
+    wheels = write_wheel_matrix(tmp_path)
+    wheels[0].unlink()
+    write_wheel(tmp_path, "win_amd64", python_tag="cp310", distribution="mssql_py_core")
+
+    result = run_validator(tmp_path, 34)
 
     assert result.returncode != 0
-    assert "expected filename prefix" in result.stderr
+    assert "Wheel matrix mismatch" in result.stderr
+    assert "mssql_py_core-0.1.0-cp310-cp310-win_amd64.whl" in result.stderr
 
 
 def test_validator_rejects_incomplete_matrix(tmp_path: Path) -> None:
@@ -109,3 +142,16 @@ def test_validator_rejects_incomplete_matrix(tmp_path: Path) -> None:
 
     assert result.returncode != 0
     assert "Expected 34 wheels, found 1" in result.stderr
+
+
+def test_validator_rejects_same_count_with_unexpected_wheel(tmp_path: Path) -> None:
+    wheels = write_wheel_matrix(tmp_path)
+    wheels[0].unlink()
+    write_wheel(tmp_path, "win_amd64", python_tag="cp400")
+
+    result = run_validator(tmp_path, 34)
+
+    assert result.returncode != 0
+    assert "Wheel matrix mismatch" in result.stderr
+    assert "cp310-cp310-win_amd64" in result.stderr
+    assert "cp400-cp400-win_amd64" in result.stderr


### PR DESCRIPTION
## Description

Rename the combined Rust Python wheel distribution and NuGet transport package to `mssql-python-rs` while preserving the `mssql_py_core` import. Enable ODBC payloads by default for non-official wheels and validate the complete 34-wheel artifact set before NuGet packaging.

The Cargo and NuGet version remains `0.1.10`; the Python distribution version remains independently versioned at `0.1.0`.

## Related Issues

https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47953

## Validation

- `cargo bfmt`
- 26 focused wheel validation and ODBC injection tests
- Real Windows wheel build, ODBC injection, and final PowerShell artifact validation
- PowerShell parser checks and `git diff --check`

`cargo bclippy` is currently blocked before compilation because the baseline frozen `Cargo.lock` requests an update even though this change does not modify Cargo manifests or the lockfile. `cargo btest` was not rerun after that prerequisite failed.

## Checklist

- [x] `cargo bfmt` passes
- [ ] `cargo bclippy` passes
- [ ] `cargo btest` passes
- [x] New/changed functionality has tests
- [x] Public API changes are documented