### PR TITLE
Fix PyPI stub checkout path

### DIFF
--- a/.pipeline/OneBranch/PyPIRelease.yml
+++ b/.pipeline/OneBranch/PyPIRelease.yml
@@ -88,6 +88,7 @@ extends:
           WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest'
         steps:
         - checkout: self
+          path: s/mssql-rs
 
         - ${{ if eq(parameters.publishToPyPI, true) }}:
           - pwsh: |
@@ -98,7 +99,7 @@ extends:
 
         - pwsh: |
             $ErrorActionPreference = 'Stop'
-            $sourceRoot = "$(Build.SourcesDirectory)/.pipeline/pypi-stub"
+            $sourceRoot = "$(Pipeline.Workspace)/s/mssql-rs/.pipeline/pypi-stub"
             $dist = Join-Path $sourceRoot 'dist'
             $stage = "$(Agent.TempDirectory)/pypi-publish"
             $extract = "$(Agent.TempDirectory)/pypi-verify"


### PR DESCRIPTION
### Summary

Fixes the Production PyPI reservation dry run failure in build 173588. OneBranch's container Get Sources task moves the self repository from `s` to `s/mssql-rs`, but `Build.SourcesDirectory` remains the parent `s` directory because repository-path updates are blocked by policy.

- Pin the self checkout to `s/mssql-rs`.
- Resolve the committed stub from the same explicit path under `Pipeline.Workspace`.
- Leave package verification and ESRP behavior unchanged.

### Validation

- Parsed `.pipeline/OneBranch/PyPIRelease.yml` successfully.
- Executed the actual `Verify and stage stub sdist` inline PowerShell against a temporary Production-shaped `s/mssql-rs` workspace.
- Verified it staged exactly `mssql_python_rs-0.0.0.tar.gz`.
- `git diff --check`
- `cargo bfmt`

[AB#47922](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47922)