### PR TITLE
Deliver result sets from parameter arrays

### DIFF
--- a/mssql-odbc/README.md
+++ b/mssql-odbc/README.md
@@ -117,6 +117,18 @@ but returning row N can now wait on row N+1's header arriving. See
 `release_busy_if_row_exhausted` in `src/api/exec_common.rs` for the full
 trade-off and why it was accepted as-is.
 
+## Parameter array results
+
+Prepared parameter arrays can return rows from `SELECT`, `INSERT ... OUTPUT`,
+and procedures. Fetch the current result normally and use `SQLMoreResults` to
+advance through the results in parameter-set order. Completion counts and
+statuses are deferred until the corresponding sets finish; inspect the final
+bookkeeping after navigation reaches `SQL_NO_DATA`. Closing the cursor drains
+unread results without executing any parameter set again.
+
+`SQLGetInfo(SQL_PARAM_ARRAY_SELECTS)` reports `SQL_PAS_BATCH`. Non-row-returning
+arrays still complete during `SQLExecute` and report their aggregate row count.
+
 ## Conventions
 
 Before writing or modifying code in this crate, read

--- a/mssql-odbc/docs/parameters_plan.md
+++ b/mssql-odbc/docs/parameters_plan.md
@@ -855,8 +855,9 @@ accept/store contract itself belongs to AB#46377 and is documented in
 [attributes_plan.md](attributes_plan.md).
 
 - **Batching.** One RPC per set in a single request, separated by
-  `RPC_BATCH_DELIMITER` (`0xff`), drained set by set (`execute_prepared_batch`,
-  `drain_prepared_batch`). 1000-row prepared `INSERT` over loopback: 21.2 ms
+  `RPC_BATCH_DELIMITER` (`0xff`), read set by set (`begin_execute_prepared_batch`).
+  The original `execute_prepared_batch` TDS API still drains all results for
+  callers that only need completion records. 1000-row prepared `INSERT` over loopback: 21.2 ms
   batched, 204.2 ms looped, 22.4 ms for msodbcsql. `mssql-odbc-bench`'s
   `executemany` scenario (`kParameterArrayRows` in `odbc_bench.cpp`) measures a
   single fixed shape - 2,000 rows, 3 narrow fixed-width columns - and that is
@@ -869,8 +870,24 @@ accept/store contract itself belongs to AB#46377 and is documented in
 - **Reporting.** `SQL_ATTR_PARAMS_PROCESSED_PTR` counts sets reached,
   `SQL_ATTR_PARAM_STATUS_PTR` is pre-filled `SQL_PARAM_UNUSED` and written per
   set, `SQL_ATTR_PARAM_OPERATION_PTR` skips a set marked `SQL_PARAM_IGNORE`, and
-  `SQLRowCount` sums the sets' affected rows, reporting
+  for non-row-returning arrays `SQLRowCount` sums the sets' affected rows, reporting
   `SQL_NO_ROWCOUNT_TOTAL` only when no set produced a count.
+- **Result delivery (AB#47944).** `SELECT`, `INSERT ... OUTPUT`, and procedures
+  can return rows for each parameter set. `SQLExecute` positions the first
+  result; `SQLFetch` / `SQLGetData` read its rows, and `SQLMoreResults` advances
+  through the remaining results in parameter-set order. Empty result sets and
+  multiple results from one procedure remain distinct. Rows are streamed, not
+  buffered for the whole array. Advancing discards any unread rows of the
+  current result; closing drains the rest of the batch without executing any
+  set again.
+- **Deferred completion.** A row-returning array is not finished when execute
+  returns. Statuses are written as RPC completions are consumed by navigation
+  or close; inspect the final processed count and status array after
+  `SQLMoreResults` reaches `SQL_NO_DATA`. A successful set is never marked
+  `SQL_PARAM_ERROR` merely for returning rows. A real per-set error retains its
+  status and diagnostic while later results remain fetchable, including when
+  `SQLMoreResults` reports `SQL_ERROR` without a status array. Pending results
+  keep the connection claimed until they are navigated or closed.
 - **Failure handling.** A set that fails to build client-side does not abort the
   batch - the request serializes as it streams, so earlier sets are already on
   the wire. The return code is decided once, from one rule, whether the set
@@ -889,7 +906,6 @@ work items. Not restated here.
 |---|---|---|---|
 | 1 | a set that fails **client-side** conversion | sets already serialized still commit and the call is partial success; msodbcsql materializes first, sends nothing, and reports total failure | AB#47945 |
 | 2 | `SQLExecDirect` with `PARAMSET_SIZE > 1` | `HYC00`, with or without markers | AB#47939 |
-| 3 | array over a **row-returning** statement | executes, discards the result sets | AB#47944 |
 | 4 | data-at-execution combined with an array | `HYC00` at execute | AB#47958 |
 | 5 | output / `InputOutput` parameters | refused at `SQLBindParameter` | driver-wide gap, not array-specific |
 | 6 | array stride for `SQL_C_SS_VECTOR` | binding refused | AB#47790 |
@@ -905,20 +921,12 @@ row-attribution is deferred.
 
 `SQL_PARAM_ARRAY_ROW_COUNTS` and `SQL_PARAM_ARRAY_SELECTS` (`SQLGetInfo`) are
 both implemented: `SQL_PARC_NO_BATCH` (one rolled-up `SQLRowCount`, matching
-the "Reporting" behaviour above) and `SQL_PAS_NO_SELECT`. Both differ from
-msodbcsql 18.6.2.1, measured: it reports `SQL_PARC_BATCH` and `SQL_PAS_BATCH`,
-and its behaviour backs the claim - an `INSERT ... OUTPUT` at `PARAMSET_SIZE` 3
-hands back three result sets through `SQLMoreResults`.
-
-`SQL_PAS_NO_SELECT` is the one value here that is not literally true of this
-driver. The spec meaning is "a result-set generating statement is not allowed
-with an array of parameters", and this driver does allow one: divergence 3 runs
-every set and discards the result sets with a `01000`. It is reported anyway
-because the alternatives mislead in a more damaging direction - `SQL_PAS_BATCH`
-would tell an application the OUTPUT rows are retrievable when zero are
-delivered, which is exactly the silent data loss the value exists to warn
-about. Making it literally true means refusing such statements outright, which
-belongs to AB#47944 rather than to `SQLGetInfo`.
+the "Reporting" behaviour above) and `SQL_PAS_BATCH`. The SELECT capability and
+row delivery match retail msodbcsql 18.6.2.1 (`SQL_DRIVER_VER` `18.06.0002`):
+case 25 in `param_array_test.cpp` fetches all three OUTPUT results and verifies
+the final processed count is 3 with three `SQL_PARAM_SUCCESS` statuses. An
+execute-only observation misses that deferred bookkeeping. The row-count
+capability difference remains: msodbcsql reports `SQL_PARC_BATCH`.
 
 Divergence 8 is defence-in-depth, not a live bug: no server behaviour is known
 to produce it. msodbcsql cannot report it because it never compares the reported

--- a/mssql-odbc/src/api/close_cursor.rs
+++ b/mssql-odbc/src/api/close_cursor.rs
@@ -339,6 +339,7 @@ fn drain_and_release_inner(
         return DrainOutcome::Failed;
     }
 
+    let array_rc = super::execute::update_parameter_array(stmt, &mut client);
     let has_server_info = match stmt.inner.lock() {
         Ok(mut stmt_state) => {
             // Drain INFO only after the lock is held so a poisoned mutex cannot
@@ -366,7 +367,9 @@ fn drain_and_release_inner(
         }
     }
 
-    if has_server_info {
+    if array_rc == SQL_ERROR {
+        DrainOutcome::Failed
+    } else if has_server_info || array_rc == SQL_SUCCESS_WITH_INFO {
         DrainOutcome::InfoPosted
     } else {
         DrainOutcome::Clean

--- a/mssql-odbc/src/api/execute.rs
+++ b/mssql-odbc/src/api/execute.rs
@@ -705,7 +705,6 @@ fn report_parameter_array(
     has_more: bool,
 ) -> SqlReturn {
     let mut failed_sets = std::mem::take(&mut batch.client_side_failures);
-    let mut had_info = false;
     let complete = result.complete;
     if let Some(count) = result.total_rows_affected() {
         batch.rows_affected = Some(batch.rows_affected.unwrap_or(0).saturating_add(count));
@@ -724,7 +723,6 @@ fn report_parameter_array(
         let row_truncated = batch.truncated_rows.binary_search(&row.row_index).is_ok();
         let status = if row.errors.is_empty() {
             if row.has_info || row_truncated {
-                had_info = true;
                 had_fractional_truncation |= row_truncated;
                 SQL_PARAM_SUCCESS_WITH_INFO
             } else {
@@ -781,7 +779,7 @@ fn report_parameter_array(
     parameter_array_return_code(
         failed_sets,
         complete || has_more,
-        had_info,
+        had_fractional_truncation,
         !batch.outputs.param_status_ptr.is_null(),
     )
 }
@@ -1850,6 +1848,54 @@ mod tests {
             errors: Vec::new(),
             has_result_set: false,
             has_info: false,
+        }
+    }
+
+    #[test]
+    fn parameter_array_prior_info_does_not_warn_without_a_new_diagnostic() {
+        for truncated in [false, true] {
+            let handles = TestHandles::with_env_dbc_stmt();
+            let stmt = unsafe { handle_from_raw::<StmtHandle>(handles.stmt) };
+            let mut state = stmt.inner.lock().unwrap();
+            let mut status = SQL_PARAM_UNUSED;
+            let mut processed = 0;
+            let mut batch = BatchClientResults {
+                outputs: ParamArrayOutputs {
+                    paramset_size: 1,
+                    param_status_ptr: &mut status,
+                    params_processed_ptr: &mut processed,
+                },
+                client_side_failures: 0,
+                truncated_rows: if truncated { vec![0] } else { Vec::new() },
+                rows_affected: None,
+                processed: 0,
+            };
+            let mut row = reported_row(0);
+            row.has_info = true;
+            row.has_result_set = true;
+            let rc = report_parameter_array(
+                &mut state,
+                PreparedBatchResult {
+                    rows: vec![row],
+                    complete: true,
+                },
+                &mut batch,
+                None,
+                false,
+            );
+            assert_eq!(status, SQL_PARAM_SUCCESS_WITH_INFO);
+            assert_eq!(processed, 1);
+            if truncated {
+                assert_eq!(rc, SQL_SUCCESS_WITH_INFO);
+                assert_eq!(state.diag_records.len(), 1);
+                assert_eq!(
+                    state.diag_records[0].sql_state,
+                    WARN_FRACTIONAL_TRUNCATION.state
+                );
+            } else {
+                assert_eq!(rc, SQL_SUCCESS);
+                assert!(state.diag_records.is_empty());
+            }
         }
     }
 

--- a/mssql-odbc/src/api/execute.rs
+++ b/mssql-odbc/src/api/execute.rs
@@ -9,8 +9,8 @@ use tracing::{debug, error};
 use std::time::Instant;
 
 use mssql_tds::connection::tds_client::{
-    ExecuteOptions, PreparedBatchResult, PreparedBatchRowResult, StatementId, StatementResult,
-    StreamedParamStatus,
+    ExecuteOptions, PreparedBatchResult, PreparedBatchRowResult, ResultSet, StatementId,
+    StatementResult, StreamedParamStatus,
 };
 use mssql_tds::error::Error as TdsError;
 use mssql_tds::message::parameters::rpc_parameters::RpcParameter;
@@ -123,17 +123,20 @@ struct BatchExecution {
     query_timeout: u32,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 struct ParamArrayOutputs {
     paramset_size: SqlULen,
     param_status_ptr: *mut SqlUSmallInt,
     params_processed_ptr: *mut SqlULen,
 }
 
-struct BatchClientResults {
+#[derive(Debug)]
+pub(crate) struct BatchClientResults {
     outputs: ParamArrayOutputs,
     client_side_failures: usize,
     truncated_rows: Vec<usize>,
+    rows_affected: Option<i64>,
+    processed: SqlULen,
 }
 
 enum ExecutionStaging {
@@ -506,7 +509,7 @@ fn sql_execute_safe(statement_handle: SqlHandle, stmt: &StmtHandle) -> SqlReturn
                 failures: Vec::new(),
                 truncated_rows: Vec::new(),
             };
-            let batch_result = dbc.runtime.block_on(client.execute_prepared_batch(
+            let batch_result = dbc.runtime.block_on(client.begin_execute_prepared_batch(
                 &mut prepared.stmt,
                 &mut rows,
                 &mut orphaned,
@@ -573,6 +576,8 @@ fn sql_execute_safe(statement_handle: SqlHandle, stmt: &StmtHandle) -> SqlReturn
                     outputs,
                     client_side_failures: failures.len(),
                     truncated_rows,
+                    rows_affected: None,
+                    processed: 0,
                 },
             )
         }
@@ -607,44 +612,117 @@ fn finish_parameter_array(
     statement_handle: SqlHandle,
     mut client: mssql_tds::connection::tds_client::TdsClient,
     result: PreparedBatchResult,
-    batch: BatchClientResults,
+    mut batch: BatchClientResults,
 ) -> SqlReturn {
-    let mut failed_sets = batch.client_side_failures;
-    let mut had_info = false;
-    let complete = result.complete;
-    let total_rows = result
-        .total_rows_affected()
-        .unwrap_or(SQL_NO_ROWCOUNT_TOTAL);
-    let processed = params_processed(complete, batch.outputs.paramset_size, &result.rows);
+    let has_more = client.has_open_batch();
+    let metadata = client.get_metadata().clone();
+    let ird_ok = super::ird::populate_ird(stmt, &metadata).is_ok();
     let info_messages = client.take_info_messages();
-
     let Ok(mut stmt_state) = stmt.inner.lock() else {
-        return_client_idle(dbc, statement_handle, client);
+        super::exec_common::return_client_busy(dbc, client);
         return SQL_ERROR;
     };
-    let mut truncated_rows = batch.truncated_rows;
-    truncated_rows.sort_unstable();
+    stmt_state.begin_batch(metadata);
+    let mut rc = report_parameter_array(
+        &mut stmt_state,
+        result,
+        &mut batch,
+        client.current_parameter_set(),
+        has_more,
+    );
+    if post_tds_info_messages(&mut stmt_state, &info_messages) && rc == SQL_SUCCESS {
+        rc = SQL_SUCCESS_WITH_INFO;
+    }
+    stmt_state.clear_exhaustion_state();
+    stmt_state.set_state(STMT_STATE_EXEC_CONTEXT);
+    stmt_state.clear_state(STMT_STATE_EXEC_STARTED);
+    if has_more {
+        stmt_state.row_count = SQL_NO_ROWCOUNT_TOTAL;
+        stmt_state.set_state(STMT_STATE_CURSOR_OPEN);
+        stmt_state.parameter_array = Some(batch);
+    } else {
+        stmt_state.row_count = batch.rows_affected.unwrap_or(SQL_NO_ROWCOUNT_TOTAL);
+        stmt_state.clear_state(STMT_STATE_CURSOR_OPEN);
+    }
+    if !ird_ok {
+        post_sql_error(
+            &mut stmt_state,
+            SQLSTATE_HY000,
+            0,
+            "Internal error refreshing result-set metadata",
+        );
+        rc = SQL_ERROR;
+    }
+    drop(stmt_state);
+    if has_more {
+        super::exec_common::return_client_busy(dbc, client);
+    } else {
+        return_client_idle(dbc, statement_handle, client);
+    }
+    rc
+}
+
+pub(super) fn update_parameter_array(
+    stmt: &StmtHandle,
+    client: &mut mssql_tds::connection::tds_client::TdsClient,
+) -> SqlReturn {
+    let Ok(mut stmt_state) = stmt.inner.lock() else {
+        return SQL_ERROR;
+    };
+    let Some(mut batch) = stmt_state.parameter_array.take() else {
+        return SQL_SUCCESS;
+    };
+    batch.outputs.param_status_ptr = stmt_state
+        .inert_attrs
+        .get(SQL_ATTR_PARAM_STATUS_PTR)
+        .unwrap_or(0) as *mut SqlUSmallInt;
+    batch.outputs.params_processed_ptr = stmt_state
+        .inert_attrs
+        .get(SQL_ATTR_PARAMS_PROCESSED_PTR)
+        .unwrap_or(0) as *mut SqlULen;
+    let has_more = client.has_open_batch();
+    let rc = match client.take_prepared_batch_results() {
+        Some(result) => report_parameter_array(
+            &mut stmt_state,
+            result,
+            &mut batch,
+            client.current_parameter_set(),
+            has_more,
+        ),
+        None => SQL_SUCCESS,
+    };
+    if has_more {
+        stmt_state.parameter_array = Some(batch);
+    }
+    rc
+}
+
+fn report_parameter_array(
+    stmt_state: &mut crate::handles::stmt::StmtState,
+    result: PreparedBatchResult,
+    batch: &mut BatchClientResults,
+    current_set: Option<usize>,
+    has_more: bool,
+) -> SqlReturn {
+    let mut failed_sets = std::mem::take(&mut batch.client_side_failures);
+    let mut had_info = false;
+    let complete = result.complete;
+    if let Some(count) = result.total_rows_affected() {
+        batch.rows_affected = Some(batch.rows_affected.unwrap_or(0).saturating_add(count));
+    }
+    batch.processed = current_set.map_or_else(
+        || {
+            params_processed(complete, batch.outputs.paramset_size, &result.rows)
+                .max(batch.processed)
+        },
+        |index| index.saturating_add(1),
+    );
+    let processed = batch.processed;
+    batch.truncated_rows.sort_unstable();
     let mut had_fractional_truncation = false;
     for row in result.rows {
-        let row_truncated = truncated_rows.binary_search(&row.row_index).is_ok();
-        // A set that returned rows still ran: the OUTPUT rows are dropped
-        // because one statement handle cannot hold N result sets (AB#47944),
-        // but reporting it SQL_PARAM_ERROR would invite a retry that
-        // double-inserts.
-        let status = if row.has_result_set && row.errors.is_empty() {
-            had_info = true;
-            had_fractional_truncation |= row_truncated;
-            post_sql_error(
-                &mut stmt_state,
-                SQLSTATE_01000,
-                0,
-                format!(
-                    "Parameter-array row {} produced a result set; its rows were discarded",
-                    row.row_index + 1
-                ),
-            );
-            SQL_PARAM_SUCCESS_WITH_INFO
-        } else if row.errors.is_empty() {
+        let row_truncated = batch.truncated_rows.binary_search(&row.row_index).is_ok();
+        let status = if row.errors.is_empty() {
             if row.has_info || row_truncated {
                 had_info = true;
                 had_fractional_truncation |= row_truncated;
@@ -655,7 +733,7 @@ fn finish_parameter_array(
         } else {
             failed_sets += 1;
             post_tds_error(
-                &mut stmt_state,
+                stmt_state,
                 &TdsError::from_sql_errors(row.errors),
                 SQLSTATE_HY000,
             );
@@ -665,9 +743,9 @@ fn finish_parameter_array(
             write_param_status(batch.outputs.param_status_ptr, row.row_index, status);
         }
     }
-    if !complete {
+    if !complete && !has_more {
         post_sql_error(
-            &mut stmt_state,
+            stmt_state,
             SQLSTATE_01000,
             0,
             format!(
@@ -677,19 +755,12 @@ fn finish_parameter_array(
         );
     }
     if had_fractional_truncation {
-        post_diag(&mut stmt_state, WARN_FRACTIONAL_TRUNCATION);
+        post_diag(stmt_state, WARN_FRACTIONAL_TRUNCATION);
     }
-    post_tds_info_messages(&mut stmt_state, &info_messages);
-    stmt_state.row_count = total_rows;
-    stmt_state.clear_exhaustion_state();
-    stmt_state.set_state(STMT_STATE_EXEC_CONTEXT);
-    stmt_state.clear_state(STMT_STATE_CURSOR_OPEN | STMT_STATE_EXEC_STARTED);
-    drop(stmt_state);
 
     unsafe {
         write_params_processed(batch.outputs.params_processed_ptr, processed);
     }
-    return_client_idle(dbc, statement_handle, client);
 
     // One rule, whether the set failed client-side before it reached the wire or
     // server-side after: a status array can carry the per-set detail, so the
@@ -709,8 +780,8 @@ fn finish_parameter_array(
     // because it has no SQL_PARAM_UNUSED pre-fill. AB#47945.
     parameter_array_return_code(
         failed_sets,
-        complete,
-        had_info || !info_messages.is_empty(),
+        complete || has_more,
+        had_info,
         !batch.outputs.param_status_ptr.is_null(),
     )
 }

--- a/mssql-odbc/src/api/get_info.rs
+++ b/mssql-odbc/src/api/get_info.rs
@@ -17,7 +17,7 @@ use crate::api::odbc_types::{
     SQL_MAX_DRIVER_CONNECTIONS, SQL_MAX_SCHEMA_NAME_LEN, SQL_MAX_STATEMENT_LEN,
     SQL_MAX_TABLE_NAME_LEN, SQL_MULTIPLE_ACTIVE_TXN, SQL_NEED_LONG_DATA_LEN, SQL_NUMERIC_FUNCTIONS,
     SQL_OAC_LEVEL2, SQL_ODBC_API_CONFORMANCE, SQL_ODBC_SQL_CONFORMANCE, SQL_ODBC_VER, SQL_OSC_CORE,
-    SQL_PARAM_ARRAY_ROW_COUNTS, SQL_PARAM_ARRAY_SELECTS, SQL_PARC_NO_BATCH, SQL_PAS_NO_SELECT,
+    SQL_PARAM_ARRAY_ROW_COUNTS, SQL_PARAM_ARRAY_SELECTS, SQL_PARC_NO_BATCH, SQL_PAS_BATCH,
     SQL_PROCEDURES, SQL_SC_SQL92_ENTRY, SQL_SCHEMA_TERM, SQL_SERVER_NAME, SQL_SPECIAL_CHARACTERS,
     SQL_SQL_CONFORMANCE, SQL_STRING_FUNCTIONS, SQL_SUCCESS, SQL_SUCCESS_WITH_INFO,
     SQL_SYSTEM_FUNCTIONS, SQL_TC_ALL, SQL_TIMEDATE_FUNCTIONS, SQL_TXN_CAPABLE,
@@ -354,14 +354,10 @@ fn sql_get_info_w_safe(
             string_length_ptr,
             "N",
         ),
-        // Array execution (`SQL_ATTR_PARAMSET_SIZE > 1`) rolls every set's
-        // count into one `SQLRowCount` and discards result sets from a
-        // row-returning statement — see divergences 3 and the array-execution
-        // notes in `parameters_plan.md`.
         SQL_PARAM_ARRAY_ROW_COUNTS => {
             write_u32(info_value_ptr, SQL_PARC_NO_BATCH, string_length_ptr)
         }
-        SQL_PARAM_ARRAY_SELECTS => write_u32(info_value_ptr, SQL_PAS_NO_SELECT, string_length_ptr),
+        SQL_PARAM_ARRAY_SELECTS => write_u32(info_value_ptr, SQL_PAS_BATCH, string_length_ptr),
         _ => {
             error!(info_type, "SQLGetInfoW: unsupported info type");
             post_diag(&mut state, ERR_INVALID_INFO_TYPE);
@@ -555,12 +551,11 @@ mod tests {
     fn param_array_info_types_match_odbc_spec_values() {
         // Pinned against the literal `sqlext.h` values (not the driver's own
         // constants) so a transcription slip in either fails this test:
-        // `SQL_PARC_NO_BATCH` is 2 (`SQL_PARC_BATCH` is 1), `SQL_PAS_NO_SELECT`
-        // is 3 (`SQL_PAS_BATCH` is 1, `SQL_PAS_NO_BATCH` is 2).
+        // `SQL_PARC_NO_BATCH` is 2; `SQL_PAS_BATCH` is 1.
         let h = TestHandles::with_env_dbc();
         for (info_type, expected) in [
             (SQL_PARAM_ARRAY_ROW_COUNTS, 2u32),
-            (SQL_PARAM_ARRAY_SELECTS, 3u32),
+            (SQL_PARAM_ARRAY_SELECTS, 1u32),
         ] {
             let (rc, val, len) = get_u32(h.dbc, info_type);
             assert_eq!(rc, SQL_SUCCESS, "info_type {info_type}");

--- a/mssql-odbc/src/api/mod.rs
+++ b/mssql-odbc/src/api/mod.rs
@@ -18,7 +18,7 @@ mod driver_connect;
 mod end_tran;
 mod exec_common;
 mod exec_direct;
-mod execute;
+pub(crate) mod execute;
 pub(crate) mod fetch;
 pub(crate) mod fetch_scroll;
 pub(crate) mod free_handle;

--- a/mssql-odbc/src/api/more_results.rs
+++ b/mssql-odbc/src/api/more_results.rs
@@ -170,7 +170,9 @@ fn sql_more_results_safe(statement_handle: SqlHandle, stmt: &StmtHandle) -> SqlR
         client
     };
 
-    match dbc.runtime.block_on(client.advance()) {
+    let result = dbc.runtime.block_on(client.advance());
+    let array_rc = super::execute::update_parameter_array(stmt, &mut client);
+    match result {
         Ok(StatementResult::Rows) => {
             // Positioned on a new row-returning result set. Refresh metadata,
             // clear row state, keep CURSOR_OPEN and active_stmt set.
@@ -225,7 +227,9 @@ fn sql_more_results_safe(statement_handle: SqlHandle, stmt: &StmtHandle) -> SqlR
                 return SQL_ERROR;
             }
             debug!("SQLMoreResults: advanced to next result set");
-            if has_server_info {
+            if array_rc != SQL_SUCCESS {
+                array_rc
+            } else if has_server_info {
                 SQL_SUCCESS_WITH_INFO
             } else {
                 SQL_SUCCESS
@@ -280,7 +284,9 @@ fn sql_more_results_safe(statement_handle: SqlHandle, stmt: &StmtHandle) -> SqlR
                 return SQL_ERROR;
             }
             debug!("SQLMoreResults: advanced to a no-row statement result");
-            if has_server_info {
+            if array_rc != SQL_SUCCESS {
+                array_rc
+            } else if has_server_info {
                 SQL_SUCCESS_WITH_INFO
             } else {
                 SQL_SUCCESS
@@ -312,7 +318,11 @@ fn sql_more_results_safe(statement_handle: SqlHandle, stmt: &StmtHandle) -> SqlR
                 }
             }
             debug!("SQLMoreResults: no more result sets");
-            SQL_NO_DATA
+            if array_rc != SQL_SUCCESS {
+                array_rc
+            } else {
+                SQL_NO_DATA
+            }
         }
         Err(e) => {
             error!(%e, "SQLMoreResults: advance failed");

--- a/mssql-odbc/src/api/odbc_types.rs
+++ b/mssql-odbc/src/api/odbc_types.rs
@@ -308,18 +308,9 @@ pub const SQL_ASYNC_NOTIFICATION_NOT_CAPABLE: u32 = 0x00000000;
 /// here — `SQLRowCount` already sums every set's affected rows).
 /// `sqlext.h`: `#define SQL_PARC_NO_BATCH 2`.
 pub const SQL_PARC_NO_BATCH: u32 = 2;
-/// `SQL_PARAM_ARRAY_SELECTS`: per spec, a driver reporting this value does
-/// not allow a result-set-generating statement to be executed with an array
-/// of parameters. This driver actually *does* execute one and discards the
-/// result sets instead of refusing it (divergence 3 in `parameters_plan.md`),
-/// so the value is not literally true here. It is reported anyway because the
-/// alternative misleads in a more damaging direction: `SQL_PAS_BATCH` would
-/// promise OUTPUT rows this driver never delivers. msodbcsql 18.6.2.1 does
-/// report `SQL_PAS_BATCH`, measured, and backs it - an `INSERT ... OUTPUT` at
-/// `PARAMSET_SIZE` 3 hands back three result sets - so this is a divergence,
-/// not a match. Making it literally true means refusing such statements,
-/// which belongs to AB#47944.
-/// `sqlext.h`: `#define SQL_PAS_NO_SELECT 3`.
+/// Parameter-array SELECTs return one result set per parameter set.
+pub const SQL_PAS_BATCH: u32 = 1;
+/// Parameter-array SELECTs are not supported (`sqlext.h`).
 pub const SQL_PAS_NO_SELECT: u32 = 3;
 
 // ODBC-SQL-type identifiers.

--- a/mssql-odbc/src/handles/stmt.rs
+++ b/mssql-odbc/src/handles/stmt.rs
@@ -453,6 +453,7 @@ pub(crate) struct StmtState {
     /// this: it is what keeps a live orphan from being discarded on the
     /// `sp_execute` reuse path.
     pub(crate) pending_unprepare: Option<StatementId>,
+    pub(crate) parameter_array: Option<crate::api::execute::BatchClientResults>,
     /// `true` when SQLFetch has positioned the cursor on a row ready for SQLGetData.
     pub(crate) row_positioned: bool,
     /// The column value captured by the most recent resume_row_to_column call, with its 1-based column index.
@@ -1270,6 +1271,7 @@ impl StmtHandle {
                 parameter_metadata: Vec::new(),
                 bound_params: Vec::new(),
                 pending_unprepare: None,
+                parameter_array: None,
                 row_positioned: false,
                 last_captured: None,
                 buffered_get_data_row: None,

--- a/mssql-odbc/tests/e2e/tests/get_info_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/get_info_test.cpp
@@ -170,13 +170,8 @@ TEST_F(GetInfoLiveTest, YesNoCapabilities) {
     }
 }
 
-// SQL_PARAM_ARRAY_ROW_COUNTS/SELECTS: literal SQL_PARC_NO_BATCH/SQL_PAS_NO_SELECT
-// against <sqlext.h>, so a transcription slip in either value still fails here.
-//
-// mssql-odbc only. Measured on msodbcsql 18.6.2.1: it answers SQL_PARC_BATCH (1)
-// and SQL_PAS_BATCH (1), and its behaviour backs the claim - an INSERT ... OUTPUT
-// at PARAMSET_SIZE 3 hands back three result sets through SQLMoreResults. This
-// driver discards them (divergence 3, AB#47944), so the values differ by design.
+// Non-row arrays return an aggregate count. Retail msodbcsql 18.6.2.1
+// advertises SQL_PARC_BATCH instead, so this assertion remains driver-specific.
 TEST_F(GetInfoLiveTest, ParamArrayCapabilities) {
     SKIP_IF_COMPARING_MSODBCSQL();
 
@@ -187,8 +182,12 @@ TEST_F(GetInfoLiveTest, ParamArrayCapabilities) {
               GetInfoU32(dbc_, SQL_PARAM_ARRAY_ROW_COUNTS, &rc, &len));
     EXPECT_TRUE(SQL_SUCCEEDED(rc));
     EXPECT_EQ(static_cast<SQLSMALLINT>(sizeof(SQLUINTEGER)), len);
+}
 
-    EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_PAS_NO_SELECT),
+TEST_F(GetInfoLiveTest, ParamArraySelectsAreNavigable) {
+    SQLRETURN rc = SQL_ERROR;
+    SQLSMALLINT len = -1;
+    EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_PAS_BATCH),
               GetInfoU32(dbc_, SQL_PARAM_ARRAY_SELECTS, &rc, &len));
     EXPECT_TRUE(SQL_SUCCEEDED(rc));
     EXPECT_EQ(static_cast<SQLSMALLINT>(sizeof(SQLUINTEGER)), len);

--- a/mssql-odbc/tests/e2e/tests/param_array_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/param_array_test.cpp
@@ -1830,6 +1830,35 @@ TEST_F(ParamArrayTest, ProcedureArrayDeliversEveryResultSet) {
     }
 }
 
+TEST_F(ParamArrayTest, PriorArrayInfoDoesNotWarnAgainDuringNavigationOrClose) {
+    Prepare("DECLARE @value int = ?; IF @value = 1 PRINT 'first set info'; SELECT @value");
+    SQLINTEGER values[3] = {1, 2, 3};
+    SQLLEN indicators[3] = {};
+    SQLUSMALLINT status[3] = {};
+    SQLULEN processed = 0;
+    BindIntArray(values, indicators, 3, status, &processed);
+
+    for (const bool close_early : {false, true}) {
+        SCOPED_TRACE(close_early ? "close" : "navigate");
+        ASSERT_EQ(SQL_SUCCESS_WITH_INFO, SQLExecute(stmt_));
+        EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "01000");
+        FetchIntResult(1);
+        if (close_early) {
+            EXPECT_EQ(SQL_SUCCESS, SQLCloseCursor(stmt_));
+            EXPECT_TRUE(ODBCTestUtils::GetDiagState(SQL_HANDLE_STMT, stmt_).empty());
+        } else {
+            for (int expected = 2; expected <= 3; ++expected) {
+                ASSERT_EQ(SQL_SUCCESS, SQLMoreResults(stmt_));
+                EXPECT_TRUE(ODBCTestUtils::GetDiagState(SQL_HANDLE_STMT, stmt_).empty());
+                FetchIntResult(expected);
+            }
+            EXPECT_EQ(SQL_NO_DATA, SQLMoreResults(stmt_));
+            EXPECT_TRUE(ODBCTestUtils::GetDiagState(SQL_HANDLE_STMT, stmt_).empty());
+            EXPECT_EQ(3u, processed);
+        }
+    }
+}
+
 TEST_F(ParamArrayTest, RowReturningArraySkipsIgnoredSets) {
     Prepare("SELECT CAST(? AS int)");
     SQLINTEGER values[4] = {1, 2, 3, 4};

--- a/mssql-odbc/tests/e2e/tests/param_array_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/param_array_test.cpp
@@ -39,7 +39,7 @@
 //  14b. ExecDirectArrayWithNoMarkersIsRefused     - same refusal, no markers
 //  15.  ArrayRollsBackWithTheTransaction          - manual-commit semantics
 //  16.  ArrayCommitsEveryRowUnderAutocommit       - partial-failure durability
-//       (17 was removed: it asserted nothing the other cases did not)
+//  17.  SelectArrayPreservesEmptyAndNullResults   - one result per set
 //  18.  ArrayWithZeroBufferLengthAliasesOneValue  - inherited msodbcsql quirk
 //  19.  DataAtExecutionWithArrayIsRefused         - documented divergence
 //  20.  QueryTimeoutBoundsTheWholeArray           - one budget for all sets
@@ -47,7 +47,7 @@
 //  22.  RowWiseArrayWalksMixedTypeStructures      - msodbcsql RowStruct shape
 //  23.  ParamsProcessedCountsTheFailingSet        - msodbcsql Variation_76
 //  24.  RowWiseArrayHonorsIgnoreForSkippedSets    - row-wise x SQL_PARAM_IGNORE
-//  25.  RowReturningArrayOnThePreparedPath        - divergence: AB#47944
+//  25.  RowReturningArrayOnThePreparedPath        - OUTPUT rows: AB#47944
 //  26.  ConversionFailureIsReportedPerSetWhereverItSits - divergence: AB#47945
 //  26b. EverySetFailingToConvertIsError          - total client-side failure
 //  27.  AnInfoMessageDegradesTheBatchOnBothDrivers - info-token parity
@@ -57,6 +57,12 @@
 //  31.  PreparedStatementReExecutesAtDifferentArraySizes - 4 -> 7 -> 2
 //  32.  TimestampoffsetArrayStridesByItsStructSize - fixed struct, not BufferLength
 //  32b. Time2ArrayStridesByItsStructSize          - the sibling C type
+//  33.  ProcedureArrayDeliversEveryResultSet      - two rowsets per set
+//  34.  RowReturningArraySkipsIgnoredSets         - no phantom results
+//  35.  RowReturningArrayContinuesAfterASetError  - errors remain per set
+//  36.  RowReturningArrayWithoutStatusReportsErrors - no lost next rowset
+//  37.  RowReturningArrayDrainsPartialLobOnAdvance - streaming cleanup
+//  38.  RowReturningArrayTimeoutDuringNavigation - cancel and reuse
 
 #include "odbc_test_fixture.h"
 
@@ -188,6 +194,30 @@ protected:
             SQLExecDirect(probe, const_cast<SQLTCHAR*>(wide.c_str()), SQL_NTS),
             SQL_HANDLE_STMT, probe);
         FreeStmt(probe);
+    }
+
+    void BindIntArray(SQLINTEGER* values, SQLLEN* indicators, SQLULEN count,
+                      SQLUSMALLINT* status = nullptr, SQLULEN* processed = nullptr) {
+        ASSERT_SQL_OK(SQLBindParameter(stmt_, 1, SQL_PARAM_INPUT, SQL_C_SLONG,
+                                       SQL_INTEGER, 10, 0, values, 0, indicators),
+                      SQL_HANDLE_STMT, stmt_);
+        ASSERT_EQ(SQL_SUCCESS, SetStmtULen(SQL_ATTR_PARAMSET_SIZE, count));
+        ASSERT_EQ(SQL_SUCCESS, SetStmtPtr(SQL_ATTR_PARAM_STATUS_PTR, status));
+        ASSERT_EQ(SQL_SUCCESS, SetStmtPtr(SQL_ATTR_PARAMS_PROCESSED_PTR, processed));
+    }
+
+    void FetchIntResult(SQLINTEGER expected) {
+        SQLSMALLINT columns = -1;
+        ASSERT_SQL_OK(SQLNumResultCols(stmt_, &columns), SQL_HANDLE_STMT, stmt_);
+        ASSERT_EQ(1, columns);
+        ASSERT_SQL_OK(SQLFetch(stmt_), SQL_HANDLE_STMT, stmt_);
+        SQLINTEGER value = -1;
+        SQLLEN length = -1;
+        ASSERT_SQL_OK(SQLGetData(stmt_, 1, SQL_C_SLONG, &value, sizeof(value), &length),
+                      SQL_HANDLE_STMT, stmt_);
+        EXPECT_EQ(expected, value);
+        EXPECT_EQ(static_cast<SQLLEN>(sizeof(value)), length);
+        EXPECT_EQ(SQL_NO_DATA, SQLFetch(stmt_));
     }
 };
 
@@ -1013,6 +1043,37 @@ TEST_F(ParamArrayTest, ArrayCommitsEveryRowUnderAutocommit) {
     EXPECT_EQ(2, ScalarInt("SELECT COUNT(*) FROM #pa"));
 }
 
+TEST_F(ParamArrayTest, SelectArrayPreservesEmptyAndNullResults) {
+    Prepare("SELECT value FROM (VALUES (CAST(? AS int))) AS source(value) "
+            "WHERE value IS NULL OR value > 0");
+    SQLINTEGER values[3] = {0, 7, 9};
+    SQLLEN indicators[3] = {0, SQL_NULL_DATA, 0};
+    SQLUSMALLINT status[3] = {0xFFFF, 0xFFFF, 0xFFFF};
+    SQLULEN processed = 0;
+    BindIntArray(values, indicators, 3, status, &processed);
+    ASSERT_EQ(SQL_SUCCESS, SQLExecute(stmt_));
+
+    SQLSMALLINT columns = -1;
+    ASSERT_SQL_OK(SQLNumResultCols(stmt_, &columns), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(1, columns);
+    EXPECT_EQ(SQL_NO_DATA, SQLFetch(stmt_));
+    ASSERT_EQ(SQL_SUCCESS, SQLMoreResults(stmt_));
+    ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt_));
+    SQLINTEGER value = -1;
+    SQLLEN length = 0;
+    ASSERT_SQL_OK(SQLGetData(stmt_, 1, SQL_C_SLONG, &value, sizeof(value), &length),
+                  SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(SQL_NULL_DATA, length);
+    EXPECT_EQ(SQL_NO_DATA, SQLFetch(stmt_));
+    ASSERT_EQ(SQL_SUCCESS, SQLMoreResults(stmt_));
+    FetchIntResult(9);
+    EXPECT_EQ(SQL_NO_DATA, SQLMoreResults(stmt_));
+    EXPECT_EQ(3u, processed);
+    for (const auto item : status) {
+        EXPECT_EQ(SQL_PARAM_SUCCESS, item);
+    }
+}
+
 // -------------------------------------------------------------------
 // 19. DIVERGENCE (mssql-odbc only): data-at-execution needs
 // SQLParamData/SQLPutData to drive one set at a time, which cannot be
@@ -1378,15 +1439,10 @@ TEST_F(ParamArrayTest, RowWiseArrayHonorsIgnoreForSkippedSets) {
 // back the id it just wrote - so three runs produce three result sets,
 // while ODBC exposes only one current result set per statement handle.
 //
-// Both drivers run every set, so no set is silently skipped. mssql-odbc
-// discards the OUTPUT rows and reports each set SQL_PARAM_SUCCESS_WITH_INFO
-// with a 01000 warning; delivering the rows is AB#47944. Measured on
-// msodbcsql 18.6.2.1: SQL_SUCCESS, the status array never written, and
-// *PARAMS_PROCESSED_PTR left at the scalar value 1 despite three sets
-// running - hence the skip rather than a shared assertion.
+// Retail msodbcsql 18.6.2.1 (SQL_DRIVER_VER 18.06.0002) delivers all
+// three result sets. Bookkeeping is deferred until navigation completes.
 // -------------------------------------------------------------------
 TEST_F(ParamArrayTest, RowReturningArrayOnThePreparedPath) {
-    SKIP_IF_COMPARING_MSODBCSQL();
     ExecDirect("CREATE TABLE #pa_out2 (id int)");
     Prepare("INSERT INTO #pa_out2 (id) OUTPUT inserted.id VALUES (?)");
 
@@ -1404,21 +1460,24 @@ TEST_F(ParamArrayTest, RowReturningArrayOnThePreparedPath) {
     const SQLRETURN rc = SQLExecute(stmt_);
     // Any later call on this handle clears its diagnostics, so read them first.
     const std::string diag = ODBCTestUtils::GetDiagState(SQL_HANDLE_STMT, stmt_);
-    SQLFreeStmt(stmt_, SQL_CLOSE);
+    ASSERT_EQ(SQL_SUCCESS, rc);
+    EXPECT_TRUE(diag.empty());
+    for (int expected = 1; expected <= 3; ++expected) {
+        FetchIntResult(expected);
+        if (expected < 3) {
+            ASSERT_EQ(SQL_SUCCESS, SQLMoreResults(stmt_));
+        }
+    }
+    EXPECT_EQ(SQL_NO_DATA, SQLMoreResults(stmt_));
+    EXPECT_EQ(3u, processed);
+    for (const auto item : status) {
+        EXPECT_EQ(SQL_PARAM_SUCCESS, item);
+    }
+    EXPECT_EQ(SQL_NO_DATA, SQLMoreResults(stmt_));
+    ASSERT_SQL_OK(SQLFreeStmt(stmt_, SQL_CLOSE), SQL_HANDLE_STMT, stmt_);
 
-    // Every set ran, and the connection survives the discarded result sets.
     EXPECT_EQ(3, ScalarInt("SELECT COUNT(*) FROM #pa_out2"));
     EXPECT_EQ(1, ScalarInt("SELECT 1"));
-
-    EXPECT_EQ(SQL_SUCCESS_WITH_INFO, rc);
-    EXPECT_EQ(3u, processed);
-    // The set ran - its row is in the table asserted above - so it is a success
-    // carrying a 01000 warning that the OUTPUT rows were discarded. Reporting
-    // SQL_PARAM_ERROR would invite a retry that double-inserts.
-    EXPECT_EQ(SQL_PARAM_SUCCESS_WITH_INFO, status[0]);
-    EXPECT_EQ(SQL_PARAM_SUCCESS_WITH_INFO, status[1]);
-    EXPECT_EQ(SQL_PARAM_SUCCESS_WITH_INFO, status[2]);
-    EXPECT_EQ("01000", diag);
 }
 
 // -------------------------------------------------------------------
@@ -1720,18 +1779,10 @@ TEST_F(ParamArrayTest, ThousandSetArrayCorrelatesFailuresToTheirOwnSets) {
 }
 
 // -------------------------------------------------------------------
-// 30. What an application actually sees on the cursor API after a
-// row-returning array execute. Case 25 asserts the statuses and that the
-// connection survives, but nothing in this suite touches
-// SQLNumResultCols / SQLFetch / SQLMoreResults afterwards - which is the
-// app-visible shape of the AB#47944 divergence.
-//
-// Pins measured behaviour rather than a desired contract: mssql-odbc
-// discards the OUTPUT rows, so the handle carries no result set and the
-// cursor calls report exactly that.
+// 30. SQLMoreResults skips unread rows, and closing before the final
+// result releases the connection without executing any parameter set twice.
 // -------------------------------------------------------------------
 TEST_F(ParamArrayTest, CursorApiAfterARowReturningArrayExecute) {
-    SKIP_IF_COMPARING_MSODBCSQL();
     ExecDirect("CREATE TABLE #pa_out3 (id int)");
     Prepare("INSERT INTO #pa_out3 (id) OUTPUT inserted.id VALUES (?)");
 
@@ -1746,36 +1797,163 @@ TEST_F(ParamArrayTest, CursorApiAfterARowReturningArrayExecute) {
     ASSERT_EQ(SQL_SUCCESS, SetStmtPtr(SQL_ATTR_PARAM_STATUS_PTR, status));
     ASSERT_EQ(SQL_SUCCESS, SetStmtPtr(SQL_ATTR_PARAMS_PROCESSED_PTR, &processed));
 
-    ASSERT_EQ(SQL_SUCCESS_WITH_INFO, SQLExecute(stmt_));
-
-    SQLSMALLINT columns = -1;
-    const SQLRETURN cols_rc = SQLNumResultCols(stmt_, &columns);
-    const std::string cols_diag =
-        ODBCTestUtils::GetDiagState(SQL_HANDLE_STMT, stmt_);
-
-    const SQLRETURN fetch_rc = SQLFetch(stmt_);
-    const std::string fetch_diag =
-        ODBCTestUtils::GetDiagState(SQL_HANDLE_STMT, stmt_);
-
-    const SQLRETURN more_rc = SQLMoreResults(stmt_);
-    const std::string more_diag =
-        ODBCTestUtils::GetDiagState(SQL_HANDLE_STMT, stmt_);
-
-    SQLFreeStmt(stmt_, SQL_CLOSE);
-
-    // The OUTPUT rows were discarded, so the handle has no result set left.
-    EXPECT_EQ(SQL_SUCCESS, cols_rc);
-    EXPECT_EQ(0, columns) << "no result set is current after the array execute";
-    EXPECT_TRUE(cols_diag.empty()) << "unexpected diagnostic: " << cols_diag;
-
-    EXPECT_EQ(SQL_ERROR, fetch_rc) << "there is no cursor to fetch from";
-    EXPECT_EQ("24000", fetch_diag);
-
-    EXPECT_EQ(SQL_NO_DATA, more_rc) << "no further result sets are queued";
-    EXPECT_TRUE(more_diag.empty()) << "unexpected diagnostic: " << more_diag;
-
-    // The statement is still usable and every set really ran.
+    ASSERT_EQ(SQL_SUCCESS, SQLExecute(stmt_));
+    ASSERT_EQ(SQL_SUCCESS, SQLMoreResults(stmt_));
+    FetchIntResult(2);
+    ASSERT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
     EXPECT_EQ(3, ScalarInt("SELECT COUNT(*) FROM #pa_out3"));
+    ASSERT_EQ(SQL_SUCCESS, SQLExecute(stmt_));
+    FetchIntResult(1);
+    ASSERT_SQL_OK(SQLFreeStmt(stmt_, SQL_CLOSE), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(6, ScalarInt("SELECT COUNT(*) FROM #pa_out3"));
+}
+
+TEST_F(ParamArrayTest, ProcedureArrayDeliversEveryResultSet) {
+    ExecDirect("CREATE PROCEDURE #pa_results @value int AS "
+               "BEGIN SET NOCOUNT ON; SELECT @value; SELECT @value + 10; END");
+    Prepare("EXEC #pa_results ?");
+    SQLINTEGER values[3] = {1, 2, 3};
+    SQLLEN indicators[3] = {};
+    SQLUSMALLINT status[3] = {0xFFFF, 0xFFFF, 0xFFFF};
+    SQLULEN processed = 0;
+    BindIntArray(values, indicators, 3, status, &processed);
+    ASSERT_EQ(SQL_SUCCESS, SQLExecute(stmt_));
+    for (int parameter_set = 1; parameter_set <= 3; ++parameter_set) {
+        FetchIntResult(parameter_set);
+        ASSERT_EQ(SQL_SUCCESS, SQLMoreResults(stmt_));
+        FetchIntResult(parameter_set + 10);
+        EXPECT_EQ(parameter_set == 3 ? SQL_NO_DATA : SQL_SUCCESS, SQLMoreResults(stmt_));
+    }
+    EXPECT_EQ(3u, processed);
+    for (const auto item : status) {
+        EXPECT_EQ(SQL_PARAM_SUCCESS, item);
+    }
+}
+
+TEST_F(ParamArrayTest, RowReturningArraySkipsIgnoredSets) {
+    Prepare("SELECT CAST(? AS int)");
+    SQLINTEGER values[4] = {1, 2, 3, 4};
+    SQLLEN indicators[4] = {};
+    SQLUSMALLINT operations[4] = {SQL_PARAM_PROCEED, SQL_PARAM_IGNORE,
+                                 SQL_PARAM_PROCEED, SQL_PARAM_IGNORE};
+    BindIntArray(values, indicators, 4);
+    ASSERT_EQ(SQL_SUCCESS, SetStmtPtr(SQL_ATTR_PARAM_OPERATION_PTR, operations));
+    ASSERT_EQ(SQL_SUCCESS, SQLExecute(stmt_));
+    FetchIntResult(1);
+    ASSERT_EQ(SQL_SUCCESS, SQLMoreResults(stmt_));
+    FetchIntResult(3);
+    EXPECT_EQ(SQL_NO_DATA, SQLMoreResults(stmt_));
+}
+
+TEST_F(ParamArrayTest, RowReturningArrayContinuesAfterASetError) {
+    Prepare("DECLARE @value int = ?; IF @value = 2 "
+            "RAISERROR ('parameter set rejected', 16, 1); ELSE SELECT @value");
+    SQLINTEGER values[3] = {1, 2, 3};
+    SQLLEN indicators[3] = {};
+    SQLUSMALLINT status[3] = {0xFFFF, 0xFFFF, 0xFFFF};
+    SQLULEN processed = 0;
+    BindIntArray(values, indicators, 3, status, &processed);
+    ASSERT_EQ(SQL_SUCCESS, SQLExecute(stmt_));
+    FetchIntResult(1);
+    SQLRETURN rc = SQLMoreResults(stmt_);
+    bool saw_error = false;
+    bool saw_last_result = false;
+    for (int boundary = 0; boundary < 8 && rc != SQL_NO_DATA; ++boundary) {
+        ASSERT_SQL_OK(rc, SQL_HANDLE_STMT, stmt_);
+        if (rc == SQL_SUCCESS_WITH_INFO) {
+            saw_error = true;
+            EXPECT_FALSE(ODBCTestUtils::GetDiagState(SQL_HANDLE_STMT, stmt_).empty());
+        }
+        SQLSMALLINT columns = -1;
+        ASSERT_SQL_OK(SQLNumResultCols(stmt_, &columns), SQL_HANDLE_STMT, stmt_);
+        if (columns > 0) {
+            EXPECT_FALSE(saw_last_result);
+            FetchIntResult(3);
+            saw_last_result = true;
+        }
+        rc = SQLMoreResults(stmt_);
+    }
+    EXPECT_EQ(SQL_NO_DATA, rc);
+    EXPECT_TRUE(saw_error);
+    EXPECT_TRUE(saw_last_result);
+    EXPECT_EQ(3u, processed);
+    EXPECT_EQ(SQL_PARAM_SUCCESS, status[0]);
+    EXPECT_EQ(SQL_PARAM_ERROR, status[1]);
+    EXPECT_EQ(SQL_PARAM_SUCCESS, status[2]);
+    EXPECT_EQ(1, ScalarInt("SELECT 1"));
+}
+
+TEST_F(ParamArrayTest, RowReturningArrayWithoutStatusReportsErrors) {
+    Prepare("DECLARE @value int = ?; IF @value = 2 "
+            "RAISERROR ('parameter set rejected', 16, 1); ELSE SELECT @value");
+    SQLINTEGER values[3] = {1, 2, 3};
+    SQLLEN indicators[3] = {};
+    BindIntArray(values, indicators, 3);
+    ASSERT_EQ(SQL_SUCCESS, SQLExecute(stmt_));
+    FetchIntResult(1);
+    SQLRETURN rc = SQLMoreResults(stmt_);
+    bool saw_error = false;
+    bool saw_last_result = false;
+    for (int boundary = 0; boundary < 8 && rc != SQL_NO_DATA; ++boundary) {
+        ASSERT_TRUE(SQL_SUCCEEDED(rc) || rc == SQL_ERROR);
+        if (rc == SQL_ERROR) {
+            saw_error = true;
+            EXPECT_FALSE(ODBCTestUtils::GetDiagState(SQL_HANDLE_STMT, stmt_).empty());
+        }
+        SQLSMALLINT columns = -1;
+        ASSERT_SQL_OK(SQLNumResultCols(stmt_, &columns), SQL_HANDLE_STMT, stmt_);
+        if (columns > 0) {
+            EXPECT_FALSE(saw_last_result);
+            FetchIntResult(3);
+            saw_last_result = true;
+        }
+        rc = SQLMoreResults(stmt_);
+    }
+    EXPECT_EQ(SQL_NO_DATA, rc);
+    EXPECT_TRUE(saw_error);
+    EXPECT_TRUE(saw_last_result);
+    EXPECT_EQ(1, ScalarInt("SELECT 1"));
+}
+
+TEST_F(ParamArrayTest, RowReturningArrayDrainsPartialLobOnAdvance) {
+    Prepare("SELECT CAST(? AS int), REPLICATE(CAST('x' AS varchar(max)), 1048576)");
+    SQLINTEGER values[2] = {1, 2};
+    SQLLEN indicators[2] = {};
+    BindIntArray(values, indicators, 2);
+    ASSERT_EQ(SQL_SUCCESS, SQLExecute(stmt_));
+    ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt_));
+    char prefix[16] = {};
+    SQLLEN length = 0;
+    EXPECT_EQ(SQL_SUCCESS_WITH_INFO,
+              SQLGetData(stmt_, 2, SQL_C_CHAR, prefix, sizeof(prefix), &length));
+    ASSERT_GT(std::strlen(prefix), 0u);
+    EXPECT_EQ(std::string(std::strlen(prefix), 'x'), std::string(prefix));
+    ASSERT_EQ(SQL_SUCCESS, SQLMoreResults(stmt_));
+    ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt_));
+    SQLINTEGER value = 0;
+    ASSERT_SQL_OK(SQLGetData(stmt_, 1, SQL_C_SLONG, &value, sizeof(value), &length),
+                  SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(2, value);
+    ASSERT_SQL_OK(SQLCloseCursor(stmt_), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(1, ScalarInt("SELECT 1"));
+}
+
+TEST_F(ParamArrayTest, RowReturningArrayTimeoutDuringNavigation) {
+    Prepare("SELECT CAST(? AS int); "
+            "RAISERROR ('result available', 0, 1) WITH NOWAIT; "
+            "WAITFOR DELAY '00:00:04'");
+    SQLINTEGER values[2] = {1, 2};
+    SQLLEN indicators[2] = {};
+    SQLUSMALLINT status[2] = {0xFFFF, 0xFFFF};
+    SQLULEN processed = 0;
+    BindIntArray(values, indicators, 2, status, &processed);
+    ASSERT_EQ(SQL_SUCCESS, SetStmtULen(SQL_ATTR_QUERY_TIMEOUT, 2));
+    ASSERT_SQL_OK(SQLExecute(stmt_), SQL_HANDLE_STMT, stmt_);
+    FetchIntResult(1);
+    EXPECT_EQ(SQL_ERROR, SQLMoreResults(stmt_));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, stmt_, "HYT00");
+    ASSERT_SQL_OK(SQLFreeStmt(stmt_, SQL_CLOSE), SQL_HANDLE_STMT, stmt_);
+    EXPECT_EQ(1, ScalarInt("SELECT 1"));
 }
 
 // -------------------------------------------------------------------

--- a/mssql-odbc/tests/e2e/tests/param_array_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/param_array_test.cpp
@@ -54,6 +54,8 @@
 //  28.  ArrayOfAThousandSetsWritesEveryRowInOrder  - depth: packing, drain, order
 //  29.  ThousandSetArrayCorrelatesFailuresToTheirOwnSets - boundary sets 0/499/999
 //  30.  CursorApiAfterARowReturningArrayExecute    - AB#47944 as the app sees it
+//  30b. PendingArrayResultKeepsConnectionBusy     - unread sets retain the wire
+//  30c. ClosingArrayCursorReleasesConnection      - close drains unread sets
 //  31.  PreparedStatementReExecutesAtDifferentArraySizes - 4 -> 7 -> 2
 //  32.  TimestampoffsetArrayStridesByItsStructSize - fixed struct, not BufferLength
 //  32b. Time2ArrayStridesByItsStructSize          - the sibling C type
@@ -1806,6 +1808,50 @@ TEST_F(ParamArrayTest, CursorApiAfterARowReturningArrayExecute) {
     FetchIntResult(1);
     ASSERT_SQL_OK(SQLFreeStmt(stmt_, SQL_CLOSE), SQL_HANDLE_STMT, stmt_);
     EXPECT_EQ(6, ScalarInt("SELECT COUNT(*) FROM #pa_out3"));
+}
+
+TEST_F(ParamArrayTest, PendingArrayResultKeepsConnectionBusy) {
+    Prepare("SELECT CAST(? AS int)");
+    SQLINTEGER values[2] = {1, 2};
+    SQLLEN indicators[2] = {};
+    BindIntArray(values, indicators, 2);
+    ASSERT_EQ(SQL_SUCCESS, SQLExecute(stmt_));
+    FetchIntResult(1);
+
+    SQLHSTMT probe = AllocStmt();
+    SqlTString select = ODBCTestUtils::ToSqlTStr("SELECT 20");
+    EXPECT_EQ(SQL_ERROR,
+              SQLExecDirect(probe, const_cast<SQLTCHAR*>(select.c_str()), SQL_NTS));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, probe, "HY000");
+
+    ASSERT_EQ(SQL_SUCCESS, SQLMoreResults(stmt_));
+    FetchIntResult(2);
+    ASSERT_EQ(SQL_NO_DATA, SQLMoreResults(stmt_));
+    ASSERT_SQL_OK(
+        SQLExecDirect(probe, const_cast<SQLTCHAR*>(select.c_str()), SQL_NTS),
+        SQL_HANDLE_STMT, probe);
+    FreeStmt(probe);
+}
+
+TEST_F(ParamArrayTest, ClosingArrayCursorReleasesConnection) {
+    Prepare("SELECT CAST(? AS int)");
+    SQLINTEGER values[2] = {1, 2};
+    SQLLEN indicators[2] = {};
+    BindIntArray(values, indicators, 2);
+    ASSERT_EQ(SQL_SUCCESS, SQLExecute(stmt_));
+    FetchIntResult(1);
+
+    SQLHSTMT probe = AllocStmt();
+    SqlTString select = ODBCTestUtils::ToSqlTStr("SELECT 20");
+    EXPECT_EQ(SQL_ERROR,
+              SQLExecDirect(probe, const_cast<SQLTCHAR*>(select.c_str()), SQL_NTS));
+    EXPECT_SQLSTATE(SQL_HANDLE_STMT, probe, "HY000");
+
+    ASSERT_SQL_OK(SQLFreeStmt(stmt_, SQL_CLOSE), SQL_HANDLE_STMT, stmt_);
+    ASSERT_SQL_OK(
+        SQLExecDirect(probe, const_cast<SQLTCHAR*>(select.c_str()), SQL_NTS),
+        SQL_HANDLE_STMT, probe);
+    FreeStmt(probe);
 }
 
 TEST_F(ParamArrayTest, ProcedureArrayDeliversEveryResultSet) {

--- a/mssql-tds/src/connection/tds_client.rs
+++ b/mssql-tds/src/connection/tds_client.rs
@@ -333,6 +333,25 @@ pub struct PreparedBatchResult {
     pub complete: bool,
 }
 
+#[derive(Debug)]
+struct PreparedBatchReadState {
+    remaining: std::vec::IntoIter<usize>,
+    current: Option<PreparedBatchRowResult>,
+    completed: Vec<PreparedBatchRowResult>,
+}
+
+impl PreparedBatchReadState {
+    fn next_row(row_index: usize) -> PreparedBatchRowResult {
+        PreparedBatchRowResult {
+            row_index,
+            rows_affected: None,
+            errors: Vec::new(),
+            has_result_set: false,
+            has_info: false,
+        }
+    }
+}
+
 impl PreparedBatchResult {
     /// Sum of reported update counts, or `None` when none were available.
     pub fn total_rows_affected(&self) -> Option<i64> {
@@ -426,6 +445,7 @@ pub struct TdsClient {
     /// layer can surface each as its own result set via
     /// [`take_dml_result_counts`](Self::take_dml_result_counts).
     dml_result_counts: Vec<i64>,
+    prepared_batch: Option<Box<PreparedBatchReadState>>,
 
     pub(in crate::connection) return_values: Vec<ReturnValue>,
     info_messages: Vec<SqlInfoMessage>,
@@ -590,6 +610,7 @@ impl TdsClient {
             count_map: HashMap::new(),
             last_rows_affected: -1,
             dml_result_counts: Vec::new(),
+            prepared_batch: None,
             return_values: Vec::new(),
             info_messages: Vec::new(),
             prepared_param_encryption: HashMap::new(),
@@ -1068,7 +1089,13 @@ impl TdsClient {
             );
             self.transport.mark_known_dead();
         }
-        SqlErrorInfo::from(error_token)
+        let error = SqlErrorInfo::from(error_token);
+        if let Some(batch) = self.prepared_batch.as_mut()
+            && let Some(row) = batch.current.as_mut()
+        {
+            row.errors.push(error.clone());
+        }
+        error
     }
 
     /// Returns the current database collation.
@@ -1599,6 +1626,7 @@ impl TdsClient {
         statement_id: StatementId,
         rows: I,
         options: impl Into<ExecuteOptions<'a>>,
+        preserve_rows: bool,
     ) -> TdsResult<PreparedBatchResult>
     where
         I: IntoIterator<Item = TdsResult<(usize, Vec<RpcParameter>)>>,
@@ -1685,13 +1713,154 @@ impl TdsClient {
             self.update_remaining_timeout(start);
         }
 
-        let result = self.drain_prepared_batch(row_indices).await;
+        let result = if preserve_rows {
+            let mut remaining = row_indices.into_iter();
+            self.prepared_batch = Some(Box::new(PreparedBatchReadState {
+                current: remaining.next().map(PreparedBatchReadState::next_row),
+                remaining,
+                completed: Vec::new(),
+            }));
+            self.current_result_set_has_been_read_till_end = true;
+            self.current_metadata = None;
+            self.advance_prepared_batch().await.map(|_| {
+                self.take_prepared_batch_results()
+                    .unwrap_or(PreparedBatchResult {
+                        rows: Vec::new(),
+                        complete: true,
+                    })
+            })
+        } else {
+            self.drain_prepared_batch(row_indices).await
+        };
         if result.is_err() {
+            self.prepared_batch = None;
             self.execution_context.set_has_open_batch(false);
             self.current_result_set_has_been_read_till_end = true;
             self.current_metadata = None;
         }
         result
+    }
+
+    /// Takes completion records accumulated while fetching or advancing a
+    /// row-preserving prepared batch. `complete` is final only once the batch
+    /// is closed; an open batch may still have parameter sets in flight.
+    pub fn take_prepared_batch_results(&mut self) -> Option<PreparedBatchResult> {
+        let batch = self.prepared_batch.as_mut()?;
+        Some(PreparedBatchResult {
+            rows: std::mem::take(&mut batch.completed),
+            complete: batch.current.is_none() && batch.remaining.len() == 0,
+        })
+    }
+
+    /// Index of the parameter set currently producing results, if any.
+    pub fn current_parameter_set(&self) -> Option<usize> {
+        self.prepared_batch
+            .as_ref()?
+            .current
+            .as_ref()
+            .map(|row| row.row_index)
+    }
+
+    fn observe_prepared_batch_done(&mut self, token: &Tokens) -> TdsResult<()> {
+        let Some(batch) = self.prepared_batch.as_mut() else {
+            return Ok(());
+        };
+        let (done, in_proc) = match token {
+            Tokens::DoneInProc(done) => (done, true),
+            Tokens::Done(done) | Tokens::DoneProc(done) => (done, false),
+            _ => return Ok(()),
+        };
+        let row = batch.current.as_mut().ok_or_else(|| {
+            crate::error::Error::ProtocolError("Unexpected prepared batch completion".to_string())
+        })?;
+        if done.has_error() && row.errors.is_empty() {
+            self.transport.mark_known_dead();
+            return Err(crate::error::Error::ProtocolError(
+                "Server reported an error for a batched RPC without an ERROR token".to_string(),
+            ));
+        }
+        if done.status.contains(DoneStatus::COUNT) && done.cur_cmd != CurrentCommand::Select {
+            row.rows_affected = Some(
+                row.rows_affected
+                    .unwrap_or(0)
+                    .saturating_add(done.row_count),
+            );
+        }
+        if in_proc {
+            return Ok(());
+        }
+        if let Some(row) = batch.current.take() {
+            batch.completed.push(row);
+        }
+        if done.status.contains(DoneStatus::RPC_IN_BATCH) {
+            batch.current = batch.remaining.next().map(PreparedBatchReadState::next_row);
+            if batch.current.is_none() {
+                self.transport.mark_known_dead();
+                return Err(crate::error::Error::ProtocolError(
+                    "Batched RPC continuation does not match the submitted parameter sets"
+                        .to_string(),
+                ));
+            }
+        } else if done.has_more() {
+            self.transport.mark_known_dead();
+            return Err(crate::error::Error::ProtocolError(
+                "Batched RPC results ended without a final DONE".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    async fn advance_prepared_batch(&mut self) -> TdsResult<StatementResult> {
+        let result = self.read_prepared_batch_result().await;
+        if let Err(error) = &result {
+            self.current_metadata = None;
+            self.current_result_set_has_been_read_till_end = true;
+            self.execution_context.set_has_open_batch(false);
+            self.prepared_batch = None;
+            if !matches!(
+                error,
+                crate::error::Error::TimeoutError(_)
+                    | crate::error::Error::OperationCancelledError(_)
+            ) {
+                self.retire_after_failed_drain(error);
+            }
+        }
+        result
+    }
+
+    async fn read_prepared_batch_result(&mut self) -> TdsResult<StatementResult> {
+        if self.maybe_has_unread_rows() {
+            self.drain_rows().await?;
+        }
+        let parser_context = ParserContext::ColumnEncryption(
+            self.negotiated_settings.is_column_encryption_supported(),
+        );
+        while self
+            .prepared_batch
+            .as_ref()
+            .is_some_and(|batch| batch.current.is_some())
+        {
+            let token = self.next_response_token(&parser_context).await?;
+            match token {
+                Tokens::ColMetadata(metadata) => {
+                    if let Some(batch) = self.prepared_batch.as_mut()
+                        && let Some(row) = batch.current.as_mut()
+                    {
+                        row.has_result_set = true;
+                    }
+                    self.last_rows_affected = -1;
+                    return Ok(
+                        self.apply_result_boundary(ResultBoundaryKind::RowSet(Arc::new(metadata)))
+                    );
+                }
+                Tokens::Done(_) | Tokens::DoneProc(_) | Tokens::DoneInProc(_) => {}
+                Tokens::Error(error) => {
+                    self.record_error_token(&error);
+                }
+                other => self.apply_drain_side_effect(other, &mut Vec::new())?,
+            }
+        }
+        Ok(self.apply_result_boundary(ResultBoundaryKind::End))
     }
 
     async fn drain_prepared_batch(
@@ -1945,7 +2114,7 @@ impl TdsClient {
         I: IntoIterator<Item = TdsResult<(usize, Vec<RpcParameter>)>>,
     {
         self.begin_command();
-        self.execute_sp_execute_batch(statement_id, rows, ExecuteOptions::default())
+        self.execute_sp_execute_batch(statement_id, rows, ExecuteOptions::default(), false)
             .await
     }
 
@@ -3516,6 +3685,38 @@ impl TdsClient {
     where
         I: IntoIterator<Item = TdsResult<(usize, Vec<RpcParameter>)>>,
     {
+        self.execute_prepared_batch_inner(statement, rows, orphaned, options, false)
+            .await
+    }
+
+    /// Executes the same batched request as `execute_prepared_batch`, but leaves
+    /// row-returning results available through `ResultSet` and `advance`.
+    /// Completion records are returned incrementally by `take_prepared_batch_results`.
+    pub async fn begin_execute_prepared_batch<'a, I>(
+        &mut self,
+        statement: &mut PreparedStatement,
+        rows: I,
+        orphaned: &mut Option<StatementId>,
+        options: impl Into<ExecuteOptions<'a>>,
+    ) -> TdsResult<PreparedBatchResult>
+    where
+        I: IntoIterator<Item = TdsResult<(usize, Vec<RpcParameter>)>>,
+    {
+        self.execute_prepared_batch_inner(statement, rows, orphaned, options, true)
+            .await
+    }
+
+    async fn execute_prepared_batch_inner<'a, I>(
+        &mut self,
+        statement: &mut PreparedStatement,
+        rows: I,
+        orphaned: &mut Option<StatementId>,
+        options: impl Into<ExecuteOptions<'a>>,
+        preserve_rows: bool,
+    ) -> TdsResult<PreparedBatchResult>
+    where
+        I: IntoIterator<Item = TdsResult<(usize, Vec<RpcParameter>)>>,
+    {
         if self.command_is_busy() {
             return Err(UsageError(ALREADY_EXECUTING_ERROR.to_string()));
         }
@@ -3588,7 +3789,7 @@ impl TdsClient {
             }
         };
 
-        self.execute_sp_execute_batch(statement_id, rows, opts)
+        self.execute_sp_execute_batch(statement_id, rows, opts, preserve_rows)
             .await
     }
 
@@ -4554,6 +4755,7 @@ impl TdsClient {
     /// cancelled result can no longer be resumed. Retaining its metadata,
     /// timeout, row cursor, or open-batch flag would expose stale state.
     fn normalize_after_attention(&mut self) {
+        self.prepared_batch = None;
         self.current_metadata = None;
         self.current_decryptor = None;
         self.buffered_row_support = None;
@@ -5011,6 +5213,7 @@ impl TdsClient {
             }
         };
         self.observe_response_token(&token)?;
+        self.observe_prepared_batch_done(&token)?;
         Ok(token)
     }
 
@@ -5036,6 +5239,9 @@ impl TdsClient {
     /// the request after the attention acknowledgement restores synchronization;
     /// the connection remains reusable.
     async fn settle_rpc_terminator(&mut self, parser_context: &ParserContext) -> TdsResult<()> {
+        if self.prepared_batch.is_some() {
+            return Ok(());
+        }
         let mut processing_error = None;
         let mut loop_count = 0u32;
         loop {
@@ -5171,6 +5377,9 @@ impl TdsClient {
     pub async fn advance(&mut self) -> TdsResult<StatementResult> {
         if !self.has_open_batch() {
             return Ok(StatementResult::End);
+        }
+        if self.prepared_batch.is_some() {
+            return self.advance_prepared_batch().await;
         }
         if self.maybe_has_unread_rows()
             && let Err(error) = self.drain_rows().await
@@ -7213,6 +7422,7 @@ impl TdsClient {
     }
 
     async fn handle_row_read_token(&mut self, token: Tokens) -> TdsResult<Option<bool>> {
+        self.observe_prepared_batch_done(&token)?;
         match token {
             Tokens::DoneInProc(done) => self.handle_row_done(done, true),
             Tokens::DoneProc(done) | Tokens::Done(done) => self.handle_row_done(done, false),
@@ -7241,6 +7451,10 @@ impl TdsClient {
             }
             Tokens::Error(error_token) => {
                 info!(?error_token);
+                if self.prepared_batch.is_some() {
+                    self.record_error_token(&error_token);
+                    return Ok(None);
+                }
                 let mut all_errors = vec![self.record_error_token(&error_token)];
                 let drain_result = self.drain_stream().await;
                 // Reset batch state before propagating: the error terminates the
@@ -7287,7 +7501,7 @@ impl TdsClient {
     ) -> TdsResult<Option<bool>> {
         info!("done while get_next_row: {:?}", done);
 
-        if done.has_error() {
+        if done.has_error() && self.prepared_batch.is_none() {
             return Err(crate::error::Error::ProtocolError(
                 "Server reported error in DONE token without preceding ERROR token".to_string(),
             ));
@@ -7297,7 +7511,8 @@ impl TdsClient {
         *count = count.saturating_add(done.row_count);
         self.current_result_set_has_been_read_till_end = true;
         self.current_result_ended_with_done_in_proc = ended_with_done_in_proc;
-        if !done.has_more() {
+        let has_more = done.has_more() || self.prepared_batch.is_some();
+        if !has_more {
             info!("No more rows for current command: {:?}", done.cur_cmd);
             self.execution_context.set_has_open_batch(false);
         }
@@ -7348,6 +7563,11 @@ impl TdsClient {
 
     fn capture_info_message(&mut self, token: &crate::token::tokens::InfoToken) {
         self.info_messages.push(SqlInfoMessage::from(token));
+        if let Some(batch) = self.prepared_batch.as_mut()
+            && let Some(row) = batch.current.as_mut()
+        {
+            row.has_info = true;
+        }
     }
 
     /// Resets the informational-message buffer at the start of a new command so
@@ -7359,6 +7579,7 @@ impl TdsClient {
     /// new session *after* this point, so those remain visible as part of the
     /// command that triggered the reconnect.
     fn begin_command(&mut self) {
+        self.prepared_batch = None;
         self.settle_abandoned_reset_verification();
         self.interrupted_read_settled = false;
         self.info_messages.clear();
@@ -14424,6 +14645,195 @@ mod tests {
             .expect_err("forced encryption is unsupported on the batch fast path");
         assert!(matches!(&error, UsageError(message) if message.contains("ForceColumnEncryption")));
         assert!(sent.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn prepared_batch_streams_result_sets_and_reports_completed_indices() {
+        let tokens = vec![
+            empty_col_metadata(),
+            batch_done_in_proc(1),
+            batch_done_proc(true, false),
+            empty_col_metadata(),
+            batch_done_in_proc(1),
+            batch_done_proc(false, false),
+        ];
+        let (mut client, _) = create_capturing_client(tokens);
+        let statement_id = client.register_prepared_handle_for_test(42);
+        let mut statement = PreparedStatement::materialized_for_test("SELECT @P1", statement_id);
+        let first = client
+            .begin_execute_prepared_batch(
+                &mut statement,
+                vec![Ok((2, Vec::new())), Ok((5, Vec::new()))],
+                &mut None,
+                (),
+            )
+            .await
+            .unwrap();
+        assert!(first.rows.is_empty());
+        assert!(!first.complete);
+        assert!(client.on_rows());
+        assert_eq!(client.current_parameter_set(), Some(2));
+        assert_eq!(client.advance().await.unwrap(), StatementResult::Rows);
+        let first = client.take_prepared_batch_results().unwrap();
+        assert_eq!(first.rows.len(), 1);
+        assert_eq!(first.rows[0].row_index, 2);
+        assert!(first.rows[0].has_result_set);
+        assert!(first.rows[0].errors.is_empty());
+        assert_eq!(first.total_rows_affected(), Some(1));
+        assert!(!first.complete);
+        assert_eq!(client.current_parameter_set(), Some(5));
+        assert_eq!(client.advance().await.unwrap(), StatementResult::End);
+        let last = client.take_prepared_batch_results().unwrap();
+        assert_eq!(last.rows.len(), 1);
+        assert_eq!(last.rows[0].row_index, 5);
+        assert!(last.complete);
+        assert!(!client.has_open_batch());
+        assert_eq!(client.advance().await.unwrap(), StatementResult::End);
+    }
+
+    #[tokio::test]
+    async fn prepared_batch_close_drains_unread_sets_without_losing_status() {
+        let tokens = vec![
+            empty_col_metadata(),
+            batch_done_in_proc(1),
+            batch_done_proc(true, false),
+            empty_col_metadata(),
+            batch_done_in_proc(1),
+            batch_done_proc(false, false),
+        ];
+        let (mut client, _) = create_capturing_client(tokens);
+        let statement_id = client.register_prepared_handle_for_test(42);
+        let mut statement = PreparedStatement::materialized_for_test("SELECT @P1", statement_id);
+        client
+            .begin_execute_prepared_batch(
+                &mut statement,
+                vec![Ok((0, Vec::new())), Ok((1, Vec::new()))],
+                &mut None,
+                (),
+            )
+            .await
+            .unwrap();
+        client.close_query().await.unwrap();
+        let result = client.take_prepared_batch_results().unwrap();
+        assert_eq!(result.rows.len(), 2);
+        assert!(result.complete);
+        assert!(
+            result
+                .rows
+                .iter()
+                .all(|row| row.has_result_set && row.errors.is_empty())
+        );
+        assert!(!client.has_open_batch());
+        assert!(!client.is_connection_dead());
+    }
+
+    #[tokio::test]
+    async fn prepared_batch_failed_resume_retires_the_unread_stream() {
+        let tokens = vec![empty_col_metadata(), batch_done_proc(true, false)];
+        let (mut client, _) = create_capturing_client(tokens);
+        let statement_id = client.register_prepared_handle_for_test(42);
+        let mut statement = PreparedStatement::materialized_for_test("SELECT @P1", statement_id);
+        client
+            .begin_execute_prepared_batch(&mut statement, vec![Ok((0, Vec::new()))], &mut None, ())
+            .await
+            .unwrap();
+        assert!(matches!(
+            client.advance().await,
+            Err(crate::error::Error::ProtocolError(_))
+        ));
+        assert!(!client.has_open_batch());
+        assert!(!client.on_rows());
+        assert!(client.is_connection_dead());
+        assert_eq!(client.advance().await.unwrap(), StatementResult::End);
+    }
+
+    #[tokio::test]
+    async fn prepared_batch_row_doneproc_keeps_completion_available_to_advance() {
+        let tokens = vec![empty_col_metadata(), batch_done_proc(false, false)];
+        let (mut client, _) = create_capturing_client(tokens);
+        let statement_id = client.register_prepared_handle_for_test(42);
+        let mut statement = PreparedStatement::materialized_for_test("SELECT @P1", statement_id);
+        client
+            .begin_execute_prepared_batch(&mut statement, vec![Ok((0, Vec::new()))], &mut None, ())
+            .await
+            .unwrap();
+        client.drain_rows().await.unwrap();
+        assert!(client.has_open_batch());
+        assert_eq!(client.advance().await.unwrap(), StatementResult::End);
+        let result = client.take_prepared_batch_results().unwrap();
+        assert!(result.complete);
+        assert_eq!(result.rows.len(), 1);
+        assert!(result.rows[0].has_result_set);
+    }
+
+    #[tokio::test]
+    async fn prepared_batch_streaming_rejects_invalid_completion_tokens() {
+        for done in [
+            batch_done_proc(false, true),
+            batch_done_proc(true, false),
+            Tokens::DoneProc(DoneToken {
+                status: DoneStatus::MORE,
+                cur_cmd: CurrentCommand::Select,
+                row_count: 0,
+            }),
+        ] {
+            let (mut client, _) = create_capturing_client(vec![done]);
+            let statement_id = client.register_prepared_handle_for_test(42);
+            let mut statement =
+                PreparedStatement::materialized_for_test("SELECT @P1", statement_id);
+            let result = client
+                .begin_execute_prepared_batch(
+                    &mut statement,
+                    vec![Ok((0, Vec::new()))],
+                    &mut None,
+                    (),
+                )
+                .await;
+            assert!(matches!(result, Err(crate::error::Error::ProtocolError(_))));
+            assert!(client.is_connection_dead());
+            assert!(!client.has_open_batch());
+        }
+    }
+
+    #[tokio::test]
+    async fn prepared_batch_streaming_preserves_an_error_after_metadata() {
+        let tokens = vec![
+            empty_col_metadata(),
+            Tokens::Error(crate::token::tokens::ErrorToken {
+                number: 2627,
+                state: 1,
+                severity: 14,
+                message: "duplicate key".to_string(),
+                server_name: "test-server".to_string(),
+                proc_name: String::new(),
+                line_number: 1,
+            }),
+            batch_done_proc(true, true),
+            empty_col_metadata(),
+            batch_done_proc(false, false),
+        ];
+        let (mut client, _) = create_capturing_client(tokens);
+        let statement_id = client.register_prepared_handle_for_test(42);
+        let mut statement = PreparedStatement::materialized_for_test("SELECT @P1", statement_id);
+        client
+            .begin_execute_prepared_batch(
+                &mut statement,
+                vec![Ok((0, Vec::new())), Ok((1, Vec::new()))],
+                &mut None,
+                (),
+            )
+            .await
+            .unwrap();
+        assert_eq!(client.advance().await.unwrap(), StatementResult::Rows);
+        let first = client.take_prepared_batch_results().unwrap();
+        assert_eq!(first.rows.len(), 1);
+        assert!(first.rows[0].has_result_set);
+        assert_eq!(first.rows[0].errors[0].number, 2627);
+        client.close_query().await.unwrap();
+        let last = client.take_prepared_batch_results().unwrap();
+        assert!(last.complete);
+        assert!(last.rows[0].errors.is_empty());
+        assert!(!client.is_connection_dead());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

Deliver row-returning prepared parameter-array results through normal ODBC fetch calls and `SQLMoreResults` instead of discarding them.

- Preserve the existing batched RPC request and add a row-preserving TDS execution API without changing the original draining API.
- Track per-set completion across navigation and cursor close. Returning rows alone never marks a set `SQL_PARAM_ERROR`; real per-set errors retain their diagnostics while later results remain available.
- Advertise `SQL_PAS_BATCH` for `SQL_PARAM_ARRAY_SELECTS` and update the parameter-array documentation.
- Cover OUTPUT rows, empty/NULL SELECT results, multiple procedure result sets, ignored sets, partial errors with and without status arrays, early close/re-execution, partial LOB reads, malformed completions, and navigation timeouts.

Measured retail msodbcsql 18.6.2.1 (`SQL_DRIVER_VER=18.06.0002`): all three OUTPUT result sets are fetchable; after navigation, the processed count is 3 and all statuses are `SQL_PARAM_SUCCESS`. Execute-only bookkeeping is provisional and does not establish a final-count defect.

## Related Issues

[AB#47944](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47944)

https://sqlclientdrivers.visualstudio.com/mssql-rs/_workitems/edit/47944

## Testing

- 3,529 TDS/ODBC unit tests passed; 51 focused batch, navigation, close, and capability checks rerun before publication.
- 45 parameter-array cases passed on Rust; retail 18.6.2.1 passed 40 with five pre-existing skips. The original 44-case suite and the added navigation-timeout case were run separately.
- Parameter-array capability checks and Unicode-mode C++ syntax checks passed.
- `cargo bfmt` and workspace `cargo bclippy` passed.
- Combined local changed-line coverage: 96.5% (includes inline test code).
- Full workspace integration tests and Windows/macOS execution remain for CI.

## Compatibility

No existing public signature removals or new dependencies. The additive TDS API preserves the original draining API. Row-returning arrays now leave a cursor open: callers must finish navigation or close it before reusing the connection. Non-row arrays retain execute-time completion and aggregate row counts.

## Checklist

- [x] `cargo bfmt` passes
- [x] `cargo bclippy` passes
- [ ] `cargo btest` passes (affected-crate unit suites passed; full workspace integration validation remains for CI)
- [x] New/changed functionality has tests
- [x] Public API changes are documented