### PR TITLE
Correct the stale bound-PLP size guidance in the agent instructions (AB#48048)

### DIFF
--- a/.github/instructions/mssql-odbc.instructions.md
+++ b/.github/instructions/mssql-odbc.instructions.md
@@ -708,21 +708,10 @@ Driver Manager (DM) provides serialization guarantees that the driver relies on
   - A success-path test.
   - A null-output-handle test.
   - An invalid-handle-type or invalid-input test.
-- **A `max`/LOB column reaches the bound *streaming* path whatever its size.**
-  `try_read_row_column` attempts `try_begin_buffered_plp` for any column whose
-  metadata says `is_plp()` and yields `CursorColumn::PlpStreaming`
-  (`tds_client.rs`); the decision is gated on the column being PLP, never on its
-  length. So an e2e that targets `deliver_bound_plp` needs no particular size -
-  a handful of bytes reaches it. `ABoundVarcharMaxTruncatedToWcharReportsNoTotal`
-  is the proof already in the suite: 5,000 wire bytes asserting `SQL_NO_TOTAL`,
-  which on the bound path only `plp_indicator` produces, and that has exactly one
-  call site - inside `deliver_bound_plp`.
-  Do not confuse this with `PLP_TYPED_MATERIALIZE_LIMIT`, a separate 1 MiB cap on
-  how much a *typed* conversion will materialize (see the parity note above).
-- **Bound binary into a typed C target is refused, and the SQLSTATE differs by
-  driver for `max`.** Measured on 18.06.0001: `varbinary(8)` into `SQL_C_SLONG`
-  is `07006` on both, and `varbinary(max)` is `07006` on msodbcsql but `HYC00`
-  here. `varchar(8)`/`varchar(max)` holding `'42'` convert to `42` on both.
+- PLP routing is gated by `is_plp()` alone, not size, so an e2e targeting
+  `deliver_bound_plp` does not need a large payload. Do not confuse this with
+  `PLP_TYPED_MATERIALIZE_LIMIT`, the separate 1 MiB cap on how much a typed
+  conversion will materialize (see the parity note above).
 - Use `cargo nextest` (via `cargo btest`), not `cargo test`.
 
 ## Code style

--- a/.github/instructions/mssql-odbc.instructions.md
+++ b/.github/instructions/mssql-odbc.instructions.md
@@ -708,16 +708,21 @@ Driver Manager (DM) provides serialization guarantees that the driver relies on
   - A success-path test.
   - A null-output-handle test.
   - An invalid-handle-type or invalid-input test.
-- **A `max`/LOB column only reaches the bound *streaming* path when it is too
-  large for the transport to buffer whole.** `try_read_buffered_column` decodes
-  any fully buffered column - PLP included - into a `ColumnValues`, so a small
-  `varchar(max)`/`varbinary(max)` is delivered by `deliver_bound`, exactly like a
-  non-max value, and never enters `deliver_bound_plp`. A few kilobytes still
-  buffers; the streaming path is reachable around a megabyte (the existing 1 MiB
-  cases in `fetch_scroll_test.cpp` prove it). Size an e2e that targets
-  `deliver_bound_plp` accordingly, or it will silently assert the non-PLP path -
-  a bound binary `max` column against a typed C target answers `22018` from the
-  typed converter when buffered, and `HYC00` when streamed.
+- **A `max`/LOB column reaches the bound *streaming* path whatever its size.**
+  `try_read_row_column` attempts `try_begin_buffered_plp` for any column whose
+  metadata says `is_plp()` and yields `CursorColumn::PlpStreaming`
+  (`tds_client.rs`); the decision is gated on the column being PLP, never on its
+  length. So an e2e that targets `deliver_bound_plp` needs no particular size -
+  a handful of bytes reaches it. `ABoundVarcharMaxTruncatedToWcharReportsNoTotal`
+  is the proof already in the suite: 5,000 wire bytes asserting `SQL_NO_TOTAL`,
+  which on the bound path only `plp_indicator` produces, and that has exactly one
+  call site - inside `deliver_bound_plp`.
+  Do not confuse this with `PLP_TYPED_MATERIALIZE_LIMIT`, a separate 1 MiB cap on
+  how much a *typed* conversion will materialize (see the parity note above).
+- **Bound binary into a typed C target is refused, and the SQLSTATE differs by
+  driver for `max`.** Measured on 18.06.0001: `varbinary(8)` into `SQL_C_SLONG`
+  is `07006` on both, and `varbinary(max)` is `07006` on msodbcsql but `HYC00`
+  here. `varchar(8)`/`varchar(max)` holding `'42'` convert to `42` on both.
 - Use `cargo nextest` (via `cargo btest`), not `cargo test`.
 
 ## Code style

--- a/mssql-odbc/tests/e2e/tests/fetch_scroll_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/fetch_scroll_test.cpp
@@ -1323,9 +1323,9 @@ TEST_F(FetchScrollLiveTest, ABoundVarbinaryMaxDeliversAcrossARowset) {
 // refused before any conversion is attempted. Same AB#47239 gap as above, so it
 // likewise asserts our own answer rather than parity.
 //
-// PLP metadata selects the streaming path regardless of the value's size. A
-// binary PLP column is refused before typed conversion, so varbinary(max) into
-// SQL_C_SLONG answers HYC00 here even for a small value.
+// PLP metadata selects the streaming path regardless of the value's size. This
+// test keeps a large value to verify that refusing a binary PLP before typed
+// conversion still drains every chunk before the trailing column and next row.
 TEST_F(FetchScrollLiveTest, ABoundStreamedVarbinaryMaxToTypedCTargetIsStillUnsupported) {
     SKIP_IF_COMPARING_MSODBCSQL();
     ExecDirect(

--- a/mssql-odbc/tests/e2e/tests/fetch_scroll_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/fetch_scroll_test.cpp
@@ -1276,9 +1276,9 @@ TEST_F(FetchScrollLiveTest, ABoundVarbinaryMaxDeliversAcrossARowset) {
     // buffer, and the value after it -- and the row after that -- still have to
     // decode, which is what a mis-sized drain would break.
     //
-    // 1,100,000 bytes, not a few thousand: a value small enough to arrive inside
-    // the already-buffered wire bytes is materialized and delivered by the bound
-    // non-PLP path, which would leave deliver_bound_plp untested.
+    // The large value is intentional to exercise repeated PLP chunk reads and
+    // draining across packets. PLP metadata selects deliver_bound_plp regardless
+    // of the value's size.
     ExecDirect(
         "SELECT n, CAST(REPLICATE(CAST(0x41 AS VARBINARY(MAX)), 1100000) AS VARBINARY(MAX)) "
         "AS lob, n * 11 AS tail "
@@ -1323,10 +1323,9 @@ TEST_F(FetchScrollLiveTest, ABoundVarbinaryMaxDeliversAcrossARowset) {
 // refused before any conversion is attempted. Same AB#47239 gap as above, so it
 // likewise asserts our own answer rather than parity.
 //
-// The value has to exceed what the transport can buffer for a whole column,
-// otherwise `try_read_buffered_column` materializes it and the row takes the
-// ordinary non-PLP delivery path instead of the streaming one under test -- a
-// small varbinary(max) here answers 22018 from the typed converter, not HYC00.
+// PLP metadata selects the streaming path regardless of the value's size. A
+// binary PLP column is refused before typed conversion, so varbinary(max) into
+// SQL_C_SLONG answers HYC00 here even for a small value.
 TEST_F(FetchScrollLiveTest, ABoundStreamedVarbinaryMaxToTypedCTargetIsStillUnsupported) {
     SKIP_IF_COMPARING_MSODBCSQL();
     ExecDirect(

--- a/mssql-odbc/tests/e2e/tests/fetch_scroll_test.cpp
+++ b/mssql-odbc/tests/e2e/tests/fetch_scroll_test.cpp
@@ -1321,7 +1321,9 @@ TEST_F(FetchScrollLiveTest, ABoundVarbinaryMaxDeliversAcrossARowset) {
 // The typed-conversion path reaches the same refusal by a different route: a
 // binary PLP column has no source encoding to convert from, so it is drained and
 // refused before any conversion is attempted. Same AB#47239 gap as above, so it
-// likewise asserts our own answer rather than parity.
+// likewise asserts our own answer rather than parity. Measured on msodbcsql
+// 18.06.0001, varbinary(max) into SQL_C_SLONG answers 07006 instead of this
+// driver's HYC00; AB#47239 tracks implementing the missing conversion here.
 //
 // PLP metadata selects the streaming path regardless of the value's size. This
 // test keeps a large value to verify that refusing a binary PLP before typed


### PR DESCRIPTION
Resolves [AB#48048](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/48048).

## The claim, verified

`.github/instructions/mssql-odbc.instructions.md` told agents that a `max`/LOB column only reaches the bound *streaming* path when it is too large for the transport to buffer whole, that "a few kilobytes still buffers", and that `deliver_bound_plp` is "reachable around a megabyte". That has been false since #446.

Checked mechanically rather than taken on faith:

- `try_read_row_column` attempts `try_begin_buffered_plp` for any column whose metadata says `is_plp()` and yields `CursorColumn::PlpStreaming`. The match arm is gated on `is_plp()` alone — no length appears in the decision at all.
- `plp_indicator` has exactly **one** production call site, inside `deliver_bound_plp`, and is the only producer of `SQL_NO_TOTAL` on the bound path.
- So `ABoundVarcharMaxTruncatedToWcharReportsNoTotal` already proves the point with **5,000** wire bytes — it asserts `SQL_NO_TOTAL`, which nothing else can produce. I ran it: it passes today.

I also measured it independently while working [AB#47240](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47240): a bound `varbinary(max)` of **10 bytes** reached `deliver_bound_plp`.

## The tail was wrong too

The bullet closed by saying a bound binary `max` column into a typed C target answers `22018` when buffered and `HYC00` when streamed. Measured on 18.06.0001:

| Case | mssql-odbc | msodbcsql |
| --- | --- | --- |
| `varbinary(8)` → `SQL_C_SLONG` | `07006` | `07006` |
| `varbinary(max)` (small) → `SQL_C_SLONG` | **`HYC00`** | **`07006`** |
| `varchar(8)` / `varchar(max)` `'42'` → `SQL_C_SLONG` | `42` | `42` |

Neither half held: non-`max` binary is `07006`, not `22018`. And the `max` row is a **real parity divergence** that the file was describing as a harmless artifact of buffering — see below.

## Also

Separated out `PLP_TYPED_MATERIALIZE_LIMIT`, a genuine and unrelated 1 MiB cap on how much a *typed* conversion will materialize, so the two 1 MiB numbers stop being conflated.

## Why this mattered

This is guidance that steers agents. It has already produced bad work: it misled a Copilot review on #533, and on #523 a review told me a 5,000-byte value was materialized, so I resized a test to 1,100,000 bytes on the strength of it. On #530 I then measured a 10-byte bound `varbinary(max)` reaching `deliver_bound_plp`, which contradicted it outright.

Documentation and test comments only; no behavior change. I left the existing 1.1 MB e2e cases alone — they are correct, just larger than they need to be.

## Found while verifying, not fixed here

- **`varbinary(max)` into a typed C target answers `HYC00` here and `07006` on msodbcsql.** The existing `ABoundStreamedVarbinaryMaxToTypedCTargetIsStillUnsupported` test covers this driver's `HYC00`; implementing the missing conversion is tracked by [AB#47239](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47239).
- **`ParamArrayTest.ParamsProcessedCountsTheFailingSet` fails on the msodbcsql leg on current `main`** (ours passes; expected 4, got 5). Pre-existing and unrelated to this change — flagging it for whoever owns [AB#47944](https://sqlclientdrivers.visualstudio.com/b95cf060-8083-439d-8ef1-405d5bf219d8/_workitems/edit/47944).
