### PR TITLE
Stop publishing unused Linux artifacts in PR validation

### DIFF
--- a/.pipeline/templates/build-template-alpine.yml
+++ b/.pipeline/templates/build-template-alpine.yml
@@ -37,16 +37,21 @@ steps:
       -v "$PWD:/workspace" \
       -e "ARCHIVE_NAME=tdslib-nextest-musl.tar.zst" \
       ${{ parameters.alpineimagetag }} /workspace/scripts/dockerentry/alpine-build.sh
-    cp tdslib-nextest-musl.tar.zst $(Build.ArtifactStagingDirectory)
   displayName: Rust Alpine container build
   condition: succeeded()
   env:
     CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_PUBLIC_TOKEN)
     CARGO_REGISTRIES_MSSQL_RS_TOKEN: $(CARGO_REGISTRIES_MSSQL_RS_TOKEN)
 
+# Only non-PR distro-matrix and full Kerberos tests consume this drop.
+- script: |
+    cp tdslib-nextest-musl.tar.zst "$(Build.ArtifactStagingDirectory)/"
+  displayName: Copy musl nextest archive
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
 
 - task: PublishBuildArtifacts@1
   displayName: Publish Build Drop
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
   inputs:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)'
     ArtifactName: $(System.PhaseName)

--- a/.pipeline/templates/build-template-container.yml
+++ b/.pipeline/templates/build-template-container.yml
@@ -429,28 +429,6 @@ steps:
       targetPath: $(Build.SourcesDirectory)/target/cobertura-odbc-e2e.xml
       artifactName: CoberturaCoverageOdbcE2E_Linux
 
-- task: CopyFiles@2
-  displayName: Copy Rust Debug Build
-  condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'), or(eq('${{parameters.buildType}}', 'Debug'), eq('${{parameters.buildType}}', 'Both')))
-  inputs:
-    SourceFolder: '$(Build.SourcesDirectory)/target/debug'
-    Contents: |
-      *
-      !.cargo-lock
-      !libmssqlodbc.so
-    TargetFolder: '$(Build.ArtifactStagingDirectory)/debug'
-
-- task: CopyFiles@2
-  displayName: Copy Rust Release Build
-  condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'), or(eq('${{parameters.buildType}}', 'Release'), eq('${{parameters.buildType}}', 'Both')))
-  inputs:
-    SourceFolder: '$(Build.SourcesDirectory)/target/release'
-    Contents: |
-      *
-      !.cargo-lock
-      !libmssqlodbc.so
-    TargetFolder: '$(Build.ArtifactStagingDirectory)/release'
-
 - script: |
     if [ -f "$(Build.SourcesDirectory)/tdslib-nextest.tar.zst" ]; then
       cp $(Build.SourcesDirectory)/tdslib-nextest.tar.zst $(Build.ArtifactStagingDirectory)/

--- a/.pipeline/templates/validation-stages.yml
+++ b/.pipeline/templates/validation-stages.yml
@@ -124,12 +124,11 @@ stages:
       - template: install-dependencies.yml
         parameters:
           osType: Windows
-      # Unit-test wheel packaging scripts on PR runs; the packaging pipeline
-      # steps themselves are non-PR gated.
+      # Packaging and artifact gates must be tested even when PR runs skip them.
       - pwsh: |
           python -m pip install --quiet pytest pyyaml
-          python -m pytest scripts/test_inject_odbc.py scripts/test_verify_python_wheels.py scripts/test_release_pipeline.py -q
-        displayName: 'Unit test Python wheel packaging scripts'
+          python -m pytest scripts/test_inject_odbc.py scripts/test_verify_python_wheels.py scripts/test_release_pipeline.py scripts/test_validation_pipeline.py -q
+        displayName: 'Unit test packaging scripts and pipeline configuration'
       - template: build-template.yml
         parameters:
           osType: Windows

--- a/scripts/test_validation_pipeline.py
+++ b/scripts/test_validation_pipeline.py
@@ -1,0 +1,98 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Regression tests for Linux validation artifact publication."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+_ROOT = Path(__file__).parents[1]
+_TEMPLATES = _ROOT / ".pipeline" / "templates"
+_NON_PR = "and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))"
+_PR = "and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))"
+
+
+def load_template(name):
+    return yaml.safe_load((_TEMPLATES / name).read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize(
+    ("job_name", "architecture"), [("Build_Linux", "x64"), ("Build_Linux_ARM", "ARM64")]
+)
+def test_linux_jobs_keep_glibc_and_alpine_builds(job_name, architecture):
+    stages = load_template("validation-stages.yml")["stages"]
+    build = next(stage for stage in stages if stage["stage"] == "Build")
+    job = next(job for job in build["jobs"] if job.get("job") == job_name)
+    templates = {step["template"]: step for step in job["steps"] if "template" in step}
+    container = templates["build-template-container.yml"]
+    alpine = templates["build-template-alpine.yml"]
+    assert container["parameters"]["architecture"] == architecture
+    assert "condition" not in container
+    assert "condition" not in alpine
+    assert job["steps"].index(container) < job["steps"].index(alpine)
+
+
+@pytest.mark.parametrize(
+    ("template", "archive"),
+    [
+        ("build-template-container.yml", "tdslib-nextest.tar.zst"),
+        ("build-template-alpine.yml", "tdslib-nextest-musl.tar.zst"),
+    ],
+)
+def test_only_nextest_archives_are_staged_on_non_pr_runs(template, archive):
+    steps = load_template(template)["steps"]
+    staging = [
+        step for step in steps if "$(Build.ArtifactStagingDirectory)" in str(step)
+    ]
+    copies = [step for step in staging if step.get("task") != "PublishBuildArtifacts@1"]
+    assert len(copies) == 1
+    copy = copies[0]
+    assert copy["condition"] == _NON_PR
+    assert "cp " in copy["script"]
+    assert archive in copy["script"]
+    assert "$(Build.ArtifactStagingDirectory)" in copy["script"]
+    assert "docker-cargo-run.sh" not in copy["script"]
+
+
+def test_linux_drop_publication_is_non_pr_only():
+    steps = load_template("build-template-alpine.yml")["steps"]
+    publishes = [step for step in steps if step.get("task") == "PublishBuildArtifacts@1"]
+    assert len(publishes) == 1
+    assert publishes[0]["condition"] == _NON_PR
+    assert publishes[0]["inputs"] == {
+        "PathtoPublish": "$(Build.ArtifactStagingDirectory)",
+        "ArtifactName": "$(System.PhaseName)",
+        "publishLocation": "Container",
+    }
+
+
+def test_alpine_gssapi_compilation_still_runs_on_prs():
+    steps = load_template("build-template-alpine.yml")["steps"]
+    build = next(
+        step for step in steps
+        if step.get("displayName") == "Rust Alpine container build"
+    )
+    assert build["condition"] == "succeeded()"
+    assert "/workspace/scripts/dockerentry/alpine-build.sh" in build["script"]
+    script = (_ROOT / "scripts" / "dockerentry" / "alpine-build.sh").read_text(
+        encoding="utf-8"
+    )
+    assert "cargo nextest archive" in script
+    assert "--features gssapi" in script
+
+
+@pytest.mark.parametrize("architecture", ["x64", "ARM64"])
+def test_linux_compilation_and_pr_tests_remain_enabled(architecture):
+    steps = load_template("build-template-container.yml")["steps"]
+    build = next(step for step in steps if step.get("displayName") == "Build in Container")
+    assert build.get("condition", "succeeded()") == "succeeded()"
+    operator = "eq" if architecture == "ARM64" else "ne"
+    branch = f"${{{{ if {operator}(parameters.architecture, 'ARM64') }}}}"
+    tests = next(
+        step for group in steps for step in group.get(branch, [])
+        if step.get("displayName") == "Run Tests and Coverage"
+    )
+    assert tests["condition"] == _PR
+    assert "/workspace/.pipeline/scripts/containerized-test.sh" in tests["script"]


### PR DESCRIPTION
<!--
Thank you for your interest in this project!

This repository is not currently accepting external pull requests. If you've found
a bug or have a feature request, please open an issue instead.

If you are a Microsoft team member, please follow the instructions in the internal
contribution guide.
-->

## Description

<!-- Briefly describe the change. -->

PR validation publishes roughly 3 GB of Linux build artifacts per sampled run without an automated consumer. Remove loose debug/release staging and restrict `Build_Linux` and `Build_Linux_ARM` publication to non-PR runs.

Non-PR runs retain the glibc and musl nextest archives at their existing paths for distro-matrix and full Kerberos tests. PR compilation and testing, including Alpine/GSSAPI compilation, remain enabled. Separate coverage, ODBC, wheel, and SQL-host artifacts are unchanged.

### Testing

`python -m pytest scripts\test_validation_pipeline.py -q`: 8 passed. The new regression tests cover archive-only staging, non-PR publication, both Linux architectures, and retained PR build/test steps. They are included in the existing pipeline test command.

Rust checks were not run because this changes only pipeline YAML and Python regression tests. Live Azure DevOps validation is pending.

### Breaking changes / migration notes

No library API changes or migration required. Linux validation drops are intentionally unavailable on PR runs.

## Related Issues

<!--
Required: link a GitHub issue OR an Azure DevOps work item. The PR check will
fail without one.
GitHub issue: Fixes #123 (or https://github.com/microsoft/mssql-rs/issues/123)
ADO work item: https://sqlclientdrivers.visualstudio.com/<...>/_workitems/edit/<ID>
  (any project/collection path is accepted, e.g. .../<project>/_workitems/edit/123
  or .../DefaultCollection/<project>/_workitems/edit/123)
-->

Fixes: #553

## Checklist

- [ ] `cargo bfmt` passes
- [ ] `cargo bclippy` passes
- [ ] `cargo btest` passes
- [x] New/changed functionality has tests
- [x] Public API changes are documented (N/A: no public API changes)