### PR TITLE
Fix PyPI release trusted branch

### DIFF
--- a/.pipeline/OneBranch/PyPIRelease.yml
+++ b/.pipeline/OneBranch/PyPIRelease.yml
@@ -14,7 +14,7 @@
 #                                                                               #
 # Manual trigger only. `publishToPyPI` defaults to false: a default run is a    #
 # dry run that verifies and stages the committed sdist with NO publish. Flip it  #
-# to true only for a deliberate publish from `main`.                             #
+# to true only for a deliberate publish from `stable`.                           #
 #                                                                               #
 # Reuses the shared 'ESRP Federated Creds (AME)' variable group (same AKV cert  #
 # / ESRP creds mssql-python publishes with).                                    #
@@ -91,10 +91,10 @@ extends:
 
         - ${{ if eq(parameters.publishToPyPI, true) }}:
           - pwsh: |
-              if ("$(Build.SourceBranch)" -ne 'refs/heads/main') {
-                throw 'PyPI publishing is allowed only from refs/heads/main.'
+              if ("$(Build.SourceBranch)" -ne 'refs/heads/stable') {
+                throw 'PyPI publishing is allowed only from refs/heads/stable.'
               }
-            displayName: 'Require main branch for publish'
+            displayName: 'Require stable branch for publish'
 
         - pwsh: |
             $ErrorActionPreference = 'Stop'


### PR DESCRIPTION
### Summary

Aligns the PyPI reservation pipeline's publish guard with the repository's trusted release branch. The Azure DevOps pipeline reads from the ADO repository, where `stable` is the reviewed mirror of GitHub `main`; ADO `main` is not the release branch.

- Require `refs/heads/stable` when `publishToPyPI=true`.
- Update the pipeline comments, failure message, and step label to match.
- Keep dry-run behavior and ESRP publication inputs unchanged.

### Validation

- Parsed `.pipeline/OneBranch/PyPIRelease.yml` with `yaml.safe_load`.
- Verified all publish-policy text references `stable` and no guard text references `main`.
- `git diff --check`
- `cargo bfmt`

[AB#47922](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47922)