### PR TITLE
Fix bulk-copy identifier quoting and input validation

### DIFF
--- a/mssql-tds/src/connection/bulk_copy.rs
+++ b/mssql-tds/src/connection/bulk_copy.rs
@@ -296,6 +296,13 @@ impl BulkCopyResult {
 /// `BulkCopy` provides a convenient builder-style API for configuring and executing
 /// bulk copy operations. It handles batching, progress reporting, and error handling.
 ///
+/// Destination names are parsed as multipart identifiers and bracket-quoted, not
+/// treated as SQL fragments. Omitted qualifiers (`database..table`), temporary
+/// tables (`#table`, `tempdb..#table`), and bracket- or double-quoted parts are
+/// supported. A missing table part, including a trailing dot, is rejected.
+/// Column names from custom metadata retrievers are also quoted; collation names
+/// must follow the token format documented on [`BulkCopyColumnMetadata::collation_name`].
+///
 /// # Example
 ///
 /// ```rust,ignore

--- a/mssql-tds/src/connection/metadata_retriever.rs
+++ b/mssql-tds/src/connection/metadata_retriever.rs
@@ -224,6 +224,67 @@ impl TryFrom<TableMetadataResult> for Vec<BulkCopyColumnMetadata> {
     }
 }
 
+fn build_table_metadata_query(table_name: &str) -> TdsResult<String> {
+    let mut parts = parse_multipart_identifier(table_name, true)?;
+    let table_part = parts[TABLE_INDEX]
+        .as_ref()
+        .filter(|part| !part.is_empty())
+        .ok_or_else(|| Error::UsageError(format!("Invalid table name: {table_name}")))?;
+
+    if table_part.starts_with('#')
+        && parts[CATALOG_INDEX]
+            .as_ref()
+            .is_none_or(|part| part.is_empty())
+    {
+        parts[CATALOG_INDEX] = Some("tempdb".to_string());
+    }
+
+    let catalog = parts[CATALOG_INDEX]
+        .as_ref()
+        .filter(|part| !part.is_empty())
+        .map(|part| escape_identifier(part));
+    let escaped_full_name = escape_string_literal(&build_multipart_name(&parts));
+
+    // The sys-view prefix is inside a nested SQL literal; the procedure prefix
+    // is executable SQL and needs only identifier escaping.
+    let catalog_prefix = catalog
+        .as_ref()
+        .map(|catalog| format!("{}.", escape_string_literal(catalog)))
+        .unwrap_or_default();
+    let catalog_for_sproc = catalog
+        .as_ref()
+        .map(|catalog| format!("{catalog}.."))
+        .unwrap_or_default();
+    let sproc_parts = [
+        None,
+        None,
+        parts[SCHEMA_INDEX].clone().filter(|part| !part.is_empty()),
+        parts[TABLE_INDEX].clone(),
+    ];
+    let sproc_table_name = escape_string_literal(&build_multipart_name(&sproc_parts));
+
+    Ok(format!(
+        r#"SELECT @@TRANCOUNT;
+
+DECLARE @Column_Names NVARCHAR(MAX) = NULL;
+DECLARE @object_id INT = OBJECT_ID(N'{escaped_full_name}');
+DECLARE @sql NVARCHAR(MAX);
+SET @sql = N'SELECT @CN = COALESCE(@CN + N'', '', N'''') + QUOTENAME([name]) FROM {catalog_prefix}sys.all_columns WHERE [object_id] = @ObjId';
+IF EXISTS (SELECT TOP 1 * FROM sys.all_columns WHERE [object_id] = OBJECT_ID('sys.all_columns') AND [name] = 'graph_type')
+    SET @sql = @sql + N' AND COALESCE([graph_type], 0) NOT IN (1, 3, 4, 6, 7)';
+SET @sql = @sql + N' ORDER BY [column_id] ASC';
+EXEC sp_executesql @sql, N'@CN NVARCHAR(MAX) OUTPUT, @ObjId INT', @CN = @Column_Names OUTPUT, @ObjId = @object_id;
+
+SELECT @Column_Names = COALESCE(@Column_Names, '*');
+
+SET FMTONLY ON;
+EXEC(N'SELECT ' + @Column_Names + N' FROM {escaped_full_name}');
+SET FMTONLY OFF;
+
+EXEC {catalog_for_sproc}sp_tablecollations_100 N'{sproc_table_name}';"#
+    ))
+}
+
 /// Fetch table metadata using SET FMTONLY ON query.
 ///
 /// This function retrieves column metadata for a table by executing a
@@ -270,82 +331,7 @@ pub(crate) async fn fetch_table_metadata(
     timeout_sec: Option<u32>,
     cancel_handle: Option<&CancelHandle>,
 ) -> TdsResult<TableMetadataResult> {
-    // Parse the multipart identifier
-    let parts = parse_multipart_identifier(table_name, false)?;
-
-    // Validate table name exists
-    let table_part = parts[TABLE_INDEX]
-        .as_ref()
-        .ok_or_else(|| Error::UsageError(format!("Invalid table name: {}", table_name)))?;
-
-    // Check if temp table
-    let is_temp_table = table_part.starts_with('#');
-
-    // Determine catalog
-    let catalog = if is_temp_table && parts[CATALOG_INDEX].is_none() {
-        "tempdb".to_string()
-    } else if let Some(cat) = &parts[CATALOG_INDEX] {
-        escape_identifier(cat)
-    } else {
-        // No catalog specified, don't prefix
-        String::new()
-    };
-
-    // Build full object name for OBJECT_ID
-    let full_name = build_multipart_name(&parts);
-    let escaped_full_name = escape_string_literal(&full_name);
-
-    // Build query with catalog prefix for sys views (single dot)
-    // and catalog spec for stored procedures (double dot)
-    let catalog_prefix = if !catalog.is_empty() {
-        format!("{}.", catalog)
-    } else {
-        String::new()
-    };
-
-    let catalog_for_sproc = if !catalog.is_empty() {
-        format!("{}..", catalog)
-    } else {
-        String::new()
-    };
-
-    // Prepare schema and table names for sp_tablecollations_100
-    // Match C# behavior: escape for use in TSQL literal block
-    let schema_name = parts[SCHEMA_INDEX]
-        .as_ref()
-        .map(|s| escape_identifier(&escape_string_literal(s)))
-        .unwrap_or_else(|| "dbo".to_string());
-
-    let table_name_escaped = escape_identifier(&escape_string_literal(table_part));
-
-    // Use SET FMTONLY ON to get metadata without query execution overhead.
-    // This matches .NET SqlBulkCopy behavior and is more efficient than SELECT TOP 0.
-    // The query structure matches C# SqlBulkCopy.CreateInitialQuery():
-    // 1. SELECT @@TRANCOUNT - produces a result set we need to skip
-    // 2. Dynamic column building with graph_type check
-    // 3. SET FMTONLY ON to get column metadata without data
-    // 4. sp_tablecollations_100 to get collation information
-    // Note: Use double-dot notation (catalog..sproc) for system stored procedures.
-    let query = format!(
-        r#"SELECT @@TRANCOUNT;
-
-DECLARE @Column_Names NVARCHAR(MAX) = NULL;
-DECLARE @object_id INT = OBJECT_ID('{escaped_full_name}');
-DECLARE @sql NVARCHAR(MAX);
-SET @sql = N'SELECT @CN = COALESCE(@CN + N'', '', N'''') + QUOTENAME([name]) FROM {catalog_prefix}sys.all_columns WHERE [object_id] = @ObjId';
-IF EXISTS (SELECT TOP 1 * FROM sys.all_columns WHERE [object_id] = OBJECT_ID('sys.all_columns') AND [name] = 'graph_type')
-    SET @sql = @sql + N' AND COALESCE([graph_type], 0) NOT IN (1, 3, 4, 6, 7)';
-SET @sql = @sql + N' ORDER BY [column_id] ASC';
-EXEC sp_executesql @sql, N'@CN NVARCHAR(MAX) OUTPUT, @ObjId INT', @CN = @Column_Names OUTPUT, @ObjId = @object_id;
-
-SELECT @Column_Names = COALESCE(@Column_Names, '*');
-
-SET FMTONLY ON;
-EXEC(N'SELECT ' + @Column_Names + N' FROM {escaped_full_name}');
-SET FMTONLY OFF;
-
-EXEC {catalog_for_sproc}sp_tablecollations_100 N'{schema_name}.{table_name_escaped}';"#
-    );
+    let query = build_table_metadata_query(table_name)?;
 
     debug!("Fetching table metadata with FMTONLY and collations");
 
@@ -475,6 +461,133 @@ mod tests {
     };
     use crate::query::metadata::ColumnMetadata;
     use crate::token::tokens::SqlCollation;
+
+    #[test]
+    fn test_metadata_query_escapes_nested_catalog_literal() {
+        for (name, nested_catalog, direct_catalog, full_name, sproc_name) in [
+            (
+                "[x'; SELECT 4242 AS audit_probe; RETURN;--].dbo.t",
+                "[x''; SELECT 4242 AS audit_probe; RETURN;--]",
+                "[x'; SELECT 4242 AS audit_probe; RETURN;--]",
+                "[x''; SELECT 4242 AS audit_probe; RETURN;--].[dbo].[t]",
+                "[dbo].[t]",
+            ),
+            (
+                "[O'Brien]]db].[s'ch]]ema].[t'ab]]le]",
+                "[O''Brien]]db]",
+                "[O'Brien]]db]",
+                "[O''Brien]]db].[s''ch]]ema].[t''ab]]le]",
+                "[s''ch]]ema].[t''ab]]le]",
+            ),
+        ] {
+            let query = build_table_metadata_query(name).unwrap();
+            assert!(query.contains(&format!(
+                "SET @sql = N'SELECT @CN = COALESCE(@CN + N'', '', N'''') + QUOTENAME([name]) FROM {nested_catalog}.sys.all_columns WHERE [object_id] = @ObjId';"
+            )), "{query}");
+            assert!(
+                query.contains(&format!("OBJECT_ID(N'{full_name}')")),
+                "{query}"
+            );
+            assert!(
+                query.contains(&format!(
+                    "EXEC(N'SELECT ' + @Column_Names + N' FROM {full_name}');"
+                )),
+                "{query}"
+            );
+            assert!(
+                query.ends_with(&format!(
+                    "EXEC {direct_catalog}..sp_tablecollations_100 N'{sproc_name}';"
+                )),
+                "{query}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_metadata_query_preserves_qualifiers_and_temp_tables() {
+        for (name, full_name, catalog_prefix, sproc_call) in [
+            ("table", "[table]", "", "sp_tablecollations_100 N'[table]';"),
+            (
+                "dbo.table",
+                "[dbo].[table]",
+                "",
+                "sp_tablecollations_100 N'[dbo].[table]';",
+            ),
+            (
+                "db..table",
+                "[db]..[table]",
+                "[db].",
+                "[db]..sp_tablecollations_100 N'[table]';",
+            ),
+            (
+                "#table",
+                "[tempdb]..[#table]",
+                "[tempdb].",
+                "[tempdb]..sp_tablecollations_100 N'[#table]';",
+            ),
+            (
+                "..#table",
+                "[tempdb]..[#table]",
+                "[tempdb].",
+                "[tempdb]..sp_tablecollations_100 N'[#table]';",
+            ),
+            (
+                "tempdb..#table",
+                "[tempdb]..[#table]",
+                "[tempdb].",
+                "[tempdb]..sp_tablecollations_100 N'[#table]';",
+            ),
+            (
+                "[tempdb].[dbo].[#table]",
+                "[tempdb].[dbo].[#table]",
+                "[tempdb].",
+                "[tempdb]..sp_tablecollations_100 N'[dbo].[#table]';",
+            ),
+            (
+                "[table ]",
+                "[table ]",
+                "",
+                "sp_tablecollations_100 N'[table ]';",
+            ),
+        ] {
+            let query = build_table_metadata_query(name).unwrap();
+            assert!(
+                query.contains(&format!("OBJECT_ID(N'{full_name}')")),
+                "{name}: {query}"
+            );
+            assert!(
+                query.contains(&format!("FROM {catalog_prefix}sys.all_columns")),
+                "{name}: {query}"
+            );
+            assert!(
+                query.ends_with(&format!("EXEC {sproc_call}")),
+                "{name}: {query}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_metadata_query_rejects_missing_or_invalid_table() {
+        for name in [
+            "",
+            " ",
+            ".",
+            "db..",
+            "dbo.",
+            "dbo.  ",
+            "[]",
+            "db.dbo.[]",
+            "\"\"",
+            "[t",
+            "[t]extra",
+            "a.b.c.d.e",
+        ] {
+            assert!(
+                matches!(build_table_metadata_query(name), Err(Error::UsageError(_))),
+                "{name}"
+            );
+        }
+    }
 
     fn make_column(name: &str, flags: u16, type_info_variant: TypeInfoVariant) -> ColumnMetadata {
         let tds_type = match &type_info_variant {

--- a/mssql-tds/src/datatypes/bulk_copy_metadata.rs
+++ b/mssql-tds/src/datatypes/bulk_copy_metadata.rs
@@ -471,6 +471,8 @@ pub struct BulkCopyColumnMetadata {
     /// Collation name (e.g., "SQL_Latin1_General_CP1_CI_AS")
     /// This is the collation name retrieved from sp_tablecollations_100
     /// and used in the INSERT BULK SQL command.
+    /// Custom names must be 1-128 ASCII letters, digits, or underscores, starting
+    /// with a letter. Invalid tokens return `Error::UsageError` during bulk copy.
     pub collation_name: Option<String>,
 
     /// Character encoding (for character types)
@@ -555,6 +557,7 @@ impl BulkCopyColumnMetadata {
 
     /// Set collation name (for character types).
     /// This is used in the INSERT BULK SQL command.
+    /// See [`Self::collation_name`] for the accepted token format.
     pub fn with_collation_name(mut self, collation_name: impl Into<String>) -> Self {
         self.collation_name = Some(collation_name.into());
         self

--- a/mssql-tds/src/datatypes/bulk_copy_metadata.rs
+++ b/mssql-tds/src/datatypes/bulk_copy_metadata.rs
@@ -472,7 +472,8 @@ pub struct BulkCopyColumnMetadata {
     /// This is the collation name retrieved from sp_tablecollations_100
     /// and used in the INSERT BULK SQL command.
     /// Custom names must be 1-128 ASCII letters, digits, or underscores, starting
-    /// with a letter. Invalid tokens return `Error::UsageError` during bulk copy.
+    /// with a letter. Invalid tokens return
+    /// [`Error::UsageError`](crate::error::Error::UsageError) during bulk copy.
     pub collation_name: Option<String>,
 
     /// Character encoding (for character types)

--- a/mssql-tds/src/message/bulk_load.rs
+++ b/mssql-tds/src/message/bulk_load.rs
@@ -15,6 +15,9 @@ use crate::datatypes::sqldatatypes::TdsDataType;
 use crate::datatypes::tds_value_serializer::{TdsTypeContext, TdsValueSerializer};
 use crate::error::Error;
 use crate::io::packet_writer::{PacketWriter, TdsPacketWriter};
+use crate::sql_identifier::{
+    TABLE_INDEX, build_multipart_name, escape_identifier, parse_multipart_identifier,
+};
 use crate::token::tokens::SqlCollation;
 use tracing::{debug, trace};
 
@@ -1041,6 +1044,16 @@ pub(crate) fn build_insert_bulk_command(
     column_metadata: &[BulkCopyColumnMetadata],
     options: &BulkCopyOptions,
 ) -> crate::core::TdsResult<String> {
+    let parts = parse_multipart_identifier(table_name, true)?;
+    if parts[TABLE_INDEX]
+        .as_ref()
+        .is_none_or(|part| part.is_empty())
+    {
+        return Err(Error::UsageError(format!(
+            "Invalid table name: {table_name}"
+        )));
+    }
+    let table_name = build_multipart_name(&parts);
     let mut command = format!("INSERT BULK {table_name} (");
 
     for (i, col_meta) in column_metadata.iter().enumerate() {
@@ -1049,7 +1062,8 @@ pub(crate) fn build_insert_bulk_command(
         }
 
         // Column name
-        command.push_str(&format!("[{}] ", col_meta.column_name));
+        command.push_str(&escape_identifier(&col_meta.column_name));
+        command.push(' ');
 
         // Type definition
         let type_def = col_meta.get_sql_type_definition()?;
@@ -1058,6 +1072,19 @@ pub(crate) fn build_insert_bulk_command(
         // Add COLLATE clause if the column needs collation and has a collation name
         if let (true, Some(collation_name)) = (col_meta.needs_collation(), &col_meta.collation_name)
         {
+            if collation_name.len() > 128
+                || !collation_name
+                    .as_bytes()
+                    .first()
+                    .is_some_and(u8::is_ascii_alphabetic)
+                || !collation_name
+                    .bytes()
+                    .all(|ch| ch.is_ascii_alphanumeric() || ch == b'_')
+            {
+                return Err(Error::UsageError(format!(
+                    "Invalid collation name: {collation_name}"
+                )));
+            }
             command.push_str(&format!(" COLLATE {}", collation_name));
         }
     }

--- a/mssql-tds/src/message/bulk_load_tests.rs
+++ b/mssql-tds/src/message/bulk_load_tests.rs
@@ -236,7 +236,7 @@ mod tests {
         );
 
         // Verify basic structure is correct
-        assert!(command.starts_with("INSERT BULK dbo.TestTable ("));
+        assert!(command.starts_with("INSERT BULK [dbo].[TestTable] ("));
         assert!(command.contains("[Id] int"));
         assert!(command.contains("[Name] nvarchar(100)"));
         assert!(command.contains("[Description] varchar(255)"));
@@ -318,5 +318,177 @@ mod tests {
             "Expected WITH clause with options, got: {}",
             command
         );
+    }
+
+    #[test]
+    fn test_insert_bulk_quotes_destination_parts() {
+        use crate::connection::bulk_copy::BulkCopyOptions;
+        use crate::message::bulk_load::build_insert_bulk_command;
+
+        let metadata = [create_int_column("id")];
+        for (name, expected) in [
+            ("Target", "[Target]"),
+            (" dbo . Target ", "[dbo].[Target]"),
+            ("db.dbo.Target", "[db].[dbo].[Target]"),
+            ("server.db.dbo.Target", "[server].[db].[dbo].[Target]"),
+            ("db..Target", "[db]..[Target]"),
+            (".Target", ".[Target]"),
+            ("..Target", "..[Target]"),
+            ("server...Target", "[server]...[Target]"),
+            ("#Target", "[#Target]"),
+            ("##Target", "[##Target]"),
+            ("tempdb..#Target", "[tempdb]..[#Target]"),
+            (
+                "[db.with.dot].[schema].[a]]b]",
+                "[db.with.dot].[schema].[a]]b]",
+            ),
+            ("\"db\".\"a\"\"b\".\" Target \"", "[db].[a\"b].[ Target ]"),
+            ("[O'Brien].[t'ab]]le]", "[O'Brien].[t'ab]]le]"),
+            (
+                "dbo.Target ([id] int); SELECT 4242 AS audit_probe;--",
+                "[dbo].[Target ([id]] int); SELECT 4242 AS audit_probe;--]",
+            ),
+            ("[a]]; SELECT 4242;--]", "[a]]; SELECT 4242;--]"),
+        ] {
+            let command =
+                build_insert_bulk_command(name, &metadata, &BulkCopyOptions::default()).unwrap();
+            assert_eq!(
+                command,
+                format!("INSERT BULK {expected} ([id] int)"),
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_insert_bulk_quotes_column_identifiers() {
+        use crate::connection::bulk_copy::BulkCopyOptions;
+        use crate::message::bulk_load::build_insert_bulk_command;
+
+        for (name, expected) in [
+            ("id", "[id]"),
+            ("a]b", "[a]]b]"),
+            ("a]]b", "[a]]]]b]"),
+            ("O'Brien", "[O'Brien]"),
+            ("a.b", "[a.b]"),
+            (" column ", "[ column ]"),
+            ("a\"b", "[a\"b]"),
+            (
+                "id] int); SELECT 4242 AS audit_probe;--",
+                "[id]] int); SELECT 4242 AS audit_probe;--]",
+            ),
+        ] {
+            let command = build_insert_bulk_command(
+                "dbo.Target",
+                &[create_int_column(name)],
+                &BulkCopyOptions::default(),
+            )
+            .unwrap();
+            assert_eq!(
+                command,
+                format!("INSERT BULK [dbo].[Target] ({expected} int)")
+            );
+        }
+    }
+
+    #[test]
+    fn test_insert_bulk_rejects_missing_or_invalid_target() {
+        use crate::connection::bulk_copy::BulkCopyOptions;
+        use crate::error::Error;
+        use crate::message::bulk_load::build_insert_bulk_command;
+
+        for name in [
+            "",
+            " ",
+            ".",
+            "dbo.",
+            "db..",
+            "db.dbo. ",
+            "[]",
+            "db.dbo.[]",
+            "\"\"",
+            "[t",
+            "[t]extra",
+            "a.b.c.d.e",
+            "a.b.c.d.",
+        ] {
+            assert!(
+                matches!(
+                    build_insert_bulk_command(
+                        name,
+                        &[create_int_column("id")],
+                        &BulkCopyOptions::default()
+                    ),
+                    Err(Error::UsageError(_))
+                ),
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_insert_bulk_rejects_invalid_collation_tokens() {
+        use crate::connection::bulk_copy::BulkCopyOptions;
+        use crate::error::Error;
+        use crate::message::bulk_load::build_insert_bulk_command;
+
+        let too_long = "A".repeat(129);
+        for name in [
+            "",
+            " Latin1_General_CI_AS",
+            "Latin1_General_CI_AS ",
+            "1Latin1",
+            "_Latin1",
+            "Latin1-General",
+            "Latin1.General",
+            "[Latin1_General_CI_AS]",
+            "'Latin1_General_CI_AS'",
+            "Latin1_General_CI_AS); SELECT 4242 AS audit_probe;--",
+            "Latin1_General_CI_AS--",
+            "Latin1_General_CI_AS/**/",
+            "Latin1\nGeneral",
+            "Latin1\0General",
+            "Lat\u{ed}n1_General",
+            &too_long,
+        ] {
+            let metadata = [create_nvarchar_column("Name", 10).with_collation_name(name)];
+            assert!(
+                matches!(
+                    build_insert_bulk_command("Target", &metadata, &BulkCopyOptions::default()),
+                    Err(Error::UsageError(message)) if message.starts_with("Invalid collation name:")
+                ),
+                "{name:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_insert_bulk_accepts_collation_tokens() {
+        use crate::connection::bulk_copy::BulkCopyOptions;
+        use crate::message::bulk_load::build_insert_bulk_command;
+
+        let max_length = "A".repeat(128);
+        for name in [
+            "SQL_Latin1_General_CP1_CI_AS",
+            "Latin1_General_100_CI_AS_SC_UTF8",
+            "Japanese_XJIS_140_CI_AS_KS_WS_VSS",
+            "SQL_EBCDIC277_2_CP1_CS_AS",
+            "Latin1_General_BIN2",
+            "a",
+            &max_length,
+        ] {
+            for column in [
+                create_nvarchar_column("Name", 10),
+                create_varchar_column("Name", 10),
+            ] {
+                let command = build_insert_bulk_command(
+                    "Target",
+                    &[column.with_collation_name(name)],
+                    &BulkCopyOptions::default(),
+                )
+                .unwrap();
+                assert!(command.ends_with(&format!(" COLLATE {name})")), "{command}");
+            }
+        }
     }
 }

--- a/mssql-tds/src/sql_identifier.rs
+++ b/mssql-tds/src/sql_identifier.rs
@@ -27,7 +27,7 @@ pub const MAX_PARTS: usize = 4;
 ///
 /// # Arguments
 /// * `name` - The identifier string to parse (e.g., "db.schema.table")
-/// * `allow_empty` - Whether to allow completely empty identifiers
+/// * `allow_empty` - Whether to allow empty identifiers and omitted parts (e.g., `db..table`)
 ///
 /// # Returns
 /// Array of 4 optional strings: [server, catalog, schema, table]
@@ -171,8 +171,19 @@ pub fn parse_multipart_identifier(
 
     // Handle final part
     match state {
-        State::InPart | State::AfterQuote => {
+        State::InPart => {
             parts.push(current_part.trim_end().to_string());
+        }
+        State::AfterQuote => {
+            parts.push(current_part);
+        }
+        State::AfterDot if allow_empty => {
+            parts.push(String::new());
+        }
+        State::AfterDot => {
+            return Err(crate::error::Error::UsageError(
+                "Empty identifier part is not allowed".to_string(),
+            ));
         }
         State::InQuotedPart => {
             return Err(crate::error::Error::UsageError(
@@ -249,6 +260,8 @@ pub fn escape_string_literal(input: &str) -> String {
 /// Build a multipart name from components.
 ///
 /// Reconstructs a qualified identifier from its parts, omitting leading None values.
+/// Empty strings and interior None values preserve omitted qualifiers as empty
+/// segments, so `[database]..[table]` keeps its default-schema semantics.
 ///
 /// # Arguments
 /// * `parts` - Array of optional identifier parts [server, catalog, schema, table]
@@ -266,11 +279,15 @@ pub fn escape_string_literal(input: &str) -> String {
 pub fn build_multipart_name(parts: &[Option<String>; MAX_PARTS]) -> String {
     let mut result = String::new();
 
-    for part in parts.iter().flatten() {
-        if !result.is_empty() {
+    for (i, part) in parts.iter().skip_while(|part| part.is_none()).enumerate() {
+        if i > 0 {
             result.push('.');
         }
-        result.push_str(&escape_identifier(part));
+        if let Some(part) = part
+            && !part.is_empty()
+        {
+            result.push_str(&escape_identifier(part));
+        }
     }
 
     result
@@ -372,6 +389,68 @@ mod tests {
     fn test_parse_unclosed_quote() {
         let result = parse_multipart_identifier("[MyTable", false);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_preserves_trailing_empty_part() {
+        for name in ["db.schema.", "db.schema.  "] {
+            assert!(parse_multipart_identifier(name, false).is_err());
+            let parts = parse_multipart_identifier(name, true).unwrap();
+            assert_eq!(parts[CATALOG_INDEX].as_deref(), Some("db"));
+            assert_eq!(parts[SCHEMA_INDEX].as_deref(), Some("schema"));
+            assert_eq!(parts[TABLE_INDEX].as_deref(), Some(""));
+            assert_eq!(build_multipart_name(&parts), "[db].[schema].");
+        }
+        assert!(parse_multipart_identifier("server.db.schema.table.", true).is_err());
+    }
+
+    #[test]
+    fn test_parse_preserves_quoted_whitespace() {
+        for name in [
+            "[ db ].[ schema ].[ table ]  ",
+            "\" db \".\" schema \".\" table \"  ",
+        ] {
+            let parts = parse_multipart_identifier(name, false).unwrap();
+            assert_eq!(parts[CATALOG_INDEX].as_deref(), Some(" db "));
+            assert_eq!(parts[SCHEMA_INDEX].as_deref(), Some(" schema "));
+            assert_eq!(parts[TABLE_INDEX].as_deref(), Some(" table "));
+            assert_eq!(build_multipart_name(&parts), "[ db ].[ schema ].[ table ]");
+        }
+    }
+
+    #[test]
+    fn test_parse_and_build_omitted_qualifiers() {
+        for (name, expected) in [
+            ("db..table", "[db]..[table]"),
+            ("db. .table", "[db]..[table]"),
+            (".table", ".[table]"),
+            ("..table", "..[table]"),
+            ("server...table", "[server]...[table]"),
+            ("tempdb..#table", "[tempdb]..[#table]"),
+        ] {
+            assert!(parse_multipart_identifier(name, false).is_err(), "{name}");
+            let parts = parse_multipart_identifier(name, true).unwrap();
+            assert_eq!(build_multipart_name(&parts), expected, "{name}");
+        }
+    }
+
+    #[test]
+    fn test_build_preserves_missing_interior_slots() {
+        let parts = [
+            None,
+            Some("db".to_string()),
+            None,
+            Some("table".to_string()),
+        ];
+        assert_eq!(build_multipart_name(&parts), "[db]..[table]");
+        let parts = [
+            Some("server".to_string()),
+            None,
+            None,
+            Some("table".to_string()),
+        ];
+        assert_eq!(build_multipart_name(&parts), "[server]...[table]");
+        assert_eq!(build_multipart_name(&[None, None, None, None]), "");
     }
 
     #[test]

--- a/mssql-tds/src/test_client_support.rs
+++ b/mssql-tds/src/test_client_support.rs
@@ -19,6 +19,11 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 
+/// Metadata strategy for testing bulk copy with custom or cached metadata.
+pub use crate::connection::metadata_retriever::MetadataRetriever;
+/// Quote identifiers used in test setup SQL.
+pub use crate::sql_identifier::escape_identifier;
+
 use crate::connection::client_context::ClientContext;
 use crate::connection::execution_context::ExecutionContext;
 use crate::connection::tds_client::TdsClient;

--- a/mssql-tds/tests/test_bulk_copy_identifiers.rs
+++ b/mssql-tds/tests/test_bulk_copy_identifiers.rs
@@ -1,0 +1,299 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+mod common;
+
+use async_trait::async_trait;
+use common::{begin_connection, build_tcp_datasource, init_tracing};
+use mssql_tds::connection::bulk_copy::{BulkCopy, BulkLoadRow};
+use mssql_tds::connection::tds_client::{ResultSet, TdsClient};
+use mssql_tds::core::TdsResult;
+use mssql_tds::datatypes::bulk_copy_metadata::BulkCopyColumnMetadata;
+use mssql_tds::datatypes::column_values::ColumnValues;
+use mssql_tds::datatypes::sql_string::SqlString;
+use mssql_tds::error::Error;
+use mssql_tds::message::bulk_load::StreamingBulkLoadWriter;
+use mssql_tds::test_client_support::{MetadataRetriever, escape_identifier};
+
+#[ctor::ctor]
+fn init() {
+    init_tracing();
+}
+
+struct TestRow(Vec<ColumnValues>);
+
+#[async_trait]
+impl BulkLoadRow for TestRow {
+    async fn write_to_packet(
+        &self,
+        writer: &mut StreamingBulkLoadWriter<'_>,
+        column_index: &mut usize,
+    ) -> TdsResult<()> {
+        for value in &self.0 {
+            writer.write_column_value(*column_index, value).await?;
+            *column_index += 1;
+        }
+        Ok(())
+    }
+}
+
+struct CachedMetadata(Vec<BulkCopyColumnMetadata>);
+
+#[async_trait]
+impl MetadataRetriever for CachedMetadata {
+    async fn retrieve_metadata(
+        &mut self,
+        _client: &mut TdsClient,
+        _table_name: &str,
+        _timeout_sec: u32,
+    ) -> TdsResult<Vec<BulkCopyColumnMetadata>> {
+        Ok(self.0.clone())
+    }
+}
+
+async fn execute_statement(client: &mut TdsClient, sql: String) -> TdsResult<()> {
+    client.execute(sql, ()).await?;
+    client.close_query().await
+}
+
+async fn assert_int_query(client: &mut TdsClient, sql: String, expected: i32) -> TdsResult<()> {
+    client.execute(sql, ()).await?;
+    let row = client
+        .next_row()
+        .await?
+        .expect("Expected an integer result");
+    assert_eq!(row[0], ColumnValues::Int(expected));
+    assert!(client.next_row().await?.is_none());
+    client.close_query().await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_bulk_copy_identifier_payloads_default_and_cached_metadata() -> TdsResult<()> {
+    let mut client = begin_connection(&build_tcp_datasource()).await;
+    let table_payload = "#Target ([id] int); SELECT 4242 AS audit_probe;--";
+    for (table_name, destination, column_name) in [
+        (
+            "#BulkIdentifiers",
+            "#BulkIdentifiers",
+            "id] int); SELECT 4242 AS audit_probe;--",
+        ),
+        (table_payload, table_payload, "id"),
+        ("#O'Brien].Table", "[#O'Brien]].Table]", "O'Brien].Column"),
+        ("#Double\"Quote", "\"#Double\"\"Quote\"", " column "),
+        ("#\u{6d4b}\u{8bd5}", "[#\u{6d4b}\u{8bd5}]", "\u{5217}]"),
+    ] {
+        let quoted_table = escape_identifier(table_name);
+        let quoted_column = escape_identifier(column_name);
+        execute_statement(
+            &mut client,
+            format!("CREATE TABLE {quoted_table} ({quoted_column} INT NOT NULL)"),
+        )
+        .await?;
+
+        let metadata = BulkCopy::new(&mut client, destination)
+            .retrieve_destination_metadata()
+            .await?;
+        assert_eq!(metadata.len(), 1);
+        assert_eq!(metadata[0].column_name, column_name);
+
+        let result = BulkCopy::new(&mut client, destination)
+            .write_to_server_zerocopy([TestRow(vec![ColumnValues::Int(7)])])
+            .await?;
+        assert_eq!(result.rows_affected, 1);
+        let result =
+            BulkCopy::with_retriever(&mut client, destination, Box::new(CachedMetadata(metadata)))
+                .write_to_server_zerocopy([TestRow(vec![ColumnValues::Int(8)])])
+                .await?;
+        assert_eq!(result.rows_affected, 1);
+        assert_int_query(
+            &mut client,
+            format!("SELECT COUNT(*) FROM {quoted_table} WHERE {quoted_column} IN (7, 8)"),
+            2,
+        )
+        .await?;
+        assert_int_query(
+            &mut client,
+            format!("SELECT SUM({quoted_column}) FROM {quoted_table}"),
+            15,
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_bulk_copy_omitted_schema_and_temp_names() -> TdsResult<()> {
+    let mut client = begin_connection(&build_tcp_datasource()).await;
+    execute_statement(
+        &mut client,
+        "CREATE TABLE #BulkOmitted (id INT NOT NULL)".to_string(),
+    )
+    .await?;
+    let metadata = BulkCopy::new(&mut client, "#BulkOmitted")
+        .retrieve_destination_metadata()
+        .await?;
+    let destinations = [
+        "#BulkOmitted",
+        "..#BulkOmitted",
+        "tempdb..#BulkOmitted",
+        "[tempdb]..[#BulkOmitted]",
+        "[tempdb].[dbo].[#BulkOmitted]",
+    ];
+    for destination in destinations {
+        let result = BulkCopy::new(&mut client, destination)
+            .write_to_server_zerocopy([TestRow(vec![ColumnValues::Int(7)])])
+            .await?;
+        assert_eq!(result.rows_affected, 1);
+        let result = BulkCopy::with_retriever(
+            &mut client,
+            destination,
+            Box::new(CachedMetadata(metadata.clone())),
+        )
+        .write_to_server_zerocopy([TestRow(vec![ColumnValues::Int(8)])])
+        .await?;
+        assert_eq!(result.rows_affected, 1);
+    }
+    assert_int_query(
+        &mut client,
+        "SELECT COUNT(*) FROM #BulkOmitted".to_string(),
+        10,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_metadata_catalog_literal_does_not_execute_payload() -> TdsResult<()> {
+    let mut client = begin_connection(&build_tcp_datasource()).await;
+    execute_statement(
+        &mut client,
+        "CREATE TABLE #BulkInjectionProbe (id INT NOT NULL)".to_string(),
+    )
+    .await?;
+
+    let catalog = "x'; INSERT INTO #BulkInjectionProbe VALUES (4242); RETURN;--";
+    let result = BulkCopy::new(&mut client, format!("{}.dbo.t", escape_identifier(catalog)))
+        .retrieve_destination_metadata()
+        .await;
+    assert!(
+        result.is_err(),
+        "The payload catalog must not resolve to a table"
+    );
+    client.close_query().await?;
+    execute_statement(&mut client, "SET FMTONLY OFF".to_string()).await?;
+    assert_int_query(
+        &mut client,
+        "SELECT COUNT(*) FROM #BulkInjectionProbe".to_string(),
+        0,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_bulk_copy_custom_metadata_rejects_invalid_targets() -> TdsResult<()> {
+    let mut client = begin_connection(&build_tcp_datasource()).await;
+    execute_statement(
+        &mut client,
+        "CREATE TABLE #BulkTargetValidation (id INT NOT NULL)".to_string(),
+    )
+    .await?;
+    let metadata = BulkCopy::new(&mut client, "#BulkTargetValidation")
+        .retrieve_destination_metadata()
+        .await?;
+
+    for destination in [
+        "",
+        " ",
+        ".",
+        "tempdb..",
+        "dbo.",
+        "[]",
+        "[t",
+        "[t]extra",
+        "a.b.c.d.e",
+    ] {
+        let result = BulkCopy::with_retriever(
+            &mut client,
+            destination,
+            Box::new(CachedMetadata(metadata.clone())),
+        )
+        .write_to_server_zerocopy([TestRow(vec![ColumnValues::Int(7)])])
+        .await;
+        assert!(matches!(result, Err(Error::UsageError(_))), "{destination}");
+    }
+    let result = BulkCopy::with_retriever(
+        &mut client,
+        "#BulkTargetValidation",
+        Box::new(CachedMetadata(metadata)),
+    )
+    .write_to_server_zerocopy([TestRow(vec![ColumnValues::Int(7)])])
+    .await?;
+    assert_eq!(result.rows_affected, 1);
+    assert_int_query(
+        &mut client,
+        "SELECT COUNT(*) FROM #BulkTargetValidation".to_string(),
+        1,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_bulk_copy_custom_metadata_rejects_invalid_collations() -> TdsResult<()> {
+    let mut client = begin_connection(&build_tcp_datasource()).await;
+    execute_statement(
+        &mut client,
+        "CREATE TABLE #BulkCollationValidation (value NVARCHAR(20) COLLATE Latin1_General_100_CI_AS NOT NULL)".to_string(),
+    ).await?;
+    let metadata = BulkCopy::new(&mut client, "#BulkCollationValidation")
+        .retrieve_destination_metadata()
+        .await?;
+    assert_eq!(
+        metadata[0].collation_name.as_deref(),
+        Some("Latin1_General_100_CI_AS")
+    );
+
+    for collation in [
+        "",
+        "Latin1_General_100_CI_AS); SELECT 4242 AS audit_probe;--",
+        "Latin1_General_100_CI_AS/*",
+        "'Latin1_General_100_CI_AS'",
+    ] {
+        let mut invalid_metadata = metadata.clone();
+        invalid_metadata[0].collation_name = Some(collation.to_string());
+        let result = BulkCopy::with_retriever(
+            &mut client,
+            "#BulkCollationValidation",
+            Box::new(CachedMetadata(invalid_metadata)),
+        )
+        .write_to_server_zerocopy([TestRow(vec![ColumnValues::Null])])
+        .await;
+        assert!(
+            matches!(
+                result,
+                Err(Error::UsageError(message)) if message.starts_with("Invalid collation name:")
+            ),
+            "{collation}"
+        );
+    }
+    assert_int_query(
+        &mut client,
+        "SELECT COUNT(*) FROM #BulkCollationValidation".to_string(),
+        0,
+    )
+    .await?;
+    let result = BulkCopy::with_retriever(
+        &mut client,
+        "#BulkCollationValidation",
+        Box::new(CachedMetadata(metadata)),
+    )
+    .write_to_server_zerocopy([TestRow(vec![ColumnValues::String(
+        SqlString::from_utf8_string("valid".to_string()),
+    )])])
+    .await?;
+    assert_eq!(result.rows_affected, 1);
+    assert_int_query(
+        &mut client,
+        "SELECT COUNT(*) FROM #BulkCollationValidation WHERE value = N'valid'".to_string(),
+        1,
+    )
+    .await
+}


### PR DESCRIPTION
<!--
Thank you for your interest in this project!

This repository is not currently accepting external pull requests. If you've found
a bug or have a feature request, please open an issue instead.

If you are a Microsoft team member, please follow the instructions in the internal
contribution guide.
-->

## Description

<!-- Briefly describe the change. -->

Make bulk-copy SQL construction handle identifiers consistently across default and custom metadata paths.

- Escape catalog names for nested SQL literals separately from direct identifier positions.
- Parse and quote multipart destinations and escape column names when constructing `INSERT BULK`.
- Validate emitted collation names as 1-128 ASCII letters, digits, or underscores, beginning with a letter.
- Preserve omitted qualifiers and quoted whitespace, reject missing table components, and resolve temporary-table metadata through `tempdb`.
- Add unit and integration coverage and document the accepted inputs.

## Related Issues

<!--
Required: link a GitHub issue OR an Azure DevOps work item. The PR check will
fail without one.
GitHub issue: Fixes #123 (or https://github.com/microsoft/mssql-rs/issues/123)
ADO work item: https://sqlclientdrivers.visualstudio.com/<...>/_workitems/edit/<ID>
  (any project/collection path is accepted, e.g. .../<project>/_workitems/edit/123
  or .../DefaultCollection/<project>/_workitems/edit/123)
-->

Fixes #549

## Testing

Passed on Windows with Rust 1.95.0:

```powershell
cargo clippy -p mssql-tds --all-features --all-targets --frozen -- -D warnings

cargo nextest run -p mssql-tds --lib --test test_bulk_copy_identifiers --all-features --frozen -E 'test(sql_identifier) | test(metadata_retriever) | test(bulk_load)'

cargo nextest run -p mssql-tds --test test_bulk_copy_identifiers --test test_bulk_copy_with_metadata --all-features --frozen

cargo nextest run -p mssql-tds --test test_bulk_copy_transactions --all-features --frozen
```

Results: 54 selected unit tests and 32 integration tests passed. Integration tests used an isolated SQL Server 2025 container with generated temporary credentials. Changed-file formatting and patch whitespace checks also passed.

Full-workspace `cargo bfmt`, `cargo bclippy`, and `cargo btest` have not been run.

## Breaking changes / migration notes

No public API signature changes or new dependencies. Bulk destinations are treated as identifiers rather than SQL fragments. Missing table components and malformed collation tokens now return `UsageError`. No migration is required for valid identifiers and server collation names.

## Checklist

- [ ] `cargo bfmt` passes
- [ ] `cargo bclippy` passes
- [ ] `cargo btest` passes
- [x] New/changed functionality has tests
- [x] Public API changes are documented