### PR TITLE
mssql-odbc: Enforce SQL_ATTR_QUERY_TIMEOUT for catalog functions, SQLGetTypeInfo and SQLDescribeParam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,20 +121,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
-- `mssql-odbc`: `SQL_ATTR_QUERY_TIMEOUT` is now enforced for the catalog
-  functions (`SQLTables`, `SQLColumns`, `SQLPrimaryKeys`, `SQLForeignKeys`,
-  `SQLSpecialColumns`, `SQLStatistics`, `SQLProcedures`, `SQLProcedureColumns`,
-  `SQLTablePrivileges`, `SQLColumnPrivileges`), `SQLGetTypeInfo` and
-  `SQLDescribeParam`. These passed a hard-coded "no timeout" to both their
-  pre-execute steps and the RPC itself, so a configured timeout bounded
-  nothing — including the row reads on the result set they open, because the
-  budget is carried on the connection for the lifetime of the batch. A blocked
-  catalog query could therefore wait forever where msodbcsql returns `HYT00`.
-  msodbcsql runs these through `SQLExecDirectW` (`sqlcdd.cpp:1866`, `:2239`)
-  and `AutoFillIPD` (`sqlcdesc.cpp:9379`), all applying the same statement
-  timeout; the ODBC reference also documents `HYT00` for every catalog function
-  and `SQLGetTypeInfo`, naming this attribute as its source. `0` (the ODBC
-  default) still means unlimited.
+- `mssql-odbc`: `SQL_ATTR_QUERY_TIMEOUT` is now enforced for the implemented
+  catalog functions (`SQLTables`, `SQLColumns`, `SQLPrimaryKeys`,
+  `SQLForeignKeys`, `SQLSpecialColumns`, `SQLStatistics`, `SQLProcedures`),
+  `SQLGetTypeInfo` and `SQLDescribeParam`. These passed a hard-coded "no
+  timeout" to both their pre-execute steps and the RPC itself, so a configured
+  timeout bounded nothing — including the row reads on the result set they
+  open, because the budget is carried on the connection for the lifetime of the
+  batch. A blocked catalog query could therefore wait forever where msodbcsql
+  returns `HYT00`. msodbcsql runs these through `SQLExecDirectW`
+  (`sqlcdd.cpp:1866`, `:2239`) and `AutoFillIPD` (`sqlcdesc.cpp:9379`), all
+  applying the same statement timeout; the ODBC reference also documents
+  `HYT00` for every catalog function and `SQLGetTypeInfo`, naming this
+  attribute as its source. `0` (the ODBC default) still means unlimited.
 
 - `mssql-odbc`: the `APP` connection-string keyword is now sent as the TDS login
   application name. It was recognized but ignored, so `APP_NAME()` reported the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- `mssql-odbc`: `SQL_ATTR_QUERY_TIMEOUT` is now enforced for the catalog
+  functions (`SQLTables`, `SQLColumns`, `SQLPrimaryKeys`, `SQLForeignKeys`,
+  `SQLSpecialColumns`, `SQLStatistics`, `SQLProcedures`, `SQLProcedureColumns`,
+  `SQLTablePrivileges`, `SQLColumnPrivileges`), `SQLGetTypeInfo` and
+  `SQLDescribeParam`. These passed a hard-coded "no timeout" to both their
+  pre-execute steps and the RPC itself, so a configured timeout bounded
+  nothing — including the row reads on the result set they open, because the
+  budget is carried on the connection for the lifetime of the batch. A blocked
+  catalog query could therefore wait forever where msodbcsql returns `HYT00`.
+  msodbcsql runs these through `SQLExecDirectW` (`sqlcdd.cpp:1866`, `:2239`)
+  and `AutoFillIPD` (`sqlcdesc.cpp:9379`), all applying the same statement
+  timeout; the ODBC reference also documents `HYT00` for every catalog function
+  and `SQLGetTypeInfo`, naming this attribute as its source. `0` (the ODBC
+  default) still means unlimited.
+
 - `mssql-odbc`: the `APP` connection-string keyword is now sent as the TDS login
   application name. It was recognized but ignored, so `APP_NAME()` reported the
   default `TDSX Rust Client` value without warning that `APP` had been dropped.

--- a/mssql-mock-tds/src/lib.rs
+++ b/mssql-mock-tds/src/lib.rs
@@ -26,8 +26,8 @@ pub mod tds_tls_wrapper;
 pub mod tls_helper;
 
 pub use query_response::{
-    ColumnDefinition, ColumnValue, InfoMessage, LeadingError, QueryRegistry, QueryResponse, Row,
-    SqlDataType, TM_BEGIN_DELAY_KEY, TerminalError,
+    ColumnDefinition, ColumnValue, InfoMessage, LeadingError, QueryRegistry, QueryResponse,
+    RPC_DELAY_KEY, Row, SqlDataType, TM_BEGIN_DELAY_KEY, TerminalError,
 };
 pub use server::{ConnectionInfo, ConnectionStore, MockTdsServer, RedirectionConfig};
 pub use tds_tls_wrapper::TdsTlsWrapper;

--- a/mssql-mock-tds/src/query_response.rs
+++ b/mssql-mock-tds/src/query_response.rs
@@ -311,6 +311,20 @@ impl QueryResponse {
 /// ignored, since `Begin` always acknowledges with an `EnvChange` + `DONE`.
 pub const TM_BEGIN_DELAY_KEY: &str = "__MOCK_TDS_TM_BEGIN_DELAY__";
 
+/// Reserved [`QueryRegistry`] key that delays the mock server's answer to an
+/// RPC request that matched no specific registration.
+///
+/// RPC responses are otherwise matched by finding the registered (upper-cased)
+/// query text inside the request body, which works for `sp_prepexec`-style
+/// calls that carry caller-controlled SQL. It cannot address a call whose
+/// wire text the test does not choose — a catalog procedure, `sp_datatype_info`
+/// or `sp_describe_undeclared_parameters` — because the driver sends those
+/// proc names in lower case. This key delays those instead, so a test can
+/// prove `SQL_ATTR_QUERY_TIMEOUT` bounds the RPC itself rather than only the
+/// steps around it. Like [`TM_BEGIN_DELAY_KEY`], only its
+/// [`QueryResponse::delay`] is consulted.
+pub const RPC_DELAY_KEY: &str = "__MOCK_TDS_RPC_DELAY__";
+
 /// Registry of query responses
 pub struct QueryRegistry {
     responses: HashMap<String, QueryResponse>,

--- a/mssql-mock-tds/src/server.rs
+++ b/mssql-mock-tds/src/server.rs
@@ -11,7 +11,7 @@ use crate::protocol::{
     build_routing_response, build_transaction_manager_response, parse_fedauth_token,
     parse_login7_auth, parse_sql_batch, parse_transaction_manager_request,
 };
-use crate::query_response::{QueryRegistry, TM_BEGIN_DELAY_KEY};
+use crate::query_response::{QueryRegistry, RPC_DELAY_KEY, TM_BEGIN_DELAY_KEY};
 use bytes::BytesMut;
 use native_tls::Identity;
 use std::collections::BTreeMap;
@@ -512,6 +512,23 @@ impl ConnectionProcessor {
                         Some(build_query_result(&response_data))
                     } else {
                         info!("No registered response for RPC request, returning empty result");
+                        // A test can still delay this answer via the reserved
+                        // `RPC_DELAY_KEY`, which is how a catalog /
+                        // `sp_datatype_info` / `sp_describe_undeclared_parameters`
+                        // call — whose lower-case proc name the substring match
+                        // cannot address — is held back long enough to prove
+                        // SQL_ATTR_QUERY_TIMEOUT bounds the RPC itself.
+                        let delay = self
+                            .query_registry
+                            .lock()
+                            .await
+                            .get(RPC_DELAY_KEY)
+                            .and_then(|r| r.delay);
+                        match self.wait_out_delay_or_attention(socket, delay).await? {
+                            DelayOutcome::Attention(ack) => return Ok(Some(ack)),
+                            DelayOutcome::Closed => return Ok(None),
+                            DelayOutcome::Elapsed => {}
+                        }
                         let response = build_done_token(0);
                         let total_length = (PACKET_HEADER_SIZE + response.len()) as u16;
                         let mut packet = BytesMut::with_capacity(total_length as usize);

--- a/mssql-odbc/docs/attributes_plan.md
+++ b/mssql-odbc/docs/attributes_plan.md
@@ -284,26 +284,32 @@ by unit + e2e tests.
 - `SQLGetConnectAttrW` deliberately has **no** arm, so it falls through to
   `HY092` exactly as msodbcsql does (`sqlcmisc.cpp:4378`).
 
-**Enforcement (AB#46385 — delivered):** every statement-scoped wire operation
-threads `StmtState::query_timeout` into `ExecuteOptions::timeout_secs`, so a
-non-zero value bounds the wait for a response: on expiry the client sends
-`ATTENTION` and reports the failure as `HYT00`, matching msodbcsql. `0` (the
-default) stays unlimited — no behavior change for the common case. See
-mssql-rs#439, where the timeout being silently dropped left a blocked statement
-with no client-side escape hatch.
+**Enforcement (AB#46385 — delivered):** the statement-scoped entry points that
+run a wire operation thread `StmtState::query_timeout` into
+`ExecuteOptions::timeout_secs`, so a non-zero value bounds the wait for a
+response: on expiry the client sends `ATTENTION` and reports the failure as
+`HYT00`, matching msodbcsql. `0` (the default) stays unlimited — no behavior
+change for the common case. See mssql-rs#439, where the timeout being silently
+dropped left a blocked statement with no client-side escape hatch.
 
 The covered surface is `SQLExecute` / `SQLExecDirectW` (mssql-rs#442) plus the
-catalog functions, `SQLGetTypeInfoW` and `SQLDescribeParam` (mssql-rs#466) —
-the latter three were left on `ExecuteOptions::default()` by #442 and closed
-separately. The budget lives on the client for the lifetime of the batch
-(`remaining_request_timeout`), so it also bounds the row reads on the result
-set each of these opens; passing `()` disabled it end to end, not just for the
-initial RPC. msodbcsql reaches the same coverage structurally: catalog
+seven implemented catalog functions, `SQLGetTypeInfoW` and `SQLDescribeParam`
+(mssql-rs#466) — the latter group was left on `ExecuteOptions::default()` by
+\#442 and closed separately. The budget lives on the client for the lifetime of
+the batch (`remaining_request_timeout`), so it also bounds the row reads on the
+result set each of these opens; passing `()` disabled it end to end, not just
+for the initial RPC. msodbcsql reaches the same coverage structurally: catalog
 functions and `SQLGetTypeInfo` are executed *through `SQLExecDirectW` itself*
 (`sqlcdd.cpp:1866`, `:2239`) and `SQLDescribeParam` reaches `AutoFillIPD`
 (`sqlcdesc.cpp:9379`), all reading the same `GetQueryTimeOut(lpstmt)`
-(`sqlcprot.h:1607`). `SQLPrepare` needs no wiring here because this driver
-defers the server-side prepare to execute.
+(`sqlcprot.h:1607`). `SQLPrepare` needs no wiring because this driver defers
+the server-side prepare to execute.
+
+**Known exception:** `SQLFreeHandle(SQL_HANDLE_STMT)`'s best-effort
+`sp_unprepare` (`free_handle.rs:497`) still runs unbounded. msodbcsql bounds
+its equivalent in `DropPrepHandle` (`sqlcfunc.cpp:790-830`); closing the gap
+here needs the timeout captured before the statement state is torn down, so it
+is tracked separately by mssql-rs#546 rather than folded into #466.
 
 **Acceptance:** `cursor.timeout = N` in mssql-python stops logging
 "Failed to set query timeout"; value round-trips through get; clamp + `01S02`

--- a/mssql-odbc/docs/attributes_plan.md
+++ b/mssql-odbc/docs/attributes_plan.md
@@ -284,13 +284,26 @@ by unit + e2e tests.
 - `SQLGetConnectAttrW` deliberately has **no** arm, so it falls through to
   `HY092` exactly as msodbcsql does (`sqlcmisc.cpp:4378`).
 
-**Enforcement (AB#46385 — delivered):** `SQLExecute` / `SQLExecDirectW` thread
-`StmtState::query_timeout` into `ExecuteOptions::timeout_secs`, so a non-zero
-value bounds the wait for a response: on expiry the client sends `ATTENTION`
-and reports the failure as `HYT00`, matching msodbcsql. `0` (the default)
-stays unlimited — no behavior change for the common case. See mssql-rs#439,
-where the timeout being silently dropped left a blocked statement with no
-client-side escape hatch.
+**Enforcement (AB#46385 — delivered):** every statement-scoped wire operation
+threads `StmtState::query_timeout` into `ExecuteOptions::timeout_secs`, so a
+non-zero value bounds the wait for a response: on expiry the client sends
+`ATTENTION` and reports the failure as `HYT00`, matching msodbcsql. `0` (the
+default) stays unlimited — no behavior change for the common case. See
+mssql-rs#439, where the timeout being silently dropped left a blocked statement
+with no client-side escape hatch.
+
+The covered surface is `SQLExecute` / `SQLExecDirectW` (mssql-rs#442) plus the
+catalog functions, `SQLGetTypeInfoW` and `SQLDescribeParam` (mssql-rs#466) —
+the latter three were left on `ExecuteOptions::default()` by #442 and closed
+separately. The budget lives on the client for the lifetime of the batch
+(`remaining_request_timeout`), so it also bounds the row reads on the result
+set each of these opens; passing `()` disabled it end to end, not just for the
+initial RPC. msodbcsql reaches the same coverage structurally: catalog
+functions and `SQLGetTypeInfo` are executed *through `SQLExecDirectW` itself*
+(`sqlcdd.cpp:1866`, `:2239`) and `SQLDescribeParam` reaches `AutoFillIPD`
+(`sqlcdesc.cpp:9379`), all reading the same `GetQueryTimeOut(lpstmt)`
+(`sqlcprot.h:1607`). `SQLPrepare` needs no wiring here because this driver
+defers the server-side prepare to execute.
 
 **Acceptance:** `cursor.timeout = N` in mssql-python stops logging
 "Failed to set query timeout"; value round-trips through get; clamp + `01S02`

--- a/mssql-odbc/src/api/catalog.rs
+++ b/mssql-odbc/src/api/catalog.rs
@@ -56,15 +56,19 @@
 //!   this catalog path can honor it; dispatch therefore remains in pattern mode
 //!   (`@fUsePattern = 1` unconditionally below).
 
+use std::time::Instant;
+
 use tracing::{debug, error};
 
+use mssql_tds::connection::tds_client::ExecuteOptions;
 use mssql_tds::datatypes::sql_string::SqlString;
 use mssql_tds::datatypes::sqltypes::SqlType;
 use mssql_tds::error::Error as TdsError;
 use mssql_tds::message::parameters::rpc_parameters::{RpcParameter, StatusFlags};
 
 use super::exec_common::{
-    claim_connection, fail_with_tds, finish_execute, flush_pending_unprepare,
+    claim_connection, deduct_query_timeout, fail_with_tds, finish_execute, flush_pending_unprepare,
+    query_timeout_expired_error,
 };
 use super::odbc_types::{
     SQL_ERROR, SQL_INVALID_HANDLE, SQL_NTS, SqlHandle, SqlReturn, SqlSmallInt, SqlUSmallInt,
@@ -526,7 +530,7 @@ fn run_catalog(
 ) -> SqlReturn {
     let dbc = stmt.parent_dbc();
 
-    {
+    let query_timeout = {
         let Ok(mut stmt_state) = stmt.inner.lock() else {
             error!("{name}: stmt mutex poisoned");
             return SQL_ERROR;
@@ -547,38 +551,87 @@ fn run_catalog(
         stmt_state.prepared = None;
         stmt_state.clear_state(STMT_STATE_PREPARED);
         stmt_state.set_state(STMT_STATE_EXEC_STARTED);
-    }
+        stmt_state.query_timeout
+    };
 
     let mut client = match claim_connection(dbc, stmt, statement_handle, name) {
         Ok(client) => client,
         Err(rc) => return rc,
     };
-    // Catalog functions don't share issue #439's blocked-statement scenario and
-    // are out of scope for the SQL_ATTR_QUERY_TIMEOUT wiring below; `0` keeps
-    // their existing unbounded behavior.
-    flush_pending_unprepare(dbc, stmt, &mut client, name, 0);
+    let budget = query_timeout;
+    let started = Instant::now();
 
-    if let Err(e) = begin_transaction_if_manual(dbc, &mut client, name, 0) {
+    // A catalog function is a result-set-generating statement like any other, so
+    // `SQL_ATTR_QUERY_TIMEOUT` bounds it: msodbcsql runs every one of these
+    // through `SQLExecDirectW` itself (`sqlcdd.cpp:1866`), inheriting
+    // `GetQueryTimeOut(lpstmt)`, and each function's documented SQLSTATE table
+    // lists `HYT00` naming this attribute. `0` (the ODBC default) stays
+    // unlimited. Steps are charged against the *fixed* original budget using
+    // *cumulative* elapsed time, so no step is double-charged and sub-second
+    // remainders accumulate rather than being floored away independently.
+    flush_pending_unprepare(dbc, stmt, &mut client, name, query_timeout);
+
+    let query_timeout = match deduct_query_timeout(budget, started.elapsed()) {
+        Ok(remaining) => remaining,
+        Err(()) => {
+            return fail_with_tds(
+                dbc,
+                stmt,
+                statement_handle,
+                client,
+                &query_timeout_expired_error(),
+            );
+        }
+    };
+
+    if let Err(e) = begin_transaction_if_manual(dbc, &mut client, name, query_timeout) {
         return fail_with_tds(dbc, stmt, statement_handle, client, &e);
     }
+
+    let query_timeout = match deduct_query_timeout(budget, started.elapsed()) {
+        Ok(remaining) => remaining,
+        Err(()) => {
+            return fail_with_tds(
+                dbc,
+                stmt,
+                statement_handle,
+                client,
+                &query_timeout_expired_error(),
+            );
+        }
+    };
 
     let (positional, named) = build_params(false);
     let mut exec_result = dbc.runtime.block_on(client.execute_stored_procedure(
         qualified_proc_name(catalog, proc),
         Some(positional),
         named,
-        (),
+        ExecuteOptions::new().timeout_secs(query_timeout),
     ));
 
     if retry_on_error && matches!(exec_result, Err(TdsError::SqlServerError { .. })) {
         debug!(%proc, "{name}: qualified catalog call failed, retrying unqualified");
         let _ = client.take_info_messages();
+        // The retry is part of the same application-visible call, so it shares
+        // the original budget rather than restarting it.
+        let retry_timeout = match deduct_query_timeout(budget, started.elapsed()) {
+            Ok(remaining) => remaining,
+            Err(()) => {
+                return fail_with_tds(
+                    dbc,
+                    stmt,
+                    statement_handle,
+                    client,
+                    &query_timeout_expired_error(),
+                );
+            }
+        };
         let (retry_positional, retry_named) = build_params(true);
         exec_result = dbc.runtime.block_on(client.execute_stored_procedure(
             qualified_proc_name(&None, proc),
             Some(retry_positional),
             retry_named,
-            (),
+            ExecuteOptions::new().timeout_secs(retry_timeout),
         ));
     }
 
@@ -1815,6 +1868,59 @@ mod tests {
         assert!(is_blank(&None));
         assert!(is_blank(&Some(String::new())));
         assert!(!is_blank(&Some("x".to_string())));
+    }
+
+    /// `SQL_ATTR_QUERY_TIMEOUT` must bound catalog functions, not just
+    /// `SQLExecute`/`SQLExecDirectW`. msodbcsql executes every catalog
+    /// procedure through `SQLExecDirectW` itself (`sqlcdd.cpp:1866`), so they
+    /// inherit `GetQueryTimeOut(lpstmt)`, and all ten functions' documented
+    /// SQLSTATE tables list `HYT00` naming this attribute.
+    ///
+    /// Delays the `sp_tables` RPC response itself (via `RPC_DELAY_KEY`) rather
+    /// than the transaction begin, so this fails if the timeout stops reaching
+    /// the RPC's own `ExecuteOptions` — the regression mssql-rs#466 describes,
+    /// where passing `()` left `remaining_request_timeout` unset for the whole
+    /// batch and left the row reads unbounded too.
+    #[test]
+    fn catalog_query_timeout_bounds_a_longer_server_delay() {
+        use crate::handles::dbc::DbcHandle;
+        use mssql_mock_tds::QueryResponse;
+        use std::time::{Duration, Instant};
+
+        const RESPONSE_DELAY: Duration = Duration::from_secs(8);
+        const STMT_TIMEOUT_SECS: u32 = 1;
+        // Comfortably above STMT_TIMEOUT_SECS plus connection/RTT overhead,
+        // comfortably below RESPONSE_DELAY — the gap is what proves the
+        // statement timeout, not the server delay, ended the wait.
+        const BOUND: Duration = Duration::from_secs(5);
+
+        let h = TestHandles::with_env_dbc_stmt();
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        let mock_server =
+            crate::test_support::connect_mock_server(dbc, "SELECT 1", QueryResponse::select_one());
+        mock_server.set_rpc_delay(RESPONSE_DELAY);
+
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        stmt.inner.lock().unwrap().query_timeout = STMT_TIMEOUT_SECS;
+
+        let started = Instant::now();
+        // No catalog argument, so the unqualified-retry path stays off and the
+        // single delayed RPC is what the timeout has to bound.
+        let ret = sql_tables_w_safe(h.stmt, stmt, None, None, None, None);
+        let elapsed = started.elapsed();
+
+        assert_eq!(ret, SQL_ERROR);
+        assert!(
+            elapsed < BOUND,
+            "SQLTablesW took {elapsed:?} — a {STMT_TIMEOUT_SECS}s SQL_ATTR_QUERY_TIMEOUT must \
+             bound the wait well below the server's {RESPONSE_DELAY:?} delay"
+        );
+        let state = stmt.inner.lock().unwrap();
+        assert_eq!(
+            state.diag_records[0].sql_state, *b"HYT00",
+            "a query-timeout expiry must report HYT00, got {:?}",
+            state.diag_records[0].sql_state
+        );
     }
 
     #[test]

--- a/mssql-odbc/src/api/catalog.rs
+++ b/mssql-odbc/src/api/catalog.rs
@@ -1942,6 +1942,58 @@ mod tests {
         );
     }
 
+    /// A best-effort `sp_unprepare` that eats the whole `SQL_ATTR_QUERY_TIMEOUT`
+    /// must stop the catalog call, not let it proceed unbounded.
+    ///
+    /// `flush_pending_unprepare` swallows its own timeout (a leaked handle must
+    /// not fail the caller), so it is the one pre-execute step that can survive
+    /// exhausting the budget — which is exactly why every call site re-checks
+    /// with `deduct_query_timeout` afterwards. This drives that arm: the
+    /// statement is armed with a pending unprepare, the mock holds the RPC well
+    /// past the budget, and the call must report `HYT00` *before* sending the
+    /// catalog procedure rather than starting it with no bound.
+    #[test]
+    fn catalog_query_timeout_exhausted_by_unprepare_fails_before_sending() {
+        use crate::handles::dbc::DbcHandle;
+        use mssql_mock_tds::QueryResponse;
+        use std::time::{Duration, Instant};
+
+        const RESPONSE_DELAY: Duration = Duration::from_secs(8);
+        const STMT_TIMEOUT_SECS: u32 = 1;
+        // A sanity bound, not the discriminator: the call must finish far
+        // inside the server's delay. What this test actually pins down is the
+        // budget-exhausted arm itself — a bypassed deduction also fails fast
+        // here, so that would not show up as a timing difference.
+        const BOUND: Duration = Duration::from_secs(5);
+
+        let h = TestHandles::with_env_dbc_stmt();
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        let mock_server =
+            crate::test_support::connect_mock_server(dbc, "SELECT 1", QueryResponse::select_one());
+        mock_server.set_rpc_delay(RESPONSE_DELAY);
+
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        crate::test_support::arm_pending_unprepare(dbc, stmt);
+        stmt.inner.lock().unwrap().query_timeout = STMT_TIMEOUT_SECS;
+
+        let started = Instant::now();
+        let ret = sql_tables_w_safe(h.stmt, stmt, None, None, None, None);
+        let elapsed = started.elapsed();
+
+        assert_eq!(ret, SQL_ERROR);
+        assert!(
+            elapsed < BOUND,
+            "SQLTablesW took {elapsed:?} — the {STMT_TIMEOUT_SECS}s budget was already spent by \
+             the unprepare, so the catalog RPC must not have been sent at all"
+        );
+        let state = stmt.inner.lock().unwrap();
+        assert_eq!(
+            state.diag_records[0].sql_state, *b"HYT00",
+            "an exhausted budget must report HYT00, got {:?}",
+            state.diag_records[0].sql_state
+        );
+    }
+
     /// `SQL_ATTR_QUERY_TIMEOUT` must bound catalog functions, not just
     /// `SQLExecute`/`SQLExecDirectW`. msodbcsql executes every catalog
     /// procedure through `SQLExecDirectW` itself (`sqlcdd.cpp:1866`), so they

--- a/mssql-odbc/src/api/catalog.rs
+++ b/mssql-odbc/src/api/catalog.rs
@@ -613,15 +613,25 @@ fn run_catalog(
         debug!(%proc, "{name}: qualified catalog call failed, retrying unqualified");
         let _ = client.take_info_messages();
         // The retry is part of the same application-visible call, so it shares
-        // the original budget rather than restarting it.
+        // the original budget with whole-second accounting, rather than
+        // restarting the full configured timeout.
+        //
+        // "Shares the budget" is not an exact 1x wall-clock cap:
+        // `deduct_query_timeout` floors elapsed time to whole seconds, so a
+        // first attempt that fails after 900ms charges nothing and the retry
+        // gets another full second — about 1.9s against a 1s timeout. What is
+        // guaranteed is that the retry draws down the *same* budget, so the
+        // overshoot is bounded by the sub-second remainder rather than
+        // doubling.
         //
         // DIVERGES from msodbcsql, deliberately: its retry is a recursive
         // `DoDD` (`sqlcdd.cpp:1894`) whose re-entered `SQLExecDirectW` re-reads
         // the *undeducted* `GetQueryTimeOut(lpstmt)`, so there the retry starts
-        // from a fresh full budget and a two-attempt call can take 2x the
-        // configured timeout. Capping at 1x keeps the attribute's documented
-        // meaning — the caller's deadline for the call they made — rather than
-        // letting a driver-internal fallback double it. Tracked by mssql-rs#547.
+        // from a genuinely fresh budget and a two-attempt call can take a full
+        // 2x the configured timeout. Sharing the budget keeps the attribute's
+        // documented meaning — the caller's deadline for the call they made —
+        // rather than letting a driver-internal fallback double it. Tracked by
+        // mssql-rs#547.
         //
         // The gate above, by contrast, MATCHES msodbcsql: only a server error
         // retries, never a timeout or transport failure, mirroring its
@@ -2003,6 +2013,87 @@ mod tests {
             "the budget must be found exhausted before the RPC is sent, not by the RPC's own \
              timeout: {}",
             state.diag_records[0].message
+        );
+    }
+
+    /// The catalog dispatcher's unqualified retry must share the original
+    /// budget, and must report the qualified attempt's own server error when
+    /// that budget is gone.
+    ///
+    /// Reaching this needs a first attempt that *returns a server error* (only
+    /// that enters the retry branch) while cumulative elapsed time still floors
+    /// to the whole budget. Those pull in opposite directions — an RPC that
+    /// outlives its own remaining budget times out instead of returning — so it
+    /// is only reachable when an earlier step contributes a *fractional* second:
+    /// the pending unprepare spends ~0.6s of the 1s budget (flooring to 0, so
+    /// the qualified call still gets a full second), that call then fails at
+    /// ~0.6s, and the ~1.2s total floors to 1 and exhausts the budget before
+    /// the retry is sent.
+    ///
+    /// The two attempts are told apart without any new mock surface: only the
+    /// qualified name carries the catalog (`[CATALOG].sys.sp_tables` vs the
+    /// retry's `[sys].sp_tables`), so a response registered under the catalog
+    /// name answers the first call only and the retry would fall through to the
+    /// unmatched bare-DONE success. That is what makes this mutation-resistant
+    /// in both directions: letting the retry restart from the full budget
+    /// (msodbcsql's behavior — see mssql-rs#547) makes the call *succeed*,
+    /// failing the `SQL_ERROR` assertion, while reporting `HYT00` here instead
+    /// of the original error fails the native-error assertion.
+    #[test]
+    fn catalog_retry_budget_exhausted_reports_the_original_server_error() {
+        use crate::handles::dbc::DbcHandle;
+        use mssql_mock_tds::{QueryResponse, TerminalError};
+        use std::time::Duration;
+
+        // Spends a sub-second slice of the budget per wire call: one call
+        // floors to 0 (so the qualified call still gets the full second and can
+        // return), but two together floor to 1 and exhaust it.
+        const WIRE_DELAY: Duration = Duration::from_millis(600);
+        const STMT_TIMEOUT_SECS: u32 = 1;
+        const INVALID_OBJECT_NAME: u32 = 208;
+        // Upper-case because `QueryRegistry::register` upper-cases its key and
+        // then matches it against the raw request bytes.
+        const CATALOG: &str = "ZZQUALIFIEDZZ";
+
+        let h = TestHandles::with_env_dbc_stmt();
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        // Answers the qualified `[ZZQUALIFIEDZZ].sys.sp_tables` call only.
+        let mock_server = crate::test_support::connect_mock_server(
+            dbc,
+            CATALOG,
+            QueryResponse::error_only(TerminalError::new(
+                INVALID_OBJECT_NAME,
+                16,
+                "Invalid object name 'sp_tables'.",
+            ))
+            .with_delay(WIRE_DELAY),
+        );
+        // Everything else — the pending unprepare, and the retry if it were
+        // ever sent — is unmatched, and only delayed.
+        mock_server.set_rpc_delay(WIRE_DELAY);
+
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        crate::test_support::arm_pending_unprepare(dbc, stmt);
+        stmt.inner.lock().unwrap().query_timeout = STMT_TIMEOUT_SECS;
+
+        // A non-blank catalog is what turns the unqualified retry on.
+        let ret = sql_tables_w_safe(h.stmt, stmt, Some(CATALOG.to_string()), None, None, None);
+
+        assert_eq!(
+            ret, SQL_ERROR,
+            "the retry must not run on an exhausted budget; had it run, the \
+             unmatched mock would have answered it with success"
+        );
+        let state = stmt.inner.lock().unwrap();
+        assert_eq!(
+            state.diag_records[0].native_error, INVALID_OBJECT_NAME as i32,
+            "the qualified attempt's own server error must be reported, not the \
+             budget expiry that stopped the retry: {:?} / {}",
+            state.diag_records[0].sql_state, state.diag_records[0].message
+        );
+        assert_ne!(
+            state.diag_records[0].sql_state, *b"HYT00",
+            "a server error must not be replaced by HYT00"
         );
     }
 

--- a/mssql-odbc/src/api/catalog.rs
+++ b/mssql-odbc/src/api/catalog.rs
@@ -1960,10 +1960,10 @@ mod tests {
 
         const RESPONSE_DELAY: Duration = Duration::from_secs(8);
         const STMT_TIMEOUT_SECS: u32 = 1;
-        // A sanity bound, not the discriminator: the call must finish far
-        // inside the server's delay. What this test actually pins down is the
-        // budget-exhausted arm itself — a bypassed deduction also fails fast
-        // here, so that would not show up as a timing difference.
+        // A sanity bound only. The real discriminator is the message
+        // assertion below: timing cannot separate the two paths, because a
+        // bypassed deduction just lets the RPC time out on its own budget
+        // and reproduce HYT00 just as quickly.
         const BOUND: Duration = Duration::from_secs(5);
 
         let h = TestHandles::with_env_dbc_stmt();
@@ -1991,6 +1991,18 @@ mod tests {
             state.diag_records[0].sql_state, *b"HYT00",
             "an exhausted budget must report HYT00, got {:?}",
             state.diag_records[0].sql_state
+        );
+        // This is what makes the test mutation-resistant: the two paths carry
+        // different text. Reaching the RPC and timing out there yields
+        // "Elapsed: deadline has elapsed", so only the pre-send budget check
+        // produces this message.
+        assert!(
+            state.diag_records[0]
+                .message
+                .contains("expired before the statement could be sent"),
+            "the budget must be found exhausted before the RPC is sent, not by the RPC's own \
+             timeout: {}",
+            state.diag_records[0].message
         );
     }
 

--- a/mssql-odbc/src/api/catalog.rs
+++ b/mssql-odbc/src/api/catalog.rs
@@ -614,16 +614,31 @@ fn run_catalog(
         let _ = client.take_info_messages();
         // The retry is part of the same application-visible call, so it shares
         // the original budget rather than restarting it.
+        //
+        // DIVERGES from msodbcsql, deliberately: its retry is a recursive
+        // `DoDD` (`sqlcdd.cpp:1894`) whose re-entered `SQLExecDirectW` re-reads
+        // the *undeducted* `GetQueryTimeOut(lpstmt)`, so there the retry starts
+        // from a fresh full budget and a two-attempt call can take 2x the
+        // configured timeout. Capping at 1x keeps the attribute's documented
+        // meaning — the caller's deadline for the call they made — rather than
+        // letting a driver-internal fallback double it. Tracked by mssql-rs#547.
+        //
+        // The gate above, by contrast, MATCHES msodbcsql: only a server error
+        // retries, never a timeout or transport failure, mirroring its
+        // `wStdErr != IDS_S1_T00_1` check (`sqlcdd.cpp:1883`).
         let retry_timeout = match deduct_query_timeout(budget, started.elapsed()) {
             Ok(remaining) => remaining,
             Err(()) => {
-                return fail_with_tds(
-                    dbc,
-                    stmt,
-                    statement_handle,
-                    client,
-                    &query_timeout_expired_error(),
-                );
+                // The budget ran out before the fallback could run. Report the
+                // qualified attempt's own server error rather than `HYT00`:
+                // "invalid object name" is far more actionable than "the budget
+                // ran out on a retry the application never asked for", and that
+                // error is otherwise dropped here along with the info messages
+                // discarded above. (msodbcsql cannot reach this state, since
+                // its retry never re-checks the budget — see mssql-rs#547.)
+                let original = exec_result.expect_err("matches! above proved this is an Err");
+                error!(%original, "{name}: query timeout expired before the unqualified retry");
+                return fail_with_tds(dbc, stmt, statement_handle, client, &original);
             }
         };
         let (retry_positional, retry_named) = build_params(true);
@@ -1870,11 +1885,69 @@ mod tests {
         assert!(!is_blank(&Some("x".to_string())));
     }
 
+    /// `SQL_ATTR_QUERY_TIMEOUT` must also bound the implicit transaction begin
+    /// `begin_transaction_if_manual` sends before a catalog RPC when the
+    /// connection is in manual-commit mode — AB#46385's AC2 makes the
+    /// pre-execute steps a first-class requirement, and AC5 requires each
+    /// covered entry point to be mutation-resistant.
+    ///
+    /// The sibling test above only delays the RPC response, so it guards the
+    /// `ExecuteOptions` half and nothing else: reverting the pre-execute
+    /// arguments back to `0` left the whole suite green. This delays only the
+    /// server's answer to the Begin request, so it fails if the wiring into
+    /// `flush_pending_unprepare` / `begin_transaction_if_manual` regresses even
+    /// though the RPC step itself is untouched — mirroring
+    /// `exec_direct_query_timeout_bounds_a_delayed_implicit_transaction_begin`.
+    #[test]
+    fn catalog_query_timeout_bounds_a_delayed_implicit_transaction_begin() {
+        use crate::handles::dbc::DbcHandle;
+        use mssql_mock_tds::QueryResponse;
+        use std::time::{Duration, Instant};
+
+        const BEGIN_DELAY: Duration = Duration::from_secs(8);
+        const STMT_TIMEOUT_SECS: u32 = 1;
+        // Comfortably above STMT_TIMEOUT_SECS plus connection/RTT overhead,
+        // comfortably below BEGIN_DELAY — the gap is what proves the statement
+        // timeout, not the server delay, ended the wait.
+        const BOUND: Duration = Duration::from_secs(5);
+
+        let h = TestHandles::with_env_dbc_stmt();
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        let mock_server =
+            crate::test_support::connect_mock_server(dbc, "SELECT 1", QueryResponse::select_one());
+        mock_server.set_tm_begin_delay(BEGIN_DELAY);
+        // Manual-commit mode with no transaction open yet is what makes
+        // `begin_transaction_if_manual` send a real Begin request instead of
+        // returning immediately.
+        dbc.inner.lock().unwrap().autocommit = false;
+
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        stmt.inner.lock().unwrap().query_timeout = STMT_TIMEOUT_SECS;
+
+        let started = Instant::now();
+        let ret = sql_tables_w_safe(h.stmt, stmt, None, None, None, None);
+        let elapsed = started.elapsed();
+
+        assert_eq!(ret, SQL_ERROR);
+        assert!(
+            elapsed < BOUND,
+            "SQLTablesW took {elapsed:?} — a {STMT_TIMEOUT_SECS}s SQL_ATTR_QUERY_TIMEOUT must \
+             bound the implicit transaction begin well below the server's {BEGIN_DELAY:?} delay"
+        );
+        let state = stmt.inner.lock().unwrap();
+        assert_eq!(
+            state.diag_records[0].sql_state, *b"HYT00",
+            "a query-timeout expiry must report HYT00, got {:?}",
+            state.diag_records[0].sql_state
+        );
+    }
+
     /// `SQL_ATTR_QUERY_TIMEOUT` must bound catalog functions, not just
     /// `SQLExecute`/`SQLExecDirectW`. msodbcsql executes every catalog
     /// procedure through `SQLExecDirectW` itself (`sqlcdd.cpp:1866`), so they
-    /// inherit `GetQueryTimeOut(lpstmt)`, and all ten functions' documented
-    /// SQLSTATE tables list `HYT00` naming this attribute.
+    /// inherit `GetQueryTimeOut(lpstmt)`, and all ten ODBC catalog functions'
+    /// reference pages list `HYT00` naming this attribute (this crate
+    /// implements seven of them).
     ///
     /// Delays the `sp_tables` RPC response itself (via `RPC_DELAY_KEY`) rather
     /// than the transaction begin, so this fails if the timeout stops reaching

--- a/mssql-odbc/src/api/catalog.rs
+++ b/mssql-odbc/src/api/catalog.rs
@@ -2047,7 +2047,12 @@ mod tests {
 
         // Spends a sub-second slice of the budget per wire call: one call
         // floors to 0 (so the qualified call still gets the full second and can
-        // return), but two together floor to 1 and exhaust it.
+        // return), but two together floor to 1 and exhaust it. That confines
+        // this to `0.5s <= delay + overhead < 1s`; measured here at 606ms after
+        // the unprepare and 1217ms at the retry check, i.e. ~6ms of overhead
+        // per call, so the sleeps dominate. Only the first bound is
+        // load-sensitive — a slow machine grows both figures, which pushes the
+        // second one further past its floor.
         const WIRE_DELAY: Duration = Duration::from_millis(600);
         const STMT_TIMEOUT_SECS: u32 = 1;
         const INVALID_OBJECT_NAME: u32 = 208;

--- a/mssql-odbc/src/api/describe_param.rs
+++ b/mssql-odbc/src/api/describe_param.rs
@@ -948,6 +948,67 @@ mod tests {
         );
     }
 
+    /// The `SQLDescribeParam` counterpart to `catalog.rs`'s
+    /// `catalog_query_timeout_exhausted_by_unprepare_fails_before_sending`:
+    /// a swallowed best-effort unprepare timeout must leave the budget
+    /// exhausted and stop the call before the metadata RPC is sent.
+    #[test]
+    fn describe_param_query_timeout_exhausted_by_unprepare_fails_before_sending() {
+        use crate::handles::dbc::DbcHandle;
+        use mssql_mock_tds::QueryResponse;
+        use std::time::{Duration, Instant};
+
+        const RESPONSE_DELAY: Duration = Duration::from_secs(8);
+        const STMT_TIMEOUT_SECS: u32 = 1;
+        // A sanity bound, not the discriminator: the call must finish far
+        // inside the server's delay. What this test actually pins down is the
+        // budget-exhausted arm itself — a bypassed deduction also fails fast
+        // here, so that would not show up as a timing difference.
+        const BOUND: Duration = Duration::from_secs(5);
+
+        let h = TestHandles::with_env_dbc_stmt();
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        let mock_server =
+            crate::test_support::connect_mock_server(dbc, "SELECT 1", QueryResponse::select_one());
+        mock_server.set_rpc_delay(RESPONSE_DELAY);
+
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        crate::test_support::arm_pending_unprepare(dbc, stmt);
+        {
+            let mut state = stmt.inner.lock().unwrap();
+            state.prepared = Some(crate::handles::stmt::PreparedPlan {
+                stmt: PreparedStatement::new("SELECT @P1".to_string()),
+                marker_count: 1,
+            });
+            state.query_timeout = STMT_TIMEOUT_SECS;
+        }
+
+        let started = Instant::now();
+        let rc = sql_describe_param_safe(
+            h.stmt,
+            stmt,
+            1,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        );
+        let elapsed = started.elapsed();
+
+        assert_eq!(rc, SQL_ERROR);
+        assert!(
+            elapsed < BOUND,
+            "SQLDescribeParam took {elapsed:?} — the {STMT_TIMEOUT_SECS}s budget was already \
+             spent by the unprepare, so the metadata RPC must not have been sent at all"
+        );
+        let state = stmt.inner.lock().unwrap();
+        assert_eq!(
+            state.diag_records[0].sql_state, *b"HYT00",
+            "an exhausted budget must report HYT00, got {:?}",
+            state.diag_records[0].sql_state
+        );
+    }
+
     #[test]
     fn invalid_ordinal_returns_07009_without_io() {
         let h = TestHandles::with_env_dbc_stmt();

--- a/mssql-odbc/src/api/describe_param.rs
+++ b/mssql-odbc/src/api/describe_param.rs
@@ -1007,6 +1007,18 @@ mod tests {
             "an exhausted budget must report HYT00, got {:?}",
             state.diag_records[0].sql_state
         );
+        // This is what makes the test mutation-resistant: the two paths carry
+        // different text. Reaching the RPC and timing out there yields
+        // "Elapsed: deadline has elapsed", so only the pre-send budget check
+        // produces this message.
+        assert!(
+            state.diag_records[0]
+                .message
+                .contains("expired before the statement could be sent"),
+            "the budget must be found exhausted before the RPC is sent, not by the RPC's own \
+             timeout: {}",
+            state.diag_records[0].message
+        );
     }
 
     #[test]

--- a/mssql-odbc/src/api/describe_param.rs
+++ b/mssql-odbc/src/api/describe_param.rs
@@ -3,9 +3,11 @@
 
 //! Implementation of SQLDescribeParam.
 
+use std::time::Instant;
+
 use tracing::{debug, error};
 
-use mssql_tds::connection::tds_client::ResultSet;
+use mssql_tds::connection::tds_client::{ExecuteOptions, ResultSet};
 use mssql_tds::datatypes::column_values::ColumnValues;
 use mssql_tds::datatypes::sql_string::SqlString;
 use mssql_tds::datatypes::sqldatatypes::TdsDataType;
@@ -13,7 +15,8 @@ use mssql_tds::datatypes::sqltypes::SqlType;
 use mssql_tds::message::parameters::rpc_parameters::{RpcParameter, StatusFlags};
 
 use super::exec_common::{
-    claim_connection, fail_with_tds, flush_pending_unprepare, return_client_idle,
+    claim_connection, deduct_query_timeout, fail_with_tds, flush_pending_unprepare,
+    query_timeout_expired_error, return_client_idle,
 };
 use super::odbc_types::*;
 use super::sqlstate::*;
@@ -127,7 +130,7 @@ fn sql_describe_param_safe(
         env_state.odbc_version != OdbcVersion::Odbc2
     };
 
-    let (sql, marker_count) = {
+    let (sql, marker_count, query_timeout) = {
         let Ok(mut stmt_state) = stmt.inner.lock() else {
             error!("SQLDescribeParam: stmt mutex poisoned");
             return SQL_ERROR;
@@ -183,27 +186,61 @@ fn sql_describe_param_safe(
 
         let sql = plan.stmt.sql().to_string();
         stmt_state.set_state(STMT_STATE_EXEC_STARTED);
-        (sql, marker_count)
+        (sql, marker_count, stmt_state.query_timeout)
     };
 
     let mut client = match claim_connection(dbc, stmt, statement_handle, "SQLDescribeParam") {
         Ok(client) => client,
         Err(rc) => return rc,
     };
-    // Not SQLExecute/SQLExecDirectW, so out of scope for the
-    // SQL_ATTR_QUERY_TIMEOUT wiring; `0` keeps existing unbounded behavior.
-    flush_pending_unprepare(dbc, stmt, &mut client, "SQLDescribeParam", 0);
+    let budget = query_timeout;
+    let started = Instant::now();
 
-    if let Err(e) = begin_transaction_if_manual(dbc, &mut client, "SQLDescribeParam", 0) {
+    // `sp_describe_undeclared_parameters` is a real server round trip, so
+    // `SQL_ATTR_QUERY_TIMEOUT` bounds it. The ODBC reference page for
+    // SQLDescribeParam does not list `HYT00`, but msodbcsql bounds this path
+    // regardless — `SQLDescribeParam` reaches `AutoFillIPD`, which reads
+    // `GetQueryTimeOut(lpstmt)` (`sqlcdesc.cpp:9379`) — so matching it is a
+    // parity requirement, not a discretionary extra. `0` stays unlimited.
+    flush_pending_unprepare(dbc, stmt, &mut client, "SQLDescribeParam", query_timeout);
+
+    let query_timeout = match deduct_query_timeout(budget, started.elapsed()) {
+        Ok(remaining) => remaining,
+        Err(()) => {
+            return fail_with_tds(
+                dbc,
+                stmt,
+                statement_handle,
+                client,
+                &query_timeout_expired_error(),
+            );
+        }
+    };
+
+    if let Err(e) = begin_transaction_if_manual(dbc, &mut client, "SQLDescribeParam", query_timeout)
+    {
         return fail_with_tds(dbc, stmt, statement_handle, client, &e);
     }
+
+    let query_timeout = match deduct_query_timeout(budget, started.elapsed()) {
+        Ok(remaining) => remaining,
+        Err(()) => {
+            return fail_with_tds(
+                dbc,
+                stmt,
+                statement_handle,
+                client,
+                &query_timeout_expired_error(),
+            );
+        }
+    };
 
     let command = RpcParameter::new(None, StatusFlags::NONE, metadata_request_value(sql));
     let execute_result = dbc.runtime.block_on(client.execute_stored_procedure(
         DESCRIBE_PARAMETERS_PROC.to_string(),
         Some(vec![command]),
         None,
-        (),
+        ExecuteOptions::new().timeout_secs(query_timeout),
     ));
     if let Err(e) = execute_result {
         error!(%e, "SQLDescribeParam: metadata RPC failed");
@@ -784,6 +821,71 @@ mod tests {
         assert_eq!(
             stmt.inner.lock().unwrap().diag_records[0].sql_state,
             SQLSTATE_HY010
+        );
+    }
+
+    /// `SQL_ATTR_QUERY_TIMEOUT` must bound `SQLDescribeParam`'s
+    /// `sp_describe_undeclared_parameters` round trip.
+    ///
+    /// The ODBC reference page for `SQLDescribeParam` does not list `HYT00`,
+    /// but msodbcsql bounds this path anyway — `SQLDescribeParam` reaches
+    /// `AutoFillIPD`, which reads `GetQueryTimeOut(lpstmt)`
+    /// (`sqlcdesc.cpp:9379`) — so matching it is a parity requirement, not a
+    /// discretionary extra. Delays the RPC response itself (via
+    /// `RPC_DELAY_KEY`), so this fails if the timeout stops reaching the RPC's
+    /// own `ExecuteOptions` (mssql-rs#466).
+    #[test]
+    fn describe_param_query_timeout_bounds_a_longer_server_delay() {
+        use crate::handles::dbc::DbcHandle;
+        use mssql_mock_tds::QueryResponse;
+        use std::time::{Duration, Instant};
+
+        const RESPONSE_DELAY: Duration = Duration::from_secs(8);
+        const STMT_TIMEOUT_SECS: u32 = 1;
+        // Comfortably above STMT_TIMEOUT_SECS plus connection/RTT overhead,
+        // comfortably below RESPONSE_DELAY — the gap is what proves the
+        // statement timeout, not the server delay, ended the wait.
+        const BOUND: Duration = Duration::from_secs(5);
+
+        let h = TestHandles::with_env_dbc_stmt();
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        let mock_server =
+            crate::test_support::connect_mock_server(dbc, "SELECT 1", QueryResponse::select_one());
+        mock_server.set_rpc_delay(RESPONSE_DELAY);
+
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        {
+            let mut state = stmt.inner.lock().unwrap();
+            state.prepared = Some(crate::handles::stmt::PreparedPlan {
+                stmt: PreparedStatement::new("SELECT @P1".to_string()),
+                marker_count: 1,
+            });
+            state.query_timeout = STMT_TIMEOUT_SECS;
+        }
+
+        let started = Instant::now();
+        let rc = sql_describe_param_safe(
+            h.stmt,
+            stmt,
+            1,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        );
+        let elapsed = started.elapsed();
+
+        assert_eq!(rc, SQL_ERROR);
+        assert!(
+            elapsed < BOUND,
+            "SQLDescribeParam took {elapsed:?} — a {STMT_TIMEOUT_SECS}s SQL_ATTR_QUERY_TIMEOUT \
+             must bound the wait well below the server's {RESPONSE_DELAY:?} delay"
+        );
+        let state = stmt.inner.lock().unwrap();
+        assert_eq!(
+            state.diag_records[0].sql_state, *b"HYT00",
+            "a query-timeout expiry must report HYT00, got {:?}",
+            state.diag_records[0].sql_state
         );
     }
 

--- a/mssql-odbc/src/api/describe_param.rs
+++ b/mssql-odbc/src/api/describe_param.rs
@@ -889,6 +889,65 @@ mod tests {
         );
     }
 
+    /// The AC2 counterpart to the test above: `SQL_ATTR_QUERY_TIMEOUT` must
+    /// also bound the implicit transaction begin that precedes the metadata
+    /// RPC. The sibling only delays the RPC response, so reverting the
+    /// pre-execute arguments to `0` left it green; this delays only the Begin
+    /// request.
+    #[test]
+    fn describe_param_query_timeout_bounds_a_delayed_implicit_transaction_begin() {
+        use crate::handles::dbc::DbcHandle;
+        use mssql_mock_tds::QueryResponse;
+        use std::time::{Duration, Instant};
+
+        const BEGIN_DELAY: Duration = Duration::from_secs(8);
+        const STMT_TIMEOUT_SECS: u32 = 1;
+        const BOUND: Duration = Duration::from_secs(5);
+
+        let h = TestHandles::with_env_dbc_stmt();
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        let mock_server =
+            crate::test_support::connect_mock_server(dbc, "SELECT 1", QueryResponse::select_one());
+        mock_server.set_tm_begin_delay(BEGIN_DELAY);
+        dbc.inner.lock().unwrap().autocommit = false;
+
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        {
+            let mut state = stmt.inner.lock().unwrap();
+            state.prepared = Some(crate::handles::stmt::PreparedPlan {
+                stmt: PreparedStatement::new("SELECT @P1".to_string()),
+                marker_count: 1,
+            });
+            state.query_timeout = STMT_TIMEOUT_SECS;
+        }
+
+        let started = Instant::now();
+        let rc = sql_describe_param_safe(
+            h.stmt,
+            stmt,
+            1,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        );
+        let elapsed = started.elapsed();
+
+        assert_eq!(rc, SQL_ERROR);
+        assert!(
+            elapsed < BOUND,
+            "SQLDescribeParam took {elapsed:?} — a {STMT_TIMEOUT_SECS}s SQL_ATTR_QUERY_TIMEOUT \
+             must bound the implicit transaction begin well below the server's \
+             {BEGIN_DELAY:?} delay"
+        );
+        let state = stmt.inner.lock().unwrap();
+        assert_eq!(
+            state.diag_records[0].sql_state, *b"HYT00",
+            "a query-timeout expiry must report HYT00, got {:?}",
+            state.diag_records[0].sql_state
+        );
+    }
+
     #[test]
     fn invalid_ordinal_returns_07009_without_io() {
         let h = TestHandles::with_env_dbc_stmt();

--- a/mssql-odbc/src/api/free_handle.rs
+++ b/mssql-odbc/src/api/free_handle.rs
@@ -493,6 +493,12 @@ fn best_effort_unprepare_on_free_inner(
 
     // `unprepare` skips a handle from a superseded session (already gone
     // server-side) and releases a live one.
+    //
+    // `()` leaves this unbounded by `SQL_ATTR_QUERY_TIMEOUT`, unlike every
+    // other statement-scoped wire operation. msodbcsql bounds its equivalent
+    // (`DropPrepHandle`, `sqlcfunc.cpp:790-830`); doing the same here needs the
+    // statement's timeout captured before its state is torn down, so it is
+    // tracked by mssql-rs#546 rather than papered over here.
     for statement_id in handles {
         if let Err(e) = dbc.runtime.block_on(client.unprepare(statement_id, ())) {
             error!(%e, "SQLFreeHandle(STMT): sp_unprepare failed — handle leaked until disconnect");

--- a/mssql-odbc/src/api/get_type_info.rs
+++ b/mssql-odbc/src/api/get_type_info.rs
@@ -11,13 +11,17 @@
 //! reference driver so this crate is a drop-in replacement behind the same
 //! Driver Manager.
 
+use std::time::Instant;
+
 use tracing::{debug, error};
 
+use mssql_tds::connection::tds_client::ExecuteOptions;
 use mssql_tds::datatypes::sqltypes::SqlType;
 use mssql_tds::message::parameters::rpc_parameters::{RpcParameter, StatusFlags};
 
 use super::exec_common::{
-    claim_connection, fail_with_tds, finish_execute, flush_pending_unprepare,
+    claim_connection, deduct_query_timeout, fail_with_tds, finish_execute, flush_pending_unprepare,
+    query_timeout_expired_error,
 };
 use super::sqlstate::*;
 use super::txn::begin_transaction_if_manual;
@@ -114,7 +118,7 @@ fn sql_get_type_info_w_safe(
     // Validate the requested type and reset prior context under the stmt lock.
     // Validation runs before any state mutation so an invalid type leaves the
     // statement unchanged, matching msodbcsql.
-    {
+    let query_timeout = {
         let Ok(mut stmt_state) = stmt.inner.lock() else {
             error!("SQLGetTypeInfoW: stmt mutex poisoned");
             return SQL_ERROR;
@@ -157,7 +161,8 @@ fn sql_get_type_info_w_safe(
         stmt_state.parameter_metadata.clear();
         stmt_state.clear_state(STMT_STATE_PREPARED);
         stmt_state.set_state(STMT_STATE_EXEC_STARTED);
-    }
+        stmt_state.query_timeout
+    };
 
     // `@data_type` is positional; 2.x applications receive the 2.x date/time id.
     let positional = vec![RpcParameter::new(
@@ -181,21 +186,52 @@ fn sql_get_type_info_w_safe(
         Ok(client) => client,
         Err(rc) => return rc,
     };
+    let budget = query_timeout;
+    let started = Instant::now();
 
     // Release any handle orphaned by the reset above before running the RPC.
-    // Not SQLExecute/SQLExecDirectW, so out of scope for the
-    // SQL_ATTR_QUERY_TIMEOUT wiring; `0` keeps existing unbounded behavior.
-    flush_pending_unprepare(dbc, stmt, &mut client, "SQLGetTypeInfoW", 0);
+    // `SQL_ATTR_QUERY_TIMEOUT` bounds this call: msodbcsql runs SQLGetTypeInfo
+    // through `SQLExecDirectW` itself (`sqlcdd.cpp:2239`), inheriting
+    // `GetQueryTimeOut(lpstmt)`, and the function's documented SQLSTATE table
+    // lists `HYT00` naming this attribute. `0` (the default) stays unlimited.
+    flush_pending_unprepare(dbc, stmt, &mut client, "SQLGetTypeInfoW", query_timeout);
 
-    if let Err(e) = begin_transaction_if_manual(dbc, &mut client, "SQLGetTypeInfoW", 0) {
+    let query_timeout = match deduct_query_timeout(budget, started.elapsed()) {
+        Ok(remaining) => remaining,
+        Err(()) => {
+            return fail_with_tds(
+                dbc,
+                stmt,
+                statement_handle,
+                client,
+                &query_timeout_expired_error(),
+            );
+        }
+    };
+
+    if let Err(e) = begin_transaction_if_manual(dbc, &mut client, "SQLGetTypeInfoW", query_timeout)
+    {
         return fail_with_tds(dbc, stmt, statement_handle, client, &e);
     }
+
+    let query_timeout = match deduct_query_timeout(budget, started.elapsed()) {
+        Ok(remaining) => remaining,
+        Err(()) => {
+            return fail_with_tds(
+                dbc,
+                stmt,
+                statement_handle,
+                client,
+                &query_timeout_expired_error(),
+            );
+        }
+    };
 
     let exec_result = dbc.runtime.block_on(client.execute_stored_procedure(
         DATATYPE_INFO_PROC.to_string(),
         Some(positional),
         named,
-        (),
+        ExecuteOptions::new().timeout_secs(query_timeout),
     ));
     if let Err(e) = exec_result {
         error!(%e, "SQLGetTypeInfoW: execution failed");
@@ -357,6 +393,57 @@ mod tests {
     fn null_handle_returns_invalid_handle() {
         let ret = unsafe { sql_get_type_info_w(SQL_NULL_HANDLE, SQL_ALL_TYPES) };
         assert_eq!(ret, SQL_INVALID_HANDLE);
+    }
+
+    /// `SQL_ATTR_QUERY_TIMEOUT` must bound `SQLGetTypeInfo`, not just
+    /// `SQLExecute`/`SQLExecDirectW`. msodbcsql runs this function through
+    /// `SQLExecDirectW` itself (`sqlcdd.cpp:2239`), so it inherits
+    /// `GetQueryTimeOut(lpstmt)`, and the function's documented SQLSTATE table
+    /// lists `HYT00` naming this attribute.
+    ///
+    /// The delay is applied to the `sp_datatype_info_100` RPC response itself
+    /// (via `RPC_DELAY_KEY`), not to the transaction begin, so this fails if
+    /// the timeout stops reaching the RPC's own `ExecuteOptions` — the exact
+    /// regression mssql-rs#466 describes, where passing `()` left
+    /// `remaining_request_timeout` unset for the whole batch.
+    #[test]
+    fn get_type_info_query_timeout_bounds_a_longer_server_delay() {
+        use crate::handles::dbc::DbcHandle;
+        use mssql_mock_tds::QueryResponse;
+        use std::time::{Duration, Instant};
+
+        const RESPONSE_DELAY: Duration = Duration::from_secs(8);
+        const STMT_TIMEOUT_SECS: u32 = 1;
+        // Comfortably above STMT_TIMEOUT_SECS plus connection/RTT overhead,
+        // comfortably below RESPONSE_DELAY — the gap is what proves the
+        // statement timeout, not the server delay, ended the wait.
+        const BOUND: Duration = Duration::from_secs(5);
+
+        let h = TestHandles::with_env_dbc_stmt();
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        let mock_server =
+            crate::test_support::connect_mock_server(dbc, "SELECT 1", QueryResponse::select_one());
+        mock_server.set_rpc_delay(RESPONSE_DELAY);
+
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        stmt.inner.lock().unwrap().query_timeout = STMT_TIMEOUT_SECS;
+
+        let started = Instant::now();
+        let ret = sql_get_type_info_w_safe(h.stmt, stmt, SQL_ALL_TYPES);
+        let elapsed = started.elapsed();
+
+        assert_eq!(ret, SQL_ERROR);
+        assert!(
+            elapsed < BOUND,
+            "SQLGetTypeInfoW took {elapsed:?} — a {STMT_TIMEOUT_SECS}s SQL_ATTR_QUERY_TIMEOUT \
+             must bound the wait well below the server's {RESPONSE_DELAY:?} delay"
+        );
+        let state = stmt.inner.lock().unwrap();
+        assert_eq!(
+            state.diag_records[0].sql_state, *b"HYT00",
+            "a query-timeout expiry must report HYT00, got {:?}",
+            state.diag_records[0].sql_state
+        );
     }
 
     #[test]

--- a/mssql-odbc/src/api/get_type_info.rs
+++ b/mssql-odbc/src/api/get_type_info.rs
@@ -446,6 +446,49 @@ mod tests {
         );
     }
 
+    /// The AC2 counterpart to the test above: `SQL_ATTR_QUERY_TIMEOUT` must
+    /// also bound the implicit transaction begin that precedes the RPC. The
+    /// sibling only delays the RPC response, so reverting the pre-execute
+    /// arguments to `0` left it green; this delays only the Begin request.
+    #[test]
+    fn get_type_info_query_timeout_bounds_a_delayed_implicit_transaction_begin() {
+        use crate::handles::dbc::DbcHandle;
+        use mssql_mock_tds::QueryResponse;
+        use std::time::{Duration, Instant};
+
+        const BEGIN_DELAY: Duration = Duration::from_secs(8);
+        const STMT_TIMEOUT_SECS: u32 = 1;
+        const BOUND: Duration = Duration::from_secs(5);
+
+        let h = TestHandles::with_env_dbc_stmt();
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        let mock_server =
+            crate::test_support::connect_mock_server(dbc, "SELECT 1", QueryResponse::select_one());
+        mock_server.set_tm_begin_delay(BEGIN_DELAY);
+        dbc.inner.lock().unwrap().autocommit = false;
+
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        stmt.inner.lock().unwrap().query_timeout = STMT_TIMEOUT_SECS;
+
+        let started = Instant::now();
+        let ret = sql_get_type_info_w_safe(h.stmt, stmt, SQL_ALL_TYPES);
+        let elapsed = started.elapsed();
+
+        assert_eq!(ret, SQL_ERROR);
+        assert!(
+            elapsed < BOUND,
+            "SQLGetTypeInfoW took {elapsed:?} — a {STMT_TIMEOUT_SECS}s SQL_ATTR_QUERY_TIMEOUT \
+             must bound the implicit transaction begin well below the server's \
+             {BEGIN_DELAY:?} delay"
+        );
+        let state = stmt.inner.lock().unwrap();
+        assert_eq!(
+            state.diag_records[0].sql_state, *b"HYT00",
+            "a query-timeout expiry must report HYT00, got {:?}",
+            state.diag_records[0].sql_state
+        );
+    }
+
     #[test]
     fn exported_wrapper_forwards_to_impl() {
         // Exercise the extern "C" entrypoint (init_tracing + delegation) rather

--- a/mssql-odbc/src/api/get_type_info.rs
+++ b/mssql-odbc/src/api/get_type_info.rs
@@ -501,10 +501,10 @@ mod tests {
 
         const RESPONSE_DELAY: Duration = Duration::from_secs(8);
         const STMT_TIMEOUT_SECS: u32 = 1;
-        // A sanity bound, not the discriminator: the call must finish far
-        // inside the server's delay. What this test actually pins down is the
-        // budget-exhausted arm itself — a bypassed deduction also fails fast
-        // here, so that would not show up as a timing difference.
+        // A sanity bound only. The real discriminator is the message
+        // assertion below: timing cannot separate the two paths, because a
+        // bypassed deduction just lets the RPC time out on its own budget
+        // and reproduce HYT00 just as quickly.
         const BOUND: Duration = Duration::from_secs(5);
 
         let h = TestHandles::with_env_dbc_stmt();
@@ -532,6 +532,18 @@ mod tests {
             state.diag_records[0].sql_state, *b"HYT00",
             "an exhausted budget must report HYT00, got {:?}",
             state.diag_records[0].sql_state
+        );
+        // This is what makes the test mutation-resistant: the two paths carry
+        // different text. Reaching the RPC and timing out there yields
+        // "Elapsed: deadline has elapsed", so only the pre-send budget check
+        // produces this message.
+        assert!(
+            state.diag_records[0]
+                .message
+                .contains("expired before the statement could be sent"),
+            "the budget must be found exhausted before the RPC is sent, not by the RPC's own \
+             timeout: {}",
+            state.diag_records[0].message
         );
     }
 

--- a/mssql-odbc/src/api/get_type_info.rs
+++ b/mssql-odbc/src/api/get_type_info.rs
@@ -489,6 +489,52 @@ mod tests {
         );
     }
 
+    /// The `SQLGetTypeInfo` counterpart to `catalog.rs`'s
+    /// `catalog_query_timeout_exhausted_by_unprepare_fails_before_sending`:
+    /// a swallowed best-effort unprepare timeout must leave the budget
+    /// exhausted and stop the call before the type-info RPC is sent.
+    #[test]
+    fn get_type_info_query_timeout_exhausted_by_unprepare_fails_before_sending() {
+        use crate::handles::dbc::DbcHandle;
+        use mssql_mock_tds::QueryResponse;
+        use std::time::{Duration, Instant};
+
+        const RESPONSE_DELAY: Duration = Duration::from_secs(8);
+        const STMT_TIMEOUT_SECS: u32 = 1;
+        // A sanity bound, not the discriminator: the call must finish far
+        // inside the server's delay. What this test actually pins down is the
+        // budget-exhausted arm itself — a bypassed deduction also fails fast
+        // here, so that would not show up as a timing difference.
+        const BOUND: Duration = Duration::from_secs(5);
+
+        let h = TestHandles::with_env_dbc_stmt();
+        let dbc = unsafe { handle_from_raw::<DbcHandle>(h.dbc) };
+        let mock_server =
+            crate::test_support::connect_mock_server(dbc, "SELECT 1", QueryResponse::select_one());
+        mock_server.set_rpc_delay(RESPONSE_DELAY);
+
+        let stmt = unsafe { handle_from_raw::<StmtHandle>(h.stmt) };
+        crate::test_support::arm_pending_unprepare(dbc, stmt);
+        stmt.inner.lock().unwrap().query_timeout = STMT_TIMEOUT_SECS;
+
+        let started = Instant::now();
+        let ret = sql_get_type_info_w_safe(h.stmt, stmt, SQL_ALL_TYPES);
+        let elapsed = started.elapsed();
+
+        assert_eq!(ret, SQL_ERROR);
+        assert!(
+            elapsed < BOUND,
+            "SQLGetTypeInfoW took {elapsed:?} — the {STMT_TIMEOUT_SECS}s budget was already spent \
+             by the unprepare, so the type-info RPC must not have been sent at all"
+        );
+        let state = stmt.inner.lock().unwrap();
+        assert_eq!(
+            state.diag_records[0].sql_state, *b"HYT00",
+            "an exhausted budget must report HYT00, got {:?}",
+            state.diag_records[0].sql_state
+        );
+    }
+
     #[test]
     fn exported_wrapper_forwards_to_impl() {
         // Exercise the extern "C" entrypoint (init_tracing + delegation) rather

--- a/mssql-odbc/src/test_support.rs
+++ b/mssql-odbc/src/test_support.rs
@@ -283,6 +283,24 @@ impl MockServer {
             );
         });
     }
+
+    /// Registers a delay for the server's answer to any RPC request that
+    /// matched no specific registration.
+    ///
+    /// The substring match `connect_mock_server`'s `query` relies on can only
+    /// address RPCs whose wire text the test chooses (`sp_prepexec`'s `@stmt`).
+    /// Catalog procedures, `sp_datatype_info_100` and
+    /// `sp_describe_undeclared_parameters` are named by the driver in lower
+    /// case, so this is how a test holds *those* responses back long enough to
+    /// prove `SQL_ATTR_QUERY_TIMEOUT` bounds the RPC itself.
+    pub(crate) fn set_rpc_delay(&self, delay: std::time::Duration) {
+        self.server_runtime.block_on(async {
+            self.query_registry.lock().await.register(
+                mssql_mock_tds::RPC_DELAY_KEY,
+                mssql_mock_tds::QueryResponse::select_one().with_delay(delay),
+            );
+        });
+    }
 }
 
 impl Drop for MockServer {

--- a/mssql-odbc/src/test_support.rs
+++ b/mssql-odbc/src/test_support.rs
@@ -303,6 +303,33 @@ impl MockServer {
     }
 }
 
+/// Arms `stmt` with a pending `sp_unprepare` that will actually reach the wire.
+///
+/// `flush_pending_unprepare` runs before every statement-scoped operation and
+/// is deliberately best-effort: it logs a failure — including a timeout — and
+/// returns normally. That is exactly why each call site re-checks the budget
+/// afterwards, and it is the only step whose timeout can be *survived*, so it
+/// is the one way a test can reach those "budget exhausted before the statement
+/// could be sent" arms deterministically rather than by racing a stopwatch.
+///
+/// `TdsClient::unprepare` skips the round trip when it holds no handle for the
+/// id, so the handle is registered on the live client and the id it issues is
+/// parked on the statement.
+pub(crate) fn arm_pending_unprepare(
+    dbc: &crate::handles::dbc::DbcHandle,
+    stmt: &crate::handles::StmtHandle,
+) {
+    let statement_id = {
+        let mut dbc_state = dbc.inner.lock().unwrap();
+        dbc_state
+            .client
+            .as_mut()
+            .expect("connect_mock_server installs a live client")
+            .register_prepared_handle_for_test(1)
+    };
+    stmt.inner.lock().unwrap().pending_unprepare = Some(statement_id);
+}
+
 impl Drop for MockServer {
     fn drop(&mut self) {
         if let Some(tx) = self.shutdown_tx.take() {


### PR DESCRIPTION
## Description

[#442](https://github.com/microsoft/mssql-rs/pull/442) wired `SQL_ATTR_QUERY_TIMEOUT` into `SQLExecute` / `SQLExecDirectW`, but three statement-scoped entry points still passed a hard-coded `0` to their pre-execute steps and `()` (i.e. `ExecuteOptions::default()`) to the RPC itself:

- `catalog.rs` — the seven implemented catalog functions (`SQLTables`, `SQLColumns`, `SQLPrimaryKeys`, `SQLForeignKeys`, `SQLSpecialColumns`, `SQLStatistics`, `SQLProcedures`)
- `get_type_info.rs` — `SQLGetTypeInfoW`
- `describe_param.rs` — `SQLDescribeParam`

**The gap was wider than #466's text describes.** The issue proposes threading the timeout into `flush_pending_unprepare` / `begin_transaction_if_manual` only. That alone would not have fixed it: the budget lives on the client as `remaining_request_timeout` for the lifetime of the batch (`tds_client.rs:2749` seeds it from `ExecuteOptions`; every read draws it down via `request_timeout_start` / `update_remaining_timeout`), so passing `()` left the RPC **and every row read on the result set it opens** unbounded. A configured timeout bounded nothing at all on these paths.

This PR threads the statement's `query_timeout` through all three, deducting from a **fixed original budget using cumulative elapsed time** — the arithmetic #442's review settled, so no step is double-charged and sub-second remainders don't get floored away independently.

`0` (the ODBC default) still means unlimited, so the common case is unchanged.

## msodbcsql parity

Verified against the msodbcsql source rather than inferred. `GetQueryTimeOut(lpstmt)` is `lpstmt->dwQueryTimeoutInMS` (`sqlcprot.h:1607`) — a field on the statement every layer reads — so msodbcsql's coverage is uniform by construction:

| Path | msodbcsql |
|---|---|
| Catalog functions | executed **through `SQLExecDirectW` itself** (`sqlcdd.cpp:1866`; the file's own comment at `:1387` says "the SP call is made with SQLExecDirectW") |
| `SQLGetTypeInfo` | same, `sqlcdd.cpp:2239` |
| `SQLDescribeParam` | `GetIPDRec` (`sqlcdesc.cpp:7839`) → `AutoFillIPD` (`:7900`) → `GetQueryTimeOut` (`:9379`) |

The ODBC reference agrees for the first two: all ten ODBC catalog functions' reference pages and `SQLGetTypeInfo`'s document `HYT00` and explicitly name `SQL_ATTR_QUERY_TIMEOUT` as its source (this crate implements seven of the ten), and [Executing Catalog Functions](https://learn.microsoft.com/en-us/sql/odbc/reference/develop-app/executing-catalog-functions) states *"almost anything that applies to SQL statements that create result sets also applies to catalog functions."*

`SQLDescribeParam` is worth calling out: its reference page does **not** list `HYT00`, so on the docs alone it would look discretionary. msodbcsql bounds it anyway via `AutoFillIPD`, so matching it is a parity requirement, not an extra.

`SQLPrepare` also documents `HYT00` but needs no wiring here — `prepare.rs:27` defers the server-side prepare to execute, so it performs no wire I/O.

### Deliberate divergence: the catalog retry budget

When a qualified catalog call fails with a server error, `run_catalog` retries it unqualified. This PR makes that retry **share the original budget** rather than restarting the full configured timeout, so the two attempts draw down one budget instead of two.

msodbcsql does not: its retry is a recursive `DoDD` (`sqlcdd.cpp:1894`) whose re-entered `SQLExecDirectW` re-reads the *undeducted* `GetQueryTimeOut(lpstmt)`, so the retry starts from a genuinely fresh budget and a two-attempt call can take a full **2x** the configured timeout. Sharing the budget keeps the attribute's documented meaning rather than letting a driver-internal fallback double the caller's deadline. Flagged inline per the repo's match/exceed/diverge rule and tracked by #547.

Note on precision: "shares the budget" is not an exact 1x wall-clock cap. `deduct_query_timeout` floors elapsed time to whole seconds, so a first attempt failing at 900ms charges nothing and the retry receives another full second — about 1.9s against a 1s timeout. The guarantee is that both attempts draw down the *same* budget, bounding the overshoot by the sub-second remainder rather than doubling it. (An earlier revision of this description said "capped at 1x"; corrected after review.)

The retry *gate* — only a `SqlServerError` retries, never a timeout or transport failure — **matches** msodbcsql's `wStdErr != IDS_S1_T00_1` check (`sqlcdd.cpp:1883`; `IDS_S1_T00_1` is "Query timeout expired"). Called out explicitly because it looks accidental and isn't.

### Known exception

`SQLFreeHandle(SQL_HANDLE_STMT)`'s best-effort `sp_unprepare` (`free_handle.rs:497`) is still unbounded. msodbcsql bounds its equivalent in `DropPrepHandle` (`sqlcfunc.cpp:790-830`); closing it needs the timeout captured before the statement state is torn down, so it's tracked by #546 with a pointer at the call site rather than folded in here. `attributes_plan.md` says so too, instead of claiming blanket coverage.

## Test infrastructure

Added a reserved `RPC_DELAY_KEY` to `mssql-mock-tds`, mirroring the existing `TM_BEGIN_DELAY_KEY`. The registry matches RPC responses by finding the registered **upper-cased** query text inside the request body, which works for `sp_prepexec`-style calls carrying caller-chosen SQL but cannot address a proc the *driver* names in lower case (`sp_tables`, `sp_datatype_info_100`, `sp_describe_undeclared_parameters`).

Seven new tests: two per entry point — one delaying the **RPC response** (guarding the `ExecuteOptions` half) and one delaying the **implicit transaction begin** (guarding the pre-execute half, AC2) — plus three covering the budget-exhausted arms and one covering the catalog retry.

**Both halves are mutation-resistant, verified separately.** Reverting only the RPC wiring to `()` fails the three RPC tests; reverting only the six pre-execute arguments to `0` fails the three begin tests. Each failure takes the full 8s server delay, proving the path was genuinely unbounded:

```
# RPC wiring reverted:
FAIL [ 8.161s] describe_param_query_timeout_bounds_a_longer_server_delay
FAIL [ 8.176s] catalog_query_timeout_bounds_a_longer_server_delay
FAIL [ 8.190s] get_type_info_query_timeout_bounds_a_longer_server_delay

# pre-execute wiring reverted:
FAIL [ 8.175s] catalog_query_timeout_bounds_a_delayed_implicit_transaction_begin
FAIL [ 8.252s] get_type_info_query_timeout_bounds_a_delayed_implicit_transaction_begin
FAIL [ 8.286s] describe_param_query_timeout_bounds_a_delayed_implicit_transaction_begin
```

The second set was added in response to review: the first three alone left the pre-execute half completely uncovered.

The three `exhausted_by_unprepare` tests pin the budget-exhausted arms. Because `flush_pending_unprepare` is best-effort and *swallows* its timeout, it is the only pre-execute step that can survive exhausting the budget — which makes those arms reachable deterministically instead of by racing a stopwatch. They discriminate on **message text**, not timing: the pre-send check reports "SQL_ATTR_QUERY_TIMEOUT expired before the statement could be sent" whereas the RPC's own expiry reports "Elapsed: deadline has elapsed", so deleting the deduction fails all three at ~2.15s (two timeouts).

A seventh test, `catalog_retry_budget_exhausted_reports_the_original_server_error`, covers the unqualified-retry branch — which no timeout test entered, since the others pass no catalog argument. Reaching it is narrow: the first attempt must *return a server error* while cumulative elapsed still floors to the whole budget, and an RPC outliving its remaining budget times out rather than returning. It is therefore only reachable when an earlier step contributes a *fractional* second, so the pending unprepare spends ~0.6s of a 1s budget (flooring to 0) and the qualified call fails at ~0.6s, flooring the ~1.2s total to 1. No new mock surface was needed: only the qualified name carries the catalog (`[CATALOG].sys.sp_tables` vs the retry's `[sys].sp_tables`), so a response registered under the catalog name answers the first call only. It discriminates both ways — restarting the retry from the full budget makes the call *succeed* (1.95s vs 1.37s, the extra round trip), and reporting `HYT00` instead of the original error fails the native-error assertion.

## Docs

`attributes_plan.md` claimed "Enforcement ([AB#46385](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46385) — delivered)" unqualified while three entry points were still unbound. Corrected to state the actual covered surface, plus the `free_handle` exception.

## Related Issues

Closes #466

[AB#46385](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46385)

Acceptance criteria for [AB#46385](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/46385) were sharpened before this change (rev 16) so the enforcement surface is explicit rather than implied; this PR satisfies AC1–AC3, AC5 and AC6. AC4 is a non-regression check owned by [AB#47454](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47454) and is unaffected. Follow-ups filed during review: #546, #547.

## Validation

- `cargo bfmt` — clean.
- `cargo clippy --workspace --frozen --all-features --all-targets -- -D warnings` — clean.
- `cargo nextest run -p mssqlodbc -p mssql-mock-tds --all-targets` — **1447 passed, 0 failed**.
- `cargo nextest run -p mssql-tds -E 'binary(test_mock_server) or binary(test_shared_single_worker_runtime)'` — 14/15 passed. The one failure, `test_strict_encryption_with_server_certificate`, is **pre-existing and unrelated**: it needs locally-generated test certificates (`scripts/generate_mock_tds_server_certs.ps1`) that aren't present in this environment. Confirmed by stashing this branch's changes and reproducing the identical failure on a clean tree.
- Live-server `mssql-tds` tests were not run — no SQL Server credentials in this environment.

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [x] `cargo btest` passes (scoped to touched crates; see Validation for the one pre-existing, environment-dependent failure)
- [x] New/changed functionality has tests
- [x] Public API changes are documented (`RPC_DELAY_KEY` is new public surface on `mssql-mock-tds`, a test-only crate, and carries a doc comment explaining when to reach for it over the substring match)