### PR TITLE
Optimize parameterized queries and row decoding in mssql-js

### DIFF
--- a/mssql-js/__test__/db.mjs
+++ b/mssql-js/__test__/db.mjs
@@ -14,9 +14,14 @@ export async function openConnection(context) {
 }
 
 export async function createContext() {
+  const port = Number(process.env.DB_PORT ?? 1433);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error('DB_PORT must be an integer between 1 and 65535');
+  }
+
   const context = {
     serverName: process.env.DB_HOST || 'localhost',
-    port: 1433,
+    port,
     userName: process.env.DB_USER || 'sa',
     password: await getPassword(),
     database: 'master',

--- a/mssql-js/__test__/integration/query/parameterized_queries.spec.mjs
+++ b/mssql-js/__test__/integration/query/parameterized_queries.spec.mjs
@@ -1,0 +1,256 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import test from 'ava';
+import { createContext, openConnection } from '../../db.mjs';
+import { Request } from '../../../dist/index.js';
+import { TYPES } from '../../../dist/datatypes/types.js';
+
+const TDS_INTN = 0x26;
+
+function recordSet(rows, columns) {
+  return Object.assign(rows, { columns, rowCount: rows.length });
+}
+
+function assertResult(t, actual, recordSets) {
+  t.deepEqual(actual, {
+    IRecordSets: recordSets,
+    IRecordSet: recordSets[0] ?? null,
+    rowCount: recordSets.reduce((total, rows) => total + rows.length, 0),
+    output: {},
+  });
+  t.is(actual.IRecordSet, actual.IRecordSets[0] ?? null);
+}
+
+test('parameterized query preserves scalar, null, and Unicode values', async (t) => {
+  const connection = await openConnection(await createContext());
+  try {
+    const label = "O'Brien \u2014 \u6771\u4eac";
+    const request = new Request(connection);
+    request.input('value', TYPES.Int, 42);
+    request.input('@nullable', TYPES.Int, null);
+    request.input('label', TYPES.NVarChar(40), label);
+
+    const result = await request.query(
+      'SELECT @value AS value, @nullable AS nullable_value, @label AS label',
+    );
+
+    assertResult(t, result, [
+      recordSet(
+        [{ value: 42, nullable_value: null, label }],
+        [
+          { index: 0, name: 'value', type: TDS_INTN },
+          { index: 1, name: 'nullable_value', type: TDS_INTN },
+          { index: 2, name: 'label', type: TYPES.NVarChar(40).sqlType },
+        ],
+      ),
+    ]);
+  } finally {
+    await connection.close();
+  }
+});
+
+test('parameterized empty result set preserves column metadata', async (t) => {
+  const connection = await openConnection(await createContext());
+  try {
+    const request = new Request(connection);
+    request.input('value', TYPES.Int, 42);
+
+    const result = await request.query(`
+      SELECT @value AS value, CAST(@value AS nvarchar(16)) AS label
+      WHERE 1 = 0
+    `);
+
+    assertResult(t, result, [
+      recordSet(
+        [],
+        [
+          { index: 0, name: 'value', type: TDS_INTN },
+          { index: 1, name: 'label', type: TYPES.NVarChar(16).sqlType },
+        ],
+      ),
+    ]);
+  } finally {
+    await connection.close();
+  }
+});
+
+test('parameterized query collects rows after leading DML and no-row statements', async (t) => {
+  const connection = await openConnection(await createContext());
+  try {
+    const request = new Request(connection);
+    request.input('value', TYPES.Int, 42);
+
+    const result = await request.query(`
+      SET NOCOUNT OFF;
+      DECLARE @rows TABLE (value int);
+      INSERT INTO @rows (value) VALUES (@value), (@value + 1);
+      UPDATE @rows SET value = value + 1;
+      SELECT value FROM @rows ORDER BY value;
+      DELETE FROM @rows;
+    `);
+
+    assertResult(t, result, [
+      recordSet(
+        [{ value: 43 }, { value: 44 }],
+        [{ index: 0, name: 'value', type: TDS_INTN }],
+      ),
+    ]);
+  } finally {
+    await connection.close();
+  }
+});
+
+test('parameterized multiple results preserve empty sets and anonymous columns', async (t) => {
+  const connection = await openConnection(await createContext());
+  try {
+    const request = new Request(connection);
+    request.input('value', TYPES.Int, 42);
+
+    const result = await request.query(`
+      SET NOCOUNT ON;
+      SELECT @value AS first_empty WHERE 1 = 0;
+      SELECT @value AS named, @value + 1, CAST(NULL AS int), @value + 2;
+      SELECT @value AS middle_empty WHERE 1 = 0;
+      SELECT @value + 3;
+      SELECT @value AS last_empty WHERE 1 = 0;
+    `);
+
+    assertResult(t, result, [
+      recordSet([], [{ index: 0, name: 'first_empty', type: TDS_INTN }]),
+      recordSet(
+        [{ named: 42, '': [43, null, 44] }],
+        [
+          { index: 0, name: 'named', type: TDS_INTN },
+          { index: 1, name: '', type: undefined },
+        ],
+      ),
+      recordSet([], [{ index: 0, name: 'middle_empty', type: TDS_INTN }]),
+      recordSet([{ '': 45 }], [{ index: 0, name: '', type: undefined }]),
+      recordSet([], [{ index: 0, name: 'last_empty', type: TDS_INTN }]),
+    ]);
+  } finally {
+    await connection.close();
+  }
+});
+
+test('parameterized DML-only query returns no recordset and allows connection reuse', async (t) => {
+  const connection = await openConnection(await createContext());
+  try {
+    await new Request(connection).query(
+      'CREATE TABLE #ParameterizedRows (value int)',
+    );
+    const request = new Request(connection);
+    request.input('value', TYPES.Int, 42);
+
+    const result = await request.query(`
+      SET NOCOUNT OFF;
+      INSERT INTO #ParameterizedRows (value) VALUES (@value);
+      UPDATE #ParameterizedRows SET value = @value + 1;
+    `);
+    assertResult(t, result, []);
+
+    const nextResult = await request.query(
+      'SELECT value FROM #ParameterizedRows WHERE value = @value + 1',
+    );
+    assertResult(t, nextResult, [
+      recordSet([{ value: 43 }], [{ index: 0, name: 'value', type: TDS_INTN }]),
+    ]);
+  } finally {
+    await connection.close();
+  }
+});
+
+test('parameterized query buffers more than 256 KiB and collects subsequent results', async (t) => {
+  const connection = await openConnection(await createContext());
+  try {
+    const count = 100_000;
+    const request = new Request(connection);
+    request.input('count', TYPES.Int, count);
+
+    const result = await request.query(`
+      SELECT value FROM GENERATE_SERIES(1, @count) ORDER BY value;
+      SELECT @count AS total;
+    `);
+
+    t.deepEqual(Object.keys(result).sort(), [
+      'IRecordSet',
+      'IRecordSets',
+      'output',
+      'rowCount',
+    ]);
+    t.true(Array.isArray(result.IRecordSets));
+    t.is(result.IRecordSets.length, 2);
+    t.is(result.rowCount, count + 1);
+    t.deepEqual(result.output, {});
+
+    const [rows, totals] = result.IRecordSets;
+    t.true(result.IRecordSet === rows);
+    t.true(Array.isArray(rows));
+    t.is(rows.length, count);
+    t.is(rows.rowCount, count);
+    t.deepEqual(rows.columns, [{ index: 0, name: 'value', type: TDS_INTN }]);
+    const mismatch = rows.findIndex(
+      (row, index) => row.value !== index + 1 || Object.keys(row).length !== 1,
+    );
+    t.is(mismatch, -1, 'Every generated row must contain its ordered integer');
+    t.deepEqual(
+      totals,
+      recordSet(
+        [{ total: count }],
+        [{ index: 0, name: 'total', type: TDS_INTN }],
+      ),
+    );
+  } finally {
+    await connection.close();
+  }
+});
+
+for (const [position, query, message] of [
+  [
+    'before rows',
+    `
+      THROW 51000, N'parameterized error before rows', 1;
+      SELECT @value AS value;
+    `,
+    /parameterized error before rows/,
+  ],
+  [
+    'after rows',
+    `
+      SELECT @value AS value;
+      THROW 51001, N'parameterized error after rows', 1;
+    `,
+    /parameterized error after rows/,
+  ],
+]) {
+  test(`parameterized SQL error ${position} propagates and allows connection reuse`, async (t) => {
+    const connection = await openConnection(await createContext());
+    try {
+      const request = new Request(connection);
+      request.input('value', TYPES.Int, 42);
+
+      await t.throwsAsync(() => request.query(query), { message });
+
+      const nextResult = await request.query('SELECT @value AS value');
+      assertResult(t, nextResult, [
+        recordSet(
+          [{ value: 42 }],
+          [{ index: 0, name: 'value', type: TDS_INTN }],
+        ),
+      ]);
+
+      const unparameterizedResult = await new Request(connection).query(
+        'SELECT 7 AS value',
+      );
+      assertResult(t, unparameterizedResult, [
+        recordSet(
+          [{ value: 7 }],
+          [{ index: 0, name: 'value', type: TYPES.Int.sqlType }],
+        ),
+      ]);
+    } finally {
+      await connection.close();
+    }
+  });
+}

--- a/mssql-js/__test__/unittests/parameterized_request.spec.mjs
+++ b/mssql-js/__test__/unittests/parameterized_request.spec.mjs
@@ -1,0 +1,304 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import test from 'ava';
+import { Request, SqlJsConnection } from '../../dist/index.js';
+import { TYPES } from '../../dist/datatypes/types.js';
+import { decodeProjectedResult, decodeRawResult } from '../../dist/decode.js';
+
+const TDS_INTN = 0x26;
+
+function intResult(values, type = TDS_INTN) {
+  const header = Buffer.alloc(19);
+  header.writeUInt32LE(0x4d535351, 0);
+  header.writeUInt8(1, 4);
+  header.writeUInt16LE(1, 5);
+  header.writeUInt32LE(values.length, 7);
+  header.writeUInt32LE(24, 11);
+
+  const column = Buffer.alloc(5);
+  column.writeUInt8(type, 4);
+
+  const name = Buffer.from('value');
+  const stringTable = Buffer.alloc(12);
+  stringTable.writeUInt32LE(1, 0);
+  stringTable.writeUInt32LE(name.length, 8);
+
+  const rows = Buffer.alloc(values.length * 5);
+  values.forEach((value, index) => {
+    rows.writeUInt8(4, index * 5);
+    rows.writeInt32LE(value, index * 5 + 1);
+  });
+  return Buffer.concat([header, column, stringTable, name, rows]);
+}
+
+function fakeConnection(buffers = []) {
+  const calls = [];
+  const connection = {
+    getEncoding: () => 'utf-8',
+    async queryRaw(query, params) {
+      calls.push({ query, params });
+      return buffers;
+    },
+  };
+  for (const method of [
+    'execute',
+    'executeWithParams',
+    'fetchChunk',
+    'nextResultSet',
+    'closeQuery',
+  ]) {
+    connection[method] = () => {
+      throw new Error(`Unexpected ${method} call`);
+    };
+  }
+  return { connection, calls };
+}
+
+function recordSet(values, type = TDS_INTN) {
+  return Object.assign(
+    values.map((value) => ({ value })),
+    {
+      columns: [{ index: 0, name: 'value', type }],
+      rowCount: values.length,
+    },
+  );
+}
+
+test('raw decoding keeps independent value arrays without a projector', (t) => {
+  const result = decodeRawResult(intResult([42, 43]));
+  t.deepEqual(result.rows, [[42], [43]]);
+  t.not(result.rows[0], result.rows[1]);
+});
+
+test('projected decoding creates the column layout once and copies borrowed values', (t) => {
+  let layouts = 0;
+  let scratch;
+  const result = decodeProjectedResult(intResult([42, 43]), (columns) => {
+    layouts++;
+    t.is(columns[0].name, 'value');
+    return (values) => {
+      if (scratch) t.is(values, scratch);
+      scratch = values;
+      return { value: values[0] };
+    };
+  });
+  t.is(layouts, 1);
+  t.deepEqual(result.rows, [{ value: 42 }, { value: 43 }]);
+  t.not(result.rows[0], result.rows[1]);
+});
+
+test('projected decoding propagates projector failures', (t) => {
+  const failure = new Error('Projection failed');
+  const error = t.throws(() =>
+    decodeProjectedResult(intResult([42]), () => () => {
+      throw failure;
+    }),
+  );
+  t.is(error, failure);
+});
+
+test('parameterized Request.query uses one queryRaw call with transformed parameters', async (t) => {
+  const { connection, calls } = fakeConnection([intResult([42])]);
+  const request = new Request(connection);
+  const label = "O'Brien \u2014 \u6771\u4eac";
+  request.input('value', TYPES.Int, '42');
+  request.input('@nullable', TYPES.Int, null);
+  request.input('label', TYPES.NVarChar(40), label);
+
+  const query =
+    'SELECT @value AS value WHERE @nullable IS NULL AND @label IS NOT NULL';
+  const result = await request.query(query);
+
+  t.deepEqual(calls, [
+    {
+      query,
+      params: [
+        {
+          name: '@value',
+          dataType: TYPES.Int.sqlType,
+          value: 42,
+          direction: 0,
+          length: undefined,
+        },
+        {
+          name: '@nullable',
+          dataType: TYPES.Int.sqlType,
+          value: null,
+          direction: 0,
+          length: undefined,
+        },
+        {
+          name: '@label',
+          dataType: TYPES.NVarChar(40).sqlType,
+          value: Buffer.from(label, 'utf16le'),
+          direction: 0,
+          length: 40,
+        },
+      ],
+    },
+  ]);
+  const expected = recordSet([42]);
+  t.deepEqual(result, {
+    IRecordSets: [expected],
+    IRecordSet: expected,
+    rowCount: 1,
+    output: {},
+  });
+  t.is(result.IRecordSet, result.IRecordSets[0]);
+});
+
+test('non-parameterized Request.query still uses one queryRaw call', async (t) => {
+  const { connection, calls } = fakeConnection([
+    intResult([7], TYPES.Int.sqlType),
+  ]);
+  const result = await new Request(connection).query('SELECT 7 AS value');
+
+  t.is(calls.length, 1);
+  t.is(calls[0].query, 'SELECT 7 AS value');
+  t.deepEqual(calls[0].params ?? [], []);
+  const expected = recordSet([7], TYPES.Int.sqlType);
+  t.deepEqual(result, {
+    IRecordSets: [expected],
+    IRecordSet: expected,
+    rowCount: 1,
+    output: {},
+  });
+  t.is(result.IRecordSet, result.IRecordSets[0]);
+});
+
+test('parameterized Request.query reshapes all buffered results, including empty sets', async (t) => {
+  const { connection, calls } = fakeConnection([
+    intResult([42, 43]),
+    intResult([]),
+    intResult([44]),
+  ]);
+  const request = new Request(connection);
+  request.input('value', TYPES.Int, 42);
+
+  const result = await request.query(
+    'SELECT @value AS value UNION ALL SELECT @value + 1; ' +
+      'SELECT @value AS value WHERE 1 = 0; SELECT @value + 2 AS value',
+  );
+
+  t.is(calls.length, 1);
+  const expected = [recordSet([42, 43]), recordSet([]), recordSet([44])];
+  t.deepEqual(result, {
+    IRecordSets: expected,
+    IRecordSet: expected[0],
+    rowCount: 3,
+    output: {},
+  });
+  t.is(result.IRecordSet, result.IRecordSets[0]);
+});
+
+test('parameterized Request.query returns no recordset for an empty buffer list', async (t) => {
+  const { connection, calls } = fakeConnection();
+  const request = new Request(connection);
+  request.input('value', TYPES.Int, 42);
+
+  const result = await request.query(
+    'DECLARE @rows TABLE (value int); INSERT INTO @rows VALUES (@value)',
+  );
+
+  t.is(calls.length, 1);
+  t.deepEqual(result, {
+    IRecordSets: [],
+    IRecordSet: null,
+    rowCount: 0,
+    output: {},
+  });
+});
+
+test('parameterized Request.query propagates the queryRaw error unchanged', async (t) => {
+  const failure = new Error('SQL execution failed');
+  const { connection, calls } = fakeConnection();
+  connection.queryRaw = async (query, params) => {
+    calls.push({ query, params });
+    throw failure;
+  };
+  const request = new Request(connection);
+  request.input('value', TYPES.Int, 42);
+
+  const error = await t.throwsAsync(() => request.query('SELECT @value'));
+
+  t.is(error, failure);
+  t.is(calls.length, 1);
+});
+
+test('SqlJsConnection.queryRaw forwards parameters to the native connection', async (t) => {
+  const buffers = [intResult([42])];
+  const { connection: nativeConnection, calls } = fakeConnection(buffers);
+  const connection = new SqlJsConnection(nativeConnection);
+  const params = [
+    {
+      name: '@value',
+      dataType: TYPES.Int.sqlType,
+      value: 42,
+      direction: 0,
+    },
+  ];
+
+  const result = await connection.queryRaw('SELECT @value AS value', params);
+
+  t.deepEqual(calls, [{ query: 'SELECT @value AS value', params }]);
+  t.is(calls[0].params, params);
+  t.is(result, buffers);
+});
+
+for (const [name, collation, expected] of [
+  [
+    'UTF-8 collation',
+    { isUtf8: true, sortId: 52, lcidLanguageId: 0x0411 },
+    'utf-8',
+  ],
+  [
+    'sort ID collation',
+    { isUtf8: false, sortId: 52, lcidLanguageId: 0x0411 },
+    'CP1252',
+  ],
+  [
+    'language ID collation',
+    { isUtf8: false, sortId: 0, lcidLanguageId: 0x0411 },
+    'CP932',
+  ],
+  ['null collation fallback', null, 'utf-8'],
+]) {
+  test(`SqlJsConnection.getEncoding lazily caches ${name}`, (t) => {
+    let calls = 0;
+    const connection = new SqlJsConnection({
+      getCollation() {
+        calls++;
+        return collation;
+      },
+    });
+
+    t.is(calls, 0);
+    t.is(connection.getEncoding(), expected);
+    t.is(connection.getEncoding(), expected);
+    t.is(connection.getEncoding(), expected);
+    t.is(calls, 1);
+  });
+}
+
+test('SqlJsConnection.getEncoding propagates native errors without caching a fallback', (t) => {
+  const failure = new Error('Native collation lookup failed');
+  let calls = 0;
+  const connection = new SqlJsConnection({
+    getCollation() {
+      calls++;
+      throw failure;
+    },
+  });
+
+  t.is(calls, 0);
+  t.is(
+    t.throws(() => connection.getEncoding()),
+    failure,
+  );
+  t.is(
+    t.throws(() => connection.getEncoding()),
+    failure,
+  );
+  t.is(calls, 2);
+});

--- a/mssql-js/lib/connection.ts
+++ b/mssql-js/lib/connection.ts
@@ -31,6 +31,8 @@ export async function create_connection(
 }
 
 export class SqlJsConnection {
+  private encoding?: Encoding;
+
   constructor(private internal_connection: Connection) {
     this.internal_connection = internal_connection;
   }
@@ -70,6 +72,9 @@ export class SqlJsConnection {
   }
 
   getEncoding(): Encoding {
+    if (this.encoding !== undefined) {
+      return this.encoding;
+    }
     let db_collation = this.internal_connection.getCollation();
     let encoding: Encoding = 'utf-8';
     if (db_collation != null) {
@@ -83,6 +88,8 @@ export class SqlJsConnection {
     } else {
       encoding = 'utf-8';
     }
+    // The native connection's collation snapshot is immutable.
+    this.encoding = encoding;
     return encoding;
   }
 
@@ -113,8 +120,8 @@ export class SqlJsConnection {
     return this.internal_connection.closeQuery();
   }
 
-  async queryRaw(query: string): Promise<Buffer[]> {
-    return this.internal_connection.queryRaw(query);
+  async queryRaw(query: string, params?: Array<Parameter>): Promise<Buffer[]> {
+    return this.internal_connection.queryRaw(query, params);
   }
 
   async fetchChunk(byteBudget: number): Promise<ChunkResult | null> {

--- a/mssql-js/lib/decode.ts
+++ b/mssql-js/lib/decode.ts
@@ -63,12 +63,16 @@ export interface RawColumnInfo {
 }
 
 /** Decoded result set. */
-export interface RawResult {
+export interface RawResult<T = unknown[]> {
   columns: RawColumnInfo[];
-  rows: unknown[][];
+  rows: T[];
   rowCount: number;
   rowsAffected: number;
 }
+
+type RowProjectorFactory<T> = (
+  columns: RawColumnInfo[],
+) => (values: unknown[]) => T;
 
 /**
  * Decode a binary buffer produced by `Connection.queryRaw()`.
@@ -78,6 +82,22 @@ export interface RawResult {
  * JS representations as the existing NapiRowWriter + transformer pipeline.
  */
 export function decodeRawResult(buf: Buffer): RawResult {
+  return decodeResult(buf, () => (values) => values, false);
+}
+
+/** The projector must not retain the borrowed, reusable values array. */
+export function decodeProjectedResult<T>(
+  buf: Buffer,
+  createProjector: RowProjectorFactory<T>,
+): RawResult<T> {
+  return decodeResult(buf, createProjector, true);
+}
+
+function decodeResult<T>(
+  buf: Buffer,
+  createProjector: RowProjectorFactory<T>,
+  reuseRow: boolean,
+): RawResult<T> {
   const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
   let pos = 0;
 
@@ -169,10 +189,12 @@ export function decodeRawResult(buf: Buffer): RawResult {
   }
 
   // --- Row data ---
-  const rows: unknown[][] = [];
+  const project = createProjector(columns);
+  const scratch = reuseRow ? new Array<unknown>(colCount) : undefined;
+  const rows: T[] = [];
 
   for (let r = 0; r < rowCount; r++) {
-    const row: unknown[] = new Array(colCount);
+    const row: unknown[] = scratch ?? new Array(colCount);
     for (let c = 0; c < colCount; c++) {
       const tag = view.getUint8(pos);
       pos += 1;
@@ -370,7 +392,7 @@ export function decodeRawResult(buf: Buffer): RawResult {
           throw new Error(`Unknown cell tag ${tag} at offset ${pos - 1}`);
       }
     }
-    rows.push(row);
+    rows.push(project(row));
   }
 
   return { columns, rows, rowCount, rowsAffected };

--- a/mssql-js/lib/request.ts
+++ b/mssql-js/lib/request.ts
@@ -5,7 +5,7 @@ import { SqlJsConnection } from '.';
 import { DataType } from './datatypes';
 import { JsSqlDataTypes } from './datatypes/enums';
 import { SqlDataTypes, Parameter } from './generated';
-import { decodeRawResult, RawResult } from './decode';
+import { decodeProjectedResult, RawColumnInfo, RawResult } from './decode';
 
 type ColumnValue = number | string | boolean | Buffer | null | Date | bigint;
 
@@ -136,18 +136,13 @@ export class Request {
   }
 
   async query(command: string): Promise<IResult> {
-    if (this.params.length === 0) {
-      return this.queryFast(command);
-    }
-    await this.connection.execute(command, this.params);
-    let result: IResult = await this.createResultFast();
-    await this.connection.closeQuery();
-    return result;
-  }
-
-  private async queryFast(command: string): Promise<IResult> {
-    const buffers = await this.connection.queryRaw(command);
-    const rawResults = buffers.map((buf) => decodeRawResult(buf));
+    const buffers = await this.connection.queryRaw(
+      command,
+      this.params.length > 0 ? this.params : undefined,
+    );
+    const rawResults = buffers.map((buf) =>
+      decodeProjectedResult(buf, createRowProjector),
+    );
     return reshapeRawToIResult(rawResults);
   }
 
@@ -178,16 +173,16 @@ export class Request {
 
   private async createResultFast(): Promise<IResult> {
     const BYTE_BUDGET = 256 * 1024;
-    const rawResults: RawResult[] = [];
+    const rawResults: RawResult<RecordSetRow>[] = [];
 
     while (true) {
-      let merged: RawResult | null = null;
+      let merged: RawResult<RecordSetRow> | null = null;
 
       while (true) {
         const chunk = await this.connection.fetchChunk(BYTE_BUDGET);
         if (!chunk) break;
 
-        const decoded = decodeRawResult(chunk.data);
+        const decoded = decodeProjectedResult(chunk.data, createRowProjector);
         if (!merged) {
           merged = decoded;
         } else {
@@ -211,8 +206,29 @@ export class Request {
   }
 }
 
+function createRowProjector(columns: RawColumnInfo[]) {
+  const names = columns.map((column) => column.name);
+  return (values: readonly unknown[]): RecordSetRow => {
+    const row: RecordSetRow = {};
+    for (let c = 0; c < names.length; c++) {
+      const name = names[c];
+      const val = values[c] as ColumnValue;
+      if (name === '' && '' in row) {
+        if (Array.isArray(row[''])) {
+          (row[''] as ColumnValue[]).push(val);
+        } else {
+          row[''] = [row[''], val];
+        }
+      } else {
+        row[name] = val;
+      }
+    }
+    return row;
+  };
+}
+
 /** Convert decoded result sets into an `IResult`. */
-function reshapeRawToIResult(rawResults: RawResult[]): IResult {
+function reshapeRawToIResult(rawResults: RawResult<RecordSetRow>[]): IResult {
   const recordSets: RecordSet[] = [];
   let totalRowCount = 0;
 
@@ -232,35 +248,15 @@ function reshapeRawToIResult(rawResults: RawResult[]): IResult {
       columns.push({
         index: i,
         name,
-        type: name.length > 0 ? (raw.columns[i].typeId as SqlDataTypes) : undefined,
+        type:
+          name.length > 0 ? (raw.columns[i].typeId as SqlDataTypes) : undefined,
       });
     }
 
-    const recordSet: RecordSet = Object.assign([] as RecordSetRow[], {
+    const recordSet: RecordSet = Object.assign(raw.rows, {
       columns,
       rowCount: raw.rowCount,
     });
-
-    for (let r = 0; r < raw.rowCount; r++) {
-      const rawRow = raw.rows[r];
-      const row: RecordSetRow = {};
-
-      for (let c = 0; c < colCount; c++) {
-        const name = colNames[c];
-        const val = rawRow[c] as ColumnValue;
-
-        if (name === '' && '' in row) {
-          if (Array.isArray(row[''])) {
-            (row[''] as ColumnValue[]).push(val);
-          } else {
-            row[''] = [row[''] as ColumnValue, val];
-          }
-        } else {
-          row[name] = val;
-        }
-      }
-      recordSet.push(row);
-    }
 
     recordSets.push(recordSet);
     totalRowCount += raw.rowCount;

--- a/mssql-js/perf/.gitignore
+++ b/mssql-js/perf/.gitignore
@@ -1,0 +1,1 @@
+results/

--- a/mssql-js/perf/README.md
+++ b/mssql-js/perf/README.md
@@ -1,4 +1,189 @@
-## How to run
+## Comparing with Tedious
+
+`compare-tedious.js` compares the release-built `mssql-js` public `Request`
+API with Tedious 20.0.0. Node.js 22 or newer is required.
+
+From `mssql-js`, build the native addon and JavaScript API:
+
+```bash
+yarn install --immutable
+yarn build --cargo-flags="--frozen"
+yarn buildapi
+cd perf
+npm ci
+```
+
+Start a disposable SQL Server container. The harness creates the
+`mssql_js_benchmark` database and replaces its `dbo.driver_bench_rows` and
+`dbo.driver_bench_lob` tables; do not point it at a production server.
+
+```bash
+export SQL_PASSWORD="$(openssl rand -base64 24)Aa1!"
+docker run --detach --name mssql-js-benchmark \
+  --cpuset-cpus 0-3 --memory 4g \
+  --publish 127.0.0.1:15433:1433 \
+  --env ACCEPT_EULA=Y --env MSSQL_PID=Developer \
+  --env MSSQL_SA_PASSWORD="$SQL_PASSWORD" \
+  mcr.microsoft.com/mssql/server:2025-latest
+```
+
+Wait for SQL Server's "ready for client connections" message in
+`docker logs mssql-js-benchmark`, then run:
+
+```bash
+taskset -c 8-11 node compare-tedious.js
+docker rm --force mssql-js-benchmark
+unset SQL_PASSWORD
+```
+
+Choose disjoint CPU sets appropriate for your machine; `taskset` is Linux-only
+and optional. On WSL without Docker Desktop integration, `docker.exe` can be
+used instead if its published loopback port is reachable.
+
+### Method
+
+The workloads cover connect/query/close, reused-connection `SELECT 1`,
+an integer-parameter lookup, 1,000 and 10,000 two-integer rows, 1,000 string
+rows (an ID, short label, and 512-character Unicode body), a 1 MiB binary
+value, and `SELECT 1` across eight pre-opened connections. Parameterized
+10,000-row, 100,000-row, 1,000-string-row, and eight-connection lookup variants exercise
+the parameterized result path separately.
+
+- Both drivers use SQL authentication, TLS with certificate verification
+  bypassed for the disposable server, and request 8,000-byte TDS packets.
+  Negotiated packet size and protocol version must match within each pair.
+  Queries use SQL batches; the parameterized workload uses `sp_executesql`
+  for both.
+- Tedious row events are collected into named JavaScript objects, matching
+  `mssql-js`'s materialized result shape. Every cell is compared with expected
+  data before each sample, and every timed operation checks the row count.
+- Reused connections get identical session SET options outside timing.
+  Connection-churn timing includes each driver's default login setup,
+  `SELECT 1`, and close; module loading is excluded.
+- Each driver/workload/round runs in a fresh child process. Driver order
+  alternates between paired rounds, with a one-second warmup before each
+  three-second measurement. GC is not forced. There are six rounds by default.
+- Throughput and latency include query execution, transfer, decoding, result
+  materialization, and row-count consumption. Concurrent latency is per query,
+  not per eight-query batch.
+
+The console reports median throughput and the median of paired
+`mssql-js / tedious` throughput ratios; values above 1 favor `mssql-js`.
+The range is the observed range of paired ratios, **not a confidence interval**.
+`results/comparison.json` retains every sample, server/session information,
+client CPU time, and process peak RSS. Peak RSS includes startup and warmup;
+it is not an allocation-per-query metric. Results are ignored by Git.
+
+| Environment variable                  | Default                                              |
+| ------------------------------------- | ---------------------------------------------------- |
+| `SQL_PASSWORD`                        | Required                                             |
+| `DB_HOST` / `DB_PORT`                 | `127.0.0.1` / `15433`                                |
+| `BENCH_ROUNDS`                        | `6`                                                  |
+| `BENCH_WARMUP_MS` / `BENCH_SAMPLE_MS` | `1000` / `3000`                                      |
+| `BENCH_SCENARIOS`                     | All; optional comma-separated workload names         |
+| `BENCH_OUTPUT`                        | `perf/results/comparison.json`                       |
+| `BENCH_BASELINE_PATH`                 | Unset; optional preserved baseline `dist` directory  |
+| `BENCH_CANDIDATE_PATH`                | `mssql-js/dist`; optional candidate `dist` directory |
+
+For a quick correctness run, set `BENCH_ROUNDS=1 BENCH_WARMUP_MS=100
+BENCH_SAMPLE_MS=100`. Do not use those short samples as performance results.
+Record the SQL image digest and container resources alongside published
+results. A local container comparison is not a production-network or
+dedicated-machine benchmark; this suite does not cover writes, bulk copy,
+streaming/backpressure, pooling, or all SQL data types.
+
+### Comparing an optimization against the previous build
+
+Before making changes, preserve the release addon and compiled API together.
+From `mssql-js`:
+
+```bash
+mkdir -p perf/results/baseline
+cp -a dist perf/results/baseline/
+cp package.json perf/results/baseline/
+```
+
+The copied `package.json` keeps the snapshot's compiled CommonJS files from
+inheriting the perf directory's ES-module configuration. After building the
+candidate, run the same workloads against all three drivers:
+
+```bash
+BENCH_BASELINE_PATH="$PWD/perf/results/baseline/dist" \
+BENCH_OUTPUT="$PWD/perf/results/optimization.json" \
+taskset -c 8-11 node perf/compare-tedious.js
+```
+
+With a baseline, six rounds cover all six driver orders. Each child loads
+only its selected driver version. Results include native-binary and wrapper
+hashes, plus paired candidate/baseline ratios under `versusBaseline`.
+Use a fresh output path for each experiment and do not compare candidate
+numbers with a baseline measured on a different run.
+
+### Before optimization: September 10, 2026
+
+Release build of commit `182af9260b66b8f4d7d752683e55588f40b0f368`,
+Node.js 22.23.2, Tedious 20.0.0, and SQL Server 2025 CU8-GDR
+(`17.0.4085.5`). The client ran under WSL on an Intel Xeon Platinum 8370C;
+SQL Server ran in Docker Desktop with 4 GiB RAM and logical CPUs 0-3.
+The client used logical CPUs 8-11. Both sessions negotiated TLS and
+8,170-byte packets. These are local-container measurements, not general
+performance guarantees.
+
+| Workload                    | mssql-js ops/s | Tedious ops/s | Median paired ratio |
+| --------------------------- | -------------: | ------------: | ------------------: |
+| Connect, SELECT 1, close    |            8.5 |           8.6 |               0.98x |
+| SELECT 1, reused connection |          895.1 |         854.3 |               1.05x |
+| Parameterized lookup        |          588.2 |         848.4 |               0.69x |
+| 1,000 integer rows          |          616.0 |         388.9 |               1.56x |
+| 10,000 integer rows         |          157.4 |          90.0 |               1.78x |
+| 1,000 string rows           |          136.2 |         120.5 |               1.13x |
+| 1 MiB binary value          |          162.6 |         158.5 |               1.03x |
+| SELECT 1, eight connections |        5,748.5 |       3,969.5 |               1.44x |
+
+The integer-result, string-result, and concurrent-query advantages appeared
+in all six pairs. The parameterized lookup was consistently slower
+(0.64-0.76x throughput). Connect/query/close, single-connection SELECT 1,
+and the binary value had paired ranges crossing 1.0; treat these as near
+ties rather than reliable wins.
+
+### Parameterized-query optimization result
+
+The retained changes are confined to `mssql-js`: execute and collect buffered
+parameterized queries in one native call, cache the native connection's
+immutable encoding snapshot, and project decoded values directly into the
+final row objects using one reusable scratch row. The public `Request` result
+shape and the low-level raw/chunked APIs are preserved.
+
+The final comparison used the same host/container configuration above and an
+unchanged release build of `182af926` as the baseline. Six rounds covered all
+three-driver orders, with a one-second warmup and two-second measurement per
+leg. Throughput below is median queries/second; improvement is the median
+paired candidate/baseline ratio.
+
+| Parameterized workload    |  Before |   After | Tedious | Improvement |
+| ------------------------- | ------: | ------: | ------: | ----------: |
+| Single-row lookup         |   584.2 |   879.9 |   850.0 |       1.50x |
+| Lookup, eight connections | 4,496.5 | 5,631.2 | 3,316.7 |       1.25x |
+| 10,000 integer rows       |   145.3 |   163.3 |    87.1 |       1.11x |
+| 100,000 integer rows      |    19.0 |    21.2 |     8.2 |       1.12x |
+
+All six pairs showed improvements for these four workloads. Single-row lookup
+median latency fell from 1.67 ms to 1.09 ms, and client CPU per query fell from
+1.23 ms to 0.51 ms. Non-parameterized controls and parameterized string results
+had changes within the observed run variation.
+
+Independent experiments isolated the fused-call gain and a further concurrent
+benefit from encoding caching. Fusion alone introduced a small 100,000-row
+slowdown; direct row projection removed it and improved the final result.
+A 512-byte initial native buffer and preallocated JS row arrays did not show
+reliable throughput gains and were not retained.
+
+The full nine-workload results are in
+`results/optimization/final-comparison.json`, with per-experiment results in
+the same ignored directory. These local measurements are not production
+performance guarantees.
+
+## Original single-driver benchmark
 
 This perf / benchmark can be run with `node query.mjs`
 

--- a/mssql-js/perf/compare-tedious.js
+++ b/mssql-js/perf/compare-tedious.js
@@ -1,0 +1,521 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import assert from 'node:assert/strict';
+import { execFileSync, fork } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { once } from 'node:events';
+import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import { dirname, resolve } from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const filename = fileURLToPath(import.meta.url);
+const directory = dirname(filename);
+const database = 'mssql_js_benchmark';
+const drivers = ['mssql-js', 'tedious'];
+const nativeDirectories = {
+  'mssql-js': resolve(
+    process.env.BENCH_CANDIDATE_PATH || `${directory}/../dist`,
+  ),
+};
+if (process.env.BENCH_BASELINE_PATH) {
+  nativeDirectories['mssql-js-baseline'] = resolve(
+    process.env.BENCH_BASELINE_PATH,
+  );
+  drivers.push('mssql-js-baseline');
+}
+const settings = {
+  host: process.env.DB_HOST || '127.0.0.1',
+  port: positiveNumber('DB_PORT', 15433),
+  rounds: positiveNumber('BENCH_ROUNDS', 6),
+  warmupMs: positiveNumber('BENCH_WARMUP_MS', 1000),
+  sampleMs: positiveNumber('BENCH_SAMPLE_MS', 3000),
+};
+const narrowSql = (count) =>
+  `SELECT TOP (${count}) id, value FROM dbo.driver_bench_rows ORDER BY id OPTION (MAXDOP 1)`;
+const scenarios = [
+  { name: 'connect-select-close', sql: 'SELECT 1 AS value', connect: true },
+  { name: 'select-one', sql: 'SELECT 1 AS value' },
+  {
+    name: 'parameterized-lookup',
+    sql: 'SELECT id, value FROM dbo.driver_bench_rows WHERE id = @id',
+    parameter: 4321,
+  },
+  {
+    name: 'parameterized-rows-10000',
+    sql: 'SELECT id, value FROM dbo.driver_bench_rows WHERE id <= @id ORDER BY id OPTION (MAXDOP 1)',
+    parameter: 10000,
+    rows: 10000,
+  },
+  {
+    name: 'parameterized-rows-100000',
+    sql: 'SELECT value AS id, value * 2 AS value FROM GENERATE_SERIES(1, @id) ORDER BY value OPTION (MAXDOP 1)',
+    parameter: 100000,
+    rows: 100000,
+  },
+  {
+    name: 'parameterized-strings-1000',
+    sql: 'SELECT id, label, body FROM dbo.driver_bench_rows WHERE id <= @id ORDER BY id OPTION (MAXDOP 1)',
+    parameter: 1000,
+    rows: 1000,
+  },
+  {
+    name: 'parameterized-lookup-concurrency-8',
+    sql: 'SELECT id, value FROM dbo.driver_bench_rows WHERE id = @id',
+    parameter: 4321,
+    concurrency: 8,
+  },
+  { name: 'rows-1000', sql: narrowSql(1000), rows: 1000 },
+  { name: 'rows-10000', sql: narrowSql(10000), rows: 10000 },
+  {
+    name: 'strings-1000',
+    sql: 'SELECT TOP (1000) id, label, body FROM dbo.driver_bench_rows ORDER BY id OPTION (MAXDOP 1)',
+    rows: 1000,
+  },
+  { name: 'binary-1mib', sql: 'SELECT payload FROM dbo.driver_bench_lob' },
+  {
+    name: 'select-one-concurrency-8',
+    sql: 'SELECT 1 AS value',
+    concurrency: 8,
+  },
+];
+const sessionSql = `
+SET NOCOUNT ON;
+SET ANSI_NULLS ON;
+SET ANSI_PADDING ON;
+SET ANSI_WARNINGS ON;
+SET ARITHABORT ON;
+SET CONCAT_NULL_YIELDS_NULL ON;
+SET QUOTED_IDENTIFIER ON;
+SET NUMERIC_ROUNDABORT OFF;
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+SET TEXTSIZE 2147483647;
+`;
+
+function positiveNumber(name, fallback) {
+  const value = Number(process.env[name] ?? fallback);
+  assert(
+    Number.isSafeInteger(value) && value > 0,
+    `${name} must be a positive integer`,
+  );
+  return value;
+}
+
+async function adapter(driver) {
+  if (Object.hasOwn(nativeDirectories, driver)) {
+    const dist = nativeDirectories[driver];
+    const { create_connection, Request } = await import(
+      pathToFileURL(`${dist}/index.js`).href
+    );
+    const { IntType } = await import(
+      pathToFileURL(`${dist}/datatypes/IntType.js`).href
+    );
+    return {
+      connect: (db = database) =>
+        create_connection({
+          serverName: settings.host,
+          port: settings.port,
+          userName: 'sa',
+          password: process.env.SQL_PASSWORD,
+          database: db,
+          trustServerCertificate: true,
+        }),
+      async query(connection, sql, parameter) {
+        const request = new Request(connection);
+        if (parameter !== undefined)
+          request.input('id', new IntType(), parameter);
+        const result = await request.query(sql);
+        return result.IRecordSet ?? [];
+      },
+      close: (connection) => connection.close(),
+    };
+  }
+  assert.equal(driver, 'tedious');
+  const { Connection, Request, TYPES } = await import('tedious');
+  return {
+    async connect(db = database) {
+      const connection = new Connection({
+        server: settings.host,
+        authentication: {
+          type: 'default',
+          options: { userName: 'sa', password: process.env.SQL_PASSWORD },
+        },
+        options: {
+          port: settings.port,
+          database: db,
+          encrypt: true,
+          trustServerCertificate: true,
+          packetSize: 8000,
+          tdsVersion: '7_4',
+          connectTimeout: 30000,
+          requestTimeout: 30000,
+          useUTC: true,
+        },
+      });
+      // Surface asynchronous connection failures rather than timing partial results.
+      connection.on('error', (error) => {
+        throw error;
+      });
+      await new Promise((resolve, reject) => {
+        connection.connect((error) => (error ? reject(error) : resolve()));
+      });
+      return connection;
+    },
+    query(connection, sql, parameter) {
+      return new Promise((resolve, reject) => {
+        const rows = [];
+        const request = new Request(sql, (error) =>
+          error ? reject(error) : resolve(rows),
+        );
+        request.on('row', (columns) => {
+          const row = {};
+          for (const column of columns)
+            row[column.metadata.colName] = column.value;
+          rows.push(row);
+        });
+        if (parameter !== undefined) {
+          request.addParameter('id', TYPES.Int, parameter);
+          connection.execSql(request);
+        } else {
+          // Match the native driver's SQL batch path, not sp_executesql.
+          connection.execSqlBatch(request);
+        }
+      });
+    },
+    async close(connection) {
+      const ended = once(connection, 'end');
+      connection.close();
+      await ended;
+    },
+  };
+}
+
+function expectedRows(scenario) {
+  if (scenario.name === 'binary-1mib') {
+    return [{ payload: Buffer.alloc(1024 * 1024, 0x61) }];
+  }
+  if (!scenario.rows) {
+    return scenario.parameter !== undefined
+      ? [{ id: scenario.parameter, value: scenario.parameter * 2 }]
+      : [{ value: 1 }];
+  }
+  return Array.from({ length: scenario.rows }, (_, index) => {
+    const id = index + 1;
+    return scenario.name.endsWith('strings-1000')
+      ? { id, label: `row-${id}`, body: 'x'.repeat(512) }
+      : { id, value: id * 2 };
+  });
+}
+
+async function setup() {
+  const api = await adapter('tedious');
+  const connection = await api.connect('master');
+  try {
+    await api.query(
+      connection,
+      `IF DB_ID('${database}') IS NULL CREATE DATABASE ${database}`,
+    );
+    await api.query(
+      connection,
+      `USE ${database};
+       ${sessionSql}
+       DROP TABLE IF EXISTS dbo.driver_bench_rows;
+       DROP TABLE IF EXISTS dbo.driver_bench_lob;
+       CREATE TABLE dbo.driver_bench_rows (
+         id int NOT NULL PRIMARY KEY, value int NOT NULL,
+         label nvarchar(64) NOT NULL, body nvarchar(512) NOT NULL
+       );
+       INSERT dbo.driver_bench_rows
+       SELECT value, value * 2, CONCAT(N'row-', value), REPLICATE(N'x', 512)
+       FROM GENERATE_SERIES(1, 10000);
+       CREATE TABLE dbo.driver_bench_lob (payload varbinary(max) NOT NULL);
+       INSERT dbo.driver_bench_lob
+       VALUES (CONVERT(varbinary(max), REPLICATE(CAST('a' AS varchar(max)), 1048576)));
+       UPDATE STATISTICS dbo.driver_bench_rows WITH FULLSCAN;`,
+    );
+    return await api.query(
+      connection,
+      `SELECT @@VERSION AS version,
+         CAST(SERVERPROPERTY('ProductVersion') AS varchar(32)) AS productVersion`,
+    );
+  } finally {
+    await api.close(connection);
+  }
+}
+
+function percentile(sorted, fraction) {
+  return sorted[Math.max(0, Math.ceil(sorted.length * fraction) - 1)];
+}
+
+function median(values) {
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2
+    ? sorted[middle]
+    : (sorted[middle - 1] + sorted[middle]) / 2;
+}
+
+async function worker(driver, scenario) {
+  const api = await adapter(driver);
+  const connections = [];
+  try {
+    for (let i = 0; i < (scenario.concurrency ?? 1); i++) {
+      const connection = await api.connect();
+      connections.push(connection);
+      await api.query(connection, sessionSql);
+      const rows = await api.query(
+        connection,
+        scenario.sql,
+        scenario.parameter,
+      );
+      // Strip the native array's metadata properties; compare every cell before timing.
+      assert.deepEqual([...rows], expectedRows(scenario));
+    }
+    const [session] = await api.query(
+      connections[0],
+      `SELECT encrypt_option, net_packet_size, protocol_version
+       FROM sys.dm_exec_connections WHERE session_id = @@SPID`,
+    );
+    assert.equal(session.encrypt_option, 'TRUE');
+    assert(session.net_packet_size > 0);
+
+    const operation = async (connection) => {
+      const active = scenario.connect ? await api.connect() : connection;
+      try {
+        const rows = await api.query(active, scenario.sql, scenario.parameter);
+        assert.equal(rows.length, scenario.rows ?? 1);
+        return rows.length;
+      } finally {
+        if (scenario.connect) await api.close(active);
+      }
+    };
+    const runFor = async (duration, record) => {
+      const latencies = [];
+      const cpuStart = process.cpuUsage();
+      const start = performance.now();
+      let operations = 0;
+      let rowCount = 0;
+      await Promise.all(
+        connections.map(async (connection) => {
+          do {
+            const before = performance.now();
+            const rows = await operation(connection);
+            rowCount += rows;
+            if (record) latencies.push(performance.now() - before);
+            operations++;
+          } while (performance.now() - start < duration);
+        }),
+      );
+      const elapsedMs = performance.now() - start;
+      const cpu = process.cpuUsage(cpuStart);
+      latencies.sort((a, b) => a - b);
+      return {
+        operations,
+        rowCount,
+        elapsedMs,
+        opsPerSecond: (operations * 1000) / elapsedMs,
+        p50Ms: record ? percentile(latencies, 0.5) : null,
+        p95Ms: record ? percentile(latencies, 0.95) : null,
+        clientCpuMsPerOp: (cpu.user + cpu.system) / 1000 / operations,
+        maxRssMiB: process.resourceUsage().maxRSS / 1024,
+      };
+    };
+    await runFor(settings.warmupMs, false);
+    return {
+      driver,
+      scenario: scenario.name,
+      session,
+      ...(await runFor(settings.sampleMs, true)),
+    };
+  } finally {
+    for (const connection of connections) await api.close(connection);
+  }
+}
+
+async function runChild(driver, scenario) {
+  const child = fork(filename, ['--worker', driver, scenario.name], {
+    stdio: ['ignore', 'inherit', 'inherit', 'ipc'],
+    timeout: Math.max(120000, (settings.warmupMs + settings.sampleMs) * 3),
+    env: { ...process.env, MSSQLJS_TRACE: 'false' },
+  });
+  let result;
+  child.on('message', (message) => {
+    result = message;
+  });
+  const [code, signal] = await once(child, 'exit');
+  assert.equal(code, 0, `${driver}/${scenario.name} failed (signal=${signal})`);
+  assert(result, `${driver}/${scenario.name} returned no measurement`);
+  return result;
+}
+
+async function nativeBuilds() {
+  const builds = {};
+  for (const [driver, dist] of Object.entries(nativeDirectories)) {
+    const names = (await readdir(`${dist}/generated`))
+      .filter((name) => name.endsWith('.node'))
+      .map((name) => `generated/${name}`);
+    assert(names.length > 0, `No native addon found in ${dist}/generated`);
+    names.push('request.js', 'connection.js', 'decode.js');
+    const hashes = {};
+    for (const name of names) {
+      hashes[name] = createHash('sha256')
+        .update(await readFile(`${dist}/${name}`))
+        .digest('hex');
+    }
+    builds[driver] = { dist, hashes };
+  }
+  return builds;
+}
+
+function pairedSpeedup(samples, scenario, comparator) {
+  const ratios = Array.from({ length: settings.rounds }, (_, index) => {
+    const pair = samples.filter(
+      (sample) => sample.scenario === scenario && sample.round === index + 1,
+    );
+    return (
+      pair.find((sample) => sample.driver === 'mssql-js').opsPerSecond /
+      pair.find((sample) => sample.driver === comparator).opsPerSecond
+    );
+  });
+  return {
+    speedup: median(ratios),
+    minSpeedup: Math.min(...ratios),
+    maxSpeedup: Math.max(...ratios),
+  };
+}
+
+async function main() {
+  assert(
+    Number(process.versions.node.split('.')[0]) >= 22,
+    'Node.js >=22 is required',
+  );
+  assert(process.env.SQL_PASSWORD, 'SQL_PASSWORD must be set');
+  if (process.argv[2] === '--worker') {
+    const scenario = scenarios.find((item) => item.name === process.argv[4]);
+    assert(scenario, 'Unknown workload');
+    process.send(await worker(process.argv[3], scenario));
+    process.disconnect();
+    return;
+  }
+  const filter = process.env.BENCH_SCENARIOS?.split(',');
+  const selected = filter
+    ? filter.map((name) => {
+        const scenario = scenarios.find((item) => item.name === name);
+        assert(scenario, `Unknown workload: ${name}`);
+        return scenario;
+      })
+    : scenarios;
+  const output = resolve(
+    process.env.BENCH_OUTPUT || `${directory}/results/comparison.json`,
+  );
+  const tediousPackage = JSON.parse(
+    await readFile(`${directory}/node_modules/tedious/package.json`, 'utf8'),
+  );
+  const report = {
+    startedAt: new Date().toISOString(),
+    commit: execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: directory,
+      encoding: 'utf8',
+    }).trim(),
+    node: process.version,
+    tedious: tediousPackage.version,
+    platform: `${os.platform()} ${os.release()} ${os.arch()}`,
+    cpu: os.cpus()[0].model,
+    availableParallelism: os.availableParallelism(),
+    nativeBuilds: await nativeBuilds(),
+    settings,
+    scenarios: selected,
+    sqlServer: await setup(),
+    samples: [],
+  };
+  await mkdir(dirname(output), { recursive: true });
+  for (let round = 0; round < settings.rounds; round++) {
+    for (const [index, scenario] of selected.entries()) {
+      const offset = (round + index) % drivers.length;
+      let order = [...drivers.slice(offset), ...drivers.slice(0, offset)];
+      if (
+        drivers.length > 2 &&
+        round % (drivers.length * 2) >= drivers.length
+      ) {
+        order = order.reverse();
+      }
+      for (const driver of order) {
+        const sample = {
+          round: round + 1,
+          ...(await runChild(driver, scenario)),
+        };
+        const pairedSample = report.samples.find(
+          (item) =>
+            item.round === sample.round && item.scenario === sample.scenario,
+        );
+        if (pairedSample)
+          assert.deepEqual(sample.session, pairedSample.session);
+        assert.equal(sample.rowCount, sample.operations * (scenario.rows ?? 1));
+        report.samples.push(sample);
+        console.log(
+          `${round + 1}/${settings.rounds} ${scenario.name} ${driver}: ${sample.opsPerSecond.toFixed(1)} ops/s, p95 ${sample.p95Ms.toFixed(3)} ms`,
+        );
+        await writeFile(output, `${JSON.stringify(report, null, 2)}\n`);
+      }
+    }
+  }
+  report.summary = selected.map((scenario) => {
+    const summaries = Object.fromEntries(
+      drivers.map((driver) => {
+        const samples = report.samples.filter(
+          (sample) =>
+            sample.driver === driver && sample.scenario === scenario.name,
+        );
+        return [
+          driver,
+          {
+            opsPerSecond: median(samples.map((sample) => sample.opsPerSecond)),
+            p50Ms: median(samples.map((sample) => sample.p50Ms)),
+            p95Ms: median(samples.map((sample) => sample.p95Ms)),
+            clientCpuMsPerOp: median(
+              samples.map((sample) => sample.clientCpuMsPerOp),
+            ),
+            maxRssMiB: median(samples.map((sample) => sample.maxRssMiB)),
+          },
+        ];
+      }),
+    );
+    return {
+      scenario: scenario.name,
+      ...summaries,
+      ...pairedSpeedup(report.samples, scenario.name, 'tedious'),
+      ...(drivers.includes('mssql-js-baseline')
+        ? {
+            versusBaseline: pairedSpeedup(
+              report.samples,
+              scenario.name,
+              'mssql-js-baseline',
+            ),
+          }
+        : {}),
+    };
+  });
+  report.completedAt = new Date().toISOString();
+  await writeFile(output, `${JSON.stringify(report, null, 2)}\n`);
+  console.table(
+    report.summary.map((item) => ({
+      workload: item.scenario,
+      'mssql-js ops/s': item['mssql-js'].opsPerSecond.toFixed(1),
+      'tedious ops/s': item.tedious.opsPerSecond.toFixed(1),
+      'paired speedup': `${item.speedup.toFixed(2)}x`,
+      range: `${item.minSpeedup.toFixed(2)}-${item.maxSpeedup.toFixed(2)}x`,
+      ...(item.versusBaseline
+        ? {
+            'baseline ops/s': item['mssql-js-baseline'].opsPerSecond.toFixed(1),
+            'vs baseline': `${item.versusBaseline.speedup.toFixed(2)}x`,
+            'baseline range': `${item.versusBaseline.minSpeedup.toFixed(2)}-${item.versusBaseline.maxSpeedup.toFixed(2)}x`,
+          }
+        : {}),
+    })),
+  );
+  console.log(`Raw results: ${output}`);
+}
+
+await main();

--- a/mssql-js/perf/package-lock.json
+++ b/mssql-js/perf/package-lock.json
@@ -1,0 +1,872 @@
+{
+  "name": "mssql-js-tedious-comparison",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mssql-js-tedious-comparison",
+      "dependencies": {
+        "tedious": "20.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@azure-rest/core-client": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@azure-rest/core-client/-/core-client-2.9.0.tgz",
+      "integrity": "sha512-6933vNLqh06RR7rumnrq3UZIeBtRLeBHDPMrieDPIljiCaMMwt0nRw++nd3TOxiohtasNtm29rC+b/9ZVKCOqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.24.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.2.0.tgz",
+      "integrity": "sha512-fNAjWnA/nZ2jz31kxR/AqRaUT8ewHBw/WuBIosK0moMy1C9e5ValbDfFdIxJzVOOYaYkV/b2F1S4H/aHiqfVQg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.11.0.tgz",
+      "integrity": "sha512-IUZydyTUkDnYdstOW9pFOOUQlBjAepK5teihDE3x6yxsPJs/hsAaaYpeGxdxrgtOiJbBKSjKW7MDk7AEhb4LRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-client": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.11.1.tgz",
+      "integrity": "sha512-2QygG2F76ZpMP2eMztiJvAiFMu71M9rDeU7vO/QKg5Css7MgM4frUOslFjhVjRhbGaCNPtz/S8M6y46/fFKVuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-lro": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.7.2.tgz",
+      "integrity": "sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-util": "^1.2.0",
+        "@azure/logger": "^1.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-paging": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.7.0.tgz",
+      "integrity": "sha512-7GEAoIsaoBr6KELNRb8nypowCqvk8dnCHFCYg4XD4lOQGY2GqjQg5IhkRjyBFRO18CGSMq05PaNqSOE9GQro3g==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-process": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-process/-/core-process-1.0.0.tgz",
+      "integrity": "sha512-/shnJ+ooO8WPxDhPEeI/2oRQuubn16gZ6CvlbpWbEswZfzwI9tI/sMAHmF3x1LuQ9yZYXfLW3TjzGMLEC5blKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.25.0.tgz",
+      "integrity": "sha512-bMs8ekJLjX8wPV+9IPBges1SLPyuDtE9g5gLDWOpxzKcoOFQnpLGkbcT1tdw3FaAmDS1gnPmMmJ6y/T5B96kIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.4.0.tgz",
+      "integrity": "sha512-eGwxD0AtncrxeBM4tG8R55Pc3rdX1hNW2WibJAgYpCVA6E93mvvVH+LcssoVjOBrSKWS55yEIHsk0X8ctHmfOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.14.0.tgz",
+      "integrity": "sha512-9n2pWK61veAuN0V20t9lOuoV4CFMdyAZ1ygZzvBGk/pBBJRib/PjL9PLXa/aI2CcPpyHfqVsxxqLCYl6uZlfDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/identity": {
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.2.tgz",
+      "integrity": "sha512-NXL2/pCJctLxgw8bvrwwgge743kEq8LBT+O1pmV0vyUwetzFPH9auP6jhkU/cgZCPPtWoewAe3ncaGCgPo07fA==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-process": "^1.0.0",
+        "@azure/core-rest-pipeline": "^1.17.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "@azure/msal-browser": "^5.5.0",
+        "@azure/msal-node": "^5.1.5",
+        "open": "^10.1.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/keyvault-common": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/keyvault-common/-/keyvault-common-2.1.0.tgz",
+      "integrity": "sha512-aCDidWuKY06LWQ4x7/8TIXK6iRqTaRWRL3t7T+LC+j1b07HtoIsOxP/tU90G4jCSBn5TAyUTCtA4MS/y5Hudaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure-rest/core-client": "^2.3.3",
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-rest-pipeline": "^1.8.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.10.0",
+        "@azure/logger": "^1.1.4",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/keyvault-keys": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@azure/keyvault-keys/-/keyvault-keys-4.10.2.tgz",
+      "integrity": "sha512-VmUSLbXRAbSzDD8grXHGPaknYs0SKr3yuf6U+d4XMpX4XuVYskNqbTTwXce0zR1LyxfTZm9rWEBcvs3vdYwCmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure-rest/core-client": "^2.3.3",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-lro": "^2.7.2",
+        "@azure/core-paging": "^1.6.2",
+        "@azure/core-rest-pipeline": "^1.19.0",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/keyvault-common": "^2.1.0",
+        "@azure/logger": "^1.1.4",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.4.0.tgz",
+      "integrity": "sha512-rbAE25KUfjU/s3XHUdJgceoCP5dEOpMx85J04kF+QMdta73XkuG9JGHHinch+XIoKpBdqljin+KqURpJriSzLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.21.0.tgz",
+      "integrity": "sha512-80OcuXDErmcEDAIH9pBtSqBsed2sPT/IWmbG3xHLoPMl5zc8TINd6SlJAbVSmN5huGa3xGAg5qR7VnpaIEK0Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.14.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.14.0.tgz",
+      "integrity": "sha512-A4rb55hI86Q9tBl/+jBj7TMz7iX2RFgQs/nExFzcAtoI/BFRVdaH5SL/MivrYD7qvweMpN8AgVvVMHV8UBYxew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-node": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.6.0.tgz",
+      "integrity": "sha512-uFY9NxrWHw8PwZx7gAX6PDn+9vdfS05+levc/kwkx77IkjfaldnQbbcQzzDIZ5Hq5Zdr6/z92oAIoRWKp6MnOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.13.0",
+        "jsonwebtoken": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
+      "version": "16.13.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.13.0.tgz",
+      "integrity": "sha512-rOAy0KUcyBbdwVJ+f3uPpthXatFLLZN+/KWAsTLzk1aB23Xl9DRmmXYwSvBFOZyXj4jUQQ5FKxxRkhAFW1fOow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@js-joda/core": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-6.1.0.tgz",
+      "integrity": "sha512-H8NTMRDJqad/leyv/D/A3kSOsf5/58Ydj4DJGDyaCWk9OU/zuZOLhndVffJgQjsgrn5GC0znHMHie7TfvPPG4w==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.2.tgz",
+      "integrity": "sha512-xlvWf4Vs9n1PEVYwP1n4vvG07M6y8WgvJ2t0vbrWTmijsIHp1cS+uJ2kMIRdY3nHZK0nCYKrPeD171+SzF4/zw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/readable-stream": {
+      "version": "4.0.24",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.24.tgz",
+      "integrity": "sha512-NRvUNC/JFGPJvqdAfEve8oginbM6V08u5NzLWpG8MwA2kTPOLnqk+wpwuPT+mp3aUsxyuT6m2gnrPuHYCruzEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.9.tgz",
+      "integrity": "sha512-edSdeAqkdxBVzA1yL1LrLCml1YjyCVvPMtMqJpbF+6K609tHe8V6sQUzFQSGcYNhcuhOceZtjvN32+mpIth30A==",
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bl": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-6.1.6.tgz",
+      "integrity": "sha512-jLsPgN/YSvPUg9UX0Kd73CXpm2Psg9FxMeCSXnk3WBO3CMT10JMwijubhGfHCnFu6TPn1ei3b975dxv7K2pWVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/readable-stream": "^4.0.0",
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.1.tgz",
+      "integrity": "sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==",
+      "license": "MIT"
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/native-duplexpair": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/native-duplexpair/-/native-duplexpair-1.0.0.tgz",
+      "integrity": "sha512-E7QQoM+3jvNtlmyfqRZ0/U75VFgCls+fSkbml2MpgWkWyz3ox8Y58gNhfuziuQYGNNQAbFZJQck55LHCnCK6CA==",
+      "license": "MIT"
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/tedious": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/tedious/-/tedious-20.0.0.tgz",
+      "integrity": "sha512-bTR0aou0Ghucf0ytvZUJjnKHGKDV8tT57jPYtEkSpfTWFe++4uR1wxJLQ4mh5wlSvAYXzmgBxbI0vaE56qigXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/core-auth": "^1.10.1",
+        "@azure/identity": "^4.13.1",
+        "@azure/keyvault-keys": "^4.10.2",
+        "@js-joda/core": "^6.0.1",
+        "@types/node": ">=22",
+        "bl": "^6.1.4",
+        "iconv-lite": "^0.7.0",
+        "js-md4": "^0.3.2",
+        "native-duplexpair": "^1.0.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/mssql-js/perf/package.json
+++ b/mssql-js/perf/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "mssql-js-tedious-comparison",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "compare": "node compare-tedious.js"
+  },
+  "dependencies": {
+    "tedious": "20.0.0"
+  }
+}

--- a/mssql-js/src/connection.rs
+++ b/mssql-js/src/connection.rs
@@ -62,6 +62,19 @@ impl Debug for Connection {
     }
 }
 
+fn input_parameters(params: Vec<Parameter>) -> napi::Result<Vec<RpcParameter>> {
+    params
+        .into_iter()
+        .map(|param| {
+            let name = param.name.clone();
+            let value = param.try_into().map_err(|error| {
+                napi::Error::from_reason(format!("Parameter conversion failed: {error}"))
+            })?;
+            Ok(RpcParameter::new(Some(name), StatusFlags::NONE, value))
+        })
+        .collect()
+}
+
 #[napi]
 impl Connection {
     #[napi]
@@ -95,27 +108,7 @@ impl Connection {
     ) -> napi::Result<()> {
         let mut client = self.tds_client.lock().await;
 
-        let rpc_params: Result<Vec<RpcParameter>, napi::Error> = params
-            .into_iter()
-            .map(|p| {
-                let param_name = p.name.clone();
-                let param_value = match p.try_into() {
-                    Ok(value) => value,
-                    Err(e) => {
-                        return Err(napi::Error::from_reason(format!(
-                            "Parameter conversion failed: {e}"
-                        )));
-                    }
-                };
-                Ok(RpcParameter::new(
-                    Some(param_name),
-                    StatusFlags::NONE,
-                    param_value,
-                ))
-            })
-            .collect();
-
-        let rpc_params = rpc_params?;
+        let rpc_params = input_parameters(params)?;
         let first = client
             .execute_sp_executesql(query, rpc_params, ())
             .await
@@ -183,15 +176,31 @@ impl Connection {
     /// one per result set, avoiding per-row N-API boundary crossings.
     ///
     /// The buffer layout is decoded on the JS side by `decode.ts`.
+    /// Parameters use `sp_executesql` without returning to JS between result stages.
     #[napi]
-    pub async fn query_raw(&self, query: String) -> napi::Result<Vec<Buffer>> {
+    pub async fn query_raw(
+        &self,
+        query: String,
+        params: Option<Vec<Parameter>>,
+    ) -> napi::Result<Vec<Buffer>> {
         let mut client = self.tds_client.lock().await;
 
         // Statement-wise execute, then collapse to row-returning result sets.
-        let first = client
-            .execute(query, ())
-            .await
-            .map_err(|e| napi::Error::from_reason(format!("Failed to execute query: {e}")))?;
+        let first = if let Some(params) = params.filter(|params| !params.is_empty()) {
+            client
+                .execute_sp_executesql(query, input_parameters(params)?, ())
+                .await
+                .map_err(|e| {
+                    napi::Error::from_reason(format!(
+                        "Failed to execute query with parameters: {e}"
+                    ))
+                })?
+        } else {
+            client
+                .execute(query, ())
+                .await
+                .map_err(|e| napi::Error::from_reason(format!("Failed to execute query: {e}")))?
+        };
         let mut has_rows = matches!(first, StatementResult::Rows);
         if !has_rows {
             has_rows = client.advance_to_rows().await.map_err(|e| {


### PR DESCRIPTION
<!--
Thank you for your interest in this project!

This repository is not currently accepting external pull requests. If you've found
a bug or have a feature request, please open an issue instead.

If you are a Microsoft team member, please follow the instructions in the internal
contribution guide.
-->

## Description

<!-- Briefly describe the change. -->

Parameterized queries in `mssql-js` paid for separate native execute, fetch, advance, and close calls even for a single row. This change keeps buffered execution and result collection in one native invocation and reduces JS-side row allocation.

- Reuse the existing `mssql-tds` row-writing path for parameterized `queryRaw` calls and cache the native connection's immutable encoding snapshot.
- Project decoded values directly into final row objects using reusable scratch storage, while preserving raw decoding, result metadata, empty/multiple result sets, and stored-procedure behavior.
- Add regression coverage and a pinned Tedious comparison harness with preserved-build comparisons, alternating driver order, result validation, and artifact hashes.

Production changes are limited to `mssql-js`; `mssql-tds` and ODBC are unchanged. Smaller native buffers and preallocated JS arrays were tried but not retained because their throughput gains were not reliable.

**Local benchmark results:** six interleaved rounds against the unchanged release build of `182af926`, using Node.js 22.23.2, Tedious 20.0.0, and SQL Server 2025 in Docker with TLS. Values are median queries/second; improvement is the median paired candidate/baseline ratio.

| Parameterized workload | Before | After | Tedious | Improvement |
| --- | ---: | ---: | ---: | ---: |
| Single-row lookup | 584.2 | 879.9 | 850.0 | 1.50x |
| Lookup, eight connections | 4,496.5 | 5,631.2 | 3,316.7 | 1.25x |
| 10,000 integer rows | 145.3 | 163.3 | 87.1 | 1.11x |
| 100,000 integer rows | 19.0 | 21.2 | 8.2 | 1.12x |

Lookup median latency fell from 1.67 ms to 1.09 ms, and client CPU per query from 1.23 ms to 0.51 ms. Non-parameterized controls stayed within observed run variation. Methodology and results are documented in `mssql-js/perf/README.md`; generated builds and raw samples are ignored by Git. These are local measurements, not production performance guarantees.

Scoped validation completed:
- `cargo bfmt`
- `cargo clippy -p mssql-js --frozen --all-targets -- -D warnings`
- `cargo nextest run -p mssql-js --frozen` - 14 tests passed
- Targeted Node.js 22 AVA unit/integration coverage - 135 tests passed
- ESLint and Prettier on changed JS/TS files

The workspace-wide `cargo bclippy` and `cargo btest` commands have not been run.

## Related Issues

<!--
Required: link a GitHub issue OR an Azure DevOps work item. The PR check will
fail without one.
GitHub issue: Fixes #123 (or https://github.com/microsoft/mssql-rs/issues/123)
ADO work item: https://sqlclientdrivers.visualstudio.com/<...>/_workitems/edit/<ID>
  (any project/collection path is accepted, e.g. .../<project>/_workitems/edit/123
  or .../DefaultCollection/<project>/_workitems/edit/123)
-->

No linked issue or work item, as requested. The required work-item gate is intentionally left failing for this draft.

## Checklist

- [x] `cargo bfmt` passes
- [ ] `cargo bclippy` passes
- [ ] `cargo btest` passes
- [x] New/changed functionality has tests
- [x] Public API changes are documented