### PR TITLE
Convert varchar(max)/text PLP chunks from the server collation to UTF-8 (AB#47566)

### DIFF
--- a/.github/instructions/mssql-odbc.instructions.md
+++ b/.github/instructions/mssql-odbc.instructions.md
@@ -241,6 +241,15 @@ does not grow every time a new msodbcsql build is measured.
    type but not the other would be worse than the divergence.
    `ABoundUtf8VarcharMaxDoesNotSplitASurrogatePairWhenWidening` carries
    `SKIP_IF_COMPARING_MSODBCSQL()`. Tracked in AB#47767.
+
+   The same rule applies to a bound UTF-8-collation `varchar(max)` delivered as
+   `SQL_C_CHAR`, which is verbatim on both drivers because the wire bytes are
+   already UTF-8. Measured on build 173919 with a 3-byte character against an
+   8-byte payload slot: msodbcsql fills all 8 and returns
+   `"\xE4\xBD\xA0\xE4\xBD\xA0\xE4\xBD"`, ending mid-character, where this driver
+   stops at 6. `ABoundUtf8CollationVarcharMaxTruncatesOnACharacterBoundary`
+   splits per-leg on `ODBC_TEST_TARGET` rather than skipping, so the shared part
+   — both truncate, report `01004`, and deliver a prefix — stays measured.
 9. A bound `time` / `datetimeoffset` column strides by
     `sizeof(SQL_SS_TIME2_STRUCT)` (12) and
     `sizeof(SQL_SS_TIMESTAMPOFFSET_STRUCT)` (20) rather than by `BufferLength`.

--- a/mssql-odbc/src/api/fetch_scroll.rs
+++ b/mssql-odbc/src/api/fetch_scroll.rs
@@ -1814,7 +1814,13 @@ unsafe fn deliver_bound_plp(
 
     let transcode_utf16_to_utf8 =
         target == SQL_C_CHAR && matches!(encoding, PlpEncoding::Utf16Text);
-    let transcode = transcode_utf16_to_utf8 || widen_narrow_to_utf16 || transcode_narrow_to_utf8;
+    // Deliberately excludes `transcode_narrow_to_utf8`: msodbcsql keys the
+    // indicator on the C types rather than on whether a conversion happens, and
+    // `sqlcdata.h:1230` takes CHAR->CHAR on its "assume a 1:1 conversion ratio"
+    // branch, so a codepage `varchar(max)` read as SQL_C_CHAR keeps a concrete
+    // count. `ABoundVarcharMaxTruncatedReportsFullLength` measures this on both
+    // legs.
+    let transcode = transcode_utf16_to_utf8 || widen_narrow_to_utf16;
     let buf_elements = char_buf_elements(target, stride);
     // Room for the payload. Character targets always write a terminator; binary
     // is not a string, so the whole slot is payload.
@@ -1851,6 +1857,11 @@ unsafe fn deliver_bound_plp(
             // multi-byte sequence split across a PLP chunk boundary; unlike the
             // streaming SQLGetData path there is no continuation call, so the
             // slot either takes the whole value or reports truncation.
+            // Cannot fire today: `transcode_narrow_to_utf8` requires
+            // `narrow_wire_encoding` to be `Some`, which is exactly when the
+            // decoder above is built. Kept as a drain-and-refuse rather than an
+            // `unreachable!()` because a panic here would cross the FFI
+            // boundary, which is UB.
             let Some(decoder) = narrow_decoder.as_mut() else {
                 drain_plp_to_end(client, runtime, scratch)?;
                 return Ok(RowOutcome::Error(RowIssue::Unsupported));

--- a/mssql-odbc/src/api/fetch_scroll.rs
+++ b/mssql-odbc/src/api/fetch_scroll.rs
@@ -1814,6 +1814,20 @@ unsafe fn deliver_bound_plp(
 
     let transcode_utf16_to_utf8 =
         target == SQL_C_CHAR && matches!(encoding, PlpEncoding::Utf16Text);
+    // Wire bytes that are already UTF-8 and are delivered by a verbatim copy:
+    // `json`, and a `SingleByteText` column whose collation is UTF-8, which the
+    // transcode branch deliberately skips for exactly that reason. Both can
+    // truncate mid-sequence at the slot boundary, so both need the partial tail
+    // trimmed -- treating them as equivalent here is what makes the "already in
+    // the target encoding" claim above actually hold. Binary is excluded: it is
+    // not text, and a binary caller asked for the bytes verbatim.
+    let verbatim_utf8_text = target != SQL_C_BINARY
+        && !transcode_narrow_to_utf8
+        && match encoding {
+            PlpEncoding::Utf8Text => true,
+            PlpEncoding::SingleByteText => narrow_wire_encoding == Some(encoding_rs::UTF_8),
+            _ => false,
+        };
     // Deliberately excludes `transcode_narrow_to_utf8`: msodbcsql keys the
     // indicator on the C types rather than on whether a conversion happens, and
     // `sqlcdata.h:1230` takes CHAR->CHAR on its "assume a 1:1 conversion ratio"
@@ -1951,9 +1965,10 @@ unsafe fn deliver_bound_plp(
                     break;
                 }
             }
-        } else if target != SQL_C_BINARY && matches!(encoding, PlpEncoding::Utf8Text) {
-            // Binary is excluded: `trim_partial_utf8` would drop a truncated tail
-            // that a binary caller asked for verbatim.
+        } else if verbatim_utf8_text {
+            // Binary is excluded from `verbatim_utf8_text`: `trim_partial_utf8`
+            // would drop a truncated tail that a binary caller asked for
+            // verbatim.
             for b in &scratch[..chunk.read] {
                 if out_bytes.len() < capacity_elements {
                     out_bytes.push(*b);

--- a/mssql-odbc/src/api/fetch_scroll.rs
+++ b/mssql-odbc/src/api/fetch_scroll.rs
@@ -32,6 +32,7 @@ use mssql_tds::datatypes::sql_json::SqlJson;
 use mssql_tds::datatypes::sql_string::{EncodingType, SqlString, get_encoding_type};
 use mssql_tds::datatypes::sql_vector::SqlVector;
 use mssql_tds::datatypes::sqldatatypes::TdsDataType;
+use mssql_tds::encoding_rs;
 use mssql_tds::error::Error as TdsError;
 use mssql_tds::query::metadata::PlpEncoding;
 use uuid::Uuid;
@@ -41,7 +42,7 @@ use crate::api::describe_col::odbc_sql_type;
 use crate::api::exec_common::release_busy_if_row_exhausted;
 use crate::api::get_data::{
     TextError, column_value_to_bytes, column_value_to_text, convert_typed_c, is_typed_c_target,
-    utf16le_chunk_to_utf8, widen_into_pending,
+    transcode_narrow_into_pending, utf16le_chunk_to_utf8, widen_into_pending,
 };
 use crate::api::odbc_types::{
     SQL_BIND_BY_COLUMN, SQL_C_BINARY, SQL_C_BIT, SQL_C_CHAR, SQL_C_DEFAULT, SQL_C_DOUBLE,
@@ -1779,11 +1780,17 @@ unsafe fn deliver_bound_plp(
             encoding,
             PlpEncoding::SingleByteText | PlpEncoding::Utf8Text
         );
-    let mut narrow_decoder = if widen_narrow_to_utf16 {
-        column_info
-            .text_encoding
-            .and_then(|encoding| encoding.encoding())
-            .map(|encoding| encoding.new_decoder_without_bom_handling())
+    let narrow_wire_encoding = column_info
+        .text_encoding
+        .and_then(|encoding| encoding.encoding());
+    // Codepage text delivered as SQL_C_CHAR must be decoded through the column's
+    // collation, since SQL_C_CHAR output is UTF-8 (AB#47566). A UTF-8 collation
+    // is already in the target encoding, so it stays on the verbatim path.
+    let transcode_narrow_to_utf8 = target == SQL_C_CHAR
+        && matches!(encoding, PlpEncoding::SingleByteText)
+        && narrow_wire_encoding.is_some_and(|encoding| encoding != encoding_rs::UTF_8);
+    let mut narrow_decoder = if widen_narrow_to_utf16 || transcode_narrow_to_utf8 {
+        narrow_wire_encoding.map(|encoding| encoding.new_decoder_without_bom_handling())
     } else {
         None
     };
@@ -1807,7 +1814,7 @@ unsafe fn deliver_bound_plp(
 
     let transcode_utf16_to_utf8 =
         target == SQL_C_CHAR && matches!(encoding, PlpEncoding::Utf16Text);
-    let transcode = transcode_utf16_to_utf8 || widen_narrow_to_utf16;
+    let transcode = transcode_utf16_to_utf8 || widen_narrow_to_utf16 || transcode_narrow_to_utf8;
     let buf_elements = char_buf_elements(target, stride);
     // Room for the payload. Character targets always write a terminator; binary
     // is not a string, so the whole slot is payload.
@@ -1820,6 +1827,7 @@ unsafe fn deliver_bound_plp(
     let mut out_bytes: Vec<u8> = Vec::new();
     let mut out_units: Vec<u16> = Vec::new();
     let mut decoded_units: Vec<u16> = Vec::new();
+    let mut decoded_utf8: Vec<u8> = Vec::new();
     let mut pending_byte: Option<u8> = None;
     let mut pending_high_surrogate: Option<u16> = None;
     let mut truncated = false;
@@ -1838,7 +1846,36 @@ unsafe fn deliver_bound_plp(
             continue;
         }
 
-        if let Some(decoder) = narrow_decoder.as_mut() {
+        if transcode_narrow_to_utf8 {
+            // Codepage text into a UTF-8 SQL_C_CHAR slot. The decoder carries a
+            // multi-byte sequence split across a PLP chunk boundary; unlike the
+            // streaming SQLGetData path there is no continuation call, so the
+            // slot either takes the whole value or reports truncation.
+            let Some(decoder) = narrow_decoder.as_mut() else {
+                drain_plp_to_end(client, runtime, scratch)?;
+                return Ok(RowOutcome::Error(RowIssue::Unsupported));
+            };
+            decoded_utf8.clear();
+            transcode_narrow_into_pending(
+                decoder,
+                &mut decoded_utf8,
+                &scratch[..chunk.read],
+                chunk.reached_end,
+                usize::MAX,
+            );
+            // Whole characters only: a partial UTF-8 sequence left in the
+            // caller's buffer would not decode.
+            for ch in String::from_utf8_lossy(&decoded_utf8).chars() {
+                let need = ch.len_utf8();
+                if out_bytes.len() + need <= capacity_elements {
+                    let mut enc = [0u8; 4];
+                    out_bytes.extend_from_slice(ch.encode_utf8(&mut enc).as_bytes());
+                } else {
+                    truncated = true;
+                    break;
+                }
+            }
+        } else if let Some(decoder) = narrow_decoder.as_mut() {
             decoded_units.clear();
             widen_into_pending(
                 decoder,

--- a/mssql-odbc/src/api/get_data.rs
+++ b/mssql-odbc/src/api/get_data.rs
@@ -226,7 +226,7 @@ fn sql_get_data_safe(
             active_plp.encoding,
             active_plp.pending_units.len(),
             active_plp.pending_utf8.len(),
-            active_plp.narrow_to_wide.is_some(),
+            active_plp.narrow_decoder.is_some(),
         );
         return stream_active_plp_chunk(
             stmt,
@@ -1649,73 +1649,72 @@ fn stream_active_plp_chunk<'a>(
         return SQL_ERROR;
     }
 
-    let (plp_encoding, widen_carry_len, utf8_carry_len) = if let Some((
-        encoding,
-        widen_carry_len,
-        utf8_carry_len,
-        widening_ready,
-    )) = prepared_stream
-    {
-        let compatible = match (target_type, encoding) {
-            (SQL_C_WCHAR, PlpEncoding::Utf16Text) => true,
-            (SQL_C_WCHAR, PlpEncoding::SingleByteText | PlpEncoding::Utf8Text) => widening_ready,
+    let (plp_encoding, widen_carry_len, utf8_carry_len, decoder_ready) =
+        if let Some((encoding, widen_carry_len, utf8_carry_len, decoder_ready)) = prepared_stream {
+            let compatible = match (target_type, encoding) {
+                (SQL_C_WCHAR, PlpEncoding::Utf16Text) => true,
+                (SQL_C_WCHAR, PlpEncoding::SingleByteText | PlpEncoding::Utf8Text) => decoder_ready,
+                (
+                    SQL_C_CHAR,
+                    PlpEncoding::SingleByteText | PlpEncoding::Utf8Text | PlpEncoding::Utf16Text,
+                ) => true,
+                // Mirrors the first-chunk gate: binary is the wire bytes whatever
+                // the encoding. The two must agree or a chunked read is admitted on
+                // its first call and refused on its second.
+                (SQL_C_BINARY, _) => true,
+                _ => false,
+            };
+            if !compatible {
+                if let Some(mut stmt_state) = retained_stmt_state.take() {
+                    post_sql_error(
+                        &mut stmt_state,
+                        SQLSTATE_HYC00,
+                        0,
+                        "Target type not yet implemented for this column",
+                    );
+                } else if let Ok(mut stmt_state) = stmt.inner.lock() {
+                    post_sql_error(
+                        &mut stmt_state,
+                        SQLSTATE_HYC00,
+                        0,
+                        "Target type not yet implemented for this column",
+                    );
+                }
+                return SQL_ERROR;
+            }
             (
-                SQL_C_CHAR,
-                PlpEncoding::SingleByteText | PlpEncoding::Utf8Text | PlpEncoding::Utf16Text,
-            ) => true,
-            // Mirrors the first-chunk gate: binary is the wire bytes whatever
-            // the encoding. The two must agree or a chunked read is admitted on
-            // its first call and refused on its second.
-            (SQL_C_BINARY, _) => true,
-            _ => false,
-        };
-        if !compatible {
-            if let Some(mut stmt_state) = retained_stmt_state.take() {
-                post_sql_error(
-                    &mut stmt_state,
-                    SQLSTATE_HYC00,
-                    0,
-                    "Target type not yet implemented for this column",
-                );
-            } else if let Ok(mut stmt_state) = stmt.inner.lock() {
-                post_sql_error(
-                    &mut stmt_state,
-                    SQLSTATE_HYC00,
-                    0,
-                    "Target type not yet implemented for this column",
-                );
-            }
-            return SQL_ERROR;
-        }
-        (Some(encoding), widen_carry_len, utf8_carry_len)
-    } else {
-        let mut stmt_state = match retained_stmt_state.take() {
-            Some(state) => state,
-            None => {
-                let Ok(state) = stmt.inner.lock() else {
-                    error!("SQLGetData: stmt mutex poisoned while preparing PLP stream read");
-                    return SQL_ERROR;
-                };
-                state
-            }
-        };
+                Some(encoding),
+                widen_carry_len,
+                utf8_carry_len,
+                decoder_ready,
+            )
+        } else {
+            let mut stmt_state = match retained_stmt_state.take() {
+                Some(state) => state,
+                None => {
+                    let Ok(state) = stmt.inner.lock() else {
+                        error!("SQLGetData: stmt mutex poisoned while preparing PLP stream read");
+                        return SQL_ERROR;
+                    };
+                    state
+                }
+            };
 
-        if starting_new_stream {
-            let column_meta = stmt_state.column_metadata.get(col_index - 1);
-            let encoding = column_meta
-                .and_then(|m| m.plp_encoding())
-                .unwrap_or(PlpEncoding::SingleByteText);
-            // Narrow text delivered as SQL_C_WCHAR is decoded through the
-            // column's own collation, matching what the non-PLP path already
-            // does via `SqlString::to_utf8_string`. Built once per stream so the
-            // decoder can carry a character split across a chunk boundary.
-            //
-            // The encoding is derived here rather than through
-            // `get_encoding_type`, which unwraps the collation and would panic
-            // on a `json` column (UTF-8 on the wire, no collation) — a panic
-            // across the FFI boundary is UB.
-            let narrow_to_wide = if target_type == SQL_C_WCHAR {
-                let encoder = match encoding {
+            if starting_new_stream {
+                let column_meta = stmt_state.column_metadata.get(col_index - 1);
+                let encoding = column_meta
+                    .and_then(|m| m.plp_encoding())
+                    .unwrap_or(PlpEncoding::SingleByteText);
+                // Narrow text is decoded through the column's own collation,
+                // matching what the non-PLP path already does via
+                // `SqlString::to_utf8_string`. Built once per stream so the decoder
+                // can carry a character split across a chunk boundary.
+                //
+                // The encoding is derived here rather than through
+                // `get_encoding_type`, which unwraps the collation and would panic
+                // on a `json` column (UTF-8 on the wire, no collation) — a panic
+                // across the FFI boundary is UB.
+                let wire_encoding = match encoding {
                     // json is UTF-8 on the wire and carries no collation.
                     PlpEncoding::Utf8Text => Some(encoding_rs::UTF_8),
                     PlpEncoding::SingleByteText => column_meta
@@ -1729,80 +1728,101 @@ fn stream_active_plp_chunk<'a>(
                         }),
                     _ => None,
                 };
-                encoder.map(|e| e.new_decoder_without_bom_handling())
-            } else {
-                None
-            };
-            stmt_state.active_plp = Some(ActivePlpStream::new(col_index, encoding, narrow_to_wide));
-            stmt_state.current_row_last_col = col_index;
-        }
-
-        if stmt_state
-            .active_plp
-            .as_ref()
-            .is_none_or(|s| s.column != col_index)
-        {
-            post_sql_error(
-                &mut stmt_state,
-                SQLSTATE_24000,
-                0,
-                "No active PLP stream for this column",
-            );
-            return SQL_ERROR;
-        }
-
-        // Supported text deliveries:
-        //   SQL_C_WCHAR  <- nvarchar(max)/xml, already UTF-16LE on the wire
-        //   SQL_C_WCHAR  <- varchar(max)/json, widened through the column's
-        //                   collation (or UTF-8 for json, which has none)
-        //   SQL_C_CHAR   <- any of the three, as UTF-8
-        // Binary columns stream through this same loop, with no terminator
-        // and the raw wire bytes (AB#47239).
-        //
-        // Codepage note: as in the non-PLP path, SQL_C_CHAR output is UTF-8
-        // unconditionally, where msodbcsql converts to the client codepage it
-        // derives from the platform -- so the two agree under a UTF-8 locale and
-        // diverge under any other. SQL_C_WCHAR is UTF-16LE on both drivers.
-        let stream = stmt_state.active_plp.as_ref();
-        let encoding = stream.map(|s| s.encoding);
-        // A narrow column can only be widened when its collation resolved to a
-        // concrete encoding; without one there is nothing to decode through.
-        let widening_ready = stream.is_some_and(|s| s.narrow_to_wide.is_some());
-        let compatible = match (target_type, encoding) {
-            (SQL_C_WCHAR, Some(PlpEncoding::Utf16Text)) => true,
-            (SQL_C_WCHAR, Some(PlpEncoding::SingleByteText | PlpEncoding::Utf8Text)) => {
-                widening_ready
+                let narrow_decoder = match target_type {
+                    // Narrow wire bytes are never UTF-16, so widening always decodes.
+                    SQL_C_WCHAR => wire_encoding,
+                    // SQL_C_CHAR output is UTF-8, so a column already UTF-8 on the
+                    // wire needs no decoder — the verbatim copy is correct and
+                    // cheaper. Anything else is codepage text and must be converted
+                    // (AB#47566); leaving it verbatim hands the caller raw codepage
+                    // bytes labelled UTF-8.
+                    SQL_C_CHAR => wire_encoding.filter(|e| *e != encoding_rs::UTF_8),
+                    _ => None,
+                };
+                let narrow_decoder = narrow_decoder.map(|e| e.new_decoder_without_bom_handling());
+                stmt_state.active_plp =
+                    Some(ActivePlpStream::new(col_index, encoding, narrow_decoder));
+                stmt_state.current_row_last_col = col_index;
             }
-            (
-                SQL_C_CHAR,
-                Some(PlpEncoding::SingleByteText | PlpEncoding::Utf8Text | PlpEncoding::Utf16Text),
-            ) => true,
-            // Binary delivery is the wire bytes whatever the column holds, so
-            // every encoding qualifies -- varbinary(max) and image, and the UDT
-            // types (hierarchyid, geometry, geography) that arrive as PLP.
-            (SQL_C_BINARY, Some(_)) => true,
-            _ => false,
-        };
-        if !compatible {
-            post_sql_error(
-                &mut stmt_state,
-                SQLSTATE_HYC00,
-                0,
-                "Target type not yet implemented for this column",
+
+            if stmt_state
+                .active_plp
+                .as_ref()
+                .is_none_or(|s| s.column != col_index)
+            {
+                post_sql_error(
+                    &mut stmt_state,
+                    SQLSTATE_24000,
+                    0,
+                    "No active PLP stream for this column",
+                );
+                return SQL_ERROR;
+            }
+
+            // Supported text deliveries:
+            //   SQL_C_WCHAR  <- nvarchar(max)/xml, already UTF-16LE on the wire
+            //   SQL_C_WCHAR  <- varchar(max)/json, widened through the column's
+            //                   collation (or UTF-8 for json, which has none)
+            //   SQL_C_CHAR   <- any of the three, as UTF-8
+            // Binary columns stream through this same loop, with no terminator
+            // and the raw wire bytes (AB#47239).
+            //
+            // Codepage note: as in the non-PLP path, SQL_C_CHAR output is UTF-8
+            // unconditionally, where msodbcsql converts to the client codepage it
+            // derives from the platform -- so the two agree under a UTF-8 locale and
+            // diverge under any other. SQL_C_WCHAR is UTF-16LE on both drivers.
+            let stream = stmt_state.active_plp.as_ref();
+            let encoding = stream.map(|s| s.encoding);
+            // A narrow column can only be converted when its collation resolved to a
+            // concrete encoding; without one there is nothing to decode through.
+            let decoder_ready = stream.is_some_and(|s| s.narrow_decoder.is_some());
+            let compatible = match (target_type, encoding) {
+                (SQL_C_WCHAR, Some(PlpEncoding::Utf16Text)) => true,
+                (SQL_C_WCHAR, Some(PlpEncoding::SingleByteText | PlpEncoding::Utf8Text)) => {
+                    decoder_ready
+                }
+                (
+                    SQL_C_CHAR,
+                    Some(
+                        PlpEncoding::SingleByteText
+                        | PlpEncoding::Utf8Text
+                        | PlpEncoding::Utf16Text,
+                    ),
+                ) => true,
+                // Binary delivery is the wire bytes whatever the column holds, so
+                // every encoding qualifies -- varbinary(max) and image, and the UDT
+                // types (hierarchyid, geometry, geography) that arrive as PLP.
+                (SQL_C_BINARY, Some(_)) => true,
+                _ => false,
+            };
+            if !compatible {
+                post_sql_error(
+                    &mut stmt_state,
+                    SQLSTATE_HYC00,
+                    0,
+                    "Target type not yet implemented for this column",
+                );
+                return SQL_ERROR;
+            }
+            let stream_state = (
+                stream.map(|s| s.encoding),
+                stream.map_or(0, |s| s.pending_units.len()),
+                stream.map_or(0, |s| s.pending_utf8.len()),
+                decoder_ready,
             );
-            return SQL_ERROR;
-        }
-        let stream_state = (
-            stream.map(|s| s.encoding),
-            stream.map_or(0, |s| s.pending_units.len()),
-            stream.map_or(0, |s| s.pending_utf8.len()),
-        );
-        retained_stmt_state = Some(stmt_state);
-        stream_state
-    };
+            retained_stmt_state = Some(stmt_state);
+            stream_state
+        };
     let is_unicode_plp = matches!(plp_encoding, Some(PlpEncoding::Utf16Text));
     // SQL_C_CHAR delivery of a UTF-16 PLP column must transcode on the fly.
     let transcode_utf16_to_utf8 = target_type == SQL_C_CHAR && is_unicode_plp;
+    // SQL_C_CHAR delivery of a codepage-text PLP column must decode through the
+    // column's collation on the fly (AB#47566). `decoder_ready` is false when
+    // the column is already UTF-8 on the wire (json, or a UTF-8 collation),
+    // where the verbatim copy below is correct.
+    let transcode_narrow_to_utf8 = target_type == SQL_C_CHAR
+        && matches!(plp_encoding, Some(PlpEncoding::SingleByteText))
+        && decoder_ready;
     // SQL_C_WCHAR delivery of a narrow (codepage or UTF-8) PLP column must
     // widen on the fly. Mirrors the compatibility gate above so the two cannot
     // drift: a Binary column never reaches here.
@@ -1854,6 +1874,8 @@ fn stream_active_plp_chunk<'a>(
         payload_capacity & !1
     } else if transcode_utf16_to_utf8 {
         utf16le_max_read(payload_capacity, utf8_carry_len)
+    } else if transcode_narrow_to_utf8 {
+        narrow_max_read(payload_capacity, utf8_carry_len)
     } else {
         payload_capacity
     };
@@ -1881,7 +1903,7 @@ fn stream_active_plp_chunk<'a>(
     let is_length_probe = buffer_length == 0 || buffer_length as usize == terminator_bytes;
     let makes_no_progress = if widen_narrow_to_utf16 {
         widen_out_units == 0
-    } else if transcode_utf16_to_utf8 {
+    } else if transcode_utf16_to_utf8 || transcode_narrow_to_utf8 {
         max_read == 0 && utf8_carry_len == 0
     } else {
         max_read == 0
@@ -1909,18 +1931,23 @@ fn stream_active_plp_chunk<'a>(
     // storage for that read so initializing a Rust byte slice cannot overwrite
     // a caller buffer when no payload is delivered. Later chunks can stream
     // directly because a prior read established that the value is non-empty.
-    let direct_wire_output = max_read > 0
-        && !target_value_ptr.is_null()
-        && !(target_type == SQL_C_BINARY && starting_new_stream)
-        && matches!(
-            (target_type, plp_encoding),
-            (SQL_C_WCHAR, Some(PlpEncoding::Utf16Text))
-                | (
-                    SQL_C_CHAR,
-                    Some(PlpEncoding::SingleByteText | PlpEncoding::Utf8Text)
-                )
-                | (SQL_C_BINARY, Some(_))
-        );
+    let first_binary_read = target_type == SQL_C_BINARY && starting_new_stream;
+    // Whether the wire bytes are already in the shape the caller asked for, so
+    // the read can land straight in their buffer. A transcoding read never can:
+    // the wire bytes are the decoder's input, not its output, so they need
+    // storage of their own. That also disables the read-ahead below for this
+    // path, which is a throughput cost rather than a correctness one.
+    let wire_shaped_output = matches!(
+        (target_type, plp_encoding),
+        (SQL_C_WCHAR, Some(PlpEncoding::Utf16Text))
+            | (
+                SQL_C_CHAR,
+                Some(PlpEncoding::SingleByteText | PlpEncoding::Utf8Text)
+            )
+            | (SQL_C_BINARY, Some(_))
+    ) && !transcode_narrow_to_utf8;
+    let direct_wire_output =
+        max_read > 0 && !target_value_ptr.is_null() && !first_binary_read && wire_shaped_output;
     let mut inline_payload = [0_u8; 256];
     let mut heap_payload = Vec::new();
     let payload = if direct_wire_output {
@@ -2125,7 +2152,7 @@ fn stream_active_plp_chunk<'a>(
         }
     };
 
-    if widen_narrow_to_utf16 || transcode_utf16_to_utf8 {
+    if widen_narrow_to_utf16 || transcode_utf16_to_utf8 || transcode_narrow_to_utf8 {
         drop(retained_stmt_state.take());
     }
 
@@ -2143,11 +2170,11 @@ fn stream_active_plp_chunk<'a>(
                 return SQL_ERROR;
             };
             let ActivePlpStream {
-                narrow_to_wide,
+                narrow_decoder,
                 pending_units,
                 ..
             } = stream;
-            let Some(decoder) = narrow_to_wide.as_mut() else {
+            let Some(decoder) = narrow_decoder.as_mut() else {
                 error!("SQLGetData: narrow PLP stream lost its decoder");
                 return SQL_ERROR;
             };
@@ -2279,14 +2306,69 @@ fn stream_active_plp_chunk<'a>(
             }
             write_if_some(strlen_or_ind_ptr, read as SqlLen);
         }
+    } else if transcode_narrow_to_utf8 {
+        // varchar(max)/char/text under a non-UTF-8 collation. The wire carries
+        // codepage text and SQL_C_CHAR output is UTF-8, so the bytes must be
+        // decoded through the column's own collation — the same conversion
+        // `SqlString::to_utf8_string` performs on the non-PLP path, so a value
+        // delivered inline and the same value streamed agree byte for byte
+        // (AB#47566).
+        //
+        // The decoder carries a multi-byte sequence split across a chunk
+        // boundary (a DBCS collation puts two wire bytes on some characters),
+        // and pending_utf8 carries output the caller's buffer had no room for,
+        // since decoding expands: CP1252 0x80 is three UTF-8 bytes.
+        {
+            let Ok(mut ss) = stmt.inner.lock() else {
+                return SQL_ERROR;
+            };
+            let Some(stream) = ss.active_plp.as_mut() else {
+                return SQL_ERROR;
+            };
+            let ActivePlpStream {
+                narrow_decoder,
+                pending_utf8,
+                ..
+            } = stream;
+            let Some(decoder) = narrow_decoder.as_mut() else {
+                error!("SQLGetData: narrow PLP stream lost its decoder");
+                return SQL_ERROR;
+            };
+            let emit = transcode_narrow_into_pending(
+                decoder,
+                pending_utf8,
+                &payload[..read],
+                reached_end,
+                payload_capacity,
+            );
+            unsafe {
+                copy_with_nul(
+                    target_value_ptr as *mut u8,
+                    buffer_length as usize,
+                    &pending_utf8[..emit],
+                );
+                write_if_some(
+                    strlen_or_ind_ptr,
+                    SqlLen::try_from(emit).unwrap_or(SqlLen::MAX),
+                );
+            }
+            pending_utf8.drain(..emit);
+            // Same forward-progress guard as the widening branch: consuming wire
+            // while emitting nothing is progress (the decoder is holding a
+            // partial sequence); doing neither is a stalled stream.
+            debug_assert!(
+                emit > 0 || read > 0 || reached_end || payload_capacity == 0,
+                "narrow to UTF-8 transcode made no forward progress"
+            );
+        }
     } else {
-        // SQL_C_CHAR delivery of a non-UTF-16 text PLP column: the wire bytes are
-        // copied verbatim. `SingleByteText` and `Utf8Text` have identical bodies
-        // today because there is no codepage conversion on this path yet, but they
-        // are kept as separate arms so the divergence is recorded: `json`
-        // (`Utf8Text`) is UTF-8 and must NOT be folded into whatever codepage
-        // conversion later lands for `varchar(max)` (`SingleByteText`), or
-        // non-ASCII json silently corrupts.
+        // SQL_C_CHAR delivery of a text PLP column whose wire bytes are already
+        // UTF-8, copied verbatim. `SingleByteText` reaches here only when its
+        // collation is UTF-8 (or did not resolve, where there is nothing to
+        // decode through); anything else took the transcode branch above. The
+        // two arms are kept separate so the distinction stays recorded: `json`
+        // (`Utf8Text`) carries no collation at all and must never be folded into
+        // the codepage conversion, or non-ASCII json silently corrupts.
         let copy_verbatim = || unsafe {
             if direct_wire_output {
                 target_value_ptr.cast::<u8>().add(read).write_unaligned(0);
@@ -2300,9 +2382,8 @@ fn stream_active_plp_chunk<'a>(
             write_if_some(strlen_or_ind_ptr, read as SqlLen);
         };
         match plp_encoding {
-            // varchar(max)/char/text — single-byte / codepage text. Delivered
-            // verbatim today, so a non-UTF-8 server collation yields raw
-            // codepage bytes labelled UTF-8. Conversion attaches here: AB#47566.
+            // varchar(max)/char/text under a UTF-8 collation — already UTF-8 on
+            // the wire, so verbatim is the conversion.
             Some(PlpEncoding::SingleByteText) => copy_verbatim(),
             // json — UTF-8 on the wire; delivered verbatim to SQL_C_CHAR. Must
             // stay distinct from SingleByteText (see above).
@@ -2377,14 +2458,15 @@ fn stream_active_plp_chunk<'a>(
     // The varchar->SQL_C_WCHAR widening falls under the same rule and for the
     // same reason: delivered UTF-16 code units are not wire bytes, so it reports
     // SQL_NO_TOTAL too.
-    let remaining_indicator = if transcode_utf16_to_utf8 || widen_narrow_to_utf16 {
-        SQL_NO_TOTAL
-    } else if let Some(total) = known_total {
-        let consumed_before = total_read.saturating_sub(read) as u64;
-        total.saturating_sub(consumed_before) as SqlLen
-    } else {
-        SQL_NO_TOTAL
-    };
+    let remaining_indicator =
+        if transcode_utf16_to_utf8 || widen_narrow_to_utf16 || transcode_narrow_to_utf8 {
+            SQL_NO_TOTAL
+        } else if let Some(total) = known_total {
+            let consumed_before = total_read.saturating_sub(read) as u64;
+            total.saturating_sub(consumed_before) as SqlLen
+        } else {
+            SQL_NO_TOTAL
+        };
     unsafe { write_if_some(strlen_or_ind_ptr, remaining_indicator) };
     post_diag(&mut stmt_state, WARN_STRING_TRUNCATION);
 
@@ -2444,6 +2526,73 @@ pub(crate) fn widen_into_pending(
         pending.truncate(base + written);
     }
     out_units.min(pending.len())
+}
+
+/// Picks how many narrow wire bytes to read for the UTF-8 room still free.
+///
+/// A single wire byte can decode to three UTF-8 bytes — CP1252 0x80 is U+20AC —
+/// and a DBCS lead/trail pair is two bytes in for at most three out, so `room /
+/// 3` is the ratio that never overshoots for either. Never below one byte, so a
+/// buffer with any payload room still consumes wire rather than stalling; the
+/// overshoot that floor allows lands in `pending_utf8` like any other surplus.
+fn narrow_max_read(payload_capacity: usize, pending_utf8_len: usize) -> usize {
+    let remaining = payload_capacity.saturating_sub(pending_utf8_len);
+    if remaining == 0 {
+        0
+    } else {
+        (remaining / 3).max(1)
+    }
+}
+
+/// Decodes one chunk of narrow PLP wire bytes to UTF-8 for `SQL_C_CHAR`
+/// delivery, accumulating into `pending`, and returns how many bytes the
+/// caller's buffer can take.
+///
+/// The UTF-8 counterpart of [`widen_into_pending`], and split the same way: the
+/// caller emits `pending[..n]` and drains it, leaving this a pure
+/// decode-and-accumulate step that can be tested without a live wire.
+///
+/// `decoder` carries a character split across a chunk boundary; `pending`
+/// carries bytes the caller's buffer had no room for. Both are needed: the wire
+/// and the caller advance at unrelated rates once the encoding is
+/// variable-width on either side.
+pub(crate) fn transcode_narrow_into_pending(
+    decoder: &mut Decoder,
+    pending: &mut Vec<u8>,
+    payload: &[u8],
+    reached_end: bool,
+    out_bytes: usize,
+) -> usize {
+    // Decode onto the tail of `pending`, sized by the decoder's own worst-case
+    // bound so the output slice cannot be short: the consumed-byte count is
+    // discarded below, so `OutputFull` would drop wire bytes silently.
+    // `max_utf8_buffer_length` also accounts for a partial sequence the decoder
+    // is already holding, which a fixed ratio could not. `None` means the length
+    // would overflow `usize`, unreachable while the read is bounded by the
+    // caller's buffer.
+    //
+    // `reached_end` flushes any half-formed sequence to U+FFFD, and the decoder
+    // must not be used afterwards. Once the wire is exhausted there is nothing
+    // left to feed it, so later calls only drain what is already decoded.
+    if !(payload.is_empty() && reached_end) {
+        let base = pending.len();
+        let headroom = decoder
+            .max_utf8_buffer_length(payload.len())
+            .unwrap_or_else(|| payload.len().saturating_mul(3).saturating_add(3));
+        pending.resize(base + headroom, 0);
+        let (result, _, written, _) =
+            decoder.decode_to_utf8(payload, &mut pending[base..], reached_end);
+        debug_assert_eq!(
+            result,
+            encoding_rs::CoderResult::InputEmpty,
+            "narrow transcode output slice was too short, so input bytes were dropped"
+        );
+        pending.truncate(base + written);
+    }
+    // A character may be split across two SQLGetData calls at the byte level,
+    // exactly as the UTF-16 transcode does it: the application concatenates the
+    // chunks, so a boundary anywhere in the byte stream is lossless.
+    out_bytes.min(pending.len())
 }
 
 /// Picks how many UTF-16LE wire bytes to read for the UTF-8 room still free.
@@ -3623,6 +3772,174 @@ mod tests {
         let emit = widen_into_pending(&mut decoder, &mut pending, b"abc", false, 0);
         assert_eq!(emit, 0);
         assert_eq!(pending, vec![b'a' as u16, b'b' as u16, b'c' as u16]);
+    }
+
+    /// Drives `transcode_narrow_into_pending` the way `stream_active_plp_chunk`
+    /// does: feed a chunk, take what the caller's buffer holds, drain it,
+    /// repeat. Returns the assembled UTF-8 and the bytes delivered per call.
+    fn drain_narrow_transcode(
+        encoding: &'static encoding_rs::Encoding,
+        wire: &[u8],
+        chunk_bytes: usize,
+        out_bytes: usize,
+    ) -> (String, Vec<usize>) {
+        let mut decoder = encoding.new_decoder_without_bom_handling();
+        let mut pending: Vec<u8> = Vec::new();
+        let mut delivered: Vec<u8> = Vec::new();
+        let mut per_call = Vec::new();
+        let mut offset = 0;
+
+        loop {
+            let end = (offset + chunk_bytes).min(wire.len());
+            let payload = &wire[offset..end];
+            let reached_end = end == wire.len();
+            offset = end;
+
+            let emit = transcode_narrow_into_pending(
+                &mut decoder,
+                &mut pending,
+                payload,
+                reached_end,
+                out_bytes,
+            );
+            delivered.extend_from_slice(&pending[..emit]);
+            pending.drain(..emit);
+            per_call.push(emit);
+
+            if reached_end && pending.is_empty() {
+                break;
+            }
+            assert!(
+                per_call.len() < 10_000,
+                "narrow transcode made no forward progress"
+            );
+        }
+        (String::from_utf8(delivered).unwrap(), per_call)
+    }
+
+    /// The regression this path exists for (AB#47566 / AB#47875): a CP1252
+    /// `varchar(max)` must arrive as UTF-8, not as the raw codepage bytes. The
+    /// wire is one byte per character here, so a verbatim copy would deliver
+    /// the right *length* and the wrong bytes — which is exactly how the
+    /// original defect hid.
+    #[test]
+    fn narrow_transcode_converts_cp1252_to_utf8() {
+        let text = "café René señor Müller Größe naïve ";
+        let wire = encoding_rs::WINDOWS_1252.encode(text).0.into_owned();
+        assert_eq!(wire.len(), text.chars().count(), "CP1252 is single-byte");
+        assert_ne!(wire, text.as_bytes(), "the defect delivered these bytes");
+
+        let (got, _) = drain_narrow_transcode(encoding_rs::WINDOWS_1252, &wire, 7, 64);
+        assert_eq!(got, text);
+    }
+
+    /// A DBCS collation puts two wire bytes on a CJK character, so an odd chunk
+    /// size splits one across almost every call. The decoder must rejoin the
+    /// halves rather than emit two U+FFFD. A single-chunk test cannot catch
+    /// this.
+    #[test]
+    fn narrow_transcode_carries_a_character_across_a_chunk_boundary() {
+        let wire = encoding_rs::GBK.encode("你好世界abc").0.into_owned();
+        let (got, _) = drain_narrow_transcode(encoding_rs::GBK, &wire, 3, 64);
+        assert_eq!(got, "你好世界abc");
+    }
+
+    /// Decoding expands, so the caller's buffer fills before the wire does:
+    /// CP1252 0x80 is one byte in and three out. The surplus has to be held in
+    /// `pending`, and a one-byte-at-a-time caller must still make progress.
+    #[test]
+    fn narrow_transcode_holds_back_output_that_does_not_fit() {
+        let text = "€€€€";
+        let wire = encoding_rs::WINDOWS_1252.encode(text).0.into_owned();
+        assert_eq!(wire.len(), 4);
+
+        let (got, per_call) = drain_narrow_transcode(encoding_rs::WINDOWS_1252, &wire, 4, 3);
+        assert_eq!(got, text);
+        assert!(
+            per_call.iter().take(per_call.len() - 1).all(|&n| n == 3),
+            "every call but the last must fill the buffer: {per_call:?}"
+        );
+    }
+
+    /// Chunking must be invisible: the same wire read at any chunk size and any
+    /// caller buffer size assembles what a single whole-buffer decode produces.
+    /// Comparing against the one-shot decode rather than the source text keeps
+    /// this honest for characters an encoding cannot represent.
+    #[test]
+    fn narrow_transcode_is_chunk_size_invariant() {
+        let cases = [
+            (encoding_rs::WINDOWS_1252, "café René € naïve Größe"),
+            (encoding_rs::GBK, "你好世界 café abc 你"),
+        ];
+        for (encoding, text) in cases {
+            let wire = encoding.encode(text).0.into_owned();
+            let expected = encoding.decode(&wire).0.into_owned();
+            for chunk in 1..=9 {
+                for out in [1_usize, 2, 3, 5, 64] {
+                    let (got, _) = drain_narrow_transcode(encoding, &wire, chunk, out);
+                    assert_eq!(got, expected, "{} chunk={chunk} out={out}", encoding.name());
+                }
+            }
+        }
+    }
+
+    /// Surplus bytes the caller had no room for outlive the wire: once
+    /// `reached_end` is reported the decoder is spent, and later calls drain
+    /// what is already decoded rather than flushing it again.
+    #[test]
+    fn narrow_transcode_drains_pending_after_the_wire_is_exhausted() {
+        let wire = encoding_rs::WINDOWS_1252.encode("abcdef").0.into_owned();
+        let mut decoder = encoding_rs::WINDOWS_1252.new_decoder_without_bom_handling();
+        let mut pending = Vec::new();
+
+        let emit = transcode_narrow_into_pending(&mut decoder, &mut pending, &wire, true, 2);
+        assert_eq!(emit, 2);
+        assert_eq!(pending.len(), 6, "the surplus must be held, not dropped");
+        pending.drain(..emit);
+
+        for _ in 0..2 {
+            let emit = transcode_narrow_into_pending(&mut decoder, &mut pending, &[], true, 2);
+            assert_eq!(emit, 2);
+            pending.drain(..emit);
+        }
+        assert!(pending.is_empty());
+    }
+
+    /// A caller with no payload room is a length probe: nothing is emitted, and
+    /// nothing decoded is lost.
+    #[test]
+    fn narrow_transcode_emits_nothing_for_a_zero_capacity_buffer() {
+        let mut decoder = encoding_rs::WINDOWS_1252.new_decoder_without_bom_handling();
+        let mut pending = Vec::new();
+        let emit = transcode_narrow_into_pending(&mut decoder, &mut pending, b"abc", false, 0);
+        assert_eq!(emit, 0);
+        assert_eq!(pending, b"abc");
+    }
+
+    #[test]
+    fn narrow_max_read_floors_to_whole_characters() {
+        // (payload_capacity, pending_utf8_len) -> expected wire bytes to read.
+        // One wire byte can expand to three UTF-8 bytes, so room/3 is the ratio
+        // that cannot overshoot; the .max(1) floor keeps a buffer too small for
+        // that ratio consuming wire instead of stalling.
+        let cases = [
+            ((0, 0), 0),
+            ((1, 0), 1),
+            ((2, 0), 1),
+            ((3, 0), 1),
+            ((9, 0), 3),
+            ((8192, 0), 2730),
+            ((10, 4), 2), // carry shrinks the room to 6
+            ((3, 3), 0),  // carry fills the room: drain only
+            ((3, 5), 0),  // carry over-fills, saturating to no read
+        ];
+        for ((capacity, carry), expected) in cases {
+            assert_eq!(
+                narrow_max_read(capacity, carry),
+                expected,
+                "narrow_max_read({capacity}, {carry})"
+            );
+        }
     }
 
     /// Option-returning shim so these tests read the same as before the

--- a/mssql-odbc/src/api/get_data.rs
+++ b/mssql-odbc/src/api/get_data.rs
@@ -2623,6 +2623,12 @@ pub(crate) fn transcode_narrow_into_pending(
     // `reached_end` flushes any half-formed sequence to U+FFFD, and the decoder
     // must not be used afterwards. Once the wire is exhausted there is nothing
     // left to feed it, so later calls only drain what is already decoded.
+    //
+    // The flush therefore only happens when the final wire bytes and
+    // `reached_end` arrive together. If `reached_end` first arrives on a call
+    // with no payload, a sequence the decoder is still holding is dropped rather
+    // than replaced. Same shape as `widen_into_pending` above, which has carried
+    // this guard since before this path existed; tracked in AB#48073.
     if !(payload.is_empty() && reached_end) {
         let base = pending.len();
         let headroom = decoder
@@ -3857,6 +3863,33 @@ mod tests {
             );
         }
         (String::from_utf8(delivered).unwrap(), per_call)
+    }
+
+    /// A malformed narrow sequence at true end-of-stream becomes U+FFFD rather
+    /// than being dropped or panicking — the UTF-8 counterpart of
+    /// `utf16_chunk_trailing_odd_byte_at_end_is_replacement`. A GBK lead byte
+    /// with no trail byte is reachable from SQL: `CAST(0xD0 AS VARCHAR(MAX))`
+    /// under a DBCS collation puts exactly that on the wire.
+    ///
+    /// Only covers the flush landing in the same call as the dangling bytes,
+    /// which is the shape the decode guard admits. When `reached_end` first
+    /// arrives on a call with no payload the decoder is never flushed and the
+    /// carry is dropped instead — pre-existing behaviour shared with
+    /// `widen_into_pending`, tracked in AB#48073.
+    #[test]
+    fn narrow_transcode_malformed_sequence_at_end_is_replacement() {
+        let mut decoder = encoding_rs::GBK.new_decoder_without_bom_handling();
+        let mut pending: Vec<u8> = Vec::new();
+
+        let emit =
+            transcode_narrow_into_pending(&mut decoder, &mut pending, b"abc\xD0", true, usize::MAX);
+
+        assert_eq!(emit, pending.len());
+        assert_eq!(
+            String::from_utf8(pending).unwrap(),
+            "abc\u{FFFD}",
+            "a dangling DBCS lead byte must become U+FFFD, not vanish"
+        );
     }
 
     /// The regression this path exists for (AB#47566 / AB#47875): a CP1252

--- a/mssql-odbc/src/api/get_data.rs
+++ b/mssql-odbc/src/api/get_data.rs
@@ -2486,12 +2486,27 @@ fn stream_active_plp_chunk<'a>(
     // from those same bytes, so reading it after the fact would count this
     // call's read twice. `pending_units` needs no equivalent: it is only filled
     // by the widening path, which reports SQL_NO_TOTAL above.
+    //
+    // Scoped to the arm that owns the carry. `pending_utf8` is only ever filled
+    // by a SQL_C_CHAR call, but it outlives that call, and the compatibility
+    // gate admits a different target on a continuation (`(SQL_C_BINARY, _)`
+    // unconditionally, and SQL_C_WCHAR on a Utf16Text column takes this same
+    // branch). Adding UTF-8 bytes to a binary or UTF-16 delivery's count would
+    // report a number in neither unit; those targets keep the plain wire count
+    // they have on main. Reaching that state needs the mid-stream target switch
+    // tracked in AB#48046, which strands the stream on 01004 regardless -- this
+    // line just does not depend on that being fixed.
+    let held_converted_bytes = if transcode_narrow_to_utf8 {
+        utf8_carry_len as u64
+    } else {
+        0
+    };
     let remaining_indicator = if transcode_utf16_to_utf8 || widen_narrow_to_utf16 {
         SQL_NO_TOTAL
     } else if let Some(total) = known_total {
         let consumed_before = total_read.saturating_sub(read) as u64;
         let wire_remaining = total.saturating_sub(consumed_before);
-        wire_remaining.saturating_add(utf8_carry_len as u64) as SqlLen
+        wire_remaining.saturating_add(held_converted_bytes) as SqlLen
     } else {
         SQL_NO_TOTAL
     };

--- a/mssql-odbc/src/api/get_data.rs
+++ b/mssql-odbc/src/api/get_data.rs
@@ -226,7 +226,7 @@ fn sql_get_data_safe(
             active_plp.encoding,
             active_plp.pending_units.len(),
             active_plp.pending_utf8.len(),
-            active_plp.narrow_decoder.is_some(),
+            active_plp.narrow_encoding,
         );
         return stream_active_plp_chunk(
             stmt,
@@ -1627,7 +1627,12 @@ fn stream_active_plp_chunk<'a>(
     buffer_length: SqlLen,
     strlen_or_ind_ptr: *mut SqlLen,
     starting_new_stream: bool,
-    prepared_stream: Option<(PlpEncoding, usize, usize, bool)>,
+    prepared_stream: Option<(
+        PlpEncoding,
+        usize,
+        usize,
+        Option<&'static encoding_rs::Encoding>,
+    )>,
     mut retained_stmt_state: Option<MutexGuard<'a, StmtState>>,
 ) -> SqlReturn {
     if target_type != SQL_C_CHAR && target_type != SQL_C_WCHAR && target_type != SQL_C_BINARY {
@@ -1649,8 +1654,10 @@ fn stream_active_plp_chunk<'a>(
         return SQL_ERROR;
     }
 
-    let (plp_encoding, widen_carry_len, utf8_carry_len, decoder_ready) =
-        if let Some((encoding, widen_carry_len, utf8_carry_len, decoder_ready)) = prepared_stream {
+    let (plp_encoding, widen_carry_len, utf8_carry_len, narrow_encoding) =
+        if let Some((encoding, widen_carry_len, utf8_carry_len, narrow_encoding)) = prepared_stream
+        {
+            let decoder_ready = narrow_encoding.is_some();
             let compatible = match (target_type, encoding) {
                 (SQL_C_WCHAR, PlpEncoding::Utf16Text) => true,
                 (SQL_C_WCHAR, PlpEncoding::SingleByteText | PlpEncoding::Utf8Text) => decoder_ready,
@@ -1686,7 +1693,7 @@ fn stream_active_plp_chunk<'a>(
                 Some(encoding),
                 widen_carry_len,
                 utf8_carry_len,
-                decoder_ready,
+                narrow_encoding,
             )
         } else {
             let mut stmt_state = match retained_stmt_state.take() {
@@ -1707,14 +1714,15 @@ fn stream_active_plp_chunk<'a>(
                     .unwrap_or(PlpEncoding::SingleByteText);
                 // Narrow text is decoded through the column's own collation,
                 // matching what the non-PLP path already does via
-                // `SqlString::to_utf8_string`. Built once per stream so the decoder
-                // can carry a character split across a chunk boundary.
+                // `SqlString::to_utf8_string`. The *encoding* is resolved once
+                // per stream and the decoder is built on first need, so it
+                // survives a target-type switch across continuation calls.
                 //
                 // The encoding is derived here rather than through
                 // `get_encoding_type`, which unwraps the collation and would panic
                 // on a `json` column (UTF-8 on the wire, no collation) — a panic
                 // across the FFI boundary is UB.
-                let wire_encoding = match encoding {
+                let narrow_encoding = match encoding {
                     // json is UTF-8 on the wire and carries no collation.
                     PlpEncoding::Utf8Text => Some(encoding_rs::UTF_8),
                     PlpEncoding::SingleByteText => column_meta
@@ -1728,20 +1736,8 @@ fn stream_active_plp_chunk<'a>(
                         }),
                     _ => None,
                 };
-                let narrow_decoder = match target_type {
-                    // Narrow wire bytes are never UTF-16, so widening always decodes.
-                    SQL_C_WCHAR => wire_encoding,
-                    // SQL_C_CHAR output is UTF-8, so a column already UTF-8 on the
-                    // wire needs no decoder — the verbatim copy is correct and
-                    // cheaper. Anything else is codepage text and must be converted
-                    // (AB#47566); leaving it verbatim hands the caller raw codepage
-                    // bytes labelled UTF-8.
-                    SQL_C_CHAR => wire_encoding.filter(|e| *e != encoding_rs::UTF_8),
-                    _ => None,
-                };
-                let narrow_decoder = narrow_decoder.map(|e| e.new_decoder_without_bom_handling());
                 stmt_state.active_plp =
-                    Some(ActivePlpStream::new(col_index, encoding, narrow_decoder));
+                    Some(ActivePlpStream::new(col_index, encoding, narrow_encoding));
                 stmt_state.current_row_last_col = col_index;
             }
 
@@ -1775,7 +1771,11 @@ fn stream_active_plp_chunk<'a>(
             let encoding = stream.map(|s| s.encoding);
             // A narrow column can only be converted when its collation resolved to a
             // concrete encoding; without one there is nothing to decode through.
-            let decoder_ready = stream.is_some_and(|s| s.narrow_decoder.is_some());
+            // Keyed on the column's encoding rather than on whether a decoder exists,
+            // so a stream opened by a `SQL_C_BINARY` read (which builds none) can
+            // still convert when a later call asks for text.
+            let narrow_encoding = stream.and_then(|s| s.narrow_encoding);
+            let decoder_ready = narrow_encoding.is_some();
             let compatible = match (target_type, encoding) {
                 (SQL_C_WCHAR, Some(PlpEncoding::Utf16Text)) => true,
                 (SQL_C_WCHAR, Some(PlpEncoding::SingleByteText | PlpEncoding::Utf8Text)) => {
@@ -1808,7 +1808,7 @@ fn stream_active_plp_chunk<'a>(
                 stream.map(|s| s.encoding),
                 stream.map_or(0, |s| s.pending_units.len()),
                 stream.map_or(0, |s| s.pending_utf8.len()),
-                decoder_ready,
+                narrow_encoding,
             );
             retained_stmt_state = Some(stmt_state);
             stream_state
@@ -1817,12 +1817,14 @@ fn stream_active_plp_chunk<'a>(
     // SQL_C_CHAR delivery of a UTF-16 PLP column must transcode on the fly.
     let transcode_utf16_to_utf8 = target_type == SQL_C_CHAR && is_unicode_plp;
     // SQL_C_CHAR delivery of a codepage-text PLP column must decode through the
-    // column's collation on the fly (AB#47566). `decoder_ready` is false when
-    // the column is already UTF-8 on the wire (json, or a UTF-8 collation),
-    // where the verbatim copy below is correct.
+    // column's collation on the fly (AB#47566). A column already UTF-8 on the
+    // wire (json, or a UTF-8 collation) is excluded: it is already in the target
+    // encoding, so the verbatim copy below is both correct and cheaper, and
+    // running it through a decoder would only risk turning an invalid sequence
+    // into U+FFFD.
     let transcode_narrow_to_utf8 = target_type == SQL_C_CHAR
         && matches!(plp_encoding, Some(PlpEncoding::SingleByteText))
-        && decoder_ready;
+        && narrow_encoding.is_some_and(|encoding| encoding != encoding_rs::UTF_8);
     // SQL_C_WCHAR delivery of a narrow (codepage or UTF-8) PLP column must
     // widen on the fly. Mirrors the compatibility gate above so the two cannot
     // drift: a Binary column never reaches here.
@@ -2169,13 +2171,14 @@ fn stream_active_plp_chunk<'a>(
                 error!("SQLGetData: narrow PLP stream vanished mid-call");
                 return SQL_ERROR;
             };
+            stream.ensure_narrow_decoder();
             let ActivePlpStream {
                 narrow_decoder,
                 pending_units,
                 ..
             } = stream;
             let Some(decoder) = narrow_decoder.as_mut() else {
-                error!("SQLGetData: narrow PLP stream lost its decoder");
+                error!("SQLGetData: narrow PLP stream has no encoding to widen through");
                 return SQL_ERROR;
             };
             let emit = widen_into_pending(
@@ -2325,13 +2328,14 @@ fn stream_active_plp_chunk<'a>(
             let Some(stream) = ss.active_plp.as_mut() else {
                 return SQL_ERROR;
             };
+            stream.ensure_narrow_decoder();
             let ActivePlpStream {
                 narrow_decoder,
                 pending_utf8,
                 ..
             } = stream;
             let Some(decoder) = narrow_decoder.as_mut() else {
-                error!("SQLGetData: narrow PLP stream lost its decoder");
+                error!("SQLGetData: narrow PLP stream has no encoding to convert through");
                 return SQL_ERROR;
             };
             let emit = transcode_narrow_into_pending(
@@ -2451,22 +2455,29 @@ fn stream_active_plp_chunk<'a>(
     //     value until we have converted all of it ... as per spec." Its own tests
     //     assert this (RegressionsODBC nvarchar->SQL_C_TCHAR under an ANSI client,
     //     and SQLVariantODBC's "Mplat driver conversion to UTF8 results in
-    //     SQL_NO_TOTAL"). Only the same-encoding varchar->SQL_C_CHAR path, where
-    //     msodbcsql assumes a 1:1 ratio, gets a concrete count -- which is exactly
-    //     the `known_total` branch below. This path is therefore already converged.
+    //     SQL_NO_TOTAL").
     //
     // The varchar->SQL_C_WCHAR widening falls under the same rule and for the
     // same reason: delivered UTF-16 code units are not wire bytes, so it reports
     // SQL_NO_TOTAL too.
-    let remaining_indicator =
-        if transcode_utf16_to_utf8 || widen_narrow_to_utf16 || transcode_narrow_to_utf8 {
-            SQL_NO_TOTAL
-        } else if let Some(total) = known_total {
-            let consumed_before = total_read.saturating_sub(read) as u64;
-            total.saturating_sub(consumed_before) as SqlLen
-        } else {
-            SQL_NO_TOTAL
-        };
+    //
+    // The codepage varchar->SQL_C_CHAR conversion does NOT, even though it also
+    // transcodes. msodbcsql keys this decision on the C types, not on whether a
+    // conversion happens: `sqlcdata.h:1230` takes CHAR->CHAR on the first branch
+    // and reports `cbDataAvail` on an explicit "assume a 1:1 conversion ratio"
+    // comment, reaching `VARMAX_LENGTH_UNLIMITED`/SQL_NO_TOTAL only on the
+    // CHAR<->WCHAR branch below it. So a `varchar(max)` read as SQL_C_CHAR keeps
+    // its concrete wire-byte count under every collation. `PlpKnownLengthIndicatorCountsDown`
+    // and `ABoundVarcharMaxTruncatedReportsFullLength` are unskipped cross-leg
+    // parity tests that measure exactly this, and they hold msodbcsql to it.
+    let remaining_indicator = if transcode_utf16_to_utf8 || widen_narrow_to_utf16 {
+        SQL_NO_TOTAL
+    } else if let Some(total) = known_total {
+        let consumed_before = total_read.saturating_sub(read) as u64;
+        total.saturating_sub(consumed_before) as SqlLen
+    } else {
+        SQL_NO_TOTAL
+    };
     unsafe { write_if_some(strlen_or_ind_ptr, remaining_indicator) };
     post_diag(&mut stmt_state, WARN_STRING_TRUNCATION);
 
@@ -2532,9 +2543,15 @@ pub(crate) fn widen_into_pending(
 ///
 /// A single wire byte can decode to three UTF-8 bytes — CP1252 0x80 is U+20AC —
 /// and a DBCS lead/trail pair is two bytes in for at most three out, so `room /
-/// 3` is the ratio that never overshoots for either. Never below one byte, so a
-/// buffer with any payload room still consumes wire rather than stalling; the
-/// overshoot that floor allows lands in `pending_utf8` like any other surplus.
+/// 3` is the ratio that does not overshoot within a single chunk. It is not an
+/// absolute bound: `encoding_rs::GBK` decodes gb18030, so a 4-byte sequence
+/// whose first three bytes are already carried emits 4 UTF-8 bytes from the one
+/// byte fed on the next call. Overshoot is harmless — it lands in `pending_utf8`
+/// like any other surplus — so the ratio only has to be right often enough to
+/// keep the carry small.
+///
+/// Never below one byte, so a buffer with any payload room still consumes wire
+/// rather than stalling.
 fn narrow_max_read(payload_capacity: usize, pending_utf8_len: usize) -> usize {
     let remaining = payload_capacity.saturating_sub(pending_utf8_len);
     if remaining == 0 {

--- a/mssql-odbc/src/api/get_data.rs
+++ b/mssql-odbc/src/api/get_data.rs
@@ -2470,11 +2470,27 @@ fn stream_active_plp_chunk<'a>(
     // its concrete wire-byte count under every collation. `PlpKnownLengthIndicatorCountsDown`
     // and `ABoundVarcharMaxTruncatedReportsFullLength` are unskipped cross-leg
     // parity tests that measure exactly this, and they hold msodbcsql to it.
+    //
+    // Decoded output can outlive the wire, so the carry is added to the wire
+    // count: converting fills `pending_utf8` faster than a small caller buffer
+    // drains it, and once the wire is exhausted the wire term alone is 0. Without
+    // this a drain-only call would report "0 bytes remaining" alongside the
+    // 01004 truncation warning it returns below -- self-contradictory, and it
+    // strands a caller that sizes its next buffer from the indicator rather than
+    // looping on the return code. This is also the term msodbcsql carries as
+    // `cbTruncatedCharsInConvBuf` in the same `sqlcdata.h:1230` expression.
+    // `pending_units` needs no equivalent: it is only filled by the widening
+    // path, which reports SQL_NO_TOTAL above.
+    let held_converted_bytes = stmt_state
+        .active_plp
+        .as_ref()
+        .map_or(0, |s| s.pending_utf8.len());
     let remaining_indicator = if transcode_utf16_to_utf8 || widen_narrow_to_utf16 {
         SQL_NO_TOTAL
     } else if let Some(total) = known_total {
         let consumed_before = total_read.saturating_sub(read) as u64;
-        total.saturating_sub(consumed_before) as SqlLen
+        let wire_remaining = total.saturating_sub(consumed_before);
+        wire_remaining.saturating_add(held_converted_bytes as u64) as SqlLen
     } else {
         SQL_NO_TOTAL
     };

--- a/mssql-odbc/src/api/get_data.rs
+++ b/mssql-odbc/src/api/get_data.rs
@@ -2479,18 +2479,19 @@ fn stream_active_plp_chunk<'a>(
     // strands a caller that sizes its next buffer from the indicator rather than
     // looping on the return code. This is also the term msodbcsql carries as
     // `cbTruncatedCharsInConvBuf` in the same `sqlcdata.h:1230` expression.
-    // `pending_units` needs no equivalent: it is only filled by the widening
-    // path, which reports SQL_NO_TOTAL above.
-    let held_converted_bytes = stmt_state
-        .active_plp
-        .as_ref()
-        .map_or(0, |s| s.pending_utf8.len());
+    //
+    // `utf8_carry_len` is the carry as it stood at entry, which is the value
+    // this indicator is defined in terms of: `wire_remaining` already includes
+    // the bytes read by this call, and the post-drain carry holds output decoded
+    // from those same bytes, so reading it after the fact would count this
+    // call's read twice. `pending_units` needs no equivalent: it is only filled
+    // by the widening path, which reports SQL_NO_TOTAL above.
     let remaining_indicator = if transcode_utf16_to_utf8 || widen_narrow_to_utf16 {
         SQL_NO_TOTAL
     } else if let Some(total) = known_total {
         let consumed_before = total_read.saturating_sub(read) as u64;
         let wire_remaining = total.saturating_sub(consumed_before);
-        wire_remaining.saturating_add(held_converted_bytes as u64) as SqlLen
+        wire_remaining.saturating_add(utf8_carry_len as u64) as SqlLen
     } else {
         SQL_NO_TOTAL
     };

--- a/mssql-odbc/src/handles/stmt.rs
+++ b/mssql-odbc/src/handles/stmt.rs
@@ -41,16 +41,18 @@ pub(crate) struct ActivePlpStream {
     /// UTF-16 surrogate pair becomes a 4-byte UTF-8 character, so a chunk is
     /// transcoded whole and only the bytes that fit are copied out.
     pub(crate) pending_utf8: Vec<u8>,
-    /// Incremental decoder for the narrow-text -> `SQL_C_WCHAR` widening path
-    /// (`varchar(max)`/`json` delivered as UTF-16LE). `None` for every other
-    /// combination.
+    /// Incremental decoder for a narrow-text PLP column that has to be
+    /// converted on the way out: to UTF-16LE for `SQL_C_WCHAR`
+    /// (`varchar(max)`/`json`), or to UTF-8 for `SQL_C_CHAR` under a non-UTF-8
+    /// collation (AB#47566). `None` when the wire bytes are already in the
+    /// target's encoding and can be copied verbatim.
     ///
     /// A decoder rather than a byte carry because the column's codepage can be
     /// multi-byte (`lcid_to_encoding` reaches SHIFT_JIS, GBK, BIG5, EUC-KR and
     /// UTF-8), so a chunk boundary can split one character across two reads.
     /// `encoding_rs::Decoder` already holds that partial sequence internally,
     /// which keeps the boundary rule in one place instead of one per codepage.
-    pub(crate) narrow_to_wide: Option<Decoder>,
+    pub(crate) narrow_decoder: Option<Decoder>,
     /// Code units already decoded on a previous call that did not fit the
     /// caller's buffer, delivered before any further wire bytes.
     ///
@@ -90,7 +92,7 @@ impl ActivePlpStream {
     pub(crate) fn new(
         column: usize,
         encoding: PlpEncoding,
-        narrow_to_wide: Option<Decoder>,
+        narrow_decoder: Option<Decoder>,
     ) -> Self {
         Self {
             column,
@@ -98,7 +100,7 @@ impl ActivePlpStream {
             pending_byte: None,
             pending_high_surrogate: None,
             pending_utf8: Vec::new(),
-            narrow_to_wide,
+            narrow_decoder,
             pending_units: Vec::new(),
             prefetched_wire: Vec::new(),
             prefetched_offset: 0,
@@ -193,7 +195,7 @@ impl std::fmt::Debug for ActivePlpStream {
             .field("pending_byte", &self.pending_byte)
             .field("pending_high_surrogate", &self.pending_high_surrogate)
             .field("pending_utf8", &self.pending_utf8.len())
-            .field("narrow_to_wide", &self.narrow_to_wide.is_some())
+            .field("narrow_decoder", &self.narrow_decoder.is_some())
             .field("pending_units", &self.pending_units.len())
             .field(
                 "prefetched_wire_remaining",

--- a/mssql-odbc/src/handles/stmt.rs
+++ b/mssql-odbc/src/handles/stmt.rs
@@ -20,6 +20,7 @@ use crate::error::{DiagRecord, HasDiagnostics};
 use crate::params::BoundParam;
 use mssql_tds::datatypes::column_values::ColumnValues;
 use mssql_tds::datatypes::sqldatatypes::TdsDataType;
+use mssql_tds::encoding_rs;
 use mssql_tds::encoding_rs::Decoder;
 use mssql_tds::query::metadata::{ColumnMetadata, PlpEncoding};
 
@@ -41,11 +42,19 @@ pub(crate) struct ActivePlpStream {
     /// UTF-16 surrogate pair becomes a 4-byte UTF-8 character, so a chunk is
     /// transcoded whole and only the bytes that fit are copied out.
     pub(crate) pending_utf8: Vec<u8>,
-    /// Incremental decoder for a narrow-text PLP column that has to be
-    /// converted on the way out: to UTF-16LE for `SQL_C_WCHAR`
-    /// (`varchar(max)`/`json`), or to UTF-8 for `SQL_C_CHAR` under a non-UTF-8
-    /// collation (AB#47566). `None` when the wire bytes are already in the
-    /// target's encoding and can be copied verbatim.
+    /// Narrow wire encoding resolved from the column's collation (or UTF-8 for
+    /// `json`, which carries none), or `None` when the column is not narrow
+    /// text. This is a property of the *column*, so a target type that arrives
+    /// only on a continuation call still finds it — unlike a decoder built from
+    /// the first call's target, which would leave a `SQL_C_BINARY`-first stream
+    /// unable to convert later.
+    pub(crate) narrow_encoding: Option<&'static encoding_rs::Encoding>,
+    /// Incremental decoder over `narrow_encoding`, built by
+    /// [`Self::ensure_narrow_decoder`] the first time a target actually needs to
+    /// convert. Serves both directions: to UTF-16LE for `SQL_C_WCHAR`
+    /// (`varchar(max)`/`json`) and to UTF-8 for `SQL_C_CHAR` under a non-UTF-8
+    /// collation (AB#47566). One decoder for both, so a target switch mid-stream
+    /// reuses a carry that is still meaningful.
     ///
     /// A decoder rather than a byte carry because the column's codepage can be
     /// multi-byte (`lcid_to_encoding` reaches SHIFT_JIS, GBK, BIG5, EUC-KR and
@@ -92,7 +101,7 @@ impl ActivePlpStream {
     pub(crate) fn new(
         column: usize,
         encoding: PlpEncoding,
-        narrow_decoder: Option<Decoder>,
+        narrow_encoding: Option<&'static encoding_rs::Encoding>,
     ) -> Self {
         Self {
             column,
@@ -100,7 +109,8 @@ impl ActivePlpStream {
             pending_byte: None,
             pending_high_surrogate: None,
             pending_utf8: Vec::new(),
-            narrow_decoder,
+            narrow_encoding,
+            narrow_decoder: None,
             pending_units: Vec::new(),
             prefetched_wire: Vec::new(),
             prefetched_offset: 0,
@@ -108,6 +118,21 @@ impl ActivePlpStream {
             prefetched_known_total: None,
             prefetched_reached_end: false,
             prefetch_error: None,
+        }
+    }
+
+    /// Builds the narrow decoder if this column has an encoding and no decoder
+    /// yet, so a caller can then take it by field alongside the carry buffers.
+    ///
+    /// Deferred to first use rather than built in `new` because the first
+    /// `SQLGetData` on a column may ask for `SQL_C_BINARY`, which needs no
+    /// decoder; a later call on the same stream may still ask for `SQL_C_CHAR`,
+    /// which does.
+    pub(crate) fn ensure_narrow_decoder(&mut self) {
+        if self.narrow_decoder.is_none()
+            && let Some(encoding) = self.narrow_encoding
+        {
+            self.narrow_decoder = Some(encoding.new_decoder_without_bom_handling());
         }
     }
 

--- a/mssql-odbc/tests/e2e/include/odbc_test_fixture.h
+++ b/mssql-odbc/tests/e2e/include/odbc_test_fixture.h
@@ -84,6 +84,37 @@ using SqlTString = std::basic_string<SQLTCHAR>;
         }                                                                      \
     } while (0)
 
+// Skip on the msodbcsql leg of a comparison run, but only on Windows, for a
+// test that asserts UTF-8 SQL_C_CHAR output.
+//
+// msodbcsql converts SQL_C_CHAR to the client's ANSI code page on Windows, so a
+// CP1252 'e-acute' arrives as the single byte E9 rather than the two UTF-8
+// bytes C3 A9. On Linux and macOS msodbcsql delivers UTF-8 and agrees with this
+// driver, so the comparison is kept there instead of being skipped on every
+// platform: that agreement is real and is the parity claim worth measuring.
+// Tracked as AB#47564 (client code page support for SQL_C_CHAR on the fetch
+// path).
+//
+// Measured, not assumed: build 173873 (Linux) passed these cases on both
+// drivers; build 173890 (Windows) failed them on the msodbcsql leg only, e.g.
+// `ABoundVarcharMaxUsesItsCollationForChar` got "\xE9" where "\xC3\xA9" was
+// expected, with indicator 1 rather than 2.
+#ifdef _WIN32
+#define SKIP_IF_COMPARING_MSODBCSQL_ON_WINDOWS()                                \
+    do {                                                                       \
+        const char* _target = std::getenv("ODBC_TEST_TARGET");                 \
+        if (_target && std::string(_target) == "msodbcsql") {                  \
+            GTEST_SKIP() << "msodbcsql delivers SQL_C_CHAR in the client ANSI " \
+                            "code page on Windows (AB#47564); the UTF-8 "      \
+                            "comparison is measured on the Linux leg";         \
+        }                                                                      \
+    } while (0)
+#else
+#define SKIP_IF_COMPARING_MSODBCSQL_ON_WINDOWS()                                \
+    do {                                                                       \
+    } while (0)
+#endif
+
 // ---------------------------------------------------------------------------
 // Forward declarations
 // ---------------------------------------------------------------------------

--- a/mssql-odbc/tests/e2e/tests/fetch_scroll_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/fetch_scroll_test.cpp
@@ -20,6 +20,7 @@
 
 #include "odbc_test_fixture.h"
 
+#include <cstdlib>
 #include <cstring>
 #include <string>
 #include <vector>
@@ -862,11 +863,15 @@ TEST_F(FetchScrollLiveTest, ABoundVarcharMaxUsesItsCollationForChar) {
 // power-of-two read exactly on a character boundary and the carry this test is
 // named for would never be exercised.
 //
-// The msodbcsql leg is measured rather than skipped, per
-// .github/instructions/mssql-odbc.instructions.md: a skip must be backed by a
-// compare run that actually fails. If this leg diverges, record the observed
-// build and result here and reinstate SKIP_IF_COMPARING_MSODBCSQL().
+// Skip is backed by a measurement, per
+// .github/instructions/mssql-odbc.instructions.md. Run unskipped on build
+// 173873 against the pinned retail msodbcsql leg: this driver passed and
+// msodbcsql failed the value comparison. Same mechanism as the SQLGetData twin
+// (VarcharMaxDbcsToCharSplitsCharacterAcrossChunks), which shows the corruption
+// verbatim: msodbcsql drops a GBK lead byte at a chunk boundary and the
+// following bytes decode shifted by one.
 TEST_F(FetchScrollLiveTest, ABoundVarcharMaxDbcsCarriesCharactersAcrossWireChunks) {
+    SKIP_IF_COMPARING_MSODBCSQL();
     ExecDirect(
         "SELECT REPLICATE(CAST(NCHAR(0x4F60) + NCHAR(0x597D) + NCHAR(0x4E16) + NCHAR(0x754C) "
         "+ N'abc' COLLATE Chinese_PRC_CI_AS AS VARCHAR(MAX)), 3000) AS c1");
@@ -894,14 +899,23 @@ TEST_F(FetchScrollLiveTest, ABoundVarcharMaxDbcsCarriesCharactersAcrossWireChunk
 }
 
 // A slot too small for the converted value truncates on a character boundary.
-// The indicator stays a concrete wire-byte count: msodbcsql keys it on the C
-// types, and `sqlcdata.h:1230` takes CHAR->CHAR on its "assume a 1:1 conversion
-// ratio" branch, so converting through the collation does not make the value
-// unmeasurable. 5,000 CP1252 characters are 5,000 wire bytes.
+// The indicator stays a concrete count rather than SQL_NO_TOTAL: msodbcsql keys
+// it on the C types, and `sqlcdata.h:1230` takes CHAR->CHAR on its "assume a
+// 1:1 conversion ratio" branch, so converting through the collation does not
+// make the value unmeasurable.
 //
-// Unskipped on the msodbcsql leg deliberately. Both the UTF-8 payload and the
-// 1:1 indicator are claims of agreement between the two drivers, so this test
-// only earns its keep by being measured against both.
+// Measured on the msodbcsql leg of build 173873. The shared, load-bearing claim
+// holds on both drivers: the indicator is NOT SQL_NO_TOTAL. The exact number
+// diverges, because msodbcsql's estimate is
+// `cbDataAvail + dwDataOffset + cbTruncatedCharsInConvBuf` -- it adds back the
+// bytes already delivered plus whatever its internal conversion buffer is
+// holding, so it reports 5008 where this driver reports the 5000 wire bytes
+// still available. Neither equals the true converted length (10,000 UTF-8
+// bytes); the msodbcsql comment says as much by calling it an assumption.
+// That internal accounting is not reproducible from outside the driver, so the
+// exact value is asserted per-leg rather than skipping the case outright --
+// skipping would also delete the SQL_NO_TOTAL check, which is the part that
+// actually pins this PR's behaviour.
 TEST_F(FetchScrollLiveTest, ABoundVarcharMaxTruncatedToCharKeepsConcreteLength) {
     ExecDirect(
         "SELECT REPLICATE(CAST(NCHAR(233) COLLATE SQL_Latin1_General_CP1_CI_AS AS VARCHAR(MAX)), "
@@ -914,8 +928,19 @@ TEST_F(FetchScrollLiveTest, ABoundVarcharMaxTruncatedToCharKeepsConcreteLength) 
                   stmt_);
     EXPECT_EQ(SQL_SUCCESS_WITH_INFO, SQLFetch(stmt_));
     EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "01004");
-    EXPECT_EQ(5000, ind) << "CHAR->CHAR keeps the 1:1 wire-byte estimate";
+
+    // The shared assertion: CHAR->CHAR keeps a concrete 1:1 estimate on both
+    // drivers and never degrades to SQL_NO_TOTAL.
+    EXPECT_NE(SQL_NO_TOTAL, ind) << "CHAR->CHAR keeps the 1:1 wire-byte estimate";
     EXPECT_STREQ("\xC3\xA9\xC3\xA9\xC3\xA9\xC3\xA9", reinterpret_cast<const char*>(buf));
+
+    const char* target = std::getenv("ODBC_TEST_TARGET");
+    if (target && std::string(target) == "msodbcsql") {
+        // 5000 on the wire + 8 delivered, per the sqlcdata.h formula above.
+        EXPECT_EQ(5008, ind);
+    } else {
+        EXPECT_EQ(5000, ind) << "wire bytes still available before this call's copy";
+    }
     SQLFreeStmt(stmt_, SQL_UNBIND);
     SQLCloseCursor(stmt_);
 }

--- a/mssql-odbc/tests/e2e/tests/fetch_scroll_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/fetch_scroll_test.cpp
@@ -839,6 +839,10 @@ TEST_F(FetchScrollLiveTest, ABoundVarcharMaxUsesItsCollationWhenWidening) {
 // Not skipped on the msodbcsql leg: both drivers deliver UTF-8 for SQL_C_CHAR
 // on Linux, so they must agree.
 TEST_F(FetchScrollLiveTest, ABoundVarcharMaxUsesItsCollationForChar) {
+    // Windows-only skip: msodbcsql returns the raw CP1252 byte E9 with
+    // indicator 1 there, rather than UTF-8 C3 A9 with indicator 2 (AB#47564).
+    // Measured as agreeing on Linux in build 173873.
+    SKIP_IF_COMPARING_MSODBCSQL_ON_WINDOWS();
     ExecDirect(
         "SELECT CAST(NCHAR(233) COLLATE SQL_Latin1_General_CP1_CI_AS AS VARCHAR(MAX)) AS c1");
 
@@ -917,6 +921,11 @@ TEST_F(FetchScrollLiveTest, ABoundVarcharMaxDbcsCarriesCharactersAcrossWireChunk
 // skipping would also delete the SQL_NO_TOTAL check, which is the part that
 // actually pins this PR's behaviour.
 TEST_F(FetchScrollLiveTest, ABoundVarcharMaxTruncatedToCharKeepsConcreteLength) {
+    // Windows-only skip: the payload assertion expects UTF-8, which msodbcsql
+    // does not deliver there (AB#47564), and its ANSI output also changes how
+    // many characters fit in the slot. The indicator comparison below is
+    // measured on the Linux leg, where both drivers deliver UTF-8.
+    SKIP_IF_COMPARING_MSODBCSQL_ON_WINDOWS();
     ExecDirect(
         "SELECT REPLICATE(CAST(NCHAR(233) COLLATE SQL_Latin1_General_CP1_CI_AS AS VARCHAR(MAX)), "
         "5000) AS c1");

--- a/mssql-odbc/tests/e2e/tests/fetch_scroll_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/fetch_scroll_test.cpp
@@ -857,16 +857,21 @@ TEST_F(FetchScrollLiveTest, ABoundVarcharMaxUsesItsCollationForChar) {
 // carry a character split across a wire chunk boundary; without the carry each
 // half becomes U+FFFD and the slot fills with replacement characters.
 //
-// Skipped on the msodbcsql leg for the same reason its SQLGetData twin is:
-// msodbcsql on Linux converts through the client locale and best-fits every CJK
-// character to '?' under a UTF-8 locale.
+// The token is 11 wire bytes (four GBK characters plus "abc"), deliberately
+// coprime with the 8 KiB PLP_BOUND_CHUNK: an 8-byte token would put every
+// power-of-two read exactly on a character boundary and the carry this test is
+// named for would never be exercised.
+//
+// The msodbcsql leg is measured rather than skipped, per
+// .github/instructions/mssql-odbc.instructions.md: a skip must be backed by a
+// compare run that actually fails. If this leg diverges, record the observed
+// build and result here and reinstate SKIP_IF_COMPARING_MSODBCSQL().
 TEST_F(FetchScrollLiveTest, ABoundVarcharMaxDbcsCarriesCharactersAcrossWireChunks) {
-    SKIP_IF_COMPARING_MSODBCSQL();
     ExecDirect(
         "SELECT REPLICATE(CAST(NCHAR(0x4F60) + NCHAR(0x597D) + NCHAR(0x4E16) + NCHAR(0x754C) "
-        "COLLATE Chinese_PRC_CI_AS AS VARCHAR(MAX)), 3000) AS c1");
+        "+ N'abc' COLLATE Chinese_PRC_CI_AS AS VARCHAR(MAX)), 3000) AS c1");
 
-    // 3000 repetitions of 4 CJK characters: 24000 wire bytes, 36000 UTF-8.
+    // 3000 repetitions of 11 wire bytes: 33,000 on the wire, 39,000 as UTF-8.
     std::vector<SQLCHAR> buf(64 * 1024, 0);
     SQLLEN ind = 0;
     ASSERT_SQL_OK(
@@ -874,7 +879,8 @@ TEST_F(FetchScrollLiveTest, ABoundVarcharMaxDbcsCarriesCharactersAcrossWireChunk
         SQL_HANDLE_STMT, stmt_);
     EXPECT_EQ(SQL_SUCCESS, SQLFetch(stmt_));
 
-    const std::string token = "\xE4\xBD\xA0\xE5\xA5\xBD\xE4\xB8\x96\xE7\x95\x8C";  // 你好世界
+    const std::string token = "\xE4\xBD\xA0\xE5\xA5\xBD\xE4\xB8\x96\xE7\x95\x8C"
+                              "abc";  // 你好世界abc
     std::string expected;
     expected.reserve(token.size() * 3000);
     for (int i = 0; i < 3000; ++i) {
@@ -887,11 +893,16 @@ TEST_F(FetchScrollLiveTest, ABoundVarcharMaxDbcsCarriesCharactersAcrossWireChunk
     SQLCloseCursor(stmt_);
 }
 
-// A slot too small for the converted value truncates on a character boundary
-// and reports SQL_NO_TOTAL: once the bytes are transcoded the wire length is
-// the wrong unit, so it cannot be reported as the remaining count.
-TEST_F(FetchScrollLiveTest, ABoundVarcharMaxTruncatedToCharReportsNoTotal) {
-    SKIP_IF_COMPARING_MSODBCSQL();  // asserts UTF-8; see AB#47564 above
+// A slot too small for the converted value truncates on a character boundary.
+// The indicator stays a concrete wire-byte count: msodbcsql keys it on the C
+// types, and `sqlcdata.h:1230` takes CHAR->CHAR on its "assume a 1:1 conversion
+// ratio" branch, so converting through the collation does not make the value
+// unmeasurable. 5,000 CP1252 characters are 5,000 wire bytes.
+//
+// Unskipped on the msodbcsql leg deliberately. Both the UTF-8 payload and the
+// 1:1 indicator are claims of agreement between the two drivers, so this test
+// only earns its keep by being measured against both.
+TEST_F(FetchScrollLiveTest, ABoundVarcharMaxTruncatedToCharKeepsConcreteLength) {
     ExecDirect(
         "SELECT REPLICATE(CAST(NCHAR(233) COLLATE SQL_Latin1_General_CP1_CI_AS AS VARCHAR(MAX)), "
         "5000) AS c1");
@@ -903,7 +914,7 @@ TEST_F(FetchScrollLiveTest, ABoundVarcharMaxTruncatedToCharReportsNoTotal) {
                   stmt_);
     EXPECT_EQ(SQL_SUCCESS_WITH_INFO, SQLFetch(stmt_));
     EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "01004");
-    EXPECT_EQ(SQL_NO_TOTAL, ind) << "the converted UTF-8 length is not known while streaming";
+    EXPECT_EQ(5000, ind) << "CHAR->CHAR keeps the 1:1 wire-byte estimate";
     EXPECT_STREQ("\xC3\xA9\xC3\xA9\xC3\xA9\xC3\xA9", reinterpret_cast<const char*>(buf));
     SQLFreeStmt(stmt_, SQL_UNBIND);
     SQLCloseCursor(stmt_);

--- a/mssql-odbc/tests/e2e/tests/fetch_scroll_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/fetch_scroll_test.cpp
@@ -830,6 +830,85 @@ TEST_F(FetchScrollLiveTest, ABoundVarcharMaxUsesItsCollationWhenWidening) {
     SQLCloseCursor(stmt_);
 }
 
+// SQL_C_CHAR output is UTF-8, so a CP1252 varchar(max) must be decoded through
+// the column's collation on the bound path exactly as on the SQLGetData path
+// (AB#47566). A verbatim copy delivers the raw 0xE9 here, which is not valid
+// UTF-8 -- the same defect AB#47875 caught through mssql-python, one file over.
+//
+// Not skipped on the msodbcsql leg: both drivers deliver UTF-8 for SQL_C_CHAR
+// on Linux, so they must agree.
+TEST_F(FetchScrollLiveTest, ABoundVarcharMaxUsesItsCollationForChar) {
+    ExecDirect(
+        "SELECT CAST(NCHAR(233) COLLATE SQL_Latin1_General_CP1_CI_AS AS VARCHAR(MAX)) AS c1");
+
+    SQLCHAR buf[16] = {};
+    SQLLEN ind = 0;
+    ASSERT_SQL_OK(SQLBindCol(stmt_, 1, SQL_C_CHAR, buf, sizeof(buf), &ind), SQL_HANDLE_STMT,
+                  stmt_);
+    EXPECT_EQ(SQL_SUCCESS, SQLFetch(stmt_));
+    EXPECT_STREQ("\xC3\xA9", reinterpret_cast<const char*>(buf));
+    EXPECT_EQ(2, ind) << "one character, two UTF-8 bytes";
+    SQLFreeStmt(stmt_, SQL_UNBIND);
+    SQLCloseCursor(stmt_);
+}
+
+// A value long enough to arrive in several PLP wire chunks, under a DBCS
+// collation where each CJK character is two wire bytes. The decoder has to
+// carry a character split across a wire chunk boundary; without the carry each
+// half becomes U+FFFD and the slot fills with replacement characters.
+//
+// Skipped on the msodbcsql leg for the same reason its SQLGetData twin is:
+// msodbcsql on Linux converts through the client locale and best-fits every CJK
+// character to '?' under a UTF-8 locale.
+TEST_F(FetchScrollLiveTest, ABoundVarcharMaxDbcsCarriesCharactersAcrossWireChunks) {
+    SKIP_IF_COMPARING_MSODBCSQL();
+    ExecDirect(
+        "SELECT REPLICATE(CAST(NCHAR(0x4F60) + NCHAR(0x597D) + NCHAR(0x4E16) + NCHAR(0x754C) "
+        "COLLATE Chinese_PRC_CI_AS AS VARCHAR(MAX)), 3000) AS c1");
+
+    // 3000 repetitions of 4 CJK characters: 24000 wire bytes, 36000 UTF-8.
+    std::vector<SQLCHAR> buf(64 * 1024, 0);
+    SQLLEN ind = 0;
+    ASSERT_SQL_OK(
+        SQLBindCol(stmt_, 1, SQL_C_CHAR, buf.data(), static_cast<SQLLEN>(buf.size()), &ind),
+        SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(SQL_SUCCESS, SQLFetch(stmt_));
+
+    const std::string token = "\xE4\xBD\xA0\xE5\xA5\xBD\xE4\xB8\x96\xE7\x95\x8C";  // 你好世界
+    std::string expected;
+    expected.reserve(token.size() * 3000);
+    for (int i = 0; i < 3000; ++i) {
+        expected += token;
+    }
+    EXPECT_EQ(expected, std::string(reinterpret_cast<const char*>(buf.data())));
+    EXPECT_EQ(static_cast<SQLLEN>(expected.size()), ind);
+    EXPECT_EQ(std::string::npos, expected.find("\xEF\xBF\xBD")) << "no U+FFFD";
+    SQLFreeStmt(stmt_, SQL_UNBIND);
+    SQLCloseCursor(stmt_);
+}
+
+// A slot too small for the converted value truncates on a character boundary
+// and reports SQL_NO_TOTAL: once the bytes are transcoded the wire length is
+// the wrong unit, so it cannot be reported as the remaining count.
+TEST_F(FetchScrollLiveTest, ABoundVarcharMaxTruncatedToCharReportsNoTotal) {
+    SKIP_IF_COMPARING_MSODBCSQL();  // asserts UTF-8; see AB#47564 above
+    ExecDirect(
+        "SELECT REPLICATE(CAST(NCHAR(233) COLLATE SQL_Latin1_General_CP1_CI_AS AS VARCHAR(MAX)), "
+        "5000) AS c1");
+
+    // 8 payload bytes: four whole two-byte characters, and no room for a fifth.
+    SQLCHAR buf[9] = {};
+    SQLLEN ind = 0;
+    ASSERT_SQL_OK(SQLBindCol(stmt_, 1, SQL_C_CHAR, buf, sizeof(buf), &ind), SQL_HANDLE_STMT,
+                  stmt_);
+    EXPECT_EQ(SQL_SUCCESS_WITH_INFO, SQLFetch(stmt_));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "01004");
+    EXPECT_EQ(SQL_NO_TOTAL, ind) << "the converted UTF-8 length is not known while streaming";
+    EXPECT_STREQ("\xC3\xA9\xC3\xA9\xC3\xA9\xC3\xA9", reinterpret_cast<const char*>(buf));
+    SQLFreeStmt(stmt_, SQL_UNBIND);
+    SQLCloseCursor(stmt_);
+}
+
 TEST_F(FetchScrollLiveTest, ABoundVarcharMaxTruncatedToWcharReportsNoTotal) {
     ExecDirect("SELECT REPLICATE(CAST('y' AS VARCHAR(MAX)), 5000) AS c1");
 

--- a/mssql-odbc/tests/e2e/tests/fetch_scroll_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/fetch_scroll_test.cpp
@@ -954,6 +954,33 @@ TEST_F(FetchScrollLiveTest, ABoundVarcharMaxTruncatedToCharKeepsConcreteLength) 
     SQLCloseCursor(stmt_);
 }
 
+// A UTF-8 collation is already in the target encoding, so it is delivered by a
+// verbatim byte copy rather than through the decoder. That makes it the one
+// SQL_C_CHAR shape whose slot boundary can land mid-sequence, so the partial
+// tail has to be trimmed exactly as it is for `json`. The token is a 3-byte
+// character against an 8-byte payload slot: two whole characters fit, and the
+// third must be dropped rather than delivered as a fragment.
+TEST_F(FetchScrollLiveTest, ABoundUtf8CollationVarcharMaxTruncatesOnACharacterBoundary) {
+    SKIP_IF_COMPARING_MSODBCSQL_ON_WINDOWS();
+    ExecDirect(
+        "SELECT REPLICATE(CAST(NCHAR(0x4F60) "
+        "COLLATE Latin1_General_100_CI_AS_SC_UTF8 AS VARCHAR(MAX)), 500) AS c1");
+
+    // 8 payload bytes: two whole 3-byte characters, and no room for a third.
+    SQLCHAR buf[9] = {};
+    SQLLEN ind = 0;
+    ASSERT_SQL_OK(SQLBindCol(stmt_, 1, SQL_C_CHAR, buf, sizeof(buf), &ind), SQL_HANDLE_STMT,
+                  stmt_);
+    EXPECT_EQ(SQL_SUCCESS_WITH_INFO, SQLFetch(stmt_));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "01004");
+
+    const std::string got(reinterpret_cast<const char*>(buf));
+    EXPECT_EQ("\xE4\xBD\xA0\xE4\xBD\xA0", got) << "a partial character must not be delivered";
+    EXPECT_EQ(6u, got.size()) << "6 bytes of whole characters, not 8 bytes ending mid-sequence";
+    SQLFreeStmt(stmt_, SQL_UNBIND);
+    SQLCloseCursor(stmt_);
+}
+
 TEST_F(FetchScrollLiveTest, ABoundVarcharMaxTruncatedToWcharReportsNoTotal) {
     ExecDirect("SELECT REPLICATE(CAST('y' AS VARCHAR(MAX)), 5000) AS c1");
 

--- a/mssql-odbc/tests/e2e/tests/fetch_scroll_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/fetch_scroll_test.cpp
@@ -959,7 +959,18 @@ TEST_F(FetchScrollLiveTest, ABoundVarcharMaxTruncatedToCharKeepsConcreteLength) 
 // SQL_C_CHAR shape whose slot boundary can land mid-sequence, so the partial
 // tail has to be trimmed exactly as it is for `json`. The token is a 3-byte
 // character against an 8-byte payload slot: two whole characters fit, and the
-// third must be dropped rather than delivered as a fragment.
+// third does not.
+//
+// The truncation contract is asserted on both legs; only the tail diverges.
+// Measured on build 173919: msodbcsql fills all 8 payload bytes and returns
+// "\xE4\xBD\xA0\xE4\xBD\xA0\xE4\xBD", ending mid-character, where this driver
+// stops at 6. That is the same deliberate deviation already registered for the
+// SQL_C_WCHAR surrogate-pair case in
+// .github/instructions/mssql-odbc.instructions.md (item 8, AB#47767): this
+// driver trims a bound `max` column to a whole character where msodbcsql fills
+// the slot. Split per-leg rather than skipped so the shared part -- that both
+// drivers truncate, report 01004, and deliver a prefix of the value -- stays
+// measured against msodbcsql.
 TEST_F(FetchScrollLiveTest, ABoundUtf8CollationVarcharMaxTruncatesOnACharacterBoundary) {
     SKIP_IF_COMPARING_MSODBCSQL_ON_WINDOWS();
     ExecDirect(
@@ -975,8 +986,20 @@ TEST_F(FetchScrollLiveTest, ABoundUtf8CollationVarcharMaxTruncatesOnACharacterBo
     EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "01004");
 
     const std::string got(reinterpret_cast<const char*>(buf));
-    EXPECT_EQ("\xE4\xBD\xA0\xE4\xBD\xA0", got) << "a partial character must not be delivered";
-    EXPECT_EQ(6u, got.size()) << "6 bytes of whole characters, not 8 bytes ending mid-sequence";
+    const std::string kSource = "\xE4\xBD\xA0\xE4\xBD\xA0\xE4\xBD\xA0";  // 你你你
+
+    // Shared on both drivers: the value truncated to a prefix that fits.
+    EXPECT_LE(got.size(), 8u);
+    EXPECT_EQ(kSource.substr(0, got.size()), got) << "delivered bytes must be a prefix";
+
+    const char* target = std::getenv("ODBC_TEST_TARGET");
+    if (target && std::string(target) == "msodbcsql") {
+        // Fills the slot, ending mid-character (build 173919).
+        EXPECT_EQ(8u, got.size());
+    } else {
+        EXPECT_EQ("\xE4\xBD\xA0\xE4\xBD\xA0", got) << "a partial character must not be delivered";
+        EXPECT_EQ(6u, got.size()) << "6 bytes of whole characters, not 8 ending mid-sequence";
+    }
     SQLFreeStmt(stmt_, SQL_UNBIND);
     SQLCloseCursor(stmt_);
 }

--- a/mssql-odbc/tests/e2e/tests/get_data_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/get_data_test.cpp
@@ -1134,12 +1134,19 @@ TEST_F(GetDataLiveTest, VarcharMaxCp1252ToCharChunkedRoundTrip) {
 // buffer sized to make the driver read an odd number of wire bytes splits one
 // across most calls. Each half must be rejoined rather than become U+FFFD.
 //
-// The msodbcsql leg is measured rather than skipped: the SQL_C_WCHAR twin's
-// documented '?' best-fit divergence was measured for a different conversion,
-// and .github/instructions/mssql-odbc.instructions.md requires a skip to be
-// backed by a compare run that actually fails. If this leg diverges, record the
-// observed build and result here and reinstate SKIP_IF_COMPARING_MSODBCSQL().
+// Skip is backed by a measurement, per
+// .github/instructions/mssql-odbc.instructions.md. Run unskipped on build
+// 173873 against the pinned retail msodbcsql leg: this driver passed and
+// msodbcsql failed, returning
+//   "...你好世界abc你好世界abc?愫檬澜鏰bc你好世界abc..."
+// where the expected value is an unbroken repetition of "你好世界abc". The
+// corruption is a dropped GBK lead byte at a chunk boundary, after which the
+// following bytes decode shifted by one ('?' then a run of unrelated CJK, then
+// "bc" where "abc" belongs). So the divergence is chunk-boundary handling in
+// msodbcsql, not the '?' best-fit its SQL_C_WCHAR twin documents -- a different
+// mechanism, and this driver is on the correct side of it.
 TEST_F(GetDataLiveTest, VarcharMaxDbcsToCharSplitsCharacterAcrossChunks) {
+    SKIP_IF_COMPARING_MSODBCSQL();
     const std::string token = "\xE4\xBD\xA0\xE5\xA5\xBD\xE4\xB8\x96\xE7\x95\x8C"
                               "abc";  // 你好世界abc
     const std::string expected = RepeatToken(token, 400);

--- a/mssql-odbc/tests/e2e/tests/get_data_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/get_data_test.cpp
@@ -1106,7 +1106,12 @@ TEST_F(GetDataLiveTest, VarcharMaxToWcharChunkedRoundTrip) {
 // Deliberately NOT skipped on the msodbcsql leg: both drivers deliver UTF-8 for
 // SQL_C_CHAR on Linux, so they must agree here. That is the whole point of this
 // test.
+// Not skipped on Linux/macOS: both drivers deliver UTF-8 for SQL_C_CHAR there
+// and this case passed on both legs of build 173873, which is the parity claim
+// this PR rests on. Skipped only on Windows, where msodbcsql uses the client
+// ANSI code page instead (AB#47564).
 TEST_F(GetDataLiveTest, VarcharMaxCp1252ToCharChunkedRoundTrip) {
+    SKIP_IF_COMPARING_MSODBCSQL_ON_WINDOWS();
     // UTF-8 spelling of "café René señor Müller Größe naïve " -- what a caller
     // asking for SQL_C_CHAR must receive.
     const std::string token = "caf\xC3\xA9 Ren\xC3\xA9 se\xC3\xB1or M\xC3\xBCller "
@@ -1192,6 +1197,9 @@ TEST_F(GetDataLiveTest, VarcharMaxCp1252ToCharChunkSizeDoesNotChangeValue) {
 // verbatim path and NOT be decoded a second time. Double-converting would
 // mangle every non-ASCII character.
 TEST_F(GetDataLiveTest, VarcharMaxUtf8CollationToCharIsNotDoubleConverted) {
+    // Windows-only skip: msodbcsql re-encodes the UTF-8 wire bytes into the
+    // client ANSI code page there (AB#47564). Measured as agreeing on Linux.
+    SKIP_IF_COMPARING_MSODBCSQL_ON_WINDOWS();
     const std::string token = "\xE4\xBD\xA0\xE5\xA5\xBD"
                               "caf\xC3\xA9\xF0\x9F\x98\x80";  // 你好café😀
     const std::string expected = RepeatToken(token, 300);
@@ -1214,6 +1222,10 @@ TEST_F(GetDataLiveTest, VarcharMaxUtf8CollationToCharIsNotDoubleConverted) {
 // eliminate. The encoding is a property of the column, so readiness must not
 // depend on call history.
 TEST_F(GetDataLiveTest, VarcharMaxBinaryFirstStillConvertsOnLaterCharRead) {
+    // Windows-only skip: the assertion is that the value comes back as UTF-8,
+    // which msodbcsql does not do on Windows (AB#47564). Measured as agreeing
+    // on Linux, where it exercises the same decoder-lifetime path.
+    SKIP_IF_COMPARING_MSODBCSQL_ON_WINDOWS();
     ASSERT_SQL_OK(
         ExecDirect("SELECT REPLICATE(CAST(N'caf' + NCHAR(0xE9) + N' ' "
                    "COLLATE SQL_Latin1_General_CP1_CI_AS AS VARCHAR(MAX)), 400) AS c1"),

--- a/mssql-odbc/tests/e2e/tests/get_data_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/get_data_test.cpp
@@ -1094,6 +1094,112 @@ TEST_F(GetDataLiveTest, VarcharMaxToWcharChunkedRoundTrip) {
     SQLCloseCursor(stmt_);
 }
 
+// The regression this conversion exists for: AB#47875, where mssql-python's
+// test_varchar_cp1252_lob_with_collation received raw CP1252 bytes and its
+// strict UTF-8 decode fell back to returning `bytes`.
+//
+// SQL_C_CHAR output is UTF-8, so a CP1252 varchar(max) must be decoded through
+// the column's collation on the way out. CP1252 is single-byte, so a verbatim
+// copy delivers the correct character *count* with the wrong bytes -- which is
+// how the defect stayed hidden. Asserting the UTF-8 spelling is what catches it.
+//
+// Deliberately NOT skipped on the msodbcsql leg: both drivers deliver UTF-8 for
+// SQL_C_CHAR on Linux, so they must agree here. That is the whole point of this
+// test.
+TEST_F(GetDataLiveTest, VarcharMaxCp1252ToCharChunkedRoundTrip) {
+    // UTF-8 spelling of "café René señor Müller Größe naïve " -- what a caller
+    // asking for SQL_C_CHAR must receive.
+    const std::string token = "caf\xC3\xA9 Ren\xC3\xA9 se\xC3\xB1or M\xC3\xBCller "
+                              "Gr\xC3\xB6\xC3\x9F"
+                              "e na\xC3\xAF"
+                              "ve ";
+    const std::string expected = RepeatToken(token, 250);
+    ASSERT_SQL_OK(
+        ExecDirect("SELECT REPLICATE(CAST(N'caf' + NCHAR(0xE9) + N' Ren' + NCHAR(0xE9) "
+                   "+ N' se' + NCHAR(0xF1) + N'or M' + NCHAR(0xFC) + N'ller "
+                   "Gr' + NCHAR(0xF6) + NCHAR(0xDF) + N'e na' + NCHAR(0xEF) + N've ' "
+                   "COLLATE SQL_Latin1_General_CP1_CI_AS AS VARCHAR(MAX)), 250) AS c1"),
+        SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+
+    const std::string got = ReadCharDataInChunks(stmt_, 1, 61);
+    EXPECT_EQ(expected, got);
+    EXPECT_GT(got.size(), 250u * 35u) << "UTF-8 must be longer than the CP1252 wire bytes";
+
+    SQLCloseCursor(stmt_);
+}
+
+// The pinning case for the chunk-boundary carry on the SQL_C_CHAR path. Under a
+// Chinese_PRC collation the wire is GBK, two bytes per CJK character, and a
+// buffer sized to make the driver read an odd number of wire bytes splits one
+// across most calls. Each half must be rejoined rather than become U+FFFD.
+//
+// Skipped on the msodbcsql leg for the same reason its SQL_C_WCHAR twin is:
+// msodbcsql on Linux converts through the client locale, which under a UTF-8
+// locale best-fits every CJK character to '?'. The disagreement is about the
+// conversion, not the chunking.
+TEST_F(GetDataLiveTest, VarcharMaxDbcsToCharSplitsCharacterAcrossChunks) {
+    SKIP_IF_COMPARING_MSODBCSQL();
+    const std::string token = "\xE4\xBD\xA0\xE5\xA5\xBD\xE4\xB8\x96\xE7\x95\x8C"
+                              "abc";  // 你好世界abc
+    const std::string expected = RepeatToken(token, 400);
+    ASSERT_SQL_OK(
+        ExecDirect("SELECT REPLICATE(CAST(NCHAR(0x4F60) + NCHAR(0x597D) + NCHAR(0x4E16) "
+                   "+ NCHAR(0x754C) + N'abc' "
+                   "COLLATE Chinese_PRC_CI_AS AS VARCHAR(MAX)), 400) AS c1"),
+        SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+
+    EXPECT_EQ(expected, ReadCharDataInChunks(stmt_, 1, 29));
+
+    SQLCloseCursor(stmt_);
+}
+
+// Chunking must be invisible on the SQL_C_CHAR path too: the same column read
+// in one call and in many must produce the same value. A buffer of 7 is the
+// tightest interesting size -- decoding expands, so the driver's read has to be
+// sized down from the caller's capacity or output overruns every call.
+TEST_F(GetDataLiveTest, VarcharMaxCp1252ToCharChunkSizeDoesNotChangeValue) {
+    const char* kQuery =
+        "SELECT REPLICATE(CAST(N'caf' + NCHAR(0xE9) + N' Gr' + NCHAR(0xF6) + NCHAR(0xDF) "
+        "+ N'e na' + NCHAR(0xEF) + N've ' "
+        "COLLATE SQL_Latin1_General_CP1_CI_AS AS VARCHAR(MAX)), 400) AS c1";
+
+    ASSERT_SQL_OK(ExecDirect(kQuery), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+    const std::string one_shot = ReadCharDataInChunks(stmt_, 1, 65536);
+    SQLCloseCursor(stmt_);
+
+    for (size_t buf_size : {7u, 16u, 33u, 1024u}) {
+        ASSERT_SQL_OK(ExecDirect(kQuery), SQL_HANDLE_STMT, stmt_);
+        ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+        EXPECT_EQ(one_shot, ReadCharDataInChunks(stmt_, 1, buf_size))
+            << "buffer size " << buf_size;
+        SQLCloseCursor(stmt_);
+    }
+
+    EXPECT_FALSE(one_shot.empty());
+}
+
+// A UTF-8 collation is already in the target encoding, so it must stay on the
+// verbatim path and NOT be decoded a second time. Double-converting would
+// mangle every non-ASCII character.
+TEST_F(GetDataLiveTest, VarcharMaxUtf8CollationToCharIsNotDoubleConverted) {
+    const std::string token = "\xE4\xBD\xA0\xE5\xA5\xBD"
+                              "caf\xC3\xA9\xF0\x9F\x98\x80";  // 你好café😀
+    const std::string expected = RepeatToken(token, 300);
+    ASSERT_SQL_OK(
+        ExecDirect("SELECT REPLICATE(CAST(NCHAR(0x4F60) + NCHAR(0x597D) + N'caf' "
+                   "+ NCHAR(0xE9) + NCHAR(0xD83D) + NCHAR(0xDE00) "
+                   "COLLATE Latin1_General_100_CI_AS_SC_UTF8 AS VARCHAR(MAX)), 300) AS c1"),
+        SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+
+    EXPECT_EQ(expected, ReadCharDataInChunks(stmt_, 1, 30));
+
+    SQLCloseCursor(stmt_);
+}
+
 // The widening decodes through the column's own collation, so a non-ASCII
 // CP1252 value must come back as the original characters and not as raw bytes
 // zero-extended into code units. A 26-byte buffer delivers 12 characters per

--- a/mssql-odbc/tests/e2e/tests/get_data_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/get_data_test.cpp
@@ -1134,12 +1134,12 @@ TEST_F(GetDataLiveTest, VarcharMaxCp1252ToCharChunkedRoundTrip) {
 // buffer sized to make the driver read an odd number of wire bytes splits one
 // across most calls. Each half must be rejoined rather than become U+FFFD.
 //
-// Skipped on the msodbcsql leg for the same reason its SQL_C_WCHAR twin is:
-// msodbcsql on Linux converts through the client locale, which under a UTF-8
-// locale best-fits every CJK character to '?'. The disagreement is about the
-// conversion, not the chunking.
+// The msodbcsql leg is measured rather than skipped: the SQL_C_WCHAR twin's
+// documented '?' best-fit divergence was measured for a different conversion,
+// and .github/instructions/mssql-odbc.instructions.md requires a skip to be
+// backed by a compare run that actually fails. If this leg diverges, record the
+// observed build and result here and reinstate SKIP_IF_COMPARING_MSODBCSQL().
 TEST_F(GetDataLiveTest, VarcharMaxDbcsToCharSplitsCharacterAcrossChunks) {
-    SKIP_IF_COMPARING_MSODBCSQL();
     const std::string token = "\xE4\xBD\xA0\xE5\xA5\xBD\xE4\xB8\x96\xE7\x95\x8C"
                               "abc";  // 你好世界abc
     const std::string expected = RepeatToken(token, 400);
@@ -1196,6 +1196,34 @@ TEST_F(GetDataLiveTest, VarcharMaxUtf8CollationToCharIsNotDoubleConverted) {
     ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
 
     EXPECT_EQ(expected, ReadCharDataInChunks(stmt_, 1, 30));
+
+    SQLCloseCursor(stmt_);
+}
+
+// A stream opened by a SQL_C_BINARY read must still convert when a later call
+// asks for SQL_C_CHAR. Keying the decoder on the first call's target type left
+// `narrow_decoder` unset here, and the SQL_C_CHAR continuation then fell through
+// to the verbatim copy — handing back the raw CP1252 bytes this PR exists to
+// eliminate. The encoding is a property of the column, so readiness must not
+// depend on call history.
+TEST_F(GetDataLiveTest, VarcharMaxBinaryFirstStillConvertsOnLaterCharRead) {
+    ASSERT_SQL_OK(
+        ExecDirect("SELECT REPLICATE(CAST(N'caf' + NCHAR(0xE9) + N' ' "
+                   "COLLATE SQL_Latin1_General_CP1_CI_AS AS VARCHAR(MAX)), 400) AS c1"),
+        SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+
+    // Zero-length SQL_C_BINARY length probe: opens the stream without asking for
+    // any conversion, exactly as mssql-python does per column.
+    SQLLEN ind = 0;
+    SQLGetData(stmt_, 1, SQL_C_BINARY, nullptr, 0, &ind);
+
+    // The same column, now as text: must be UTF-8, not raw CP1252.
+    const std::string got = ReadCharDataInChunks(stmt_, 1, 64);
+    EXPECT_NE(std::string::npos, got.find("caf\xC3\xA9"))
+        << "SQL_C_CHAR after a binary probe must still decode through the collation";
+    EXPECT_EQ(std::string::npos, got.find('\xE9'))
+        << "a raw CP1252 byte means the conversion was skipped";
 
     SQLCloseCursor(stmt_);
 }

--- a/mssql-odbc/tests/e2e/tests/get_data_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/get_data_test.cpp
@@ -1103,9 +1103,6 @@ TEST_F(GetDataLiveTest, VarcharMaxToWcharChunkedRoundTrip) {
 // copy delivers the correct character *count* with the wrong bytes -- which is
 // how the defect stayed hidden. Asserting the UTF-8 spelling is what catches it.
 //
-// Deliberately NOT skipped on the msodbcsql leg: both drivers deliver UTF-8 for
-// SQL_C_CHAR on Linux, so they must agree here. That is the whole point of this
-// test.
 // Not skipped on Linux/macOS: both drivers deliver UTF-8 for SQL_C_CHAR there
 // and this case passed on both legs of build 173873, which is the parity claim
 // this PR rests on. Skipped only on Windows, where msodbcsql uses the client


### PR DESCRIPTION
## Description

`SQL_C_CHAR` output is UTF-8 on this driver, but PLP delivery of a `SingleByteText` column copied the wire bytes **verbatim**. Under a non-UTF-8 collation the caller got raw code page bytes labelled UTF-8. The non-PLP path was already correct — it decodes through the collation via `SqlString::to_utf8_string` — so the *same value* delivered inline and streamed disagreed byte for byte.

The offending line documented its own defect:

```rust
// Delivered verbatim today, so a non-UTF-8 server collation yields raw
// codepage bytes labelled UTF-8. Conversion attaches here: [AB#47566](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47566).
Some(PlpEncoding::SingleByteText) => copy_verbatim(),
```

### What changed

- **`get_data.rs` (`SQLGetData`)** — `SingleByteText` is decoded through the column's collation. Reuses the per-stream `encoding_rs::Decoder` that already served the `SQL_C_WCHAR` widening, so a multi-byte DBCS sequence split across a chunk boundary is carried rather than corrupted. `pending_utf8` holds back output the caller's buffer had no room for — decoding expands, e.g. CP1252 `0x80` is 3 UTF-8 bytes.
- **`fetch_scroll.rs` (`SQLBindCol` + `SQLFetch`)** — carried the byte-for-byte identical verbatim copy. Converted the same way. This arm was **latent**: no test read a `varchar(max)` under a non-UTF-8 collation through a bound fetch, so nothing failed on it.
- **The resolved encoding lives on `ActivePlpStream`**, with the decoder built lazily on first need. Keying it on the first call's target type meant a `SQL_C_BINARY` probe — the shape mssql-python issues per column — left a later `SQL_C_CHAR` read on the verbatim path, reintroducing the very defect being fixed.
- **`max_read` sized for expansion** via `narrow_max_read`, mirroring `utf16le_max_read`.
- **UTF-8 collations and `json` stay verbatim**, explicitly not double-converted — and now share a truncation gate. `trim_partial_utf8` was keyed on `json` alone, so a UTF-8-collated `varchar(max)` truncating in a bound slot could end mid-character. Pre-existing, but this change is what makes the two shapes equivalent, so they are generalized to one `verbatim_utf8_text` condition.
- **The indicator keeps its concrete count** rather than degrading to `SQL_NO_TOTAL`, and now includes held converted output. See below — the first revision got this wrong twice.

### Verification

Build **173899** — full PR validation green, all legs, at `c5a292d8`. Commits after that are review fixes; build **173938** re-confirmed the compare legs at `08384258` with `Summary: 40 parity, 0 divergence(s), 0 shared failure(s)` (up from 38/2).

**The bug this fixes:** `tests.test_017_varchar_cp1252_boundary::test_varchar_cp1252_lob_with_collation` → **Passed** (test run 3372229), after failing on 6/6 consecutive prior runs.

**No regressions**, measured rather than asserted: the full mssql-python failure set went **159 → 158** against the pre-fix baseline (build 173751, run 3368660). Newly failing: **none**. Newly passing: that one test, and only that test. The remaining 158 are pre-existing and unrelated (decimal/money binding, `getinfo`, `executemany`).

Diff coverage 89% (target 85%).

### Parity, as measured

Linux (build 173873) — **both drivers agree**, which is the central claim of the PR, now measured rather than argued:

| Test | mssql-odbc | msodbcsql |
|---|---|---|
| `VarcharMaxCp1252ToCharChunkedRoundTrip` | PASS | PASS |
| `VarcharMaxCp1252ToCharChunkSizeDoesNotChangeValue` | PASS | PASS |
| `VarcharMaxUtf8CollationToCharIsNotDoubleConverted` | PASS | PASS |
| `ABoundVarcharMaxUsesItsCollationForChar` | PASS | PASS |
| `VarcharMaxBinaryFirstStillConvertsOnLaterCharRead` | PASS | PASS |

Diverging, each now carrying its measurement in-comment rather than an assumption:

- **Windows only (build 173890)** — msodbcsql converts `SQL_C_CHAR` to the client ANSI code page there, returning `\xE9` with indicator 1 where `\xC3\xA9` with indicator 2 is expected. Known [AB#47564](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47564). A new `SKIP_IF_COMPARING_MSODBCSQL_ON_WINDOWS()` scopes the skip to Windows rather than suppressing the comparison everywhere — the Linux agreement above is real and worth keeping.
- **Both DBCS cases** — msodbcsql returned `...你好世界abc?愫檬澜鏰bc你好世界abc...` where an unbroken repetition of `你好世界abc` was expected. It drops a GBK lead byte at a chunk boundary and the following bytes decode shifted by one. This is *not* the `?` best-fit documented on the `SQL_C_WCHAR` twin — a different mechanism, and this driver is on the correct side of it. `SKIP_IF_COMPARING_MSODBCSQL()` retained with build 173873 and the observed output quoted.
- **`ABoundVarcharMaxTruncatedToCharKeepsConcreteLength`** — kept running on **both** Linux legs. The load-bearing claim is shared: CHAR→CHAR never degrades to `SQL_NO_TOTAL`. Only the number differs — msodbcsql's estimate is `cbDataAvail + dwDataOffset + cbTruncatedCharsInConvBuf`, so it reports 5008 where this driver reports the 5000 wire bytes still available. Neither is the true converted length (10,000), which is what msodbcsql means by "assume a 1:1 conversion ratio". Asserted per-leg via the `ODBC_TEST_TARGET` pattern already used in `attributes_test.cpp`; skipping would have deleted the one assertion that pins this PR's behaviour.

### On the indicator — one correction and two follow-on fixes

The first revision reported `SQL_NO_TOTAL` for the converted arm, on the strength of [AB#47566](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47566)'s scope item 4. **That was wrong**, and build 173839 proved it by failing two pre-existing unskipped cross-leg parity tests with `ind = -4`:

```
get_data_test.cpp:713      Expected: (ind) != ((-4)), actual: -4 vs -4
fetch_scroll_test.cpp:796  Expected equality of these values: 5000 / ind / Which is: -4
```

msodbcsql keys the indicator on the **C types**, not on whether a conversion happens: `sqlcdata.h:1230` takes CHAR→CHAR on the 1:1 branch and only reaches `SQL_NO_TOTAL` on CHAR↔WCHAR. Reverted at both sites; the file's own pre-existing comment had the rule right. [AB#47566](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47566)'s scope item 4 has been corrected, since the work item mandated the wrong behaviour.

Review then surfaced two real defects in that same arm, both fixed:

- **`remaining_indicator` ignored `pending_utf8`.** Decoded output can outlive the wire, so once the wire was exhausted a drain-only call reported "0 bytes remaining" *alongside* the `01004` truncation warning it returns — self-contradictory, and it strands a caller that sizes its next buffer from the indicator instead of looping on the return code. The carry is now added, using the entry-time `utf8_carry_len` (reading it post-drain double-counts the current read), and scoped to `transcode_narrow_to_utf8` so a `SQL_C_BINARY` or `SQL_C_WCHAR` continuation cannot inherit UTF-8 bytes into a count of a different unit. This is the term msodbcsql carries as `cbTruncatedCharsInConvBuf` in the same `sqlcdata.h:1230` expression — I had used half the formula, and initially at the wrong time.
- Reachability is narrow (payload capacity < 3 plus the gb18030 4:1 case), so this is robustness rather than live corruption.

### Background

- **msodbcsql18** on Linux/macOS transcodes `SQLCHAR` to the process locale encoding, defaulting to UTF-8, having already converted from the column collation ([programming guidelines](https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/programming-guidelines)).
- **MS-TDS** [2.2.5.2.3](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tds/7d26a257-083e-409b-81ba-897e0c672be0): `BIGVARCHARTYPE` is the same type whether framed as `USHORTLEN_TYPE` or `PARTLENTYPE`. COLLATION arrives once in `COLMETADATA`; PLP chunk boundaries are byte-aligned framing with no character semantics. No basis for decoding max and non-max `varchar` differently.

### Why this shipped

Every existing CP1252/DBCS PLP test targeted `SQL_C_WCHAR`. Every existing `SQL_C_CHAR` PLP test was either `nvarchar(max)` (UTF-16 source, correctly transcoded) or ASCII `varchar(max)` — where verbatim happens to equal UTF-8. Nothing covered `varchar(max)` + non-UTF-8 collation into `SQL_C_CHAR`.

## Related Issues

https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47566

Also fixes https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47875 — `tests.test_017_varchar_cp1252_boundary::test_varchar_cp1252_lob_with_collation`. mssql-python's `GetEffectiveCharDecoding` hardcodes `"utf-8"` on Linux/macOS (it assumes the driver already converted), so our raw CP1252 bytes failed its strict decode and hit the `except` branch returning `bytes`. The character count matched only because CP1252 is single-byte.

Follow-ups filed from review: **[AB#48046](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/48046)** (pre-existing target-switch carry stranding), **[AB#48047](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/48047)** (`narrow_max_read` round-trip cost), **[AB#48048](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/48048)** (stale ~1 MiB bound-PLP threshold in the instructions file), and **[AB#48073](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/48073)** (pre-existing: the PLP decoder flush is skipped when `reached_end` arrives on an empty read, dropping a partial sequence instead of replacing it — affects the `SQL_C_WCHAR` widening on `main` as well).

## Tests

Unit (no live server): `narrow_transcode_converts_cp1252_to_utf8` asserts the CP1252 wire bytes *differ* from the UTF-8 output — the exact confusion that hid this bug; plus chunk-boundary carry, output hold-back, chunk-size invariance, post-wire drain, zero-capacity probe, `narrow_max_read` sizing, and `narrow_transcode_malformed_sequence_at_end_is_replacement` (a dangling GBK lead byte, reachable as `CAST(0xD0 AS VARCHAR(MAX))` under a DBCS collation, must become U+FFFD).

E2E: the five agreeing cases above, the two DBCS carry cases, the truncation/indicator case, and `ABoundUtf8CollationVarcharMaxTruncatesOnACharacterBoundary` — a 3-byte character against an 8-byte slot, asserting 6 bytes of whole characters rather than 8 ending mid-sequence. That last one is split per-leg on `ODBC_TEST_TARGET`: msodbcsql fills the slot and ends mid-character (measured, build 173919), which is the same deviation already registered as item 8 of `.github/instructions/mssql-odbc.instructions.md` ([AB#47767](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47767)), so it is recorded there rather than skipped — the shared contract (both truncate, report `01004`, deliver a real prefix) still runs on both legs.

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes — 1418/1418 `mssqlodbc` unit tests
- [x] New/changed functionality has tests
- [x] Public API changes are documented — no public API change; `ActivePlpStream` is `pub(crate)`