### PR TITLE
Package the macOS docker toolchain and install CI from our own feed

### DIFF
--- a/.pipeline/macos-docker-toolchain-pipeline.yml
+++ b/.pipeline/macos-docker-toolchain-pipeline.yml
@@ -1,0 +1,79 @@
+# Publishes the macOS docker toolchain (docker CLI, colima, lima and the guest
+# disk image colima boots) as a Universal Package per architecture, so macOS CI
+# jobs install it from our own feed instead of reaching Homebrew, ghcr.io and
+# github.com at job time.
+#
+# Background: Homebrew stopped bottling the docker CLI for Intel macOS at 29.8.0,
+# so `brew install docker` began source-building it (and Go with it, ~8 min),
+# timing out Test MacOS. Colima also downloads a ~350 MB guest image from a
+# personal GitHub repo on every run, which has independently failed on DNS.
+#
+# Manual trigger by design: bumping the toolchain should be a deliberate act with
+# a reviewed version, not something an agent's Homebrew state decides.
+#
+# The build runs on Linux -- it only fetches, verifies and repacks; nothing in
+# the payload is executed here. build-macos-docker-toolchain.py checks the Mach-O
+# architecture of every binary it packs, so a mis-resolved bottle fails the build
+# rather than shipping.
+
+trigger: none
+pr: none
+
+parameters:
+# Versioning is about the payload, not the tools inside it -- manifest.json is
+# the record of which docker/colima/lima/image versions a package contains:
+#   MAJOR  the directory layout changed, so consumers must change with it
+#   MINOR  component versions changed (a colima or docker bump)
+#   PATCH  same components, rebuilt
+- name: packageVersion
+  displayName: 'Package version, e.g. 1.2.0 (SemVer, immutable once published)'
+  type: string
+
+- name: publishX64
+  displayName: 'Publish x86_64 package'
+  type: boolean
+  default: true
+
+- name: publishArm64
+  displayName: 'Publish arm64 package'
+  type: boolean
+  default: true
+
+- name: dryRun
+  displayName: 'Dry run (build and inspect, do not publish)'
+  type: boolean
+  default: false
+
+- name: macosMajorFloor
+  displayName: 'Oldest macOS major version the payload must run on'
+  type: number
+  default: 14
+
+# A parameter rather than a variable: the job template consumes it at compile
+# time, where runtime variables are not available.
+- name: feed
+  displayName: 'Azure Artifacts feed to publish to'
+  type: string
+  default: 'public/mssql-rs_Public'
+
+stages:
+- stage: Publish_macOS_Docker_Toolchain
+  displayName: 'Publish macOS docker toolchain'
+  jobs:
+  - ${{ if eq(parameters.publishX64, true) }}:
+    - template: templates/macos-toolchain-job.yml
+      parameters:
+        arch: x86_64
+        packageVersion: ${{ parameters.packageVersion }}
+        macosMajorFloor: ${{ parameters.macosMajorFloor }}
+        dryRun: ${{ parameters.dryRun }}
+        feed: ${{ parameters.feed }}
+
+  - ${{ if eq(parameters.publishArm64, true) }}:
+    - template: templates/macos-toolchain-job.yml
+      parameters:
+        arch: arm64
+        packageVersion: ${{ parameters.packageVersion }}
+        macosMajorFloor: ${{ parameters.macosMajorFloor }}
+        dryRun: ${{ parameters.dryRun }}
+        feed: ${{ parameters.feed }}

--- a/.pipeline/macos-docker-toolchain-pipeline.yml
+++ b/.pipeline/macos-docker-toolchain-pipeline.yml
@@ -110,19 +110,33 @@ stages:
         - imageOverride -equals RUST-UBUSLIM
     steps:
     - checkout: self
+    # Every run-dialog value is passed as an environment variable, never
+    # substituted into the script body: `${{ parameters.x }}` is textual
+    # substitution into shell source before bash sees it, so a value containing
+    # a quote closes the quoting and the rest of it runs as commands. As an
+    # environment value it is data, and the shell never parses it.
     - script: |
         set -euo pipefail
+        args=()
+        for arch in $ARCHITECTURES; do args+=(--arch "$arch"); done
         python3 .pipeline/scripts/resolve-toolchain-version.py \
-          --org '$(System.CollectionUri)' \
-          --feed '${{ parameters.feed }}' \
-          --arch ${{ join(' --arch ', parameters.architectures) }} \
-          --macos-major ${{ parameters.macosMajorFloor }} \
-          --version '${{ parameters.packageVersion }}' \
+          --org "$ORG" \
+          --feed "$FEED" \
+          "${args[@]}" \
+          --macos-major "$MACOS_MAJOR" \
+          --version "$PACKAGE_VERSION" \
           $(forceFlag)
       name: decide
       displayName: 'Compare upstream against the feed'
       env:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        ORG: $(System.CollectionUri)
+        FEED: ${{ parameters.feed }}
+        # Word-split into the array above rather than eval'd, and each value
+        # still has to satisfy the script's own --arch choices.
+        ARCHITECTURES: ${{ join(' ', parameters.architectures) }}
+        MACOS_MAJOR: ${{ parameters.macosMajorFloor }}
+        PACKAGE_VERSION: ${{ parameters.packageVersion }}
 
   - ${{ each arch in parameters.architectures }}:
     - template: templates/macos-toolchain-job.yml

--- a/.pipeline/macos-docker-toolchain-pipeline.yml
+++ b/.pipeline/macos-docker-toolchain-pipeline.yml
@@ -78,6 +78,13 @@ parameters:
   type: string
   default: 'public/mssql-rs_Public'
 
+variables:
+# Nothing here is built: the payload is fetched, checksummed and repacked, and
+# the macOS binaries inside it are Homebrew's builds, not ours. CodeQL has no
+# compilation to observe, so the org decorator's injection only adds job time.
+- name: Codeql.SkipTaskAutoInjection
+  value: true
+
 stages:
 - stage: Publish_macOS_Docker_Toolchain
   displayName: 'Publish macOS docker toolchain'

--- a/.pipeline/macos-docker-toolchain-pipeline.yml
+++ b/.pipeline/macos-docker-toolchain-pipeline.yml
@@ -8,8 +8,11 @@
 # timing out Test MacOS. Colima also downloads a ~350 MB guest image from a
 # personal GitHub repo on every run, which has independently failed on DNS.
 #
-# Manual trigger by design: bumping the toolchain should be a deliberate act with
-# a reviewed version, not something an agent's Homebrew state decides.
+# Runs on a schedule so upstream releases land within a couple of weeks, and
+# decides for itself whether there is anything to publish: resolve-toolchain-
+# version.py compares the bottles upstream has now against what the feed already
+# carries, and a run that finds nothing moved publishes nothing. That keeps the
+# version history a record of upstream movement rather than of the schedule.
 #
 # The build runs on Linux -- it only fetches, verifies and repacks; nothing in
 # the payload is executed here. build-macos-docker-toolchain.py checks the Mach-O
@@ -19,15 +22,32 @@
 trigger: none
 pr: none
 
+schedules:
+# The point is to notice upstream moving, which leaves no trace in this repo, so
+# `always` is required -- without it a scheduled run is skipped whenever the
+# branch has not changed, which is precisely the case this exists to cover.
+- cron: '0 9 1,16 * *'
+  displayName: 'Twice monthly upstream refresh (1st and 16th, 09:00 UTC)'
+  branches:
+    include:
+    - main
+  always: true
+
 parameters:
-# Versioning is about the payload, not the tools inside it -- manifest.json is
-# the record of which docker/colima/lima/image versions a package contains:
-#   MAJOR  the directory layout changed, so consumers must change with it
-#   MINOR  component versions changed (a colima or docker bump)
-#   PATCH  same components, rebuilt
+# Normally left empty: the version is derived from what is already published.
+#   PATCH  an upstream docker/colima/lima release, same payload layout
+#   MINOR  the layout changed (PAYLOAD_FORMAT in build-macos-docker-toolchain.py),
+#          so consumers resolving paths into the tree may have to change with it
+# Set this only to force a specific number, e.g. a deliberate 1.0.0.
 - name: packageVersion
-  displayName: 'Package version, e.g. 1.2.0 (SemVer, immutable once published)'
+  displayName: 'Package version override (leave empty to derive it)'
   type: string
+  default: ''
+
+- name: forcePublish
+  displayName: 'Publish even if nothing changed upstream'
+  type: boolean
+  default: false
 
 - name: publishX64
   displayName: 'Publish x86_64 package'
@@ -60,11 +80,45 @@ stages:
 - stage: Publish_macOS_Docker_Toolchain
   displayName: 'Publish macOS docker toolchain'
   jobs:
+  # Resolves both architectures before anything is downloaded, so an unchanged
+  # upstream costs a few HTTP calls instead of two 430 MB builds. One decision
+  # covers every architecture, so a given version always means the same run
+  # produced all of them.
+  - job: Decide
+    displayName: 'Decide whether to publish, and at what version'
+    timeoutInMinutes: 10
+    variables:
+    # A dry run should always build something to look at, so it forces too.
+    - ${{ if or(eq(parameters.forcePublish, true), eq(parameters.dryRun, true)) }}:
+      - name: forceFlag
+        value: '--force'
+    - ${{ else }}:
+      - name: forceFlag
+        value: ''
+    pool:
+      name: RUST-UTIL-WUS3
+      demands:
+        - imageOverride -equals RUST-UBUSLIM
+    steps:
+    - checkout: self
+    - script: |
+        set -euo pipefail
+        python3 .pipeline/scripts/resolve-toolchain-version.py \
+          --org '$(System.CollectionUri)' \
+          --feed '${{ parameters.feed }}' \
+          --arch x86_64 --arch arm64 \
+          --macos-major ${{ parameters.macosMajorFloor }} \
+          --version '${{ parameters.packageVersion }}' \
+          $(forceFlag)
+      name: decide
+      displayName: 'Compare upstream against the feed'
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
   - ${{ if eq(parameters.publishX64, true) }}:
     - template: templates/macos-toolchain-job.yml
       parameters:
         arch: x86_64
-        packageVersion: ${{ parameters.packageVersion }}
         macosMajorFloor: ${{ parameters.macosMajorFloor }}
         dryRun: ${{ parameters.dryRun }}
         feed: ${{ parameters.feed }}
@@ -73,7 +127,6 @@ stages:
     - template: templates/macos-toolchain-job.yml
       parameters:
         arch: arm64
-        packageVersion: ${{ parameters.packageVersion }}
         macosMajorFloor: ${{ parameters.macosMajorFloor }}
         dryRun: ${{ parameters.dryRun }}
         feed: ${{ parameters.feed }}

--- a/.pipeline/macos-docker-toolchain-pipeline.yml
+++ b/.pipeline/macos-docker-toolchain-pipeline.yml
@@ -51,15 +51,13 @@ parameters:
   type: boolean
   default: false
 
-- name: publishX64
-  displayName: 'Publish x86_64 package'
-  type: boolean
-  default: true
-
-- name: publishArm64
-  displayName: 'Publish arm64 package'
-  type: boolean
-  default: true
+# The architectures a version covers, deliberately a set rather than a toggle
+# each: they publish together or not at all.
+- name: architectures
+  type: object
+  default:
+  - x86_64
+  - arm64
 
 - name: dryRun
   displayName: 'Dry run (build and inspect, do not publish)'
@@ -92,7 +90,9 @@ stages:
   # Resolves both architectures before anything is downloaded, so an unchanged
   # upstream costs a few HTTP calls instead of two 430 MB builds. One decision
   # covers every architecture, so a given version always means the same run
-  # produced all of them.
+  # produced all of them -- which is also why there is no per-architecture
+  # publish toggle: skipping one would publish a version that exists for the
+  # other alone, and packages are immutable, so it could never be completed.
   - job: Decide
     displayName: 'Decide whether to publish, and at what version'
     timeoutInMinutes: 10
@@ -115,7 +115,7 @@ stages:
         python3 .pipeline/scripts/resolve-toolchain-version.py \
           --org '$(System.CollectionUri)' \
           --feed '${{ parameters.feed }}' \
-          --arch x86_64 --arch arm64 \
+          --arch ${{ join(' --arch ', parameters.architectures) }} \
           --macos-major ${{ parameters.macosMajorFloor }} \
           --version '${{ parameters.packageVersion }}' \
           $(forceFlag)
@@ -124,18 +124,10 @@ stages:
       env:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
-  - ${{ if eq(parameters.publishX64, true) }}:
+  - ${{ each arch in parameters.architectures }}:
     - template: templates/macos-toolchain-job.yml
       parameters:
-        arch: x86_64
-        macosMajorFloor: ${{ parameters.macosMajorFloor }}
-        dryRun: ${{ parameters.dryRun }}
-        feed: ${{ parameters.feed }}
-
-  - ${{ if eq(parameters.publishArm64, true) }}:
-    - template: templates/macos-toolchain-job.yml
-      parameters:
-        arch: arm64
+        arch: ${{ arch }}
         macosMajorFloor: ${{ parameters.macosMajorFloor }}
         dryRun: ${{ parameters.dryRun }}
         feed: ${{ parameters.feed }}

--- a/.pipeline/macos-docker-toolchain-pipeline.yml
+++ b/.pipeline/macos-docker-toolchain-pipeline.yml
@@ -34,15 +34,17 @@ schedules:
   always: true
 
 parameters:
-# Normally left empty: the version is derived from what is already published.
+# Normally left at 'auto': the version is derived from what is already published.
 #   PATCH  an upstream docker/colima/lima release, same payload layout
 #   MINOR  the layout changed (PAYLOAD_FORMAT in build-macos-docker-toolchain.py),
 #          so consumers resolving paths into the tree may have to change with it
-# Set this only to force a specific number, e.g. a deliberate 1.0.0.
+# Override with an explicit X.Y.Z only to force a specific number, e.g. a
+# deliberate 1.0.0. A sentinel rather than an empty default because the run
+# panel refuses to queue with a blank string parameter.
 - name: packageVersion
-  displayName: 'Package version override (leave empty to derive it)'
+  displayName: "Package version ('auto' derives it from the feed)"
   type: string
-  default: ''
+  default: 'auto'
 
 - name: forcePublish
   displayName: 'Publish even if nothing changed upstream'

--- a/.pipeline/scripts/README.md
+++ b/.pipeline/scripts/README.md
@@ -116,6 +116,35 @@ then caps the retries as a whole.
 `COLIMA_BUDGET_SECONDS` (480), `INSTALL_TIMEOUT_SECONDS` (300),
 `DOCKER_CLI_DIR`.
 
+### build-macos-docker-toolchain.py
+Assembles the macOS docker toolchain payload for one architecture: the install
+prefixes of the `docker`, `colima` and `lima` Homebrew bottles, plus the Ubuntu
+guest disk image colima boots, plus a `manifest.json` recording versions, source
+URLs and digests. Published as a Universal Package by
+`.pipeline/macos-docker-toolchain-pipeline.yml`, so macOS jobs install the
+toolchain from our own feed rather than reaching Homebrew, ghcr.io and
+github.com at job time.
+
+The whole prefix is packaged, not just `bin/`: `limactl` resolves
+`../share/lima/lima-guestagent.*` and `../libexec/lima/*` relative to itself, so
+a bin-only payload yields a lima that cannot boot a VM. The build fails if the
+guest agent is missing rather than shipping one that would.
+
+The guest image is not hard-coded. colima embeds a table of
+`<arch> <runtime> <url> <sha512> <filename>` for the image release it expects, so
+both the image and the checksum to verify it against are read out of the binary
+being packaged — colima 0.10.3 wants colima-core v0.10.4, which a hand-maintained
+mapping would get wrong.
+
+Runs on Linux and cross-builds both macOS payloads, so it verifies the Mach-O
+architecture of every binary it packs; a mis-resolved bottle fails the build
+instead of shipping.
+
+**Usage:** `build-macos-docker-toolchain.py --arch x86_64|arm64 --out <dir>`
+`--macos-major` sets the oldest macOS the payload must run on (default 14);
+bottles built for an older macOS run on newer hosts, so this is a compatibility
+floor rather than a target.
+
 ### install-brew-bottle.py
 Installs the newest Homebrew bottle of a formula that exists for the running
 platform, by reading Homebrew's OCI registry on ghcr.io directly. Used as the
@@ -137,7 +166,11 @@ each costs a registry round-trip, and this keeps a no-match failure from eating
 the caller's install budget before it reports.
 
 **Usage:** `install-brew-bottle.py <formula> <dest-bin-dir>`; prints the resolved
-version. Test overrides: `BOTTLE_ARCH_OVERRIDE`, `BOTTLE_MACOS_MAJOR_OVERRIDE`.
+version. `extract_bin` flattens just the executables (what the docker CLI
+fallback needs); `extract_prefix` keeps the whole install tree (what a packaged
+lima needs). `BOTTLE_ARCH_OVERRIDE` and `BOTTLE_MACOS_MAJOR_OVERRIDE` select a
+platform other than the running one — used by the toolchain producer to
+cross-build both macOS payloads from Linux, and handy for testing.
 Covered by `test_install_brew_bottle.py`.
 
 ### start-sql-server-macos.sh

--- a/.pipeline/scripts/README.md
+++ b/.pipeline/scripts/README.md
@@ -87,44 +87,34 @@ coreutils `timeout`, so long-running commands are bounded by running them in the
 background and killing them on overrun. Returns 124 on timeout.
 
 ### start-colima-macos.sh
-Installs Docker + Colima on a hosted macOS agent and boots the VM, retrying on
-the transient lima hostagent boot failures seen in ~3% of runs. VM size stays at
-the long-standing 4 GiB / 4 CPU.
+Boots a Colima VM on a hosted macOS agent from the packaged toolchain, retrying
+on the transient lima hostagent boot failures seen in ~3% of runs. VM size stays
+at the long-standing 4 GiB / 4 CPU.
 
-In CI the toolchain comes from our own feed: `TOOLCHAIN_DIR` points at a payload
-downloaded by `.pipeline/templates/macos-docker-steps.yml`, and the script puts
-its `bin/` on PATH and copies the guest image into
+Nothing is installed or downloaded here. `TOOLCHAIN_DIR` points at a payload
+fetched by `.pipeline/templates/macos-docker-steps.yml`; the script puts its
+`bin/` on PATH and copies the guest image into
 `~/Library/Caches/colima/caches/<cache_filename>`, which is where colima looks
-for it by sha256 of the URL it would otherwise download from. So a CI run
-contacts neither Homebrew nor github.com. The executable bit is restored on the
-way in because Universal Packages do not preserve POSIX modes.
+for it by sha256 of the URL it would otherwise download from. So a run contacts
+neither Homebrew nor ghcr.io nor github.com. The executable bit is restored on
+the way in because Universal Packages do not preserve POSIX modes.
 
-Without `TOOLCHAIN_DIR` — a developer running this directly, or CI if the
-download step is ever removed — it installs from Homebrew as before. The docker
-CLI is installed with `brew install --force-bottle`, which uses Homebrew's
-bottle when one exists for the platform and *fails* rather than falling back to
-a source build. When it fails, `install-brew-bottle.py` installs the newest
-version that *is* bottled for this platform, taken straight from Homebrew's own
-registry. As of 29.8.0 there is no Intel macOS bottle, so a bare `brew install
-docker` compiles the CLI and builds Go to do it: measured over 147 runs, the
-bottled path took 29s median and failed 1% of the time, the source-build path
-took 441s median (774s max) and failed 36%. `colima` and `lima` are still
-bottled on Intel and install normally.
+`TOOLCHAIN_DIR` is required, and a payload missing its manifest, any of
+`bin/{docker,colima,limactl}`, or its guest image fails the step by name. There
+is deliberately no Homebrew fallback: it would reintroduce the dependency this
+exists to remove, and a path that only runs when the primary breaks is a path
+nothing ever exercises.
 
-The whole install phase (`brew update`, `colima`, the docker CLI) is bounded by
-`INSTALL_TIMEOUT_SECONDS` so a slow install fails here with a message rather than
-surfacing as an opaque step timeout. Each `colima start` is bounded by
-`COLIMA_START_TIMEOUT_SECONDS` so a wedged boot still reaches the delete/retry
-path rather than running until the pipeline step timeout. That bound sits above
-the slowest healthy boot observed (509s over 113 runs in 2026-08; re-measured
-2026-09 at max 453s over 123 runs) — the real failures give up within seconds, so
-a shorter bound would only kill slow-but-healthy boots. `COLIMA_BUDGET_SECONDS`
-then caps the retries as a whole.
+Each `colima start` is bounded by `COLIMA_START_TIMEOUT_SECONDS` so a wedged
+boot still reaches the delete/retry path rather than running until the pipeline
+step timeout. That bound sits above the slowest healthy boot observed (509s over
+113 runs in 2026-08; re-measured 2026-09 at max 453s over 123 runs) — the real
+failures give up within seconds, so a shorter bound would only kill
+slow-but-healthy boots. `COLIMA_BUDGET_SECONDS` then caps the retries as a whole.
 
-**Environment overrides:** `COLIMA_CPU`, `COLIMA_MEMORY`, `COLIMA_DISK`,
-`COLIMA_START_ATTEMPTS` (3), `COLIMA_START_TIMEOUT_SECONDS` (540),
-`COLIMA_BUDGET_SECONDS` (480), `INSTALL_TIMEOUT_SECONDS` (300),
-`DOCKER_CLI_DIR`, `TOOLCHAIN_DIR`.
+**Environment overrides:** `TOOLCHAIN_DIR` (required), `COLIMA_CPU`,
+`COLIMA_MEMORY`, `COLIMA_DISK`, `COLIMA_START_ATTEMPTS` (3),
+`COLIMA_START_TIMEOUT_SECONDS` (540), `COLIMA_BUDGET_SECONDS` (480).
 
 ### build-macos-docker-toolchain.py
 Assembles the macOS docker toolchain payload for one architecture: the install
@@ -194,10 +184,11 @@ fails if the built payload disagrees with what was resolved, which means a
 release landed mid-run. Covered by `test_resolve_toolchain_version.py`.
 
 ### install-brew-bottle.py
-Installs the newest Homebrew bottle of a formula that exists for the running
-platform, by reading Homebrew's OCI registry on ghcr.io directly. Used as the
-docker CLI fallback above, and generic enough to cover `colima` or `lima` if they
-lose their Intel bottles too.
+Installs the newest Homebrew bottle of a formula that exists for a given
+platform, by reading Homebrew's OCI registry on ghcr.io directly — no `brew`, no
+taps, no local Homebrew state. `build-macos-docker-toolchain.py` uses it to
+assemble the toolchain payload, cross-building both macOS architectures from
+Linux.
 
 Bottles are content-addressed, so the download is verified against the digest the
 registry advertises rather than a checksum vendored here. Bottles built for an

--- a/.pipeline/scripts/README.md
+++ b/.pipeline/scripts/README.md
@@ -91,15 +91,25 @@ Installs Docker + Colima on a hosted macOS agent and boots the VM, retrying on
 the transient lima hostagent boot failures seen in ~3% of runs. VM size stays at
 the long-standing 4 GiB / 4 CPU.
 
-The docker CLI is installed with `brew install --force-bottle`, which uses
-Homebrew's bottle when one exists for the platform and *fails* rather than
-falling back to a source build. When it fails, `install-brew-bottle.py` installs
-the newest version that *is* bottled for this platform, taken straight from
-Homebrew's own registry. As of 29.8.0 there is no Intel macOS bottle, so a bare
-`brew install docker` compiles the CLI and builds Go to do it: measured over 147
-runs, the bottled path took 29s median and failed 1% of the time, the
-source-build path took 441s median (774s max) and failed 36%. `colima` and
-`lima` are still bottled on Intel and install normally.
+In CI the toolchain comes from our own feed: `TOOLCHAIN_DIR` points at a payload
+downloaded by `.pipeline/templates/macos-docker-steps.yml`, and the script puts
+its `bin/` on PATH and copies the guest image into
+`~/Library/Caches/colima/caches/<cache_filename>`, which is where colima looks
+for it by sha256 of the URL it would otherwise download from. So a CI run
+contacts neither Homebrew nor github.com. The executable bit is restored on the
+way in because Universal Packages do not preserve POSIX modes.
+
+Without `TOOLCHAIN_DIR` — a developer running this directly, or CI if the
+download step is ever removed — it installs from Homebrew as before. The docker
+CLI is installed with `brew install --force-bottle`, which uses Homebrew's
+bottle when one exists for the platform and *fails* rather than falling back to
+a source build. When it fails, `install-brew-bottle.py` installs the newest
+version that *is* bottled for this platform, taken straight from Homebrew's own
+registry. As of 29.8.0 there is no Intel macOS bottle, so a bare `brew install
+docker` compiles the CLI and builds Go to do it: measured over 147 runs, the
+bottled path took 29s median and failed 1% of the time, the source-build path
+took 441s median (774s max) and failed 36%. `colima` and `lima` are still
+bottled on Intel and install normally.
 
 The whole install phase (`brew update`, `colima`, the docker CLI) is bounded by
 `INSTALL_TIMEOUT_SECONDS` so a slow install fails here with a message rather than
@@ -114,7 +124,7 @@ then caps the retries as a whole.
 **Environment overrides:** `COLIMA_CPU`, `COLIMA_MEMORY`, `COLIMA_DISK`,
 `COLIMA_START_ATTEMPTS` (3), `COLIMA_START_TIMEOUT_SECONDS` (540),
 `COLIMA_BUDGET_SECONDS` (480), `INSTALL_TIMEOUT_SECONDS` (300),
-`DOCKER_CLI_DIR`.
+`DOCKER_CLI_DIR`, `TOOLCHAIN_DIR`.
 
 ### build-macos-docker-toolchain.py
 Assembles the macOS docker toolchain payload for one architecture: the install

--- a/.pipeline/scripts/README.md
+++ b/.pipeline/scripts/README.md
@@ -150,6 +150,37 @@ instead of shipping.
 bottles built for an older macOS run on newer hosts, so this is a compatibility
 floor rather than a target.
 
+### resolve-toolchain-version.py
+Decides whether the toolchain needs republishing, and at what version, so nobody
+has to read the feed and pick a number. The payload is a derived artifact — its
+bytes are a function of the three bottles, the macOS floor they are selected for,
+and `PAYLOAD_FORMAT` — so `payload_identity()` digests exactly those inputs and
+the decision falls out of comparing that digest with what is already published.
+
+Nothing is downloaded to decide. Bottle versions and digests come from registry
+metadata, and the published side is read back out of the package description,
+where publishing records it as `[layout:N id:...]`. The guest image is
+deliberately not part of the identity: colima carries the image URL and checksum
+in its own binary, so the colima bottle digest already covers it.
+
+A scheduled run that finds upstream unmoved publishes nothing, which keeps the
+version history a record of upstream movement rather than of the schedule
+firing. Otherwise the version is derived: a patch bump for an upstream release,
+a minor bump when `PAYLOAD_FORMAT` changed, since consumers resolving paths into
+the tree may have to change with it.
+
+The decision is made once for every architecture rather than per package, so a
+given version always means the same build produced all of them — worth more than
+skipping the occasional unchanged republish.
+
+**Usage:** `resolve-toolchain-version.py --org <url> --feed <project/feed> --arch
+x86_64 --arch arm64 --macos-major 14 [--version X.Y.Z] [--force]`, reading
+`SYSTEM_ACCESSTOKEN`; emits `shouldPublish`, `packageVersion` and
+`identity_<arch>` as pipeline output variables. `--describe <manifest.json>
+--expect-identity <id>` is the publish side: it composes the description and
+fails if the built payload disagrees with what was resolved, which means a
+release landed mid-run. Covered by `test_resolve_toolchain_version.py`.
+
 ### install-brew-bottle.py
 Installs the newest Homebrew bottle of a formula that exists for the running
 platform, by reading Homebrew's OCI registry on ghcr.io directly. Used as the

--- a/.pipeline/scripts/README.md
+++ b/.pipeline/scripts/README.md
@@ -130,6 +130,11 @@ The whole prefix is packaged, not just `bin/`: `limactl` resolves
 a bin-only payload yields a lima that cannot boot a VM. The build fails if the
 guest agent is missing rather than shipping one that would.
 
+The three prefixes merge into one tree, so each formula's `LICENSE`, `NOTICE`,
+`README.md` and `sbom.spdx.json` — all of which sit at the prefix root — go to
+`metadata/<formula>/`. Merged flat they would overwrite each other and leave the
+payload describing itself as whichever formula was extracted last.
+
 The guest image is not hard-coded. colima embeds a table of
 `<arch> <runtime> <url> <sha512> <filename>` for the image release it expects, so
 both the image and the checksum to verify it against are read out of the binary

--- a/.pipeline/scripts/README.md
+++ b/.pipeline/scripts/README.md
@@ -174,9 +174,11 @@ given version always means the same build produced all of them — worth more th
 skipping the occasional unchanged republish.
 
 **Usage:** `resolve-toolchain-version.py --org <url> --feed <project/feed> --arch
-x86_64 --arch arm64 --macos-major 14 [--version X.Y.Z] [--force]`, reading
+x86_64 --arch arm64 --macos-major 14 [--version X.Y.Z|auto] [--force]`, reading
 `SYSTEM_ACCESSTOKEN`; emits `shouldPublish`, `packageVersion` and
-`identity_<arch>` as pipeline output variables. `--describe <manifest.json>
+`identity_<arch>` as pipeline output variables. `--version auto` is the normal
+case — a sentinel rather than an empty string because the run panel refuses to
+queue with a blank string parameter. `--describe <manifest.json>
 --expect-identity <id>` is the publish side: it composes the description and
 fails if the built payload disagrees with what was resolved, which means a
 release landed mid-run. Covered by `test_resolve_toolchain_version.py`.

--- a/.pipeline/scripts/build-macos-docker-toolchain.py
+++ b/.pipeline/scripts/build-macos-docker-toolchain.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Assemble the macOS docker toolchain payload for one architecture.
+
+Collects everything a hosted macOS agent needs to run containers, so the job
+itself touches nothing but our own feed:
+
+  bin/     docker, colima, limactl and lima's helpers, from Homebrew bottles
+  image/   the Ubuntu guest disk image colima boots
+  manifest.json  what went in, where it came from, and its digests
+
+The guest image reference is not hard-coded. colima embeds a table of
+"<arch> <runtime> <url> <sha512> <filename>" for the image release it expects,
+so the image and the checksum to verify it against are read out of the very
+binary being packaged. colima 0.10.3 wants colima-core v0.10.4, which any
+hand-maintained mapping would get wrong.
+
+Runs on Linux: nothing here is executed, only fetched, checked and repacked.
+
+Usage: build-macos-docker-toolchain.py --arch x86_64|arm64 --out <dir>
+"""
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+import re
+import shutil
+import struct
+import sys
+import time
+import urllib.error
+import urllib.request
+
+FORMULAE = ("docker", "colima", "lima")
+ARCH_TO_COLIMA = {"x86_64": "amd64", "arm64": "arm64"}
+MACHO_MAGIC_64 = 0xFEEDFACF
+MACHO_CPU_TYPE = {"x86_64": 0x01000007, "arm64": 0x0100000C}
+# Bottles built for an older macOS run on newer hosts, so target the oldest
+# release we might schedule on and stay compatible with everything above it.
+DEFAULT_MACOS_MAJOR = 14
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def load_bottle_helper():
+    path = os.path.join(HERE, "install-brew-bottle.py")
+    spec = importlib.util.spec_from_file_location("install_brew_bottle", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def verify_macho(path, arch):
+    """Guard against packaging the wrong slice: this cross-builds on Linux."""
+    with open(path, "rb") as handle:
+        header = handle.read(8)
+    if len(header) < 8:
+        raise RuntimeError(f"{path}: too short to be a Mach-O binary")
+    magic, cpu_type = struct.unpack("<II", header)
+    if magic != MACHO_MAGIC_64:
+        raise RuntimeError(f"{path}: not a 64-bit Mach-O binary (magic {magic:#x})")
+    if cpu_type != MACHO_CPU_TYPE[arch]:
+        wrong = next((k for k, v in MACHO_CPU_TYPE.items() if v == cpu_type), hex(cpu_type))
+        raise RuntimeError(f"{path}: built for {wrong}, expected {arch}")
+
+
+def image_entry(colima_binary, arch):
+    """Read colima's embedded (arch, runtime) -> image URL + sha512 table."""
+    with open(colima_binary, "rb") as handle:
+        blob = handle.read()
+    pattern = (
+        rb"(" + ARCH_TO_COLIMA[arch].encode() + rb")\s+docker\s+"
+        rb"(https://\S+\.raw\.gz)\s+([0-9a-f]{128})\s+(\S+\.raw\.gz)"
+    )
+    match = re.search(pattern, blob)
+    if not match:
+        raise RuntimeError(
+            f"colima binary has no docker image entry for {arch}; "
+            "the embedded image table may have changed format"
+        )
+    return {
+        "url": match.group(2).decode(),
+        "sha512": match.group(3).decode(),
+        "filename": match.group(4).decode(),
+    }
+
+
+def download_verified(url, sha512, dest, attempts=3):
+    """Stream to disk, hashing as we go -- the image is ~350 MB."""
+    for attempt in range(attempts):
+        digest = hashlib.sha512()
+        try:
+            with urllib.request.urlopen(url, timeout=300) as resp, open(dest, "wb") as out:
+                while True:
+                    chunk = resp.read(1 << 20)
+                    if not chunk:
+                        break
+                    digest.update(chunk)
+                    out.write(chunk)
+        except (urllib.error.URLError, TimeoutError) as exc:
+            if attempt == attempts - 1:
+                raise RuntimeError(f"downloading {url} failed: {exc}") from None
+            time.sleep(10 * (attempt + 1))
+            continue
+
+        actual = digest.hexdigest()
+        if actual == sha512:
+            return os.path.getsize(dest)
+        raise RuntimeError(
+            f"{url}: sha512 mismatch against colima's own manifest\n"
+            f"  expected {sha512}\n  actual   {actual}"
+        )
+    raise RuntimeError(f"downloading {url} failed after {attempts} attempts")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--arch", required=True, choices=sorted(ARCH_TO_COLIMA))
+    parser.add_argument("--out", required=True)
+    parser.add_argument(
+        "--macos-major",
+        type=int,
+        default=DEFAULT_MACOS_MAJOR,
+        help="oldest macOS major version the payload must run on (default: %(default)s)",
+    )
+    args = parser.parse_args()
+
+    helper = load_bottle_helper()
+    os.environ["BOTTLE_ARCH_OVERRIDE"] = args.arch
+    os.environ["BOTTLE_MACOS_MAJOR_OVERRIDE"] = str(args.macos_major)
+
+    bin_dir = os.path.join(args.out, "bin")
+    image_dir = os.path.join(args.out, "image")
+    if os.path.exists(args.out):
+        shutil.rmtree(args.out)
+    os.makedirs(bin_dir)
+    os.makedirs(image_dir)
+
+    components = {}
+    for formula in FORMULAE:
+        token = helper.anonymous_token(formula)
+        version, manifest_digest, ref = helper.find_bottle(formula, token)
+        blob = helper.download_blob(formula, token, manifest_digest)
+        # Whole prefix, not just bin/: limactl reaches for ../share/lima and
+        # ../libexec/lima, so a bin-only copy cannot boot a VM.
+        extracted = helper.extract_prefix(blob, formula, version, args.out)
+        components[formula] = {
+            "version": version,
+            "bottle_tag": ref,
+            "bottle_digest": manifest_digest,
+            "files": len(extracted),
+        }
+        print(f"{formula:8s} {version:10s} {ref:24s} -> {len(extracted)} files")
+
+    for name in ("docker", "colima", "limactl"):
+        verify_macho(os.path.join(bin_dir, name), args.arch)
+    print(f"verified {args.arch} Mach-O binaries")
+
+    # limactl resolves the guest agent relative to its own location, so its
+    # absence is a boot failure on the agent rather than a build failure here.
+    guest_agent = os.path.join(args.out, "share", "lima")
+    agents = [f for f in os.listdir(guest_agent) if f.startswith("lima-guestagent")] \
+        if os.path.isdir(guest_agent) else []
+    if not agents:
+        raise RuntimeError("payload has no share/lima/lima-guestagent.*; lima could not boot a VM")
+    print(f"guest agent present: {', '.join(agents)}")
+
+    entry = image_entry(os.path.join(bin_dir, "colima"), args.arch)
+    image_path = os.path.join(image_dir, entry["filename"])
+    size = download_verified(entry["url"], entry["sha512"], image_path)
+    print(f"image    {entry['filename']} ({size / 1e6:.0f} MB) sha512 verified")
+
+    manifest = {
+        "arch": args.arch,
+        "macos_major_floor": args.macos_major,
+        "components": components,
+        "image": {
+            **entry,
+            "size": size,
+            # colima looks the image up in its cache by sha256 of the URL, so the
+            # consumer can seed it without colima ever reaching the network.
+            "cache_filename": hashlib.sha256(entry["url"].encode()).hexdigest(),
+        },
+    }
+    with open(os.path.join(args.out, "manifest.json"), "w") as out:
+        json.dump(manifest, out, indent=2, sort_keys=True)
+
+    versions = "-".join(f"{name}{components[name]['version']}" for name in FORMULAE)
+    print(f"\npayload ready: {args.out}")
+    print(f"  contents: {versions}, image {entry['url'].split('/')[-2]}")
+    print(f"  cache filename: {manifest['image']['cache_filename']}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except RuntimeError as exc:
+        print(f"##[error]{exc}")
+        sys.exit(1)

--- a/.pipeline/scripts/build-macos-docker-toolchain.py
+++ b/.pipeline/scripts/build-macos-docker-toolchain.py
@@ -36,11 +36,37 @@ FORMULAE = ("docker", "colima", "lima")
 ARCH_TO_COLIMA = {"x86_64": "amd64", "arm64": "arm64"}
 MACHO_MAGIC_64 = 0xFEEDFACF
 MACHO_CPU_TYPE = {"x86_64": 0x01000007, "arm64": 0x0100000C}
+# Where files land in the payload. Bump when the tree moves, so consumers that
+# resolve paths into it can tell, and so a republish is triggered for a change
+# the component versions below cannot show.
+PAYLOAD_FORMAT = 2
 # Bottles built for an older macOS run on newer hosts, so target the oldest
 # release we might schedule on and stay compatible with everything above it.
 DEFAULT_MACOS_MAJOR = 14
 
 HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def payload_identity(components, macos_major, payload_format=PAYLOAD_FORMAT):
+    """Digest of everything that decides the payload's bytes.
+
+    The guest image is deliberately absent: colima carries the image URL and
+    checksum in its own binary, so the colima bottle digest already covers it.
+
+    resolve-toolchain-version.py calls this with versions read from the
+    registry, before anything is downloaded, to compare against a published
+    package. Keep it a pure function of these inputs or that comparison drifts.
+    """
+    key = {
+        "payload_format": payload_format,
+        "macos_major_floor": macos_major,
+        "components": {
+            name: [components[name]["version"], components[name]["bottle_digest"]]
+            for name in sorted(components)
+        },
+    }
+    canonical = json.dumps(key, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()[:16]
 
 
 def load_bottle_helper():
@@ -174,6 +200,8 @@ def main():
     manifest = {
         "arch": args.arch,
         "macos_major_floor": args.macos_major,
+        "payload_format": PAYLOAD_FORMAT,
+        "identity": payload_identity(components, args.macos_major),
         "components": components,
         "image": {
             **entry,

--- a/.pipeline/scripts/build-macos-docker-toolchain.py
+++ b/.pipeline/scripts/build-macos-docker-toolchain.py
@@ -91,6 +91,30 @@ def verify_macho(path, arch):
         raise RuntimeError(f"{path}: built for {wrong}, expected {arch}")
 
 
+def verify_every_macho(root, arch):
+    """Check every Mach-O in the payload, not just the entry points.
+
+    lima ships helpers under libexec/ and extra CLIs in bin/, and a bottle
+    resolved for the wrong platform would put a mixed-architecture helper in
+    the payload that only fails once a macOS job runs it. Files that are not
+    Mach-O -- scripts, templates, the guest image -- are skipped by magic.
+    """
+    checked = 0
+    for directory, _, names in os.walk(root):
+        for name in names:
+            path = os.path.join(directory, name)
+            if os.path.islink(path):
+                continue
+            with open(path, "rb") as handle:
+                magic = handle.read(4)
+            if magic in (b"\xcf\xfa\xed\xfe", b"\xce\xfa\xed\xfe") or magic == b"\xca\xfe\xba\xbe":
+                verify_macho(path, arch)
+                checked += 1
+    if not checked:
+        raise RuntimeError(f"{root}: no Mach-O binaries found; the payload cannot be right")
+    return checked
+
+
 def image_entry(colima_binary, arch):
     """Read colima's embedded (arch, runtime) -> image URL + sha512 table."""
     with open(colima_binary, "rb") as handle:
@@ -188,7 +212,8 @@ def main():
 
     for name in ("docker", "colima", "limactl"):
         verify_macho(os.path.join(bin_dir, name), args.arch)
-    print(f"verified {args.arch} Mach-O binaries")
+    checked = verify_every_macho(args.out, args.arch)
+    print(f"verified {checked} {args.arch} Mach-O binaries")
 
     # limactl resolves the guest agent relative to its own location, so its
     # absence is a boot failure on the agent rather than a build failure here.

--- a/.pipeline/scripts/build-macos-docker-toolchain.py
+++ b/.pipeline/scripts/build-macos-docker-toolchain.py
@@ -105,10 +105,17 @@ def image_entry(colima_binary, arch):
             f"colima binary has no docker image entry for {arch}; "
             "the embedded image table may have changed format"
         )
+    # This name becomes a path under the payload, and it is read out of a
+    # downloaded binary, so it gets treated as data rather than trusted.
+    filename = match.group(4).decode()
+    if filename in ("", ".", "..") or os.path.basename(filename) != filename:
+        raise RuntimeError(
+            f"colima's image table gave {filename!r}, which is not a plain file name"
+        )
     return {
         "url": match.group(2).decode(),
         "sha512": match.group(3).decode(),
-        "filename": match.group(4).decode(),
+        "filename": filename,
     }
 
 

--- a/.pipeline/scripts/install-brew-bottle.py
+++ b/.pipeline/scripts/install-brew-bottle.py
@@ -245,6 +245,48 @@ def extract_bin(blob, formula, version, dest_dir):
     return installed
 
 
+def extract_prefix(blob, formula, version, dest_root):
+    """Extract the whole install prefix, merging it into dest_root.
+
+    lima is not self-contained in bin/: limactl reaches for
+    ../share/lima/lima-guestagent.* and ../libexec/lima/*, so a bin-only copy
+    produces a lima that cannot boot a VM.
+    """
+    base, _ = ref_parts(version)
+    root = f"{formula}/{base}/"
+    extracted = []
+    with tarfile.open(fileobj=io.BytesIO(blob), mode="r:gz") as tar:
+        for member in tar.getmembers():
+            if not (member.isfile() or member.issym()):
+                continue
+            # Never a path that escapes the prefix -- the archive is untrusted.
+            name = os.path.normpath(member.name).replace(os.sep, "/")
+            if not name.startswith(root) or ".." in name.split("/"):
+                continue
+            relative = name[len(root):]
+            if relative.startswith(".brew/"):
+                continue
+            target = os.path.join(dest_root, relative)
+            os.makedirs(os.path.dirname(target), exist_ok=True)
+            if member.issym():
+                if os.path.isabs(member.linkname) or member.linkname.startswith("../"):
+                    continue
+                if os.path.lexists(target):
+                    os.unlink(target)
+                os.symlink(member.linkname, target)
+            else:
+                src = tar.extractfile(member)
+                if src is None:
+                    continue
+                with open(target, "wb") as out:
+                    shutil.copyfileobj(src, out)
+                os.chmod(target, member.mode or 0o644)
+            extracted.append(relative)
+    if not extracted:
+        raise RuntimeError(f"bottle for {formula} {version} extracted nothing")
+    return extracted
+
+
 def main():
     if len(sys.argv) != 3:
         print(__doc__, file=sys.stderr)

--- a/.pipeline/scripts/install-brew-bottle.py
+++ b/.pipeline/scripts/install-brew-bottle.py
@@ -280,7 +280,14 @@ def extract_prefix(blob, formula, version, dest_root):
             target = os.path.join(dest_root, relative)
             os.makedirs(os.path.dirname(target), exist_ok=True)
             if member.issym():
-                if os.path.isabs(member.linkname) or member.linkname.startswith("../"):
+                # Where the link would land, relative to dest_root. Testing the
+                # linkname for a leading `../` is not enough: `a/../../outside`
+                # has none and still escapes, and a later member writing
+                # through the link would follow it out of the prefix.
+                landing = os.path.normpath(
+                    os.path.join(os.path.dirname(relative), member.linkname)
+                )
+                if os.path.isabs(member.linkname) or landing.split("/")[0] == "..":
                     continue
                 if os.path.lexists(target):
                     os.unlink(target)

--- a/.pipeline/scripts/install-brew-bottle.py
+++ b/.pipeline/scripts/install-brew-bottle.py
@@ -251,6 +251,12 @@ def extract_prefix(blob, formula, version, dest_root):
     lima is not self-contained in bin/: limactl reaches for
     ../share/lima/lima-guestagent.* and ../libexec/lima/*, so a bin-only copy
     produces a lima that cannot boot a VM.
+
+    Files at the prefix root are per-formula metadata (LICENSE, NOTICE,
+    README.md, sbom.spdx.json, ...) and every formula ships its own, so a
+    merged prefix would keep only whichever was extracted last. Those go to
+    metadata/<formula>/ instead; everything functional lives in a subdirectory
+    and merges as-is.
     """
     base, _ = ref_parts(version)
     root = f"{formula}/{base}/"
@@ -266,6 +272,8 @@ def extract_prefix(blob, formula, version, dest_root):
             relative = name[len(root):]
             if relative.startswith(".brew/"):
                 continue
+            if "/" not in relative:
+                relative = f"metadata/{formula}/{relative}"
             target = os.path.join(dest_root, relative)
             os.makedirs(os.path.dirname(target), exist_ok=True)
             if member.issym():

--- a/.pipeline/scripts/install-brew-bottle.py
+++ b/.pipeline/scripts/install-brew-bottle.py
@@ -5,11 +5,14 @@
 """Install the newest Homebrew bottle of a formula that exists for this platform.
 
 Homebrew publishes bottles as OCI artifacts on ghcr.io, readable anonymously.
-When `brew install --force-bottle` fails because the *current* formula version
-has no bottle for the running platform (docker 29.8.0 ships arm64 macOS and
-Linux only), the previous version usually still does. This walks the registry
-newest-first, finds a version bottled for this platform, and extracts its
-binaries.
+That is the only thing this needs: no `brew`, no taps, no local Homebrew state.
+It walks the registry newest-first, finds a version bottled for the requested
+platform, and extracts it — which matters because the current version is not
+always bottled everywhere (docker 29.8.0 ships arm64 macOS and Linux only, so
+Intel resolves to 29.7.2-1).
+
+Used by build-macos-docker-toolchain.py to assemble the macOS docker toolchain
+payload, cross-building both architectures from Linux via BOTTLE_ARCH_OVERRIDE.
 
 The bottle blob is content-addressed: the layer digest is its SHA-256, so the
 download is verified against the digest the registry advertises rather than a

--- a/.pipeline/scripts/install-brew-bottle.py
+++ b/.pipeline/scripts/install-brew-bottle.py
@@ -83,6 +83,10 @@ def _get(url, token=None, accept=None, binary=False, attempts=3):
 
 
 def anonymous_token(formula):
+    # The name is pasted into registry URLs below, so it has to look like a
+    # formula and not like more path or query.
+    if not re.match(r"^[a-z0-9][a-z0-9._+-]*$", formula):
+        raise RuntimeError(f"{formula!r} is not a Homebrew formula name")
     scope = f"repository:{REPO_PREFIX}/{formula}:pull"
     data, _ = _get(f"{REGISTRY}/token?service=ghcr.io&scope={scope}")
     return data["token"]
@@ -298,7 +302,10 @@ def extract_prefix(blob, formula, version, dest_root):
                     continue
                 with open(target, "wb") as out:
                     shutil.copyfileobj(src, out)
-                os.chmod(target, member.mode or 0o644)
+                # Masked, not honoured: the archive should not get to ask for
+                # setuid, setgid, sticky or group/other write on a file being
+                # unpacked onto the agent.
+                os.chmod(target, (member.mode or 0o644) & 0o755)
             extracted.append(relative)
     if not extracted:
         raise RuntimeError(f"bottle for {formula} {version} extracted nothing")

--- a/.pipeline/scripts/resolve-toolchain-version.py
+++ b/.pipeline/scripts/resolve-toolchain-version.py
@@ -210,15 +210,20 @@ def decide(state, override=None, force=False):
     not exist for that package yet.
     """
     versions = {arch: s["version"] for arch, s in state.items()}
-    behind = [arch for arch, v in versions.items() if v is not None]
-    leader = max((versions[a] for a in behind), default=None, key=version_key)
-    lagging = {arch for arch, v in versions.items() if v is not None and v != leader}
+    leader = max(
+        (v for v in versions.values() if v is not None), default=None, key=version_key
+    )
+    # Absent counts as lagging, not just behind: a first publish that uploaded
+    # one architecture and failed on the other leaves the second with no
+    # version at all, and bumping past the leader strands it exactly the same.
+    lagging = {arch for arch, v in versions.items() if v != leader}
 
     # Repair first: with a partial publish outstanding, a laggard's contents
     # differing from *its* version is the symptom, not a reason to bump past the
     # version it is missing. Only sound while the leader is itself current --
     # otherwise that version predates upstream and nobody should join it.
-    if lagging and not override and all(state[a]["current"] for a in state if a not in lagging):
+    if leader and lagging and not override \
+            and all(state[a]["current"] for a in state if a not in lagging):
         return leader, lagging, [
             f"partial publish: {', '.join(sorted(lagging))} never reached {leader}",
         ]
@@ -230,10 +235,16 @@ def decide(state, override=None, force=False):
         elif not state[arch]["current"]:
             reasons.append(f"- {arch}: differs from {versions[arch]}")
 
-    if not reasons and not force:
+    # An explicit version is itself the reason to publish: asking for a number
+    # and getting nothing published would be a silent no-op.
+    if not reasons and not force and not override:
         return next_version(leader, layout_changed=False), set(), []
     if not reasons:
-        reasons = ["nothing changed upstream, but a publish was forced"]
+        reasons = [
+            f"nothing changed upstream, but {override} was asked for explicitly"
+            if override
+            else "nothing changed upstream, but a publish was forced"
+        ]
     else:
         reasons.insert(0, "republishing because:")
 

--- a/.pipeline/scripts/resolve-toolchain-version.py
+++ b/.pipeline/scripts/resolve-toolchain-version.py
@@ -88,10 +88,14 @@ def organization(collection_uri):
 
 
 def published_packages(org_url, project, feed, token):
+    # Filtered by name rather than listing the feed: the response is paginated,
+    # and a feed with enough packages would push these off the first page and
+    # make them look unpublished. Only the two names can match this prefix.
     url = (
         f"https://feeds.dev.azure.com/{organization(org_url)}/{project}"
         f"/_apis/packaging/Feeds/{feed}/packages"
-        f"?protocolType=upack&includeDescription=true&api-version={API_VERSION}"
+        f"?protocolType=upack&packageNameQuery={PACKAGE_PREFIX}"
+        f"&includeDescription=true&api-version={API_VERSION}"
     )
     request = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
     try:
@@ -176,6 +180,59 @@ def next_version(latest, layout_changed):
     return f"{major}.{minor}.{patch + 1}"
 
 
+def version_key(version):
+    return [int(part) for part in version.split(".")]
+
+
+def decide(state, override=None, force=False):
+    """(version, architectures to publish, reasons) from each architecture's state.
+
+    `state[arch]` is the published version (None if absent), whether that
+    published package already matches upstream, and whether its layout is stale.
+
+    A version is meant to mean the same build produced every architecture, so
+    the normal path publishes all of them together at a version that exists for
+    none. Publishing is not atomic across packages though: a failure after the
+    first upload leaves one architecture behind at a version the other already
+    has. That is repaired rather than papered over -- the laggard is published
+    at the version the others reached, which is legal precisely because it does
+    not exist for that package yet.
+    """
+    versions = {arch: s["version"] for arch, s in state.items()}
+    behind = [arch for arch, v in versions.items() if v is not None]
+    leader = max((versions[a] for a in behind), default=None, key=version_key)
+    lagging = {arch for arch, v in versions.items() if v is not None and v != leader}
+
+    # Repair first: with a partial publish outstanding, a laggard's contents
+    # differing from *its* version is the symptom, not a reason to bump past the
+    # version it is missing. Only sound while the leader is itself current --
+    # otherwise that version predates upstream and nobody should join it.
+    if lagging and not override and all(state[a]["current"] for a in state if a not in lagging):
+        return leader, lagging, [
+            f"partial publish: {', '.join(sorted(lagging))} never reached {leader}",
+        ]
+
+    reasons = []
+    for arch in sorted(state):
+        if versions[arch] is None:
+            reasons.append(f"- {arch}: not published yet")
+        elif not state[arch]["current"]:
+            reasons.append(f"- {arch}: differs from {versions[arch]}")
+
+    if not reasons and not force:
+        return next_version(leader, layout_changed=False), set(), []
+    if not reasons:
+        reasons = ["nothing changed upstream, but a publish was forced"]
+    else:
+        reasons.insert(0, "republishing because:")
+
+    # A version nobody holds yet, so every architecture can take it. A stale or
+    # absent layout is the minor bump: consumers resolving paths into the tree
+    # may have to move with it, where a component bump leaves the tree alone.
+    layout_changed = any(s["layout_stale"] for s in state.values())
+    return override or next_version(leader, layout_changed), set(state), reasons
+
+
 def emit(name, value):
     print(f"##vso[task.setvariable variable={name};isOutput=true]{value}")
 
@@ -246,10 +303,7 @@ def main():
     bottle = load("install-brew-bottle.py")
     published = published_packages(args.org, project, feed, token)
 
-    changed = []
-    latest_versions = []
-    layout_changed = False
-
+    state = {}
     for arch in args.arch:
         package = PACKAGE_PREFIX + arch
         components = resolve_components(bottle, arch, args.macos_major)
@@ -260,40 +314,34 @@ def main():
         summary = ", ".join(f"{n} {components[n]['version']}" for n in sorted(components))
         print(f"\n{package}")
         print(f"  upstream now : {summary} (layout {builder.PAYLOAD_FORMAT}, id {identity})")
-
         if version is None:
             print("  published    : nothing yet")
-            changed.append(f"{arch}: not published yet")
-            layout_changed = True
-            continue
+        else:
+            print(f"  published    : {version} (layout {layout}, id {published_identity})")
+        state[arch] = {
+            "version": version,
+            "layout_stale": version is None or layout != builder.PAYLOAD_FORMAT,
+            "current": version is not None
+            and layout == builder.PAYLOAD_FORMAT
+            and published_identity == identity,
+        }
 
-        print(f"  published    : {version} (layout {layout}, id {published_identity})")
-        latest_versions.append(version)
-        if layout != builder.PAYLOAD_FORMAT:
-            layout_changed = True
-            changed.append(f"{arch}: payload layout {layout} -> {builder.PAYLOAD_FORMAT}")
-        if published_identity != identity:
-            changed.append(f"{arch}: contents differ from {version}")
-
-    # One decision for every architecture, so a given version means the same
-    # build produced all of them -- worth more than skipping the odd republish.
-    should_publish = bool(changed) or args.force
-    version = override or next_version(
-        max(latest_versions, default=None, key=lambda v: [int(p) for p in v.split(".")]),
-        layout_changed,
-    )
+    version, publish_for, reasons = decide(state, override, args.force)
 
     print("\n" + "=" * 62)
-    if changed:
-        print("republishing because:")
-        for reason in changed:
-            print(f"  - {reason}")
-    elif args.force:
-        print("nothing changed upstream, but a publish was forced")
+    for reason in reasons:
+        print(f"  {reason}")
+    if publish_for:
+        print(f"publishing {', '.join(sorted(publish_for))} as {version}"
+              + (" (explicit override)" if override else ""))
     else:
         print("nothing changed upstream; leaving the feed alone")
-    if should_publish:
-        print(f"version: {version}" + (" (explicit override)" if override else ""))
+
+    for arch in args.arch:
+        emit(f"publish_{arch}", "true" if arch in publish_for else "false")
+    emit("shouldPublish", "true" if publish_for else "false")
+    emit("packageVersion", version)
+    return 0
 
     emit("shouldPublish", "true" if should_publish else "false")
     emit("packageVersion", version)

--- a/.pipeline/scripts/resolve-toolchain-version.py
+++ b/.pipeline/scripts/resolve-toolchain-version.py
@@ -91,9 +91,14 @@ def published_packages(org_url, project, feed, token):
     # Filtered by name rather than listing the feed: the response is paginated,
     # and a feed with enough packages would push these off the first page and
     # make them look unpublished. Only the two names can match this prefix.
+    #
+    # The project and feed come from a pipeline parameter, so they are quoted
+    # into the path rather than pasted: an unescaped `?` or `&` would otherwise
+    # rewrite the query string this relies on.
     url = (
-        f"https://feeds.dev.azure.com/{organization(org_url)}/{project}"
-        f"/_apis/packaging/Feeds/{feed}/packages"
+        f"https://feeds.dev.azure.com/{urllib.parse.quote(organization(org_url), safe='')}"
+        f"/{urllib.parse.quote(project, safe='')}"
+        f"/_apis/packaging/Feeds/{urllib.parse.quote(feed, safe='')}/packages"
         f"?protocolType=upack&packageNameQuery={PACKAGE_PREFIX}"
         f"&includeDescription=true&api-version={API_VERSION}"
     )
@@ -340,10 +345,6 @@ def main():
     for arch in args.arch:
         emit(f"publish_{arch}", "true" if arch in publish_for else "false")
     emit("shouldPublish", "true" if publish_for else "false")
-    emit("packageVersion", version)
-    return 0
-
-    emit("shouldPublish", "true" if should_publish else "false")
     emit("packageVersion", version)
     return 0
 

--- a/.pipeline/scripts/resolve-toolchain-version.py
+++ b/.pipeline/scripts/resolve-toolchain-version.py
@@ -20,7 +20,7 @@ Version:
   layout unchanged  patch bump   (an upstream docker/colima/lima release)
   layout changed    minor bump   (consumers resolve paths into the tree)
   no package yet    0.1.0
-An explicit --version overrides all of it.
+An explicit --version X.Y.Z overrides all of it; 'auto' derives it.
 
 Emits Azure Pipelines output variables: shouldPublish, packageVersion, and
 identity_<arch> for the publish step to record.
@@ -42,6 +42,9 @@ import urllib.request
 HERE = os.path.dirname(os.path.abspath(__file__))
 PACKAGE_PREFIX = "macos-docker-toolchain-"
 API_VERSION = "7.1-preview.1"
+# The pipeline passes this rather than an empty string: the run panel refuses to
+# queue with a blank string parameter.
+DERIVE = "auto"
 
 
 def load(name):
@@ -120,6 +123,23 @@ def format_description(manifest):
     )
 
 
+def requested_version(raw):
+    """The explicit override, or None to derive one.
+
+    Checked before the comparison runs so a typo fails immediately rather than
+    after the network work -- and, since packages are immutable, before it can
+    burn a version number.
+    """
+    value = (raw or "").strip()
+    if not value or value.lower() == DERIVE:
+        return None
+    if not re.match(r"^\d+\.\d+\.\d+$", value):
+        raise RuntimeError(
+            f"version override {value!r} is not X.Y.Z; use '{DERIVE}' to derive it"
+        )
+    return value
+
+
 def next_version(latest, layout_changed):
     if latest is None:
         return "0.1.0"
@@ -162,7 +182,11 @@ def main():
     parser.add_argument("--feed", help="<project>/<feed>")
     parser.add_argument("--arch", action="append", choices=["x86_64", "arm64"])
     parser.add_argument("--macos-major", type=int)
-    parser.add_argument("--version", default="", help="override; skips the comparison")
+    parser.add_argument(
+        "--version",
+        default=DERIVE,
+        help=f"X.Y.Z to force a number, or '{DERIVE}' (default) to derive it",
+    )
     parser.add_argument("--force", action="store_true", help="publish even if nothing changed")
     parser.add_argument(
         "--describe",
@@ -190,6 +214,8 @@ def main():
     if "/" not in args.feed:
         raise RuntimeError(f"--feed must be <project>/<feed>, got {args.feed!r}")
     project, feed = args.feed.split("/", 1)
+
+    override = requested_version(args.version)
 
     token = os.environ.get("SYSTEM_ACCESSTOKEN", "")
     if not token:
@@ -231,7 +257,7 @@ def main():
     # One decision for every architecture, so a given version means the same
     # build produced all of them -- worth more than skipping the odd republish.
     should_publish = bool(changed) or args.force
-    version = args.version or next_version(
+    version = override or next_version(
         max(latest_versions, default=None, key=lambda v: [int(p) for p in v.split(".")]),
         layout_changed,
     )
@@ -246,7 +272,7 @@ def main():
     else:
         print("nothing changed upstream; leaving the feed alone")
     if should_publish:
-        print(f"version: {version}" + (" (explicit override)" if args.version else ""))
+        print(f"version: {version}" + (" (explicit override)" if override else ""))
 
     emit("shouldPublish", "true" if should_publish else "false")
     emit("packageVersion", version)

--- a/.pipeline/scripts/resolve-toolchain-version.py
+++ b/.pipeline/scripts/resolve-toolchain-version.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Decide whether the macOS docker toolchain needs republishing, and at what version.
+
+The payload is a derived artifact: its bytes are a function of the docker,
+colima and lima bottles it repacks, the macOS floor those bottles are selected
+for, and the layout this repo packs them into. None of that is a judgement
+call, so neither is the version -- this resolves that function and compares the
+result with what is already on the feed.
+
+Nothing is downloaded to do it. Bottle versions and digests come from registry
+metadata, and the published side is read back out of the package description,
+where publishing records it as "[layout:N id:...]". So the decision costs a
+handful of HTTP round-trips rather than the 430 MB the payload weighs.
+
+Publishes only when something actually changed. A scheduled run that finds
+upstream unmoved exits without publishing, which keeps the version history a
+record of upstream movement instead of a record of the schedule firing.
+
+Version:
+  layout unchanged  patch bump   (an upstream docker/colima/lima release)
+  layout changed    minor bump   (consumers resolve paths into the tree)
+  no package yet    0.1.0
+An explicit --version overrides all of it.
+
+Emits Azure Pipelines output variables: shouldPublish, packageVersion, and
+identity_<arch> for the publish step to record.
+
+Usage: resolve-toolchain-version.py --org <url> --feed <project/feed> \
+           --arch x86_64 --arch arm64 --macos-major 14 [--version X.Y.Z] [--force]
+Reads SYSTEM_ACCESSTOKEN from the environment.
+"""
+
+import argparse
+import importlib.util
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PACKAGE_PREFIX = "macos-docker-toolchain-"
+API_VERSION = "7.1-preview.1"
+
+
+def load(name):
+    path = os.path.join(HERE, name)
+    spec = importlib.util.spec_from_file_location(
+        os.path.splitext(name)[0].replace("-", "_"), path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def resolve_components(bottle, arch, macos_major):
+    """Bottle versions and digests for one architecture, without fetching blobs."""
+    os.environ["BOTTLE_ARCH_OVERRIDE"] = arch
+    os.environ["BOTTLE_MACOS_MAJOR_OVERRIDE"] = str(macos_major)
+    components = {}
+    for formula in ("docker", "colima", "lima"):
+        token = bottle.anonymous_token(formula)
+        version, manifest_digest, _ = bottle.find_bottle(formula, token)
+        components[formula] = {"version": version, "bottle_digest": manifest_digest}
+    return components
+
+
+def published_packages(org_url, project, feed, token):
+    org = org_url.rstrip("/").rsplit("/", 1)[-1]
+    url = (
+        f"https://feeds.dev.azure.com/{org}/{project}/_apis/packaging/Feeds/{feed}"
+        f"/packages?protocolType=upack&includeDescription=true&api-version={API_VERSION}"
+    )
+    request = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            body = json.load(response)
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"listing feed {project}/{feed} failed: {exc.code} {exc.reason}") from None
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"listing feed {project}/{feed} failed: {exc}") from None
+
+    published = {}
+    for package in body.get("value", []):
+        versions = package.get("versions") or []
+        if versions:
+            published[package["name"]] = versions[0]
+    return published
+
+
+def describe_published(entry):
+    """(version, layout, identity) for a published package; layout/identity may be None."""
+    if entry is None:
+        return None, None, None
+    description = entry.get("packageDescription") or ""
+    layout = re.search(r"\blayout:(\d+)\b", description)
+    identity = re.search(r"\bid:([0-9a-f]+)\b", description)
+    return (
+        entry.get("version"),
+        int(layout.group(1)) if layout else None,
+        identity.group(1) if identity else None,
+    )
+
+
+def format_description(manifest):
+    """The published description, which the next run parses back with describe_published.
+
+    Prose first so the feed UI says something useful, then the machine-readable
+    markers. Changing this format without changing the parser above strands
+    every published package as "unknown", forcing a needless republish.
+    """
+    versions = ", ".join(
+        f"{name} {manifest['components'][name]['version']}"
+        for name in ("docker", "colima", "lima")
+    )
+    return (
+        f"{versions} for macOS {manifest['macos_major_floor']}+ {manifest['arch']} "
+        f"[layout:{manifest['payload_format']} id:{manifest['identity']}]"
+    )
+
+
+def next_version(latest, layout_changed):
+    if latest is None:
+        return "0.1.0"
+    parsed = re.match(r"^(\d+)\.(\d+)\.(\d+)$", latest)
+    if not parsed:
+        raise RuntimeError(
+            f"published version {latest!r} is not X.Y.Z, so the next one cannot be "
+            f"derived; pass an explicit --version"
+        )
+    major, minor, patch = (int(part) for part in parsed.groups())
+    if layout_changed:
+        return f"{major}.{minor + 1}.0"
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def emit(name, value):
+    print(f"##vso[task.setvariable variable={name};isOutput=true]{value}")
+
+
+def describe_payload(manifest_path, expect_identity):
+    with open(manifest_path) as handle:
+        manifest = json.load(handle)
+    # The build resolved upstream independently of the decision. If they
+    # disagree, a release landed between the two jobs and the description
+    # would misdescribe what is in the package.
+    if expect_identity and manifest["identity"] != expect_identity:
+        raise RuntimeError(
+            f"payload identity {manifest['identity']} does not match the resolved "
+            f"{expect_identity}; upstream moved mid-run"
+        )
+    description = format_description(manifest)
+    print(f"description: {description}")
+    print(f"##vso[task.setvariable variable=packageDescription]{description}")
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--org", help="e.g. https://dev.azure.com/sqlclientdrivers")
+    parser.add_argument("--feed", help="<project>/<feed>")
+    parser.add_argument("--arch", action="append", choices=["x86_64", "arm64"])
+    parser.add_argument("--macos-major", type=int)
+    parser.add_argument("--version", default="", help="override; skips the comparison")
+    parser.add_argument("--force", action="store_true", help="publish even if nothing changed")
+    parser.add_argument(
+        "--describe",
+        metavar="MANIFEST",
+        help="emit the publish description for a built payload and exit",
+    )
+    parser.add_argument(
+        "--expect-identity",
+        help="with --describe, fail unless the built payload has this identity",
+    )
+    args = parser.parse_args()
+
+    if args.describe:
+        return describe_payload(args.describe, args.expect_identity)
+
+    missing = [
+        flag
+        for flag, value in (("--org", args.org), ("--feed", args.feed),
+                            ("--arch", args.arch), ("--macos-major", args.macos_major))
+        if not value
+    ]
+    if missing:
+        raise RuntimeError(f"missing required arguments: {', '.join(missing)}")
+
+    if "/" not in args.feed:
+        raise RuntimeError(f"--feed must be <project>/<feed>, got {args.feed!r}")
+    project, feed = args.feed.split("/", 1)
+
+    token = os.environ.get("SYSTEM_ACCESSTOKEN", "")
+    if not token:
+        raise RuntimeError("SYSTEM_ACCESSTOKEN is empty; the decide step needs it to read the feed")
+
+    builder = load("build-macos-docker-toolchain.py")
+    bottle = load("install-brew-bottle.py")
+    published = published_packages(args.org, project, feed, token)
+
+    changed = []
+    latest_versions = []
+    layout_changed = False
+
+    for arch in args.arch:
+        package = PACKAGE_PREFIX + arch
+        components = resolve_components(bottle, arch, args.macos_major)
+        identity = builder.payload_identity(components, args.macos_major)
+        emit(f"identity_{arch}", identity)
+
+        version, layout, published_identity = describe_published(published.get(package))
+        summary = ", ".join(f"{n} {components[n]['version']}" for n in sorted(components))
+        print(f"\n{package}")
+        print(f"  upstream now : {summary} (layout {builder.PAYLOAD_FORMAT}, id {identity})")
+
+        if version is None:
+            print("  published    : nothing yet")
+            changed.append(f"{arch}: not published yet")
+            layout_changed = True
+            continue
+
+        print(f"  published    : {version} (layout {layout}, id {published_identity})")
+        latest_versions.append(version)
+        if layout != builder.PAYLOAD_FORMAT:
+            layout_changed = True
+            changed.append(f"{arch}: payload layout {layout} -> {builder.PAYLOAD_FORMAT}")
+        if published_identity != identity:
+            changed.append(f"{arch}: contents differ from {version}")
+
+    # One decision for every architecture, so a given version means the same
+    # build produced all of them -- worth more than skipping the odd republish.
+    should_publish = bool(changed) or args.force
+    version = args.version or next_version(
+        max(latest_versions, default=None, key=lambda v: [int(p) for p in v.split(".")]),
+        layout_changed,
+    )
+
+    print("\n" + "=" * 62)
+    if changed:
+        print("republishing because:")
+        for reason in changed:
+            print(f"  - {reason}")
+    elif args.force:
+        print("nothing changed upstream, but a publish was forced")
+    else:
+        print("nothing changed upstream; leaving the feed alone")
+    if should_publish:
+        print(f"version: {version}" + (" (explicit override)" if args.version else ""))
+
+    emit("shouldPublish", "true" if should_publish else "false")
+    emit("packageVersion", version)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except RuntimeError as exc:
+        print(f"##[error]{exc}")
+        sys.exit(1)

--- a/.pipeline/scripts/resolve-toolchain-version.py
+++ b/.pipeline/scripts/resolve-toolchain-version.py
@@ -170,23 +170,29 @@ def requested_version(raw):
     return value
 
 
+def version_key(version):
+    """Sortable form of an X.Y.Z version, refusing anything else.
+
+    Published versions come off the feed, where a hand-published prerelease is
+    possible; ordering one with a bare int() gives a traceback rather than a
+    failure anyone can act on.
+    """
+    parsed = re.match(r"^(\d+)\.(\d+)\.(\d+)$", version)
+    if not parsed:
+        raise RuntimeError(
+            f"published version {version!r} is not X.Y.Z, so versions cannot be "
+            f"ordered; pass an explicit --version"
+        )
+    return [int(part) for part in parsed.groups()]
+
+
 def next_version(latest, layout_changed):
     if latest is None:
         return "0.1.0"
-    parsed = re.match(r"^(\d+)\.(\d+)\.(\d+)$", latest)
-    if not parsed:
-        raise RuntimeError(
-            f"published version {latest!r} is not X.Y.Z, so the next one cannot be "
-            f"derived; pass an explicit --version"
-        )
-    major, minor, patch = (int(part) for part in parsed.groups())
+    major, minor, patch = version_key(latest)
     if layout_changed:
         return f"{major}.{minor + 1}.0"
     return f"{major}.{minor}.{patch + 1}"
-
-
-def version_key(version):
-    return [int(part) for part in version.split(".")]
 
 
 def decide(state, override=None, force=False):

--- a/.pipeline/scripts/resolve-toolchain-version.py
+++ b/.pipeline/scripts/resolve-toolchain-version.py
@@ -37,6 +37,7 @@ import os
 import re
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -69,20 +70,40 @@ def resolve_components(bottle, arch, macos_major):
     return components
 
 
+def organization(collection_uri):
+    """Organization name out of either form of System.CollectionUri.
+
+    Older organizations -- this one included -- still hand agents
+    https://<org>.visualstudio.com/ rather than https://dev.azure.com/<org>/,
+    so taking the last path segment yields a hostname and a feed URL that 404s.
+    """
+    parsed = urllib.parse.urlparse(collection_uri.strip().rstrip("/"))
+    host = parsed.netloc or parsed.path
+    if host.endswith(".visualstudio.com"):
+        return host.split(".", 1)[0]
+    segments = [segment for segment in parsed.path.split("/") if segment]
+    if not segments:
+        raise RuntimeError(f"cannot read an organization out of {collection_uri!r}")
+    return segments[-1]
+
+
 def published_packages(org_url, project, feed, token):
-    org = org_url.rstrip("/").rsplit("/", 1)[-1]
     url = (
-        f"https://feeds.dev.azure.com/{org}/{project}/_apis/packaging/Feeds/{feed}"
-        f"/packages?protocolType=upack&includeDescription=true&api-version={API_VERSION}"
+        f"https://feeds.dev.azure.com/{organization(org_url)}/{project}"
+        f"/_apis/packaging/Feeds/{feed}/packages"
+        f"?protocolType=upack&includeDescription=true&api-version={API_VERSION}"
     )
     request = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
     try:
         with urllib.request.urlopen(request, timeout=60) as response:
             body = json.load(response)
     except urllib.error.HTTPError as exc:
-        raise RuntimeError(f"listing feed {project}/{feed} failed: {exc.code} {exc.reason}") from None
+        # The URL matters more than the feed name here: a 404 is equally what
+        # you get from a malformed organization and from an identity that
+        # cannot see the feed.
+        raise RuntimeError(f"GET {url} failed: {exc.code} {exc.reason}") from None
     except urllib.error.URLError as exc:
-        raise RuntimeError(f"listing feed {project}/{feed} failed: {exc}") from None
+        raise RuntimeError(f"GET {url} failed: {exc}") from None
 
     published = {}
     for package in body.get("value", []):

--- a/.pipeline/scripts/start-colima-macos.sh
+++ b/.pipeline/scripts/start-colima-macos.sh
@@ -44,7 +44,21 @@ fail() {
 }
 
 manifest_field() {
-  python3 -c "import json,sys;print(json.load(open(sys.argv[1]))$1)" "$TOOLCHAIN_DIR/manifest.json"
+  python3 -c 'import json, sys
+value = json.load(open(sys.argv[1]))
+for key in sys.argv[2:]:
+    value = value[key]
+print(value)' "$TOOLCHAIN_DIR/manifest.json" "$@"
+}
+
+# Manifest values that become paths are checked rather than trusted. The
+# payload is ours, but "it came from our feed" is not the same as "it is
+# well-formed", and these are joined onto a directory.
+plain_name() {
+  case "$1" in
+    "" | . | .. | */* | *[!A-Za-z0-9._-]*)
+      fail "toolchain manifest gave $2 as '$1', which is not a plain file name" ;;
+  esac
 }
 
 # Puts the packaged toolchain on PATH and seeds colima's image cache. Nothing
@@ -74,14 +88,18 @@ install_from_package() {
   # otherwise download it from, so seeding it under that name is what keeps the
   # ~350 MB fetch from github.com out of the job.
   local cache_dir="$HOME/Library/Caches/colima/caches"
-  local cached image
-  cached="$cache_dir/$(manifest_field "['image']['cache_filename']")"
-  image="$TOOLCHAIN_DIR/image/$(manifest_field "['image']['filename']")"
+  local cache_name image_name cached image
+  cache_name=$(manifest_field image cache_filename)
+  image_name=$(manifest_field image filename)
+  plain_name "$cache_name" "image.cache_filename"
+  plain_name "$image_name" "image.filename"
+  cached="$cache_dir/$cache_name"
+  image="$TOOLCHAIN_DIR/image/$image_name"
   [ -f "$image" ] || fail "toolchain payload has no guest image at $image"
   mkdir -p "$cache_dir"
   [ -f "$cached" ] || cp "$image" "$cached"
 
-  echo "toolchain: $(manifest_field "['arch']") payload, layout $(manifest_field "['payload_format']"), id $(manifest_field "['identity']")"
+  echo "toolchain: $(manifest_field arch) payload, layout $(manifest_field payload_format), id $(manifest_field identity)"
   echo "guest image seeded at $cached ($(du -h "$cached" | cut -f1))"
 }
 

--- a/.pipeline/scripts/start-colima-macos.sh
+++ b/.pipeline/scripts/start-colima-macos.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
-# Installs Docker + Colima on a Microsoft-hosted macOS agent and boots the VM.
+# Boots a Colima VM on a Microsoft-hosted macOS agent from a prebuilt toolchain.
+#
+# Nothing is installed here and nothing is downloaded: TOOLCHAIN_DIR points at a
+# payload of docker, colima, lima and colima's guest image, fetched from our own
+# feed by .pipeline/templates/macos-docker-steps.yml and produced by
+# .pipeline/macos-docker-toolchain-pipeline.yml. A run therefore contacts
+# neither Homebrew nor ghcr.io nor github.com, which is the point: Homebrew
+# dropping the Intel docker bottle at 29.8.0 turned `brew install docker` into
+# an 8-minute Go build, and colima's image download has failed on DNS.
 #
 # Colima's VM boot is flaky on hosted macOS (~3% of runs): the lima hostagent
 # either misses its 5s startup window or never emits the `running` event. Both
@@ -25,122 +33,42 @@ COLIMA_START_TIMEOUT_SECONDS=${COLIMA_START_TIMEOUT_SECONDS:-540}
 # The macOS job only gets 60 minutes, so cap the retries by wall clock rather
 # than letting three boots of an unhealthy agent eat the test budget.
 COLIMA_BUDGET_SECONDS=${COLIMA_BUDGET_SECONDS:-480}
-# `brew install docker` is deliberately not used bare. Homebrew ships no bottle
-# for the docker CLI on Intel macOS as of 29.8.0, so a bare install compiles it
-# from source and builds Go (~8 min) to do so. Measured over 147 runs: agents
-# that resolved the bottled 29.7.2 finished this phase in 29s median and failed
-# 1% of the time, while agents that built 29.8.0 took 441s median (774s max) and
-# failed 36% — the build alone exhausted the step timeout.
-#
-# `--force-bottle` makes brew refuse to build the *requested* formula from
-# source, but Homebrew dropping bottle support for Intel macOS entirely
-# (September 2026) exposed a gap that assumption doesn't cover: brew still
-# resolves and starts fetching source for docker's *build dependencies* (go,
-# go-md2man) before it gets around to reporting "docker has no bottle", so the
-# attempt can hang well past that error on a platform with no bottles at all.
-# Bounded separately and tightly so that hang is cut short well before it could
-# exhaust the whole install budget, falling through instead to the fallback
-# below, which doesn't invoke brew and isn't subject to this at all. No
-# measured p95/max for this one, unlike the other limits in this file: a
-# healthy-but-slow bottled install that this cuts off still lands on the
-# fallback and still installs docker, just slower, so the failure mode of
-# sizing this wrong is "occasionally takes the slower path", not a stuck step.
-#
-# When it does fail (or is cut short), install-brew-bottle.py takes the newest
-# version that *is* bottled for this platform straight from Homebrew's
-# registry, so there is no version to pin by hand and no third-party download.
-# Both paths therefore install exactly what Homebrew would have, and this
-# self-heals once the current version is bottled again — which on arm64 it
-# already is.
-DOCKER_CLI_DIR=${DOCKER_CLI_DIR:-$HOME/.docker-cli/bin}
-DOCKER_BOTTLE_TIMEOUT_SECONDS=${DOCKER_BOTTLE_TIMEOUT_SECONDS:-90}
-# Bounded so a slow install fails here with a message rather than silently
-# consuming the step budget and surfacing as an opaque "task has timed out".
-INSTALL_TIMEOUT_SECONDS=${INSTALL_TIMEOUT_SECONDS:-300}
-# A payload from our own feed, published by
-# .pipeline/macos-docker-toolchain-pipeline.yml. When set, none of the Homebrew
-# reasoning above applies: the toolchain is already resolved, verified and
-# pinned, so the job reaches nothing but Azure Artifacts. The brew path below
-# stays for runs that do not have one, such as a developer running this script.
+# The payload to run from. Required: there is no second way to get a docker CLI
+# onto the agent, and a run that quietly found one some other way would not be
+# the run we tested.
 TOOLCHAIN_DIR=${TOOLCHAIN_DIR:-}
 
-# A leftover directory would make the "did we fall back?" check below lie.
-rm -rf "$DOCKER_CLI_DIR"
-
-# Every install step is bounded directly by run_bounded here, one call each,
-# none nested inside another. run_bounded's timeout path signals the bounded
-# command's *own* process group (`set -m` gives it one), specifically so a
-# hang doesn't leave a grandchild alive holding the task's stdout after the
-# bound fires. Wrapping this whole sequence in one more, outer run_bounded --
-# as an earlier version of this script did, backgrounding the function that
-# contains these calls -- would put that function in its own group and each
-# command it bounds in a *further* nested group of its own: if the outer
-# bound fired while a command was still inside its own inner bound, the outer
-# kill would reach the function's group but not the nested command's, leaving
-# exactly the orphan this helper exists to prevent. Flat, single-level bounds
-# don't have that failure mode: whichever bound owns a command is the only
-# one that can ever signal it.
-install_deadline=$(( $(date +%s) + INSTALL_TIMEOUT_SECONDS ))
-
-fail_install() {
+fail() {
   echo "##[error]$1"
   exit 1
-}
-
-# Whatever remains of the overall install budget, capped at $1 when given
-# and smaller, or 0 once the budget is exhausted. Never calls fail_install
-# itself: every caller reads this through a plain `$(...)` command
-# substitution, where an `exit` only ends that subshell, not the script --
-# so the 0 case has to be checked, and failed, by the caller instead.
-budget_limit() {
-  local cap=${1:-}
-  local left=$((install_deadline - $(date +%s)))
-  [ "$left" -gt 0 ] || left=0
-  if [ -n "$cap" ] && [ "$cap" -lt "$left" ]; then
-    echo "$cap"
-  else
-    echo "$left"
-  fi
-}
-
-# Bounds "$@" by whatever remains of the overall install budget, failing the
-# step immediately -- rather than letting a later step start against an
-# already-exhausted or barely-alive budget -- on timeout or a non-zero exit.
-run_install_step() {
-  local limit
-  limit=$(budget_limit)
-  if [ "$limit" -eq 0 ]; then
-    fail_install "Installing colima and the docker CLI did not finish within ${INSTALL_TIMEOUT_SECONDS}s"
-  fi
-  # Not `run_bounded ... ; local status=$?`: under `set -e`, a non-zero
-  # exit from a plain (untested) command aborts the script on the spot,
-  # before this function ever reaches the `local` line to capture it. `||`
-  # is a test, so it's the only way to observe the real code here.
-  local status=0
-  run_bounded "$limit" "$@" || status=$?
-  if [ "$status" -eq 124 ]; then
-    fail_install "Installing colima and the docker CLI did not finish within ${INSTALL_TIMEOUT_SECONDS}s"
-  elif [ "$status" -ne 0 ]; then
-    fail_install "Installing colima and the docker CLI failed (exit $status)"
-  fi
 }
 
 manifest_field() {
   python3 -c "import json,sys;print(json.load(open(sys.argv[1]))$1)" "$TOOLCHAIN_DIR/manifest.json"
 }
 
-# Puts the packaged toolchain on PATH and seeds colima's image cache, so
-# neither Homebrew nor github.com is contacted. Nothing here is bounded: it is
-# local file work against a payload the agent already has.
+# Puts the packaged toolchain on PATH and seeds colima's image cache. Nothing
+# here is bounded, unlike `colima start` below: it is local file work against a
+# payload the agent already has.
 install_from_package() {
+  [ -n "$TOOLCHAIN_DIR" ] \
+    || fail "TOOLCHAIN_DIR is not set; this script runs from the packaged toolchain (see .pipeline/templates/macos-docker-steps.yml)"
   [ -f "$TOOLCHAIN_DIR/manifest.json" ] \
-    || fail_install "no manifest.json in the toolchain payload at $TOOLCHAIN_DIR"
+    || fail "no manifest.json in the toolchain payload at $TOOLCHAIN_DIR"
 
   # Universal Packages do not carry POSIX modes, so the executable bit does not
   # survive the round trip through the feed.
   chmod -R +x "$TOOLCHAIN_DIR/bin" "$TOOLCHAIN_DIR/libexec" 2>/dev/null || true
   export PATH="$TOOLCHAIN_DIR/bin:$PATH"
   echo "##vso[task.prependpath]$TOOLCHAIN_DIR/bin"
+
+  # Checked here rather than left to fail at the first use: `colima start`
+  # reporting a missing limactl is a much longer walk back to "the payload was
+  # incomplete".
+  local tool
+  for tool in docker colima limactl; do
+    [ -x "$TOOLCHAIN_DIR/bin/$tool" ] || fail "toolchain payload has no executable bin/$tool"
+  done
 
   # colima looks the guest image up in this cache by sha256 of the URL it would
   # otherwise download it from, so seeding it under that name is what keeps the
@@ -149,7 +77,7 @@ install_from_package() {
   local cached image
   cached="$cache_dir/$(manifest_field "['image']['cache_filename']")"
   image="$TOOLCHAIN_DIR/image/$(manifest_field "['image']['filename']")"
-  [ -f "$image" ] || fail_install "toolchain payload has no guest image at $image"
+  [ -f "$image" ] || fail "toolchain payload has no guest image at $image"
   mkdir -p "$cache_dir"
   [ -f "$cached" ] || cp "$image" "$cached"
 
@@ -157,34 +85,7 @@ install_from_package() {
   echo "guest image seeded at $cached ($(du -h "$cached" | cut -f1))"
 }
 
-if [ -n "$TOOLCHAIN_DIR" ]; then
-  install_from_package
-else
-  run_install_step brew update
-  run_install_step brew install colima
-
-  # The docker-bottle attempt is the one step allowed to fail without ending
-  # the job: that failure is the expected, handled path into the fallback, not
-  # an install error. It is also the only step that needs a cap tighter than
-  # the overall budget (DOCKER_BOTTLE_TIMEOUT_SECONDS), which is why it can't
-  # go through run_install_step: that helper treats any non-zero exit as
-  # fatal.
-  bottle_limit=$(budget_limit "$DOCKER_BOTTLE_TIMEOUT_SECONDS")
-  if [ "$bottle_limit" -eq 0 ]; then
-    fail_install "Installing colima and the docker CLI did not finish within ${INSTALL_TIMEOUT_SECONDS}s"
-  fi
-  if ! run_bounded "$bottle_limit" brew install --force-bottle docker; then
-    echo "##[warning]No docker CLI bottle for the current version on this platform (or the attempt ran past ${bottle_limit}s); falling back to the newest bottled version"
-    run_install_step python3 "$(dirname "$0")/install-brew-bottle.py" docker "$DOCKER_CLI_DIR"
-  fi
-
-  # Only the fallback populates DOCKER_CLI_DIR; brew's own docker is already on PATH.
-  # prependpath only affects later steps, so also fix PATH for this one.
-  if [ -x "$DOCKER_CLI_DIR/docker" ]; then
-    export PATH="$DOCKER_CLI_DIR:$PATH"
-    echo "##vso[task.prependpath]$DOCKER_CLI_DIR"
-  fi
-fi
+install_from_package
 
 docker --version
 colima version | head -1
@@ -207,6 +108,11 @@ while [ "$attempts" -lt "$COLIMA_START_ATTEMPTS" ]; do
 
   attempts=$((attempts + 1))
   echo "##[group]colima start (attempt $attempts/$COLIMA_START_ATTEMPTS, ${limit}s limit)"
+  # The only bounded command in this script, and it must stay that way: on
+  # timeout run_bounded signals the bounded command's own process group, so a
+  # wedged boot cannot leave limactl or qemu alive holding the task's stdout.
+  # Nesting another run_bounded around this one would put that group out of
+  # reach of the outer kill and reintroduce exactly that orphan.
   if run_bounded "$limit" colima start --cpu "$COLIMA_CPU" --memory "$COLIMA_MEMORY" --disk "$COLIMA_DISK"; then
     echo "##[endgroup]"
     docker context use colima >/dev/null || true

--- a/.pipeline/scripts/start-colima-macos.sh
+++ b/.pipeline/scripts/start-colima-macos.sh
@@ -57,6 +57,12 @@ DOCKER_BOTTLE_TIMEOUT_SECONDS=${DOCKER_BOTTLE_TIMEOUT_SECONDS:-90}
 # Bounded so a slow install fails here with a message rather than silently
 # consuming the step budget and surfacing as an opaque "task has timed out".
 INSTALL_TIMEOUT_SECONDS=${INSTALL_TIMEOUT_SECONDS:-300}
+# A payload from our own feed, published by
+# .pipeline/macos-docker-toolchain-pipeline.yml. When set, none of the Homebrew
+# reasoning above applies: the toolchain is already resolved, verified and
+# pinned, so the job reaches nothing but Azure Artifacts. The brew path below
+# stays for runs that do not have one, such as a developer running this script.
+TOOLCHAIN_DIR=${TOOLCHAIN_DIR:-}
 
 # A leftover directory would make the "did we fall back?" check below lie.
 rm -rf "$DOCKER_CLI_DIR"
@@ -119,31 +125,69 @@ run_install_step() {
   fi
 }
 
-run_install_step brew update
-run_install_step brew install colima
+manifest_field() {
+  python3 -c "import json,sys;print(json.load(open(sys.argv[1]))$1)" "$TOOLCHAIN_DIR/manifest.json"
+}
 
-# The docker-bottle attempt is the one step allowed to fail without ending
-# the job: that failure is the expected, handled path into the fallback, not
-# an install error. It is also the only step that needs a cap tighter than
-# the overall budget (DOCKER_BOTTLE_TIMEOUT_SECONDS), which is why it can't
-# go through run_install_step: that helper treats any non-zero exit as
-# fatal.
-bottle_limit=$(budget_limit "$DOCKER_BOTTLE_TIMEOUT_SECONDS")
-if [ "$bottle_limit" -eq 0 ]; then
-  fail_install "Installing colima and the docker CLI did not finish within ${INSTALL_TIMEOUT_SECONDS}s"
-fi
-if ! run_bounded "$bottle_limit" brew install --force-bottle docker; then
-  echo "##[warning]No docker CLI bottle for the current version on this platform (or the attempt ran past ${bottle_limit}s); falling back to the newest bottled version"
-  run_install_step python3 "$(dirname "$0")/install-brew-bottle.py" docker "$DOCKER_CLI_DIR"
+# Puts the packaged toolchain on PATH and seeds colima's image cache, so
+# neither Homebrew nor github.com is contacted. Nothing here is bounded: it is
+# local file work against a payload the agent already has.
+install_from_package() {
+  [ -f "$TOOLCHAIN_DIR/manifest.json" ] \
+    || fail_install "no manifest.json in the toolchain payload at $TOOLCHAIN_DIR"
+
+  # Universal Packages do not carry POSIX modes, so the executable bit does not
+  # survive the round trip through the feed.
+  chmod -R +x "$TOOLCHAIN_DIR/bin" "$TOOLCHAIN_DIR/libexec" 2>/dev/null || true
+  export PATH="$TOOLCHAIN_DIR/bin:$PATH"
+  echo "##vso[task.prependpath]$TOOLCHAIN_DIR/bin"
+
+  # colima looks the guest image up in this cache by sha256 of the URL it would
+  # otherwise download it from, so seeding it under that name is what keeps the
+  # ~350 MB fetch from github.com out of the job.
+  local cache_dir="$HOME/Library/Caches/colima/caches"
+  local cached image
+  cached="$cache_dir/$(manifest_field "['image']['cache_filename']")"
+  image="$TOOLCHAIN_DIR/image/$(manifest_field "['image']['filename']")"
+  [ -f "$image" ] || fail_install "toolchain payload has no guest image at $image"
+  mkdir -p "$cache_dir"
+  [ -f "$cached" ] || cp "$image" "$cached"
+
+  echo "toolchain: $(manifest_field "['arch']") payload, layout $(manifest_field "['payload_format']"), id $(manifest_field "['identity']")"
+  echo "guest image seeded at $cached ($(du -h "$cached" | cut -f1))"
+}
+
+if [ -n "$TOOLCHAIN_DIR" ]; then
+  install_from_package
+else
+  run_install_step brew update
+  run_install_step brew install colima
+
+  # The docker-bottle attempt is the one step allowed to fail without ending
+  # the job: that failure is the expected, handled path into the fallback, not
+  # an install error. It is also the only step that needs a cap tighter than
+  # the overall budget (DOCKER_BOTTLE_TIMEOUT_SECONDS), which is why it can't
+  # go through run_install_step: that helper treats any non-zero exit as
+  # fatal.
+  bottle_limit=$(budget_limit "$DOCKER_BOTTLE_TIMEOUT_SECONDS")
+  if [ "$bottle_limit" -eq 0 ]; then
+    fail_install "Installing colima and the docker CLI did not finish within ${INSTALL_TIMEOUT_SECONDS}s"
+  fi
+  if ! run_bounded "$bottle_limit" brew install --force-bottle docker; then
+    echo "##[warning]No docker CLI bottle for the current version on this platform (or the attempt ran past ${bottle_limit}s); falling back to the newest bottled version"
+    run_install_step python3 "$(dirname "$0")/install-brew-bottle.py" docker "$DOCKER_CLI_DIR"
+  fi
+
+  # Only the fallback populates DOCKER_CLI_DIR; brew's own docker is already on PATH.
+  # prependpath only affects later steps, so also fix PATH for this one.
+  if [ -x "$DOCKER_CLI_DIR/docker" ]; then
+    export PATH="$DOCKER_CLI_DIR:$PATH"
+    echo "##vso[task.prependpath]$DOCKER_CLI_DIR"
+  fi
 fi
 
-# Only the fallback populates DOCKER_CLI_DIR; brew's own docker is already on PATH.
-# prependpath only affects later steps, so also fix PATH for this one.
-if [ -x "$DOCKER_CLI_DIR/docker" ]; then
-  export PATH="$DOCKER_CLI_DIR:$PATH"
-  echo "##vso[task.prependpath]$DOCKER_CLI_DIR"
-fi
 docker --version
+colima version | head -1
 
 start_time=$(date +%s)
 deadline=$((start_time + COLIMA_BUDGET_SECONDS))

--- a/.pipeline/scripts/test_install_brew_bottle.py
+++ b/.pipeline/scripts/test_install_brew_bottle.py
@@ -189,5 +189,80 @@ class Extraction(unittest.TestCase):
             self.extract([("docker/29.7.2/README.md", True)])
 
 
+class PrefixExtraction(unittest.TestCase):
+    """extract_prefix merges several bottles into one relocatable prefix."""
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+
+    def extract(self, formula, version, entries):
+        return bottle.extract_prefix(make_bottle(entries), formula, version, self.root)
+
+    def on_disk(self):
+        return sorted(
+            str(p.relative_to(self.root))
+            for p in Path(self.root).rglob("*")
+            if p.is_file() or p.is_symlink()
+        )
+
+    def test_root_metadata_is_namespaced_per_formula(self):
+        # Every formula ships its own LICENSE/sbom at the prefix root; merging
+        # them flat would keep only the last one extracted.
+        self.extract("docker", "29.7.2", [
+            ("docker/29.7.2/LICENSE", True),
+            ("docker/29.7.2/sbom.spdx.json", True),
+        ])
+        self.extract("lima", "2.2.0", [
+            ("lima/2.2.0/LICENSE", True),
+            ("lima/2.2.0/sbom.spdx.json", True),
+        ])
+        self.assertEqual(self.on_disk(), [
+            "metadata/docker/LICENSE",
+            "metadata/docker/sbom.spdx.json",
+            "metadata/lima/LICENSE",
+            "metadata/lima/sbom.spdx.json",
+        ])
+
+    def test_functional_content_still_merges_into_a_shared_prefix(self):
+        # limactl resolves ../share/lima relative to its own bin/, so the
+        # subdirectories must merge rather than be namespaced.
+        self.extract("docker", "29.7.2", [("docker/29.7.2/bin/docker", True)])
+        self.extract("lima", "2.2.0", [
+            ("lima/2.2.0/bin/limactl", True),
+            ("lima/2.2.0/share/lima/lima-guestagent.Linux-x86_64.gz", True),
+            ("lima/2.2.0/libexec/lima/lima-driver-vz", True),
+        ])
+        self.assertEqual(self.on_disk(), [
+            "bin/docker",
+            "bin/limactl",
+            "libexec/lima/lima-driver-vz",
+            "share/lima/lima-guestagent.Linux-x86_64.gz",
+        ])
+
+    def test_brew_bookkeeping_is_not_shipped(self):
+        self.extract("docker", "29.7.2", [
+            ("docker/29.7.2/.brew/docker.rb", True),
+            ("docker/29.7.2/bin/docker", True),
+        ])
+        self.assertEqual(self.on_disk(), ["bin/docker"])
+
+    def test_revision_tag_reads_the_unrevised_cellar_directory(self):
+        self.extract("docker", "29.7.2-1", [("docker/29.7.2/bin/docker", True)])
+        self.assertEqual(self.on_disk(), ["bin/docker"])
+
+    def test_traversal_outside_the_prefix_is_refused(self):
+        with self.assertRaises(RuntimeError):
+            self.extract("docker", "29.7.2", [("docker/29.7.2/bin/../../../evil", True)])
+        self.assertEqual(self.on_disk(), [])
+
+    def test_symlink_escaping_the_prefix_is_refused(self):
+        # make_bottle points its symlinks at ../elsewhere.
+        self.extract("docker", "29.7.2", [
+            ("docker/29.7.2/bin/docker", True),
+            ("docker/29.7.2/bin/escape", False),
+        ])
+        self.assertEqual(self.on_disk(), ["bin/docker"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.pipeline/scripts/test_install_brew_bottle.py
+++ b/.pipeline/scripts/test_install_brew_bottle.py
@@ -141,11 +141,20 @@ class HostRanking(unittest.TestCase):
 
 
 def make_bottle(entries):
-    """A gzipped tar of `(name, is_file)` members, as the registry serves them."""
+    """A gzipped tar of `(name, is_file)` members, as the registry serves them.
+
+    A member may also be `(name, 'symlink', linkname)` to aim a link precisely.
+    """
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-        for name, is_file in entries:
-            if is_file:
+        for entry in entries:
+            name, kind = entry[0], entry[1]
+            if kind == "symlink":
+                info = tarfile.TarInfo(name)
+                info.type = tarfile.SYMTYPE
+                info.linkname = entry[2]
+                tar.addfile(info)
+            elif kind:
                 payload = b"#!/bin/sh\n"
                 info = tarfile.TarInfo(name)
                 info.size = len(payload)
@@ -255,13 +264,45 @@ class PrefixExtraction(unittest.TestCase):
             self.extract("docker", "29.7.2", [("docker/29.7.2/bin/../../../evil", True)])
         self.assertEqual(self.on_disk(), [])
 
-    def test_symlink_escaping_the_prefix_is_refused(self):
-        # make_bottle points its symlinks at ../elsewhere.
+    def test_an_absolute_symlink_is_refused(self):
         self.extract("docker", "29.7.2", [
             ("docker/29.7.2/bin/docker", True),
-            ("docker/29.7.2/bin/escape", False),
+            ("docker/29.7.2/bin/escape", "symlink", "/etc/passwd"),
         ])
         self.assertEqual(self.on_disk(), ["bin/docker"])
+
+    def test_a_relative_symlink_that_lands_back_inside_is_kept(self):
+        # `../elsewhere` from bin/ resolves to <prefix>/elsewhere, which is in
+        # the prefix. Judging the linkname by its leading `../` would refuse a
+        # link that never leaves.
+        self.extract("docker", "29.7.2", [
+            ("docker/29.7.2/bin/docker", True),
+            ("docker/29.7.2/bin/sibling", "symlink", "../elsewhere"),
+        ])
+        self.assertEqual(self.on_disk(), ["bin/docker", "bin/sibling"])
+
+    def test_a_symlink_climbing_out_through_a_subdirectory_is_refused(self):
+        # No leading `../`, so a prefix test on the linkname alone accepts it,
+        # and a later member written through the link lands outside the prefix.
+        for linkname in ("a/../../../outside", "./../../outside", "bin/../../.."):
+            with self.subTest(linkname=linkname):
+                self.setUp()
+                self.extract("docker", "29.7.2", [
+                    ("docker/29.7.2/bin/docker", True),
+                    ("docker/29.7.2/bin/escape", "symlink", linkname),
+                ])
+                self.assertEqual(self.on_disk(), ["bin/docker"])
+
+    def test_a_symlink_staying_inside_the_prefix_is_kept(self):
+        # lima ships these, so refusing every symlink is not an option.
+        self.extract("lima", "2.2.0", [
+            ("lima/2.2.0/bin/limactl", True),
+            ("lima/2.2.0/bin/nested/../limactl-alias", "symlink", "limactl"),
+            ("lima/2.2.0/share/lima/link", "symlink", "../../bin/limactl"),
+        ])
+        self.assertEqual(
+            self.on_disk(), ["bin/limactl", "bin/limactl-alias", "share/lima/link"]
+        )
 
 
 if __name__ == "__main__":

--- a/.pipeline/scripts/test_install_brew_bottle.py
+++ b/.pipeline/scripts/test_install_brew_bottle.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import importlib.util
 import io
 import os
+import stat
 import tarfile
 import tempfile
 import unittest
@@ -281,6 +282,22 @@ class PrefixExtraction(unittest.TestCase):
         ])
         self.assertEqual(self.on_disk(), ["bin/docker", "bin/sibling"])
 
+    def test_the_archive_cannot_ask_for_setuid(self):
+        blob = make_bottle([("docker/29.7.2/bin/docker", True)])
+        # Rewrite the member's mode: tarfile keeps whatever the archive says.
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=io.BytesIO(blob)) as src, \
+                tarfile.open(fileobj=buf, mode="w:gz") as out:
+            for member in src.getmembers():
+                member.mode = 0o4777
+                out.addfile(member, src.extractfile(member))
+        bottle.extract_prefix(buf.getvalue(), "docker", "29.7.2", self.root)
+        mode = os.stat(os.path.join(self.root, "bin/docker")).st_mode
+        self.assertFalse(mode & stat.S_ISUID, "setuid survived extraction")
+        self.assertFalse(mode & stat.S_ISGID, "setgid survived extraction")
+        self.assertFalse(mode & stat.S_IWOTH, "world-writable survived extraction")
+        self.assertTrue(mode & stat.S_IXUSR, "the executable bit should survive")
+
     def test_a_symlink_climbing_out_through_a_subdirectory_is_refused(self):
         # No leading `../`, so a prefix test on the linkname alone accepts it,
         # and a later member written through the link lands outside the prefix.
@@ -303,6 +320,14 @@ class PrefixExtraction(unittest.TestCase):
         self.assertEqual(
             self.on_disk(), ["bin/limactl", "bin/limactl-alias", "share/lima/link"]
         )
+
+
+class FormulaNames(unittest.TestCase):
+    def test_a_name_that_is_really_more_url_is_refused(self):
+        # The name is pasted into registry URLs.
+        for name in ("../../evil", "docker/../other", "docker?tag=x", "", "Docker"):
+            with self.assertRaises(RuntimeError, msg=name):
+                bottle.anonymous_token(name)
 
 
 if __name__ == "__main__":

--- a/.pipeline/scripts/test_resolve_toolchain_version.py
+++ b/.pipeline/scripts/test_resolve_toolchain_version.py
@@ -170,6 +170,82 @@ class Organization(unittest.TestCase):
             resolve.organization("https://dev.azure.com/")
 
 
+class Decision(unittest.TestCase):
+    """Which architectures publish, and at what version."""
+
+    def arch(self, version, current=True, layout_stale=False):
+        return {"version": version, "current": current, "layout_stale": layout_stale}
+
+    def both(self, **kwargs):
+        return {"x86_64": self.arch(**kwargs), "arm64": self.arch(**kwargs)}
+
+    def test_an_unchanged_feed_publishes_nothing(self):
+        _, publish, reasons = resolve.decide(self.both(version="0.1.0"))
+        self.assertEqual(publish, set())
+        self.assertEqual(reasons, [])
+
+    def test_an_upstream_bump_moves_every_architecture_together(self):
+        version, publish, _ = resolve.decide(self.both(version="0.1.0", current=False))
+        self.assertEqual(version, "0.1.1")
+        self.assertEqual(publish, {"x86_64", "arm64"})
+
+    def test_one_architecture_drifting_still_republishes_both(self):
+        # A version has to mean the same build produced both, so the unchanged
+        # architecture comes along rather than being left a version behind.
+        state = {"x86_64": self.arch("0.1.0", current=False), "arm64": self.arch("0.1.0")}
+        version, publish, _ = resolve.decide(state)
+        self.assertEqual(version, "0.1.1")
+        self.assertEqual(publish, {"x86_64", "arm64"})
+
+    def test_a_layout_change_is_the_minor_bump(self):
+        version, _, _ = resolve.decide(self.both(version="0.1.3", current=False, layout_stale=True))
+        self.assertEqual(version, "0.2.0")
+
+    def test_a_partial_publish_is_repaired_at_the_version_it_missed(self):
+        # x86_64 uploaded 0.1.1 and arm64's upload failed. Bumping to 0.1.2
+        # would strand 0.1.1 as x86_64-only forever, since packages are
+        # immutable and a consumer pinning it would 404 on arm64.
+        state = {
+            "x86_64": self.arch("0.1.1"),
+            "arm64": self.arch("0.1.0", current=False),
+        }
+        version, publish, reasons = resolve.decide(state)
+        self.assertEqual(version, "0.1.1")
+        self.assertEqual(publish, {"arm64"})
+        self.assertIn("partial publish", reasons[0])
+
+    def test_a_laggard_is_not_dragged_onto_a_version_that_predates_upstream(self):
+        # Both are behind upstream, so 0.1.1 is not what should ship; that is a
+        # normal bump for both, not a repair.
+        state = {
+            "x86_64": self.arch("0.1.1", current=False),
+            "arm64": self.arch("0.1.0", current=False),
+        }
+        version, publish, _ = resolve.decide(state)
+        self.assertEqual(version, "0.1.2")
+        self.assertEqual(publish, {"x86_64", "arm64"})
+
+    def test_an_explicit_override_wins_over_a_repair(self):
+        state = {
+            "x86_64": self.arch("0.1.1"),
+            "arm64": self.arch("0.1.0", current=False),
+        }
+        version, publish, _ = resolve.decide(state, override="2.0.0")
+        self.assertEqual(version, "2.0.0")
+        self.assertEqual(publish, {"x86_64", "arm64"})
+
+    def test_a_first_publish_covers_every_architecture(self):
+        version, publish, _ = resolve.decide(self.both(version=None, current=False, layout_stale=True))
+        self.assertEqual(version, "0.1.0")
+        self.assertEqual(publish, {"x86_64", "arm64"})
+
+    def test_forcing_republishes_everything_unchanged(self):
+        version, publish, reasons = resolve.decide(self.both(version="0.1.0"), force=True)
+        self.assertEqual(version, "0.1.1")
+        self.assertEqual(publish, {"x86_64", "arm64"})
+        self.assertIn("forced", reasons[0])
+
+
 class RequestedVersion(unittest.TestCase):
     def test_the_sentinel_means_derive_it(self):
         # The pipeline passes 'auto' rather than '' because the run panel

--- a/.pipeline/scripts/test_resolve_toolchain_version.py
+++ b/.pipeline/scripts/test_resolve_toolchain_version.py
@@ -224,6 +224,19 @@ class Decision(unittest.TestCase):
         self.assertEqual(publish, {"arm64"})
         self.assertIn("partial publish", reasons[0])
 
+    def test_a_partial_FIRST_publish_is_repaired_too(self):
+        # The laggard has no version at all rather than an older one. Treating
+        # only "behind" as lagging left this to the normal path, which bumped
+        # to 0.2.0 and stranded 0.1.0 as x86_64-only.
+        state = {
+            "x86_64": self.arch("0.1.0"),
+            "arm64": self.arch(None, current=False, layout_stale=True),
+        }
+        version, publish, reasons = resolve.decide(state)
+        self.assertEqual(version, "0.1.0")
+        self.assertEqual(publish, {"arm64"})
+        self.assertIn("partial publish", reasons[0])
+
     def test_a_laggard_is_not_dragged_onto_a_version_that_predates_upstream(self):
         # Both are behind upstream, so 0.1.1 is not what should ship; that is a
         # normal bump for both, not a repair.
@@ -254,6 +267,14 @@ class Decision(unittest.TestCase):
         self.assertEqual(version, "0.1.1")
         self.assertEqual(publish, {"x86_64", "arm64"})
         self.assertIn("forced", reasons[0])
+
+    def test_an_explicit_version_publishes_even_when_nothing_changed(self):
+        # Asking for a specific number and getting a run that publishes nothing
+        # is a silent no-op; the request is itself the reason to publish.
+        version, publish, reasons = resolve.decide(self.both(version="0.1.0"), override="1.0.0")
+        self.assertEqual(version, "1.0.0")
+        self.assertEqual(publish, {"x86_64", "arm64"})
+        self.assertIn("1.0.0", reasons[0])
 
 
 class RequestedVersion(unittest.TestCase):

--- a/.pipeline/scripts/test_resolve_toolchain_version.py
+++ b/.pipeline/scripts/test_resolve_toolchain_version.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Tests for the toolchain publish/version decision.
+
+Run: python3 -m unittest test_resolve_toolchain_version
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def load(name):
+    spec = importlib.util.spec_from_file_location(
+        os.path.splitext(name)[0].replace("-", "_"), os.path.join(HERE, name)
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+resolve = load("resolve-toolchain-version.py")
+builder = load("build-macos-docker-toolchain.py")
+
+
+def components(docker="29.7.2-1", colima="0.10.3", lima="2.2.0", digest="sha256:aa"):
+    return {
+        "docker": {"version": docker, "bottle_digest": digest},
+        "colima": {"version": colima, "bottle_digest": digest},
+        "lima": {"version": lima, "bottle_digest": digest},
+    }
+
+
+class Identity(unittest.TestCase):
+    def test_same_inputs_give_the_same_digest(self):
+        self.assertEqual(
+            builder.payload_identity(components(), 14),
+            builder.payload_identity(components(), 14),
+        )
+
+    def test_an_upstream_bump_changes_it(self):
+        self.assertNotEqual(
+            builder.payload_identity(components(), 14),
+            builder.payload_identity(components(docker="29.8.0"), 14),
+        )
+
+    def test_a_rebuilt_bottle_changes_it_even_at_the_same_version(self):
+        # Homebrew can republish a version; the digest is what actually ships.
+        self.assertNotEqual(
+            builder.payload_identity(components(digest="sha256:aa"), 14),
+            builder.payload_identity(components(digest="sha256:bb"), 14),
+        )
+
+    def test_the_macos_floor_changes_it(self):
+        self.assertNotEqual(
+            builder.payload_identity(components(), 14),
+            builder.payload_identity(components(), 15),
+        )
+
+    def test_the_payload_layout_changes_it(self):
+        # Without this the metadata/ move would have looked like a no-op and
+        # the scheduled run would have skipped publishing the fix.
+        self.assertNotEqual(
+            builder.payload_identity(components(), 14, payload_format=1),
+            builder.payload_identity(components(), 14, payload_format=2),
+        )
+
+    def test_extra_manifest_fields_are_ignored(self):
+        # resolve-toolchain-version.py computes this from registry metadata and
+        # has no file counts; the producer must agree with it anyway.
+        enriched = components()
+        for entry in enriched.values():
+            entry["files"] = 42
+            entry["bottle_tag"] = "29.7.2.sonoma.1"
+        self.assertEqual(
+            builder.payload_identity(components(), 14),
+            builder.payload_identity(enriched, 14),
+        )
+
+
+class PublishedDescription(unittest.TestCase):
+    def parse(self, description):
+        return resolve.describe_published({"version": "1.2.3", "packageDescription": description})
+
+    def manifest(self, **overrides):
+        m = {
+            "arch": "x86_64",
+            "macos_major_floor": 14,
+            "payload_format": builder.PAYLOAD_FORMAT,
+            "identity": "0c9acc130659bfcb",
+            "components": components(),
+        }
+        m.update(overrides)
+        return m
+
+    def test_publishing_and_reading_back_agree(self):
+        # The whole skip-if-unchanged scheme rests on this round-trip: publish
+        # writes the description, the next run parses it. Drift between the two
+        # would silently republish forever.
+        m = self.manifest()
+        _, layout, identity = self.parse(resolve.format_description(m))
+        self.assertEqual(layout, m["payload_format"])
+        self.assertEqual(identity, m["identity"])
+
+    def test_the_description_leads_with_something_a_human_can_read(self):
+        described = resolve.format_description(self.manifest())
+        self.assertTrue(described.startswith("docker 29.7.2-1, colima 0.10.3, lima 2.2.0"))
+        self.assertIn("for macOS 14+ x86_64", described)
+
+    def test_markers_are_read_back_out(self):
+        version, layout, identity = self.parse(
+            "docker 29.7.2-1, colima 0.10.3, lima 2.2.0 for macOS 14+ x86_64 "
+            "[layout:2 id:0c9acc130659bfcb]"
+        )
+        self.assertEqual((version, layout, identity), ("1.2.3", 2, "0c9acc130659bfcb"))
+
+    def test_a_package_published_before_the_markers_existed(self):
+        # 0.0.1 shipped with a prose-only description.
+        _, layout, identity = self.parse("docker CLI, colima, lima and colima guest image")
+        self.assertIsNone(layout)
+        self.assertIsNone(identity)
+
+    def test_a_missing_package_is_not_an_error(self):
+        self.assertEqual(resolve.describe_published(None), (None, None, None))
+
+    def test_a_missing_description_is_not_an_error(self):
+        self.assertEqual(self.parse(None), ("1.2.3", None, None))
+
+
+class NextVersion(unittest.TestCase):
+    def test_an_upstream_bump_moves_the_patch(self):
+        self.assertEqual(resolve.next_version("0.1.0", layout_changed=False), "0.1.1")
+
+    def test_a_layout_change_moves_the_minor_and_resets_the_patch(self):
+        self.assertEqual(resolve.next_version("0.1.7", layout_changed=True), "0.2.0")
+
+    def test_the_first_publish_starts_at_a_minor(self):
+        self.assertEqual(resolve.next_version(None, layout_changed=True), "0.1.0")
+
+    def test_a_version_it_cannot_reason_about_is_an_error(self):
+        with self.assertRaises(RuntimeError):
+            resolve.next_version("1.0.0-beta", layout_changed=False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.pipeline/scripts/test_resolve_toolchain_version.py
+++ b/.pipeline/scripts/test_resolve_toolchain_version.py
@@ -144,6 +144,16 @@ class NextVersion(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             resolve.next_version("1.0.0-beta", layout_changed=False)
 
+    def test_ordering_a_published_prerelease_fails_cleanly(self):
+        # A hand-published prerelease on the feed used to reach int() and give
+        # a ValueError traceback rather than something anyone could act on.
+        state = {
+            "x86_64": {"version": "1.0.0-rc1", "current": False, "layout_stale": False},
+            "arm64": {"version": "0.1.0", "current": False, "layout_stale": False},
+        }
+        with self.assertRaises(RuntimeError):
+            resolve.decide(state)
+
 
 class Organization(unittest.TestCase):
     def test_the_modern_collection_uri(self):

--- a/.pipeline/scripts/test_resolve_toolchain_version.py
+++ b/.pipeline/scripts/test_resolve_toolchain_version.py
@@ -145,6 +145,31 @@ class NextVersion(unittest.TestCase):
             resolve.next_version("1.0.0-beta", layout_changed=False)
 
 
+class Organization(unittest.TestCase):
+    def test_the_modern_collection_uri(self):
+        self.assertEqual(resolve.organization("https://dev.azure.com/sqlclientdrivers/"), "sqlclientdrivers")
+
+    def test_the_legacy_collection_uri(self):
+        # This organization is one of these: taking the last path segment gives
+        # the hostname, and the feed URL built from it 404s.
+        self.assertEqual(
+            resolve.organization("https://sqlclientdrivers.visualstudio.com/"),
+            "sqlclientdrivers",
+        )
+
+    def test_a_missing_trailing_slash_is_fine(self):
+        for uri in ("https://dev.azure.com/sqlclientdrivers",
+                    "https://sqlclientdrivers.visualstudio.com"):
+            self.assertEqual(resolve.organization(uri), "sqlclientdrivers", uri)
+
+    def test_a_bare_organization_name_is_accepted(self):
+        self.assertEqual(resolve.organization("sqlclientdrivers"), "sqlclientdrivers")
+
+    def test_something_with_no_organization_in_it_is_an_error(self):
+        with self.assertRaises(RuntimeError):
+            resolve.organization("https://dev.azure.com/")
+
+
 class RequestedVersion(unittest.TestCase):
     def test_the_sentinel_means_derive_it(self):
         # The pipeline passes 'auto' rather than '' because the run panel

--- a/.pipeline/scripts/test_resolve_toolchain_version.py
+++ b/.pipeline/scripts/test_resolve_toolchain_version.py
@@ -145,5 +145,29 @@ class NextVersion(unittest.TestCase):
             resolve.next_version("1.0.0-beta", layout_changed=False)
 
 
+class RequestedVersion(unittest.TestCase):
+    def test_the_sentinel_means_derive_it(self):
+        # The pipeline passes 'auto' rather than '' because the run panel
+        # refuses to queue with a blank string parameter.
+        self.assertIsNone(resolve.requested_version("auto"))
+
+    def test_the_sentinel_is_not_case_or_space_sensitive(self):
+        for raw in (" auto ", "AUTO", "Auto"):
+            self.assertIsNone(resolve.requested_version(raw), raw)
+
+    def test_an_empty_value_still_means_derive_it(self):
+        for raw in ("", "   ", None):
+            self.assertIsNone(resolve.requested_version(raw), repr(raw))
+
+    def test_an_explicit_version_is_taken_as_given(self):
+        self.assertEqual(resolve.requested_version(" 1.0.0 "), "1.0.0")
+
+    def test_a_typo_is_refused_rather_than_published(self):
+        # Packages are immutable, so a bad override burns the number.
+        for raw in ("1.0", "v1.0.0", "1.0.0-rc1", "latest"):
+            with self.assertRaises(RuntimeError, msg=raw):
+                resolve.requested_version(raw)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.pipeline/templates/macos-docker-steps.yml
+++ b/.pipeline/templates/macos-docker-steps.yml
@@ -1,0 +1,44 @@
+# Installs the macOS docker toolchain from our own feed and boots the Colima VM.
+#
+# Used by every macOS job that needs containers. The payload is produced by
+# .pipeline/macos-docker-toolchain-pipeline.yml; see .pipeline/scripts/README.md
+# for why it exists. Shared rather than inlined so the two macOS templates
+# cannot drift apart on the version they pin.
+
+parameters:
+# Pinned rather than floating. The feed supports '*', but floating means an
+# upstream docker release can change CI behaviour with no commit to point at,
+# which is the class of surprise this package exists to remove. Bumping this is
+# how a new toolchain reaches CI, and it goes through PR validation like any
+# other change.
+- name: toolchainVersion
+  type: string
+  default: '0.1.0'
+
+steps:
+# Hosted macOS images are Intel today and Apple silicon eventually; reading the
+# architecture off the agent means that migration is not a silent breakage.
+- script: |
+    set -euo pipefail
+    arch=$(uname -m)
+    echo "agent architecture: $arch"
+    echo "##vso[task.setvariable variable=toolchainPackage]macos-docker-toolchain-$arch"
+  displayName: 'Select the toolchain package for this agent'
+
+- task: UniversalPackages@0
+  displayName: 'Download macOS docker toolchain ${{ parameters.toolchainVersion }}'
+  inputs:
+    command: download
+    downloadDirectory: '$(Agent.TempDirectory)/docker-toolchain'
+    feedsToUse: internal
+    vstsFeed: 'public/mssql-rs_Public'
+    vstsFeedPackage: '$(toolchainPackage)'
+    vstsPackageVersion: '${{ parameters.toolchainVersion }}'
+
+# timeoutInMinutes backstops the script's own wall-clock budgets: the macOS job
+# is time-capped and SQL setup must not be what exhausts it.
+- script: bash .pipeline/scripts/start-colima-macos.sh
+  displayName: 'Install and start Colima-based Docker'
+  timeoutInMinutes: 15
+  env:
+    TOOLCHAIN_DIR: '$(Agent.TempDirectory)/docker-toolchain'

--- a/.pipeline/templates/macos-toolchain-job.yml
+++ b/.pipeline/templates/macos-toolchain-job.yml
@@ -1,0 +1,68 @@
+# Builds and publishes the macOS docker toolchain payload for one architecture.
+# See macos-docker-toolchain-pipeline.yml for why this exists.
+
+parameters:
+- name: arch
+  type: string
+  values:
+  - x86_64
+  - arm64
+- name: packageVersion
+  type: string
+- name: macosMajorFloor
+  type: number
+- name: dryRun
+  type: boolean
+- name: feed
+  type: string
+
+jobs:
+- job: Build_${{ parameters.arch }}
+  displayName: 'Build and publish ${{ parameters.arch }}'
+  timeoutInMinutes: 30
+  # Downloads, verifies and repacks ~400 MB; nothing is compiled, so the cheap
+  # util pool is enough.
+  pool:
+    name: RUST-UTIL-WUS3
+    demands:
+      - imageOverride -equals RUST-UBUSLIM
+  steps:
+  - checkout: self
+
+  - script: |
+      set -euo pipefail
+      python3 .pipeline/scripts/build-macos-docker-toolchain.py \
+        --arch ${{ parameters.arch }} \
+        --macos-major ${{ parameters.macosMajorFloor }} \
+        --out "$(Build.ArtifactStagingDirectory)/${{ parameters.arch }}"
+    displayName: 'Assemble payload'
+
+  - script: |
+      set -euo pipefail
+      payload="$(Build.ArtifactStagingDirectory)/${{ parameters.arch }}"
+      echo "##[group]manifest.json"
+      cat "$payload/manifest.json"
+      echo "##[endgroup]"
+      echo "payload size: $(du -sh "$payload" | cut -f1)"
+    displayName: 'Show manifest'
+
+  # Published even on a dry run: the manifest is the record of what a given
+  # package version actually contains.
+  - task: PublishPipelineArtifact@1
+    displayName: 'Publish manifest as a build artifact'
+    inputs:
+      targetPath: '$(Build.ArtifactStagingDirectory)/${{ parameters.arch }}/manifest.json'
+      artifact: 'manifest-${{ parameters.arch }}'
+
+  - ${{ if eq(parameters.dryRun, false) }}:
+    - task: UniversalPackages@0
+      displayName: 'Publish macos-docker-toolchain-${{ parameters.arch }} ${{ parameters.packageVersion }}'
+      inputs:
+        command: publish
+        publishDirectory: '$(Build.ArtifactStagingDirectory)/${{ parameters.arch }}'
+        feedsToUsePublish: 'internal'
+        vstsFeedPublish: '${{ parameters.feed }}'
+        vstsFeedPackagePublish: 'macos-docker-toolchain-${{ parameters.arch }}'
+        versionOption: 'custom'
+        versionPublish: '${{ parameters.packageVersion }}'
+        packagePublishDescription: 'docker CLI, colima, lima and colima guest image for macOS ${{ parameters.arch }}'

--- a/.pipeline/templates/macos-toolchain-job.yml
+++ b/.pipeline/templates/macos-toolchain-job.yml
@@ -7,8 +7,6 @@ parameters:
   values:
   - x86_64
   - arm64
-- name: packageVersion
-  type: string
 - name: macosMajorFloor
   type: number
 - name: dryRun
@@ -19,7 +17,14 @@ parameters:
 jobs:
 - job: Build_${{ parameters.arch }}
   displayName: 'Build and publish ${{ parameters.arch }}'
+  dependsOn: Decide
+  # Nothing moved upstream means nothing to build; the run succeeds having done
+  # the one useful thing, which was checking.
+  condition: and(succeeded(), eq(dependencies.Decide.outputs['decide.shouldPublish'], 'true'))
   timeoutInMinutes: 30
+  variables:
+    packageVersion: $[ dependencies.Decide.outputs['decide.packageVersion'] ]
+    payloadIdentity: $[ dependencies.Decide.outputs['decide.identity_${{ parameters.arch }}'] ]
   # Downloads, verifies and repacks ~400 MB; nothing is compiled, so the cheap
   # util pool is enough.
   pool:
@@ -37,14 +42,21 @@ jobs:
         --out "$(Build.ArtifactStagingDirectory)/${{ parameters.arch }}"
     displayName: 'Assemble payload'
 
+  # The description is load-bearing: the next run reads its markers back out of
+  # the feed to decide whether anything changed.
   - script: |
       set -euo pipefail
-      payload="$(Build.ArtifactStagingDirectory)/${{ parameters.arch }}"
       echo "##[group]manifest.json"
-      cat "$payload/manifest.json"
+      cat "$PAYLOAD/manifest.json"
       echo "##[endgroup]"
-      echo "payload size: $(du -sh "$payload" | cut -f1)"
-    displayName: 'Show manifest'
+      echo "payload size: $(du -sh "$PAYLOAD" | cut -f1)"
+      python3 .pipeline/scripts/resolve-toolchain-version.py \
+        --describe "$PAYLOAD/manifest.json" \
+        --expect-identity "$RESOLVED_IDENTITY"
+    displayName: 'Check the payload against the decision and describe it'
+    env:
+      PAYLOAD: '$(Build.ArtifactStagingDirectory)/${{ parameters.arch }}'
+      RESOLVED_IDENTITY: '$(payloadIdentity)'
 
   # Published even on a dry run: the manifest is the record of what a given
   # package version actually contains.
@@ -56,7 +68,7 @@ jobs:
 
   - ${{ if eq(parameters.dryRun, false) }}:
     - task: UniversalPackages@0
-      displayName: 'Publish macos-docker-toolchain-${{ parameters.arch }} ${{ parameters.packageVersion }}'
+      displayName: 'Publish macos-docker-toolchain-${{ parameters.arch }} $(packageVersion)'
       inputs:
         command: publish
         publishDirectory: '$(Build.ArtifactStagingDirectory)/${{ parameters.arch }}'
@@ -64,5 +76,5 @@ jobs:
         vstsFeedPublish: '${{ parameters.feed }}'
         vstsFeedPackagePublish: 'macos-docker-toolchain-${{ parameters.arch }}'
         versionOption: 'custom'
-        versionPublish: '${{ parameters.packageVersion }}'
-        packagePublishDescription: 'docker CLI, colima, lima and colima guest image for macOS ${{ parameters.arch }}'
+        versionPublish: '$(packageVersion)'
+        packagePublishDescription: '$(packageDescription)'

--- a/.pipeline/templates/macos-toolchain-job.yml
+++ b/.pipeline/templates/macos-toolchain-job.yml
@@ -38,10 +38,14 @@ jobs:
   - script: |
       set -euo pipefail
       python3 .pipeline/scripts/build-macos-docker-toolchain.py \
-        --arch ${{ parameters.arch }} \
-        --macos-major ${{ parameters.macosMajorFloor }} \
-        --out "$(Build.ArtifactStagingDirectory)/${{ parameters.arch }}"
+        --arch "$ARCH" \
+        --macos-major "$MACOS_MAJOR" \
+        --out "$PAYLOAD"
     displayName: 'Assemble payload'
+    env:
+      ARCH: ${{ parameters.arch }}
+      MACOS_MAJOR: ${{ parameters.macosMajorFloor }}
+      PAYLOAD: '$(Build.ArtifactStagingDirectory)/${{ parameters.arch }}'
 
   # The description is load-bearing: the next run reads its markers back out of
   # the feed to decide whether anything changed.

--- a/.pipeline/templates/macos-toolchain-job.yml
+++ b/.pipeline/templates/macos-toolchain-job.yml
@@ -18,9 +18,10 @@ jobs:
 - job: Build_${{ parameters.arch }}
   displayName: 'Build and publish ${{ parameters.arch }}'
   dependsOn: Decide
-  # Nothing moved upstream means nothing to build; the run succeeds having done
-  # the one useful thing, which was checking.
-  condition: and(succeeded(), eq(dependencies.Decide.outputs['decide.shouldPublish'], 'true'))
+  # Per architecture rather than one flag for the stage: normally these move
+  # together, but a partial publish leaves one behind and only that one is
+  # rebuilt to catch it up.
+  condition: and(succeeded(), eq(dependencies.Decide.outputs['decide.publish_${{ parameters.arch }}'], 'true'))
   timeoutInMinutes: 30
   variables:
     packageVersion: $[ dependencies.Decide.outputs['decide.packageVersion'] ]

--- a/.pipeline/templates/sql-setup-template.yml
+++ b/.pipeline/templates/sql-setup-template.yml
@@ -258,11 +258,7 @@ steps:
     displayName: "Update CA certificates on the client"
 
 - ${{ if eq(parameters.buildTarget, 'MacOS') }}:
-  # timeoutInMinutes backstops the scripts' own wall-clock budgets: the macOS
-  # job caps at 60 minutes and SQL setup must not be what exhausts it.
-  - script: bash .pipeline/scripts/start-colima-macos.sh
-    displayName: 'Install and start Colima-based Docker'
-    timeoutInMinutes: 15
+  - template: macos-docker-steps.yml
 
   - script: bash .pipeline/scripts/start-sql-server-macos.sh
     displayName: 'Start SQL Server (Docker, no TLS certs)'

--- a/.pipeline/templates/test-mssql-python-macos-template.yml
+++ b/.pipeline/templates/test-mssql-python-macos-template.yml
@@ -97,11 +97,7 @@ steps:
     CARGO_REGISTRIES_MSSQL_RS_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_TOKEN)
 
 # ── 4. Start Docker via Colima ───────────────────────────────────────────────
-# timeoutInMinutes backstops the scripts' own wall-clock budgets: the macOS job
-# caps at 60 minutes and SQL setup must not be what exhausts it.
-- script: bash .pipeline/scripts/start-colima-macos.sh
-  displayName: 'Install and start Colima-based Docker'
-  timeoutInMinutes: 15
+- template: macos-docker-steps.yml
 
 # ── 5. Start SQL Server (no TLS certs) ──────────────────────────────────────
 - script: bash .pipeline/scripts/start-sql-server-macos.sh


### PR DESCRIPTION
## Description

macOS CI rebuilt its container runtime from scratch on every run, reaching Homebrew's registry for three bottles and github.com for the ~350 MB guest image colima boots. Both have failed: Homebrew dropping the Intel docker bottle at 29.8.0 turned `brew install docker` into an 8-minute Go build (#499), and colima's image download has failed on DNS.

This packages the toolchain — the `docker`, `colima` and `lima` install prefixes plus the guest image — as a Universal Package per architecture, and switches macOS jobs to install from our own feed. A macOS run now contacts neither Homebrew nor ghcr.io nor github.com.

### Producer

**The whole install prefix is packaged, not just `bin/`.** `limactl` resolves `../share/lima/lima-guestagent.*` and `../libexec/lima/*` relative to itself, so a bin-only payload yields a lima that cannot boot a VM. The build fails if the guest agent is missing rather than shipping one that would.

**The guest image is not hard-coded.** colima embeds a table of `<arch> <runtime> <url> <sha512> <filename>` for the image release it expects, so both the image and the checksum to verify it against are read out of the very binary being packaged. colima 0.10.3 wants colima-core v0.10.4, which a hand-maintained mapping would get wrong.

**The version is derived, not chosen.** The payload contains no authored content — its bytes are a function of the three bottles, the macOS floor they are selected for, and `PAYLOAD_FORMAT`. `resolve-toolchain-version.py` digests exactly those inputs, reads the published side back out of the package description (`[layout:N id:...]`), and publishes only when they differ: a patch bump for an upstream release, a minor bump when the layout moves. Nothing is downloaded to decide — registry metadata plus one REST call — so an unchanged upstream costs a few HTTP round-trips instead of two 430 MB builds.

**Scheduled on the 1st and 16th** with `always: true`. Upstream moving leaves no trace in this repo, so without `always` a scheduled run is skipped whenever the branch has not changed — precisely the case the schedule exists to cover.

The build runs on Linux and cross-builds both macOS payloads, so it verifies the Mach-O architecture of every binary it packs; a mis-resolved bottle fails the build instead of shipping.

### Consumer

`start-colima-macos.sh` now runs from the payload: it puts `bin/` on PATH and copies the guest image into `~/Library/Caches/colima/caches/<cache_filename>`, which is where colima looks for it by sha256 of the URL it would otherwise download from — so colima finds it already there. The executable bit is restored on the way in, because Universal Packages do not preserve POSIX modes.

**There is no Homebrew fallback.** It would reintroduce the dependency this removes, and a path that only runs when the primary breaks is a path nothing exercises, so it would be broken by the time it mattered. `TOOLCHAIN_DIR` is required, and a payload missing its manifest, any of `bin/{docker,colima,limactl}`, or its guest image fails the step naming what was missing. The script drops from 205 lines to 131, since the install-budget machinery existed only to bound `brew`.

Both macOS templates share one steps template rather than inlining the download twice, so they cannot drift on the version they pin. The package name is read off `uname -m` rather than hardcoded, so hosted images moving to Apple silicon is not a silent breakage. The version is pinned rather than floating on `*`: floating would let an upstream docker release change CI behaviour with no commit to point at, which is the surprise this exists to remove.

### Verification

- **`0.1.0` is published and verified for both architectures.** Correct Mach-O architecture on every binary, lima's guest agents and helper tree complete, guest image digest matching both our manifest and colima's own table, and `cache_filename == sha256(url)`.
- **Producer dry run** ([20260908.2](https://dev.azure.com/SqlClientDrivers/mssql-rs/_build/results?buildId=173465)) and **publish run** ([20260908.3](https://dev.azure.com/SqlClientDrivers/mssql-rs/_build/results?buildId=173469)) both green.
- **The skip path is proven end to end**: re-running the decision against the just-published feed reports `nothing changed upstream; leaving the feed alone`, exercising the full publish → parse round trip on real packages.
- **The consumer's failure modes are exercised locally** — missing `TOOLCHAIN_DIR`, missing manifest, missing binary, missing image — each failing by name, plus a complete payload seeding the cache and resolving `docker`/`colima` from it.
- **69 unit tests**, covering bottle selection, prefix extraction, the identity digest, description round-tripping, version derivation, and both forms of `System.CollectionUri`.
- `Test MacOS` on this PR is the real end-to-end test of the consumer side.

Earlier verification caught two defects before they reached CI: a payload that shipped `bin/` only and could not boot a VM, and per-formula `LICENSE`/`NOTICE`/`README.md`/`sbom.spdx.json` overwriting each other in the merged prefix, leaving the package's SBOM claiming to be lima alone. Both are fixed here, the latter by routing prefix-root metadata to `metadata/<formula>/`.

### After merge

The producer pipeline definition currently points at this branch and needs repointing to `main` for the schedule to take effect.

## Related Issues

Fixes #524

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes
- [x] New/changed functionality has tests
- [x] Public API changes are documented

<sub>This PR touches only `.pipeline/`; no Rust sources change, so the three cargo gates are unaffected.</sub>
