### PR TITLE
Repair glibc wheels into manylinux tags for PyPI

### DIFF
--- a/.pipeline/OneBranch/stages.yml
+++ b/.pipeline/OneBranch/stages.yml
@@ -302,6 +302,17 @@ stages:
             --drivers-dir "$(Build.SourcesDirectory)/drivers"
         displayName: 'Inject ODBC driver into wheels (Linux x64)'
         condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+      - script: |
+          set -e
+          sudo chown -R $(whoami):$(whoami) "$(ob_outputDirectory)/wheels"
+          docker run --rm \
+            -v "$(ob_outputDirectory)/wheels:/wheels" \
+            -v "$(Build.SourcesDirectory)/scripts:/scripts:ro" \
+            -e AUDITWHEEL_PLAT=manylinux_2_34 \
+            ghcr.io/microsoft/mssql-rs/python-build/manylinux_2_34_x86_64_rust:latest \
+            bash /scripts/repair-glibc-wheels-in-container.sh /wheels
+        displayName: 'Repair glibc wheels into manylinux (Linux x64)'
+        condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
     - task: PublishPipelineArtifact@1
       displayName: 'Publish Linux x64 Artifacts'
       inputs:
@@ -380,6 +391,17 @@ stages:
               --wheels-dir "$(ob_outputDirectory)/wheels" \
               --drivers-dir "$(Build.SourcesDirectory)/drivers"
           displayName: 'Inject ODBC driver into wheels (Linux ARM64)'
+          condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+        - script: |
+            set -e
+            sudo chown -R $(whoami):$(whoami) "$(ob_outputDirectory)/wheels"
+            docker run --rm \
+              -v "$(ob_outputDirectory)/wheels:/wheels" \
+              -v "$(Build.SourcesDirectory)/scripts:/scripts:ro" \
+              -e AUDITWHEEL_PLAT=manylinux_2_34 \
+              ghcr.io/microsoft/mssql-rs/python-build/manylinux_2_34_aarch64_rust:latest \
+              bash /scripts/repair-glibc-wheels-in-container.sh /wheels
+          displayName: 'Repair glibc wheels into manylinux (Linux ARM64)'
           condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
       - task: PublishPipelineArtifact@1
         displayName: 'Publish Linux ARM64 Artifacts'

--- a/.pipeline/scripts/verify-python-wheels.ps1
+++ b/.pipeline/scripts/verify-python-wheels.ps1
@@ -18,6 +18,25 @@ function ConvertTo-CanonicalName {
     return [regex]::Replace($Name.ToLowerInvariant(), '[-_.]+', '-')
 }
 
+function Assert-PyPICompatiblePlatformTag {
+    param([string]$WheelName)
+
+    $platformTag = [System.IO.Path]::GetFileNameWithoutExtension($WheelName).Split('-')[-1]
+    $accepted = @(
+        '^win_amd64$',
+        '^win_arm64$',
+        '^macosx_\d+_\d+_universal2$',
+        '^manylinux_\d+_\d+_(x86_64|aarch64)$',
+        '^musllinux_\d+_\d+_(x86_64|aarch64)$'
+    )
+    foreach ($pattern in $accepted) {
+        if ($platformTag -match $pattern) {
+            return
+        }
+    }
+    throw "$WheelName has platform tag '$platformTag' which PyPI rejects. Linux wheels must carry a manylinux or musllinux tag, not a bare linux tag."
+}
+
 function Get-ExpectedOdbcMembers {
     param([string]$WheelName)
 
@@ -58,8 +77,8 @@ function Get-ExpectedWheelNames {
     $pythonTags = 'cp310', 'cp311', 'cp312', 'cp313', 'cp314'
     $platforms = @(
         'win_amd64',
-        'linux_x86_64',
-        'linux_aarch64',
+        'manylinux_2_34_x86_64',
+        'manylinux_2_34_aarch64',
         'musllinux_1_2_x86_64',
         'musllinux_1_2_aarch64',
         'macosx_15_0_universal2'
@@ -81,6 +100,9 @@ $filenamePrefix = $ExpectedName.Replace('-', '_')
 $expectedFilenamePrefix = "$filenamePrefix-$ExpectedVersion-"
 $expectedWheelNames = @(Get-ExpectedWheelNames $filenamePrefix $ExpectedVersion)
 $wheels = @(Get-ChildItem -Path $WheelsDir -Filter '*.whl' -File)
+foreach ($wheel in $wheels) {
+    Assert-PyPICompatiblePlatformTag $wheel.Name
+}
 if ($wheels.Count -ne $expectedWheelNames.Count) {
     throw "Expected $($expectedWheelNames.Count) wheels, found $($wheels.Count)"
 }

--- a/mssql-py-core/pyproject.toml
+++ b/mssql-py-core/pyproject.toml
@@ -15,10 +15,12 @@ classifiers = [
 [tool.maturin]
 module-name = "mssql_py_core"
 features = ["pyo3/extension-module"]
-# Don't vendor shared libraries (libssl, libcrypto) into the wheel.
-# Built on manylinux_2_34 (AlmaLinux 9) so the native extension links against
-# libssl.so.3 / libcrypto.so.3 and expects the OS to provide OpenSSL 3.x at runtime.
-# On macOS (Security.framework) and Windows (SChannel) there is no OpenSSL dep.
+# Skip maturin's build-time auditwheel: the mssql-odbc driver is injected into
+# the wheel after the build, so repair must run on the final wheel. The pipeline
+# runs `auditwheel repair` post-injection (scripts/repair-glibc-wheels-in-container.sh)
+# to resolve the native dependencies of both the extension and mssqlodbc.so and
+# retag the glibc wheels manylinux_*. macOS (Security.framework) and Windows
+# (SChannel) have no OpenSSL dependency.
 auditwheel = "skip"
 
 [project.optional-dependencies]

--- a/scripts/repair-glibc-wheels-in-container.sh
+++ b/scripts/repair-glibc-wheels-in-container.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Repair glibc Linux wheels into manylinux wheels AFTER the ODBC driver has been
+# injected, so auditwheel resolves and vendors the native dependencies of both
+# the PyO3 extension and the embedded mssqlodbc.so. PyPI rejects bare linux_*
+# tags; auditwheel retags the repaired wheels manylinux_*, which PyPI accepts.
+# musllinux and non-linux wheels are left untouched. Run inside the matching
+# manylinux build image (has auditwheel and the OpenSSL 3 runtime).
+set -euo pipefail
+
+WHEELS_DIR="${1:?usage: repair-glibc-wheels-in-container.sh <wheels-dir>}"
+PLAT="${AUDITWHEEL_PLAT:-manylinux_2_34}"
+
+if ! command -v auditwheel >/dev/null 2>&1; then
+    echo "ERROR: auditwheel not found in container" >&2
+    exit 1
+fi
+
+shopt -s nullglob
+repaired=0
+for wheel in "$WHEELS_DIR"/*.whl; do
+    name="$(basename "$wheel")"
+    tag="${name%.whl}"
+    tag="${tag##*-}"
+
+    case "$tag" in
+        linux_x86_64) plat="${PLAT}_x86_64" ;;
+        linux_aarch64) plat="${PLAT}_aarch64" ;;
+        *) continue ;;
+    esac
+
+    echo "==> Repairing $name -> $plat"
+    tmp="$(mktemp -d)"
+    auditwheel repair --plat "$plat" --wheel-dir "$tmp" "$wheel"
+    count=$(find "$tmp" -maxdepth 1 -name '*.whl' | wc -l)
+    if [ "$count" -ne 1 ]; then
+        echo "ERROR: expected exactly one repaired wheel for $name, got $count" >&2
+        exit 1
+    fi
+    rm -f "$wheel"
+    mv "$tmp"/*.whl "$WHEELS_DIR/"
+    rm -rf "$tmp"
+    repaired=$((repaired + 1))
+done
+
+echo "Repaired $repaired glibc wheel(s) into $PLAT wheels."

--- a/scripts/test_verify_python_wheels.py
+++ b/scripts/test_verify_python_wheels.py
@@ -14,8 +14,8 @@ _LIBS = "mssql_py_core/libs"
 _PLATFORM_DRIVERS = {
     "win_amd64": (f"{_LIBS}/windows/x64/mssqlodbc.dll",),
     "win_arm64": (f"{_LIBS}/windows/arm64/mssqlodbc.dll",),
-    "linux_x86_64": (f"{_LIBS}/linux/glibc/x86_64/lib/mssqlodbc.so",),
-    "linux_aarch64": (f"{_LIBS}/linux/glibc/arm64/lib/mssqlodbc.so",),
+    "manylinux_2_34_x86_64": (f"{_LIBS}/linux/glibc/x86_64/lib/mssqlodbc.so",),
+    "manylinux_2_34_aarch64": (f"{_LIBS}/linux/glibc/arm64/lib/mssqlodbc.so",),
     "musllinux_1_2_x86_64": (f"{_LIBS}/linux/musl/x86_64/lib/mssqlodbc.so",),
     "musllinux_1_2_aarch64": (f"{_LIBS}/linux/musl/arm64/lib/mssqlodbc.so",),
     "macosx_15_0_universal2": (
@@ -116,9 +116,11 @@ def test_validator_rejects_missing_odbc_driver(tmp_path: Path) -> None:
 
 def test_validator_rejects_wrong_case_odbc_driver(tmp_path: Path) -> None:
     wheels = write_wheel_matrix(tmp_path)
-    linux_wheel = next(wheel for wheel in wheels if "cp310-cp310-linux_x86_64" in wheel.name)
+    linux_wheel = next(
+        wheel for wheel in wheels if "cp310-cp310-manylinux_2_34_x86_64" in wheel.name
+    )
     linux_wheel.unlink()
-    write_wheel(tmp_path, "linux_x86_64", python_tag="cp310", uppercase_odbc=True)
+    write_wheel(tmp_path, "manylinux_2_34_x86_64", python_tag="cp310", uppercase_odbc=True)
 
     result = run_validator(tmp_path)
 
@@ -211,11 +213,29 @@ def test_validator_rejects_same_count_with_unexpected_wheel(tmp_path: Path) -> N
 
 def test_validator_rejects_wrong_case_wheel_filename(tmp_path: Path) -> None:
     wheels = write_wheel_matrix(tmp_path)
-    linux_wheel = next(wheel for wheel in wheels if "cp310-cp310-linux_x86_64" in wheel.name)
-    uppercase_name = linux_wheel.name.replace("linux", "LINUX")
+    linux_wheel = next(
+        wheel for wheel in wheels if "cp310-cp310-manylinux_2_34_x86_64" in wheel.name
+    )
+    uppercase_name = linux_wheel.name.replace("cp310", "CP310")
     linux_wheel.rename(linux_wheel.with_name(uppercase_name))
 
     result = run_validator(tmp_path)
 
     assert result.returncode != 0
     assert "Wheel matrix mismatch" in result.stderr
+
+
+def test_validator_rejects_non_pypi_linux_tag(tmp_path: Path) -> None:
+    wheels = write_wheel_matrix(tmp_path)
+    manylinux_wheel = next(
+        wheel for wheel in wheels if "cp310-cp310-manylinux_2_34_x86_64" in wheel.name
+    )
+    manylinux_wheel.unlink()
+    write_wheel(tmp_path, "linux_x86_64", python_tag="cp310", include_odbc=False)
+
+    result = run_validator(tmp_path)
+
+    normalized = "".join(result.stderr.split())
+    assert result.returncode != 0
+    assert "linux_x86_64" in normalized
+    assert "PyPIrejects" in normalized


### PR DESCRIPTION
## Summary

PyPI rejects the bare `linux_x86_64` and `linux_aarch64` platform tags that maturin emits for the glibc `mssql-python-rs` wheels (built with `auditwheel = "skip"`). Warehouse's upload handler returns HTTP 400 (`unsupported platform tag`) for those tags, so 10 of the 34 wheels in the matrix cannot be published. This is the producer-side prerequisite for publishing to PyPI (#532), which must consume genuinely manylinux-compatible artifacts.

The ODBC driver (`mssqlodbc.so`) is injected into each wheel *after* the maturin build, so repair has to run on the final wheel — not at build time. This change runs `auditwheel repair` on the glibc wheels after injection, resolving the native dependencies of both the PyO3 extension and the embedded `mssqlodbc.so`, and retagging them `manylinux_2_34_*`.

### Changes

- **`scripts/repair-glibc-wheels-in-container.sh`** (new): runs `auditwheel repair --plat manylinux_2_34_<arch>` on the bare `linux_*` wheels in a wheels dir; leaves musllinux and non-linux wheels untouched.
- **`.pipeline/OneBranch/stages.yml`**: adds a containerized repair step after ODBC injection for Linux x64 and ARM64, using the matching manylinux build image.
- **`.pipeline/scripts/verify-python-wheels.ps1`**: expected matrix now uses `manylinux_2_34_{x86_64,aarch64}`; adds a PyPI platform-tag preflight that rejects bare `linux_*` tags before publication.
- **`scripts/test_verify_python_wheels.py`**: fixtures updated to the manylinux tags; adds a regression test asserting bare `linux_*` tags are rejected. `test_release_pipeline.py` reuses this matrix, so it is covered transitively.
- **`mssql-py-core/pyproject.toml`**: clarifies why maturin's build-time auditwheel stays skipped (repair runs post-injection).

### Validation

- `python -m pytest scripts/test_verify_python_wheels.py` — 13 passed (includes the new preflight regression).
- `python -m pytest scripts/test_release_pipeline.py scripts/test_inject_odbc.py` — 63 passed (1 pre-existing, unrelated ANSI-wrapping assertion failure on Windows, tracked separately).
- PowerShell parse + `bash -n` + `git diff --check` clean.
- The container `auditwheel repair` step itself must be validated in CI (draft): it depends on the manylinux image runtime and the injected driver's resolvable dependencies.

### Dependency

Prerequisite for #532 (Publish official Python wheels to PyPI). #532 stays a byte-for-byte consumer and should rebase onto this once merged, since the shared `verify-python-wheels.ps1` is also used by the Official Build.

<!-- Link the work item below, e.g. AB#<id> -->
