### PR TITLE
Fix Alpine SQLGetInfo truncation test buffer overrun

### DIFF
--- a/mssql-odbc/tests/e2e/tests/get_info_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/get_info_test.cpp
@@ -9,12 +9,9 @@
 // This suite builds wide on Windows and narrow on Unix (see ODBC_E2E_FORCE_UNICODE
 // in CMakeLists.txt), so lengths are asserted in SQLTCHAR units rather than
 // hard-coded to UTF-16. On the narrow build the driver manager re-encodes the
-// driver's UTF-16 output, and it -- not the driver -- decides what a too-small
-// buffer and a null-pointer size probe report: msodbcsql18 and mssql-odbc behave
-// identically there. The exact SQLGetInfoW buffer contract (byte length, NUL
-// placement, untruncated length on 01004) is therefore pinned by the Rust unit
-// tests in `mssql-odbc/src/api/get_info.rs`; what is asserted here is the part
-// that survives the driver manager unchanged.
+// driver's UTF-16 output and determines what a null-pointer size probe reports.
+// The truncation test calls SQLGetInfoW explicitly to check its byte-length and
+// buffer-boundary contract without the driver manager's ANSI conversion.
 
 #include "odbc_test_fixture.h"
 
@@ -241,12 +238,28 @@ TEST_F(GetInfoLiveTest, NullBufferReportsRequiredLength) {
 
 // A short buffer must be reported as a truncation, not a silent short read.
 TEST_F(GetInfoLiveTest, ShortBufferTruncatesWith01004) {
+    // unixODBC 2.3.11/2.3.12 SQLGetInfoInternal reuses its expanded wide-buffer
+    // length for unicode_to_ansi_copy, overrunning a short ANSI output buffer.
+    // Use the wide entry point on every platform to test the driver's contract.
+    SQLSMALLINT fullLen = -1;
+    ASSERT_EQ(SQL_SUCCESS, SQLGetInfoW(dbc_, SQL_KEYWORDS, nullptr, 0, &fullLen));
+
     // Not named `small`: the Windows SDK's rpcndr.h defines that as a macro for `char`.
-    SQLTCHAR tiny[4] = {};
+    struct {
+        SQLWCHAR value[4];
+        SQLWCHAR guard;
+    } tiny = {{0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF}, 0xFFFF};
     SQLSMALLINT len = -1;
-    SQLRETURN rc = SQLGetInfo(dbc_, SQL_KEYWORDS, tiny, sizeof(tiny), &len);
+    SQLRETURN rc = SQLGetInfoW(dbc_, SQL_KEYWORDS, tiny.value, sizeof(tiny.value), &len);
     EXPECT_EQ(SQL_SUCCESS_WITH_INFO, rc);
     EXPECT_TRUE(ODBCTestUtils::HasDiagState(SQL_HANDLE_DBC, dbc_, "01004"));
+    EXPECT_EQ(fullLen, len);
+    EXPECT_GT(len, static_cast<SQLSMALLINT>(sizeof(tiny.value)));
+    EXPECT_EQ(static_cast<SQLWCHAR>('B'), tiny.value[0]);
+    EXPECT_EQ(static_cast<SQLWCHAR>('A'), tiny.value[1]);
+    EXPECT_EQ(static_cast<SQLWCHAR>('C'), tiny.value[2]);
+    EXPECT_EQ(0, tiny.value[3]);
+    EXPECT_EQ(0xFFFF, tiny.guard);
 }
 
 // SQLGetInfo must work while a cursor is open on a non-MARS connection, and


### PR DESCRIPTION
<!--
Thank you for your interest in this project!

This repository is not currently accepting external pull requests. If you've found
a bug or have a feature request, please open an issue instead.

If you are a Microsoft team member, please follow the instructions in the internal
contribution guide.
-->

## Description

<!-- Briefly describe the change. -->

Fix the Alpine `GetInfoLiveTest.ShortBufferTruncatesWith01004` crash reported in [pipeline run 20260910.2](https://sqlclientdrivers.visualstudio.com/mssql-rs/_build/results?buildId=173966&view=logs). unixODBC reuses its expanded wide-buffer capacity when copying results back to the four-byte ANSI buffer, writing the terminating NUL past its end. Reproduced locally on Alpine 3.18; GDB confirms the crash in musl's `__stack_chk_fail`.

Call `SQLGetInfoW` explicitly for the truncation test on every platform. Keep the `SQL_SUCCESS_WITH_INFO`/`01004` assertions and add checks for the full required byte length, copied prefix, NUL termination, and an untouched trailing guard. Other tests retain their existing ANSI routing on Unix. No driver behavior, CI configuration, or test skips change.

Local validation: all 12 `SQLGetInfo` E2E cases passed in Alpine 3.18 and 3.21 containers against a local SQL Server 2022, including a Unicode build on Alpine 3.18. The 19 Rust `SQLGetInfo` tests and targeted `mssqlodbc` clippy (`--all-targets --all-features -- -D warnings`) also passed on Alpine. The full-workspace commands below were not run.

## Related Issues

<!--
Required: link a GitHub issue OR an Azure DevOps work item. The PR check will
fail without one.
GitHub issue: Fixes #123 (or https://github.com/microsoft/mssql-rs/issues/123)
ADO work item: https://sqlclientdrivers.visualstudio.com/<...>/_workitems/edit/<ID>
  (any project/collection path is accepted, e.g. .../<project>/_workitems/edit/123
  or .../DefaultCollection/<project>/_workitems/edit/123)
-->

Related: [AB#47086](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47086). Follow-up to #535.

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes
- [x] New/changed functionality has tests
- [x] Public API changes are documented (N/A: test-only change)