### PR TITLE
Write ODBC traces to configured files

### DIFF
--- a/mssql-odbc/Cargo.toml
+++ b/mssql-odbc/Cargo.toml
@@ -19,6 +19,7 @@ mssql-tds = { path = "../mssql-tds" }
 tokio = { version = "1", features = ["rt-multi-thread", "sync"] }
 tracing = { version = "0.1.43", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+chrono = { version = "0.4", features = ["clock"] }
 async-trait = "0.1"
 # The azure SDK only ships a rustls-based reqwest transport (its `reqwest_rustls`
 # default), which drags in the vulnerable `ring` crate. Disable those defaults and

--- a/mssql-odbc/README.md
+++ b/mssql-odbc/README.md
@@ -72,6 +72,7 @@ Tracing is disabled by default. Enable it with environment variables:
 |---|---|---|
 | `MSSQL_TDS_TRACE` | `false` | Set to `true` to enable tracing output |
 | `MSSQL_TDS_TRACE_LEVEL` | `warn` | Tracing filter expression (`tracing_subscriber::EnvFilter`) |
+| `MSSQL_TDS_TRACE_DIR` | unset | Non-empty directory for a per-process trace file; when unset, tracing uses stderr |
 
 Examples:
 
@@ -84,7 +85,21 @@ MSSQL_TDS_TRACE=true MSSQL_TDS_TRACE_LEVEL="warn,mssqlodbc=debug" cargo btest -p
 
 # Full filter syntax is supported
 MSSQL_TDS_TRACE=true MSSQL_TDS_TRACE_LEVEL="warn,mssqlodbc=debug,mssql_tds=off" cargo btest -p mssqlodbc
+
+# Write to a timestamped file in an explicit directory
+MSSQL_TDS_TRACE=true MSSQL_TDS_TRACE_DIR=/var/log/myapp cargo btest -p mssqlodbc
+
+# Write to the current directory explicitly
+MSSQL_TDS_TRACE=true MSSQL_TDS_TRACE_DIR=. cargo btest -p mssqlodbc
 ```
+
+Trace filenames have the form `mssql_tds_trace_<timestamp>_<pid>.log`. Trace files can contain
+SQL text and parameter values; configure a directory whose permissions are appropriate for
+sensitive data. The driver warns when the configured directory is the system temporary directory
+and, on Unix, refuses directories writable by group or other users. Relative directories, including
+`.`, are resolved when the first ODBC call captures the configuration and are unaffected by later
+changes to the host process's current directory. Configuration cannot be changed while the driver
+remains loaded. Trace files are not rotated or removed automatically.
 
 ## Architecture
 

--- a/mssql-odbc/README.md
+++ b/mssql-odbc/README.md
@@ -105,9 +105,11 @@ directories, including `.`, are resolved when the first ODBC call captures the c
 are unaffected by later changes to the host process's current directory. Configuration cannot be
 changed while the driver remains loaded.
 
-File tracing is intended for diagnostics. The driver opens and closes the file for each event so it
-does not retain an operating-system handle after the unloadable driver library is released. This
-adds filesystem overhead, particularly at `debug` and `trace` levels. Trace files are not rotated or
+File tracing is intended for diagnostics. The driver keeps one synchronized file handle open while
+an ODBC environment is live and closes it after the last environment is freed, before the host may
+unload the driver. Events emitted without a live environment use transient handles. If another
+environment is later allocated in the same process, the file is reopened lazily. Writes are
+synchronous; the driver does not create a background logging thread. Trace files are not rotated or
 removed automatically.
 
 ## Architecture

--- a/mssql-odbc/README.md
+++ b/mssql-odbc/README.md
@@ -93,13 +93,22 @@ MSSQL_TDS_TRACE=true MSSQL_TDS_TRACE_DIR=/var/log/myapp cargo btest -p mssqlodbc
 MSSQL_TDS_TRACE=true MSSQL_TDS_TRACE_DIR=. cargo btest -p mssqlodbc
 ```
 
-Trace filenames have the form `mssql_tds_trace_<timestamp>_<pid>.log`. Trace files can contain
-SQL text and parameter values; configure a directory whose permissions are appropriate for
-sensitive data. The driver warns when the configured directory is the system temporary directory
-and, on Unix, refuses directories writable by group or other users. Relative directories, including
-`.`, are resolved when the first ODBC call captures the configuration and are unaffected by later
-changes to the host process's current directory. Configuration cannot be changed while the driver
-remains loaded. Trace files are not rotated or removed automatically.
+Trace filenames have the form `mssql_tds_trace_<timestamp>_<pid>.log`. Each event starts with an
+RFC 3339 UTC timestamp, thread ID, level, target, and event fields. Multiline event values can
+continue onto subsequent lines. General span fields are excluded because they can contain SQL text
+and parameter values. Event fields may still contain sensitive data; configure a trusted directory
+whose permissions are appropriate for it.
+
+On Unix, trace files are created with mode `0600`. The driver rejects world-writable directories
+without the sticky bit, warns for group-writable directories, and warns when the directory is inside
+the system temporary directory. Relative directories, including `.`, are resolved when the first
+ODBC call captures the configuration and are unaffected by later changes to the host process's
+current directory. Configuration cannot be changed while the driver remains loaded.
+
+File tracing is intended for diagnostics. The driver opens and closes the file for each event so it
+does not retain an operating-system handle after the unloadable driver library is released. This
+adds filesystem overhead, particularly at `debug` and `trace` levels. Trace files are not rotated or
+removed automatically.
 
 ## Architecture
 

--- a/mssql-odbc/README.md
+++ b/mssql-odbc/README.md
@@ -72,7 +72,7 @@ Tracing is disabled by default. Enable it with environment variables:
 |---|---|---|
 | `MSSQL_TDS_TRACE` | `false` | Set to `true` to enable tracing output |
 | `MSSQL_TDS_TRACE_LEVEL` | `warn` | Tracing filter expression (`tracing_subscriber::EnvFilter`) |
-| `MSSQL_TDS_TRACE_DIR` | unset | Non-empty directory for a per-process trace file; when unset, tracing uses stderr |
+| `MSSQL_TDS_TRACE_DIR` | unset | When tracing is enabled, non-empty directory for a per-process trace file; when unset, tracing uses stderr |
 
 Examples:
 

--- a/mssql-odbc/README.md
+++ b/mssql-odbc/README.md
@@ -99,11 +99,11 @@ continue onto subsequent lines. General span fields are excluded because they ca
 and parameter values. Event fields may still contain sensitive data; configure a trusted directory
 whose permissions are appropriate for it.
 
-On Unix, trace files are created with mode `0600`. The driver rejects world-writable directories
-without the sticky bit, warns for group-writable directories, and warns when the directory is inside
-the system temporary directory. Relative directories, including `.`, are resolved when the first
-ODBC call captures the configuration and are unaffected by later changes to the host process's
-current directory. Configuration cannot be changed while the driver remains loaded.
+On Unix, trace files are created with mode `0600`. The driver warns for directories writable by
+group or other users and when the directory is inside the system temporary directory. Relative
+directories, including `.`, are resolved when the first ODBC call captures the configuration and
+are unaffected by later changes to the host process's current directory. Configuration cannot be
+changed while the driver remains loaded.
 
 File tracing is intended for diagnostics. The driver opens and closes the file for each event so it
 does not retain an operating-system handle after the unloadable driver library is released. This

--- a/mssql-odbc/src/api/exports.rs
+++ b/mssql-odbc/src/api/exports.rs
@@ -29,7 +29,6 @@ pub unsafe extern "C" fn SQLAllocHandle(
     input_handle: SqlHandle,
     output_handle_ptr: *mut SqlHandle,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe { super::alloc_handle::sql_alloc_handle(handle_type, input_handle, output_handle_ptr) }
 }
 
@@ -40,7 +39,6 @@ pub unsafe extern "C" fn SQLAllocHandle(
 /// - `handle` must have been allocated by [`SQLAllocHandle`] and not already freed.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn SQLFreeHandle(handle_type: SqlSmallInt, handle: SqlHandle) -> SqlReturn {
-    crate::init_tracing();
     unsafe { super::free_handle::sql_free_handle(handle_type, handle) }
 }
 
@@ -57,7 +55,6 @@ pub unsafe extern "C" fn SQLSetEnvAttr(
     value_ptr: SqlPointer,
     string_length: SqlInteger,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::set_env_attr::sql_set_env_attr(
             environment_handle,
@@ -81,7 +78,6 @@ pub unsafe extern "C" fn SQLGetEnvAttr(
     buffer_length: SqlInteger,
     string_length_ptr: *mut SqlInteger,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::get_env_attr::sql_get_env_attr(
             environment_handle,
@@ -111,7 +107,6 @@ pub unsafe extern "C" fn SQLSetConnectAttrW(
     value_ptr: SqlPointer,
     string_length: SqlInteger,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::set_connect_attr::sql_set_connect_attr_w(
             connection_handle,
@@ -147,7 +142,6 @@ pub unsafe extern "C" fn SQLSetConnectAttr(
     value_ptr: SqlPointer,
     string_length: SqlInteger,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::set_connect_attr::sql_set_connect_attr(
             connection_handle,
@@ -172,7 +166,6 @@ pub unsafe extern "C" fn SQLGetStmtAttrW(
     buffer_length: SqlInteger,
     string_length_ptr: *mut SqlInteger,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::set_stmt_attr::sql_get_stmt_attr_w(
             statement_handle,
@@ -195,7 +188,6 @@ pub unsafe extern "C" fn SQLGetFunctions(
     function_id: SqlUSmallInt,
     supported_ptr: *mut SqlUSmallInt,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::get_functions::sql_get_functions(connection_handle, function_id, supported_ptr)
     }
@@ -214,7 +206,6 @@ pub unsafe extern "C" fn SQLGetInfoW(
     buffer_length: SqlSmallInt,
     string_length_ptr: *mut SqlSmallInt,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::get_info::sql_get_info_w(
             connection_handle,
@@ -250,7 +241,6 @@ pub unsafe extern "C" fn SQLGetDiagRecW(
     buffer_length: SqlSmallInt,
     text_length_ptr: *mut SqlSmallInt,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::get_diag::sql_get_diag_rec_w(
             handle_type,
@@ -284,7 +274,6 @@ pub unsafe extern "C" fn SQLGetDiagFieldW(
     buffer_length: SqlSmallInt,
     string_length_ptr: *mut SqlSmallInt,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::get_diag::sql_get_diag_field_w(
             handle_type,
@@ -320,7 +309,6 @@ pub unsafe extern "C" fn SQLConnectW(
     authentication: *const SqlWChar,
     name_length3: SqlSmallInt,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::connect::sql_connect_w(
             connection_handle,
@@ -353,7 +341,6 @@ pub unsafe extern "C" fn SQLDriverConnectW(
     string_length2_ptr: *mut SqlSmallInt,
     driver_completion: SqlUSmallInt,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::driver_connect::sql_driver_connect_w(
             connection_handle,
@@ -375,7 +362,6 @@ pub unsafe extern "C" fn SQLDriverConnectW(
 ///   `SQLAllocHandle(SQL_HANDLE_DBC, ...)`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn SQLDisconnect(connection_handle: SqlHandle) -> SqlReturn {
-    crate::init_tracing();
     unsafe { super::disconnect::sql_disconnect(connection_handle) }
 }
 
@@ -397,7 +383,6 @@ pub unsafe extern "C" fn SQLEndTran(
     handle: SqlHandle,
     completion_type: SqlSmallInt,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe { super::end_tran::sql_end_tran(handle_type, handle, completion_type) }
 }
 
@@ -411,7 +396,6 @@ pub unsafe extern "C" fn SQLEndTran(
 /// - `statement_handle` must be a valid STMT handle returned by `SQLAllocHandle`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn SQLCloseCursor(statement_handle: SqlHandle) -> SqlReturn {
-    crate::init_tracing();
     unsafe { super::close_cursor::sql_close_cursor(statement_handle) }
 }
 
@@ -428,7 +412,6 @@ pub unsafe extern "C" fn SQLFreeStmt(
     statement_handle: SqlHandle,
     option: SqlUSmallInt,
 ) -> SqlReturn {
-    crate::init_tracing();
     match option {
         SQL_CLOSE => unsafe { super::close_cursor::sql_free_stmt_close(statement_handle) },
         SQL_RESET_PARAMS => unsafe {
@@ -470,7 +453,6 @@ pub unsafe extern "C" fn SQLBindParameter(
     buffer_length: SqlLen,
     strlen_or_ind_ptr: *mut SqlLen,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::bind_param::sql_bind_parameter(
             statement_handle,
@@ -502,7 +484,6 @@ pub unsafe extern "C" fn SQLPrepareW(
     statement_text: *const SqlWChar,
     text_length: SqlSmallInt,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe { super::prepare::sql_prepare_w(statement_handle, statement_text, text_length) }
 }
 
@@ -521,7 +502,6 @@ pub unsafe extern "C" fn SQLDescribeParam(
     decimal_digits_ptr: *mut SqlSmallInt,
     nullable_ptr: *mut SqlSmallInt,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::describe_param::sql_describe_param(
             statement_handle,
@@ -553,7 +533,6 @@ pub unsafe extern "C" fn SQLExecDirectW(
     statement_text: *const SqlWChar,
     text_length: SqlSmallInt,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe { super::exec_direct::sql_exec_direct_w(statement_handle, statement_text, text_length) }
 }
 
@@ -567,7 +546,6 @@ pub unsafe extern "C" fn SQLGetTypeInfoW(
     statement_handle: SqlHandle,
     data_type: SqlSmallInt,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe { super::get_type_info::sql_get_type_info_w(statement_handle, data_type) }
 }
 
@@ -583,7 +561,6 @@ pub unsafe extern "C" fn SQLGetTypeInfoW(
 ///   offset pointer itself must remain readable for one `SqlLen`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn SQLExecute(statement_handle: SqlHandle) -> SqlReturn {
-    crate::init_tracing();
     unsafe { super::execute::sql_execute(statement_handle) }
 }
 
@@ -603,7 +580,6 @@ pub unsafe extern "C" fn SQLParamData(
     statement_handle: SqlHandle,
     value_ptr_ptr: *mut SqlPointer,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe { super::param_data::sql_param_data(statement_handle, value_ptr_ptr) }
 }
 
@@ -628,7 +604,6 @@ pub unsafe extern "C" fn SQLPutData(
     data_ptr: SqlPointer,
     strlen_or_ind: SqlLen,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe { super::put_data::sql_put_data(statement_handle, data_ptr, strlen_or_ind) }
 }
 
@@ -655,7 +630,6 @@ pub unsafe extern "C" fn SQLPutData(
 ///   `SqlUSmallInt` values for `SQL_ATTR_ROW_STATUS_PTR`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn SQLFetch(statement_handle: SqlHandle) -> SqlReturn {
-    crate::init_tracing();
     unsafe { super::fetch::sql_fetch(statement_handle) }
 }
 
@@ -685,7 +659,6 @@ pub unsafe extern "C" fn SQLBindCol(
     buffer_length: SqlLen,
     strlen_or_ind_ptr: *mut SqlLen,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::bind_col::sql_bind_col(
             statement_handle,
@@ -723,7 +696,6 @@ pub unsafe extern "C" fn SQLFetchScroll(
     fetch_orientation: SqlSmallInt,
     fetch_offset: SqlLen,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::fetch_scroll::sql_fetch_scroll(statement_handle, fetch_orientation, fetch_offset)
     }
@@ -739,7 +711,6 @@ pub unsafe extern "C" fn SQLNumResultCols(
     statement_handle: SqlHandle,
     column_count_ptr: *mut SqlSmallInt,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe { super::num_result_cols::sql_num_result_cols(statement_handle, column_count_ptr) }
 }
 
@@ -761,7 +732,6 @@ pub unsafe extern "C" fn SQLDescribeColW(
     decimal_digits_ptr: *mut SqlSmallInt,
     nullable_ptr: *mut SqlSmallInt,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::describe_col::sql_describe_col_w(
             statement_handle,
@@ -796,7 +766,6 @@ pub unsafe extern "C" fn SQLColAttributeW(
     string_length_ptr: *mut SqlSmallInt,
     numeric_attribute_ptr: *mut SqlLen,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::col_attribute::sql_col_attribute_w(
             statement_handle,
@@ -828,7 +797,6 @@ pub unsafe extern "C" fn SQLGetData(
     buffer_length: SqlLen,
     strlen_or_ind_ptr: *mut SqlLen,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::get_data::sql_get_data(
             statement_handle,
@@ -851,7 +819,6 @@ pub unsafe extern "C" fn SQLGetData(
 /// - `statement_handle` must be a valid STMT handle.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn SQLMoreResults(statement_handle: SqlHandle) -> SqlReturn {
-    crate::init_tracing();
     unsafe { super::more_results::sql_more_results(statement_handle) }
 }
 
@@ -867,7 +834,6 @@ pub unsafe extern "C" fn SQLRowCount(
     statement_handle: SqlHandle,
     row_count_ptr: *mut SqlLen,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe { super::row_count::sql_row_count(statement_handle, row_count_ptr) }
 }
 
@@ -893,7 +859,6 @@ pub unsafe extern "C" fn SQLTablesW(
     table_type: *const SqlWChar,
     name_length_4: SqlSmallInt,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::catalog::sql_tables_w(
             statement_handle,
@@ -929,7 +894,6 @@ pub unsafe extern "C" fn SQLColumnsW(
     column_name: *const SqlWChar,
     name_length_4: SqlSmallInt,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::catalog::sql_columns_w(
             statement_handle,
@@ -962,7 +926,6 @@ pub unsafe extern "C" fn SQLPrimaryKeysW(
     table_name: *const SqlWChar,
     name_length_3: SqlSmallInt,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::catalog::sql_primary_keys_w(
             statement_handle,
@@ -1000,7 +963,6 @@ pub unsafe extern "C" fn SQLForeignKeysW(
     fk_table_name: *const SqlWChar,
     name_length_6: SqlSmallInt,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::catalog::sql_foreign_keys_w(
             statement_handle,
@@ -1040,7 +1002,6 @@ pub unsafe extern "C" fn SQLStatisticsW(
     unique: SqlUSmallInt,
     reserved: SqlUSmallInt,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::catalog::sql_statistics_w(
             statement_handle,
@@ -1078,7 +1039,6 @@ pub unsafe extern "C" fn SQLSpecialColumnsW(
     scope: SqlUSmallInt,
     nullable: SqlUSmallInt,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::catalog::sql_special_columns_w(
             statement_handle,
@@ -1112,7 +1072,6 @@ pub unsafe extern "C" fn SQLProceduresW(
     proc_name: *const SqlWChar,
     name_length_3: SqlSmallInt,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::catalog::sql_procedures_w(
             statement_handle,
@@ -1142,7 +1101,6 @@ pub unsafe extern "C" fn SQLGetConnectAttrW(
     buffer_length: SqlInteger,
     string_length_ptr: *mut SqlInteger,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::get_connect_attr::sql_get_connect_attr_w(
             connection_handle,
@@ -1168,7 +1126,6 @@ pub unsafe extern "C" fn SQLSetStmtAttrW(
     value_ptr: SqlPointer,
     string_length: SqlInteger,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::set_stmt_attr::sql_set_stmt_attr_w(
             statement_handle,
@@ -1197,7 +1154,6 @@ pub unsafe extern "C" fn SQLGetDescFieldW(
     buffer_length: SqlInteger,
     string_length_ptr: *mut SqlInteger,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::get_desc_field::sql_get_desc_field_w(
             descriptor_handle,
@@ -1229,7 +1185,6 @@ pub unsafe extern "C" fn SQLSetDescFieldW(
     value_ptr: SqlPointer,
     buffer_length: SqlInteger,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::set_desc_field::sql_set_desc_field_w(
             descriptor_handle,
@@ -1264,7 +1219,6 @@ pub unsafe extern "C" fn SQLGetDescRecW(
     scale_ptr: *mut SqlSmallInt,
     nullable_ptr: *mut SqlSmallInt,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::get_desc_rec::sql_get_desc_rec_w(
             descriptor_handle,
@@ -1311,7 +1265,6 @@ pub unsafe extern "C" fn SQLSetDescRec(
     string_length_ptr: *mut SqlLen,
     indicator_ptr: *mut SqlLen,
 ) -> SqlReturn {
-    crate::init_tracing();
     unsafe {
         super::set_desc_rec::sql_set_desc_rec(
             descriptor_handle,
@@ -1334,6 +1287,5 @@ pub unsafe extern "C" fn SQLSetDescRec(
 /// - `statement_handle` must be a valid STMT handle.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn SQLCancel(statement_handle: SqlHandle) -> SqlReturn {
-    crate::init_tracing();
     unsafe { super::cancel::sql_cancel(statement_handle) }
 }

--- a/mssql-odbc/src/api/free_handle.rs
+++ b/mssql-odbc/src/api/free_handle.rs
@@ -97,6 +97,9 @@ unsafe fn free_env(handle: SqlHandle) -> SqlReturn {
     );
 
     unsafe { free_handle::<EnvHandle>(handle) };
+    if crate::handles::live_env_count() == 0 {
+        crate::tracing_init::close_trace_file();
+    }
     SQL_SUCCESS
 }
 

--- a/mssql-odbc/src/handles/mod.rs
+++ b/mssql-odbc/src/handles/mod.rs
@@ -15,6 +15,7 @@ pub(crate) use stmt::StmtHandle;
 
 use std::collections::HashMap;
 use std::ffi::c_void;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{LazyLock, Mutex, MutexGuard};
 
 use tracing::{debug, trace};
@@ -75,6 +76,7 @@ pub(crate) enum HandleType {
 /// already documents and does not attempt to close here.
 static LIVE_HANDLES: LazyLock<Mutex<HashMap<usize, HandleType>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
+static LIVE_ENV_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 /// Locks `LIVE_HANDLES`, recovering the guard even if the mutex is
 /// poisoned. Its critical sections are a single `HashMap` operation each,
@@ -100,6 +102,10 @@ pub(crate) fn live_type(raw: *mut c_void) -> Option<HandleType> {
     live_handles().get(&(raw as usize)).copied()
 }
 
+pub(crate) fn live_env_count() -> usize {
+    LIVE_ENV_COUNT.load(Ordering::Acquire)
+}
+
 /// Returns whether `raw` currently refers to a live handle of any type.
 /// Only used by tests today — production call sites need the type check
 /// `live_type` itself provides, so they match on it directly.
@@ -116,6 +122,9 @@ pub(crate) fn handle_to_raw<T: HasObjectType>(mut handle: Box<T>) -> *mut c_void
     let object_type = *handle.object_type_mut();
     let raw = Box::into_raw(handle) as *mut c_void;
     live_handles().insert(raw as usize, object_type);
+    if object_type == HandleType::Env {
+        LIVE_ENV_COUNT.fetch_add(1, Ordering::Release);
+    }
     raw
 }
 
@@ -162,6 +171,9 @@ pub(crate) unsafe fn free_handle<T: HasObjectType>(raw: *mut c_void) {
         live_handles().remove(&(raw as usize));
         let handle = unsafe { &mut *(raw as *mut T) };
         let object_type = *handle.object_type_mut();
+        if object_type == HandleType::Env {
+            LIVE_ENV_COUNT.fetch_sub(1, Ordering::Release);
+        }
         debug!(?raw, ?object_type, "Freeing handle");
         *handle.object_type_mut() = HandleType::Invalid;
         let _ = unsafe { Box::from_raw(raw as *mut T) };

--- a/mssql-odbc/src/lib.rs
+++ b/mssql-odbc/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::sync::Once;
-
 pub mod api;
 mod auth;
 mod connection;
@@ -10,6 +8,7 @@ mod conversion;
 mod error;
 mod handles;
 mod params;
+mod tracing_init;
 
 // Internal parse/convert helpers re-exposed as safe wrappers for coverage-guided
 // fuzzing (see `fuzz/`). The `fuzzing` cfg is set only by cargo-fuzz, so the
@@ -20,37 +19,7 @@ pub mod fuzz_support;
 #[cfg(test)]
 pub(crate) mod test_support;
 
-static INIT_TRACING: Once = Once::new();
-
-const ENV_TRACE: &str = "MSSQL_TDS_TRACE";
-const ENV_TRACE_LEVEL: &str = "MSSQL_TDS_TRACE_LEVEL";
-const DEFAULT_TRACE_LEVEL: &str = "warn";
-
-pub(crate) fn init_tracing() {
-    INIT_TRACING.call_once(|| {
-        let enabled = std::env::var(ENV_TRACE)
-            .map(|v| v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false);
-
-        if !enabled {
-            return;
-        }
-
-        let level = std::env::var(ENV_TRACE_LEVEL).unwrap_or_else(|_| DEFAULT_TRACE_LEVEL.into());
-        let filter = tracing_subscriber::EnvFilter::try_new(level.as_str()).unwrap_or_else(|err| {
-            eprintln!(
-                "[mssql-odbc] ERROR: Invalid {ENV_TRACE_LEVEL} value '{level}': {err}. Falling back to '{DEFAULT_TRACE_LEVEL}'."
-            );
-            tracing_subscriber::EnvFilter::new(DEFAULT_TRACE_LEVEL)
-        });
-
-        let _ = tracing_subscriber::fmt()
-            .with_env_filter(filter)
-            .with_ansi(false)
-            .with_writer(std::io::stderr)
-            .try_init();
-    });
-}
+pub(crate) use tracing_init::init_tracing;
 
 /// Wraps an FFI entry-point body in `catch_unwind` so a Rust panic crossing
 /// the C ABI is converted into `SQL_ERROR` rather than unwinding into C

--- a/mssql-odbc/src/lib.rs
+++ b/mssql-odbc/src/lib.rs
@@ -21,16 +21,17 @@ pub(crate) mod test_support;
 
 pub(crate) use tracing_init::init_tracing;
 
-/// Wraps an FFI entry-point body in `catch_unwind` so a Rust panic crossing
-/// the C ABI is converted into `SQL_ERROR` rather than unwinding into C
-/// (which is undefined behaviour). `$name` is the SQL function's display name
-/// used in the panic-caught error log and the trailing trace log.
-///
-/// Caller is responsible for `crate::init_tracing()` — already done at the
-/// export-layer call site in `api::exports`.
+/// Initializes tracing and wraps an FFI entry-point body in `catch_unwind` so
+/// a Rust panic crossing the C ABI is converted into `SQL_ERROR` rather than
+/// unwinding into C (which is undefined behaviour). `$name` is the SQL
+/// function's display name used in the panic-caught error log and the trailing
+/// trace log.
 macro_rules! ffi_entry {
     ($name:literal, $body:expr $(,)?) => {{
-        let ret = match ::std::panic::catch_unwind(|| $body) {
+        let ret = match ::std::panic::catch_unwind(|| {
+            $crate::init_tracing();
+            $body
+        }) {
             ::std::result::Result::Ok(rc) => rc,
             ::std::result::Result::Err(_) => {
                 ::tracing::error!(concat!($name, ": panic caught at FFI boundary"));

--- a/mssql-odbc/src/tracing_init.rs
+++ b/mssql-odbc/src/tracing_init.rs
@@ -7,13 +7,14 @@ use std::fmt;
 use std::fs::{OpenOptions, create_dir_all, remove_file};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, MutexGuard, Once};
+use std::sync::{Arc, Mutex, MutexGuard, Once, Weak};
 use tracing::{Event, Subscriber};
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields, MakeWriter};
 use tracing_subscriber::registry::LookupSpan;
 
 static INIT_TRACING: Once = Once::new();
+static TRACE_FILE_WRITER: Mutex<Option<Weak<TraceFileWriter>>> = Mutex::new(None);
 
 const ENV_TRACE: &str = "MSSQL_TDS_TRACE";
 const ENV_TRACE_LEVEL: &str = "MSSQL_TDS_TRACE_LEVEL";
@@ -56,13 +57,42 @@ where
 
 struct TraceFileWriter {
     path: PathBuf,
-    write_lock: Mutex<()>,
+    file: Mutex<Option<std::fs::File>>,
+    #[cfg(test)]
+    open_count: std::sync::atomic::AtomicU32,
+}
+
+#[derive(Clone)]
+struct SharedTraceFileWriter(Arc<TraceFileWriter>);
+
+impl TraceFileWriter {
+    fn new(path: PathBuf, file: std::fs::File) -> Self {
+        Self {
+            path,
+            file: Mutex::new(Some(file)),
+            #[cfg(test)]
+            open_count: std::sync::atomic::AtomicU32::new(1),
+        }
+    }
+
+    fn file(&self) -> MutexGuard<'_, Option<std::fs::File>> {
+        self.file
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn close(&self) {
+        self.file().take();
+    }
 }
 
 enum TraceWriter<'writer> {
-    File {
+    Cached {
+        file: MutexGuard<'writer, Option<std::fs::File>>,
+    },
+    Transient {
         file: std::fs::File,
-        _guard: MutexGuard<'writer, ()>,
+        _guard: MutexGuard<'writer, Option<std::fs::File>>,
     },
     Sink(io::Sink),
 }
@@ -70,45 +100,106 @@ enum TraceWriter<'writer> {
 impl Write for TraceWriter<'_> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         match self {
-            Self::File { file, .. } => file.write(buf),
+            Self::Cached { file } => file
+                .as_mut()
+                .ok_or_else(|| io::Error::other("trace file is closed"))?
+                .write(buf),
+            Self::Transient { file, .. } => file.write(buf),
             Self::Sink(sink) => sink.write(buf),
         }
     }
 
     fn flush(&mut self) -> io::Result<()> {
         match self {
-            Self::File { file, .. } => file.flush(),
+            Self::Cached { file } => file
+                .as_mut()
+                .ok_or_else(|| io::Error::other("trace file is closed"))?
+                .flush(),
+            Self::Transient { file, .. } => file.flush(),
             Self::Sink(sink) => sink.flush(),
         }
     }
 }
 
-impl<'writer> MakeWriter<'writer> for TraceFileWriter {
+impl<'writer> MakeWriter<'writer> for SharedTraceFileWriter {
     type Writer = TraceWriter<'writer>;
 
     fn make_writer(&'writer self) -> Self::Writer {
-        let guard = self
-            .write_lock
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        match OpenOptions::new().append(true).open(&self.path) {
-            Ok(file) => TraceWriter::File {
-                file,
-                _guard: guard,
-            },
-            Err(error) => {
-                drop(guard);
-                report(format_args!(
-                    "[mssql-odbc] ERROR: could not write trace file {:?}: {error}",
-                    self.path
-                ));
-                TraceWriter::Sink(io::sink())
+        if crate::handles::process_is_shutting_down() {
+            return TraceWriter::Sink(io::sink());
+        }
+
+        let file = self.0.file();
+        let has_live_env = crate::handles::live_env_count() != 0;
+        self.make_writer_for_env_state(file, has_live_env)
+    }
+}
+
+impl SharedTraceFileWriter {
+    fn make_writer_for_env_state<'writer>(
+        &'writer self,
+        mut cached_file: MutexGuard<'writer, Option<std::fs::File>>,
+        has_live_env: bool,
+    ) -> TraceWriter<'writer> {
+        if !has_live_env {
+            return match OpenOptions::new().append(true).open(&self.0.path) {
+                Ok(file) => TraceWriter::Transient {
+                    file,
+                    _guard: cached_file,
+                },
+                Err(error) => {
+                    report(format_args!(
+                        "[mssql-odbc] ERROR: could not reopen trace file {:?}: {error}",
+                        self.0.path
+                    ));
+                    TraceWriter::Sink(io::sink())
+                }
+            };
+        }
+
+        if cached_file.is_none() {
+            match OpenOptions::new().append(true).open(&self.0.path) {
+                Ok(reopened) => {
+                    *cached_file = Some(reopened);
+                    #[cfg(test)]
+                    self.0
+                        .open_count
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                }
+                Err(error) => {
+                    drop(cached_file);
+                    report(format_args!(
+                        "[mssql-odbc] ERROR: could not reopen trace file {:?}: {error}",
+                        self.0.path
+                    ));
+                    return TraceWriter::Sink(io::sink());
+                }
             }
         }
+        TraceWriter::Cached { file: cached_file }
+    }
+}
+
+pub(crate) fn close_trace_file() {
+    if crate::handles::process_is_shutting_down() {
+        return;
+    }
+
+    let writer = TRACE_FILE_WRITER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .as_ref()
+        .and_then(Weak::upgrade);
+    if let Some(writer) = writer {
+        writer.close();
     }
 }
 
 pub(crate) fn init_tracing() {
+    if crate::handles::process_is_shutting_down() {
+        return;
+    }
+
     if std::panic::catch_unwind(init_tracing_once).is_err() {
         report(format_args!(
             "[mssql-odbc] ERROR: panic while initializing tracing"
@@ -166,22 +257,24 @@ fn init_file_tracing(dir: OsString) -> Result<(), String> {
     let dir = prepare_trace_directory(PathBuf::from(dir))?;
 
     let timestamp = Local::now().format("%Y%m%d%H%M%S%3f").to_string();
-    let log_path = reserve_trace_file(&dir, &timestamp, std::process::id())
+    let (log_path, file) = reserve_trace_file(&dir, &timestamp, std::process::id())
         .map_err(|error| format!("could not create a trace file in {dir:?}: {error}"))?;
+    let writer = Arc::new(TraceFileWriter::new(log_path.clone(), file));
 
     let init_result = tracing_subscriber::fmt()
         .with_env_filter(trace_filter())
         .with_ansi(false)
-        .with_writer(TraceFileWriter {
-            path: log_path.clone(),
-            write_lock: Mutex::new(()),
-        })
+        .with_writer(SharedTraceFileWriter(Arc::clone(&writer)))
         .event_format(LogFormatter)
         .try_init();
     if let Err(error) = init_result {
         let _ = remove_file(&log_path);
         return Err(format!("could not install tracing subscriber: {error}"));
     }
+    *TRACE_FILE_WRITER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(Arc::downgrade(&writer));
+    writer.close();
 
     report(format_args!("[mssql-odbc] Tracing to {log_path:?}"));
     Ok(())
@@ -211,7 +304,11 @@ fn prepare_trace_directory(dir: PathBuf) -> Result<PathBuf, String> {
     Ok(resolved_dir)
 }
 
-fn reserve_trace_file(dir: &Path, timestamp: &str, pid: u32) -> io::Result<PathBuf> {
+fn reserve_trace_file(
+    dir: &Path,
+    timestamp: &str,
+    pid: u32,
+) -> io::Result<(PathBuf, std::fs::File)> {
     for attempt in 0..MAX_FILENAME_ATTEMPTS {
         let log_path = trace_log_path(dir, timestamp, pid, attempt);
         let mut options = OpenOptions::new();
@@ -224,7 +321,7 @@ fn reserve_trace_file(dir: &Path, timestamp: &str, pid: u32) -> io::Result<PathB
         }
 
         match options.open(&log_path) {
-            Ok(_) => return Ok(log_path),
+            Ok(file) => return Ok((log_path, file)),
             Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
             Err(error) => return Err(error),
         }
@@ -288,6 +385,19 @@ mod tests {
 
     static NEXT_TEST_DIR: AtomicU32 = AtomicU32::new(0);
 
+    #[derive(Clone)]
+    struct TestWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for TestWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap().write(buf)
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
     fn test_directory(test_name: &str) -> PathBuf {
         let sequence = NEXT_TEST_DIR.fetch_add(1, Ordering::Relaxed);
         let path = std::env::temp_dir().join(format!(
@@ -347,8 +457,8 @@ mod tests {
     #[test]
     fn reserve_trace_file_retries_a_filename_collision() {
         let dir = test_directory("collision");
-        let first_path = reserve_trace_file(&dir, "20260910123456789", 42).unwrap();
-        let second_path = reserve_trace_file(&dir, "20260910123456789", 42).unwrap();
+        let (first_path, first_file) = reserve_trace_file(&dir, "20260910123456789", 42).unwrap();
+        let (second_path, second_file) = reserve_trace_file(&dir, "20260910123456789", 42).unwrap();
 
         assert_eq!(
             first_path.file_name().unwrap(),
@@ -368,54 +478,111 @@ mod tests {
             );
         }
 
+        drop((first_file, second_file));
         remove_dir_all(dir).unwrap();
     }
 
     #[test]
-    fn trace_file_writer_appends_and_releases_each_handle() {
+    fn trace_file_writer_reuses_the_handle_until_closed() {
         let dir = test_directory("writer");
-        let path = reserve_trace_file(&dir, "20260910123456789", 42).unwrap();
-        let make_writer = TraceFileWriter {
-            path: path.clone(),
-            write_lock: Mutex::new(()),
-        };
+        let (path, file) = reserve_trace_file(&dir, "20260910123456789", 42).unwrap();
+        let writer = Arc::new(TraceFileWriter::new(path.clone(), file));
+        let make_writer = SharedTraceFileWriter(Arc::clone(&writer));
 
-        make_writer.make_writer().write_all(b"first\n").unwrap();
-        make_writer.make_writer().write_all(b"second\n").unwrap();
+        make_writer
+            .make_writer_for_env_state(writer.file(), true)
+            .write_all(b"first\n")
+            .unwrap();
+        make_writer
+            .make_writer_for_env_state(writer.file(), true)
+            .write_all(b"second\n")
+            .unwrap();
 
-        assert_eq!(std::fs::read_to_string(path).unwrap(), "first\nsecond\n");
+        assert_eq!(writer.open_count.load(Ordering::Relaxed), 1);
+        writer.close();
+
+        let moved_path = path.with_extension("moved");
+        std::fs::rename(&path, &moved_path).unwrap();
+        std::fs::rename(&moved_path, &path).unwrap();
+
+        make_writer
+            .make_writer_for_env_state(writer.file(), true)
+            .write_all(b"third\n")
+            .unwrap();
+        assert_eq!(writer.open_count.load(Ordering::Relaxed), 2);
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "first\nsecond\nthird\n"
+        );
+
+        writer.close();
+        remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn trace_file_writer_does_not_cache_without_an_environment() {
+        let dir = test_directory("transient-writer");
+        let (path, file) = reserve_trace_file(&dir, "20260910123456789", 42).unwrap();
+        let writer = Arc::new(TraceFileWriter::new(path.clone(), file));
+        writer.close();
+        let make_writer = SharedTraceFileWriter(Arc::clone(&writer));
+
+        make_writer
+            .make_writer_for_env_state(writer.file(), false)
+            .write_all(b"first\n")
+            .unwrap();
+        std::fs::rename(&path, path.with_extension("moved")).unwrap();
+
         remove_dir_all(dir).unwrap();
     }
 
     #[test]
     fn trace_file_writer_recovers_a_poisoned_lock() {
         let dir = test_directory("poison");
-        let path = reserve_trace_file(&dir, "20260910123456789", 42).unwrap();
-        let make_writer = TraceFileWriter {
-            path: path.clone(),
-            write_lock: Mutex::new(()),
-        };
+        let (path, file) = reserve_trace_file(&dir, "20260910123456789", 42).unwrap();
+        let writer = Arc::new(TraceFileWriter::new(path.clone(), file));
+        let make_writer = SharedTraceFileWriter(Arc::clone(&writer));
         let _ = std::panic::catch_unwind(|| {
-            let _guard = make_writer.write_lock.lock().unwrap();
+            let _guard = writer.file.lock().unwrap();
             panic!("poison the trace serialization lock");
         });
 
         make_writer
-            .make_writer()
+            .make_writer_for_env_state(writer.file(), true)
             .write_all(b"after poison\n")
             .unwrap();
 
         assert_eq!(std::fs::read_to_string(path).unwrap(), "after poison\n");
+        writer.close();
+        remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn event_writer_serializes_close_until_it_is_dropped() {
+        let dir = test_directory("close-serialization");
+        let (path, file) = reserve_trace_file(&dir, "20260910123456789", 42).unwrap();
+        let writer = Arc::new(TraceFileWriter::new(path, file));
+        let make_writer = SharedTraceFileWriter(Arc::clone(&writer));
+        let event_writer = make_writer.make_writer_for_env_state(writer.file(), true);
+
+        assert!(matches!(
+            writer.file.try_lock(),
+            Err(std::sync::TryLockError::WouldBlock)
+        ));
+        drop(event_writer);
+        writer.close();
+        assert!(writer.file().is_none());
         remove_dir_all(dir).unwrap();
     }
 
     #[test]
     fn formatter_emits_stable_fields_without_span_context() {
         let output = Arc::new(Mutex::new(Vec::new()));
+        let test_output = Arc::clone(&output);
         let subscriber = tracing_subscriber::registry().with(
             tracing_subscriber::fmt::layer()
                 .with_ansi(false)
-                .with_writer(output.clone())
+                .with_writer(move || TestWriter(Arc::clone(&test_output)))
                 .event_format(LogFormatter),
         );
 

--- a/mssql-odbc/src/tracing_init.rs
+++ b/mssql-odbc/src/tracing_init.rs
@@ -1,0 +1,373 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use chrono::Local;
+use std::ffi::OsString;
+use std::fmt;
+use std::fs::{OpenOptions, create_dir_all, remove_file};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard, Once};
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::fmt::MakeWriter;
+
+static INIT_TRACING: Once = Once::new();
+
+const ENV_TRACE: &str = "MSSQL_TDS_TRACE";
+const ENV_TRACE_LEVEL: &str = "MSSQL_TDS_TRACE_LEVEL";
+const ENV_TRACE_DIR: &str = "MSSQL_TDS_TRACE_DIR";
+const DEFAULT_TRACE_LEVEL: &str = "warn";
+const LOG_FILE_PREFIX: &str = "mssql_tds_trace";
+const MAX_FILENAME_ATTEMPTS: u32 = 100;
+
+struct TraceFileWriter {
+    path: PathBuf,
+    write_lock: Mutex<()>,
+}
+
+enum TraceWriter<'writer> {
+    File {
+        file: std::fs::File,
+        _guard: MutexGuard<'writer, ()>,
+    },
+    Sink(io::Sink),
+}
+
+impl Write for TraceWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self {
+            Self::File { file, .. } => file.write(buf),
+            Self::Sink(sink) => sink.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match self {
+            Self::File { file, .. } => file.flush(),
+            Self::Sink(sink) => sink.flush(),
+        }
+    }
+}
+
+impl<'writer> MakeWriter<'writer> for TraceFileWriter {
+    type Writer = TraceWriter<'writer>;
+
+    fn make_writer(&'writer self) -> Self::Writer {
+        let guard = self
+            .write_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        match OpenOptions::new().append(true).open(&self.path) {
+            Ok(file) => TraceWriter::File {
+                file,
+                _guard: guard,
+            },
+            Err(error) => {
+                drop(guard);
+                report(format_args!(
+                    "[mssql-odbc] ERROR: could not write trace file {:?}: {error}",
+                    self.path
+                ));
+                TraceWriter::Sink(io::sink())
+            }
+        }
+    }
+}
+
+pub(crate) fn init_tracing() {
+    if std::panic::catch_unwind(init_tracing_once).is_err() {
+        report(format_args!(
+            "[mssql-odbc] ERROR: panic while initializing tracing"
+        ));
+    }
+}
+
+fn init_tracing_once() {
+    INIT_TRACING.call_once(|| {
+        let enabled = std::env::var(ENV_TRACE)
+            .map(|value| value.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+
+        if !enabled {
+            return;
+        }
+
+        let trace_dir = std::env::var_os(ENV_TRACE_DIR);
+        let result = match trace_dir {
+            Some(dir) => init_file_tracing(dir),
+            None => init_stderr_tracing(),
+        };
+
+        if let Err(error) = result {
+            report(format_args!("[mssql-odbc] ERROR: {error}"));
+        }
+    });
+}
+
+fn trace_filter() -> EnvFilter {
+    let level = std::env::var(ENV_TRACE_LEVEL).unwrap_or_else(|_| DEFAULT_TRACE_LEVEL.into());
+    EnvFilter::try_new(level.as_str()).unwrap_or_else(|error| {
+        report(format_args!(
+            "[mssql-odbc] ERROR: Invalid {ENV_TRACE_LEVEL} value '{level}': {error}. Falling back to '{DEFAULT_TRACE_LEVEL}'."
+        ));
+        EnvFilter::new(DEFAULT_TRACE_LEVEL)
+    })
+}
+
+fn init_stderr_tracing() -> Result<(), String> {
+    tracing_subscriber::fmt()
+        .with_env_filter(trace_filter())
+        .with_ansi(false)
+        .with_writer(std::io::stderr)
+        .try_init()
+        .map_err(|error| format!("could not install tracing subscriber: {error}"))
+}
+
+fn init_file_tracing(dir: OsString) -> Result<(), String> {
+    if dir.is_empty() {
+        return Err(format!("{ENV_TRACE_DIR} must not be empty"));
+    }
+
+    let dir = prepare_trace_directory(PathBuf::from(dir))?;
+
+    let timestamp = Local::now().format("%Y%m%d%H%M%S%3f").to_string();
+    let log_path = reserve_trace_file(&dir, &timestamp, std::process::id())
+        .map_err(|error| format!("could not create a trace file in {dir:?}: {error}"))?;
+
+    let init_result = tracing_subscriber::fmt()
+        .with_env_filter(trace_filter())
+        .with_ansi(false)
+        .with_writer(TraceFileWriter {
+            path: log_path.clone(),
+            write_lock: Mutex::new(()),
+        })
+        .try_init();
+    if let Err(error) = init_result {
+        let _ = remove_file(&log_path);
+        return Err(format!("could not install tracing subscriber: {error}"));
+    }
+
+    report(format_args!("[mssql-odbc] Tracing to {log_path:?}"));
+    Ok(())
+}
+
+fn prepare_trace_directory(dir: PathBuf) -> Result<PathBuf, String> {
+    let absolute_dir = if dir.is_absolute() {
+        dir
+    } else {
+        std::env::current_dir()
+            .map_err(|error| format!("could not resolve {ENV_TRACE_DIR}: {error}"))?
+            .join(dir)
+    };
+    create_dir_all(&absolute_dir)
+        .map_err(|error| format!("could not create trace directory {absolute_dir:?}: {error}"))?;
+    let resolved_dir = absolute_dir
+        .canonicalize()
+        .map_err(|error| format!("could not resolve trace directory {absolute_dir:?}: {error}"))?;
+
+    if !resolved_dir.is_dir() {
+        return Err(format!(
+            "{ENV_TRACE_DIR} is not a directory: {resolved_dir:?}"
+        ));
+    }
+
+    validate_trace_directory(&resolved_dir)?;
+    Ok(resolved_dir)
+}
+
+fn reserve_trace_file(dir: &Path, timestamp: &str, pid: u32) -> io::Result<PathBuf> {
+    for attempt in 0..MAX_FILENAME_ATTEMPTS {
+        let log_path = trace_log_path(dir, timestamp, pid, attempt);
+        let mut options = OpenOptions::new();
+        options.create_new(true).write(true);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+
+        match options.open(&log_path) {
+            Ok(_) => return Ok(log_path),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error),
+        }
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::AlreadyExists,
+        "could not allocate a unique trace filename",
+    ))
+}
+
+fn trace_log_path(dir: &Path, timestamp: &str, pid: u32, attempt: u32) -> PathBuf {
+    let collision_suffix = if attempt == 0 {
+        String::new()
+    } else {
+        format!("_{attempt}")
+    };
+    dir.join(format!(
+        "{LOG_FILE_PREFIX}_{timestamp}_{pid}{collision_suffix}.log"
+    ))
+}
+
+fn validate_trace_directory(dir: &Path) -> Result<(), String> {
+    let temp_dir = std::env::temp_dir();
+    let resolved_temp_dir = temp_dir.canonicalize().unwrap_or(temp_dir);
+    if dir.starts_with(&resolved_temp_dir) {
+        report(format_args!(
+            "[mssql-odbc] WARNING: {ENV_TRACE_DIR} points inside the system temporary directory. Trace files may contain SQL text and parameter values."
+        ));
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let metadata = dir
+            .metadata()
+            .map_err(|error| format!("could not inspect trace directory {dir:?}: {error}"))?;
+        if metadata.permissions().mode() & 0o022 != 0 {
+            return Err(format!(
+                "{ENV_TRACE_DIR} must not be writable by group or other users: {dir:?}"
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn report(args: fmt::Arguments<'_>) {
+    let _ = writeln!(io::stderr().lock(), "{args}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::remove_dir_all;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    static NEXT_TEST_DIR: AtomicU32 = AtomicU32::new(0);
+
+    fn test_directory(test_name: &str) -> PathBuf {
+        let sequence = NEXT_TEST_DIR.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "mssqlodbc-{test_name}-{}-{sequence}",
+            std::process::id()
+        ));
+        let _ = remove_dir_all(&path);
+        std::fs::create_dir(&path).unwrap();
+        path
+    }
+
+    #[test]
+    fn trace_log_path_contains_timestamp_and_pid() {
+        let path = trace_log_path(Path::new("trace-dir"), "20260910123456789", 42, 0);
+
+        assert_eq!(
+            path,
+            Path::new("trace-dir").join("mssql_tds_trace_20260910123456789_42.log")
+        );
+    }
+
+    #[test]
+    fn current_directory_is_an_explicit_trace_directory() {
+        let path = trace_log_path(Path::new("."), "20260910123456789", 42, 0);
+
+        assert_eq!(
+            path,
+            Path::new(".").join("mssql_tds_trace_20260910123456789_42.log")
+        );
+    }
+
+    #[test]
+    fn relative_trace_directory_is_resolved_to_an_absolute_path() {
+        let dir_name = format!(
+            "mssqlodbc-relative-{}-{}",
+            std::process::id(),
+            NEXT_TEST_DIR.fetch_add(1, Ordering::Relaxed)
+        );
+        let expected = std::env::current_dir().unwrap().join(&dir_name);
+
+        let resolved = prepare_trace_directory(PathBuf::from(&dir_name)).unwrap();
+
+        assert!(resolved.is_absolute());
+        assert_eq!(resolved, expected.canonicalize().unwrap());
+        remove_dir_all(expected).unwrap();
+    }
+
+    #[test]
+    fn filename_collision_adds_attempt_suffix() {
+        let path = trace_log_path(Path::new("trace-dir"), "20260910123456789", 42, 3);
+
+        assert_eq!(
+            path,
+            Path::new("trace-dir").join("mssql_tds_trace_20260910123456789_42_3.log")
+        );
+    }
+
+    #[test]
+    fn reserve_trace_file_retries_a_filename_collision() {
+        let dir = test_directory("collision");
+        let first_path = reserve_trace_file(&dir, "20260910123456789", 42).unwrap();
+        let second_path = reserve_trace_file(&dir, "20260910123456789", 42).unwrap();
+
+        assert_eq!(
+            first_path.file_name().unwrap(),
+            "mssql_tds_trace_20260910123456789_42.log"
+        );
+        assert_eq!(
+            second_path.file_name().unwrap(),
+            "mssql_tds_trace_20260910123456789_42_1.log"
+        );
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                first_path.metadata().unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+
+        remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn trace_file_writer_appends_and_releases_each_handle() {
+        let dir = test_directory("writer");
+        let path = reserve_trace_file(&dir, "20260910123456789", 42).unwrap();
+        let make_writer = TraceFileWriter {
+            path: path.clone(),
+            write_lock: Mutex::new(()),
+        };
+
+        make_writer.make_writer().write_all(b"first\n").unwrap();
+        make_writer.make_writer().write_all(b"second\n").unwrap();
+
+        assert_eq!(std::fs::read_to_string(path).unwrap(), "first\nsecond\n");
+        remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn trace_file_writer_recovers_a_poisoned_lock() {
+        let dir = test_directory("poison");
+        let path = reserve_trace_file(&dir, "20260910123456789", 42).unwrap();
+        let make_writer = TraceFileWriter {
+            path: path.clone(),
+            write_lock: Mutex::new(()),
+        };
+        let _ = std::panic::catch_unwind(|| {
+            let _guard = make_writer.write_lock.lock().unwrap();
+            panic!("poison the trace serialization lock");
+        });
+
+        make_writer
+            .make_writer()
+            .write_all(b"after poison\n")
+            .unwrap();
+
+        assert_eq!(std::fs::read_to_string(path).unwrap(), "after poison\n");
+        remove_dir_all(dir).unwrap();
+    }
+}

--- a/mssql-odbc/src/tracing_init.rs
+++ b/mssql-odbc/src/tracing_init.rs
@@ -200,14 +200,6 @@ pub(crate) fn init_tracing() {
         return;
     }
 
-    if std::panic::catch_unwind(init_tracing_once).is_err() {
-        report(format_args!(
-            "[mssql-odbc] ERROR: panic while initializing tracing"
-        ));
-    }
-}
-
-fn init_tracing_once() {
     INIT_TRACING.call_once(|| {
         let enabled = std::env::var(ENV_TRACE)
             .map(|value| value.eq_ignore_ascii_case("true"))

--- a/mssql-odbc/src/tracing_init.rs
+++ b/mssql-odbc/src/tracing_init.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use chrono::{Local, Utc};
+use chrono::Utc;
 use std::ffi::OsString;
 use std::fmt;
 use std::fs::{OpenOptions, create_dir_all, remove_file};
@@ -256,7 +256,7 @@ fn init_file_tracing(dir: OsString) -> Result<(), String> {
 
     let dir = prepare_trace_directory(PathBuf::from(dir))?;
 
-    let timestamp = Local::now().format("%Y%m%d%H%M%S%3f").to_string();
+    let timestamp = Utc::now().format("%Y%m%d%H%M%S%3f").to_string();
     let (log_path, file) = reserve_trace_file(&dir, &timestamp, std::process::id())
         .map_err(|error| format!("could not create a trace file in {dir:?}: {error}"))?;
     let writer = Arc::new(TraceFileWriter::new(log_path.clone(), file));
@@ -531,7 +531,7 @@ mod tests {
             .make_writer_for_env_state(writer.file(), false)
             .write_all(b"first\n")
             .unwrap();
-        std::fs::rename(&path, path.with_extension("moved")).unwrap();
+        assert!(writer.file().is_none());
 
         remove_dir_all(dir).unwrap();
     }

--- a/mssql-odbc/src/tracing_init.rs
+++ b/mssql-odbc/src/tracing_init.rs
@@ -264,14 +264,9 @@ fn validate_trace_directory(dir: &Path) -> Result<(), String> {
             .metadata()
             .map_err(|error| format!("could not inspect trace directory {dir:?}: {error}"))?;
         let mode = metadata.permissions().mode();
-        if mode & 0o002 != 0 && mode & 0o1000 == 0 {
-            return Err(format!(
-                "{ENV_TRACE_DIR} must not be world-writable without the sticky bit: {dir:?}"
-            ));
-        }
-        if mode & 0o020 != 0 {
+        if mode & 0o022 != 0 {
             report(format_args!(
-                "[mssql-odbc] WARNING: {ENV_TRACE_DIR} is group-writable. Ensure every user with write access is trusted: {dir:?}"
+                "[mssql-odbc] WARNING: {ENV_TRACE_DIR} is writable by group or other users. Ensure every user with write access is trusted: {dir:?}"
             ));
         }
     }
@@ -451,24 +446,15 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn group_writable_trace_directory_is_allowed() {
+    fn group_and_world_writable_trace_directories_are_allowed() {
         use std::os::unix::fs::PermissionsExt;
 
-        let dir = test_directory("group-writable");
+        let dir = test_directory("writable");
         std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o770)).unwrap();
-
         assert!(validate_trace_directory(&dir).is_ok());
-        remove_dir_all(dir).unwrap();
-    }
 
-    #[cfg(unix)]
-    #[test]
-    fn world_writable_trace_directory_requires_sticky_bit() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let dir = test_directory("world-writable");
         std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o777)).unwrap();
-        assert!(validate_trace_directory(&dir).is_err());
+        assert!(validate_trace_directory(&dir).is_ok());
 
         std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o1777)).unwrap();
         assert!(validate_trace_directory(&dir).is_ok());

--- a/mssql-odbc/src/tracing_init.rs
+++ b/mssql-odbc/src/tracing_init.rs
@@ -1,15 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use chrono::Local;
+use chrono::{Local, Utc};
 use std::ffi::OsString;
 use std::fmt;
 use std::fs::{OpenOptions, create_dir_all, remove_file};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, MutexGuard, Once};
+use tracing::{Event, Subscriber};
 use tracing_subscriber::EnvFilter;
-use tracing_subscriber::fmt::MakeWriter;
+use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields, MakeWriter};
+use tracing_subscriber::registry::LookupSpan;
 
 static INIT_TRACING: Once = Once::new();
 
@@ -19,6 +21,38 @@ const ENV_TRACE_DIR: &str = "MSSQL_TDS_TRACE_DIR";
 const DEFAULT_TRACE_LEVEL: &str = "warn";
 const LOG_FILE_PREFIX: &str = "mssql_tds_trace";
 const MAX_FILENAME_ATTEMPTS: u32 = 100;
+
+struct LogFormatter;
+
+impl<S, N> FormatEvent<S, N> for LogFormatter
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+    N: for<'writer> FormatFields<'writer> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: tracing_subscriber::fmt::format::Writer<'_>,
+        event: &Event<'_>,
+    ) -> fmt::Result {
+        let timestamp = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        let thread_id = format!("{:?}", std::thread::current().id());
+        let thread_id = thread_id
+            .strip_prefix("ThreadId(")
+            .and_then(|value| value.strip_suffix(')'))
+            .unwrap_or("unknown");
+        let metadata = event.metadata();
+
+        write!(
+            writer,
+            "{timestamp}, {thread_id}, {}, {}, ",
+            metadata.level(),
+            metadata.target()
+        )?;
+        ctx.field_format().format_fields(writer.by_ref(), event)?;
+        writeln!(writer)
+    }
+}
 
 struct TraceFileWriter {
     path: PathBuf,
@@ -119,6 +153,7 @@ fn init_stderr_tracing() -> Result<(), String> {
         .with_env_filter(trace_filter())
         .with_ansi(false)
         .with_writer(std::io::stderr)
+        .event_format(LogFormatter)
         .try_init()
         .map_err(|error| format!("could not install tracing subscriber: {error}"))
 }
@@ -141,6 +176,7 @@ fn init_file_tracing(dir: OsString) -> Result<(), String> {
             path: log_path.clone(),
             write_lock: Mutex::new(()),
         })
+        .event_format(LogFormatter)
         .try_init();
     if let Err(error) = init_result {
         let _ = remove_file(&log_path);
@@ -227,9 +263,15 @@ fn validate_trace_directory(dir: &Path) -> Result<(), String> {
         let metadata = dir
             .metadata()
             .map_err(|error| format!("could not inspect trace directory {dir:?}: {error}"))?;
-        if metadata.permissions().mode() & 0o022 != 0 {
+        let mode = metadata.permissions().mode();
+        if mode & 0o002 != 0 && mode & 0o1000 == 0 {
             return Err(format!(
-                "{ENV_TRACE_DIR} must not be writable by group or other users: {dir:?}"
+                "{ENV_TRACE_DIR} must not be world-writable without the sticky bit: {dir:?}"
+            ));
+        }
+        if mode & 0o020 != 0 {
+            report(format_args!(
+                "[mssql-odbc] WARNING: {ENV_TRACE_DIR} is group-writable. Ensure every user with write access is trusted: {dir:?}"
             ));
         }
     }
@@ -245,7 +287,9 @@ fn report(args: fmt::Arguments<'_>) {
 mod tests {
     use super::*;
     use std::fs::remove_dir_all;
+    use std::sync::Arc;
     use std::sync::atomic::{AtomicU32, Ordering};
+    use tracing_subscriber::layer::SubscriberExt;
 
     static NEXT_TEST_DIR: AtomicU32 = AtomicU32::new(0);
 
@@ -272,12 +316,11 @@ mod tests {
 
     #[test]
     fn current_directory_is_an_explicit_trace_directory() {
-        let path = trace_log_path(Path::new("."), "20260910123456789", 42, 0);
+        let expected = std::env::current_dir().unwrap().canonicalize().unwrap();
 
-        assert_eq!(
-            path,
-            Path::new(".").join("mssql_tds_trace_20260910123456789_42.log")
-        );
+        let resolved = prepare_trace_directory(PathBuf::from(".")).unwrap();
+
+        assert_eq!(resolved, expected);
     }
 
     #[test]
@@ -368,6 +411,67 @@ mod tests {
             .unwrap();
 
         assert_eq!(std::fs::read_to_string(path).unwrap(), "after poison\n");
+        remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn formatter_emits_stable_fields_without_span_context() {
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .with_ansi(false)
+                .with_writer(output.clone())
+                .event_format(LogFormatter),
+        );
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!(
+                target: "mssql_tds::connection::tds_client",
+                "execute",
+                sql_command = "SELECT 'SECRET_SQL_LITERAL'"
+            );
+            let _entered = span.enter();
+            tracing::info!(target: "mssqlodbc::test", operation_id = 42_u64, "completed");
+        });
+
+        let output = output.lock().unwrap();
+        let output = std::str::from_utf8(&output).unwrap();
+        let fields: Vec<_> = output.splitn(5, ',').collect();
+        assert_eq!(fields.len(), 5);
+        assert!(fields[0].contains('T'));
+        assert!(fields[0].ends_with('Z'));
+        assert!(fields[1].trim().parse::<u64>().is_ok());
+        assert_eq!(fields[2].trim(), "INFO");
+        assert_eq!(fields[3].trim(), "mssqlodbc::test");
+        assert!(fields[4].contains("completed"));
+        assert!(fields[4].contains("operation_id=42"));
+        assert!(!output.contains("sql_command"));
+        assert!(!output.contains("SECRET_SQL_LITERAL"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn group_writable_trace_directory_is_allowed() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = test_directory("group-writable");
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o770)).unwrap();
+
+        assert!(validate_trace_directory(&dir).is_ok());
+        remove_dir_all(dir).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn world_writable_trace_directory_requires_sticky_bit() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = test_directory("world-writable");
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o777)).unwrap();
+        assert!(validate_trace_directory(&dir).is_err());
+
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o1777)).unwrap();
+        assert!(validate_trace_directory(&dir).is_ok());
         remove_dir_all(dir).unwrap();
     }
 }

--- a/mssql-odbc/tests/e2e/tests/dll_unload_stress_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/dll_unload_stress_test.cpp
@@ -51,7 +51,9 @@
 #include <sqlext.h>
 
 #include <cstdlib>
+#include <filesystem>
 #include <string>
+#include <vector>
 
 namespace {
 
@@ -64,6 +66,29 @@ using SQLExecDirectWFn = SQLRETURN(SQL_API*)(SQLHSTMT, SQLWCHAR*, SQLINTEGER);
 using SQLFetchFn = SQLRETURN(SQL_API*)(SQLHSTMT);
 using SQLDisconnectFn = SQLRETURN(SQL_API*)(SQLHDBC);
 using SQLFreeHandleFn = SQLRETURN(SQL_API*)(SQLSMALLINT, SQLHANDLE);
+
+class ScopedEnvironmentVariable {
+   public:
+    ScopedEnvironmentVariable(const char* name, const char* value) : name_(name) {
+        const DWORD length = GetEnvironmentVariableA(name, nullptr, 0);
+        if (length != 0) {
+            previous_.resize(length);
+            GetEnvironmentVariableA(name, previous_.data(), length);
+            previous_.resize(length - 1);
+            existed_ = true;
+        }
+        SetEnvironmentVariableA(name, value);
+    }
+
+    ~ScopedEnvironmentVariable() {
+        SetEnvironmentVariableA(name_.c_str(), existed_ ? previous_.c_str() : nullptr);
+    }
+
+   private:
+    std::string name_;
+    std::string previous_;
+    bool existed_ = false;
+};
 
 std::string GetEnvOr(const char* name, const char* fallback) {
     char* buf = nullptr;
@@ -205,6 +230,86 @@ TEST(DllUnloadStress, FreeEnvThenUnloadRepeatedly) {
     for (int i = 1; i <= iterations; ++i) {
         ASSERT_NO_FATAL_FAILURE(LoadUseUnload(dll_path, wide_conn, i));
     }
+}
+
+TEST(DllUnloadStress, TraceFileClosesAfterLastEnvironment) {
+    const std::string dll_path = GetEnvOr("MSSQL_ODBC_DLL", "");
+    if (dll_path.empty()) {
+        GTEST_SKIP() << "MSSQL_ODBC_DLL is not set; skipping the DLL unload stress test";
+    }
+
+    const std::filesystem::path trace_dir =
+        std::filesystem::temp_directory_path() /
+        ("mssqlodbc-trace-unload-" + std::to_string(GetCurrentProcessId()));
+    std::filesystem::remove_all(trace_dir);
+    ASSERT_TRUE(std::filesystem::create_directory(trace_dir));
+
+    ScopedEnvironmentVariable trace_enabled("MSSQL_TDS_TRACE", "true");
+    ScopedEnvironmentVariable trace_level("MSSQL_TDS_TRACE_LEVEL", "trace");
+    ScopedEnvironmentVariable trace_directory("MSSQL_TDS_TRACE_DIR",
+                                                trace_dir.string().c_str());
+
+    for (int iteration = 1; iteration <= 20; ++iteration) {
+        HMODULE driver = LoadLibraryA(dll_path.c_str());
+        ASSERT_NE(driver, nullptr) << "iteration " << iteration << ": LoadLibraryA failed";
+
+        auto alloc_handle =
+            reinterpret_cast<SQLAllocHandleFn>(GetProcAddress(driver, "SQLAllocHandle"));
+        auto free_handle =
+            reinterpret_cast<SQLFreeHandleFn>(GetProcAddress(driver, "SQLFreeHandle"));
+        ASSERT_TRUE(alloc_handle && free_handle)
+            << "iteration " << iteration << ": driver is missing handle exports";
+
+        EXPECT_EQ(alloc_handle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, nullptr), SQL_INVALID_HANDLE);
+        std::vector<std::filesystem::path> trace_files;
+        for (const auto& entry : std::filesystem::directory_iterator(trace_dir)) {
+            if (entry.is_regular_file()) {
+                trace_files.push_back(entry.path());
+            }
+        }
+        ASSERT_EQ(trace_files.size(), 1u) << "iteration " << iteration;
+        const std::filesystem::path trace_file = trace_files.front();
+
+        HANDLE exclusive = CreateFileW(trace_file.c_str(), GENERIC_READ, 0, nullptr,
+                                       OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+        ASSERT_NE(exclusive, INVALID_HANDLE_VALUE)
+            << "tracing retained a file handle without a live ENV; error="
+            << GetLastError();
+        CloseHandle(exclusive);
+
+        SQLHANDLE first_env = SQL_NULL_HANDLE;
+        SQLHANDLE second_env = SQL_NULL_HANDLE;
+        ASSERT_TRUE(SQL_SUCCEEDED(
+            alloc_handle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &first_env)));
+        ASSERT_TRUE(SQL_SUCCEEDED(
+            alloc_handle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &second_env)));
+
+        ASSERT_TRUE(SQL_SUCCEEDED(free_handle(SQL_HANDLE_ENV, first_env)));
+        SetLastError(ERROR_SUCCESS);
+        exclusive = CreateFileW(trace_file.c_str(), GENERIC_READ, 0, nullptr, OPEN_EXISTING,
+                                FILE_ATTRIBUTE_NORMAL, nullptr);
+        const DWORD exclusive_error = GetLastError();
+        EXPECT_EQ(exclusive, INVALID_HANDLE_VALUE)
+            << "trace file closed while an ENV was still live";
+        EXPECT_EQ(exclusive_error, ERROR_SHARING_VIOLATION)
+            << "exclusive open failed for an unexpected reason";
+        if (exclusive != INVALID_HANDLE_VALUE) {
+            CloseHandle(exclusive);
+        }
+
+        ASSERT_TRUE(SQL_SUCCEEDED(free_handle(SQL_HANDLE_ENV, second_env)));
+        exclusive = CreateFileW(trace_file.c_str(), GENERIC_READ, 0, nullptr, OPEN_EXISTING,
+                                FILE_ATTRIBUTE_NORMAL, nullptr);
+        ASSERT_NE(exclusive, INVALID_HANDLE_VALUE)
+            << "trace file remained open after the last ENV was freed; error="
+            << GetLastError();
+        CloseHandle(exclusive);
+
+        ASSERT_NE(FreeLibrary(driver), 0) << "iteration " << iteration;
+        ASSERT_TRUE(std::filesystem::remove(trace_file)) << "iteration " << iteration;
+    }
+
+    std::filesystem::remove_all(trace_dir);
 }
 
 }  // namespace


### PR DESCRIPTION
## Description

Add file tracing for `mssql-odbc` when `MSSQL_TDS_TRACE_DIR` is set. The driver creates a unique `mssql_tds_trace_<UTC timestamp>_<pid>.log` file in the configured directory; relative paths such as `.` are resolved once at initialization so later host CWD changes cannot redirect output. When the variable is unset, tracing continues to use stderr.

Both sinks use a consistent event format with an RFC 3339 UTC timestamp, thread ID, level, target, and event fields. General span context is intentionally excluded so instrumented fields such as `sql_command` are not copied into every event. Event fields can still contain SQL text or parameter values and must be treated as sensitive.

The file writer is synchronous and keeps one serialized file handle cached while at least one ODBC environment is live. Freeing the last environment closes the handle before the host may unload the driver; a later environment reopens it lazily. Events emitted without a live environment use an event-scoped transient handle. This avoids per-event open/close overhead in normal use without introducing the background worker and process-lifetime guard used by `tracing_appender::non_blocking`, which are unsafe for arbitrary DLL unload.

Initialization, writes, close, and reopen recover poisoned locks. Filename collisions receive a numeric suffix, process-shutdown logging is discarded rather than acquiring DLL-owned locks, and failed subscriber installation removes the empty file.

Tracing initialization runs inside the shared `ffi_entry!` panic boundary, so initialization and ODBC implementation panics use the same logging and `SQL_ERROR` policy.

On Unix, files are created with mode `0600`. Directories writable by group or other users and paths inside the system temporary directory are allowed with warnings because they can be valid operational choices, but the configured directory must be trusted.

Rotation and retention are intentionally separate follow-up [AB#48091](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/48091).

## Related Issues

[AB#48083](https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/48083)

## Validation

- `cargo bfmt`
- `cargo check -p mssqlodbc --tests`
- `cargo bclippy`
- CMake build of `dll_unload_stress_test` (Debug)
- `git diff --check`

Rust unit tests and the Windows DLL lifecycle test compile. The normal runtime test path is blocked locally before the ODBC tests run because `crc32fast` uses LLVM SIMD intrinsics not implemented by the installed Rust 1.95 compiler. A PR-head DLL built with the temporary scalar-codegen workaround `RUSTFLAGS="-C target-feature=-sse2,-pclmulqdq"` passed three direct `LoadLibrary` -> `SQLAllocHandle(SQL_HANDLE_ENV)` -> `SQLFreeHandle(SQL_HANDLE_ENV)` -> `FreeLibrary` cycles with file tracing enabled. CI validation remains required.

## Trace sample

```text
2026-09-11T13:15:13.266Z, 1, DEBUG, mssqlodbc::api::alloc_handle, Allocated ENV handle raw=0x1df689e70d0
2026-09-11T13:15:13.268Z, 1, TRACE, mssqlodbc::api::alloc_handle, SQLAllocHandle returning ret=0
2026-09-11T13:15:13.268Z, 1, DEBUG, mssqlodbc::api::free_handle, SQLFreeHandle called handle_type=1 handle=0x1df689e70d0
2026-09-11T13:15:13.268Z, 1, DEBUG, mssqlodbc::handles, Freeing handle raw=0x1df689e70d0 object_type=Env
2026-09-11T13:15:13.269Z, 1, TRACE, mssqlodbc::handles, Handle freed raw=0x1df689e70d0
2026-09-11T13:15:13.270Z, 1, TRACE, mssqlodbc::api::free_handle, SQLFreeHandle returning ret=0
```

The second field (`1`) is Rust's process-local thread ID. The process ID is included in the trace filename, for example `mssql_tds_trace_20260911131513202_29080.log` for PID `29080`.
## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [ ] `cargo btest` passes
- [x] New/changed functionality has tests
- [x] Public behavior is documented