### PR TITLE
Isolate crate releases from NuGet and fix OneBranch Git checkout

### DIFF
--- a/.pipeline/OneBranch/OfficialPythonWheelsRelease.yml
+++ b/.pipeline/OneBranch/OfficialPythonWheelsRelease.yml
@@ -96,6 +96,8 @@ extends:
     ###########################################################################
     - stage: Release
       displayName: 'Release NuGet Package'
+      dependsOn: []
+      condition: and(succeeded(), ${{ eq(parameters.publishNuGet, true) }})
       jobs:
       - job: PublishRelease
         displayName: 'Download Build Artifacts and Publish'
@@ -104,11 +106,9 @@ extends:
         variables:
           ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
           ob_nugetPublishing_enabled: ${{ parameters.publishNuGet }}
+          ob_git_fetchDepth: 0
+          ob_git_persistCredentials: true
         steps:
-        - checkout: self
-          persistCredentials: true
-          fetchDepth: 0
-
         #####################################################################
         # Step 1: Download NuGet artifact from the Official Build pipeline
         #####################################################################
@@ -146,40 +146,16 @@ extends:
         - pwsh: |
             $ErrorActionPreference = 'Stop'
 
-            $commitSha = "$(resources.pipeline.officialBuild.sourceCommit)"
-            $sourceBranch = "$(resources.pipeline.officialBuild.sourceBranch)"
-            git fetch origin $sourceBranch
-            if ($LASTEXITCODE -ne 0) {
-              throw "Could not fetch selected build branch $sourceBranch"
-            }
-            git cat-file -e "${commitSha}^{commit}"
-            if ($LASTEXITCODE -ne 0) {
-              throw "Selected build commit $commitSha was not found on $sourceBranch"
-            }
-            function Get-BuildSourceFile {
-              param([string]$Path)
-
-              $content = & git show "${commitSha}:$Path"
-              if ($LASTEXITCODE -ne 0) {
-                throw "Could not read $Path from selected build commit $commitSha"
-              }
-              return $content -join "`n"
-            }
-
-            $cargoToml = Get-BuildSourceFile "mssql-py-core/Cargo.toml"
-            if ($cargoToml -notmatch '(?ms)^\[package\]\s*$.*?^version\s*=\s*"([^"]+)"') {
-              throw "Could not extract [package].version from selected build commit"
-            }
+            $metadata = & "$(Build.SourcesDirectory)/.pipeline/scripts/get-python-release-metadata.ps1" `
+              -RepositoryDirectory "$(Build.SourcesDirectory)" `
+              -CommitSha "$(resources.pipeline.officialBuild.sourceCommit)" `
+              -SourceBranch "$(resources.pipeline.officialBuild.sourceBranch)" `
+              -IncludeWheelMetadata
+            $commitSha = $metadata.SourceCommit
             # Official release: clean semver, no prerelease suffix
-            $packageVersion = $Matches[1]
-
-            $pyprojectToml = Get-BuildSourceFile "mssql-py-core/pyproject.toml"
-            if ($pyprojectToml -notmatch '(?ms)^\[project\]\s*$.*?^name\s*=\s*"([^"]+)".*?^version\s*=\s*"([^"]+)"') {
-              throw "Could not extract [project] name and version from selected build commit"
-            }
-            $distributionName = $Matches[1]
-            $pythonVersion = $Matches[2]
-
+            $packageVersion = $metadata.Version
+            $distributionName = $metadata.DistributionName
+            $pythonVersion = $metadata.PythonVersion
             $shortSha = $commitSha.Substring(0, 8)
 
             Write-Host "Release version: $packageVersion"
@@ -226,6 +202,7 @@ extends:
             $nuspecContent | Out-File -FilePath $nuspecPath -Encoding utf8
             Write-Host "Created nuspec: $nuspecPath"
           displayName: 'Prepare release NuGet package'
+          workingDirectory: '$(Build.SourcesDirectory)'
 
         - task: NuGetCommand@2
           displayName: 'Create NuGet package'
@@ -240,11 +217,7 @@ extends:
             Get-ChildItem "$(ob_outputDirectory)/packages" -Filter *.nupkg | ForEach-Object {
               Write-Host "  $($_.Name)  ($([math]::Round($_.Length/1MB, 2)) MB)"
             }
-            if ($${{ parameters.publishNuGet }}) {
-              Write-Host "NuGet WILL be published to feed (publishNuGet=true)"
-            } else {
-              Write-Host "DRY RUN — NuGet will NOT be published (publishNuGet=false)"
-            }
+            Write-Host "NuGet WILL be published to feed (publishNuGet=true)"
           displayName: 'Verify NuGet package'
 
     ###########################################################################
@@ -253,7 +226,7 @@ extends:
     - ${{ if or(eq(parameters.publishMssqlTds, true), eq(parameters.publishMssqlMockTds, true), eq(parameters.validateCratesOnly, true)) }}:
       - stage: ReleaseCrates
         displayName: 'Release Rust Crates'
-        dependsOn: Release
+        dependsOn: []
         jobs:
         - job: PublishRustCrates
           displayName: 'Publish Rust crates to crates.io'
@@ -267,8 +240,6 @@ extends:
           - name: ob_outputDirectory
             value: '$(Build.ArtifactStagingDirectory)'
           steps:
-          - checkout: self
-
           - download: officialBuild
             artifact: 'drop_Build_RustCrates'
             displayName: 'Download Rust crate artifacts'
@@ -365,7 +336,10 @@ extends:
     - ${{ if eq(parameters.tagRelease, true) }}:
       - stage: Tag
         displayName: 'Tag mssql-py-core Release'
-        dependsOn: Release
+        ${{ if eq(parameters.publishNuGet, true) }}:
+          dependsOn: Release
+        ${{ else }}:
+          dependsOn: []
         jobs:
         - job: TagAndBranch
           displayName: 'Git tag + release branch'
@@ -373,33 +347,18 @@ extends:
             type: windows
           variables:
             ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
+            ob_git_fetchDepth: 0
+            ob_git_persistCredentials: true
           steps:
-          - checkout: self
-            persistCredentials: true
-            fetchDepth: 0
-
           - pwsh: |
               $ErrorActionPreference = 'Stop'
 
-              $commitSha = "$(resources.pipeline.officialBuild.sourceCommit)"
-              $sourceBranch = "$(resources.pipeline.officialBuild.sourceBranch)"
-              git fetch origin $sourceBranch
-              if ($LASTEXITCODE -ne 0) {
-                throw "Could not fetch selected build branch $sourceBranch"
-              }
-              git cat-file -e "${commitSha}^{commit}"
-              if ($LASTEXITCODE -ne 0) {
-                throw "Selected build commit $commitSha was not found on $sourceBranch"
-              }
-              $cargoToml = & git show "${commitSha}:mssql-py-core/Cargo.toml"
-              if ($LASTEXITCODE -ne 0) {
-                throw "Could not read Cargo.toml from selected build commit $commitSha"
-              }
-              if (($cargoToml -join "`n") -match '(?ms)^\[package\]\s*$.*?^version\s*=\s*"([^"]+)"') {
-                $version = $Matches[1]
-              } else {
-                throw "Could not extract [package].version from selected build commit"
-              }
+              $metadata = & "$(Build.SourcesDirectory)/.pipeline/scripts/get-python-release-metadata.ps1" `
+                -RepositoryDirectory "$(Build.SourcesDirectory)" `
+                -CommitSha "$(resources.pipeline.officialBuild.sourceCommit)" `
+                -SourceBranch "$(resources.pipeline.officialBuild.sourceBranch)"
+              $commitSha = $metadata.SourceCommit
+              $version = $metadata.Version
 
               $tagName = "v$version"
               $branchName = "release/$version"
@@ -410,18 +369,18 @@ extends:
               Write-Host "Branch:     $branchName"
 
               # Create annotated tag on the build's source commit
-              git tag -a $tagName $commitSha -m "Release $version"
+              git -C "$(Build.SourcesDirectory)" tag -a $tagName $commitSha -m "Release $version"
               if ($LASTEXITCODE -ne 0) { Write-Error "Failed to create tag"; exit 1 }
 
               # Create release branch from the tagged commit
-              git branch $branchName $commitSha
+              git -C "$(Build.SourcesDirectory)" branch $branchName $commitSha
               if ($LASTEXITCODE -ne 0) { Write-Error "Failed to create branch"; exit 1 }
 
               # Push tag and branch
-              git push origin $tagName
+              git -C "$(Build.SourcesDirectory)" push origin $tagName
               if ($LASTEXITCODE -ne 0) { Write-Error "Failed to push tag"; exit 1 }
 
-              git push origin $branchName
+              git -C "$(Build.SourcesDirectory)" push origin $branchName
               if ($LASTEXITCODE -ne 0) { Write-Error "Failed to push branch"; exit 1 }
 
               Write-Host "====================================="
@@ -430,3 +389,4 @@ extends:
               Write-Host "  Branch: $branchName"
               Write-Host "====================================="
             displayName: 'Create git tag and release branch'
+            workingDirectory: '$(Build.SourcesDirectory)'

--- a/.pipeline/OneBranch/OfficialPythonWheelsRelease.yml
+++ b/.pipeline/OneBranch/OfficialPythonWheelsRelease.yml
@@ -92,15 +92,14 @@ extends:
 
     stages:
     ###########################################################################
-    # Stage 1: Download artifacts, verify, and publish NuGet
+    # Stage 1: Always validate wheels; optionally package and publish NuGet
     ###########################################################################
     - stage: Release
-      displayName: 'Release NuGet Package'
+      displayName: 'Validate Wheels and Optionally Publish NuGet'
       dependsOn: []
-      condition: and(succeeded(), ${{ eq(parameters.publishNuGet, true) }})
       jobs:
       - job: PublishRelease
-        displayName: 'Download Build Artifacts and Publish'
+        displayName: 'Validate Official Wheels and Optionally Publish'
         pool:
           type: windows
         variables:
@@ -110,7 +109,7 @@ extends:
           ob_git_persistCredentials: true
         steps:
         #####################################################################
-        # Step 1: Download NuGet artifact from the Official Build pipeline
+        # Step 1: Download artifacts from the Official Build pipeline
         #####################################################################
         - download: officialBuild
           displayName: 'Download all artifacts from Official Build'
@@ -139,9 +138,7 @@ extends:
           displayName: 'List downloaded artifacts'
 
         #####################################################################
-        # Step 3: Extract version and create NuGet package
-        # This reuses the same version logic from stages.yml but with
-        # isOfficial=true, producing a clean semver (no prerelease suffix).
+        # Step 3: Validate wheels against the selected build's exact source
         #####################################################################
         - pwsh: |
             $ErrorActionPreference = 'Stop'
@@ -156,13 +153,10 @@ extends:
             $packageVersion = $metadata.Version
             $distributionName = $metadata.DistributionName
             $pythonVersion = $metadata.PythonVersion
-            $shortSha = $commitSha.Substring(0, 8)
 
             Write-Host "Release version: $packageVersion"
             Write-Host "Source commit: $commitSha"
             Write-Host "Build run: $(resources.pipeline.officialBuild.runID)"
-            Write-Host "##vso[task.setvariable variable=releaseVersion]$packageVersion"
-            Write-Host "##vso[task.setvariable variable=sourceCommit]$commitSha"
 
             # Collect wheels
             $wheelsDir = "$(Build.StagingDirectory)/wheels"
@@ -170,7 +164,7 @@ extends:
             $wheels = Get-ChildItem "$(Pipeline.Workspace)/officialBuild" -Filter *.whl -Recurse |
               Where-Object { $_.FullName -match '[\\/]+wheels[\\/][^\\/]+\.whl$' }
             if ($wheels.Count -eq 0) {
-              Write-Error "No wheels found to package. Aborting."
+              Write-Error "No wheels found to validate. Aborting."
               exit 1
             }
             $wheels | Copy-Item -Destination $wheelsDir -Force
@@ -182,43 +176,54 @@ extends:
               -ExpectedVersion $pythonVersion `
               -RequireOdbc:$true
 
-            # Create .nuspec
-            $nuspecContent = @"
-            <?xml version="1.0"?>
-            <package>
-              <metadata>
-                <id>mssql-python-rs-wheels</id>
-                <version>$packageVersion</version>
-                <description>Python wheels containing the $distributionName TDS core and ODBC driver. Commit: $shortSha. Build: $(resources.pipeline.officialBuild.runID)</description>
-                <authors>SqlClientDrivers</authors>
-              </metadata>
-              <files>
-                <file src="wheels\**\*.whl" target="wheels" />
-              </files>
-            </package>
-            "@
-
-            $nuspecPath = "$(Build.StagingDirectory)/mssql-python-rs-wheels.nuspec"
-            $nuspecContent | Out-File -FilePath $nuspecPath -Encoding utf8
-            Write-Host "Created nuspec: $nuspecPath"
-          displayName: 'Prepare release NuGet package'
+            Write-Host "##vso[task.setvariable variable=releaseVersion]$packageVersion"
+            Write-Host "##vso[task.setvariable variable=sourceCommit]$commitSha"
+            Write-Host "##vso[task.setvariable variable=releaseDistributionName]$distributionName"
+          displayName: 'Validate official Python wheels'
           workingDirectory: '$(Build.SourcesDirectory)'
 
-        - task: NuGetCommand@2
-          displayName: 'Create NuGet package'
-          inputs:
-            command: pack
-            packagesToPack: '$(Build.StagingDirectory)/mssql-python-rs-wheels.nuspec'
-            packDestination: '$(ob_outputDirectory)/packages'
-            basePath: '$(Build.StagingDirectory)'
+        - ${{ if eq(parameters.publishNuGet, true) }}:
+          - pwsh: |
+              $ErrorActionPreference = 'Stop'
+              $packageVersion = "$(releaseVersion)"
+              $distributionName = "$(releaseDistributionName)"
+              $shortSha = "$(sourceCommit)".Substring(0, 8)
 
-        - pwsh: |
-            Write-Host "=== Release NuGet package ==="
-            Get-ChildItem "$(ob_outputDirectory)/packages" -Filter *.nupkg | ForEach-Object {
-              Write-Host "  $($_.Name)  ($([math]::Round($_.Length/1MB, 2)) MB)"
-            }
-            Write-Host "NuGet WILL be published to feed (publishNuGet=true)"
-          displayName: 'Verify NuGet package'
+              $nuspecContent = @"
+              <?xml version="1.0"?>
+              <package>
+                <metadata>
+                  <id>mssql-python-rs-wheels</id>
+                  <version>$packageVersion</version>
+                  <description>Python wheels containing the $distributionName TDS core and ODBC driver. Commit: $shortSha. Build: $(resources.pipeline.officialBuild.runID)</description>
+                  <authors>SqlClientDrivers</authors>
+                </metadata>
+                <files>
+                  <file src="wheels\**\*.whl" target="wheels" />
+                </files>
+              </package>
+              "@
+
+              $nuspecPath = "$(Build.StagingDirectory)/mssql-python-rs-wheels.nuspec"
+              $nuspecContent | Out-File -FilePath $nuspecPath -Encoding utf8
+              Write-Host "Created nuspec: $nuspecPath"
+            displayName: 'Prepare release NuGet package'
+
+          - task: NuGetCommand@2
+            displayName: 'Create NuGet package'
+            inputs:
+              command: pack
+              packagesToPack: '$(Build.StagingDirectory)/mssql-python-rs-wheels.nuspec'
+              packDestination: '$(ob_outputDirectory)/packages'
+              basePath: '$(Build.StagingDirectory)'
+
+          - pwsh: |
+              Write-Host "=== Release NuGet package ==="
+              Get-ChildItem "$(ob_outputDirectory)/packages" -Filter *.nupkg | ForEach-Object {
+                Write-Host "  $($_.Name)  ($([math]::Round($_.Length/1MB, 2)) MB)"
+              }
+              Write-Host "NuGet WILL be published to feed (publishNuGet=true)"
+            displayName: 'Verify NuGet package'
 
     ###########################################################################
     # Stage 2: Publish Rust crates through ESRP
@@ -336,10 +341,7 @@ extends:
     - ${{ if eq(parameters.tagRelease, true) }}:
       - stage: Tag
         displayName: 'Tag mssql-py-core Release'
-        ${{ if eq(parameters.publishNuGet, true) }}:
-          dependsOn: Release
-        ${{ else }}:
-          dependsOn: []
+        dependsOn: Release
         jobs:
         - job: TagAndBranch
           displayName: 'Git tag + release branch'

--- a/.pipeline/scripts/get-python-release-metadata.ps1
+++ b/.pipeline/scripts/get-python-release-metadata.ps1
@@ -1,0 +1,59 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$RepositoryDirectory,
+    [Parameter(Mandatory = $true)][ValidatePattern('^[0-9a-fA-F]{40}$')][string]$CommitSha,
+    [Parameter(Mandatory = $true)][ValidatePattern('^refs/heads/.+')][string]$SourceBranch,
+    [switch]$IncludeWheelMetadata
+)
+
+$ErrorActionPreference = 'Stop'
+
+git -C $RepositoryDirectory fetch origin $SourceBranch
+if ($LASTEXITCODE -ne 0) {
+    throw "Could not fetch selected build branch $SourceBranch in $RepositoryDirectory"
+}
+git -C $RepositoryDirectory cat-file -e "${CommitSha}^{commit}"
+if ($LASTEXITCODE -ne 0) {
+    throw "Selected build commit $CommitSha was not found after fetching $SourceBranch"
+}
+
+function Get-BuildSourceFile {
+    param([string]$Path)
+
+    $content = & git -C $RepositoryDirectory show "${CommitSha}:$Path"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Could not read $Path from selected build commit $CommitSha"
+    }
+    return $content -join "`n"
+}
+
+function Get-TomlField {
+    param([string]$Content, [string]$Section, [string]$Field)
+
+    $sectionMatch = [regex]::Match(
+        $Content, ('(?ms)^\[{0}\]\s*$(?<body>.*?)(?=^\[|\z)' -f [regex]::Escape($Section))
+    )
+    $fieldMatch = [regex]::Match(
+        $sectionMatch.Groups['body'].Value, ('(?m)^\s*{0}\s*=\s*"([^"]+)"' -f [regex]::Escape($Field))
+    )
+    if (-not $fieldMatch.Success) {
+        throw "Could not extract [$Section].$Field from selected build commit $CommitSha"
+    }
+    return $fieldMatch.Groups[1].Value
+}
+
+$cargoToml = Get-BuildSourceFile 'mssql-py-core/Cargo.toml'
+$metadata = @{
+    SourceCommit = $CommitSha
+    Version = Get-TomlField $cargoToml 'package' 'version'
+}
+if ($IncludeWheelMetadata) {
+    $pyprojectToml = Get-BuildSourceFile 'mssql-py-core/pyproject.toml'
+    $metadata.DistributionName = Get-TomlField $pyprojectToml 'project' 'name'
+    $metadata.PythonVersion = Get-TomlField $pyprojectToml 'project' 'version'
+}
+
+[pscustomobject]$metadata

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -127,8 +127,8 @@ stages:
       # Unit-test wheel packaging scripts on PR runs; the packaging pipeline
       # steps themselves are non-PR gated.
       - pwsh: |
-          python -m pip install --quiet pytest
-          python -m pytest scripts/test_inject_odbc.py scripts/test_verify_python_wheels.py -q
+          python -m pip install --quiet pytest pyyaml
+          python -m pytest scripts/test_inject_odbc.py scripts/test_verify_python_wheels.py scripts/test_release_pipeline.py -q
         displayName: 'Unit test Python wheel packaging scripts'
       - template: build-template.yml
         parameters:

--- a/docs/release-management.md
+++ b/docs/release-management.md
@@ -248,26 +248,29 @@ git push origin release/0.2.1
 
 `.pipeline/OneBranch/OfficialPythonWheelsRelease.yml` consumes the selected
 `Official Python Wheels Build` run without rebuilding it. All release switches
-default to `false`.
+default to `false`. Official wheel artifacts are always downloaded and validated
+against that build's source metadata, even when NuGet publishing is disabled.
 
 | Switch | Behavior |
 |---|---|
-| `publishNuGet` | Download and validate wheels, prepare and pack the NuGet package, then publish it. When false, the entire NuGet stage is skipped, not run as a dry run. |
+| `publishNuGet` | Prepare, pack, verify and publish the NuGet package after wheel validation. When false, these NuGet-only steps are omitted; wheel download and validation still run. |
 | `publishMssqlTds` | Select `mssql-tds` for crates.io publication through ESRP. |
 | `publishMssqlMockTds` | Select `mssql-mock-tds` for crates.io publication through ESRP. |
 | `validateCratesOnly` | Validate the crate artifact and run selected-crate preflights without ESRP publication. Can also validate the artifact with neither crate selected. |
 | `tagRelease` | Tag and branch the selected build's `mssql-py-core` version. This does not tag Rust crate versions. |
 
-The NuGet and Rust crate stages have no dependency on each other. Crate-only
-publication and validation do not download or validate wheels, and a NuGet
-failure does not block the crate stage. OneBranch's per-job policy validation
-still applies. When publishing both crates, the core must become available on
+The wheel validation/NuGet and Rust crate stages have no dependency on each other.
+The crate stage downloads only crate artifacts and does not wait for wheel
+validation or NuGet. A failure in either wheel validation or NuGet does not block
+crates. OneBranch's per-job policy validation still applies. When publishing both
+crates, the core must become available on
 crates.io before the mock is published; mock-only publication requires the core
 version to be available already.
 
-Tagging waits for NuGet only when `publishNuGet` is also selected. With NuGet
-disabled, `tagRelease` can run independently, and it never waits for Rust crate
-publication. Leaving all switches off performs no release work.
+Tagging always waits for successful wheel validation, plus NuGet publication when
+`publishNuGet` is selected. It never waits for Rust crate publication. Leaving all
+switches off is a wheel validation-only run: no NuGet packaging or publication,
+ESRP, Git tags, or release-branch writes.
 
 NuGet and tag metadata come from the selected build's exact source commit, not
 the release pipeline's checkout or the current branch tip. A missing branch,
@@ -277,6 +280,13 @@ These jobs configure OneBranch's built-in checkout with `ob_git_fetchDepth` and
 checkout can relocate the repository while governed task restrictions prevent
 updating the source path. Git commands use the explicit source directory, and
 wheel validation and packaging remain inside the governed build container.
+
+For release-pipeline changes, use the ADO Preview API first to inspect expanded
+gates and OneBranch policy/checkout settings without queuing a run. Once a live
+run is authorized, select a known successful Official Build and leave all switches
+off to exercise genuine artifacts in the governed container without publishing.
+Local regression tests also cover missing wheels, incorrect names/versions,
+missing ODBC payloads, and exact-source metadata failures.
 
 ### Hotfix process
 

--- a/docs/release-management.md
+++ b/docs/release-management.md
@@ -244,6 +244,40 @@ git push origin release/0.2.1
 3. Update `mssql-python` version (e.g., bump to `1.4.0`)
 4. Publish to PyPI
 
+### Releasing existing Official Build artifacts
+
+`.pipeline/OneBranch/OfficialPythonWheelsRelease.yml` consumes the selected
+`Official Python Wheels Build` run without rebuilding it. All release switches
+default to `false`.
+
+| Switch | Behavior |
+|---|---|
+| `publishNuGet` | Download and validate wheels, prepare and pack the NuGet package, then publish it. When false, the entire NuGet stage is skipped, not run as a dry run. |
+| `publishMssqlTds` | Select `mssql-tds` for crates.io publication through ESRP. |
+| `publishMssqlMockTds` | Select `mssql-mock-tds` for crates.io publication through ESRP. |
+| `validateCratesOnly` | Validate the crate artifact and run selected-crate preflights without ESRP publication. Can also validate the artifact with neither crate selected. |
+| `tagRelease` | Tag and branch the selected build's `mssql-py-core` version. This does not tag Rust crate versions. |
+
+The NuGet and Rust crate stages have no dependency on each other. Crate-only
+publication and validation do not download or validate wheels, and a NuGet
+failure does not block the crate stage. OneBranch's per-job policy validation
+still applies. When publishing both crates, the core must become available on
+crates.io before the mock is published; mock-only publication requires the core
+version to be available already.
+
+Tagging waits for NuGet only when `publishNuGet` is also selected. With NuGet
+disabled, `tagRelease` can run independently, and it never waits for Rust crate
+publication. Leaving all switches off performs no release work.
+
+NuGet and tag metadata come from the selected build's exact source commit, not
+the release pipeline's checkout or the current branch tip. A missing branch,
+commit, or required source file fails the operation without a checkout fallback.
+These jobs configure OneBranch's built-in checkout with `ob_git_fetchDepth` and
+`ob_git_persistCredentials`; do not add a second `checkout: self`. A duplicate
+checkout can relocate the repository while governed task restrictions prevent
+updating the source path. Git commands use the explicit source directory, and
+wheel validation and packaging remain inside the governed build container.
+
 ### Hotfix process
 
 If a critical bug is found after release:
@@ -272,6 +306,7 @@ Steps:
 |---|---|
 | `.pipeline/OneBranch/NonOfficialPythonWheelsPublish.yml` | Pipeline entry point (NonOfficial) — triggers, schedule, nugetPublishing config |
 | `.pipeline/OneBranch/stages.yml` | Build + Publish stages — 5 build jobs, NuGet packaging |
+| `.pipeline/OneBranch/OfficialPythonWheelsRelease.yml` | Independent opt-in NuGet and Rust crate releases from an existing Official Build, plus optional `mssql-py-core` tagging |
 | `.pipeline/templates/build-python-wheels-template.yml` | Shared wheel build template (manylinux, musllinux, Windows, macOS) |
 | `.pipeline/templates/install-dependencies.yml` | Dependency installation (Rust, Python, etc.) |
 | `.pipeline/templates/cargo-authenticate-template.yml` | Cargo registry authentication |

--- a/scripts/test_release_pipeline.py
+++ b/scripts/test_release_pipeline.py
@@ -9,11 +9,15 @@ import ast
 import itertools
 import json
 import re
+import shutil
 import subprocess
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 import pytest
 import yaml
+
+from test_verify_python_wheels import write_wheel_matrix
 
 _ROOT = Path(__file__).parents[1]
 _PIPELINE = _ROOT / ".pipeline" / "OneBranch" / "OfficialPythonWheelsRelease.yml"
@@ -112,10 +116,21 @@ def test_release_switch_graph(values):
 
     release = stages["Release"]
     assert release["dependsOn"] == []
-    assert evaluate(release["condition"], flags) == nuget
-    assert not evaluate(release["condition"], flags, succeeded=False)
+    assert evaluate(release.get("condition", "succeeded()"), flags)
+    assert not evaluate(release.get("condition", "succeeded()"), flags, succeeded=False)
     assert release["jobs"][0]["variables"]["ob_nugetPublishing_enabled"] == str(nuget).lower()
-    # All wheel-only downloads, metadata, validation and packing are in this gated stage.
+    release_steps = release["jobs"][0]["steps"]
+    release_names = [step.get("displayName") for step in release_steps]
+    assert any(step.get("download") == "officialBuild" for step in release_steps)
+    assert "Validate official Python wheels" in release_names
+    for name in ("Prepare release NuGet package", "Create NuGet package", "Verify NuGet package"):
+        assert (name in release_names) == nuget
+        if nuget:
+            assert release_names.index("Validate official Python wheels") < release_names.index(name)
+    assert any(step.get("task") == "NuGetCommand@2" for step in release_steps) == nuget
+    if not nuget:
+        assert ".nuspec" not in str(release_steps)
+        assert ".nupkg" not in str(release_steps)
     for name, stage in stages.items():
         if name != "Release":
             assert "verify-python-wheels" not in str(stage)
@@ -128,7 +143,7 @@ def test_release_switch_graph(values):
     assert ("ReleaseCrates" in stages) == (core or mock or dry_run)
     if "ReleaseCrates" in stages:
         crates = stages["ReleaseCrates"]
-        # Explicitly empty: an unrelated NuGet failure/skip cannot block crates.
+        # Explicitly empty: wheel validation or NuGet failure cannot block crates.
         assert crates["dependsOn"] == []
         steps = crates["jobs"][0]["steps"]
         tasks = [step["displayName"] for step in steps if step.get("task") == "EsrpRelease@12"]
@@ -148,7 +163,8 @@ def test_release_switch_graph(values):
 
     assert ("Tag" in stages) == tag
     if tag:
-        assert stages["Tag"]["dependsOn"] == ("Release" if nuget else [])
+        assert stages["Tag"]["dependsOn"] == "Release"
+        assert not evaluate(stages["Tag"].get("condition", "succeeded()"), flags, succeeded=False)
         assert stages["Tag"]["displayName"] == "Tag mssql-py-core Release"
         assert "mssqlTdsCrateVersion" not in str(stages["Tag"])
 
@@ -169,6 +185,18 @@ def test_release_switch_graph(values):
         assert '-CommitSha "$(resources.pipeline.officialBuild.sourceCommit)"' in step["pwsh"]
         assert '-SourceBranch "$(resources.pipeline.officialBuild.sourceBranch)"' in step["pwsh"]
         assert ("-IncludeWheelMetadata" in step["pwsh"]) == (name == "Release")
+        if name == "Release":
+            assert step["displayName"] == "Validate official Python wheels"
+            assert "condition" not in step
+            assert "verify-python-wheels.ps1" in step["pwsh"]
+            assert ".nuspec" not in step["pwsh"]
+            for variable in ("releaseVersion", "sourceCommit", "releaseDistributionName"):
+                assert step["pwsh"].index("verify-python-wheels.ps1") < step["pwsh"].index(
+                    f"task.setvariable variable={variable}"
+                )
+                if nuget:
+                    preparation = release_steps[release_names.index("Prepare release NuGet package")]
+                    assert f"$({variable})" in preparation["pwsh"]
         if name == "Tag":
             git_commands = re.findall(r"^\s*git .+$", step["pwsh"], re.MULTILINE)
             assert len(git_commands) == 4
@@ -211,6 +239,68 @@ def source_repositories(tmp_path):
     selected = commit_metadata(remote, "0.1.10")
     commit_metadata(remote, "8.8.8")
     return remote, checkout, selected
+
+
+@pytest.mark.parametrize("nuget,wheels_present", [(False, False), (False, True), (True, True)])
+def test_wheel_validation_and_optional_nuspec(source_repositories, tmp_path, nuget, wheels_present):
+    remote, checkout, _ = source_repositories
+    (remote / "mssql-py-core" / "pyproject.toml").write_text(
+        '[project]\nname = "mssql-python-rs"\nversion = "0.1.0"\n', encoding="utf-8"
+    )
+    selected = commit_metadata(remote, "0.1.10", python=False)
+    scripts = checkout / ".pipeline" / "scripts"
+    scripts.mkdir(parents=True)
+    for filename in ("get-python-release-metadata.ps1", "verify-python-wheels.ps1"):
+        shutil.copy2(_ROOT / ".pipeline" / "scripts" / filename, scripts / filename)
+
+    artifact_wheels = tmp_path / "officialBuild" / "drop" / "wheels"
+    artifact_wheels.mkdir(parents=True)
+    if wheels_present:
+        write_wheel_matrix(artifact_wheels)
+    staging = tmp_path / "staging"
+    flags = dict.fromkeys(_SWITCHES, False) | {"publishNuGet": nuget}
+    pipeline = expand(yaml.safe_load(_PIPELINE.read_text(encoding="utf-8")), flags)
+    steps = pipeline["extends"]["parameters"]["stages"][0]["jobs"][0]["steps"]
+    variables = {
+        "Build.SourcesDirectory": str(checkout),
+        "Build.StagingDirectory": str(staging),
+        "Pipeline.Workspace": str(tmp_path),
+        "resources.pipeline.officialBuild.sourceCommit": selected,
+        "resources.pipeline.officialBuild.sourceBranch": "refs/heads/main",
+        "resources.pipeline.officialBuild.runID": "123",
+    }
+
+    def run_step(name):
+        script = next(step["pwsh"] for step in steps if step.get("displayName") == name)
+        for key, value in variables.items():
+            script = script.replace(f"$({key})", value)
+        return subprocess.run(
+            ["pwsh", "-NoProfile", "-Command", script],
+            cwd=tmp_path, capture_output=True, text=True, check=False,
+        )
+
+    result = run_step("Validate official Python wheels")
+    assert not list(staging.glob("*.nuspec"))
+    assert not list(staging.glob("**/*.nupkg"))
+    if not wheels_present:
+        assert result.returncode != 0
+        assert "No wheels found to validate" in result.stderr
+        assert "task.setvariable" not in result.stdout
+        return
+
+    assert result.returncode == 0, result.stderr
+    assert "Validated 34 mssql-python-rs wheels" in result.stdout
+    variables.update(re.findall(r"##vso\[task.setvariable variable=(\w+)\](.*)", result.stdout))
+    assert variables["releaseVersion"] == "0.1.10"
+    assert variables["sourceCommit"] == selected
+    assert variables["releaseDistributionName"] == "mssql-python-rs"
+    if nuget:
+        result = run_step("Prepare release NuGet package")
+        assert result.returncode == 0, result.stderr
+        metadata = ET.parse(staging / "mssql-python-rs-wheels.nuspec").find("metadata")
+        assert metadata.findtext("version") == "0.1.10"
+        assert selected[:8] in metadata.findtext("description")
+        assert "mssql-python-rs" in metadata.findtext("description")
 
 
 def read_metadata(checkout, commit, cwd, branch="refs/heads/main", wheels=True):

--- a/scripts/test_release_pipeline.py
+++ b/scripts/test_release_pipeline.py
@@ -1,0 +1,287 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Local release gates; does not execute publishing, tagging, or ADO jobs."""
+
+from __future__ import annotations
+
+import ast
+import itertools
+import json
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+_ROOT = Path(__file__).parents[1]
+_PIPELINE = _ROOT / ".pipeline" / "OneBranch" / "OfficialPythonWheelsRelease.yml"
+_METADATA = _ROOT / ".pipeline" / "scripts" / "get-python-release-metadata.ps1"
+_SWITCHES = (
+    "publishNuGet",
+    "publishMssqlTds",
+    "publishMssqlMockTds",
+    "validateCratesOnly",
+    "tagRelease",
+)
+
+
+def evaluate(expression, parameters, succeeded=True):
+    """Evaluate only the boolean expression subset used by this pipeline."""
+    expression = re.sub(r"\band\(", "all_(", expression)
+    expression = re.sub(r"\bor\(", "any_(", expression)
+
+    def visit(node):
+        if isinstance(node, ast.Name):
+            return {"true": True, "false": False}[node.id.lower()]
+        if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+            assert node.value.id == "parameters"
+            return parameters[node.attr]
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            args = [visit(arg) for arg in node.args]
+            return {
+                "eq": lambda a, b: a == b,
+                "ne": lambda a, b: a != b,
+                "all_": lambda *values: all(values),
+                "any_": lambda *values: any(values),
+                "succeeded": lambda: succeeded,
+            }[node.func.id](*args)
+        raise AssertionError(f"Unsupported pipeline expression: {expression}")
+
+    return visit(ast.parse(expression.strip(), mode="eval").body)
+
+
+def expand(value, parameters):
+    if isinstance(value, str):
+        return re.sub(
+            r"\$\{\{(.+?)\}\}",
+            lambda match: str(evaluate(match[1], parameters)).lower(),
+            value,
+        )
+    if isinstance(value, list):
+        result = []
+        for item in value:
+            expanded = expand(item, parameters)
+            if isinstance(expanded, list):
+                result.extend(expanded)
+            elif expanded:
+                result.append(expanded)
+        return result
+    if isinstance(value, dict):
+        result = {}
+        matched = False
+        for key, item in value.items():
+            if key.startswith("${{"):
+                clause = key[3:-2].strip()
+                enabled = not matched if clause == "else" else evaluate(
+                    clause.removeprefix("if "), parameters
+                )
+                matched |= enabled
+                if enabled:
+                    expanded = expand(item, parameters)
+                    if isinstance(expanded, list):
+                        assert len(value) == 1
+                        return expanded
+                    result.update(expanded)
+            else:
+                result[key] = expand(item, parameters)
+        return result
+    return value
+
+
+def test_release_defaults_are_safe():
+    pipeline = yaml.safe_load(_PIPELINE.read_text(encoding="utf-8"))
+    assert {p["name"]: p["default"] for p in pipeline["parameters"]} == dict.fromkeys(
+        _SWITCHES, False
+    )
+    assert pipeline["trigger"] == "none"
+    assert pipeline["pr"] == "none"
+    assert pipeline["resources"]["pipelines"][0]["source"] == "Official Python Wheels Build"
+
+
+@pytest.mark.parametrize("values", list(itertools.product((False, True), repeat=5)))
+def test_release_switch_graph(values):
+    flags = dict(zip(_SWITCHES, values))
+    pipeline = expand(yaml.safe_load(_PIPELINE.read_text(encoding="utf-8")), flags)
+    stages = {stage["stage"]: stage for stage in pipeline["extends"]["parameters"]["stages"]}
+    nuget, core, mock, dry_run, tag = values
+    for stage in stages.values():
+        for job in stage["jobs"]:
+            assert not any("checkout" in step or "target" in step for step in job["steps"])
+
+    release = stages["Release"]
+    assert release["dependsOn"] == []
+    assert evaluate(release["condition"], flags) == nuget
+    assert not evaluate(release["condition"], flags, succeeded=False)
+    assert release["jobs"][0]["variables"]["ob_nugetPublishing_enabled"] == str(nuget).lower()
+    # All wheel-only downloads, metadata, validation and packing are in this gated stage.
+    for name, stage in stages.items():
+        if name != "Release":
+            assert "verify-python-wheels" not in str(stage)
+            assert "NuGetCommand@" not in str(stage)
+            assert not any(
+                step.get("download") == "officialBuild" and "artifact" not in step
+                for job in stage["jobs"] for step in job["steps"]
+            )
+
+    assert ("ReleaseCrates" in stages) == (core or mock or dry_run)
+    if "ReleaseCrates" in stages:
+        crates = stages["ReleaseCrates"]
+        # Explicitly empty: an unrelated NuGet failure/skip cannot block crates.
+        assert crates["dependsOn"] == []
+        steps = crates["jobs"][0]["steps"]
+        tasks = [step["displayName"] for step in steps if step.get("task") == "EsrpRelease@12"]
+        assert tasks == (
+            (["Publish mssql-tds to crates.io"] if core and not dry_run else [])
+            + (["Publish mssql-mock-tds to crates.io"] if mock and not dry_run else [])
+        )
+        names = [step.get("displayName") for step in steps]
+        assert "Validate Rust crate release artifact" in names
+        assert ("Preflight mssql-tds version" in names) == core
+        assert ("Preflight mssql-mock-tds version" in names) == mock
+        assert ("Verify mssql-tds dependency is published" in names) == (mock and not core)
+        if core and mock and not dry_run:
+            assert names.index("Publish mssql-tds to crates.io") < names.index(
+                "Wait for mssql-tds on crates.io"
+            ) < names.index("Publish mssql-mock-tds to crates.io")
+
+    assert ("Tag" in stages) == tag
+    if tag:
+        assert stages["Tag"]["dependsOn"] == ("Release" if nuget else [])
+        assert stages["Tag"]["displayName"] == "Tag mssql-py-core Release"
+        assert "mssqlTdsCrateVersion" not in str(stages["Tag"])
+
+    for name in ("Release", "Tag"):
+        if name not in stages:
+            continue
+        job = stages[name]["jobs"][0]
+        assert job["variables"]["ob_git_fetchDepth"] == 0
+        assert job["variables"]["ob_git_persistCredentials"] is True
+        metadata_steps = [
+            step for step in job["steps"]
+            if "get-python-release-metadata.ps1" in step.get("pwsh", "")
+        ]
+        assert len(metadata_steps) == 1
+        step = metadata_steps[0]
+        assert step["workingDirectory"] == "$(Build.SourcesDirectory)"
+        assert '-RepositoryDirectory "$(Build.SourcesDirectory)"' in step["pwsh"]
+        assert '-CommitSha "$(resources.pipeline.officialBuild.sourceCommit)"' in step["pwsh"]
+        assert '-SourceBranch "$(resources.pipeline.officialBuild.sourceBranch)"' in step["pwsh"]
+        assert ("-IncludeWheelMetadata" in step["pwsh"]) == (name == "Release")
+        if name == "Tag":
+            git_commands = re.findall(r"^\s*git .+$", step["pwsh"], re.MULTILINE)
+            assert len(git_commands) == 4
+            assert all('git -C "$(Build.SourcesDirectory)"' in line for line in git_commands)
+
+
+def git(directory, *arguments):
+    return subprocess.run(
+        ["git", "-C", str(directory), *arguments],
+        check=True, capture_output=True, text=True,
+    ).stdout.strip()
+
+
+def commit_metadata(directory, version, python=True):
+    source = directory / "mssql-py-core"
+    source.mkdir(exist_ok=True)
+    (source / "Cargo.toml").write_text(
+        f'[package]\nname = "mssql-py-core"\nversion = "{version}"\n',
+        encoding="utf-8",
+    )
+    if python:
+        (source / "pyproject.toml").write_text(
+            '[project]\nversion = "0.9.2"\nname = "mssql-python-rs"\n',
+            encoding="utf-8",
+        )
+    git(directory, "add", ".")
+    git(directory, "-c", "user.name=Test", "-c", "user.email=test@example.invalid",
+        "-c", "commit.gpgsign=false", "commit", "-m", "Synthetic release metadata")
+    return git(directory, "rev-parse", "HEAD")
+
+
+@pytest.fixture
+def source_repositories(tmp_path):
+    remote = tmp_path / "source"
+    remote.mkdir()
+    git(remote, "init", "-b", "main")
+    commit_metadata(remote, "9.9.9")
+    checkout = tmp_path / "checkout"
+    git(tmp_path, "clone", str(remote), str(checkout))
+    selected = commit_metadata(remote, "0.1.10")
+    commit_metadata(remote, "8.8.8")
+    return remote, checkout, selected
+
+
+def read_metadata(checkout, commit, cwd, branch="refs/heads/main", wheels=True):
+    # Pass arguments separately; exercise the real helper from a non-repository CWD.
+    command = [
+        "pwsh", "-NoProfile", "-Command",
+        "& { param($script, $repo, $sha, $branch, $wheels) "
+        "& $script -RepositoryDirectory $repo -CommitSha $sha -SourceBranch $branch "
+        "-IncludeWheelMetadata:($wheels -eq 'true') | ConvertTo-Json -Compress }",
+        str(_METADATA), str(checkout), commit, branch, str(wheels).lower(),
+    ]
+    return subprocess.run(command, cwd=cwd, capture_output=True, text=True, check=False)
+
+
+def test_metadata_uses_selected_commit_not_checkout_or_branch_tip(source_repositories, tmp_path):
+    _, checkout, selected = source_repositories
+    checkout_head = git(checkout, "rev-parse", "HEAD")
+    result = read_metadata(checkout, selected, tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {
+        "SourceCommit": selected, "Version": "0.1.10",
+        "DistributionName": "mssql-python-rs", "PythonVersion": "0.9.2",
+    }
+    assert git(checkout, "rev-parse", "HEAD") == checkout_head
+
+
+def test_missing_branch_does_not_use_stale_fetch_head(source_repositories, tmp_path):
+    _, checkout, selected = source_repositories
+    assert read_metadata(checkout, selected, tmp_path).returncode == 0
+    result = read_metadata(checkout, selected, tmp_path, branch="refs/heads/missing")
+    assert result.returncode != 0
+    assert "Could not fetch selected build branch" in result.stderr
+    assert '"Version"' not in result.stdout
+
+
+def test_missing_commit_does_not_use_checkout(source_repositories, tmp_path):
+    _, checkout, _ = source_repositories
+    result = read_metadata(checkout, "0" * 40, tmp_path)
+    assert result.returncode != 0
+    assert "was not found after fetching" in result.stderr
+
+
+def test_missing_git_context_fails_explicitly(source_repositories, tmp_path):
+    _, _, selected = source_repositories
+    result = read_metadata(tmp_path, selected, tmp_path)
+    assert result.returncode != 0
+    assert "Could not fetch selected build branch" in result.stderr
+
+
+def test_tag_metadata_does_not_require_wheel_metadata(source_repositories, tmp_path):
+    remote, checkout, _ = source_repositories
+    (remote / "mssql-py-core" / "pyproject.toml").unlink()
+    selected = commit_metadata(remote, "0.2.0", python=False)
+    result = read_metadata(checkout, selected, tmp_path, wheels=False)
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {"SourceCommit": selected, "Version": "0.2.0"}
+    result = read_metadata(checkout, selected, tmp_path, wheels=True)
+    assert result.returncode != 0
+    assert "Could not read mssql-py-core/pyproject.toml" in result.stderr
+
+
+def test_missing_package_version_does_not_match_dependency(source_repositories, tmp_path):
+    remote, checkout, _ = source_repositories
+    cargo = remote / "mssql-py-core" / "Cargo.toml"
+    cargo.write_text(
+        '[package]\nname = "mssql-py-core"\n[dependencies.fake]\nversion = "1.2.3"\n',
+        encoding="utf-8",
+    )
+    git(remote, "add", ".")
+    git(remote, "-c", "user.name=Test", "-c", "user.email=test@example.invalid",
+        "-c", "commit.gpgsign=false", "commit", "-m", "Missing package version")
+    result = read_metadata(checkout, git(remote, "rev-parse", "HEAD"), tmp_path)
+    assert result.returncode != 0
+    assert "Could not extract [package].version" in result.stderr

--- a/scripts/test_verify_python_wheels.py
+++ b/scripts/test_verify_python_wheels.py
@@ -6,6 +6,8 @@ import subprocess
 import zipfile
 from pathlib import Path
 
+import pytest
+
 _VALIDATOR = Path(__file__).parents[1] / ".pipeline" / "scripts" / "verify-python-wheels.ps1"
 
 _LIBS = "mssql_py_core/libs"
@@ -32,12 +34,14 @@ def write_wheel(
     distribution: str = "mssql_python_rs",
     include_odbc: bool = True,
     uppercase_odbc: bool = False,
+    metadata_name: str = "mssql-python-rs",
+    metadata_version: str = "0.1.0",
 ) -> Path:
     wheel_path = directory / f"{distribution}-0.1.0-{python_tag}-{python_tag}-{platform}.whl"
     with zipfile.ZipFile(wheel_path, "w") as wheel:
         wheel.writestr(
             "mssql_python_rs-0.1.0.dist-info/METADATA",
-            "Metadata-Version: 2.4\nName: mssql-python-rs\nVersion: 0.1.0\n",
+            f"Metadata-Version: 2.4\nName: {metadata_name}\nVersion: {metadata_version}\n",
         )
         wheel.writestr("mssql_py_core/__init__.py", "")
         if include_odbc:
@@ -155,6 +159,41 @@ def test_validator_rejects_incomplete_matrix(tmp_path: Path) -> None:
 
     assert result.returncode != 0
     assert "Expected 34 wheels, found 1" in result.stderr
+
+
+def test_validator_rejects_no_wheels(tmp_path: Path) -> None:
+    result = run_validator(tmp_path)
+
+    assert result.returncode != 0
+    assert "Expected 34 wheels, found 0" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("metadata", "message"),
+    [
+        ({"metadata_name": "wrong-distribution"}, "metadata Name is 'wrong-distribution'"),
+        ({"metadata_version": "9.9.9"}, "metadata Version is '9.9.9'"),
+    ],
+)
+def test_validator_rejects_wrong_metadata(tmp_path: Path, metadata: dict, message: str) -> None:
+    wheels = write_wheel_matrix(tmp_path)
+    wheels[0].unlink()
+    write_wheel(tmp_path, "win_amd64", python_tag="cp310", **metadata)
+
+    result = run_validator(tmp_path)
+
+    assert result.returncode != 0
+    assert message in result.stderr
+
+
+def test_validator_rejects_wrong_filename_version(tmp_path: Path) -> None:
+    wheels = write_wheel_matrix(tmp_path)
+    wheels[0].rename(wheels[0].with_name(wheels[0].name.replace("-0.1.0-", "-9.9.9-")))
+
+    result = run_validator(tmp_path)
+
+    assert result.returncode != 0
+    assert "Wheel matrix mismatch" in result.stderr
 
 
 def test_validator_rejects_same_count_with_unexpected_wheel(tmp_path: Path) -> None:


### PR DESCRIPTION
<!--
Thank you for your interest in this project!

This repository is not currently accepting external pull requests. If you've found
a bug or have a feature request, please open an issue instead.

If you are a Microsoft team member, please follow the instructions in the internal
contribution guide.
-->

## Description

<!-- Briefly describe the change. -->

Fresh follow-up to merged #515, based on `main`. Updated in `5cd17304` to keep wheel validation always enabled, per the requested validation-only workflow.

- Always download official wheel artifacts, resolve metadata from the selected build's exact source commit, and run the existing wheel/ODBC validator. With every switch off, this is a safe wheel validation-only run.
- Gate only NuGet-specific nuspec preparation, packing, package verification, and feed publication on `publishNuGet`. These tasks, including OneBranch's injected NuGet publisher, are absent when the switch is false. There is no new validation-only parameter.
- Give `ReleaseCrates` explicit `dependsOn: []`: crate publication/validation never waits for wheel validation or NuGet and is not blocked by their failure. Preserve OneBranch's injected PolicyValidation, core-before-mock ESRP ordering, default-false release switches, and the ESRP-free crate validation mode.
- Keep `tagRelease` specific to `mssql-py-core` and independent of crates. It always waits for successful wheel validation, plus NuGet publication when selected; it cannot tag ahead of validation when NuGet is off.
- Remove duplicate user checkouts from all three governed jobs. Configure OneBranch's built-in checkout through `ob_git_fetchDepth: 0` and `ob_git_persistCredentials: true` where authenticated Git is needed. Share an exact-selected-commit metadata helper using `git -C`, with explicit working directories for validation and tagging. No fallback to checkout HEAD, branch-tip metadata, or stale FETCH_HEAD.
- Wire release regression coverage into the existing Windows Python packaging test step and document the switches, checkout constraints, and safe validation workflow.

### Root cause

[Release run 173942](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build/results?buildId=173942) failed during `Prepare release NuGet package`. Log 46 records the second checkout moving the repository from `D:\a\_work\1\s` to `D:\a\_work\1\s\mssql-rs`, while policy rejects `plugininternal.updaterepositorypath`. The following script uses the stale default source directory and fails `git fetch`. Log 13 confirms the full workspace mount: this is a duplicate-checkout/source-path problem, not an absent `.git` mount.

The deployed governed templates support the checkout variables used here and reject user `target: host` for this manual pipeline. Metadata, wheel validation, packing, and tagging remain in the governed Windows container; no host-target workaround is introduced.

## Related Issues

<!--
Required: link a GitHub issue OR an Azure DevOps work item. The PR check will
fail without one.
GitHub issue: Fixes #123 (or https://github.com/microsoft/mssql-rs/issues/123)
ADO work item: https://sqlclientdrivers.visualstudio.com/<...>/_workitems/edit/<ID>
  (any project/collection path is accepted, e.g. .../<project>/_workitems/edit/123
  or .../DefaultCollection/<project>/_workitems/edit/123)
-->

Related #514 (the original issue linked by #515).
Follow-up to #515. Failed run: [173942](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build/results?buildId=173942).

## Validation

- `python -m pytest scripts/test_release_pipeline.py scripts/test_verify_python_wheels.py scripts/test_inject_odbc.py -q`: **76 passed** on the revised behavior. Covers all 32 switch combinations, always-on validation, NuGet task exclusion, tag sequencing, ESRP ordering/exclusion, and governed checkout settings. Executes the actual inline validation and optional nuspec steps against synthetic local repositories and wheels to verify metadata handoff and absence of packaging when disabled.
- Negative cases cover no wheels, wrong filename/version and METADATA name/version, incomplete matrices, missing required ODBC payload, missing branch/commit/files, stale FETCH_HEAD, and selected source differing from both checkout and branch tip. Synthetic tests do not tag, push, pack, or publish packages.
- **34 genuine wheels** from [Official Build 173831](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build/results?buildId=173831), source `5e23a321c84766530be15f5130b868a3baa843f2`, passed the existing validator with `-RequireOdbc`. Expected distribution/version `mssql-python-rs 0.1.0` was read from that exact commit through the Git Items API. All five wheel artifacts were downloaded read-only; provenance and per-wheel SHA-256s were recorded locally.
- Safe ADO Preview API expansion succeeded for **all-off, NuGet-on, crate-only, tag-only, and crate-validation**. Assertions confirm validation/downloads always present; NuGet preparation/pack/verify and injected `onebranch.pipeline.nugetpush` absent when disabled; unconditional Tag dependency on Release; independent crates; one checkout at `s` per job; correct full-fetch/persist settings; preserved PolicyValidation; and restricted Windows container execution.
- `git diff --check` passes. Independent local review of the revised diff found no significant issues. Copilot's review of the initial commit covered all five files with zero inline comments; a fresh review is requested for the revision.
- Earlier `cargo bfmt` and `cargo bclippy` passed after restoring the ignored Cargo.lock from the local cache. Full `cargo btest` was attempted but stopped after missing certificate-fixture failures and SQL connection timeouts. Rust sources are unchanged; these broad suites were not rerun for this YAML/test/documentation revision.
- **No live release pipeline was queued**, and no ESRP/NuGet release, Git tag, or release-branch write was performed. Preview checks template expansion, and genuine-artifact checks ran locally, not in a live governed container. A future authorized run with a known successful Official Build and all switches off is the remaining end-to-end confidence check.
- Assess PR CI on the latest commit; live governed-container execution remains untested. The user's readiness and reviewer decisions are unchanged.

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [ ] `cargo btest` passes
- [x] New/changed functionality has tests
- [x] Public API changes are documented (no public API change; release behavior documented)
